### PR TITLE
[codex] define AegisOps naming conventions

### DIFF
--- a/.codex-supervisor/issues/3/issue-journal.md
+++ b/.codex-supervisor/issues/3/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #3: design: define AegisOps naming conventions for hosts, compose projects, indexes, and workflows
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/3
+- Branch: codex/issue-3
+- Workspace: .
+- Journal: .codex-supervisor/issues/3/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 832a445f7b047915d2b2e7c3c09b509c6d5c60ad
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-01T05:04:44.550Z
+
+## Latest Codex Summary
+- Added a focused naming-conventions verifier, used it to reproduce a missing hostname naming section in `docs/requirements-baseline.md`, then expanded section 7 to cover hostnames, compose projects, OpenSearch indexes, detectors, n8n workflows, and secrets/environment variables with explicit examples.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Issue #3 is satisfied by tightening the baseline naming section and adding a narrow verifier that proves all required naming categories and examples exist without introducing runtime changes.
+- What changed: Added `scripts/verify-naming-conventions-doc.sh`; updated `docs/requirements-baseline.md` section 7 with explicit hostname naming rules, renamed and expanded compose/index/detector/workflow/secret subsections, and added concrete AegisOps examples.
+- Current blocker: none
+- Next exact step: Commit the documentation and verifier changes, then report the focused verification results.
+- Verification gap: No broader markdown lint or repository-wide doc validation exists in this workspace; focused naming and repository-structure checks passed.
+- Files touched: `docs/requirements-baseline.md`, `scripts/verify-naming-conventions-doc.sh`
+- Rollback concern: low; documentation and verification-script only.
+- Last focused command: `scripts/verify-naming-conventions-doc.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/requirements-baseline.md
+++ b/docs/requirements-baseline.md
@@ -281,9 +281,43 @@ The name **AegisOps** SHOULD be used consistently in:
 * deployment identifiers
 * operational runbooks
 
-### 7.2 Docker and Compose
+Examples:
 
-* Compose project names SHOULD use the prefix: `aegisops-*`
+* `AegisOps Platform Requirements Baseline`
+* `AegisOps Repository Structure Baseline`
+* `aegisops-opensearch`
+
+### 7.2 Hostname Naming
+
+Hostnames MUST use lowercase letters, digits, and hyphens only.
+
+Hostnames MUST start with the `aegisops-` product namespace and SHOULD end with a stable role-specific suffix.
+
+Where multiple hosts share the same role, hostnames SHOULD use a zero-padded ordinal suffix.
+
+Recommended pattern:
+
+`aegisops-<role>-node-<nn>`
+
+Recommended examples:
+
+* `aegisops-opensearch-node-01`
+* `aegisops-opensearch-node-02`
+* `aegisops-ingest-node-01`
+
+Single-instance roles MAY omit the ordinal only when future expansion is not expected to create ambiguity.
+
+Recommended examples:
+
+* `aegisops-n8n-node`
+* `aegisops-proxy-node`
+
+### 7.3 Docker Compose Project Naming
+
+Compose project names:
+
+* MUST use the `aegisops-` prefix
+* MUST use lowercase letters, digits, and hyphens only
 * Service names SHOULD remain stable across environments where possible
 * Container names SHOULD NOT be hard-coded unless operationally justified
 
@@ -294,9 +328,15 @@ Recommended examples:
 * `aegisops-ingest`
 * `aegisops-proxy`
 
-### 7.3 OpenSearch Index Naming
+### 7.4 OpenSearch Index Naming
 
-Recommended index naming patterns:
+OpenSearch index names:
+
+* MUST use lowercase letters, digits, and hyphens only
+* MUST start with the `aegisops-` namespace
+* SHOULD group data by type before source
+
+Recommended patterns:
 
 * `aegisops-logs-windows-*`
 * `aegisops-logs-linux-*`
@@ -307,9 +347,12 @@ Recommended index naming patterns:
 
 Any deviation from index naming conventions MUST be documented.
 
-### 7.4 Detector Naming
+### 7.5 Detector Naming
 
-Detector names SHOULD be descriptive and stable.
+Detector names:
+
+* SHOULD be descriptive, stable, and namespace-prefixed
+* SHOULD use lowercase letters, digits, and hyphens only
 
 Recommended pattern:
 
@@ -319,9 +362,13 @@ Example:
 
 `aegisops-windows-suspicious-powershell-high`
 
-### 7.5 n8n Workflow Naming
+### 7.6 n8n Workflow Naming
 
-Workflow names SHOULD follow functional prefixes and SHOULD include the product namespace where appropriate.
+Workflow names:
+
+* MUST use the `aegisops_` namespace
+* SHOULD follow functional prefixes
+* SHOULD use lowercase letters, digits, and underscores only so they remain easy to map into exported workflow assets and automation tooling
 
 Recommended patterns:
 
@@ -331,15 +378,25 @@ Recommended patterns:
 * `aegisops_notify_*`
 * `aegisops_response_*`
 
-### 7.6 Secret and Environment Variable Naming
+Examples:
 
-Secret and environment variable names SHOULD be uppercase and scoped by component.
+* `aegisops_alert_ingest_opensearch_findings`
+* `aegisops_enrich_ip_reputation`
+* `aegisops_approve_host_isolation`
+
+### 7.7 Secret and Environment Variable Naming
+
+Secret and environment variable names:
+
+* SHOULD be uppercase, underscore-delimited, and scoped by component
+* SHOULD retain the same naming convention between environment variables and secret identifiers where practical
 
 Examples:
 
 * `AEGISOPS_OPENSEARCH_ADMIN_PASSWORD`
 * `AEGISOPS_N8N_ENCRYPTION_KEY`
 * `AEGISOPS_POSTGRES_PASSWORD`
+* `AEGISOPS_PROXY_TLS_CERT_PATH`
 
 ---
 

--- a/scripts/verify-naming-conventions-doc.sh
+++ b/scripts/verify-naming-conventions-doc.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+doc_path="${repo_root}/docs/requirements-baseline.md"
+
+required_headings=(
+  "### 7.1 Product Naming"
+  "### 7.2 Hostname Naming"
+  "### 7.3 Docker Compose Project Naming"
+  "### 7.4 OpenSearch Index Naming"
+  "### 7.5 Detector Naming"
+  "### 7.6 n8n Workflow Naming"
+  "### 7.7 Secret and Environment Variable Naming"
+)
+
+required_examples=(
+  "aegisops-opensearch-node-01"
+  "aegisops-opensearch"
+  "aegisops-logs-windows-*"
+  "aegisops-windows-suspicious-powershell-high"
+  "aegisops_enrich_*"
+  "AEGISOPS_OPENSEARCH_ADMIN_PASSWORD"
+)
+
+legacy_names=(
+  "wazuh"
+  "elastic"
+  "elk"
+  "securityonion"
+  "security onion"
+  "splunk"
+  "sentinel"
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing requirements baseline document: ${doc_path}" >&2
+  exit 1
+fi
+
+section_text="$(
+  awk '
+    /^## 7\. Naming Conventions$/ { in_section=1 }
+    /^## / && in_section && !/^## 7\. Naming Conventions$/ { exit }
+    in_section { print }
+  ' "${doc_path}"
+)"
+
+if [[ -z "${section_text}" ]]; then
+  echo "Missing naming conventions section in ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" <<<"${section_text}"; then
+    echo "Missing naming heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for example in "${required_examples[@]}"; do
+  if ! grep -Fq "${example}" <<<"${section_text}"; then
+    echo "Missing naming example: ${example}" >&2
+    exit 1
+  fi
+done
+
+for legacy_name in "${legacy_names[@]}"; do
+  if grep -Eiq "(^|[^[:alnum:]])${legacy_name}([^[:alnum:]]|$)" <<<"${section_text}"; then
+    echo "Legacy product naming found in naming conventions section: ${legacy_name}" >&2
+    exit 1
+  fi
+done
+
+echo "Naming conventions section covers the required categories and examples."


### PR DESCRIPTION
## What changed
- expanded `docs/requirements-baseline.md` section 7 to define AegisOps naming rules for hostnames, Docker Compose projects, OpenSearch indexes, detectors, n8n workflows, and secrets/environment variables
- added AegisOps-specific examples for each naming category
- added `scripts/verify-naming-conventions-doc.sh` to validate the required naming headings, examples, and absence of legacy product naming in the naming section

## Why
Issue #3 requires a single documented naming baseline for core AegisOps artifacts without changing runtime behavior.

## Impact
- gives future implementation work a consistent naming contract
- adds a narrow verification check for the naming document
- does not change runtime behavior

## Validation
- `scripts/verify-naming-conventions-doc.sh`
- `scripts/verify-repository-structure-doc.sh`
