### PR TITLE
[codex] Add parameter category docs skeleton

### DIFF
--- a/.codex-supervisor/issues/15/issue-journal.md
+++ b/.codex-supervisor/issues/15/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #15: impl: add docs parameters skeleton for AegisOps
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/15
+- Branch: codex/issue-15
+- Workspace: .
+- Journal: .codex-supervisor/issues/15/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: fe46f30508a5e3ab4e3d332d45ace851bbbb3549
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-01T07:28:55.237Z
+
+## Latest Codex Summary
+- Added a focused verifier for parameter category placeholder docs and created the six initial human-readable category skeleton files under `docs/parameters/`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Issue #15 fails because the required human-readable parameter category placeholder documents do not yet exist under `docs/parameters/`.
+- What changed: Added `scripts/verify-parameter-category-docs.sh` and created placeholder docs for `network`, `compute`, `storage`, `platform`, `security`, and `operations`.
+- Current blocker: none
+- Next exact step: Commit the focused docs skeleton change set on `codex/issue-15`.
+- Verification gap: No broader CI suite was run because this issue only changes documentation and a focused shell verifier.
+- Files touched: `.codex-supervisor/issues/15/issue-journal.md`, `scripts/verify-parameter-category-docs.sh`, `docs/parameters/network-parameters.md`, `docs/parameters/compute-parameters.md`, `docs/parameters/storage-parameters.md`, `docs/parameters/platform-parameters.md`, `docs/parameters/security-parameters.md`, `docs/parameters/operations-parameters.md`
+- Rollback concern: low; docs-only placeholders plus a narrow verifier script
+- Last focused command: `rg -n "AKIA|BEGIN (RSA|EC|OPENSSH|PGP)|password\\s*[:=]|secret\\s*[:=]|token\\s*[:=]|api[_-]?key\\s*[:=]" docs/parameters/*.md scripts/verify-parameter-category-docs.sh -S`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/parameters/compute-parameters.md
+++ b/docs/parameters/compute-parameters.md
@@ -1,0 +1,9 @@
+# AegisOps Compute Parameters
+
+This placeholder document exists to reserve the approved `compute` parameter category for future AegisOps catalog entries.
+
+It describes category purpose only.
+
+The `compute` category will document node roles, sizing references, runtime capacity assumptions, and similar infrastructure-level identifiers that guide future deployment planning.
+
+No production values, environment-specific settings, or secrets belong in this file.

--- a/docs/parameters/network-parameters.md
+++ b/docs/parameters/network-parameters.md
@@ -1,0 +1,9 @@
+# AegisOps Network Parameters
+
+This placeholder document exists to reserve the approved `network` parameter category for future AegisOps catalog entries.
+
+It describes category purpose only.
+
+The `network` category will document hostnames, IP addressing, subnets, DNS dependencies, and approved service endpoints that operators must review before environment-specific implementation work.
+
+No production values, environment-specific settings, or secrets belong in this file.

--- a/docs/parameters/operations-parameters.md
+++ b/docs/parameters/operations-parameters.md
@@ -1,0 +1,9 @@
+# AegisOps Operations Parameters
+
+This placeholder document exists to reserve the approved `operations` parameter category for future AegisOps catalog entries.
+
+It describes category purpose only.
+
+The `operations` category will document backup schedules, monitoring hooks, maintenance metadata, and other operator-facing control parameters that require reviewable documentation.
+
+No production values, environment-specific settings, or secrets belong in this file.

--- a/docs/parameters/platform-parameters.md
+++ b/docs/parameters/platform-parameters.md
@@ -1,0 +1,9 @@
+# AegisOps Platform Parameters
+
+This placeholder document exists to reserve the approved `platform` parameter category for future AegisOps catalog entries.
+
+It describes category purpose only.
+
+The `platform` category will document component identifiers, Docker Compose project names, execution modes, retention defaults, and other product-level runtime settings in descriptive form.
+
+No production values, environment-specific settings, or secrets belong in this file.

--- a/docs/parameters/security-parameters.md
+++ b/docs/parameters/security-parameters.md
@@ -1,0 +1,9 @@
+# AegisOps Security Parameters
+
+This placeholder document exists to reserve the approved `security` parameter category for future AegisOps catalog entries.
+
+It describes category purpose only.
+
+The `security` category will document TLS material references, secret identifier names, approval-related parameter names, and access-control-related configuration keys without exposing live credentials.
+
+No production values, environment-specific settings, or secrets belong in this file.

--- a/docs/parameters/storage-parameters.md
+++ b/docs/parameters/storage-parameters.md
@@ -1,0 +1,9 @@
+# AegisOps Storage Parameters
+
+This placeholder document exists to reserve the approved `storage` parameter category for future AegisOps catalog entries.
+
+It describes category purpose only.
+
+The `storage` category will document mount points, data paths, backup targets, persistence-related parameter names, and other storage references that reviewers need to assess safely.
+
+No production values, environment-specific settings, or secrets belong in this file.

--- a/scripts/verify-parameter-category-docs.sh
+++ b/scripts/verify-parameter-category-docs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+docs_dir="${repo_root}/docs/parameters"
+
+doc_names=(
+  "network-parameters.md"
+  "compute-parameters.md"
+  "storage-parameters.md"
+  "platform-parameters.md"
+  "security-parameters.md"
+  "operations-parameters.md"
+)
+
+required_phrases=(
+  "This placeholder document exists to reserve the approved"
+  "parameter category for future AegisOps catalog entries."
+  "It describes category purpose only."
+  "No production values, environment-specific settings, or secrets belong in this file."
+)
+
+for doc_name in "${doc_names[@]}"; do
+  doc_path="${docs_dir}/${doc_name}"
+
+  if [[ ! -f "${doc_path}" ]]; then
+    echo "Missing parameter category document: ${doc_path}" >&2
+    exit 1
+  fi
+
+  for phrase in "${required_phrases[@]}"; do
+    if ! grep -Fq "${phrase}" "${doc_path}"; then
+      echo "Missing placeholder statement in ${doc_path}: ${phrase}" >&2
+      exit 1
+    fi
+  done
+
+  if ! grep -Eq '^# AegisOps .+ Parameters$' "${doc_path}"; then
+    echo "Missing parameter document title in ${doc_path}" >&2
+    exit 1
+  fi
+done
+
+echo "Parameter category placeholder documents exist and remain descriptive-only."


### PR DESCRIPTION
## Summary
- add the initial `docs/parameters/` catalog skeleton for AegisOps
- add one descriptive placeholder document for each approved parameter category
- add a focused verifier to ensure the category docs exist and remain descriptive-only

## Why
Issue #15 requires a human-readable parameter catalog scaffold without introducing any deployment values, secrets, or runtime behavior changes.

## Validation
- `./scripts/verify-parameter-category-docs.sh`
- `./scripts/verify-parameter-catalog-structure-doc.sh`
- `rg -n "AKIA|BEGIN (RSA|EC|OPENSSH|PGP)|password\\s*[:=]|secret\\s*[:=]|token\\s*[:=]|api[_-]?key\\s*[:=]" docs/parameters/*.md scripts/verify-parameter-category-docs.sh -S`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added six new parameter category placeholder documents (compute, network, operations, platform, security, storage) to reserve categories for future entries and define their intended scope.

* **Chores**
  * Added verification script to validate parameter category documentation presence and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->