### PR TITLE
[codex] docs: add runbook skeleton

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,82 @@
+# AegisOps Runbook Skeleton
+
+This runbook is an initial skeleton for approved future operational procedures.
+
+It supplements `docs/requirements-baseline.md` by reserving a structured home for startup, shutdown, restore, approval handling, and validation guidance as implementation artifacts mature.
+
+It does not claim production completeness and does not authorize environment-specific commands.
+
+## 1. Purpose and Status
+
+This document exists to define the minimum approved structure for future operator procedures without implying that those procedures are complete today.
+
+The current content is intentionally limited to placeholders, constraints, and documentation expectations that align with the AegisOps baseline.
+
+Any future operational detail added here must remain consistent with the approved architecture, repository assets, and validation requirements.
+
+## 2. Startup
+
+Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+Future startup guidance should describe:
+
+- approved prerequisites and dependencies,
+- the order in which platform components may be started,
+- the records or evidence operators must capture during startup, and
+- the validation checkpoints required before the platform is treated as ready.
+
+This section must not be expanded with environment-specific commands until those commands are backed by approved version-controlled artifacts.
+
+## 3. Shutdown
+
+Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+Future shutdown guidance should describe:
+
+- when a controlled shutdown is permitted,
+- the sequence that preserves data integrity and auditability,
+- what approvals or change records are required before shutdown, and
+- what post-shutdown checks confirm the platform is in a safe state.
+
+This section must not be expanded with unsupported emergency procedures or ad-hoc manual shortcuts.
+
+## 4. Restore
+
+Detailed restore steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+Future restore guidance should describe:
+
+- the approved restore inputs and dependencies,
+- the order for restoring services and data-bearing components,
+- how restore success is validated before normal operations resume, and
+- what evidence must be retained for audit and review.
+
+This section must not imply that hypervisor snapshots alone are a sufficient recovery procedure unless an approved ADR changes that baseline.
+
+## 5. Approval Handling
+
+The approved baseline requires explicit approval for SOAR workflows that perform write or destructive actions by default.
+
+Approval handling procedures must preserve human review, auditability, and the separation between detection and execution.
+
+Future approval guidance should describe:
+
+- who may approve which categories of actions,
+- how approval decisions are recorded,
+- how rejected or expired approvals are handled, and
+- how operators verify that unapproved actions were not executed.
+
+This section must remain consistent with the business-hours-oriented operating model and must not imply unrestricted autonomous response.
+
+## 6. Validation
+
+Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure.
+
+Future validation guidance should describe:
+
+- the minimum checks required after startup, shutdown, or restore activity,
+- the logs, alerts, or workflow evidence that must be reviewed,
+- the conditions that require escalation instead of continued operation, and
+- the repository artifacts that define the expected state.
+
+Until those procedures exist, this section serves only as a placeholder for approved future validation content.

--- a/scripts/verify-runbook-doc.sh
+++ b/scripts/verify-runbook-doc.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+doc_path="${repo_root}/docs/runbook.md"
+
+required_headings=(
+  "## 1. Purpose and Status"
+  "## 2. Startup"
+  "## 3. Shutdown"
+  "## 4. Restore"
+  "## 5. Approval Handling"
+  "## 6. Validation"
+)
+
+required_phrases=(
+  "This runbook is an initial skeleton for approved future operational procedures."
+  "It does not claim production completeness and does not authorize environment-specific commands."
+  "The approved baseline requires explicit approval for SOAR workflows that perform write or destructive actions by default."
+  "Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist."
+  "Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist."
+  "Detailed restore steps are intentionally deferred until implementation artifacts and validation procedures exist."
+  "Approval handling procedures must preserve human review, auditability, and the separation between detection and execution."
+  "Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing runbook document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing runbook heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Missing runbook statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+echo "Runbook document is present and limited to an approved skeleton."


### PR DESCRIPTION
## Summary
- add `docs/runbook.md` as the initial AegisOps runbook skeleton
- add `scripts/verify-runbook-doc.sh` to enforce the required placeholder sections and non-completeness guardrails

## Why
Issue #18 needs an approved home and structure for future operational procedures without introducing environment-specific commands or unsupported claims.

## Impact
- runtime behavior is unchanged
- future startup, shutdown, restore, approval handling, and validation procedures now have a baseline-aligned placeholder document

## Validation
- `bash scripts/verify-runbook-doc.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AegisOps Runbook Skeleton guide establishing the approved structure for operator procedures with sections for startup, shutdown, restore, approval handling, and validation.

* **Chores**
  * Added validation to ensure runbook documentation conforms to approved structural requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->