### PR TITLE
Add OpenSearch Dashboards compose skeleton

### DIFF
--- a/opensearch/docker-compose.yml
+++ b/opensearch/docker-compose.yml
@@ -5,4 +5,7 @@ services:
     image: opensearchproject/opensearch:2.19.0
     volumes:
       - /srv/aegisops/opensearch-data-placeholder:/usr/share/opensearch/data
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:2.19.0
+    # access must remain behind the approved reverse proxy; no direct ports publication here
     # skeleton only; not production-ready until approved runtime settings are supplied

--- a/scripts/test-verify-opensearch-compose-skeleton.sh
+++ b/scripts/test-verify-opensearch-compose-skeleton.sh
@@ -65,6 +65,8 @@ services:
     image: opensearchproject/opensearch:2.19.0
     volumes:
       - /srv/aegisops/opensearch-data-placeholder:/usr/share/opensearch/data
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:2.19.0
     # skeleton only; not production-ready until approved runtime settings are supplied"
 assert_passes "${valid_repo}"
 
@@ -81,6 +83,8 @@ services:
     image: opensearchproject/opensearch:latest
     volumes:
       - /srv/aegisops/opensearch-data-placeholder:/usr/share/opensearch/data
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:2.19.0
     # skeleton only; not production-ready until approved runtime settings are supplied"
 assert_fails_with "${latest_tag_repo}" "must not use the latest tag"
 
@@ -92,6 +96,8 @@ services:
     image: opensearchproject/opensearch:2.19.0
     volumes:
       - /tmp/opensearch:/usr/share/opensearch/data
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:2.19.0
     # skeleton only; not production-ready until approved runtime settings are supplied"
 assert_fails_with "${bad_mount_repo}" "persistent mount placeholder"
 
@@ -103,7 +109,35 @@ services:
     image: nginx:1.27.0
     volumes:
       - /srv/aegisops/opensearch-data-placeholder:/usr/share/opensearch/data
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:2.19.0
     # skeleton only; not production-ready until approved runtime settings are supplied"
 assert_fails_with "${bad_image_repo}" "must pin opensearchproject/opensearch"
+
+missing_dashboards_repo="${workdir}/missing-dashboards"
+create_repo "${missing_dashboards_repo}"
+write_compose "${missing_dashboards_repo}" "name: aegisops-opensearch
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.19.0
+    volumes:
+      - /srv/aegisops/opensearch-data-placeholder:/usr/share/opensearch/data
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+assert_fails_with "${missing_dashboards_repo}" "must define a dashboards service"
+
+dashboards_ports_repo="${workdir}/dashboards-ports"
+create_repo "${dashboards_ports_repo}"
+write_compose "${dashboards_ports_repo}" "name: aegisops-opensearch
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.19.0
+    volumes:
+      - /srv/aegisops/opensearch-data-placeholder:/usr/share/opensearch/data
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:2.19.0
+    ports:
+      - 5601:5601
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+assert_fails_with "${dashboards_ports_repo}" "must not publish Dashboards directly with ports"
 
 echo "verify-opensearch-compose-skeleton tests passed"

--- a/scripts/verify-opensearch-compose-skeleton.sh
+++ b/scripts/verify-opensearch-compose-skeleton.sh
@@ -33,8 +33,12 @@ require_pattern() {
 require_fixed_string "name: aegisops-opensearch"
 require_fixed_string "services:"
 require_fixed_string "  opensearch:"
+require_pattern '^  dashboards:$' \
+  "OpenSearch compose skeleton must define a dashboards service."
 require_pattern '^    image: opensearchproject/opensearch:[^[:space:]]+$' \
   "OpenSearch compose skeleton must pin opensearchproject/opensearch to an explicit version tag."
+require_pattern '^    image: opensearchproject/opensearch-dashboards:[^[:space:]]+$' \
+  "OpenSearch compose skeleton must pin opensearchproject/opensearch-dashboards to an explicit version tag."
 
 if grep -En '^    image: .*:latest$' "${compose_path}" >/dev/null; then
   echo "OpenSearch compose skeleton must not use the latest tag." >&2
@@ -54,5 +58,17 @@ require_pattern 'skeleton only' \
   "OpenSearch compose skeleton must state that it is a skeleton only."
 require_pattern 'not production-ready' \
   "OpenSearch compose skeleton must state that it is not production-ready."
+
+if awk '
+  BEGIN { in_dashboards = 0; has_ports = 0 }
+  $0 == "  dashboards:" { in_dashboards = 1; next }
+  in_dashboards && /^  [a-z0-9-]+:/ { in_dashboards = 0 }
+  in_dashboards && /^[^[:space:]]/ { in_dashboards = 0 }
+  in_dashboards && $0 == "    ports:" { has_ports = 1 }
+  END { exit(has_ports ? 0 : 1) }
+' "${compose_path}"; then
+  echo "OpenSearch compose skeleton must not publish Dashboards directly with ports." >&2
+  exit 1
+fi
 
 echo "OpenSearch compose skeleton matches the approved placeholder-safe contract."


### PR DESCRIPTION
## Summary
- add an OpenSearch Dashboards compose skeleton under `opensearch/`
- keep the skeleton aligned to the approved reverse-proxy access model by avoiding direct `ports:` publication
- tighten the focused verifier/tests to require the Dashboards service and pinned image naming

## Verification
- `./scripts/test-verify-opensearch-compose-skeleton.sh`
- `./scripts/verify-opensearch-compose-skeleton.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboards service to OpenSearch Docker environment.

* **Tests**
  * Enhanced validation to require dashboards service in configurations.
  * Enforces explicit version tagging for the dashboards container image.
  * Prevents direct external port exposure for dashboards service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->