### PR TITLE
impl: add AegisOps reverse proxy compose skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,14 @@ jobs:
           bash scripts/verify-documentation-ownership-map.sh
           bash scripts/verify-naming-conventions-doc.sh
           bash scripts/verify-network-exposure-policy-doc.sh
+          bash scripts/verify-n8n-compose-skeleton.sh
           bash scripts/verify-opensearch-compose-skeleton.sh
           bash scripts/verify-parameter-catalog-alignment.sh
           bash scripts/verify-parameter-catalog-structure-doc.sh
           bash scripts/verify-parameter-category-docs.sh
           bash scripts/verify-parameter-config-files.sh
           bash scripts/verify-postgres-compose-skeleton.sh
+          bash scripts/verify-proxy-compose-skeleton.sh
           bash scripts/verify-repository-skeleton.sh
           bash scripts/verify-repository-structure-doc.sh
           bash scripts/verify-runbook-doc.sh
@@ -39,6 +41,8 @@ jobs:
 
       - name: Run focused shell tests
         run: |
+          bash scripts/test-verify-n8n-compose-skeleton.sh
           bash scripts/test-verify-opensearch-compose-skeleton.sh
           bash scripts/test-verify-postgres-compose-skeleton.sh
+          bash scripts/test-verify-proxy-compose-skeleton.sh
           bash scripts/test-verify-repository-skeleton.sh

--- a/proxy/.gitkeep
+++ b/proxy/.gitkeep
@@ -1,1 +1,0 @@
-Placeholder file to preserve the approved top-level proxy directory.

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -1,0 +1,13 @@
+name: aegisops-proxy
+
+services:
+  proxy:
+    image: nginx:1.27.0
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d-placeholder:/etc/nginx/conf.d:ro
+      - /srv/aegisops/proxy-certs-placeholder:/etc/nginx/certs:ro
+    # approved ingress layer for user-facing UI access only
+    # backend UIs remain internal behind this proxy; no direct backend ports publication here
+    # route implementation, live certificates, and public publication remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied

--- a/proxy/nginx/conf.d-placeholder/default.conf
+++ b/proxy/nginx/conf.d-placeholder/default.conf
@@ -1,0 +1,8 @@
+# Placeholder ingress config only.
+# Approved upstream routes, TLS server blocks, and public listeners are added later.
+server {
+  listen 8080 default_server;
+  server_name _;
+
+  return 503;
+}

--- a/proxy/nginx/nginx.conf
+++ b/proxy/nginx/nginx.conf
@@ -1,0 +1,15 @@
+worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  sendfile on;
+  keepalive_timeout 65;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/scripts/test-verify-proxy-compose-skeleton.sh
+++ b/scripts/test-verify-proxy-compose-skeleton.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-proxy-compose-skeleton.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/proxy/nginx/conf.d-placeholder"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_fixture() {
+  local target="$1"
+  local path="$2"
+  local content="$3"
+
+  printf '%s\n' "${content}" >"${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit -q --allow-empty -m "fixture"
+}
+
+write_valid_proxy_files() {
+  local target="$1"
+
+  write_fixture "${target}" "proxy/docker-compose.yml" "name: aegisops-proxy
+services:
+  proxy:
+    image: nginx:1.27.0
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d-placeholder:/etc/nginx/conf.d:ro
+      - /srv/aegisops/proxy-certs-placeholder:/etc/nginx/certs:ro
+    # approved ingress layer for user-facing UI access only
+    # backend UIs remain internal behind this proxy; no direct backend ports publication here
+    # route implementation, live certificates, and public publication remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+  write_fixture "${target}" "proxy/nginx/nginx.conf" "worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  sendfile on;
+  keepalive_timeout 65;
+
+  include /etc/nginx/conf.d/*.conf;
+}"
+  write_fixture "${target}" "proxy/nginx/conf.d-placeholder/default.conf" "# Placeholder ingress config only.
+# Approved upstream routes, TLS server blocks, and public listeners are added later.
+server {
+  listen 8080 default_server;
+  server_name _;
+
+  return 503;
+}"
+  commit_fixture "${target}"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_valid_proxy_files "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_file_repo="${workdir}/missing-file"
+create_repo "${missing_file_repo}"
+commit_fixture "${missing_file_repo}"
+assert_fails_with "${missing_file_repo}" "Missing proxy compose skeleton"
+
+latest_tag_repo="${workdir}/latest-tag"
+create_repo "${latest_tag_repo}"
+write_valid_proxy_files "${latest_tag_repo}"
+write_fixture "${latest_tag_repo}" "proxy/docker-compose.yml" "name: aegisops-proxy
+services:
+  proxy:
+    image: nginx:latest
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d-placeholder:/etc/nginx/conf.d:ro
+      - /srv/aegisops/proxy-certs-placeholder:/etc/nginx/certs:ro
+    # approved ingress layer for user-facing UI access only
+    # backend UIs remain internal behind this proxy; no direct backend ports publication here
+    # route implementation, live certificates, and public publication remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+commit_fixture "${latest_tag_repo}"
+assert_fails_with "${latest_tag_repo}" "must not use the latest tag"
+
+bad_mount_repo="${workdir}/bad-mount"
+create_repo "${bad_mount_repo}"
+write_valid_proxy_files "${bad_mount_repo}"
+write_fixture "${bad_mount_repo}" "proxy/docker-compose.yml" "name: aegisops-proxy
+services:
+  proxy:
+    image: nginx:1.27.0
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d-placeholder:/etc/nginx/conf.d:ro
+      - /etc/letsencrypt:/etc/nginx/certs:ro
+    # approved ingress layer for user-facing UI access only
+    # backend UIs remain internal behind this proxy; no direct backend ports publication here
+    # route implementation, live certificates, and public publication remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+commit_fixture "${bad_mount_repo}"
+assert_fails_with "${bad_mount_repo}" "placeholder-safe certificate mount"
+
+ports_repo="${workdir}/ports"
+create_repo "${ports_repo}"
+write_valid_proxy_files "${ports_repo}"
+write_fixture "${ports_repo}" "proxy/docker-compose.yml" "name: aegisops-proxy
+services:
+  proxy:
+    image: nginx:1.27.0
+    ports:
+      - 443:443
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d-placeholder:/etc/nginx/conf.d:ro
+      - /srv/aegisops/proxy-certs-placeholder:/etc/nginx/certs:ro
+    # approved ingress layer for user-facing UI access only
+    # backend UIs remain internal behind this proxy; no direct backend ports publication here
+    # route implementation, live certificates, and public publication remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+commit_fixture "${ports_repo}"
+assert_fails_with "${ports_repo}" "must not publish ports"
+
+live_route_repo="${workdir}/live-route"
+create_repo "${live_route_repo}"
+write_valid_proxy_files "${live_route_repo}"
+write_fixture "${live_route_repo}" "proxy/nginx/conf.d-placeholder/default.conf" "# Placeholder ingress config only.
+server {
+  listen 8080 default_server;
+  server_name _;
+
+  location / {
+    proxy_pass http://dashboards:5601;
+  }
+
+  return 503;
+}"
+commit_fixture "${live_route_repo}"
+assert_fails_with "${live_route_repo}" "must not define live upstream routes yet"
+
+live_cert_repo="${workdir}/live-cert"
+create_repo "${live_cert_repo}"
+write_valid_proxy_files "${live_cert_repo}"
+write_fixture "${live_cert_repo}" "proxy/nginx/conf.d-placeholder/default.conf" "# Placeholder ingress config only.
+server {
+  listen 443 ssl default_server;
+  server_name _;
+  ssl_certificate /etc/letsencrypt/live/aegisops/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/aegisops/privkey.pem;
+
+  return 503;
+}"
+commit_fixture "${live_cert_repo}"
+assert_fails_with "${live_cert_repo}" "must not reference live certificate material"
+
+echo "verify-proxy-compose-skeleton tests passed"

--- a/scripts/verify-parameter-catalog-alignment.sh
+++ b/scripts/verify-parameter-catalog-alignment.sh
@@ -31,25 +31,61 @@ config_required_phrases=(
   "values: {}"
 )
 
-declare -A doc_category_descriptions=(
-  [network]='The `network` category will document hostnames, IP addressing, subnets, DNS dependencies, and approved service endpoints that operators must review before environment-specific implementation work.'
-  [compute]='The `compute` category will document node roles, sizing references, runtime capacity assumptions, and similar infrastructure-level identifiers that guide future deployment planning.'
-  [storage]='The `storage` category will document mount points, data paths, backup targets, persistence-related parameter names, and other storage references that reviewers need to assess safely.'
-  [platform]='The `platform` category will document component identifiers, Docker Compose project names, execution modes, retention defaults, and other product-level runtime settings in descriptive form.'
-  [security]='The `security` category will document TLS material references, secret identifier names, approval-related parameter names, and access-control-related configuration keys without exposing live credentials.'
-  [operations]='The `operations` category will document backup schedules, monitoring hooks, maintenance metadata, and other operator-facing control parameters that require reviewable documentation.'
-)
-
-declare -A config_category_descriptions=(
-  [network]="Placeholder parameter catalog for non-production network settings."
-  [compute]="Placeholder parameter catalog for non-production compute settings."
-  [storage]="Placeholder parameter catalog for non-production storage settings."
-  [platform]="Placeholder parameter catalog for non-production platform settings."
-  [security]="Placeholder parameter catalog for non-production security metadata."
-  [operations]="Placeholder parameter catalog for non-production operations settings."
-)
-
 secret_pattern='(^|[^[:alnum:]_])\.env([^[:alnum:]_]|$)|BEGIN [A-Z ]+PRIVATE KEY|AKIA[0-9A-Z]{16}'
+
+doc_category_description() {
+  case "$1" in
+    network)
+      printf '%s\n' 'The `network` category will document hostnames, IP addressing, subnets, DNS dependencies, and approved service endpoints that operators must review before environment-specific implementation work.'
+      ;;
+    compute)
+      printf '%s\n' 'The `compute` category will document node roles, sizing references, runtime capacity assumptions, and similar infrastructure-level identifiers that guide future deployment planning.'
+      ;;
+    storage)
+      printf '%s\n' 'The `storage` category will document mount points, data paths, backup targets, persistence-related parameter names, and other storage references that reviewers need to assess safely.'
+      ;;
+    platform)
+      printf '%s\n' 'The `platform` category will document component identifiers, Docker Compose project names, execution modes, retention defaults, and other product-level runtime settings in descriptive form.'
+      ;;
+    security)
+      printf '%s\n' 'The `security` category will document TLS material references, secret identifier names, approval-related parameter names, and access-control-related configuration keys without exposing live credentials.'
+      ;;
+    operations)
+      printf '%s\n' 'The `operations` category will document backup schedules, monitoring hooks, maintenance metadata, and other operator-facing control parameters that require reviewable documentation.'
+      ;;
+    *)
+      echo "Unexpected parameter category: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+config_category_description() {
+  case "$1" in
+    network)
+      printf '%s\n' 'Placeholder parameter catalog for non-production network settings.'
+      ;;
+    compute)
+      printf '%s\n' 'Placeholder parameter catalog for non-production compute settings.'
+      ;;
+    storage)
+      printf '%s\n' 'Placeholder parameter catalog for non-production storage settings.'
+      ;;
+    platform)
+      printf '%s\n' 'Placeholder parameter catalog for non-production platform settings.'
+      ;;
+    security)
+      printf '%s\n' 'Placeholder parameter catalog for non-production security metadata.'
+      ;;
+    operations)
+      printf '%s\n' 'Placeholder parameter catalog for non-production operations settings.'
+      ;;
+    *)
+      echo "Unexpected parameter category: $1" >&2
+      exit 1
+      ;;
+  esac
+}
 
 contains_exact_line() {
   local needle="$1"
@@ -75,8 +111,12 @@ category_title_from_doc_path() {
   IFS='-' read -r -a words <<< "${category_slug}"
 
   local title=""
+  local first_char
+  local rest
   for word in "${words[@]}"; do
-    title+="${title:+ }${word^}"
+    first_char="$(printf '%s' "${word:0:1}" | tr '[:lower:]' '[:upper:]')"
+    rest="${word:1}"
+    title+="${title:+ }${first_char}${rest}"
   done
 
   printf '%s\n' "${title}"
@@ -90,9 +130,19 @@ assert_exact_file_set() {
   local -a expected_files=("$@")
   local -a expected_sorted=()
   local -a actual_sorted=()
+  local path
 
-  mapfile -t expected_sorted < <(printf '%s\n' "${expected_files[@]}" | sort)
-  mapfile -t actual_sorted < <(find "${dir_path}" -maxdepth 1 -type f -printf '%f\n' | sort)
+  expected_sorted=($(printf '%s\n' "${expected_files[@]}" | LC_ALL=C sort))
+
+  for path in "${dir_path}"/*; do
+    if [[ -f "${path}" ]]; then
+      actual_sorted+=("${path##*/}")
+    fi
+  done
+
+  if [[ "${#actual_sorted[@]}" -gt 0 ]]; then
+    actual_sorted=($(printf '%s\n' "${actual_sorted[@]}" | LC_ALL=C sort))
+  fi
 
   if [[ "${#actual_sorted[@]}" -ne "${#expected_sorted[@]}" ]]; then
     echo "Unexpected ${label} file count in ${dir_path}" >&2
@@ -115,6 +165,9 @@ assert_exact_file_set() {
 validate_placeholder_doc() {
   local category="$1"
   local doc_path="$2"
+  local category_description
+
+  category_description="$(doc_category_description "${category}")"
 
   local expected_title="# AegisOps $(category_title_from_doc_path "${doc_path}") Parameters"
   local actual_title
@@ -129,7 +182,7 @@ validate_placeholder_doc() {
     "${expected_title}"
     "This placeholder document exists to reserve the approved \`${category}\` parameter category for future AegisOps catalog entries."
     "It describes category purpose only."
-    "${doc_category_descriptions[${category}]}"
+    "${category_description}"
     "No production values, environment-specific settings, or secrets belong in this file."
   )
 
@@ -166,6 +219,9 @@ validate_placeholder_doc() {
 validate_placeholder_config() {
   local category="$1"
   local config_path="$2"
+  local category_description
+
+  category_description="$(config_category_description "${category}")"
 
   local -a allowed_lines=(
     "schema_version: 1"
@@ -173,7 +229,7 @@ validate_placeholder_config() {
     "status: placeholder"
     "non_secret: true"
     "environment: template"
-    "description: ${config_category_descriptions[${category}]}"
+    "description: ${category_description}"
     "values: {}"
   )
 
@@ -251,10 +307,12 @@ for category in "${approved_categories[@]}"; do
   validate_placeholder_config "${category}" "${config_path}"
 done
 
-if find "${docs_dir}" "${config_dir}" -maxdepth 1 -type f -name '.env*' | grep -q .; then
-  echo "Active .env file detected in parameter catalog locations" >&2
-  exit 1
-fi
+for env_path in "${docs_dir}"/.env* "${config_dir}"/.env*; do
+  if [[ -f "${env_path}" ]]; then
+    echo "Active .env file detected in parameter catalog locations" >&2
+    exit 1
+  fi
+done
 
 if [[ ! -f "${validation_doc}" ]]; then
   echo "Missing parameter catalog validation result document: ${validation_doc}" >&2

--- a/scripts/verify-proxy-compose-skeleton.sh
+++ b/scripts/verify-proxy-compose-skeleton.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+compose_path="${repo_root}/proxy/docker-compose.yml"
+nginx_conf_path="${repo_root}/proxy/nginx/nginx.conf"
+placeholder_conf_path="${repo_root}/proxy/nginx/conf.d-placeholder/default.conf"
+
+if [[ ! -f "${compose_path}" ]]; then
+  echo "Missing proxy compose skeleton: ${compose_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${nginx_conf_path}" ]]; then
+  echo "Missing proxy nginx skeleton config: ${nginx_conf_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${placeholder_conf_path}" ]]; then
+  echo "Missing proxy placeholder route config: ${placeholder_conf_path}" >&2
+  exit 1
+fi
+
+require_fixed_string() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required line in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_pattern() {
+  local file_path="$1"
+  local pattern="$2"
+  local message="$3"
+
+  if ! grep -En "${pattern}" "${file_path}" >/dev/null; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+extract_proxy_block() {
+  awk '
+    /^  proxy:[[:space:]]*(#.*)?$/ { in_proxy = 1 }
+    in_proxy && /^[^[:space:]]/ { exit }
+    in_proxy && /^  [a-z0-9_-]+:[[:space:]]*(#.*)?$/ && $0 !~ /^  proxy:[[:space:]]*(#.*)?$/ { exit }
+    in_proxy { print }
+  ' "${compose_path}"
+}
+
+require_proxy_pattern() {
+  local pattern="$1"
+  local message="$2"
+
+  if ! extract_proxy_block | grep -En "${pattern}" >/dev/null; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_string "${compose_path}" "name: aegisops-proxy"
+require_fixed_string "${compose_path}" "services:"
+require_fixed_string "${compose_path}" "  proxy:"
+require_proxy_pattern '^    image: nginx:[^[:space:]]+$' \
+  "Proxy compose skeleton must pin nginx to an explicit version tag."
+
+if grep -En '^    image: .*:latest$' "${compose_path}" >/dev/null; then
+  echo "Proxy compose skeleton must not use the latest tag." >&2
+  exit 1
+fi
+
+if grep -En '^[[:space:]]*container_name:' "${compose_path}" >/dev/null; then
+  echo "Proxy compose skeleton must not hard-code container_name." >&2
+  exit 1
+fi
+
+require_proxy_pattern '^    volumes:$' \
+  "Proxy compose skeleton must declare placeholder-safe mount references."
+require_proxy_pattern '^      - \./nginx/nginx\.conf:/etc/nginx/nginx\.conf:ro$' \
+  "Proxy compose skeleton must mount the tracked nginx base config read-only."
+require_proxy_pattern '^      - \./nginx/conf\.d-placeholder:/etc/nginx/conf\.d:ro$' \
+  "Proxy compose skeleton must mount the tracked placeholder route config directory read-only."
+require_proxy_pattern '^      - /srv/aegisops/proxy-certs-placeholder:/etc/nginx/certs:ro$' \
+  "Proxy compose skeleton must use the explicit placeholder-safe certificate mount."
+require_pattern "${compose_path}" 'approved ingress layer for user-facing UI access only' \
+  "Proxy compose skeleton must limit its role to the approved ingress boundary."
+require_pattern "${compose_path}" 'backend UIs remain internal behind this proxy' \
+  "Proxy compose skeleton must state that backend UIs remain internal behind the proxy."
+require_pattern "${compose_path}" 'route implementation, live certificates, and public publication remain out of scope here' \
+  "Proxy compose skeleton must explicitly defer live routes, certificates, and public publication."
+require_pattern "${compose_path}" 'skeleton only' \
+  "Proxy compose skeleton must state that it is a skeleton only."
+require_pattern "${compose_path}" 'not production-ready' \
+  "Proxy compose skeleton must state that it is not production-ready."
+
+if extract_proxy_block | awk '
+  BEGIN { has_ports = 0 }
+  $0 ~ /^    ["'"'"']?ports["'"'"']?:[[:space:]]*(#.*)?$/ { has_ports = 1 }
+  END { exit(has_ports ? 0 : 1) }
+' ; then
+  echo "Proxy compose skeleton must not publish ports before approved runtime exposure is supplied." >&2
+  exit 1
+fi
+
+require_fixed_string "${nginx_conf_path}" "http {"
+require_pattern "${nginx_conf_path}" 'include /etc/nginx/conf\.d/\*\.conf;' \
+  "Proxy nginx skeleton config must load the placeholder route directory."
+
+require_pattern "${placeholder_conf_path}" '^# Placeholder ingress config only\.$' \
+  "Proxy placeholder route config must declare itself as a placeholder."
+require_pattern "${placeholder_conf_path}" '^  return 503;$' \
+  "Proxy placeholder route config must fail closed with a 503 placeholder response."
+
+if grep -En 'proxy_pass[[:space:]]+' "${placeholder_conf_path}" >/dev/null; then
+  echo "Proxy placeholder route config must not define live upstream routes yet." >&2
+  exit 1
+fi
+
+if grep -En '(ssl_certificate|ssl_certificate_key|/etc/letsencrypt|acme\.json|fullchain\.pem|privkey\.pem)' "${placeholder_conf_path}" >/dev/null; then
+  echo "Proxy placeholder route config must not reference live certificate material." >&2
+  exit 1
+fi
+
+echo "Proxy compose skeleton matches the approved placeholder-safe ingress contract."


### PR DESCRIPTION
## Summary
- add a placeholder-safe reverse proxy compose skeleton under `proxy/`
- add tracked nginx placeholder config plus verifier and shell-test coverage
- wire proxy and existing n8n compose checks into CI and make parameter catalog alignment verification work under the local Bash 3.2 environment

## Testing
- bash scripts/verify-adr-review-path-doc.sh
- bash scripts/verify-architecture-doc.sh
- bash scripts/verify-contributor-naming-guide-doc.sh
- bash scripts/verify-documentation-ownership-map.sh
- bash scripts/verify-naming-conventions-doc.sh
- bash scripts/verify-network-exposure-policy-doc.sh
- bash scripts/verify-n8n-compose-skeleton.sh
- bash scripts/verify-opensearch-compose-skeleton.sh
- bash scripts/verify-parameter-catalog-alignment.sh
- bash scripts/verify-parameter-catalog-structure-doc.sh
- bash scripts/verify-parameter-category-docs.sh
- bash scripts/verify-parameter-config-files.sh
- bash scripts/verify-postgres-compose-skeleton.sh
- bash scripts/verify-proxy-compose-skeleton.sh
- bash scripts/verify-repository-skeleton.sh
- bash scripts/verify-repository-structure-doc.sh
- bash scripts/verify-runbook-doc.sh
- bash scripts/verify-storage-policy-doc.sh
- bash scripts/test-verify-n8n-compose-skeleton.sh
- bash scripts/test-verify-opensearch-compose-skeleton.sh
- bash scripts/test-verify-postgres-compose-skeleton.sh
- bash scripts/test-verify-proxy-compose-skeleton.sh
- bash scripts/test-verify-repository-skeleton.sh