### PR TITLE
[codex] add AegisOps ingest compose skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           bash scripts/verify-architecture-doc.sh
           bash scripts/verify-contributor-naming-guide-doc.sh
           bash scripts/verify-documentation-ownership-map.sh
+          bash scripts/verify-ingest-compose-skeleton.sh
           bash scripts/verify-naming-conventions-doc.sh
           bash scripts/verify-network-exposure-policy-doc.sh
           bash scripts/verify-n8n-compose-skeleton.sh
@@ -42,6 +43,7 @@ jobs:
       - name: Run focused shell tests
         run: |
           bash scripts/test-verify-n8n-compose-skeleton.sh
+          bash scripts/test-verify-ingest-compose-skeleton.sh
           bash scripts/test-verify-opensearch-compose-skeleton.sh
           bash scripts/test-verify-postgres-compose-skeleton.sh
           bash scripts/test-verify-proxy-compose-skeleton.sh

--- a/ingest/docker-compose.yml
+++ b/ingest/docker-compose.yml
@@ -1,0 +1,14 @@
+name: aegisops-ingest
+
+services:
+  collector:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+  parser:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+    # collection and parsing placeholder services only
+    # source integrations, parsing logic, and routing remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied

--- a/scripts/test-verify-ingest-compose-skeleton.sh
+++ b/scripts/test-verify-ingest-compose-skeleton.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-ingest-compose-skeleton.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/ingest"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_compose() {
+  local target="$1"
+  local content="$2"
+
+  printf '%s\n' "${content}" >"${target}/ingest/docker-compose.yml"
+  git -C "${target}" add ingest/docker-compose.yml
+  git -C "${target}" commit -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_compose "${valid_repo}" "name: aegisops-ingest
+services:
+  collector:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+  parser:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+    # collection and parsing placeholder services only
+    # source integrations, parsing logic, and routing remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+assert_passes "${valid_repo}"
+
+missing_file_repo="${workdir}/missing-file"
+create_repo "${missing_file_repo}"
+git -C "${missing_file_repo}" commit -q --allow-empty -m "fixture"
+assert_fails_with "${missing_file_repo}" "Missing ingest compose skeleton"
+
+latest_tag_repo="${workdir}/latest-tag"
+create_repo "${latest_tag_repo}"
+write_compose "${latest_tag_repo}" "name: aegisops-ingest
+services:
+  collector:
+    image: alpine:latest
+    profiles:
+      - placeholder
+  parser:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+    # collection and parsing placeholder services only
+    # source integrations, parsing logic, and routing remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+assert_fails_with "${latest_tag_repo}" "must not use the latest tag"
+
+missing_profile_repo="${workdir}/missing-profile"
+create_repo "${missing_profile_repo}"
+write_compose "${missing_profile_repo}" "name: aegisops-ingest
+services:
+  collector:
+    image: alpine:3.22.1
+  parser:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+    # collection and parsing placeholder services only
+    # source integrations, parsing logic, and routing remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+assert_fails_with "${missing_profile_repo}" "must keep collector behind a placeholder-only profile"
+
+ports_repo="${workdir}/ports"
+create_repo "${ports_repo}"
+write_compose "${ports_repo}" "name: aegisops-ingest
+services:
+  collector:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+    ports:
+      - 5514:5514
+  parser:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+    # collection and parsing placeholder services only
+    # source integrations, parsing logic, and routing remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+assert_fails_with "${ports_repo}" "must not publish ports"
+
+source_specific_repo="${workdir}/source-specific"
+create_repo "${source_specific_repo}"
+write_compose "${source_specific_repo}" "name: aegisops-ingest
+services:
+  collector:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+    command: [\"syslog-listener\"]
+  parser:
+    image: alpine:3.22.1
+    profiles:
+      - placeholder
+    # collection and parsing placeholder services only
+    # source integrations, parsing logic, and routing remain out of scope here
+    # skeleton only; not production-ready until approved runtime settings are supplied"
+assert_fails_with "${source_specific_repo}" "must not introduce source-specific transport or parser behavior"
+
+echo "verify-ingest-compose-skeleton tests passed"

--- a/scripts/verify-ingest-compose-skeleton.sh
+++ b/scripts/verify-ingest-compose-skeleton.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+compose_path="${repo_root}/ingest/docker-compose.yml"
+
+if [[ ! -f "${compose_path}" ]]; then
+  echo "Missing ingest compose skeleton: ${compose_path}" >&2
+  exit 1
+fi
+
+require_fixed_string() {
+  local expected="$1"
+
+  if ! grep -Fqx "${expected}" "${compose_path}" >/dev/null; then
+    echo "Missing required Compose line: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_pattern() {
+  local pattern="$1"
+  local message="$2"
+
+  if ! grep -En "${pattern}" "${compose_path}" >/dev/null; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+extract_service_block() {
+  local service_name="$1"
+
+  awk -v service_name="${service_name}" '
+    $0 == "  " service_name ":" { in_service = 1; next }
+    in_service && /^  [a-z0-9-]+:/ { exit }
+    in_service && /^[^[:space:]]/ { exit }
+    in_service { print }
+  ' "${compose_path}"
+}
+
+require_service_pattern() {
+  local service_name="$1"
+  local pattern="$2"
+  local message="$3"
+
+  if ! extract_service_block "${service_name}" | grep -En "${pattern}" >/dev/null; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_string "name: aegisops-ingest"
+require_fixed_string "services:"
+require_fixed_string "  collector:"
+require_fixed_string "  parser:"
+require_service_pattern "collector" '^    image: alpine:[^[:space:]]+$' \
+  "Ingest compose skeleton must pin collector to an explicit placeholder image tag."
+require_service_pattern "parser" '^    image: alpine:[^[:space:]]+$' \
+  "Ingest compose skeleton must pin parser to an explicit placeholder image tag."
+require_service_pattern "collector" '^    profiles:$' \
+  "Ingest compose skeleton must keep collector behind a placeholder-only profile."
+require_service_pattern "collector" '^      - placeholder$' \
+  "Ingest compose skeleton must mark collector as placeholder-only."
+require_service_pattern "parser" '^    profiles:$' \
+  "Ingest compose skeleton must keep parser behind a placeholder-only profile."
+require_service_pattern "parser" '^      - placeholder$' \
+  "Ingest compose skeleton must mark parser as placeholder-only."
+require_pattern 'collection and parsing placeholder services only' \
+  "Ingest compose skeleton must state that it is limited to collection and parsing placeholders only."
+require_pattern 'source integrations, parsing logic, and routing remain out of scope here' \
+  "Ingest compose skeleton must explicitly defer integrations, parsing logic, and routing behavior."
+require_pattern 'skeleton only' \
+  "Ingest compose skeleton must state that it is a skeleton only."
+require_pattern 'not production-ready' \
+  "Ingest compose skeleton must state that it is not production-ready."
+
+if grep -En '^    image: .*:latest$' "${compose_path}" >/dev/null; then
+  echo "Ingest compose skeleton must not use the latest tag." >&2
+  exit 1
+fi
+
+if grep -En '^[[:space:]]*container_name:' "${compose_path}" >/dev/null; then
+  echo "Ingest compose skeleton must not hard-code container_name." >&2
+  exit 1
+fi
+
+if grep -En '^[[:space:]]*ports:' "${compose_path}" >/dev/null; then
+  echo "Ingest compose skeleton must not publish ports." >&2
+  exit 1
+fi
+
+if grep -Ei '(syslog|filebeat|fluent-bit|fluentbit|vector|logstash|kafka|otlp|http input|tcp input|udp input)' "${compose_path}" >/dev/null; then
+  echo "Ingest compose skeleton must not introduce source-specific transport or parser behavior." >&2
+  exit 1
+fi
+
+echo "Ingest compose skeleton matches the approved placeholder-safe contract."


### PR DESCRIPTION
## What changed
- added a placeholder-only ingest compose skeleton under `ingest/docker-compose.yml`
- added `scripts/verify-ingest-compose-skeleton.sh` to enforce the ingest skeleton contract
- added `scripts/test-verify-ingest-compose-skeleton.sh` and wired the new verifier/test into CI

## Why
The repository already reserved `ingest/` as the approved home for ingestion assets, but it did not yet have a compose skeleton or focused verification comparable to the other component directories.

## Impact
- reserves the approved ingest compose location without introducing source-specific runtime behavior
- keeps the ingest layer explicitly placeholder-only and not production-ready
- prevents regressions through verifier and shell-test coverage

## Validation
- `bash scripts/verify-ingest-compose-skeleton.sh`
- `bash scripts/test-verify-ingest-compose-skeleton.sh`
- full local CI-equivalent verifier/test chain from `.github/workflows/ci.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ingest pipeline Docker Compose configuration with placeholder collector and parser services for foundational setup.

* **Chores**
  * Enhanced CI pipeline to validate ingest Docker Compose configurations.
  * Added automated verification tests for Docker Compose skeleton requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->