### PR TITLE
Add compose env sample placeholders

### DIFF
--- a/n8n/.env.sample
+++ b/n8n/.env.sample
@@ -1,0 +1,12 @@
+# Sample environment placeholders for the n8n compose skeleton only.
+# Do not use these placeholder values in production.
+
+AEGISOPS_POSTGRES_HOST=postgres
+AEGISOPS_POSTGRES_PORT=5432
+AEGISOPS_POSTGRES_DB=aegisops_n8n_placeholder
+AEGISOPS_POSTGRES_USER=aegisops_n8n_placeholder
+AEGISOPS_POSTGRES_PASSWORD=placeholder-not-a-secret
+AEGISOPS_N8N_ENCRYPTION_KEY=placeholder-not-a-secret
+AEGISOPS_N8N_HOST=n8n-placeholder.internal
+AEGISOPS_N8N_USER_FOLDER=/data/n8n-placeholder
+AEGISOPS_N8N_WEBHOOK_URL=https://n8n-placeholder.example.invalid/

--- a/postgres/.env.sample
+++ b/postgres/.env.sample
@@ -1,0 +1,6 @@
+# Sample environment placeholders for the PostgreSQL compose skeleton only.
+# Do not use these placeholder values in production.
+
+AEGISOPS_POSTGRES_DB=aegisops_n8n_placeholder
+AEGISOPS_POSTGRES_USER=aegisops_n8n_placeholder
+AEGISOPS_POSTGRES_PASSWORD=placeholder-not-a-secret

--- a/scripts/test-verify-n8n-compose-skeleton.sh
+++ b/scripts/test-verify-n8n-compose-skeleton.sh
@@ -22,11 +22,30 @@ create_repo() {
   git -C "${target}" config user.email "codex@example.com"
 }
 
+write_env_sample() {
+  local target="$1"
+  local content="$2"
+
+  printf '%s\n' "${content}" >"${target}/n8n/.env.sample"
+}
+
 write_compose() {
   local target="$1"
   local content="$2"
 
   printf '%s\n' "${content}" >"${target}/n8n/docker-compose.yml"
+  write_env_sample "${target}" "# Sample environment placeholders for the n8n compose skeleton only.
+# Do not use these placeholder values in production.
+AEGISOPS_POSTGRES_HOST=postgres
+AEGISOPS_POSTGRES_PORT=5432
+AEGISOPS_POSTGRES_DB=aegisops_n8n_placeholder
+AEGISOPS_POSTGRES_USER=aegisops_n8n_placeholder
+AEGISOPS_POSTGRES_PASSWORD=placeholder-not-a-secret
+AEGISOPS_N8N_ENCRYPTION_KEY=placeholder-not-a-secret
+AEGISOPS_N8N_HOST=n8n-placeholder.internal
+AEGISOPS_N8N_USER_FOLDER=/data/n8n-placeholder
+AEGISOPS_N8N_WEBHOOK_URL=https://n8n-placeholder.example.invalid/"
+  git -C "${target}" add n8n/.env.sample
   git -C "${target}" add n8n/docker-compose.yml
   git -C "${target}" commit -q -m "fixture"
 }
@@ -84,6 +103,18 @@ missing_file_repo="${workdir}/missing-file"
 create_repo "${missing_file_repo}"
 git -C "${missing_file_repo}" commit -q --allow-empty -m "fixture"
 assert_fails_with "${missing_file_repo}" "Missing n8n compose skeleton"
+
+missing_env_sample_repo="${workdir}/missing-env-sample"
+create_repo "${missing_env_sample_repo}"
+printf '%s\n' "name: aegisops-n8n
+services:
+  n8n:
+    image: n8nio/n8n:1.89.2
+    environment:
+      DB_TYPE: \${AEGISOPS_POSTGRES_HOST:-postgres}" >"${missing_env_sample_repo}/n8n/docker-compose.yml"
+git -C "${missing_env_sample_repo}" add n8n/docker-compose.yml
+git -C "${missing_env_sample_repo}" commit -q -m "fixture"
+assert_fails_with "${missing_env_sample_repo}" "Missing n8n environment sample placeholder"
 
 latest_tag_repo="${workdir}/latest-tag"
 create_repo "${latest_tag_repo}"

--- a/scripts/test-verify-postgres-compose-skeleton.sh
+++ b/scripts/test-verify-postgres-compose-skeleton.sh
@@ -22,11 +22,24 @@ create_repo() {
   git -C "${target}" config user.email "codex@example.com"
 }
 
+write_env_sample() {
+  local target="$1"
+  local content="$2"
+
+  printf '%s\n' "${content}" >"${target}/postgres/.env.sample"
+}
+
 write_compose() {
   local target="$1"
   local content="$2"
 
   printf '%s\n' "${content}" >"${target}/postgres/docker-compose.yml"
+  write_env_sample "${target}" "# Sample environment placeholders for the PostgreSQL compose skeleton only.
+# Do not use these placeholder values in production.
+AEGISOPS_POSTGRES_DB=aegisops_n8n_placeholder
+AEGISOPS_POSTGRES_USER=aegisops_n8n_placeholder
+AEGISOPS_POSTGRES_PASSWORD=placeholder-not-a-secret"
+  git -C "${target}" add postgres/.env.sample
   git -C "${target}" add postgres/docker-compose.yml
   git -C "${target}" commit -q -m "fixture"
 }
@@ -77,6 +90,16 @@ missing_file_repo="${workdir}/missing-file"
 create_repo "${missing_file_repo}"
 git -C "${missing_file_repo}" commit -q --allow-empty -m "fixture"
 assert_fails_with "${missing_file_repo}" "Missing PostgreSQL compose skeleton"
+
+missing_env_sample_repo="${workdir}/missing-env-sample"
+create_repo "${missing_env_sample_repo}"
+printf '%s\n' "name: aegisops-postgres
+services:
+  postgres:
+    image: postgres:16.4" >"${missing_env_sample_repo}/postgres/docker-compose.yml"
+git -C "${missing_env_sample_repo}" add postgres/docker-compose.yml
+git -C "${missing_env_sample_repo}" commit -q -m "fixture"
+assert_fails_with "${missing_env_sample_repo}" "Missing PostgreSQL environment sample placeholder"
 
 latest_tag_repo="${workdir}/latest-tag"
 create_repo "${latest_tag_repo}"

--- a/scripts/verify-n8n-compose-skeleton.sh
+++ b/scripts/verify-n8n-compose-skeleton.sh
@@ -5,26 +5,34 @@ set -euo pipefail
 default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo_root="${1:-${default_repo_root}}"
 compose_path="${repo_root}/n8n/docker-compose.yml"
+env_sample_path="${repo_root}/n8n/.env.sample"
 
 if [[ ! -f "${compose_path}" ]]; then
   echo "Missing n8n compose skeleton: ${compose_path}" >&2
   exit 1
 fi
 
-require_fixed_string() {
-  local expected="$1"
+if [[ ! -f "${env_sample_path}" ]]; then
+  echo "Missing n8n environment sample placeholder: ${env_sample_path}" >&2
+  exit 1
+fi
 
-  if ! grep -Fqx "${expected}" "${compose_path}" >/dev/null; then
-    echo "Missing required Compose line: ${expected}" >&2
+require_fixed_string() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required line in ${file_path}: ${expected}" >&2
     exit 1
   fi
 }
 
 require_pattern() {
-  local pattern="$1"
-  local message="$2"
+  local file_path="$1"
+  local pattern="$2"
+  local message="$3"
 
-  if ! grep -En "${pattern}" "${compose_path}" >/dev/null; then
+  if ! grep -En "${pattern}" "${file_path}" >/dev/null; then
     echo "${message}" >&2
     exit 1
   fi
@@ -49,9 +57,9 @@ require_n8n_pattern() {
   fi
 }
 
-require_fixed_string "name: aegisops-n8n"
-require_fixed_string "services:"
-require_fixed_string "  n8n:"
+require_fixed_string "${compose_path}" "name: aegisops-n8n"
+require_fixed_string "${compose_path}" "services:"
+require_fixed_string "${compose_path}" "  n8n:"
 require_n8n_pattern '^    image: n8nio/n8n:[^[:space:]]+$' \
   "n8n compose skeleton must pin n8nio/n8n to an explicit version tag."
 
@@ -91,14 +99,38 @@ require_n8n_pattern '^    volumes:$' \
   "n8n compose skeleton must declare volumes."
 require_n8n_pattern '^      - /srv/aegisops/n8n-data-placeholder:/data/n8n-placeholder$' \
   "n8n compose skeleton must use the explicit AegisOps n8n persistent mount placeholder."
-require_pattern 'n8n orchestration only' \
+require_pattern "${compose_path}" 'n8n orchestration only' \
   "n8n compose skeleton must limit its role to the approved n8n orchestration boundary."
-require_pattern 'queue mode, Redis, and workflow import remain out of scope here' \
+require_pattern "${compose_path}" 'queue mode, Redis, and workflow import remain out of scope here' \
   "n8n compose skeleton must explicitly keep queue mode, Redis, and workflow import out of scope."
-require_pattern 'skeleton only' \
+require_pattern "${compose_path}" 'skeleton only' \
   "n8n compose skeleton must state that it is a skeleton only."
-require_pattern 'not production-ready' \
+require_pattern "${compose_path}" 'not production-ready' \
   "n8n compose skeleton must state that it is not production-ready."
+
+require_pattern "${env_sample_path}" '^# Sample environment placeholders for the n8n compose skeleton only\.$' \
+  "n8n environment sample placeholder must declare itself as sample-only."
+require_pattern "${env_sample_path}" '^# Do not use these placeholder values in production\.$' \
+  "n8n environment sample placeholder must declare itself non-production."
+require_fixed_string "${env_sample_path}" "AEGISOPS_POSTGRES_HOST=postgres"
+require_fixed_string "${env_sample_path}" "AEGISOPS_POSTGRES_PORT=5432"
+require_fixed_string "${env_sample_path}" "AEGISOPS_POSTGRES_DB=aegisops_n8n_placeholder"
+require_fixed_string "${env_sample_path}" "AEGISOPS_POSTGRES_USER=aegisops_n8n_placeholder"
+require_fixed_string "${env_sample_path}" "AEGISOPS_POSTGRES_PASSWORD=placeholder-not-a-secret"
+require_fixed_string "${env_sample_path}" "AEGISOPS_N8N_ENCRYPTION_KEY=placeholder-not-a-secret"
+require_fixed_string "${env_sample_path}" "AEGISOPS_N8N_HOST=n8n-placeholder.internal"
+require_fixed_string "${env_sample_path}" "AEGISOPS_N8N_USER_FOLDER=/data/n8n-placeholder"
+require_fixed_string "${env_sample_path}" "AEGISOPS_N8N_WEBHOOK_URL=https://n8n-placeholder.example.invalid/"
+
+if grep -Env '^[A-Z0-9_]+=.+$|^#|^$' "${env_sample_path}" >/dev/null; then
+  echo "n8n environment sample placeholder must contain only comments, blank lines, and simple KEY=value entries." >&2
+  exit 1
+fi
+
+if grep -E '^[^#[:space:]=]+=' "${env_sample_path}" | cut -d '=' -f 1 | grep -Ev '^AEGISOPS_' >/dev/null; then
+  echo "n8n environment sample placeholder must use only approved AEGISOPS_* variable names." >&2
+  exit 1
+fi
 
 if extract_n8n_block | awk '
   BEGIN { has_ports = 0 }

--- a/scripts/verify-postgres-compose-skeleton.sh
+++ b/scripts/verify-postgres-compose-skeleton.sh
@@ -5,35 +5,43 @@ set -euo pipefail
 default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo_root="${1:-${default_repo_root}}"
 compose_path="${repo_root}/postgres/docker-compose.yml"
+env_sample_path="${repo_root}/postgres/.env.sample"
 
 if [[ ! -f "${compose_path}" ]]; then
   echo "Missing PostgreSQL compose skeleton: ${compose_path}" >&2
   exit 1
 fi
 
-require_fixed_string() {
-  local expected="$1"
+if [[ ! -f "${env_sample_path}" ]]; then
+  echo "Missing PostgreSQL environment sample placeholder: ${env_sample_path}" >&2
+  exit 1
+fi
 
-  if ! grep -Fqx "${expected}" "${compose_path}" >/dev/null; then
-    echo "Missing required Compose line: ${expected}" >&2
+require_fixed_string() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required line in ${file_path}: ${expected}" >&2
     exit 1
   fi
 }
 
 require_pattern() {
-  local pattern="$1"
-  local message="$2"
+  local file_path="$1"
+  local pattern="$2"
+  local message="$3"
 
-  if ! grep -En "${pattern}" "${compose_path}" >/dev/null; then
+  if ! grep -En "${pattern}" "${file_path}" >/dev/null; then
     echo "${message}" >&2
     exit 1
   fi
 }
 
-require_fixed_string "name: aegisops-postgres"
-require_fixed_string "services:"
-require_fixed_string "  postgres:"
-require_pattern '^    image: postgres:[^[:space:]]+$' \
+require_fixed_string "${compose_path}" "name: aegisops-postgres"
+require_fixed_string "${compose_path}" "services:"
+require_fixed_string "${compose_path}" "  postgres:"
+require_pattern "${compose_path}" '^    image: postgres:[^[:space:]]+$' \
   "PostgreSQL compose skeleton must pin postgres to an explicit version tag."
 
 if grep -En '^    image: .*:latest$' "${compose_path}" >/dev/null; then
@@ -46,24 +54,41 @@ if grep -En '^[[:space:]]*container_name:' "${compose_path}" >/dev/null; then
   exit 1
 fi
 
-require_pattern '^    environment:$' \
+require_pattern "${compose_path}" '^    environment:$' \
   "PostgreSQL compose skeleton must declare environment variables."
-require_pattern '^      POSTGRES_DB: \${AEGISOPS_POSTGRES_DB:-aegisops_n8n_placeholder}$' \
+require_pattern "${compose_path}" '^      POSTGRES_DB: \${AEGISOPS_POSTGRES_DB:-aegisops_n8n_placeholder}$' \
   "PostgreSQL compose skeleton must use placeholder-safe environment references for POSTGRES_DB."
-require_pattern '^      POSTGRES_USER: \${AEGISOPS_POSTGRES_USER:-aegisops_n8n_placeholder}$' \
+require_pattern "${compose_path}" '^      POSTGRES_USER: \${AEGISOPS_POSTGRES_USER:-aegisops_n8n_placeholder}$' \
   "PostgreSQL compose skeleton must use placeholder-safe environment references for POSTGRES_USER."
-require_pattern '^      POSTGRES_PASSWORD: \${AEGISOPS_POSTGRES_PASSWORD:\?set-in-runtime-secret-source}$' \
+require_pattern "${compose_path}" '^      POSTGRES_PASSWORD: \${AEGISOPS_POSTGRES_PASSWORD:\?set-in-runtime-secret-source}$' \
   "PostgreSQL compose skeleton must use placeholder-safe environment references for POSTGRES_PASSWORD."
-require_pattern '^    volumes:$' \
+require_pattern "${compose_path}" '^    volumes:$' \
   "PostgreSQL compose skeleton must declare volumes."
-require_pattern '^      - /srv/aegisops/postgres-data-placeholder:/var/lib/postgresql/data$' \
+require_pattern "${compose_path}" '^      - /srv/aegisops/postgres-data-placeholder:/var/lib/postgresql/data$' \
   "PostgreSQL compose skeleton must use the explicit AegisOps PostgreSQL persistent mount placeholder."
-require_pattern 'n8n metadata and execution state only' \
+require_pattern "${compose_path}" 'n8n metadata and execution state only' \
   "PostgreSQL compose skeleton must limit its role to n8n metadata and execution state only."
-require_pattern 'skeleton only' \
+require_pattern "${compose_path}" 'skeleton only' \
   "PostgreSQL compose skeleton must state that it is a skeleton only."
-require_pattern 'not production-ready' \
+require_pattern "${compose_path}" 'not production-ready' \
   "PostgreSQL compose skeleton must state that it is not production-ready."
+require_pattern "${env_sample_path}" '^# Sample environment placeholders for the PostgreSQL compose skeleton only\.$' \
+  "PostgreSQL environment sample placeholder must declare itself as sample-only."
+require_pattern "${env_sample_path}" '^# Do not use these placeholder values in production\.$' \
+  "PostgreSQL environment sample placeholder must declare itself non-production."
+require_fixed_string "${env_sample_path}" "AEGISOPS_POSTGRES_DB=aegisops_n8n_placeholder"
+require_fixed_string "${env_sample_path}" "AEGISOPS_POSTGRES_USER=aegisops_n8n_placeholder"
+require_fixed_string "${env_sample_path}" "AEGISOPS_POSTGRES_PASSWORD=placeholder-not-a-secret"
+
+if grep -Env '^[A-Z0-9_]+=.+$|^#|^$' "${env_sample_path}" >/dev/null; then
+  echo "PostgreSQL environment sample placeholder must contain only comments, blank lines, and simple KEY=value entries." >&2
+  exit 1
+fi
+
+if grep -E '^[^#[:space:]=]+=' "${env_sample_path}" | cut -d '=' -f 1 | grep -Ev '^AEGISOPS_' >/dev/null; then
+  echo "PostgreSQL environment sample placeholder must use only approved AEGISOPS_* variable names." >&2
+  exit 1
+fi
 
 if awk '
   BEGIN { in_postgres = 0; has_ports = 0 }


### PR DESCRIPTION
## Summary
- add placeholder-only `.env.sample` files for the `n8n` and `postgres` compose skeletons
- tighten the focused skeleton verifiers so these sample files are required and restricted to approved `AEGISOPS_*` names
- add focused regression tests for missing component env sample placeholders

## Testing
- `bash scripts/test-verify-n8n-compose-skeleton.sh`
- `bash scripts/test-verify-postgres-compose-skeleton.sh`
- `bash scripts/verify-n8n-compose-skeleton.sh .`
- `bash scripts/verify-postgres-compose-skeleton.sh .`

Closes #43