### PR TITLE
[codex] Add compose skeleton validation report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           bash scripts/verify-adr-review-path-doc.sh
           bash scripts/verify-architecture-doc.sh
           bash scripts/verify-contributor-naming-guide-doc.sh
+          bash scripts/verify-compose-skeleton-validation.sh
           bash scripts/verify-documentation-ownership-map.sh
           bash scripts/verify-ingest-compose-skeleton.sh
           bash scripts/verify-naming-conventions-doc.sh
@@ -47,4 +48,5 @@ jobs:
           bash scripts/test-verify-opensearch-compose-skeleton.sh
           bash scripts/test-verify-postgres-compose-skeleton.sh
           bash scripts/test-verify-proxy-compose-skeleton.sh
+          bash scripts/test-verify-compose-skeleton-validation.sh
           bash scripts/test-verify-repository-skeleton.sh

--- a/docs/compose-skeleton-validation.md
+++ b/docs/compose-skeleton-validation.md
@@ -1,0 +1,26 @@
+# Compose Skeleton Validation
+
+- Validation date: 2026-04-02
+- Baseline references: `docs/contributor-naming-guide.md`, `docs/requirements-baseline.md`
+- Verification command: `bash scripts/verify-compose-skeleton-validation.sh`
+- Validation status: PASS
+
+## Reviewed Artifacts
+
+- `opensearch/docker-compose.yml`
+- `n8n/docker-compose.yml`
+- `proxy/docker-compose.yml`
+- `ingest/docker-compose.yml`
+
+## Naming Review Result
+
+- Compose project names use the approved `aegisops-` namespace examples from the contributor naming guide.
+- Service names remain aligned to the component roles shown in the checked skeletons: `opensearch`, `dashboards`, `n8n`, `proxy`, `collector`, and `parser`.
+
+## Image Tag Review Result
+
+- No checked compose artifact uses the `latest` image tag.
+
+## Deviations
+
+- No deviations found.

--- a/scripts/test-verify-compose-skeleton-validation.sh
+++ b/scripts/test-verify-compose-skeleton-validation.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-compose-skeleton-validation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p \
+    "${target}/docs" \
+    "${target}/opensearch" \
+    "${target}/n8n" \
+    "${target}/proxy" \
+    "${target}/ingest"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_file() {
+  local target="$1"
+  local path="$2"
+  local content="$3"
+
+  printf '%s\n' "${content}" >"${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit -q -m "fixture"
+}
+
+write_valid_naming_guide() {
+  local target="$1"
+
+  write_file "${target}" "docs/contributor-naming-guide.md" "# AegisOps Contributor Naming Guide
+
+## Compose Projects
+
+Examples:
+
+- \`aegisops-opensearch\`
+- \`aegisops-n8n\`
+- \`aegisops-ingest\`
+- \`aegisops-proxy\`"
+}
+
+write_valid_compose_files() {
+  local target="$1"
+
+  write_file "${target}" "opensearch/docker-compose.yml" "name: aegisops-opensearch
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.19.0
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:2.19.0"
+
+  write_file "${target}" "n8n/docker-compose.yml" "name: aegisops-n8n
+services:
+  n8n:
+    image: n8nio/n8n:1.89.2"
+
+  write_file "${target}" "proxy/docker-compose.yml" "name: aegisops-proxy
+services:
+  proxy:
+    image: nginx:1.27.0"
+
+  write_file "${target}" "ingest/docker-compose.yml" "name: aegisops-ingest
+services:
+  collector:
+    image: alpine:3.22.1
+  parser:
+    image: alpine:3.22.1"
+}
+
+write_valid_report() {
+  local target="$1"
+
+  write_file "${target}" "docs/compose-skeleton-validation.md" "# Compose Skeleton Validation
+
+- Validation date: 2026-04-02
+- Baseline references: \`docs/contributor-naming-guide.md\`, \`docs/requirements-baseline.md\`
+- Verification command: \`bash scripts/verify-compose-skeleton-validation.sh\`
+- Validation status: PASS
+
+## Reviewed Artifacts
+
+- \`opensearch/docker-compose.yml\`
+- \`n8n/docker-compose.yml\`
+- \`proxy/docker-compose.yml\`
+- \`ingest/docker-compose.yml\`
+
+## Naming Review Result
+
+- Compose project names use the approved \`aegisops-\` namespace examples from the contributor naming guide.
+- Service names remain aligned to the component roles shown in the checked skeletons: \`opensearch\`, \`dashboards\`, \`n8n\`, \`proxy\`, \`collector\`, and \`parser\`.
+
+## Image Tag Review Result
+
+- No checked compose artifact uses the \`latest\` image tag.
+
+## Deviations
+
+- No deviations found."
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_valid_naming_guide "${valid_repo}"
+write_valid_compose_files "${valid_repo}"
+write_valid_report "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_report_repo="${workdir}/missing-report"
+create_repo "${missing_report_repo}"
+write_valid_naming_guide "${missing_report_repo}"
+write_valid_compose_files "${missing_report_repo}"
+commit_fixture "${missing_report_repo}"
+assert_fails_with "${missing_report_repo}" "Missing compose skeleton validation result document"
+
+bad_project_name_repo="${workdir}/bad-project-name"
+create_repo "${bad_project_name_repo}"
+write_valid_naming_guide "${bad_project_name_repo}"
+write_valid_compose_files "${bad_project_name_repo}"
+write_file "${bad_project_name_repo}" "opensearch/docker-compose.yml" "name: opensearch
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.19.0
+  dashboards:
+    image: opensearchproject/opensearch-dashboards:2.19.0"
+write_valid_report "${bad_project_name_repo}"
+commit_fixture "${bad_project_name_repo}"
+assert_fails_with "${bad_project_name_repo}" "must use approved Compose project names"
+
+latest_tag_repo="${workdir}/latest-tag"
+create_repo "${latest_tag_repo}"
+write_valid_naming_guide "${latest_tag_repo}"
+write_valid_compose_files "${latest_tag_repo}"
+write_file "${latest_tag_repo}" "proxy/docker-compose.yml" "name: aegisops-proxy
+services:
+  proxy:
+    image: nginx:latest"
+write_valid_report "${latest_tag_repo}"
+commit_fixture "${latest_tag_repo}"
+assert_fails_with "${latest_tag_repo}" "must not use the latest tag"
+
+echo "verify-compose-skeleton-validation tests passed"

--- a/scripts/verify-compose-skeleton-validation.sh
+++ b/scripts/verify-compose-skeleton-validation.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+naming_guide_path="${repo_root}/docs/contributor-naming-guide.md"
+validation_doc_path="${repo_root}/docs/compose-skeleton-validation.md"
+
+compose_files=(
+  "opensearch/docker-compose.yml"
+  "n8n/docker-compose.yml"
+  "proxy/docker-compose.yml"
+  "ingest/docker-compose.yml"
+)
+
+expected_project_names=(
+  "opensearch/docker-compose.yml:name: aegisops-opensearch"
+  "n8n/docker-compose.yml:name: aegisops-n8n"
+  "proxy/docker-compose.yml:name: aegisops-proxy"
+  "ingest/docker-compose.yml:name: aegisops-ingest"
+)
+
+expected_service_names=(
+  "opensearch/docker-compose.yml:opensearch"
+  "opensearch/docker-compose.yml:dashboards"
+  "n8n/docker-compose.yml:n8n"
+  "proxy/docker-compose.yml:proxy"
+  "ingest/docker-compose.yml:collector"
+  "ingest/docker-compose.yml:parser"
+)
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_pattern() {
+  local path="$1"
+  local pattern="$2"
+  local message="$3"
+
+  if ! grep -Eq -- "${pattern}" "${path}"; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_string() {
+  local path="$1"
+  local expected="$2"
+  local message="$3"
+
+  if ! grep -Fqx -- "${expected}" "${path}"; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_fragment() {
+  local path="$1"
+  local expected="$2"
+  local message="$3"
+
+  if ! grep -Fq -- "${expected}" "${path}"; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+require_file "${naming_guide_path}" "Missing contributor naming guide"
+require_file "${validation_doc_path}" "Missing compose skeleton validation result document"
+
+for compose_file in "${compose_files[@]}"; do
+  require_file "${repo_root}/${compose_file}" "Missing compose skeleton"
+done
+
+for expected_name in \
+  "aegisops-opensearch" \
+  "aegisops-n8n" \
+  "aegisops-ingest" \
+  "aegisops-proxy"; do
+  require_fixed_fragment \
+    "${naming_guide_path}" \
+    "\`${expected_name}\`" \
+    "Contributor naming guide must include approved Compose project example ${expected_name}."
+done
+
+for project_entry in "${expected_project_names[@]}"; do
+  compose_file="${project_entry%%:*}"
+  expected_line="${project_entry#*:}"
+  require_fixed_string \
+    "${repo_root}/${compose_file}" \
+    "${expected_line}" \
+    "${compose_file} must use approved Compose project names from the contributor naming guide."
+done
+
+for service_entry in "${expected_service_names[@]}"; do
+  compose_file="${service_entry%%:*}"
+  service_name="${service_entry#*:}"
+  require_fixed_string \
+    "${repo_root}/${compose_file}" \
+    "  ${service_name}:" \
+    "${compose_file} must use approved service names aligned to the checked skeleton examples."
+done
+
+if grep -REn '^([[:space:]]*)image:[[:space:]]+[^[:space:]]+:latest$' \
+  "${repo_root}/opensearch" \
+  "${repo_root}/n8n" \
+  "${repo_root}/proxy" \
+  "${repo_root}/ingest" >/dev/null; then
+  echo "Checked compose artifacts must not use the latest tag." >&2
+  exit 1
+fi
+
+require_fixed_string "${validation_doc_path}" "# Compose Skeleton Validation" \
+  "Compose skeleton validation document must use the approved title."
+require_pattern "${validation_doc_path}" '^- Validation date: [0-9]{4}-[0-9]{2}-[0-9]{2}$' \
+  "Compose skeleton validation document must record a validation date."
+require_fixed_string "${validation_doc_path}" "- Baseline references: \`docs/contributor-naming-guide.md\`, \`docs/requirements-baseline.md\`" \
+  "Compose skeleton validation document must cite the naming guide and requirements baseline."
+require_fixed_string "${validation_doc_path}" "- Verification command: \`bash scripts/verify-compose-skeleton-validation.sh\`" \
+  "Compose skeleton validation document must record the verification command."
+require_fixed_string "${validation_doc_path}" "- Validation status: PASS" \
+  "Compose skeleton validation document must record a PASS status."
+require_fixed_string "${validation_doc_path}" "## Reviewed Artifacts" \
+  "Compose skeleton validation document must list reviewed artifacts."
+require_fixed_string "${validation_doc_path}" "## Naming Review Result" \
+  "Compose skeleton validation document must summarize the naming review."
+require_fixed_string "${validation_doc_path}" "## Image Tag Review Result" \
+  "Compose skeleton validation document must summarize the image tag review."
+require_fixed_string "${validation_doc_path}" "## Deviations" \
+  "Compose skeleton validation document must include a deviations section."
+
+for artifact in "${compose_files[@]}"; do
+  require_fixed_string "${validation_doc_path}" "- \`${artifact}\`" \
+    "Compose skeleton validation document must list ${artifact} as reviewed."
+done
+
+require_fixed_fragment "${validation_doc_path}" "approved \`aegisops-\` namespace examples" \
+  "Compose skeleton validation document must record the approved Compose project naming result."
+require_fixed_fragment "${validation_doc_path}" "\`opensearch\`, \`dashboards\`, \`n8n\`, \`proxy\`, \`collector\`, and \`parser\`" \
+  "Compose skeleton validation document must record the reviewed service names."
+require_fixed_fragment "${validation_doc_path}" "No checked compose artifact uses the \`latest\` image tag." \
+  "Compose skeleton validation document must record the image tag review result."
+require_fixed_string "${validation_doc_path}" "- No deviations found." \
+  "Compose skeleton validation document must explicitly record the deviation outcome."
+
+echo "Compose skeleton validation matches the approved naming and image-tag review record."


### PR DESCRIPTION
## What changed
- add `scripts/verify-compose-skeleton-validation.sh` to validate the scoped compose skeletons against the contributor naming guide and reject any `latest` tags
- add `scripts/test-verify-compose-skeleton-validation.sh` to cover the combined validation/reporting path
- add `docs/compose-skeleton-validation.md` to store the checked validation result in-repo
- run the new verifier/test from `.github/workflows/ci.yml`

## Why
Issue #44 required a repository-stored validation result for the compose skeletons under `opensearch/`, `n8n/`, `proxy/`, and `ingest/`. The compose files were already compliant, but the repo did not yet have a combined validation artifact and verifier proving naming-guide alignment and no use of `latest` tags.

## Impact
- keeps the compose skeleton implementations unchanged
- makes the naming and image-tag review explicit and repeatable in CI
- records that no deviations were found in the checked compose artifacts

## Validation
- local equivalent of the current CI workflow completed successfully
- `bash scripts/verify-compose-skeleton-validation.sh`
- `bash scripts/test-verify-compose-skeleton-validation.sh`
- `bash scripts/verify-opensearch-compose-skeleton.sh`
- `bash scripts/verify-n8n-compose-skeleton.sh`
- `bash scripts/verify-proxy-compose-skeleton.sh`
- `bash scripts/verify-ingest-compose-skeleton.sh`
- `bash scripts/test-verify-opensearch-compose-skeleton.sh`
- `bash scripts/test-verify-n8n-compose-skeleton.sh`
- `bash scripts/test-verify-ingest-compose-skeleton.sh`
- `bash scripts/test-verify-postgres-compose-skeleton.sh`
- `bash scripts/test-verify-proxy-compose-skeleton.sh`
- `bash scripts/test-verify-repository-skeleton.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compose skeleton validation system with automated verification of Docker Compose artifacts and naming conventions.

* **Documentation**
  * Added documentation detailing compose skeleton validation procedures and review results.

* **Tests**
  * Added test suite to verify validation functionality across multiple scenarios.

* **Chores**
  * Updated CI pipeline to include new validation and testing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->