### PR TITLE
[codex] Tighten compose skeleton validation

### DIFF
--- a/docs/compose-skeleton-validation.md
+++ b/docs/compose-skeleton-validation.md
@@ -1,25 +1,39 @@
 # Compose Skeleton Validation
 
 - Validation date: 2026-04-02
-- Baseline references: `docs/contributor-naming-guide.md`, `docs/requirements-baseline.md`
+- Baseline references: `docs/contributor-naming-guide.md`, `docs/requirements-baseline.md`, `docs/network-exposure-and-access-path-policy.md`
 - Verification command: `bash scripts/verify-compose-skeleton-validation.sh`
 - Validation status: PASS
 
 ## Reviewed Artifacts
 
+- `.env.sample`
 - `opensearch/docker-compose.yml`
 - `n8n/docker-compose.yml`
+- `n8n/.env.sample`
+- `postgres/docker-compose.yml`
+- `postgres/.env.sample`
 - `proxy/docker-compose.yml`
 - `ingest/docker-compose.yml`
 
 ## Naming Review Result
 
 - Compose project names use the approved `aegisops-` namespace examples from the contributor naming guide.
-- Service names remain aligned to the component roles shown in the checked skeletons: `opensearch`, `dashboards`, `n8n`, `proxy`, `collector`, and `parser`.
+- Service names remain aligned to the component roles shown in the checked skeletons: `opensearch`, `dashboards`, `n8n`, `postgres`, `proxy`, `collector`, and `parser`.
 
 ## Image Tag Review Result
 
 - No checked compose artifact uses the `latest` image tag.
+
+## Secret and Env Review Result
+
+- No checked compose or sample env artifact contains a live secret or production-sensitive value.
+- No active `.env` file is committed; only tracked `.env.sample` placeholders are present.
+
+## Exposure Review Result
+
+- No checked compose skeleton publishes backend services directly with `ports:`.
+- Backend access assumptions remain aligned to `docs/network-exposure-and-access-path-policy.md` and the approved reverse proxy or internal-only access model.
 
 ## Deviations
 

--- a/docs/contributor-naming-guide.md
+++ b/docs/contributor-naming-guide.md
@@ -56,6 +56,7 @@ Examples:
 
 - `aegisops-opensearch`
 - `aegisops-n8n`
+- `aegisops-postgres`
 - `aegisops-ingest`
 - `aegisops-proxy`
 

--- a/scripts/test-verify-compose-skeleton-validation.sh
+++ b/scripts/test-verify-compose-skeleton-validation.sh
@@ -20,6 +20,7 @@ create_repo() {
     "${target}/docs" \
     "${target}/opensearch" \
     "${target}/n8n" \
+    "${target}/postgres" \
     "${target}/proxy" \
     "${target}/ingest"
   git -C "${target}" init -q
@@ -53,8 +54,18 @@ Examples:
 
 - \`aegisops-opensearch\`
 - \`aegisops-n8n\`
+- \`aegisops-postgres\`
 - \`aegisops-ingest\`
 - \`aegisops-proxy\`"
+}
+
+write_valid_network_policy() {
+  local target="$1"
+
+  write_file "${target}" "docs/network-exposure-and-access-path-policy.md" "# AegisOps Network Exposure and Access Path Policy
+
+All user-facing UI access must traverse the approved reverse proxy.
+Direct unaudited publication of service ports to general user networks or the public internet is not approved."
 }
 
 write_valid_compose_files() {
@@ -72,6 +83,11 @@ services:
   n8n:
     image: n8nio/n8n:1.89.2"
 
+  write_file "${target}" "postgres/docker-compose.yml" "name: aegisops-postgres
+services:
+  postgres:
+    image: postgres:16.4"
+
   write_file "${target}" "proxy/docker-compose.yml" "name: aegisops-proxy
 services:
   proxy:
@@ -85,31 +101,63 @@ services:
     image: alpine:3.22.1"
 }
 
+write_valid_env_samples() {
+  local target="$1"
+
+  write_file "${target}" ".env.sample" "# Sample environment file for repository structure only.
+# Do not store real secrets or active environment values in this repository."
+
+  write_file "${target}" "n8n/.env.sample" "# Sample environment placeholders for the n8n compose skeleton only.
+# Do not use these placeholder values in production.
+
+AEGISOPS_POSTGRES_PASSWORD=placeholder-not-a-secret
+AEGISOPS_N8N_ENCRYPTION_KEY=placeholder-not-a-secret"
+
+  write_file "${target}" "postgres/.env.sample" "# Sample environment placeholders for the PostgreSQL compose skeleton only.
+# Do not use these placeholder values in production.
+
+AEGISOPS_POSTGRES_PASSWORD=placeholder-not-a-secret"
+}
+
 write_valid_report() {
   local target="$1"
 
   write_file "${target}" "docs/compose-skeleton-validation.md" "# Compose Skeleton Validation
 
 - Validation date: 2026-04-02
-- Baseline references: \`docs/contributor-naming-guide.md\`, \`docs/requirements-baseline.md\`
+- Baseline references: \`docs/contributor-naming-guide.md\`, \`docs/requirements-baseline.md\`, \`docs/network-exposure-and-access-path-policy.md\`
 - Verification command: \`bash scripts/verify-compose-skeleton-validation.sh\`
 - Validation status: PASS
 
 ## Reviewed Artifacts
 
+- \`.env.sample\`
 - \`opensearch/docker-compose.yml\`
 - \`n8n/docker-compose.yml\`
+- \`n8n/.env.sample\`
+- \`postgres/docker-compose.yml\`
+- \`postgres/.env.sample\`
 - \`proxy/docker-compose.yml\`
 - \`ingest/docker-compose.yml\`
 
 ## Naming Review Result
 
 - Compose project names use the approved \`aegisops-\` namespace examples from the contributor naming guide.
-- Service names remain aligned to the component roles shown in the checked skeletons: \`opensearch\`, \`dashboards\`, \`n8n\`, \`proxy\`, \`collector\`, and \`parser\`.
+- Service names remain aligned to the component roles shown in the checked skeletons: \`opensearch\`, \`dashboards\`, \`n8n\`, \`postgres\`, \`proxy\`, \`collector\`, and \`parser\`.
 
 ## Image Tag Review Result
 
 - No checked compose artifact uses the \`latest\` image tag.
+
+## Secret and Env Review Result
+
+- No checked compose or sample env artifact contains a live secret or production-sensitive value.
+- No active \`.env\` file is committed; only tracked \`.env.sample\` placeholders are present.
+
+## Exposure Review Result
+
+- No checked compose skeleton publishes backend services directly with \`ports:\`.
+- Backend access assumptions remain aligned to \`docs/network-exposure-and-access-path-policy.md\` and the approved reverse proxy or internal-only access model.
 
 ## Deviations
 
@@ -145,7 +193,9 @@ assert_fails_with() {
 valid_repo="${workdir}/valid"
 create_repo "${valid_repo}"
 write_valid_naming_guide "${valid_repo}"
+write_valid_network_policy "${valid_repo}"
 write_valid_compose_files "${valid_repo}"
+write_valid_env_samples "${valid_repo}"
 write_valid_report "${valid_repo}"
 commit_fixture "${valid_repo}"
 assert_passes "${valid_repo}"
@@ -153,14 +203,18 @@ assert_passes "${valid_repo}"
 missing_report_repo="${workdir}/missing-report"
 create_repo "${missing_report_repo}"
 write_valid_naming_guide "${missing_report_repo}"
+write_valid_network_policy "${missing_report_repo}"
 write_valid_compose_files "${missing_report_repo}"
+write_valid_env_samples "${missing_report_repo}"
 commit_fixture "${missing_report_repo}"
 assert_fails_with "${missing_report_repo}" "Missing compose skeleton validation result document"
 
 bad_project_name_repo="${workdir}/bad-project-name"
 create_repo "${bad_project_name_repo}"
 write_valid_naming_guide "${bad_project_name_repo}"
+write_valid_network_policy "${bad_project_name_repo}"
 write_valid_compose_files "${bad_project_name_repo}"
+write_valid_env_samples "${bad_project_name_repo}"
 write_file "${bad_project_name_repo}" "opensearch/docker-compose.yml" "name: opensearch
 services:
   opensearch:
@@ -174,7 +228,9 @@ assert_fails_with "${bad_project_name_repo}" "must use approved Compose project 
 latest_tag_repo="${workdir}/latest-tag"
 create_repo "${latest_tag_repo}"
 write_valid_naming_guide "${latest_tag_repo}"
+write_valid_network_policy "${latest_tag_repo}"
 write_valid_compose_files "${latest_tag_repo}"
+write_valid_env_samples "${latest_tag_repo}"
 write_file "${latest_tag_repo}" "proxy/docker-compose.yml" "name: aegisops-proxy
 services:
   proxy:
@@ -182,5 +238,46 @@ services:
 write_valid_report "${latest_tag_repo}"
 commit_fixture "${latest_tag_repo}"
 assert_fails_with "${latest_tag_repo}" "must not use the latest tag"
+
+active_env_repo="${workdir}/active-env"
+create_repo "${active_env_repo}"
+write_valid_naming_guide "${active_env_repo}"
+write_valid_network_policy "${active_env_repo}"
+write_valid_compose_files "${active_env_repo}"
+write_valid_env_samples "${active_env_repo}"
+write_valid_report "${active_env_repo}"
+write_file "${active_env_repo}" "n8n/.env" "AEGISOPS_POSTGRES_PASSWORD=supersecret"
+commit_fixture "${active_env_repo}"
+assert_fails_with "${active_env_repo}" "must not commit active .env files"
+
+live_secret_repo="${workdir}/live-secret"
+create_repo "${live_secret_repo}"
+write_valid_naming_guide "${live_secret_repo}"
+write_valid_network_policy "${live_secret_repo}"
+write_valid_compose_files "${live_secret_repo}"
+write_valid_env_samples "${live_secret_repo}"
+write_file "${live_secret_repo}" "postgres/.env.sample" "# Sample environment placeholders for the PostgreSQL compose skeleton only.
+# Do not use these placeholder values in production.
+
+AEGISOPS_POSTGRES_PASSWORD=supersecret"
+write_valid_report "${live_secret_repo}"
+commit_fixture "${live_secret_repo}"
+assert_fails_with "${live_secret_repo}" "must not contain live secret-looking values"
+
+direct_exposure_repo="${workdir}/direct-exposure"
+create_repo "${direct_exposure_repo}"
+write_valid_naming_guide "${direct_exposure_repo}"
+write_valid_network_policy "${direct_exposure_repo}"
+write_valid_compose_files "${direct_exposure_repo}"
+write_valid_env_samples "${direct_exposure_repo}"
+write_file "${direct_exposure_repo}" "postgres/docker-compose.yml" "name: aegisops-postgres
+services:
+  postgres:
+    image: postgres:16.4
+    ports:
+      - \"5432:5432\""
+write_valid_report "${direct_exposure_repo}"
+commit_fixture "${direct_exposure_repo}"
+assert_fails_with "${direct_exposure_repo}" "must not publish backend services directly with ports"
 
 echo "verify-compose-skeleton-validation tests passed"

--- a/scripts/verify-compose-skeleton-validation.sh
+++ b/scripts/verify-compose-skeleton-validation.sh
@@ -5,18 +5,27 @@ set -euo pipefail
 default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo_root="${1:-${default_repo_root}}"
 naming_guide_path="${repo_root}/docs/contributor-naming-guide.md"
+network_policy_path="${repo_root}/docs/network-exposure-and-access-path-policy.md"
 validation_doc_path="${repo_root}/docs/compose-skeleton-validation.md"
 
 compose_files=(
   "opensearch/docker-compose.yml"
   "n8n/docker-compose.yml"
+  "postgres/docker-compose.yml"
   "proxy/docker-compose.yml"
   "ingest/docker-compose.yml"
+)
+
+env_sample_files=(
+  ".env.sample"
+  "n8n/.env.sample"
+  "postgres/.env.sample"
 )
 
 expected_project_names=(
   "opensearch/docker-compose.yml:name: aegisops-opensearch"
   "n8n/docker-compose.yml:name: aegisops-n8n"
+  "postgres/docker-compose.yml:name: aegisops-postgres"
   "proxy/docker-compose.yml:name: aegisops-proxy"
   "ingest/docker-compose.yml:name: aegisops-ingest"
 )
@@ -25,6 +34,7 @@ expected_service_names=(
   "opensearch/docker-compose.yml:opensearch"
   "opensearch/docker-compose.yml:dashboards"
   "n8n/docker-compose.yml:n8n"
+  "postgres/docker-compose.yml:postgres"
   "proxy/docker-compose.yml:proxy"
   "ingest/docker-compose.yml:collector"
   "ingest/docker-compose.yml:parser"
@@ -74,15 +84,21 @@ require_fixed_fragment() {
 }
 
 require_file "${naming_guide_path}" "Missing contributor naming guide"
+require_file "${network_policy_path}" "Missing network exposure policy"
 require_file "${validation_doc_path}" "Missing compose skeleton validation result document"
 
 for compose_file in "${compose_files[@]}"; do
   require_file "${repo_root}/${compose_file}" "Missing compose skeleton"
 done
 
+for env_sample_file in "${env_sample_files[@]}"; do
+  require_file "${repo_root}/${env_sample_file}" "Missing sample environment placeholder"
+done
+
 for expected_name in \
   "aegisops-opensearch" \
   "aegisops-n8n" \
+  "aegisops-postgres" \
   "aegisops-ingest" \
   "aegisops-proxy"; do
   require_fixed_fragment \
@@ -112,9 +128,52 @@ done
 if grep -REn '^([[:space:]]*)image:[[:space:]]+[^[:space:]]+:latest$' \
   "${repo_root}/opensearch" \
   "${repo_root}/n8n" \
+  "${repo_root}/postgres" \
   "${repo_root}/proxy" \
   "${repo_root}/ingest" >/dev/null; then
   echo "Checked compose artifacts must not use the latest tag." >&2
+  exit 1
+fi
+
+if git -C "${repo_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if git -C "${repo_root}" ls-files | grep -E '(^|/)\.env$' >/dev/null; then
+    echo "Checked compose artifacts must not commit active .env files." >&2
+    exit 1
+  fi
+fi
+
+if grep -REn '^[[:space:]]*ports:[[:space:]]*(#.*)?$' \
+  "${repo_root}/opensearch" \
+  "${repo_root}/n8n" \
+  "${repo_root}/postgres" \
+  "${repo_root}/proxy" \
+  "${repo_root}/ingest" >/dev/null; then
+  echo "Checked compose skeletons must not publish backend services directly with ports." >&2
+  exit 1
+fi
+
+while IFS= read -r secret_line; do
+  if [[ "${secret_line}" != *=placeholder-not-a-secret ]]; then
+    echo "Checked sample environment placeholders must not contain live secret-looking values." >&2
+    exit 1
+  fi
+done < <(
+  grep -Eh '^[A-Z0-9_]*(PASSWORD|SECRET|TOKEN|KEY)[A-Z0-9_]*=.+' \
+    "${repo_root}/n8n/.env.sample" \
+    "${repo_root}/postgres/.env.sample" || true
+)
+
+if awk '
+  /^[[:space:]]*[A-Z0-9_]*(PASSWORD|SECRET|TOKEN|KEY)[A-Z0-9_]*:[[:space:]]+/ {
+    if ($0 !~ /\$\{/) {
+      found = 1
+    }
+  }
+  END { exit(found ? 0 : 1) }
+' \
+  "${repo_root}/n8n/docker-compose.yml" \
+  "${repo_root}/postgres/docker-compose.yml"; then
+  echo "Checked compose skeletons must not inline live secret-looking values." >&2
   exit 1
 fi
 
@@ -122,8 +181,8 @@ require_fixed_string "${validation_doc_path}" "# Compose Skeleton Validation" \
   "Compose skeleton validation document must use the approved title."
 require_pattern "${validation_doc_path}" '^- Validation date: [0-9]{4}-[0-9]{2}-[0-9]{2}$' \
   "Compose skeleton validation document must record a validation date."
-require_fixed_string "${validation_doc_path}" "- Baseline references: \`docs/contributor-naming-guide.md\`, \`docs/requirements-baseline.md\`" \
-  "Compose skeleton validation document must cite the naming guide and requirements baseline."
+require_fixed_string "${validation_doc_path}" "- Baseline references: \`docs/contributor-naming-guide.md\`, \`docs/requirements-baseline.md\`, \`docs/network-exposure-and-access-path-policy.md\`" \
+  "Compose skeleton validation document must cite the naming guide, requirements baseline, and network exposure policy."
 require_fixed_string "${validation_doc_path}" "- Verification command: \`bash scripts/verify-compose-skeleton-validation.sh\`" \
   "Compose skeleton validation document must record the verification command."
 require_fixed_string "${validation_doc_path}" "- Validation status: PASS" \
@@ -134,6 +193,10 @@ require_fixed_string "${validation_doc_path}" "## Naming Review Result" \
   "Compose skeleton validation document must summarize the naming review."
 require_fixed_string "${validation_doc_path}" "## Image Tag Review Result" \
   "Compose skeleton validation document must summarize the image tag review."
+require_fixed_string "${validation_doc_path}" "## Secret and Env Review Result" \
+  "Compose skeleton validation document must summarize the secret and env review."
+require_fixed_string "${validation_doc_path}" "## Exposure Review Result" \
+  "Compose skeleton validation document must summarize the exposure review."
 require_fixed_string "${validation_doc_path}" "## Deviations" \
   "Compose skeleton validation document must include a deviations section."
 
@@ -142,12 +205,25 @@ for artifact in "${compose_files[@]}"; do
     "Compose skeleton validation document must list ${artifact} as reviewed."
 done
 
+for artifact in "${env_sample_files[@]}"; do
+  require_fixed_string "${validation_doc_path}" "- \`${artifact}\`" \
+    "Compose skeleton validation document must list ${artifact} as reviewed."
+done
+
 require_fixed_fragment "${validation_doc_path}" "approved \`aegisops-\` namespace examples" \
   "Compose skeleton validation document must record the approved Compose project naming result."
-require_fixed_fragment "${validation_doc_path}" "\`opensearch\`, \`dashboards\`, \`n8n\`, \`proxy\`, \`collector\`, and \`parser\`" \
+require_fixed_fragment "${validation_doc_path}" "\`opensearch\`, \`dashboards\`, \`n8n\`, \`postgres\`, \`proxy\`, \`collector\`, and \`parser\`" \
   "Compose skeleton validation document must record the reviewed service names."
 require_fixed_fragment "${validation_doc_path}" "No checked compose artifact uses the \`latest\` image tag." \
   "Compose skeleton validation document must record the image tag review result."
+require_fixed_fragment "${validation_doc_path}" "No checked compose or sample env artifact contains a live secret or production-sensitive value." \
+  "Compose skeleton validation document must record the live secret review result."
+require_fixed_fragment "${validation_doc_path}" "No active \`.env\` file is committed; only tracked \`.env.sample\` placeholders are present." \
+  "Compose skeleton validation document must record the active .env review result."
+require_fixed_fragment "${validation_doc_path}" "No checked compose skeleton publishes backend services directly with \`ports:\`." \
+  "Compose skeleton validation document must record the direct exposure review result."
+require_fixed_fragment "${validation_doc_path}" "approved reverse proxy or internal-only access model" \
+  "Compose skeleton validation document must record network policy alignment."
 require_fixed_string "${validation_doc_path}" "- No deviations found." \
   "Compose skeleton validation document must explicitly record the deviation outcome."
 


### PR DESCRIPTION
## Summary
- tighten the repo-level compose skeleton validation to cover `postgres/docker-compose.yml`, sample env placeholders, tracked active `.env` files, live secret-looking values, and direct `ports:` exposure
- update the recorded compose validation result to document the secret/env review and network exposure policy alignment
- add `aegisops-postgres` to the contributor naming guide examples so the checked compose project set is fully documented

## Why
The individual compose skeleton verifiers already guarded secret placeholders and direct exposure. The gap was the top-level validation contract and report, which could still pass without verifying sample env placeholders, postgres coverage, or policy-aligned exposure assumptions.

## Validation
- `bash scripts/test-verify-compose-skeleton-validation.sh`
- `bash scripts/verify-compose-skeleton-validation.sh`
- `bash scripts/test-verify-n8n-compose-skeleton.sh`
- `bash scripts/test-verify-postgres-compose-skeleton.sh`
- `bash scripts/test-verify-opensearch-compose-skeleton.sh`
- `bash scripts/test-verify-proxy-compose-skeleton.sh`
- `bash scripts/test-verify-ingest-compose-skeleton.sh`

Closes #45
