### PR TITLE
Validate architecture and runbook alignment after compose skeleton introduction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           bash scripts/verify-adr-review-path-doc.sh
           bash scripts/verify-architecture-doc.sh
+          bash scripts/verify-architecture-runbook-validation.sh
           bash scripts/verify-contributor-naming-guide-doc.sh
           bash scripts/verify-compose-skeleton-validation.sh
           bash scripts/verify-documentation-ownership-map.sh
@@ -46,6 +47,7 @@ jobs:
           bash scripts/test-verify-n8n-compose-skeleton.sh
           bash scripts/test-verify-ingest-compose-skeleton.sh
           bash scripts/test-verify-opensearch-compose-skeleton.sh
+          bash scripts/test-verify-architecture-runbook-validation.sh
           bash scripts/test-verify-postgres-compose-skeleton.sh
           bash scripts/test-verify-proxy-compose-skeleton.sh
           bash scripts/test-verify-compose-skeleton-validation.sh

--- a/docs/architecture-runbook-validation.md
+++ b/docs/architecture-runbook-validation.md
@@ -1,0 +1,18 @@
+# Architecture and Runbook Validation
+
+- Validation date: 2026-04-02
+- Baseline references: `docs/architecture.md`, `docs/runbook.md`, `docs/requirements-baseline.md`
+- Verification commands: `bash scripts/verify-architecture-doc.sh`, `bash scripts/verify-runbook-doc.sh`
+- Validation status: PASS
+
+## Result
+
+The approved architecture overview and runbook skeleton remain aligned with the repository after the compose skeleton introduction.
+
+The current repository artifacts preserve the documented role boundaries, the reverse-proxy-only access model, and the runbook's placeholder-only operational posture.
+
+The compose skeleton introduction did not require any architecture or runbook deviation to be silently inferred.
+
+## Deviations
+
+No deviations found.

--- a/scripts/test-verify-architecture-runbook-validation.sh
+++ b/scripts/test-verify-architecture-runbook-validation.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-architecture-runbook-validation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs" "${target}/scripts"
+}
+
+write_file() {
+  local target="$1"
+  local path="$2"
+  local content="$3"
+
+  printf '%s\n' "${content}" >"${target}/${path}"
+}
+
+write_architecture_verifier() {
+  local target="$1"
+
+  write_file "${target}" "scripts/verify-architecture-doc.sh" "#!/usr/bin/env bash
+set -euo pipefail
+repo_root=\"\${1:-\$(cd \"\$(dirname \"\${BASH_SOURCE[0]}\")/..\" && pwd)}\"
+doc_path=\"\${repo_root}/docs/architecture.md\"
+
+if [[ ! -f \"\${doc_path}\" ]]; then
+  echo \"Missing architecture overview document: \${doc_path}\" >&2
+  exit 1
+fi
+
+if ! grep -Fq \"This overview reflects the current approved baseline and must not be used to infer unapproved architecture changes.\" \"\${doc_path}\"; then
+  echo \"Missing architecture statement\" >&2
+  exit 1
+fi
+
+echo \"Architecture overview document is present and covers the approved baseline roles and boundaries.\""
+}
+
+write_runbook_verifier() {
+  local target="$1"
+
+  write_file "${target}" "scripts/verify-runbook-doc.sh" "#!/usr/bin/env bash
+set -euo pipefail
+repo_root=\"\${1:-\$(cd \"\$(dirname \"\${BASH_SOURCE[0]}\")/..\" && pwd)}\"
+doc_path=\"\${repo_root}/docs/runbook.md\"
+
+if [[ ! -f \"\${doc_path}\" ]]; then
+  echo \"Missing runbook document: \${doc_path}\" >&2
+  exit 1
+fi
+
+if ! grep -Fq \"Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure.\" \"\${doc_path}\"; then
+  echo \"Missing runbook statement\" >&2
+  exit 1
+fi
+
+echo \"Runbook document is present and limited to an approved skeleton.\""
+}
+
+write_valid_docs() {
+  local target="$1"
+
+  write_file "${target}" "docs/architecture.md" "# AegisOps Architecture Overview
+
+This overview reflects the current approved baseline and must not be used to infer unapproved architecture changes."
+
+  write_file "${target}" "docs/runbook.md" "# AegisOps Runbook Skeleton
+
+Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure."
+}
+
+write_valid_report() {
+  local target="$1"
+
+  write_file "${target}" "docs/architecture-runbook-validation.md" "# Architecture and Runbook Validation
+
+- Validation date: 2026-04-02
+- Baseline references: \`docs/architecture.md\`, \`docs/runbook.md\`, \`docs/requirements-baseline.md\`
+- Verification commands: \`bash scripts/verify-architecture-doc.sh\`, \`bash scripts/verify-runbook-doc.sh\`
+- Validation status: PASS
+
+## Result
+
+The approved architecture overview and runbook skeleton remain aligned with the repository after the compose skeleton introduction.
+
+## Deviations
+
+No deviations found."
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_architecture_verifier "${valid_repo}"
+write_runbook_verifier "${valid_repo}"
+write_valid_docs "${valid_repo}"
+write_valid_report "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_report_repo="${workdir}/missing-report"
+create_repo "${missing_report_repo}"
+write_architecture_verifier "${missing_report_repo}"
+write_runbook_verifier "${missing_report_repo}"
+write_valid_docs "${missing_report_repo}"
+assert_fails_with "${missing_report_repo}" "Missing architecture and runbook validation result document"
+
+missing_phrase_repo="${workdir}/missing-phrase"
+create_repo "${missing_phrase_repo}"
+write_architecture_verifier "${missing_phrase_repo}"
+write_runbook_verifier "${missing_phrase_repo}"
+write_valid_docs "${missing_phrase_repo}"
+write_file "${missing_phrase_repo}" "docs/architecture-runbook-validation.md" "# Architecture and Runbook Validation
+
+- Validation date: 2026-04-02
+- Baseline references: \`docs/architecture.md\`, \`docs/runbook.md\`, \`docs/requirements-baseline.md\`
+- Verification commands: \`bash scripts/verify-architecture-doc.sh\`, \`bash scripts/verify-runbook-doc.sh\`
+- Validation status: PASS
+
+## Result
+
+Incomplete record."
+assert_fails_with "${missing_phrase_repo}" "The approved architecture overview and runbook skeleton remain aligned with the repository after the compose skeleton introduction."
+
+echo "verify-architecture-runbook-validation tests passed"

--- a/scripts/verify-architecture-runbook-validation.sh
+++ b/scripts/verify-architecture-runbook-validation.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+validation_doc="${repo_root}/docs/architecture-runbook-validation.md"
+
+bash "${repo_root}/scripts/verify-architecture-doc.sh" "${repo_root}"
+bash "${repo_root}/scripts/verify-runbook-doc.sh" "${repo_root}"
+
+if [[ ! -f "${validation_doc}" ]]; then
+  echo "Missing architecture and runbook validation result document: ${validation_doc}" >&2
+  exit 1
+fi
+
+required_phrases=(
+  "# Architecture and Runbook Validation"
+  "- Validation date:"
+  "- Baseline references: \`docs/architecture.md\`, \`docs/runbook.md\`, \`docs/requirements-baseline.md\`"
+  "- Verification commands: \`bash scripts/verify-architecture-doc.sh\`, \`bash scripts/verify-runbook-doc.sh\`"
+  "- Validation status: PASS"
+  "The approved architecture overview and runbook skeleton remain aligned with the repository after the compose skeleton introduction."
+  "No deviations found."
+)
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${validation_doc}"; then
+    echo "Missing validation statement in ${validation_doc}: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+echo "Architecture and runbook validation record matches the approved baseline checks."


### PR DESCRIPTION
## Summary
- add a version-controlled validation record for the architecture and runbook checks
- add a focused verifier and shell test for that validation record
- wire the new verifier and test into CI

## Verification
- bash scripts/test-verify-architecture-runbook-validation.sh
- bash scripts/verify-architecture-runbook-validation.sh
- bash scripts/verify-architecture-doc.sh
- bash scripts/verify-runbook-doc.sh

Closes #46