### PR TITLE
[codex] add OpenSearch index template placeholders

### DIFF
--- a/docs/contributor-naming-guide.md
+++ b/docs/contributor-naming-guide.md
@@ -73,6 +73,7 @@ Examples:
 - `aegisops-logs-windows-*`
 - `aegisops-logs-linux-*`
 - `aegisops-logs-network-*`
+- `aegisops-logs-saas-*`
 - `aegisops-alerts-*`
 - `aegisops-findings-*`
 

--- a/opensearch/index-templates/aegisops-logs-linux-template.json
+++ b/opensearch/index-templates/aegisops-logs-linux-template.json
@@ -1,0 +1,9 @@
+{
+  "index_patterns": [
+    "aegisops-logs-linux-*"
+  ],
+  "template": {},
+  "_meta": {
+    "description": "AegisOps linux log index template placeholder only. Not production-ready."
+  }
+}

--- a/opensearch/index-templates/aegisops-logs-network-template.json
+++ b/opensearch/index-templates/aegisops-logs-network-template.json
@@ -1,0 +1,9 @@
+{
+  "index_patterns": [
+    "aegisops-logs-network-*"
+  ],
+  "template": {},
+  "_meta": {
+    "description": "AegisOps network log index template placeholder only. Not production-ready."
+  }
+}

--- a/opensearch/index-templates/aegisops-logs-saas-template.json
+++ b/opensearch/index-templates/aegisops-logs-saas-template.json
@@ -1,0 +1,9 @@
+{
+  "index_patterns": [
+    "aegisops-logs-saas-*"
+  ],
+  "template": {},
+  "_meta": {
+    "description": "AegisOps saas log index template placeholder only. Not production-ready."
+  }
+}

--- a/opensearch/index-templates/aegisops-logs-windows-template.json
+++ b/opensearch/index-templates/aegisops-logs-windows-template.json
@@ -1,0 +1,9 @@
+{
+  "index_patterns": [
+    "aegisops-logs-windows-*"
+  ],
+  "template": {},
+  "_meta": {
+    "description": "AegisOps windows log index template placeholder only. Not production-ready."
+  }
+}

--- a/scripts/test-verify-contributor-naming-guide-doc.sh
+++ b/scripts/test-verify-contributor-naming-guide-doc.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-contributor-naming-guide-doc.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_doc() {
+  local target="$1"
+  local doc_content="$2"
+
+  printf '%s\n' "${doc_content}" >"${target}/docs/contributor-naming-guide.md"
+  git -C "${target}" add docs/contributor-naming-guide.md
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_doc "${valid_repo}" "# AegisOps Contributor Naming Guide
+
+## Purpose
+
+Guide text.
+
+## Baseline Source
+
+docs/requirements-baseline.md remains the source of truth for naming policy.
+
+## Naming Rules
+
+### Hosts
+
+- aegisops-opensearch-node-01
+- aegisops-n8n-node
+
+### Compose Projects
+
+- aegisops-opensearch
+
+### OpenSearch Indexes
+
+- aegisops-logs-windows-*
+- aegisops-logs-saas-*
+- aegisops-findings-*
+
+### Detectors
+
+- aegisops-windows-suspicious-powershell-high
+
+### n8n Workflows
+
+- aegisops_enrich_ip_reputation
+
+### Environment Variables and Secrets
+
+- AEGISOPS_OPENSEARCH_ADMIN_PASSWORD"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_saas_repo="${workdir}/missing-saas"
+create_repo "${missing_saas_repo}"
+write_doc "${missing_saas_repo}" "# AegisOps Contributor Naming Guide
+
+## Purpose
+
+Guide text.
+
+## Baseline Source
+
+docs/requirements-baseline.md remains the source of truth for naming policy.
+
+## Naming Rules
+
+### Hosts
+
+- aegisops-opensearch-node-01
+- aegisops-n8n-node
+
+### Compose Projects
+
+- aegisops-opensearch
+
+### OpenSearch Indexes
+
+- aegisops-logs-windows-*
+- aegisops-findings-*
+
+### Detectors
+
+- aegisops-windows-suspicious-powershell-high
+
+### n8n Workflows
+
+- aegisops_enrich_ip_reputation
+
+### Environment Variables and Secrets
+
+- AEGISOPS_OPENSEARCH_ADMIN_PASSWORD"
+commit_fixture "${missing_saas_repo}"
+assert_fails_with "${missing_saas_repo}" "aegisops-logs-saas-*"
+
+echo "verify-contributor-naming-guide-doc tests passed"

--- a/scripts/test-verify-opensearch-index-template-placeholders.sh
+++ b/scripts/test-verify-opensearch-index-template-placeholders.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-opensearch-index-template-placeholders.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs" "${target}/opensearch/index-templates"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_file() {
+  local target="$1"
+  local path="$2"
+  local content="$3"
+
+  printf '%s\n' "${content}" >"${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit -q -m "fixture"
+}
+
+write_docs() {
+  local target="$1"
+
+  write_file "${target}" "docs/requirements-baseline.md" "### 7.4 OpenSearch Index Naming
+
+Recommended patterns:
+
+* \`aegisops-logs-windows-*\`
+* \`aegisops-logs-linux-*\`
+* \`aegisops-logs-network-*\`
+* \`aegisops-logs-saas-*\`"
+
+  write_file "${target}" "docs/contributor-naming-guide.md" "### OpenSearch Indexes
+
+- \`aegisops-logs-windows-*\`
+- \`aegisops-logs-linux-*\`
+- \`aegisops-logs-network-*\`
+- \`aegisops-logs-saas-*\`"
+}
+
+write_placeholders() {
+  local target="$1"
+
+  for family in windows linux network saas; do
+    write_file "${target}" "opensearch/index-templates/aegisops-logs-${family}-template.json" "{
+  \"index_patterns\": [
+    \"aegisops-logs-${family}-*\"
+  ],
+  \"template\": {},
+  \"_meta\": {
+    \"description\": \"AegisOps ${family} log index template placeholder only. Not production-ready.\"
+  }
+}"
+  done
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_docs "${valid_repo}"
+write_placeholders "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_template_repo="${workdir}/missing-template"
+create_repo "${missing_template_repo}"
+write_docs "${missing_template_repo}"
+write_placeholders "${missing_template_repo}"
+rm "${missing_template_repo}/opensearch/index-templates/aegisops-logs-saas-template.json"
+git -C "${missing_template_repo}" add -u
+commit_fixture "${missing_template_repo}"
+assert_fails_with "${missing_template_repo}" "aegisops-logs-saas-template.json"
+
+ilm_repo="${workdir}/ilm-placeholder"
+create_repo "${ilm_repo}"
+write_docs "${ilm_repo}"
+write_placeholders "${ilm_repo}"
+write_file "${ilm_repo}" "opensearch/index-templates/aegisops-logs-linux-template.json" "{
+  \"index_patterns\": [
+    \"aegisops-logs-linux-*\"
+  ],
+  \"template\": {
+    \"settings\": {
+      \"index.lifecycle.name\": \"logs-hot-warm\"
+    }
+  },
+  \"_meta\": {
+    \"description\": \"AegisOps linux log index template placeholder only. Not production-ready.\"
+  }
+}"
+commit_fixture "${ilm_repo}"
+assert_fails_with "${ilm_repo}" "must not define ILM behavior"
+
+echo "verify-opensearch-index-template-placeholders tests passed"

--- a/scripts/verify-contributor-naming-guide-doc.sh
+++ b/scripts/verify-contributor-naming-guide-doc.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
 doc_path="${repo_root}/docs/contributor-naming-guide.md"
 
 required_headings=(
@@ -22,6 +23,7 @@ required_examples=(
   "aegisops-n8n-node"
   "aegisops-opensearch"
   "aegisops-logs-windows-*"
+  "aegisops-logs-saas-*"
   "aegisops-findings-*"
   "aegisops-windows-suspicious-powershell-high"
   "aegisops_enrich_ip_reputation"

--- a/scripts/verify-opensearch-index-template-placeholders.sh
+++ b/scripts/verify-opensearch-index-template-placeholders.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+templates_dir="${repo_root}/opensearch/index-templates"
+baseline_doc="${repo_root}/docs/requirements-baseline.md"
+naming_guide_doc="${repo_root}/docs/contributor-naming-guide.md"
+
+families=(
+  "windows"
+  "linux"
+  "network"
+  "saas"
+)
+
+if ! git -C "${repo_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not a Git working tree: ${repo_root}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${templates_dir}" ]]; then
+  echo "Missing OpenSearch index template directory: ${templates_dir}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${baseline_doc}" ]]; then
+  echo "Missing baseline document: ${baseline_doc}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${naming_guide_doc}" ]]; then
+  echo "Missing contributor naming guide: ${naming_guide_doc}" >&2
+  exit 1
+fi
+
+for family in "${families[@]}"; do
+  pattern="aegisops-logs-${family}-*"
+  template_path="${templates_dir}/aegisops-logs-${family}-template.json"
+
+  if ! grep -Fq "${pattern}" "${baseline_doc}"; then
+    echo "Baseline is missing approved index naming pattern: ${pattern}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "${pattern}" "${naming_guide_doc}"; then
+    echo "Contributor naming guide is missing approved index naming pattern: ${pattern}" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "${template_path}" ]]; then
+    echo "Missing OpenSearch index template placeholder: ${template_path}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "\"${pattern}\"" "${template_path}"; then
+    echo "Template placeholder must declare the approved index pattern: ${template_path}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "placeholder only" "${template_path}"; then
+    echo "Template placeholder must state that it is a placeholder only: ${template_path}" >&2
+    exit 1
+  fi
+
+  if grep -Fq '"mappings"' "${template_path}"; then
+    echo "Template placeholder must not define production-ready mappings: ${template_path}" >&2
+    exit 1
+  fi
+
+  if grep -Fq '"index.lifecycle' "${template_path}"; then
+    echo "Template placeholder must not define ILM behavior: ${template_path}" >&2
+    exit 1
+  fi
+done
+
+echo "OpenSearch index template placeholders match the approved log-family naming baseline."


### PR DESCRIPTION
## What changed
- add placeholder OpenSearch index template files for the approved windows, linux, network, and saas log families under `opensearch/index-templates/`
- add a focused verifier and test for the placeholder template set
- align the contributor naming guide and its verifier with the approved `aegisops-logs-saas-*` pattern

## Why
The repository documented the approved OpenSearch log-family naming model, but it did not yet contain the corresponding placeholder index template files or a focused check that those placeholder assets exist and stay aligned with the naming baseline.

## Impact
- reserves the expected template file layout for future OpenSearch work without introducing production mappings or ILM behavior
- makes naming drift around the approved log-family set detectable in local verification

## Validation
- `bash scripts/test-verify-contributor-naming-guide-doc.sh`
- `bash scripts/test-verify-opensearch-index-template-placeholders.sh`
- `bash scripts/verify-contributor-naming-guide-doc.sh`
- `bash scripts/verify-opensearch-index-template-placeholders.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added index templates for Windows, Linux, Network, and SaaS logs to standardize indexing patterns.
  * Expanded naming conventions documentation to include SaaS log patterns.

* **Tests**
  * Added automated validation scripts for index template and naming guide compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->