### PR TITLE
docs: add OpenSearch index template placeholder guidance

### DIFF
--- a/opensearch/index-templates/README.md
+++ b/opensearch/index-templates/README.md
@@ -1,0 +1,36 @@
+# AegisOps OpenSearch Index Template Placeholders
+
+This document explains the purpose and current limits of the tracked OpenSearch index template placeholders.
+
+## 1. Purpose
+
+These files exist to reserve the approved OpenSearch log index-template names and directory ownership for AegisOps contributors.
+
+They are placeholders only and are not production-ready index templates.
+
+## 2. Placeholder Scope
+
+- Keep the approved `aegisops-logs-<family>-*` naming pattern visible in version control.
+- Reserve a stable location for future index-template work under the approved `opensearch/` repository boundary.
+- Make it clear that the current JSON files are scaffolding for contributors and reviewers, not finished OpenSearch content.
+
+## 3. What Remains Out of Scope
+
+Do not treat the current files as approved mappings, settings, shard plans, lifecycle policies, or ingestion contracts.
+
+- Production field mappings and analyzers.
+- Index lifecycle management, rollover, and retention behavior.
+- Environment-specific shard counts, replica counts, or performance tuning.
+- Template priorities, aliases, or pipeline attachments beyond the current placeholder state.
+
+## 4. Contributor Guidance
+
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+
+When updating these placeholders, keep them descriptive-only and aligned to the approved naming baseline until production template requirements are formally documented.
+
+## 5. Reference Documents
+
+- `docs/requirements-baseline.md`
+- `docs/contributor-naming-guide.md`
+- `docs/repository-structure-baseline.md`

--- a/scripts/test-verify-opensearch-index-template-guidance.sh
+++ b/scripts/test-verify-opensearch-index-template-guidance.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-opensearch-index-template-guidance.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/opensearch/index-templates"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_file() {
+  local target="$1"
+  local path="$2"
+  local content="$3"
+
+  printf '%s\n' "${content}" >"${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+write_valid_doc() {
+  local target="$1"
+
+  write_file "${target}" "opensearch/index-templates/README.md" "# AegisOps OpenSearch Index Template Placeholders
+
+This document explains the purpose and current limits of the tracked OpenSearch index template placeholders.
+
+## 1. Purpose
+
+These files exist to reserve the approved OpenSearch log index-template names and directory ownership for AegisOps contributors.
+
+They are placeholders only and are not production-ready index templates.
+
+## 2. Placeholder Scope
+
+- Keep the approved \`aegisops-logs-<family>-*\` naming pattern visible in version control.
+- Reserve a stable location for future index-template work under the approved \`opensearch/\` repository boundary.
+- Make it clear that the current JSON files are scaffolding for contributors and reviewers, not finished OpenSearch content.
+
+## 3. What Remains Out of Scope
+
+Do not treat the current files as approved mappings, settings, shard plans, lifecycle policies, or ingestion contracts.
+
+- Production field mappings and analyzers.
+- Index lifecycle management, rollover, and retention behavior.
+- Environment-specific shard counts, replica counts, or performance tuning.
+- Template priorities, aliases, or pipeline attachments beyond the current placeholder state.
+
+## 4. Contributor Guidance
+
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+
+When updating these placeholders, keep them descriptive-only and aligned to the approved naming baseline until production template requirements are formally documented.
+
+## 5. Reference Documents
+
+- \`docs/requirements-baseline.md\`
+- \`docs/contributor-naming-guide.md\`
+- \`docs/repository-structure-baseline.md\`"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_valid_doc "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing OpenSearch index template guidance document"
+
+missing_reference_repo="${workdir}/missing-reference"
+create_repo "${missing_reference_repo}"
+write_file "${missing_reference_repo}" "opensearch/index-templates/README.md" "# AegisOps OpenSearch Index Template Placeholders
+
+This document explains the purpose and current limits of the tracked OpenSearch index template placeholders.
+
+## 1. Purpose
+
+These files exist to reserve the approved OpenSearch log index-template names and directory ownership for AegisOps contributors.
+
+They are placeholders only and are not production-ready index templates.
+
+## 2. Placeholder Scope
+
+- Keep the approved \`aegisops-logs-<family>-*\` naming pattern visible in version control.
+- Reserve a stable location for future index-template work under the approved \`opensearch/\` repository boundary.
+- Make it clear that the current JSON files are scaffolding for contributors and reviewers, not finished OpenSearch content.
+
+## 3. What Remains Out of Scope
+
+Do not treat the current files as approved mappings, settings, shard plans, lifecycle policies, or ingestion contracts.
+
+- Production field mappings and analyzers.
+- Index lifecycle management, rollover, and retention behavior.
+- Environment-specific shard counts, replica counts, or performance tuning.
+- Template priorities, aliases, or pipeline attachments beyond the current placeholder state.
+
+## 4. Contributor Guidance
+
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+
+When updating these placeholders, keep them descriptive-only and aligned to the approved naming baseline until production template requirements are formally documented.
+
+## 5. Reference Documents
+
+- \`docs/requirements-baseline.md\`
+- \`docs/repository-structure-baseline.md\`"
+commit_fixture "${missing_reference_repo}"
+assert_fails_with "${missing_reference_repo}" "Missing OpenSearch index template guidance reference"
+
+echo "OpenSearch index template guidance verifier tests passed."

--- a/scripts/verify-opensearch-index-template-guidance.sh
+++ b/scripts/verify-opensearch-index-template-guidance.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+doc_path="${repo_root}/opensearch/index-templates/README.md"
+
+required_headings=(
+  "## 1. Purpose"
+  "## 2. Placeholder Scope"
+  "## 3. What Remains Out of Scope"
+  "## 4. Contributor Guidance"
+  "## 5. Reference Documents"
+)
+
+required_phrases=(
+  "These files exist to reserve the approved OpenSearch log index-template names and directory ownership for AegisOps contributors."
+  "They are placeholders only and are not production-ready index templates."
+  "Do not treat the current files as approved mappings, settings, shard plans, lifecycle policies, or ingestion contracts."
+  "Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline."
+)
+
+required_references=(
+  '`docs/requirements-baseline.md`'
+  '`docs/contributor-naming-guide.md`'
+  '`docs/repository-structure-baseline.md`'
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing OpenSearch index template guidance document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing OpenSearch index template guidance heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Missing OpenSearch index template guidance statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for reference in "${required_references[@]}"; do
+  if ! grep -Fq "${reference}" "${doc_path}"; then
+    echo "Missing OpenSearch index template guidance reference: ${reference}" >&2
+    exit 1
+  fi
+done
+
+echo "OpenSearch index template guidance documents placeholder intent, limits, and baseline references."


### PR DESCRIPTION
## Summary
- add placeholder guidance under `opensearch/index-templates/` to explain intent and current limits
- add a focused verifier for the guidance document and a fixture-based test for that verifier
- keep the tracked OpenSearch index template placeholders unchanged

## Verification
- `bash scripts/verify-opensearch-index-template-guidance.sh`
- `bash scripts/test-verify-opensearch-index-template-guidance.sh`
- `bash scripts/verify-opensearch-index-template-placeholders.sh`

Refs #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for OpenSearch index templates, defining scope, purpose, and contributor best practices while clarifying out-of-scope items.

* **Tests**
  * Added automated validation to verify compliance with index template guidance documentation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->