### PR TITLE
[codex] add sigma suppressed skeleton markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For the detailed approved structure, see:
 - `docs/repository-structure-baseline.md`
 - `docs/requirements-baseline.md`
 
-Within `sigma/`, the `curated/` directory is reserved for reviewed Sigma rules that are approved for future onboarding. Placeholder markers may exist there before any actual detection content is admitted.
+Within `sigma/`, the `curated/` directory is reserved for reviewed Sigma rules that are approved for future onboarding, and the `suppressed/` directory is reserved for future documented suppression decisions. Placeholder markers may exist there before any actual rule or suppression content is admitted.
 
 ---
 

--- a/docs/repository-structure-baseline.md
+++ b/docs/repository-structure-baseline.md
@@ -29,3 +29,5 @@ It translates the repository structure guidance from `docs/requirements-baseline
 - New top-level directories require explicit approval because they change the repository baseline.
 - `.codex-supervisor/` is supervisor-local working state and is not an approved tracked top-level repository entry.
 - This document defines structure only and does not authorize runtime, deployment, or workflow implementation.
+
+Within `sigma/`, placeholder marker files may reserve approved homes such as `curated/` and `suppressed/` before any real detection or suppression content is admitted.

--- a/scripts/test-verify-sigma-suppressed-skeleton.sh
+++ b/scripts/test-verify-sigma-suppressed-skeleton.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-sigma-suppressed-skeleton.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_suppressed_readme() {
+  local target="$1"
+  local content="$2"
+
+  mkdir -p "${target}/sigma/suppressed"
+  printf '%s\n' "${content}" > "${target}/sigma/suppressed/README.md"
+}
+
+assert_passes() {
+  local target="$1"
+  if ! "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+  if "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+passing_repo="${workdir}/passing"
+create_repo "${passing_repo}"
+write_suppressed_readme \
+  "${passing_repo}" \
+"# Sigma Suppressed Directory
+
+Purpose: approved home for future Sigma suppression decisions that have been reviewed and documented.
+Status: placeholder only; no active Sigma suppression rules, exceptions, or decisions are committed here yet.
+Any future suppression entry must include documented justification, review, and approval before real content is added."
+assert_passes "${passing_repo}"
+
+missing_marker_repo="${workdir}/missing-marker"
+create_repo "${missing_marker_repo}"
+write_suppressed_readme \
+  "${missing_marker_repo}" \
+"# Sigma Suppressed Directory
+
+Purpose: approved home for future Sigma suppression decisions that have been reviewed and documented."
+assert_fails_with \
+  "${missing_marker_repo}" \
+  "Missing required sigma suppressed marker text: Status: placeholder only; no active Sigma suppression rules, exceptions, or decisions are committed here yet."
+
+unexpected_file_repo="${workdir}/unexpected-file"
+create_repo "${unexpected_file_repo}"
+write_suppressed_readme \
+  "${unexpected_file_repo}" \
+"# Sigma Suppressed Directory
+
+Purpose: approved home for future Sigma suppression decisions that have been reviewed and documented.
+Status: placeholder only; no active Sigma suppression rules, exceptions, or decisions are committed here yet.
+Any future suppression entry must include documented justification, review, and approval before real content is added."
+printf 'suppression: real-decision\n' > "${unexpected_file_repo}/sigma/suppressed/decision.yml"
+assert_fails_with \
+  "${unexpected_file_repo}" \
+  "Unexpected placeholder content in ${unexpected_file_repo}/sigma/suppressed; only ${unexpected_file_repo}/sigma/suppressed/README.md is allowed."
+
+unexpected_directory_repo="${workdir}/unexpected-directory"
+create_repo "${unexpected_directory_repo}"
+write_suppressed_readme \
+  "${unexpected_directory_repo}" \
+"# Sigma Suppressed Directory
+
+Purpose: approved home for future Sigma suppression decisions that have been reviewed and documented.
+Status: placeholder only; no active Sigma suppression rules, exceptions, or decisions are committed here yet.
+Any future suppression entry must include documented justification, review, and approval before real content is added."
+mkdir -p "${unexpected_directory_repo}/sigma/suppressed/pending"
+assert_fails_with \
+  "${unexpected_directory_repo}" \
+  "Unexpected placeholder content in ${unexpected_directory_repo}/sigma/suppressed; only ${unexpected_directory_repo}/sigma/suppressed/README.md is allowed."
+
+echo "verify-sigma-suppressed-skeleton tests passed"

--- a/scripts/verify-sigma-suppressed-skeleton.sh
+++ b/scripts/verify-sigma-suppressed-skeleton.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+suppressed_dir="${repo_root}/sigma/suppressed"
+readme_path="${suppressed_dir}/README.md"
+
+required_markers=(
+  "Purpose: approved home for future Sigma suppression decisions that have been reviewed and documented."
+  "Status: placeholder only; no active Sigma suppression rules, exceptions, or decisions are committed here yet."
+  "Any future suppression entry must include documented justification, review, and approval before real content is added."
+)
+
+if [[ ! -d "${suppressed_dir}" ]]; then
+  echo "Missing sigma suppressed directory: ${suppressed_dir}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing sigma suppressed placeholder marker: ${readme_path}" >&2
+  exit 1
+fi
+
+for marker in "${required_markers[@]}"; do
+  if ! grep -Fq "${marker}" "${readme_path}"; then
+    echo "Missing required sigma suppressed marker text: ${marker}" >&2
+    exit 1
+  fi
+done
+
+unexpected_entries=()
+while IFS= read -r path; do
+  unexpected_entries+=("${path}")
+done < <(find "${suppressed_dir}" -mindepth 1 ! -path "${readme_path}" | LC_ALL=C sort)
+
+if (( ${#unexpected_entries[@]} > 0 )); then
+  echo "Unexpected placeholder content in ${suppressed_dir}; only ${readme_path} is allowed." >&2
+  printf ' %s\n' "${unexpected_entries[@]}" >&2
+  exit 1
+fi
+
+echo "Sigma suppressed skeleton markers are present and placeholder-safe."

--- a/sigma/suppressed/README.md
+++ b/sigma/suppressed/README.md
@@ -1,0 +1,9 @@
+# Sigma Suppressed Directory
+
+Purpose: approved home for future Sigma suppression decisions that have been reviewed and documented.
+
+Status: placeholder only; no active Sigma suppression rules, exceptions, or decisions are committed here yet.
+
+This directory reserves the approved location for future documented suppression entries after review.
+
+Any future suppression entry must include documented justification, review, and approval before real content is added.


### PR DESCRIPTION
## Summary
- add a focused verifier and fixture test for `sigma/suppressed/` placeholder markers
- add `sigma/suppressed/README.md` as the approved placeholder-safe home for future suppression decisions
- document the suppressed placeholder path in the repository docs without adding any real suppression content

## Why
The repository reserved Sigma curated content but did not yet reserve an explicit placeholder-safe location for future documented suppression decisions.

## Validation
- `scripts/verify-sigma-suppressed-skeleton.sh`
- `scripts/test-verify-sigma-suppressed-skeleton.sh`
- `scripts/test-verify-sigma-curated-skeleton.sh`

Closes #64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository structure documentation to clarify the `suppressed` directory, reserved for documented suppression decisions.
  * Added notes clarifying placeholder marker files for reserved subdirectories.

* **Tests**
  * Added new verification tests to validate the suppressed directory placeholder structure and content requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->