### PR TITLE
[codex] docs: add sigma curated content guidance

### DIFF
--- a/scripts/test-verify-sigma-guidance-doc.sh
+++ b/scripts/test-verify-sigma-guidance-doc.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-sigma-guidance-doc.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/sigma"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_doc() {
+  local target="$1"
+  local doc_content="$2"
+
+  printf '%s\n' "${doc_content}" >"${target}/sigma/README.md"
+  git -C "${target}" add sigma/README.md
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_doc "${valid_repo}" '# AegisOps Sigma Content Guidance
+
+## Purpose
+
+This document records the approved governance model for Sigma content tracked in this repository.
+
+The baseline source of truth remains docs/requirements-baseline.md.
+
+## Directory Roles
+
+### `curated/`
+
+This directory is reserved for reviewed Sigma rules that are approved for future AegisOps onboarding.
+
+A rule belongs in `curated/` when it has passed content review and is retained as an approved candidate for future platform onboarding.
+
+### `suppressed/`
+
+This directory is reserved for documented suppression decisions for Sigma content that should remain excluded from onboarding.
+
+An entry belongs in `suppressed/` when the decision to exclude or defer Sigma content must be preserved with documented rationale, review, and approval context.
+
+## Review Expectations
+
+Any future addition under either directory must remain reviewable, attributable, and explicitly approved before placeholder-only status is removed.
+
+## Validation Expectations
+
+Contributors must validate that directory purpose, review state, and supporting documentation remain clear before merging changes.
+
+## Scope Boundary
+
+This document defines repository content governance only. It does not activate detections, create suppression behavior, or change runtime execution in OpenSearch, Sigma tooling, or n8n.'
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing Sigma guidance document:"
+
+missing_validation_repo="${workdir}/missing-validation"
+create_repo "${missing_validation_repo}"
+write_doc "${missing_validation_repo}" '# AegisOps Sigma Content Guidance
+
+## Purpose
+
+This document records the approved governance model for Sigma content tracked in this repository.
+
+The baseline source of truth remains docs/requirements-baseline.md.
+
+## Directory Roles
+
+### `curated/`
+
+This directory is reserved for reviewed Sigma rules that are approved for future AegisOps onboarding.
+
+A rule belongs in `curated/` when it has passed content review and is retained as an approved candidate for future platform onboarding.
+
+### `suppressed/`
+
+This directory is reserved for documented suppression decisions for Sigma content that should remain excluded from onboarding.
+
+An entry belongs in `suppressed/` when the decision to exclude or defer Sigma content must be preserved with documented rationale, review, and approval context.
+
+## Review Expectations
+
+Any future addition under either directory must remain reviewable, attributable, and explicitly approved before placeholder-only status is removed.
+
+## Scope Boundary
+
+This document defines repository content governance only. It does not activate detections, create suppression behavior, or change runtime execution in OpenSearch, Sigma tooling, or n8n.'
+commit_fixture "${missing_validation_repo}"
+assert_fails_with "${missing_validation_repo}" "Missing heading in Sigma guidance document: ## Validation Expectations"
+
+echo "verify-sigma-guidance-doc tests passed"

--- a/scripts/verify-sigma-guidance-doc.sh
+++ b/scripts/verify-sigma-guidance-doc.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+doc_path="${repo_root}/sigma/README.md"
+
+required_headings=(
+  "## Purpose"
+  "## Directory Roles"
+  '### `curated/`'
+  '### `suppressed/`'
+  "## Review Expectations"
+  "## Validation Expectations"
+  "## Scope Boundary"
+)
+
+required_markers=(
+  "reviewed Sigma rules that are approved for future AegisOps onboarding"
+  "documented suppression decisions for Sigma content that should remain excluded from onboarding"
+  'A rule belongs in `curated/` when it has passed content review and is retained as an approved candidate for future platform onboarding.'
+  'An entry belongs in `suppressed/` when the decision to exclude or defer Sigma content must be preserved with documented rationale, review, and approval context.'
+  "Any future addition under either directory must remain reviewable, attributable, and explicitly approved before placeholder-only status is removed."
+  "Contributors must validate that directory purpose, review state, and supporting documentation remain clear before merging changes."
+  "This document defines repository content governance only. It does not activate detections, create suppression behavior, or change runtime execution in OpenSearch, Sigma tooling, or n8n."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Sigma guidance document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing heading in Sigma guidance document: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for marker in "${required_markers[@]}"; do
+  if ! grep -Fq "${marker}" "${doc_path}"; then
+    echo "Missing required Sigma guidance text: ${marker}" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Fq "docs/requirements-baseline.md" "${doc_path}"; then
+  echo "Sigma guidance document must cite docs/requirements-baseline.md as the baseline source." >&2
+  exit 1
+fi
+
+echo "Sigma guidance document is present and covers curated content governance."

--- a/sigma/README.md
+++ b/sigma/README.md
@@ -1,0 +1,47 @@
+# AegisOps Sigma Content Guidance
+
+## Purpose
+
+This document records the approved governance model for Sigma content tracked under `sigma/` and supplements the Sigma baseline in `docs/requirements-baseline.md`.
+
+It explains how AegisOps distinguishes reviewed curated content from documented suppressed content so future contributors preserve the approved onboarding and review model.
+
+## Directory Roles
+
+### `curated/`
+
+`sigma/curated/` is reserved for reviewed Sigma rules that are approved for future AegisOps onboarding.
+
+A rule belongs in `curated/` when it has passed content review and is retained as an approved candidate for future platform onboarding.
+
+Placeholder-only status in this directory must remain explicit until real Sigma content is admitted through review and approval.
+
+### `suppressed/`
+
+`sigma/suppressed/` is reserved for documented suppression decisions for Sigma content that should remain excluded from onboarding.
+
+An entry belongs in `suppressed/` when the decision to exclude or defer Sigma content must be preserved with documented rationale, review, and approval context.
+
+This directory is for governance records about exclusion or deferral, not for quietly disabling detections through undocumented repository changes.
+
+## Review Expectations
+
+Any future addition under either directory must remain reviewable, attributable, and explicitly approved before placeholder-only status is removed.
+
+Changes should preserve clear authorship, decision context, and rationale so reviewers can distinguish approved onboarding candidates from approved exclusion decisions.
+
+If a contribution changes the intended governance model for Sigma content, that change must be reviewed against `docs/requirements-baseline.md` and handled through the normal baseline review path.
+
+## Validation Expectations
+
+Contributors must validate that directory purpose, review state, and supporting documentation remain clear before merging changes.
+
+Validation for Sigma repository content should confirm:
+
+- the directory purpose still matches the approved distinction between curated and suppressed content
+- placeholder markers or future entries remain internally consistent with their stated review status
+- review and approval language remains explicit enough for future onboarding and audit work
+
+## Scope Boundary
+
+This document defines repository content governance only. It does not activate detections, create suppression behavior, or change runtime execution in OpenSearch, Sigma tooling, or n8n.


### PR DESCRIPTION
## Summary
- add Sigma governance guidance under `sigma/`
- explain the distinction between curated onboarding candidates and suppressed exclusion records
- add a focused verifier and test for the guidance document without changing runtime behavior

## Validation
- `bash scripts/test-verify-sigma-guidance-doc.sh`
- `bash scripts/test-verify-sigma-curated-skeleton.sh`
- `bash scripts/test-verify-sigma-suppressed-skeleton.sh`

Closes #69.
