### PR TITLE
[codex] docs: add AegisOps n8n workflow category guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           bash scripts/verify-naming-conventions-doc.sh
           bash scripts/verify-network-exposure-policy-doc.sh
           bash scripts/verify-n8n-compose-skeleton.sh
+          bash scripts/verify-n8n-workflow-category-guidance.sh
           bash scripts/verify-n8n-workflow-skeleton.sh
           bash scripts/verify-opensearch-compose-skeleton.sh
           bash scripts/verify-parameter-catalog-alignment.sh
@@ -48,6 +49,7 @@ jobs:
       - name: Run focused shell tests
         run: |
           bash scripts/test-verify-n8n-compose-skeleton.sh
+          bash scripts/test-verify-n8n-workflow-category-guidance.sh
           bash scripts/test-verify-n8n-workflow-skeleton.sh
           bash scripts/test-verify-ingest-compose-skeleton.sh
           bash scripts/test-verify-opensearch-compose-skeleton.sh

--- a/n8n/workflows/README.md
+++ b/n8n/workflows/README.md
@@ -1,0 +1,47 @@
+# AegisOps n8n Workflow Category Guidance
+
+This document explains the approved purpose and current boundaries of the tracked n8n workflow categories in AegisOps.
+
+## 1. Purpose
+
+This directory exists to document the approved workflow-category boundaries for AegisOps n8n assets.
+
+The approved workflow categories are alert ingest, enrich, approve, notify, and response.
+
+## 2. Approved Workflow Categories
+
+- `aegisops_alert_ingest` reserves the category for workflows that receive validated findings or alerts into the SOAR layer after detection has already occurred elsewhere.
+- `aegisops_enrich` reserves the category for read-oriented context gathering, lookup, and triage support steps that help analysts evaluate an alert.
+- `aegisops_approve` reserves the category for explicit approval handling before approval-required actions continue.
+- `aegisops_notify` reserves the category for notification, escalation, and operator-routing steps that communicate approved workflow state.
+- `aegisops_response` reserves the category for controlled downstream execution after validation and required approvals are complete.
+
+## 3. Placeholder Boundary
+
+Placeholder directories and marker files under `n8n/workflows/` are not production workflows.
+
+They reserve approved homes for future workflow assets without claiming that exported workflows, credentials, triggers, or integrations are already implemented here.
+
+Do not infer live runtime behavior, integration coverage, or production-ready response logic from the current placeholders.
+
+## 4. Control vs Execution Alignment
+
+OpenSearch remains responsible for detection and analytics, while n8n is limited to approved orchestration, enrichment, approval handling, notification routing, and controlled downstream execution.
+
+This separation preserves the approved control-versus-execution model: alerts are detected in the analytics plane first, then routed into the orchestration plane for reviewable enrichment, approval, notification, and response handling.
+
+The guidance in this directory does not authorize direct destructive actions from raw inbound alerts, hidden write operations inside read-only workflows, or approval bypass by implementation detail.
+
+## 5. Contributor Guidance
+
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+
+Keep future workflow additions within the approved category boundary and preserve explicit approval gates for write or destructive actions.
+
+When real workflow assets are introduced in later approved work, they should remain auditable, clearly named, and explicit about whether a step is read-only, notify-only, approval-handling, or response-executing.
+
+## 6. Reference Documents
+
+- `docs/architecture.md`
+- `docs/requirements-baseline.md`
+- `docs/repository-structure-baseline.md`

--- a/scripts/test-verify-n8n-workflow-category-guidance.sh
+++ b/scripts/test-verify-n8n-workflow-category-guidance.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-n8n-workflow-category-guidance.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/n8n/workflows"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+write_valid_doc() {
+  local target="$1"
+
+  cat >"${target}/n8n/workflows/README.md" <<'EOF'
+# AegisOps n8n Workflow Category Guidance
+
+This document explains the approved purpose and current boundaries of the tracked n8n workflow categories in AegisOps.
+
+## 1. Purpose
+
+This directory exists to document the approved workflow-category boundaries for AegisOps n8n assets.
+
+The approved workflow categories are alert ingest, enrich, approve, notify, and response.
+
+## 2. Approved Workflow Categories
+
+- `aegisops_alert_ingest` reserves the category for workflows that receive validated findings or alerts into the SOAR layer.
+- `aegisops_enrich` reserves the category for read-oriented context gathering and triage support steps.
+- `aegisops_approve` reserves the category for explicit approval handling before approval-required actions continue.
+- `aegisops_notify` reserves the category for notification and operator-routing steps.
+- `aegisops_response` reserves the category for controlled downstream execution after validation and required approvals are complete.
+
+## 3. Placeholder Boundary
+
+Placeholder directories and marker files under `n8n/workflows/` are not production workflows.
+
+Do not infer live runtime behavior, integration coverage, or production-ready response logic from the current placeholders.
+
+## 4. Control vs Execution Alignment
+
+OpenSearch remains responsible for detection and analytics, while n8n is limited to approved orchestration, enrichment, approval handling, notification routing, and controlled downstream execution.
+
+This separation preserves the approved control-versus-execution model and prevents raw detections from becoming unreviewed direct response actions.
+
+## 5. Contributor Guidance
+
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+
+Keep future workflow additions within the approved category boundary and preserve explicit approval gates for write or destructive actions.
+
+## 6. Reference Documents
+
+- `docs/architecture.md`
+- `docs/requirements-baseline.md`
+- `docs/repository-structure-baseline.md`
+EOF
+  git -C "${target}" add n8n/workflows/README.md
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_valid_doc "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing n8n workflow category guidance document"
+
+missing_statement_repo="${workdir}/missing-statement"
+create_repo "${missing_statement_repo}"
+cat >"${missing_statement_repo}/n8n/workflows/README.md" <<'EOF'
+# AegisOps n8n Workflow Category Guidance
+
+This document explains the approved purpose and current boundaries of the tracked n8n workflow categories in AegisOps.
+
+## 1. Purpose
+
+This directory exists to document the approved workflow-category boundaries for AegisOps n8n assets.
+
+The approved workflow categories are alert ingest, enrich, approve, notify, and response.
+
+## 2. Approved Workflow Categories
+
+- `aegisops_alert_ingest` reserves the category for workflows that receive validated findings or alerts into the SOAR layer.
+- `aegisops_enrich` reserves the category for read-oriented context gathering and triage support steps.
+- `aegisops_approve` reserves the category for explicit approval handling before approval-required actions continue.
+- `aegisops_notify` reserves the category for notification and operator-routing steps.
+- `aegisops_response` reserves the category for controlled downstream execution after validation and required approvals are complete.
+
+## 3. Placeholder Boundary
+
+Placeholder directories and marker files under `n8n/workflows/` are not production workflows.
+
+## 4. Control vs Execution Alignment
+
+OpenSearch remains responsible for detection and analytics, while n8n is limited to approved orchestration, enrichment, approval handling, notification routing, and controlled downstream execution.
+
+## 5. Contributor Guidance
+
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+
+## 6. Reference Documents
+
+- `docs/architecture.md`
+- `docs/requirements-baseline.md`
+- `docs/repository-structure-baseline.md`
+EOF
+git -C "${missing_statement_repo}" add n8n/workflows/README.md
+commit_fixture "${missing_statement_repo}"
+assert_fails_with "${missing_statement_repo}" "Missing n8n workflow category guidance statement"
+
+missing_reference_repo="${workdir}/missing-reference"
+create_repo "${missing_reference_repo}"
+cat >"${missing_reference_repo}/n8n/workflows/README.md" <<'EOF'
+# AegisOps n8n Workflow Category Guidance
+
+This document explains the approved purpose and current boundaries of the tracked n8n workflow categories in AegisOps.
+
+## 1. Purpose
+
+This directory exists to document the approved workflow-category boundaries for AegisOps n8n assets.
+
+The approved workflow categories are alert ingest, enrich, approve, notify, and response.
+
+## 2. Approved Workflow Categories
+
+- `aegisops_alert_ingest` reserves the category for workflows that receive validated findings or alerts into the SOAR layer.
+- `aegisops_enrich` reserves the category for read-oriented context gathering and triage support steps.
+- `aegisops_approve` reserves the category for explicit approval handling before approval-required actions continue.
+- `aegisops_notify` reserves the category for notification and operator-routing steps.
+- `aegisops_response` reserves the category for controlled downstream execution after validation and required approvals are complete.
+
+## 3. Placeholder Boundary
+
+Placeholder directories and marker files under `n8n/workflows/` are not production workflows.
+
+Do not infer live runtime behavior, integration coverage, or production-ready response logic from the current placeholders.
+
+## 4. Control vs Execution Alignment
+
+OpenSearch remains responsible for detection and analytics, while n8n is limited to approved orchestration, enrichment, approval handling, notification routing, and controlled downstream execution.
+
+## 5. Contributor Guidance
+
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+
+## 6. Reference Documents
+
+- `docs/architecture.md`
+- `docs/requirements-baseline.md`
+EOF
+git -C "${missing_reference_repo}" add n8n/workflows/README.md
+commit_fixture "${missing_reference_repo}"
+assert_fails_with "${missing_reference_repo}" "Missing n8n workflow category guidance reference"
+
+echo "n8n workflow category guidance verifier tests passed."

--- a/scripts/verify-n8n-workflow-category-guidance.sh
+++ b/scripts/verify-n8n-workflow-category-guidance.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+doc_path="${repo_root}/n8n/workflows/README.md"
+
+required_headings=(
+  "## 1. Purpose"
+  "## 2. Approved Workflow Categories"
+  "## 3. Placeholder Boundary"
+  "## 4. Control vs Execution Alignment"
+  "## 5. Contributor Guidance"
+  "## 6. Reference Documents"
+)
+
+required_phrases=(
+  "This directory exists to document the approved workflow-category boundaries for AegisOps n8n assets."
+  "The approved workflow categories are alert ingest, enrich, approve, notify, and response."
+  'Placeholder directories and marker files under `n8n/workflows/` are not production workflows.'
+  "OpenSearch remains responsible for detection and analytics, while n8n is limited to approved orchestration, enrichment, approval handling, notification routing, and controlled downstream execution."
+  "Do not infer live runtime behavior, integration coverage, or production-ready response logic from the current placeholders."
+  "Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline."
+)
+
+required_references=(
+  '`docs/architecture.md`'
+  '`docs/requirements-baseline.md`'
+  '`docs/repository-structure-baseline.md`'
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing n8n workflow category guidance document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing n8n workflow category guidance heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Missing n8n workflow category guidance statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for reference in "${required_references[@]}"; do
+  if ! grep -Fq "${reference}" "${doc_path}"; then
+    echo "Missing n8n workflow category guidance reference: ${reference}" >&2
+    exit 1
+  fi
+done
+
+echo "n8n workflow category guidance documents approved categories, placeholder limits, and control-versus-execution boundaries."


### PR DESCRIPTION
## Summary
- add `n8n/workflows/README.md` documenting the approved `alert_ingest`, `enrich`, `approve`, `notify`, and `response` workflow categories
- state explicitly that workflow placeholders under `n8n/workflows/` are not production workflows and must not be used to infer live runtime behavior
- add a focused verifier, shell test, and CI wiring so the category guidance remains aligned with the control-vs-execution baseline

## Why
Issue #70 requires baseline-safe guidance for the approved n8n workflow categories without changing runtime behavior. The added verifier keeps the documentation contract reviewable and prevents future drift.

## Impact
This change is documentation and verification only. It does not add runtime workflows, integrations, credentials, or response behavior.

## Testing
- bash scripts/verify-n8n-workflow-category-guidance.sh
- bash scripts/test-verify-n8n-workflow-category-guidance.sh
- bash scripts/verify-n8n-workflow-skeleton.sh
- bash scripts/test-verify-n8n-workflow-skeleton.sh
- bash scripts/verify-adr-review-path-doc.sh
- bash scripts/verify-architecture-doc.sh
- bash scripts/verify-architecture-runbook-validation.sh
- bash scripts/verify-contributor-naming-guide-doc.sh
- bash scripts/verify-compose-skeleton-validation.sh
- bash scripts/verify-compose-skeleton-overview-doc.sh
- bash scripts/verify-documentation-ownership-map.sh
- bash scripts/verify-ingest-compose-skeleton.sh
- bash scripts/verify-naming-conventions-doc.sh
- bash scripts/verify-network-exposure-policy-doc.sh
- bash scripts/verify-n8n-compose-skeleton.sh
- bash scripts/verify-opensearch-compose-skeleton.sh
- bash scripts/verify-parameter-catalog-alignment.sh
- bash scripts/verify-parameter-catalog-structure-doc.sh
- bash scripts/verify-parameter-category-docs.sh
- bash scripts/verify-parameter-config-files.sh
- bash scripts/verify-postgres-compose-skeleton.sh
- bash scripts/verify-proxy-compose-skeleton.sh
- bash scripts/verify-repository-skeleton.sh
- bash scripts/verify-repository-structure-doc.sh
- bash scripts/verify-runbook-doc.sh
- bash scripts/verify-sigma-curated-skeleton.sh
- bash scripts/verify-storage-policy-doc.sh
- bash scripts/test-verify-n8n-compose-skeleton.sh
- bash scripts/test-verify-ingest-compose-skeleton.sh
- bash scripts/test-verify-opensearch-compose-skeleton.sh
- bash scripts/test-verify-architecture-runbook-validation.sh
- bash scripts/test-verify-postgres-compose-skeleton.sh
- bash scripts/test-verify-proxy-compose-skeleton.sh
- bash scripts/test-verify-compose-skeleton-validation.sh
- bash scripts/test-verify-compose-skeleton-overview-doc.sh
- bash scripts/test-verify-repository-skeleton.sh
- bash scripts/test-verify-sigma-curated-skeleton.sh

Closes #70


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added n8n workflow category guidance documentation outlining approved categories, role assignments, placeholder clarifications, and contributor guidelines for maintaining workflow boundaries.

* **Tests**
  * Added test suite to validate workflow category verification requirements including success and failure cases.

* **Chores**
  * Added automated CI pipeline checks to enforce and monitor n8n workflow category compliance throughout the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->