### PR TITLE
docs: define source onboarding contract for normalized telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/requirements-baseline.md`
 - `docs/architecture.md`
 - `docs/canonical-telemetry-schema-baseline.md`
+- `docs/source-onboarding-contract.md`
 - `docs/secops-domain-model.md`
 - `docs/runbook.md`
 - `docs/repository-structure-baseline.md`

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -26,6 +26,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | ---- | ---- | ---- |
 | `docs/requirements-baseline.md` | Requirements baseline | IT Operations, Information Systems Department |
 | `docs/canonical-telemetry-schema-baseline.md` | Canonical telemetry schema baseline | IT Operations, Information Systems Department |
+| `docs/source-onboarding-contract.md` | Source onboarding contract baseline | IT Operations, Information Systems Department |
 | `docs/secops-domain-model.md` | SecOps domain model baseline | IT Operations, Information Systems Department |
 | `docs/adr/` | Architecture Decision Records (ADRs) | IT Operations, Information Systems Department |
 | `docs/parameters/` | Parameter documentation | IT Operations, Information Systems Department |
@@ -38,6 +39,8 @@ ADR records under `docs/adr/` may identify specific document proposers or review
 The SecOps domain model document remains the shared semantic reference for baseline object definitions and state boundaries and must stay aligned with the approved architecture and requirements baseline.
 
 The canonical telemetry schema baseline remains the shared semantic reference for normalized event field expectations and must stay aligned with ECS usage rules, source provenance requirements, and the approved SecOps domain model.
+
+The source onboarding contract baseline remains the shared readiness reference for admitting new telemetry families and must stay aligned with the canonical telemetry schema baseline, provenance expectations, and explicit non-goals for sources that are not yet detection-ready.
 
 Parameter documents under `docs/parameters/` remain the authoritative human-readable home for parameter references, category explanations, ownership notes, and review guidance.
 

--- a/docs/source-onboarding-contract.md
+++ b/docs/source-onboarding-contract.md
@@ -1,0 +1,96 @@
+# AegisOps Source Onboarding Contract
+
+## 1. Purpose
+
+This document defines the minimum onboarding contract for any telemetry source family that seeks admission into the AegisOps normalized telemetry baseline.
+
+It establishes the required evidence, ownership, field coverage, provenance, and readiness checks that must exist before downstream detection content can rely on a source family.
+
+This contract governs documentation and validation expectations only. It does not approve live ingestion, parser deployment, source credentials, or runtime onboarding behavior.
+
+## 2. Contract Scope and Non-Goals
+
+The contract applies to source families rather than one-off products or ad hoc integrations.
+
+Each source family onboarding package must identify the source family description, parser ownership, raw payload reference, normalization mapping, and sample data plan.
+
+This contract does not approve live collector enrollment, parser rollout, source-side credentials, or production activation of detectors.
+
+This contract also does not require every future source family to be detection-ready immediately. It requires every source family to declare its current readiness state and evidence gaps explicitly.
+
+## 3. Minimum Onboarding Package
+
+Every source family onboarding package must provide the minimum artifacts below before review can treat the family as schema-reviewed.
+
+| Artifact | Expectation |
+| ---- | ---- |
+| Source family description | Required artifact |
+| Parser ownership and lifecycle | Required artifact |
+| Raw payload reference | Required artifact |
+| Normalization mapping | Required artifact |
+| Sample data and replay plan | Required artifact |
+
+Minimum package interpretation:
+
+- The source family description must explain the family boundary, what products or event classes it covers, and why it belongs to one canonical family rather than another.
+- Parser ownership and lifecycle must identify the owning team or maintainer, the parser implementation boundary, and how versioned parser changes will be reviewed.
+- Raw payload reference must point to representative source-native records or wrapped ingest-boundary records that preserve original source meaning.
+- Normalization mapping must show how source-native fields map into the canonical telemetry schema and where values remain source-specific under approved provenance or extension rules.
+- Sample data and replay plan must define the approved validation corpus for future parser and mapping checks without implying live ingestion approval.
+
+## 4. Detection-Ready Evidence Requirements
+
+Detection-ready status requires explicit evidence for canonical field coverage, timestamp quality, identity linkage, asset linkage, provenance, and parser version traceability.
+
+Field coverage evidence must map source fields into the canonical telemetry schema baseline and must identify required, optional, unavailable, and intentionally deferred fields without ambiguity.
+
+Timestamp evidence must identify the source event time, any collector-created time, ingest arrival time, known clock-quality limitations, and the chosen mapping for `@timestamp`, `event.created`, and `event.ingested`.
+
+Identity and asset linkage evidence must show which principals, hosts, workloads, tenants, devices, or observers the source can represent and where that context is absent or unreliable.
+
+Provenance evidence must preserve source product, provider, module or dataset, collector path, and parser version details so normalized events remain traceable to their collection path.
+
+A source family is not detection-ready until parser version evidence, field coverage evidence, and provenance evidence are documented and reviewable.
+
+Detection-ready review must also confirm the following:
+
+- The normalization mapping uses canonical schema semantics first and reserves `aegisops.*` extensions for additive cases that ECS does not already cover.
+- Required field groups from the canonical telemetry schema are either populated, marked unavailable with justification, or explicitly deferred with a documented non-goal.
+- Timestamp quality limitations are preserved as evidence rather than hidden by silently rewriting source meaning.
+- Identity and asset linkage claims are supported by actual source fields, not by fabricated enrichment assumptions.
+- Detection authors can determine exactly which normalized fields are stable enough to depend on before activating rule content for the family.
+
+## 5. Replay and Sample Data Expectations
+
+Replay-capable sample data must be sufficient for future parser and mapping validation without implying that live source onboarding is approved.
+
+Sample datasets must preserve provenance, capture representative success and failure cases, and document any redaction or synthetic substitutions.
+
+Sources that are not yet detection-ready must state their explicit non-goals, known schema gaps, and why downstream detections must not depend on them yet.
+
+Replay and sample-data expectations include:
+
+- At least one representative raw payload set for normal successful parsing and one set for malformed, partial, or edge-case records when those cases matter to schema coverage.
+- Documentation of whether samples are vendor-provided examples, internally captured payloads, synthetic fixtures, or redacted operational records.
+- Sufficient examples to validate field coverage, timestamp behavior, provenance preservation, and identity or asset linkage claims for the family.
+- Clear notes when a source family is admitted only as a future candidate so replay assets exist for design work but not for live onboarding.
+
+## 6. Readiness States
+
+Readiness states must distinguish at least `candidate`, `schema-reviewed`, and `detection-ready` source families.
+
+State expectations:
+
+- `candidate` means the family is recognized, scoped, and documented enough to reserve a future onboarding path, but detection content must not depend on it.
+- `schema-reviewed` means the minimum onboarding package exists and the canonical mapping and evidence gaps have been reviewed, but detection activation remains blocked until readiness evidence is complete.
+- `detection-ready` means the family has completed the required evidence package and may be referenced by future detection content subject to separate detector and rollout review.
+
+This contract is schema-driven and family-oriented. It must not become source-specific ad hoc guidance for individual products.
+
+## 7. Baseline Alignment Notes
+
+This contract remains aligned to `docs/canonical-telemetry-schema-baseline.md` and does not approve runtime parsers, ingest pipelines, or credential handling.
+
+It also remains aligned to `docs/secops-domain-model.md` by treating normalized telemetry readiness as distinct from detection activation, alert routing, approval workflows, and response execution.
+
+Future implementation work may add parser code, replay tooling, or source-specific assets, but those changes require separate approved issues and must continue to satisfy this onboarding contract.

--- a/scripts/test-verify-source-onboarding-contract-doc.sh
+++ b/scripts/test-verify-source-onboarding-contract-doc.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-source-onboarding-contract-doc.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_doc() {
+  local target="$1"
+  local doc_content="$2"
+
+  printf '%s\n' "${doc_content}" >"${target}/docs/source-onboarding-contract.md"
+  git -C "${target}" add docs/source-onboarding-contract.md
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_doc "${valid_repo}" '# AegisOps Source Onboarding Contract
+
+## 1. Purpose
+
+This document defines the minimum onboarding contract for any telemetry source family that seeks admission into the AegisOps normalized telemetry baseline.
+
+It establishes the required evidence, ownership, field coverage, provenance, and readiness checks that must exist before downstream detection content can rely on a source family.
+
+This contract governs documentation and validation expectations only. It does not approve live ingestion, parser deployment, source credentials, or runtime onboarding behavior.
+
+## 2. Contract Scope and Non-Goals
+
+Each source family onboarding package must identify the source family description, parser ownership, raw payload reference, normalization mapping, and sample data plan.
+
+## 3. Minimum Onboarding Package
+
+| Artifact | Expectation |
+| ---- | ---- |
+| Source family description | Required artifact |
+| Parser ownership and lifecycle | Required artifact |
+| Raw payload reference | Required artifact |
+| Normalization mapping | Required artifact |
+| Sample data and replay plan | Required artifact |
+
+## 4. Detection-Ready Evidence Requirements
+
+Detection-ready status requires explicit evidence for canonical field coverage, timestamp quality, identity linkage, asset linkage, provenance, and parser version traceability.
+
+Field coverage evidence must map source fields into the canonical telemetry schema baseline and must identify required, optional, unavailable, and intentionally deferred fields without ambiguity.
+
+Timestamp evidence must identify the source event time, any collector-created time, ingest arrival time, known clock-quality limitations, and the chosen mapping for `@timestamp`, `event.created`, and `event.ingested`.
+
+Identity and asset linkage evidence must show which principals, hosts, workloads, tenants, devices, or observers the source can represent and where that context is absent or unreliable.
+
+Provenance evidence must preserve source product, provider, module or dataset, collector path, and parser version details so normalized events remain traceable to their collection path.
+
+A source family is not detection-ready until parser version evidence, field coverage evidence, and provenance evidence are documented and reviewable.
+
+## 5. Replay and Sample Data Expectations
+
+Replay-capable sample data must be sufficient for future parser and mapping validation without implying that live source onboarding is approved.
+
+Sample datasets must preserve provenance, capture representative success and failure cases, and document any redaction or synthetic substitutions.
+
+Sources that are not yet detection-ready must state their explicit non-goals, known schema gaps, and why downstream detections must not depend on them yet.
+
+## 6. Readiness States
+
+Readiness states must distinguish at least `candidate`, `schema-reviewed`, and `detection-ready` source families.
+
+This contract is schema-driven and family-oriented. It must not become source-specific ad hoc guidance for individual products.
+
+## 7. Baseline Alignment Notes
+
+This contract remains aligned to `docs/canonical-telemetry-schema-baseline.md` and does not approve runtime parsers, ingest pipelines, or credential handling.'
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing source onboarding contract document:"
+
+missing_state_repo="${workdir}/missing-state"
+create_repo "${missing_state_repo}"
+write_doc "${missing_state_repo}" '# AegisOps Source Onboarding Contract
+
+## 1. Purpose
+
+This document defines the minimum onboarding contract for any telemetry source family that seeks admission into the AegisOps normalized telemetry baseline.
+
+It establishes the required evidence, ownership, field coverage, provenance, and readiness checks that must exist before downstream detection content can rely on a source family.
+
+This contract governs documentation and validation expectations only. It does not approve live ingestion, parser deployment, source credentials, or runtime onboarding behavior.
+
+## 2. Contract Scope and Non-Goals
+
+Each source family onboarding package must identify the source family description, parser ownership, raw payload reference, normalization mapping, and sample data plan.
+
+## 3. Minimum Onboarding Package
+
+| Artifact | Expectation |
+| ---- | ---- |
+| Source family description | Required artifact |
+| Parser ownership and lifecycle | Required artifact |
+| Raw payload reference | Required artifact |
+| Normalization mapping | Required artifact |
+| Sample data and replay plan | Required artifact |
+
+## 4. Detection-Ready Evidence Requirements
+
+Detection-ready status requires explicit evidence for canonical field coverage, timestamp quality, identity linkage, asset linkage, provenance, and parser version traceability.
+
+Field coverage evidence must map source fields into the canonical telemetry schema baseline and must identify required, optional, unavailable, and intentionally deferred fields without ambiguity.
+
+Timestamp evidence must identify the source event time, any collector-created time, ingest arrival time, known clock-quality limitations, and the chosen mapping for `@timestamp`, `event.created`, and `event.ingested`.
+
+Identity and asset linkage evidence must show which principals, hosts, workloads, tenants, devices, or observers the source can represent and where that context is absent or unreliable.
+
+Provenance evidence must preserve source product, provider, module or dataset, collector path, and parser version details so normalized events remain traceable to their collection path.
+
+A source family is not detection-ready until parser version evidence, field coverage evidence, and provenance evidence are documented and reviewable.
+
+## 5. Replay and Sample Data Expectations
+
+Replay-capable sample data must be sufficient for future parser and mapping validation without implying that live source onboarding is approved.
+
+Sample datasets must preserve provenance, capture representative success and failure cases, and document any redaction or synthetic substitutions.
+
+Sources that are not yet detection-ready must state their explicit non-goals, known schema gaps, and why downstream detections must not depend on them yet.
+
+## 6. Readiness States
+
+This contract is schema-driven and family-oriented. It must not become source-specific ad hoc guidance for individual products.
+
+## 7. Baseline Alignment Notes
+
+This contract remains aligned to `docs/canonical-telemetry-schema-baseline.md` and does not approve runtime parsers, ingest pipelines, or credential handling.'
+commit_fixture "${missing_state_repo}"
+assert_fails_with "${missing_state_repo}" 'Readiness states must distinguish at least `candidate`, `schema-reviewed`, and `detection-ready` source families.'
+
+echo "verify-source-onboarding-contract-doc tests passed"

--- a/scripts/verify-documentation-ownership-map.sh
+++ b/scripts/verify-documentation-ownership-map.sh
@@ -18,6 +18,7 @@ required_phrases=(
   "Document owner means the team accountable for keeping the document area current, reviewable, and aligned with the approved baseline and accepted ADRs."
   '| `docs/requirements-baseline.md` | Requirements baseline | IT Operations, Information Systems Department |'
   '| `docs/canonical-telemetry-schema-baseline.md` | Canonical telemetry schema baseline | IT Operations, Information Systems Department |'
+  '| `docs/source-onboarding-contract.md` | Source onboarding contract baseline | IT Operations, Information Systems Department |'
   '| `docs/secops-domain-model.md` | SecOps domain model baseline | IT Operations, Information Systems Department |'
   '| `docs/adr/` | Architecture Decision Records (ADRs) | IT Operations, Information Systems Department |'
   '| `docs/parameters/` | Parameter documentation | IT Operations, Information Systems Department |'

--- a/scripts/verify-source-onboarding-contract-doc.sh
+++ b/scripts/verify-source-onboarding-contract-doc.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/source-onboarding-contract.md"
+
+required_headings=(
+  "# AegisOps Source Onboarding Contract"
+  "## 1. Purpose"
+  "## 2. Contract Scope and Non-Goals"
+  "## 3. Minimum Onboarding Package"
+  "## 4. Detection-Ready Evidence Requirements"
+  "## 5. Replay and Sample Data Expectations"
+  "## 6. Readiness States"
+  "## 7. Baseline Alignment Notes"
+)
+
+required_phrases=(
+  "This document defines the minimum onboarding contract for any telemetry source family that seeks admission into the AegisOps normalized telemetry baseline."
+  "It establishes the required evidence, ownership, field coverage, provenance, and readiness checks that must exist before downstream detection content can rely on a source family."
+  "This contract governs documentation and validation expectations only. It does not approve live ingestion, parser deployment, source credentials, or runtime onboarding behavior."
+  "Each source family onboarding package must identify the source family description, parser ownership, raw payload reference, normalization mapping, and sample data plan."
+  '| Source family description | Required artifact |'
+  '| Parser ownership and lifecycle | Required artifact |'
+  '| Raw payload reference | Required artifact |'
+  '| Normalization mapping | Required artifact |'
+  '| Sample data and replay plan | Required artifact |'
+  "Detection-ready status requires explicit evidence for canonical field coverage, timestamp quality, identity linkage, asset linkage, provenance, and parser version traceability."
+  "Field coverage evidence must map source fields into the canonical telemetry schema baseline and must identify required, optional, unavailable, and intentionally deferred fields without ambiguity."
+  'Timestamp evidence must identify the source event time, any collector-created time, ingest arrival time, known clock-quality limitations, and the chosen mapping for `@timestamp`, `event.created`, and `event.ingested`.'
+  "Identity and asset linkage evidence must show which principals, hosts, workloads, tenants, devices, or observers the source can represent and where that context is absent or unreliable."
+  "Provenance evidence must preserve source product, provider, module or dataset, collector path, and parser version details so normalized events remain traceable to their collection path."
+  "A source family is not detection-ready until parser version evidence, field coverage evidence, and provenance evidence are documented and reviewable."
+  "Replay-capable sample data must be sufficient for future parser and mapping validation without implying that live source onboarding is approved."
+  "Sample datasets must preserve provenance, capture representative success and failure cases, and document any redaction or synthetic substitutions."
+  "Sources that are not yet detection-ready must state their explicit non-goals, known schema gaps, and why downstream detections must not depend on them yet."
+  'Readiness states must distinguish at least `candidate`, `schema-reviewed`, and `detection-ready` source families.'
+  "This contract is schema-driven and family-oriented. It must not become source-specific ad hoc guidance for individual products."
+  'This contract remains aligned to `docs/canonical-telemetry-schema-baseline.md` and does not approve runtime parsers, ingest pipelines, or credential handling.'
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing source onboarding contract document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing source onboarding contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Missing source onboarding contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+echo "Source onboarding contract document is present and defines the required onboarding evidence, readiness states, and sample-data expectations."


### PR DESCRIPTION
## Summary
- add a schema-driven source onboarding contract for normalized telemetry families
- define minimum onboarding artifacts, readiness states, evidence requirements, and replay/sample-data expectations
- add focused verification for the new contract and update documentation discoverability/ownership references

## Testing
- bash scripts/verify-source-onboarding-contract-doc.sh
- bash scripts/test-verify-source-onboarding-contract-doc.sh
- bash scripts/verify-documentation-ownership-map.sh
- bash scripts/verify-canonical-telemetry-schema-doc.sh

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced new source onboarding contract documentation defining minimum requirements for telemetry sources, including evidence of schema review, readiness states, and validation expectations.
  * Updated documentation index and ownership mapping to reflect new onboarding guidelines.

* **Tests**
  * Added validation tests to ensure onboarding contract requirements are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->