### PR TITLE
[codex] define AegisOps finding-to-alert, case, and disposition model

### DIFF
--- a/docs/secops-domain-model.md
+++ b/docs/secops-domain-model.md
@@ -16,6 +16,7 @@ This document defines baseline semantics, ownership boundaries, and state transi
 | `Normalized Event` | Telemetry transformed into the approved event schema used by the analytics plane. |
 | `Detection Rule` | Reviewed detection logic that evaluates normalized telemetry and declares matching conditions. |
 | `Finding` | Detection result produced when a detection rule matches relevant telemetry. |
+| `Correlation` | Explicit relationship that links related findings, alerts, cases, assets, or identities because they share meaningful operator-facing context. |
 | `Alert` | Routed analyst-facing notification or queue item created from one or more findings that require attention. |
 | `Case` | Investigation record that groups analyst work, related alerts, evidence, and response coordination for one work item. |
 | `Incident` | Higher-order security event declaration used when one or more cases represent a material security event that needs coordinated handling. |
@@ -34,6 +35,8 @@ A `Raw Event` becomes a `Normalized Event` when the analytics plane has accepted
 A `Detection Rule` evaluates `Normalized Event` records. It does not own source telemetry, approvals, or action execution.
 
 A finding is the normalized analytic assertion that detection logic matched relevant telemetry.
+
+Correlation is the explicit relationship that links related findings, alerts, cases, assets, or identities because they share meaningful operator-facing context.
 
 An alert is the routed operator-facing notification or queue item created from one or more findings after baseline triage policy decides analyst attention is required.
 
@@ -73,6 +76,7 @@ OpenSearch findings, n8n workflow runs, and future case state must remain separa
 | `Normalized Event` | OpenSearch ingestion and analytics plane | The analytics plane owns normalized telemetry shape and analytic readiness. |
 | `Detection Rule` | Sigma for reviewed source definition; OpenSearch for deployed runtime materialization | Sigma remains the reviewable rule-definition source, while OpenSearch owns the deployed detector representation used at runtime. |
 | `Finding` | OpenSearch detection and analytics plane | A finding is an analytics-plane output and must not be redefined as workflow state. |
+| `Correlation` | Future AegisOps correlation and triage control layer | Correlation records operator-meaningful relationships without replacing the lifecycle of the linked records. |
 | `Alert` | Future AegisOps alert routing and triage control layer | Alert lifecycle belongs to the future control layer that decides routing, deduplication, and analyst attention. |
 | `Case` | Future AegisOps case management control layer | Case lifecycle must be owned separately from analytics outputs and workflow runs. |
 | `Incident` | Future AegisOps incident command and coordination control layer | Incident lifecycle is the coordinated operational record above individual cases. |
@@ -84,7 +88,53 @@ OpenSearch findings, n8n workflow runs, and future case state must remain separa
 | `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state | n8n and its workflow state store own execution attempts and completion records, not the approval verdict. |
 | `Disposition` | The owner of the record being closed | Disposition belongs to the lifecycle authority of the finding, alert, case, or incident it classifies. |
 
-## 5. Baseline Alignment Notes
+## 5. Promotion and Correlation Rules
+
+A finding promotes to an alert only when triage policy determines that analyst attention, tracking, notification, or downstream workflow handling is required.
+
+A finding may remain a finding without becoming an alert when the result is retained only for analytics, threshold accumulation, tuning review, or later correlation and does not yet require direct operator handling.
+
+Correlation links records by shared context, but it does not by itself create an alert, open a case, or declare an incident.
+
+Correlation may connect records through common asset, identity, detection family, campaign hypothesis, time-bounded pattern, or other analyst-meaningful context, but it must not merge unrelated claims into a single lifecycle record without an explicit promotion decision.
+
+An alert promotes to a case only when the operator needs a durable work record for investigation, evidence handling, ownership, or response coordination beyond the alert queue item itself.
+
+An incident is declared only when one or more cases represent a material security event that requires coordinated operational handling beyond a single investigative work item.
+
+## 6. Grouping, Deduplication, and Case Creation Expectations
+
+A case must not be created for every alert by default.
+
+Grouping means related findings may be collected under one alert when they express the same operator-facing claim closely enough that one analyst work item can review them coherently.
+
+Deduplication means additional findings are attached to an existing alert or case when they restate the same analytic claim against materially the same operational target within the active review window.
+
+A new alert must be created instead of deduplicating when severity, target scope, response owner, or review window changes enough that analyst handling would differ.
+
+Grouping and deduplication must reduce alert volume without erasing accountability. The retained alert or case must still preserve references to the contributing findings and the rule used to collapse them.
+
+A case is created when analyst work requires durable ownership, evidence collection, note-taking, handoff, or coordinated response beyond the alert record itself.
+
+An alert may be closed without a case when the required analyst review fits inside the alert lifecycle and does not require broader investigation management.
+
+## 7. Disposition and Closure Taxonomy
+
+Closure disposition must classify both operational outcome and future tuning implications in reviewable terms.
+
+The same label may appear across findings, alerts, cases, and incidents, but each record type owns its own disposition decision and rationale.
+
+| Disposition | Meaning | Tuning implication |
+| ---- | ---- | ---- |
+| `False Positive` | The analytic claim was incorrect. | Detection logic, enrichment, or source mapping should be corrected or tightened. |
+| `Benign Positive` | The activity occurred as detected but does not represent harmful or policy-violating behavior in context. | Detection scope, routing, or enrichment may need adjustment so expected benign activity is separated from true security work. |
+| `Duplicate` | The record does not represent new work because another active or closed record already tracks the same claim. | Grouping and deduplication logic should preserve linkage and avoid repeated analyst work. |
+| `Expected Administrative Activity` | The activity is legitimate administrative, maintenance, or approved operational work that should remain distinguishable from suspicious behavior. | Tuning should prefer explicit allowlisting, context enrichment, or operator guidance rather than treating the event as unexplained noise. |
+| `Accepted Risk` | The activity or exposure is known and consciously accepted by the accountable owner, so no further investigative escalation is required under the current baseline. | Future alerts should retain the acceptance context and review horizon rather than reopening identical work without changed conditions. |
+
+Disposition must not be used to hide unresolved ownership. If the operator cannot explain why a record is closed, the record is not ready for closure.
+
+## 8. Baseline Alignment Notes
 
 This baseline keeps detection, investigation, approval, and execution as separate first-class concerns.
 

--- a/scripts/test-verify-secops-domain-model-doc.sh
+++ b/scripts/test-verify-secops-domain-model-doc.sh
@@ -80,6 +80,7 @@ This document defines baseline semantics, ownership boundaries, and state transi
 | `Normalized Event` | Event translated into the approved analytic schema. |
 | `Detection Rule` | Reviewed detection logic that evaluates normalized telemetry. |
 | `Finding` | Detection result produced when rule logic matches telemetry. |
+| `Correlation` | Explicit relationship that links related records through shared operator-facing context. |
 | `Alert` | Routed analyst-facing item created from findings that require attention. |
 | `Case` | Investigation record for an analyst work item. |
 | `Incident` | Coordinated security event declaration across one or more cases. |
@@ -94,6 +95,8 @@ This document defines baseline semantics, ownership boundaries, and state transi
 ## 3. Relationship and State Boundaries
 
 A finding is the normalized analytic assertion that detection logic matched relevant telemetry.
+
+Correlation is the explicit relationship that links related findings, alerts, cases, assets, or identities because they share meaningful operator-facing context.
 
 An alert is the routed operator-facing notification or queue item created from one or more findings after baseline triage policy decides analyst attention is required.
 
@@ -112,12 +115,41 @@ OpenSearch findings, n8n workflow runs, and future case state must remain separa
 | Object or boundary | Baseline system of record |
 | ---- | ---- |
 | `Finding` | OpenSearch detection and analytics plane |
+| `Correlation` | Future AegisOps correlation and triage control layer |
 | `Alert` | Future AegisOps alert routing and triage control layer |
 | `Case` | Future AegisOps case management control layer |
 | `Approval Decision` | Future AegisOps approval control layer |
 | `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state |
 
-## 5. Baseline Alignment Notes
+## 5. Promotion and Correlation Rules
+
+A finding promotes to an alert only when triage policy determines that analyst attention, tracking, notification, or downstream workflow handling is required.
+
+Correlation links records by shared context, but it does not by itself create an alert, open a case, or declare an incident.
+
+## 6. Grouping, Deduplication, and Case Creation Expectations
+
+A case must not be created for every alert by default.
+
+Deduplication means additional findings are attached to an existing alert or case when they restate the same analytic claim against materially the same operational target within the active review window.
+
+A new alert must be created instead of deduplicating when severity, target scope, response owner, or review window changes enough that analyst handling would differ.
+
+A case is created when analyst work requires durable ownership, evidence collection, note-taking, handoff, or coordinated response beyond the alert record itself.
+
+An incident is declared only when one or more cases represent a material security event that requires coordinated operational handling beyond a single investigative work item.
+
+## 7. Disposition and Closure Taxonomy
+
+| Disposition | Meaning |
+| ---- | ---- |
+| `False Positive` | The analytic claim was incorrect. |
+| `Benign Positive` | The activity occurred as detected but does not represent harmful or policy-violating behavior in context. |
+| `Duplicate` | The record does not represent new work because another active or closed record already tracks the same claim. |
+| `Expected Administrative Activity` | The activity is legitimate administrative, maintenance, or approved operational work that should remain distinguishable from suspicious behavior. |
+| `Accepted Risk` | The activity or exposure is known and consciously accepted by the accountable owner, so no further investigative escalation is required under the current baseline. |
+
+## 8. Baseline Alignment Notes
 
 The baseline keeps detection, approval, and execution as separate control decisions.'
 commit_fixture "${valid_repo}"
@@ -161,6 +193,8 @@ This document defines baseline semantics, ownership boundaries, and state transi
 
 A finding is the normalized analytic assertion that detection logic matched relevant telemetry.
 
+Correlation is the explicit relationship that links related findings, alerts, cases, assets, or identities because they share meaningful operator-facing context.
+
 An alert is the routed operator-facing notification or queue item created from one or more findings after baseline triage policy decides analyst attention is required.
 
 A case is the investigation record that groups alerts, evidence, analyst notes, and response coordination for one work item.
@@ -176,15 +210,129 @@ An action execution records the actual downstream attempt or completion state fo
 | Object or boundary | Baseline system of record |
 | ---- | ---- |
 | `Finding` | OpenSearch detection and analytics plane |
+| `Correlation` | Future AegisOps correlation and triage control layer |
 | `Alert` | Future AegisOps alert routing and triage control layer |
 | `Case` | Future AegisOps case management control layer |
 | `Approval Decision` | Future AegisOps approval control layer |
 | `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state |
 
-## 5. Baseline Alignment Notes
+## 5. Promotion and Correlation Rules
+
+A finding promotes to an alert only when triage policy determines that analyst attention, tracking, notification, or downstream workflow handling is required.
+
+Correlation links records by shared context, but it does not by itself create an alert, open a case, or declare an incident.
+
+## 6. Grouping, Deduplication, and Case Creation Expectations
+
+A case must not be created for every alert by default.
+
+Deduplication means additional findings are attached to an existing alert or case when they restate the same analytic claim against materially the same operational target within the active review window.
+
+A new alert must be created instead of deduplicating when severity, target scope, response owner, or review window changes enough that analyst handling would differ.
+
+A case is created when analyst work requires durable ownership, evidence collection, note-taking, handoff, or coordinated response beyond the alert record itself.
+
+An incident is declared only when one or more cases represent a material security event that requires coordinated operational handling beyond a single investigative work item.
+
+## 7. Disposition and Closure Taxonomy
+
+| Disposition | Meaning |
+| ---- | ---- |
+| `False Positive` | The analytic claim was incorrect. |
+| `Benign Positive` | The activity occurred as detected but does not represent harmful or policy-violating behavior in context. |
+| `Duplicate` | The record does not represent new work because another active or closed record already tracks the same claim. |
+| `Expected Administrative Activity` | The activity is legitimate administrative, maintenance, or approved operational work that should remain distinguishable from suspicious behavior. |
+| `Accepted Risk` | The activity or exposure is known and consciously accepted by the accountable owner, so no further investigative escalation is required under the current baseline. |
+
+## 8. Baseline Alignment Notes
 
 The baseline keeps detection, approval, and execution as separate control decisions.'
 commit_fixture "${missing_boundary_repo}"
 assert_fails_with "${missing_boundary_repo}" "OpenSearch findings, n8n workflow runs, and future case state must remain separate records and must not be treated as interchangeable identifiers or lifecycle states."
+
+missing_dedup_repo="${workdir}/missing-dedup"
+create_repo "${missing_dedup_repo}"
+write_doc "${missing_dedup_repo}" '# AegisOps SecOps Domain Model
+
+## 1. Purpose
+
+This document defines the first-class SecOps domain model for the AegisOps baseline.
+
+This document defines baseline semantics, ownership boundaries, and state transitions only. It does not introduce runtime behavior, workflow automation, or architecture changes.
+
+## 2. Core Domain Objects
+
+| Object | Definition |
+| ---- | ---- |
+| `Raw Event` | Uninterpreted source telemetry before normalization. |
+| `Normalized Event` | Event translated into the approved analytic schema. |
+| `Detection Rule` | Reviewed detection logic that evaluates normalized telemetry. |
+| `Finding` | Detection result produced when rule logic matches telemetry. |
+| `Correlation` | Explicit relationship that links related records through shared operator-facing context. |
+| `Alert` | Routed analyst-facing item created from findings that require attention. |
+| `Case` | Investigation record for an analyst work item. |
+| `Incident` | Coordinated security event declaration across one or more cases. |
+| `Asset` | Managed host, service, application, or environment entity relevant to operations. |
+| `Identity` | Human or machine principal associated with activity or response scope. |
+| `Evidence` | Preserved supporting record used to explain or justify SecOps decisions. |
+| `Action Request` | Proposed response step waiting for approval or execution disposition. |
+| `Approval Decision` | Explicit decision for a specific action request. |
+| `Action Execution` | Record of the actual attempted or completed action. |
+| `Disposition` | Closure or outcome classification applied to findings, alerts, cases, or incidents under the correct owner boundary. |
+
+## 3. Relationship and State Boundaries
+
+A finding is the normalized analytic assertion that detection logic matched relevant telemetry.
+
+Correlation is the explicit relationship that links related findings, alerts, cases, assets, or identities because they share meaningful operator-facing context.
+
+An alert is the routed operator-facing notification or queue item created from one or more findings after baseline triage policy decides analyst attention is required.
+
+A case is the investigation record that groups alerts, evidence, analyst notes, and response coordination for one work item.
+
+An incident is the higher-order security event declaration used when one or more cases represent a material security event that needs coordinated operational handling.
+
+An approval decision records whether a specific action request is authorized, rejected, or expired.
+
+An action execution records the actual downstream attempt or completion state for an approved or explicitly allowed action request.
+
+OpenSearch findings, n8n workflow runs, and future case state must remain separate records and must not be treated as interchangeable identifiers or lifecycle states.
+
+## 4. Baseline System of Record
+
+| Object or boundary | Baseline system of record |
+| ---- | ---- |
+| `Finding` | OpenSearch detection and analytics plane |
+| `Correlation` | Future AegisOps correlation and triage control layer |
+| `Alert` | Future AegisOps alert routing and triage control layer |
+| `Case` | Future AegisOps case management control layer |
+| `Approval Decision` | Future AegisOps approval control layer |
+| `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state |
+
+## 5. Promotion and Correlation Rules
+
+A finding promotes to an alert only when triage policy determines that analyst attention, tracking, notification, or downstream workflow handling is required.
+
+Correlation links records by shared context, but it does not by itself create an alert, open a case, or declare an incident.
+
+## 6. Grouping, Deduplication, and Case Creation Expectations
+
+A case must not be created for every alert by default.
+
+## 7. Disposition and Closure Taxonomy
+
+| Disposition | Meaning |
+| ---- | ---- |
+| `False Positive` | The analytic claim was incorrect. |
+| `Benign Positive` | The activity occurred as detected but does not represent harmful or policy-violating behavior in context. |
+| `Duplicate` | The record does not represent new work because another active or closed record already tracks the same claim. |
+| `Expected Administrative Activity` | The activity is legitimate administrative, maintenance, or approved operational work that should remain distinguishable from suspicious behavior. |
+| `Accepted Risk` | The activity or exposure is known and consciously accepted by the accountable owner, so no further investigative escalation is required under the current baseline. |
+
+## 8. Baseline Alignment Notes
+
+The baseline keeps detection, approval, and execution as separate control decisions.'
+commit_fixture "${missing_dedup_repo}"
+assert_fails_with "${missing_dedup_repo}" "Deduplication means additional findings are attached to an existing alert or case when they restate the same analytic claim against materially the same operational target within the active review window."
 
 echo "verify-secops-domain-model-doc tests passed"

--- a/scripts/verify-secops-domain-model-doc.sh
+++ b/scripts/verify-secops-domain-model-doc.sh
@@ -11,7 +11,10 @@ required_headings=(
   "## 2. Core Domain Objects"
   "## 3. Relationship and State Boundaries"
   "## 4. Baseline System of Record"
-  "## 5. Baseline Alignment Notes"
+  "## 5. Promotion and Correlation Rules"
+  "## 6. Grouping, Deduplication, and Case Creation Expectations"
+  "## 7. Disposition and Closure Taxonomy"
+  "## 8. Baseline Alignment Notes"
 )
 
 required_phrases=(
@@ -21,6 +24,7 @@ required_phrases=(
   '| `Normalized Event` |'
   '| `Detection Rule` |'
   '| `Finding` |'
+  '| `Correlation` |'
   '| `Alert` |'
   '| `Case` |'
   '| `Incident` |'
@@ -32,6 +36,7 @@ required_phrases=(
   '| `Action Execution` |'
   '| `Disposition` |'
   "A finding is the normalized analytic assertion that detection logic matched relevant telemetry."
+  "Correlation is the explicit relationship that links related findings, alerts, cases, assets, or identities because they share meaningful operator-facing context."
   "An alert is the routed operator-facing notification or queue item created from one or more findings after baseline triage policy decides analyst attention is required."
   "A case is the investigation record that groups alerts, evidence, analyst notes, and response coordination for one work item."
   "An incident is the higher-order security event declaration used when one or more cases represent a material security event that needs coordinated operational handling."
@@ -39,10 +44,23 @@ required_phrases=(
   "An action execution records the actual downstream attempt or completion state for an approved or explicitly allowed action request."
   "OpenSearch findings, n8n workflow runs, and future case state must remain separate records and must not be treated as interchangeable identifiers or lifecycle states."
   '| `Finding` | OpenSearch detection and analytics plane |'
+  '| `Correlation` | Future AegisOps correlation and triage control layer |'
   '| `Alert` | Future AegisOps alert routing and triage control layer |'
   '| `Case` | Future AegisOps case management control layer |'
   '| `Approval Decision` | Future AegisOps approval control layer |'
   '| `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state |'
+  "A finding promotes to an alert only when triage policy determines that analyst attention, tracking, notification, or downstream workflow handling is required."
+  "Correlation links records by shared context, but it does not by itself create an alert, open a case, or declare an incident."
+  "A case must not be created for every alert by default."
+  "Deduplication means additional findings are attached to an existing alert or case when they restate the same analytic claim against materially the same operational target within the active review window."
+  "A new alert must be created instead of deduplicating when severity, target scope, response owner, or review window changes enough that analyst handling would differ."
+  "A case is created when analyst work requires durable ownership, evidence collection, note-taking, handoff, or coordinated response beyond the alert record itself."
+  "An incident is declared only when one or more cases represent a material security event that requires coordinated operational handling beyond a single investigative work item."
+  '| `False Positive` | The analytic claim was incorrect.'
+  '| `Benign Positive` | The activity occurred as detected but does not represent harmful or policy-violating behavior in context.'
+  '| `Duplicate` | The record does not represent new work because another active or closed record already tracks the same claim.'
+  '| `Expected Administrative Activity` | The activity is legitimate administrative, maintenance, or approved operational work that should remain distinguishable from suspicious behavior.'
+  '| `Accepted Risk` | The activity or exposure is known and consciously accepted by the accountable owner, so no further investigative escalation is required under the current baseline.'
 )
 
 if [[ ! -f "${doc_path}" ]]; then


### PR DESCRIPTION
## What changed
- expanded `docs/secops-domain-model.md` to define non-overlapping operator meanings for findings, correlation, alerts, cases, incidents, and dispositions
- added explicit promotion, grouping, deduplication, and case-creation rules so future implementations can avoid a one-event one-alert default
- tightened the focused SecOps domain-model verifier and extended its fixture tests to cover the new required semantics

## Why
Issue #91 requires an operator-facing model that separates analytics outputs, analyst work records, and higher-order incident records while keeping closure outcomes reviewable and attributable.

## Impact
- future design and implementation work now has a baseline for when findings stay analytic-only versus becoming alerts, cases, or incidents
- closure outcomes such as `False Positive`, `Benign Positive`, `Duplicate`, `Expected Administrative Activity`, and `Accepted Risk` now have explicit meanings and tuning implications
- the focused verifier now prevents this document from regressing on the required promotion and closure semantics

## Validation
- `bash scripts/verify-secops-domain-model-doc.sh`
- `bash scripts/test-verify-secops-domain-model-doc.sh`
