### PR TITLE
docs: define response action safety and approval binding model

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/sigma-to-opensearch-translation-strategy.md`
 - `docs/detection-lifecycle-and-rule-qa-framework.md`
 - `docs/secops-domain-model.md`
+- `docs/response-action-safety-model.md`
 - `docs/runbook.md`
 - `docs/repository-structure-baseline.md`
 - `docs/network-exposure-and-access-path-policy.md`

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -30,6 +30,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/sigma-to-opensearch-translation-strategy.md` | Sigma-to-OpenSearch translation strategy baseline | IT Operations, Information Systems Department |
 | `docs/detection-lifecycle-and-rule-qa-framework.md` | Detection lifecycle and rule QA framework baseline | IT Operations, Information Systems Department |
 | `docs/secops-domain-model.md` | SecOps domain model baseline | IT Operations, Information Systems Department |
+| `docs/response-action-safety-model.md` | Response action safety and approval binding baseline | IT Operations, Information Systems Department |
 | `docs/adr/` | Architecture Decision Records (ADRs) | IT Operations, Information Systems Department |
 | `docs/parameters/` | Parameter documentation | IT Operations, Information Systems Department |
 | `docs/runbook.md` | Runbooks | IT Operations, Information Systems Department |
@@ -39,6 +40,8 @@ The requirements baseline owner recorded in `docs/requirements-baseline.md` rema
 ADR records under `docs/adr/` may identify specific document proposers or reviewers, but repository-level ownership for the ADR area remains assigned to IT Operations, Information Systems Department unless this map is updated explicitly.
 
 The SecOps domain model document remains the shared semantic reference for baseline object definitions and state boundaries and must stay aligned with the approved architecture and requirements baseline.
+
+The response action safety model remains the baseline policy reference for action classes, approval binding, idempotency expectations, and post-approval drift protection for future response execution work.
 
 The canonical telemetry schema baseline remains the shared semantic reference for normalized event field expectations and must stay aligned with ECS usage rules, source provenance requirements, and the approved SecOps domain model.
 

--- a/docs/response-action-safety-model.md
+++ b/docs/response-action-safety-model.md
@@ -1,0 +1,97 @@
+# AegisOps Response Action Safety and Approval Binding Model
+
+## 1. Purpose
+
+This document defines the baseline safety model and approval binding requirements for future AegisOps response actions.
+
+It supplements `docs/requirements-baseline.md` and `docs/secops-domain-model.md` by making approval-gated response expectations specific enough to review, audit, and verify before any live workflow implementation exists.
+
+This document defines policy and evidence requirements only. It does not introduce live workflows, approval-exempt write paths, or autonomous response behavior.
+
+## 2. Action Safety Classes
+
+Action classes define the minimum approval and evidence posture required before execution may proceed.
+
+| Class | Meaning | Minimum expectation |
+| ---- | ---- | ---- |
+| `Read` | Collect, inspect, validate, or simulate state without changing the target system. | Request context and execution logging are still required, but approval may be policy-driven instead of human-gated when the action remains strictly non-mutating. |
+| `Notify` | Send operator-facing or stakeholder-facing communication without changing the protected target itself. | The request must identify recipients, message intent, and escalation path so notification does not become an unreviewed indirect write against the wrong audience. |
+| `Soft Write` | Change workflow, coordination, quarantine, ticketing, or other reversible control state with bounded impact. | Human approval is required unless an approved future policy narrowly authorizes the exact action pattern and records equivalent evidence. |
+| `Hard Write` | Change production or security-relevant target state with material operational effect, including disablement, deletion, credential impact, or infrastructure mutation. | Explicit human approval, strong binding evidence, rollback or containment planning, and post-action verification are mandatory. |
+
+Class assignment must be conservative. If an action could plausibly change protected target state or operator trust state, it must not be classified as `Read`.
+
+## 3. Minimum Action Request Fields
+
+Every action request must identify the requester, the intended action class, the target, the justification, and the exact payload or payload reference proposed for execution.
+
+At minimum, an action request must record:
+
+| Field | Required binding purpose |
+| ---- | ---- |
+| Request identifier | Distinguishes one requested action from later edits, retries, or related cases. |
+| Requester identity | Binds the proposed action to the accountable human or approved service principal that asked for it. |
+| Linked case, alert, finding, or incident reference | Preserves the investigative context that justified the request. |
+| Action class | Determines the minimum approval, dry-run, rollback, and verification expectations. |
+| Target type and target identifier | Makes the affected host, account, workflow object, recipient set, or other target specific enough to review. |
+| Target snapshot or version reference | Captures the reviewed target state that approval covers. |
+| Requested payload or payload reference | Prevents approval from floating across materially different commands, parameters, or templates. |
+| Payload hash | Gives execution a stable integrity check against the approved payload. |
+| Requested authority and rationale | States why the action is needed and what authority boundary it expects to cross. |
+| Approval requirement and quorum rule | Declares whether the action needs one approver, multiple approvers, or another explicit approval policy outcome. |
+| Expiry timestamp | Prevents stale approval from being replayed against later conditions. |
+| Dry-run requirement | States whether reviewed dry-run evidence is mandatory before execution. |
+| Rollback or containment expectation | Records the expected reversal or containment posture for write actions. |
+| Verification plan | Defines what evidence must be collected after execution to prove the intended effect. |
+
+Execution must not proceed when the action request lacks target specificity, approval requirements, expiry, or the evidence needed to bind approval context to execution context.
+
+A generic "run containment" or "approve action" request is insufficient. The request must be precise enough that a reviewer can tell exactly who asked for what action, against which target snapshot, with which payload, under which time bound.
+
+## 4. Approval Binding Requirements
+
+Approval decisions must remain separate from execution attempts.
+
+An approval decision answers whether a specific action request is authorized under policy. It does not prove that the action was attempted, and execution metadata must not be used as a substitute for the approval record.
+
+The approval record must bind the requester identity, approver identity, target snapshot, payload hash, approval timestamp, expiry, and required quorum result to the specific action request.
+
+The approval record must also capture the approval outcome, the approver rationale or conditions, and any execution constraints that narrow what may happen after approval.
+
+If dry-run evidence is required for the action class, the approval record must reference the reviewed dry-run result that matches the approved target snapshot and payload hash.
+
+If quorum is required, each participating approver must be individually attributable, and the final approval state must record whether the quorum was satisfied before expiry.
+
+Execution must perform post-approval drift checks before acting.
+
+At minimum, drift checks must compare the current requester identity, target snapshot, payload hash, approval status, expiry, quorum result, and dry-run evidence against the approved record before any downstream write occurs.
+
+An execution attempt must be rejected when requester identity, target snapshot, payload hash, expiry, quorum, or required dry-run evidence no longer matches the approved record.
+
+Approval reuse is prohibited across materially different targets, payloads, or time windows even if the operator intent appears similar. A new action request and approval decision are required when the reviewed context changes.
+
+## 5. Execution Safeguards
+
+Every execution attempt must carry an idempotency key that is unique for the approved action request and execution intent.
+
+The idempotency key must let the execution layer distinguish first execution from retried delivery, duplicate trigger, or replay attempt without treating those paths as fresh approvals.
+
+Execution records must capture the downstream result, verification evidence, and rollback or containment outcome where applicable.
+
+Duplicate execution attempts for the same approved action request must be prevented unless an explicitly recorded retry policy allows another attempt under the same binding context.
+
+Allowed retries must remain tied to the same approved request, payload hash, target snapshot, and expiry window. A retry must not silently widen target scope or change the action payload.
+
+Write-capable actions must record rollback expectations before execution and must record whether rollback, compensation, or explicit containment guidance was used after any partial or failed execution.
+
+Post-action verification must confirm the expected target state or clearly record the residual risk and operator follow-up required.
+
+If verification fails or remains inconclusive, the execution record must preserve that outcome explicitly rather than implying success from approval or workflow completion alone.
+
+## 6. Baseline Alignment Notes
+
+This model preserves the baseline separation between detection, approval, and execution and prevents approval from degrading into a generic approve button.
+
+It reinforces the requirements baseline rule that destructive or high-impact actions require approval, that executed actions must be logged, that dry-run behavior should exist where applicable, and that write actions need rollback or containment guidance.
+
+It also keeps `Action Request`, `Approval Decision`, and `Action Execution` aligned with the domain-model boundaries already defined in `docs/secops-domain-model.md`.

--- a/scripts/test-verify-response-action-safety-model-doc.sh
+++ b/scripts/test-verify-response-action-safety-model-doc.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-response-action-safety-model-doc.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_doc() {
+  local target="$1"
+  local doc_content="$2"
+
+  printf '%s\n' "${doc_content}" >"${target}/docs/response-action-safety-model.md"
+  git -C "${target}" add docs/response-action-safety-model.md
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_doc "${valid_repo}" '# AegisOps Response Action Safety and Approval Binding Model
+
+## 1. Purpose
+
+This document defines the baseline safety model and approval binding requirements for future AegisOps response actions.
+
+This document defines policy and evidence requirements only. It does not introduce live workflows, approval-exempt write paths, or autonomous response behavior.
+
+## 2. Action Safety Classes
+
+| Class | Meaning |
+| ---- | ---- |
+| `Read` | Collect, inspect, or validate state without changing the target system. |
+| `Notify` | Send operator-facing or stakeholder-facing communication without changing the protected target. |
+| `Soft Write` | Change workflow, coordination, or reversible control state with bounded impact. |
+| `Hard Write` | Change production or security-relevant target state with material operational effect. |
+
+## 3. Minimum Action Request Fields
+
+Every action request must identify the requester, the intended action class, the target, the justification, and the exact payload or payload reference proposed for execution.
+
+Execution must not proceed when the action request lacks target specificity, approval requirements, expiry, or the evidence needed to bind approval context to execution context.
+
+## 4. Approval Binding Requirements
+
+Approval decisions must remain separate from execution attempts.
+
+The approval record must bind the requester identity, approver identity, target snapshot, payload hash, approval timestamp, expiry, and required quorum result to the specific action request.
+
+If dry-run evidence is required for the action class, the approval record must reference the reviewed dry-run result that matches the approved target snapshot and payload hash.
+
+Execution must perform post-approval drift checks before acting.
+
+An execution attempt must be rejected when requester identity, target snapshot, payload hash, expiry, quorum, or required dry-run evidence no longer matches the approved record.
+
+## 5. Execution Safeguards
+
+Every execution attempt must carry an idempotency key that is unique for the approved action request and execution intent.
+
+Execution records must capture the downstream result, verification evidence, and rollback or containment outcome where applicable.
+
+Duplicate execution attempts for the same approved action request must be prevented unless an explicitly recorded retry policy allows another attempt under the same binding context.
+
+Post-action verification must confirm the expected target state or clearly record the residual risk and operator follow-up required.
+
+## 6. Baseline Alignment Notes
+
+This model preserves the baseline separation between detection, approval, and execution and prevents approval from degrading into a generic approve button.'
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing response action safety model document:"
+
+missing_binding_repo="${workdir}/missing-binding"
+create_repo "${missing_binding_repo}"
+write_doc "${missing_binding_repo}" '# AegisOps Response Action Safety and Approval Binding Model
+
+## 1. Purpose
+
+This document defines the baseline safety model and approval binding requirements for future AegisOps response actions.
+
+This document defines policy and evidence requirements only. It does not introduce live workflows, approval-exempt write paths, or autonomous response behavior.
+
+## 2. Action Safety Classes
+
+| Class | Meaning |
+| ---- | ---- |
+| `Read` | Collect, inspect, or validate state without changing the target system. |
+| `Notify` | Send operator-facing or stakeholder-facing communication without changing the protected target. |
+| `Soft Write` | Change workflow, coordination, or reversible control state with bounded impact. |
+| `Hard Write` | Change production or security-relevant target state with material operational effect. |
+
+## 3. Minimum Action Request Fields
+
+Every action request must identify the requester, the intended action class, the target, the justification, and the exact payload or payload reference proposed for execution.
+
+Execution must not proceed when the action request lacks target specificity, approval requirements, expiry, or the evidence needed to bind approval context to execution context.
+
+## 4. Approval Binding Requirements
+
+Approval decisions must remain separate from execution attempts.
+
+Execution must perform post-approval drift checks before acting.
+
+## 5. Execution Safeguards
+
+Every execution attempt must carry an idempotency key that is unique for the approved action request and execution intent.
+
+Execution records must capture the downstream result, verification evidence, and rollback or containment outcome where applicable.
+
+Duplicate execution attempts for the same approved action request must be prevented unless an explicitly recorded retry policy allows another attempt under the same binding context.
+
+Post-action verification must confirm the expected target state or clearly record the residual risk and operator follow-up required.
+
+## 6. Baseline Alignment Notes
+
+This model preserves the baseline separation between detection, approval, and execution and prevents approval from degrading into a generic approve button.'
+commit_fixture "${missing_binding_repo}"
+assert_fails_with "${missing_binding_repo}" "The approval record must bind the requester identity, approver identity, target snapshot, payload hash, approval timestamp, expiry, and required quorum result to the specific action request."
+
+missing_execution_guard_repo="${workdir}/missing-execution-guard"
+create_repo "${missing_execution_guard_repo}"
+write_doc "${missing_execution_guard_repo}" '# AegisOps Response Action Safety and Approval Binding Model
+
+## 1. Purpose
+
+This document defines the baseline safety model and approval binding requirements for future AegisOps response actions.
+
+This document defines policy and evidence requirements only. It does not introduce live workflows, approval-exempt write paths, or autonomous response behavior.
+
+## 2. Action Safety Classes
+
+| Class | Meaning |
+| ---- | ---- |
+| `Read` | Collect, inspect, or validate state without changing the target system. |
+| `Notify` | Send operator-facing or stakeholder-facing communication without changing the protected target. |
+| `Soft Write` | Change workflow, coordination, or reversible control state with bounded impact. |
+| `Hard Write` | Change production or security-relevant target state with material operational effect. |
+
+## 3. Minimum Action Request Fields
+
+Every action request must identify the requester, the intended action class, the target, the justification, and the exact payload or payload reference proposed for execution.
+
+Execution must not proceed when the action request lacks target specificity, approval requirements, expiry, or the evidence needed to bind approval context to execution context.
+
+## 4. Approval Binding Requirements
+
+Approval decisions must remain separate from execution attempts.
+
+The approval record must bind the requester identity, approver identity, target snapshot, payload hash, approval timestamp, expiry, and required quorum result to the specific action request.
+
+If dry-run evidence is required for the action class, the approval record must reference the reviewed dry-run result that matches the approved target snapshot and payload hash.
+
+Execution must perform post-approval drift checks before acting.
+
+An execution attempt must be rejected when requester identity, target snapshot, payload hash, expiry, quorum, or required dry-run evidence no longer matches the approved record.
+
+## 5. Execution Safeguards
+
+Execution records must capture the downstream result, verification evidence, and rollback or containment outcome where applicable.
+
+Duplicate execution attempts for the same approved action request must be prevented unless an explicitly recorded retry policy allows another attempt under the same binding context.
+
+Post-action verification must confirm the expected target state or clearly record the residual risk and operator follow-up required.
+
+## 6. Baseline Alignment Notes
+
+This model preserves the baseline separation between detection, approval, and execution and prevents approval from degrading into a generic approve button.'
+commit_fixture "${missing_execution_guard_repo}"
+assert_fails_with "${missing_execution_guard_repo}" "Every execution attempt must carry an idempotency key that is unique for the approved action request and execution intent."
+
+echo "Response action safety model verifier enforces required policy statements."

--- a/scripts/verify-response-action-safety-model-doc.sh
+++ b/scripts/verify-response-action-safety-model-doc.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/response-action-safety-model.md"
+
+required_headings=(
+  "# AegisOps Response Action Safety and Approval Binding Model"
+  "## 1. Purpose"
+  "## 2. Action Safety Classes"
+  "## 3. Minimum Action Request Fields"
+  "## 4. Approval Binding Requirements"
+  "## 5. Execution Safeguards"
+  "## 6. Baseline Alignment Notes"
+)
+
+required_phrases=(
+  "This document defines the baseline safety model and approval binding requirements for future AegisOps response actions."
+  "This document defines policy and evidence requirements only. It does not introduce live workflows, approval-exempt write paths, or autonomous response behavior."
+  '| `Read` |'
+  '| `Notify` |'
+  '| `Soft Write` |'
+  '| `Hard Write` |'
+  "Every action request must identify the requester, the intended action class, the target, the justification, and the exact payload or payload reference proposed for execution."
+  "Execution must not proceed when the action request lacks target specificity, approval requirements, expiry, or the evidence needed to bind approval context to execution context."
+  "Approval decisions must remain separate from execution attempts."
+  "The approval record must bind the requester identity, approver identity, target snapshot, payload hash, approval timestamp, expiry, and required quorum result to the specific action request."
+  "If dry-run evidence is required for the action class, the approval record must reference the reviewed dry-run result that matches the approved target snapshot and payload hash."
+  "Execution must perform post-approval drift checks before acting."
+  "An execution attempt must be rejected when requester identity, target snapshot, payload hash, expiry, quorum, or required dry-run evidence no longer matches the approved record."
+  "Every execution attempt must carry an idempotency key that is unique for the approved action request and execution intent."
+  "Execution records must capture the downstream result, verification evidence, and rollback or containment outcome where applicable."
+  "Duplicate execution attempts for the same approved action request must be prevented unless an explicitly recorded retry policy allows another attempt under the same binding context."
+  "Post-action verification must confirm the expected target state or clearly record the residual risk and operator follow-up required."
+  "This model preserves the baseline separation between detection, approval, and execution and prevents approval from degrading into a generic approve button."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing response action safety model document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing response action safety model heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Missing response action safety model statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+echo "Response action safety model document is present and defines action classes, approval binding, and execution safeguards."


### PR DESCRIPTION
## Summary
- add a baseline response action safety and approval binding model document
- add a focused verifier and fixture-backed test for the new policy artifact
- register the new document in the README and documentation ownership map

## Testing
- bash scripts/verify-response-action-safety-model-doc.sh
- bash scripts/test-verify-response-action-safety-model-doc.sh
- bash scripts/verify-secops-domain-model-doc.sh

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on response action safety and approval binding model, including action safety classifications, mandatory request fields, approval binding requirements, drift check procedures, and execution safeguards with idempotency protections.
  * Updated documentation reference materials to reflect new safety model documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->