### PR TITLE
[codex] Define retention and replay readiness baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/auth-baseline.md`
 - `docs/response-action-safety-model.md`
 - `docs/control-plane-state-model.md`
+- `docs/retention-evidence-and-replay-readiness-baseline.md`
 - `docs/runbook.md`
 - `docs/repository-structure-baseline.md`
 - `docs/network-exposure-and-access-path-policy.md`

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -33,6 +33,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/auth-baseline.md` | Authentication, authorization, and service account ownership baseline | IT Operations, Information Systems Department |
 | `docs/response-action-safety-model.md` | Response action safety and approval binding baseline | IT Operations, Information Systems Department |
 | `docs/control-plane-state-model.md` | Control-plane state and reconciliation baseline | IT Operations, Information Systems Department |
+| `docs/retention-evidence-and-replay-readiness-baseline.md` | Retention, evidence lifecycle, and replay readiness baseline | IT Operations, Information Systems Department |
 | `docs/adr/` | Architecture Decision Records (ADRs) | IT Operations, Information Systems Department |
 | `docs/parameters/` | Parameter documentation | IT Operations, Information Systems Department |
 | `docs/runbook.md` | Runbooks | IT Operations, Information Systems Department |
@@ -48,6 +49,8 @@ The auth baseline remains the policy reference for operator personas, least-priv
 The response action safety model remains the baseline policy reference for action classes, approval binding, idempotency expectations, and post-approval drift protection for future response execution work.
 
 The control-plane state model remains the baseline ownership reference for which records stay in OpenSearch, which stay in n8n, and which require future AegisOps control-plane authority rather than implicit storage inside component-local state.
+
+The retention, evidence lifecycle, and replay readiness baseline remains the policy reference for record-family retention classes, evidence expiration constraints, replay dataset preservation, and restore-readiness assumptions.
 
 The canonical telemetry schema baseline remains the shared semantic reference for normalized event field expectations and must stay aligned with ECS usage rules, source provenance requirements, and the approved SecOps domain model.
 

--- a/docs/retention-evidence-and-replay-readiness-baseline.md
+++ b/docs/retention-evidence-and-replay-readiness-baseline.md
@@ -1,0 +1,83 @@
+# AegisOps Retention, Evidence Lifecycle, and Replay Readiness Baseline
+
+## 1. Purpose
+
+This document defines the baseline retention classes, evidence lifecycle assumptions, and replay readiness expectations for AegisOps-owned records.
+
+It supplements `docs/requirements-baseline.md`, `docs/storage-layout-and-mount-policy.md`, `docs/runbook.md`, `docs/control-plane-state-model.md`, and `docs/response-action-safety-model.md` by making policy-level retention and restore expectations explicit before any runtime storage lifecycle is implemented.
+
+This document defines baseline policy only. It does not introduce live ILM policies, index rollovers, shard sizing, snapshot schedules, database retention jobs, or production storage tier configuration in this phase.
+
+## 2. Retention Classes
+
+Retention classes must remain reviewable by record family rather than inherited implicitly from whichever component currently stores the data.
+
+The baseline classes below define relative expectations for hot, warm, cold, and archival handling. Concrete day counts, index ages, bucket policies, and storage sizes remain future implementation parameters.
+
+| Record family | Baseline retention class | Policy-level expectation |
+| ---- | ---- | ---- |
+| `Raw Event` | Shorter-lived high-volume telemetry | Keep hot retention limited to the period needed for immediate triage, parser troubleshooting, and near-term detection review. Warm or cold retention may be used for short historical reach, but raw events should age out before normalized investigative records unless an approved source-specific need requires longer preservation. |
+| `Normalized Event` | Medium-lived operational analysis record | Retain longer than raw events so analysts can investigate, correlate, and re-run approved detection or mapping checks after raw payload windows expire. Normalized events are the default replay substrate for most platform-level validation and investigation work. |
+| `Finding` | Medium-lived analytics outcome | Retain long enough to support alert review, tuning analysis, false-positive tracking, and post-incident reconstruction of why the analytics layer produced a result. Findings may roll from hot to warm storage once active triage pressure drops. |
+| `Alert` | Longer-lived operator work and audit record | Retain longer than findings because alert lifecycle, analyst disposition, escalation, and linkage to cases or response actions remain part of the durable audit trail. Alert records should remain recoverable even after the originating analytics-plane artifacts have moved to colder storage. |
+| `Evidence` | Case and audit preservation record | Retain longer than alerts when the record substantiates analyst conclusions, approvals, execution outcomes, or incident reporting. Evidence must support hot access for active work, warm access for routine review, and cold or archive preservation for closed investigations that still require auditability. |
+| `Approval Decision` | Durable control and audit record | Retain at least as long as the evidence and execution records needed to prove who approved or rejected a request, under what scope, and with what expiry or conditions. Approval records must not age out before the linked execution and verification trail. |
+| `Action Execution` | Durable execution and reconciliation record | Retain long enough to reconstruct what downstream action actually ran, whether it matched approved intent, what verification evidence was collected, and whether retry or manual recovery occurred. Execution records must remain reviewable alongside the approval and evidence they reference. |
+
+Retention changes for any class above must be explicit, documented, and approved rather than emerging indirectly from default component behavior.
+
+## 3. Replay Dataset and Restore Readiness Expectations
+
+Replay-capable datasets must be retained long enough to support parser validation, rule validation, and targeted historical reprocessing for approved investigations and recovery exercises.
+
+The baseline replay assumption is that representative normalized datasets are the primary future replay input, while selected raw-event samples may be preserved where parser validation, provenance review, or source-specific troubleshooting requires them.
+
+Replay readiness must preserve enough provenance, timestamp fidelity, source-family context, and schema version context that future operators can explain what a replay dataset represents and what it cannot prove.
+
+Restore readiness must assume application-aware restore procedures for OpenSearch, PostgreSQL, and future platform-owned control records rather than treating hypervisor snapshots as the primary recovery model.
+
+Hypervisor snapshots may assist short-lived infrastructure rollback or maintenance windows, but they are supplemental tooling only and must not be treated as the authoritative replay or disaster-recovery baseline for AegisOps data.
+
+Policy-level storage expectations for future sizing and readiness work are:
+
+- hot retention exists for records required for current triage, active workflow execution, and recent validation;
+- warm retention exists for records that remain routinely searchable without claiming top-tier performance;
+- cold or archive retention exists for records kept mainly for audit, investigation follow-up, selective replay, or regulated preservation;
+- and rollover, compaction, or dataset handoff decisions must preserve record family boundaries and restore traceability rather than optimizing only for storage efficiency.
+
+Future validation work must prove that retained replay datasets, retained approval records, and retained execution evidence can be restored or reviewed together closely enough to reconstruct a decision chain without depending on one component's incidental log detail.
+
+## 4. Evidence Lifecycle and Legal-Hold Baseline
+
+Evidence retention must preserve chain-of-custody context, source provenance, review references, and legal-hold status long enough to support audit, investigation, and post-incident review.
+
+Evidence lifecycle handling must distinguish between:
+
+- active evidence still being collected or reviewed;
+- closed but routinely reviewable evidence for completed investigations or approvals;
+- colder evidence kept mainly for audit, compliance, dispute resolution, or later replay support; and
+- explicitly held evidence whose expiration is suspended.
+
+Evidence references must remain stable enough that linked alerts, approvals, and action execution records do not become unverifiable when underlying artifacts move between storage classes.
+
+Legal hold must suspend ordinary expiration for specifically scoped evidence and related approval or execution records until the hold is explicitly released through approved process.
+
+When legal hold applies, the baseline expectation is to preserve the minimum linked record set needed to keep evidence interpretable: custody context, ownership annotations, approval context where relevant, execution outcomes where relevant, and the release decision when the hold ends.
+
+This baseline does not approve a runtime legal-hold service, case-management product, or storage lock mechanism. It requires only that future implementations preserve the concept and do not design ordinary retention in a way that makes legal hold impossible.
+
+## 5. Lifecycle Policy Constraints
+
+This baseline defines policy-level hot, warm, cold, or rollover expectations only. It does not introduce live ILM policies, shard counts, index templates, storage tier automation, or production retention settings in this phase.
+
+No record family may rely on container filesystem layers, dashboard state, ad hoc exports, or hypervisor snapshots as its sole long-term retention mechanism.
+
+No future retention implementation may dissolve approval, evidence, or execution records into a single component-local history stream if that would make replay, audit, or restore validation ambiguous.
+
+Parameterization of concrete durations, tier thresholds, rollover triggers, backup schedules, and restore objectives must remain in future approved parameter documents, runbooks, or ADRs once the implementation approach is chosen.
+
+## 6. Baseline Alignment Notes
+
+This baseline keeps retention and replay expectations explicit without pretending that current repository scaffolding already provides a production retention implementation.
+
+It remains aligned with the storage policy rule that application-aware backup and restore take precedence over hypervisor snapshots, the runbook rule that restore evidence must be reviewable, and the control-plane state model rule that approvals and execution are first-class records rather than incidental workflow logs.

--- a/scripts/test-verify-retention-baseline-doc.sh
+++ b/scripts/test-verify-retention-baseline-doc.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-retention-baseline-doc.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+}
+
+write_doc() {
+  local target="$1"
+  local content="$2"
+
+  printf '%s\n' "${content}" >"${target}/docs/retention-evidence-and-replay-readiness-baseline.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_doc "${valid_repo}" '# AegisOps Retention, Evidence Lifecycle, and Replay Readiness Baseline
+
+## 1. Purpose
+
+This document defines the baseline retention classes, evidence lifecycle assumptions, and replay readiness expectations for AegisOps-owned records.
+
+## 2. Retention Classes
+
+| Record family | Baseline |
+| ---- | ---- |
+| `Raw Event` | Baseline placeholder |
+| `Normalized Event` | Baseline placeholder |
+| `Finding` | Baseline placeholder |
+| `Alert` | Baseline placeholder |
+| `Evidence` | Baseline placeholder |
+| `Approval Decision` | Baseline placeholder |
+| `Action Execution` | Baseline placeholder |
+
+## 3. Replay Dataset and Restore Readiness Expectations
+
+Replay-capable datasets must be retained long enough to support parser validation, rule validation, and targeted historical reprocessing for approved investigations and recovery exercises.
+
+Restore readiness must assume application-aware restore procedures for OpenSearch, PostgreSQL, and future platform-owned control records rather than treating hypervisor snapshots as the primary recovery model.
+
+## 4. Evidence Lifecycle and Legal-Hold Baseline
+
+Evidence retention must preserve chain-of-custody context, source provenance, review references, and legal-hold status long enough to support audit, investigation, and post-incident review.
+
+Legal hold must suspend ordinary expiration for specifically scoped evidence and related approval or execution records until the hold is explicitly released through approved process.
+
+## 5. Lifecycle Policy Constraints
+
+This baseline defines policy-level hot, warm, cold, or rollover expectations only. It does not introduce live ILM policies, shard counts, index templates, storage tier automation, or production retention settings in this phase.
+
+## 6. Baseline Alignment Notes
+
+The document remains a baseline artifact only.'
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing retention baseline document:"
+
+missing_phrase_repo="${workdir}/missing-phrase"
+create_repo "${missing_phrase_repo}"
+write_doc "${missing_phrase_repo}" '# AegisOps Retention, Evidence Lifecycle, and Replay Readiness Baseline
+
+## 1. Purpose
+
+This document defines the baseline retention classes, evidence lifecycle assumptions, and replay readiness expectations for AegisOps-owned records.
+
+## 2. Retention Classes
+
+| Record family | Baseline |
+| ---- | ---- |
+| `Raw Event` | Baseline placeholder |
+| `Normalized Event` | Baseline placeholder |
+| `Finding` | Baseline placeholder |
+| `Alert` | Baseline placeholder |
+| `Evidence` | Baseline placeholder |
+| `Approval Decision` | Baseline placeholder |
+| `Action Execution` | Baseline placeholder |
+
+## 3. Replay Dataset and Restore Readiness Expectations
+
+Restore readiness must assume application-aware restore procedures for OpenSearch, PostgreSQL, and future platform-owned control records rather than treating hypervisor snapshots as the primary recovery model.
+
+## 4. Evidence Lifecycle and Legal-Hold Baseline
+
+Evidence retention must preserve chain-of-custody context, source provenance, review references, and legal-hold status long enough to support audit, investigation, and post-incident review.
+
+Legal hold must suspend ordinary expiration for specifically scoped evidence and related approval or execution records until the hold is explicitly released through approved process.
+
+## 5. Lifecycle Policy Constraints
+
+This baseline defines policy-level hot, warm, cold, or rollover expectations only. It does not introduce live ILM policies, shard counts, index templates, storage tier automation, or production retention settings in this phase.
+
+## 6. Baseline Alignment Notes
+
+The document remains a baseline artifact only.'
+assert_fails_with "${missing_phrase_repo}" "Replay-capable datasets must be retained long enough to support parser validation, rule validation, and targeted historical reprocessing for approved investigations and recovery exercises."
+
+echo "verify-retention-baseline-doc tests passed"

--- a/scripts/verify-documentation-ownership-map.sh
+++ b/scripts/verify-documentation-ownership-map.sh
@@ -23,10 +23,13 @@ required_phrases=(
   '| `docs/detection-lifecycle-and-rule-qa-framework.md` | Detection lifecycle and rule QA framework baseline | IT Operations, Information Systems Department |'
   '| `docs/secops-domain-model.md` | SecOps domain model baseline | IT Operations, Information Systems Department |'
   '| `docs/auth-baseline.md` | Authentication, authorization, and service account ownership baseline | IT Operations, Information Systems Department |'
+  '| `docs/response-action-safety-model.md` | Response action safety and approval binding baseline | IT Operations, Information Systems Department |'
   '| `docs/control-plane-state-model.md` | Control-plane state and reconciliation baseline | IT Operations, Information Systems Department |'
+  '| `docs/retention-evidence-and-replay-readiness-baseline.md` | Retention, evidence lifecycle, and replay readiness baseline | IT Operations, Information Systems Department |'
   '| `docs/adr/` | Architecture Decision Records (ADRs) | IT Operations, Information Systems Department |'
   '| `docs/parameters/` | Parameter documentation | IT Operations, Information Systems Department |'
   '| `docs/runbook.md` | Runbooks | IT Operations, Information Systems Department |'
+  'The retention, evidence lifecycle, and replay readiness baseline remains the policy reference for record-family retention classes, evidence expiration constraints, replay dataset preservation, and restore-readiness assumptions.'
 )
 
 if [[ ! -f "${doc_path}" ]]; then

--- a/scripts/verify-retention-baseline-doc.sh
+++ b/scripts/verify-retention-baseline-doc.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/retention-evidence-and-replay-readiness-baseline.md"
+
+required_headings=(
+  "# AegisOps Retention, Evidence Lifecycle, and Replay Readiness Baseline"
+  "## 1. Purpose"
+  "## 2. Retention Classes"
+  "## 3. Replay Dataset and Restore Readiness Expectations"
+  "## 4. Evidence Lifecycle and Legal-Hold Baseline"
+  "## 5. Lifecycle Policy Constraints"
+  "## 6. Baseline Alignment Notes"
+)
+
+required_phrases=(
+  '| `Raw Event` |'
+  '| `Normalized Event` |'
+  '| `Finding` |'
+  '| `Alert` |'
+  '| `Evidence` |'
+  '| `Approval Decision` |'
+  '| `Action Execution` |'
+  "Replay-capable datasets must be retained long enough to support parser validation, rule validation, and targeted historical reprocessing for approved investigations and recovery exercises."
+  "Restore readiness must assume application-aware restore procedures for OpenSearch, PostgreSQL, and future platform-owned control records rather than treating hypervisor snapshots as the primary recovery model."
+  "Evidence retention must preserve chain-of-custody context, source provenance, review references, and legal-hold status long enough to support audit, investigation, and post-incident review."
+  "Legal hold must suspend ordinary expiration for specifically scoped evidence and related approval or execution records until the hold is explicitly released through approved process."
+  "This baseline defines policy-level hot, warm, cold, or rollover expectations only. It does not introduce live ILM policies, shard counts, index templates, storage tier automation, or production retention settings in this phase."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing retention baseline document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing retention baseline heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Missing retention baseline statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+echo "Retention, evidence lifecycle, and replay readiness baseline document covers the required rules."


### PR DESCRIPTION
## What changed
- add a retention, evidence lifecycle, and replay readiness baseline document
- define baseline retention classes for raw events, normalized events, findings, alerts, evidence, approval decisions, and action execution records
- define replay dataset retention assumptions, restore-readiness expectations, legal-hold constraints, and policy-level hot/warm/cold guidance without introducing live ILM or storage settings
- wire the new baseline into the documentation ownership map and add a focused verifier plus self-test

## Why it changed
Issue #95 required a baseline artifact for retention and replay readiness. The repository previously had no explicit document covering these record families or the evidence lifecycle assumptions future recovery and sizing work need.

## Impact
- reviewers have a single baseline artifact for retention and restore assumptions
- future implementation work has a narrow verifier that proves the artifact exists and covers the required policy statements
- no production retention policy, ILM action, shard setting, or runtime storage behavior is changed by this PR

## Validation
- `bash scripts/verify-retention-baseline-doc.sh`
- `bash scripts/test-verify-retention-baseline-doc.sh`
- `bash scripts/verify-documentation-ownership-map.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added baseline documentation for data retention, evidence lifecycle, and replay/restore readiness policies, establishing record-family-specific retention guidance and restore procedures.
  * Updated documentation ownership map to reflect new baseline documentation.

* **Chores**
  * Added verification scripts to enforce compliance with documentation baselines and ownership requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->