### PR TITLE
[codex] define business-hours secops operating model

### DIFF
--- a/.codex-supervisor/issues/96/issue-journal.md
+++ b/.codex-supervisor/issues/96/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #96: operations: define AegisOps business-hours SecOps daily operating model
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/96
+- Branch: codex/issue-96
+- Workspace: .
+- Journal: .codex-supervisor/issues/96/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 419a1f24a185307890348db9aa9ac568953b9d35
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-02T19:11:22.919Z
+
+## Latest Codex Summary
+- Added a focused verifier and fixture test for a missing business-hours SecOps operating-model document, reproduced the gap as a missing-doc failure, then added the baseline operating-model artifact and minimal documentation inventory updates.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Issue #96 is satisfied by a documentation-first baseline artifact plus a focused verifier that proves the operating-model contract exists and preserves business-hours assumptions, approval timeout handling, after-hours escalation, manual fallback, and analyst records.
+- What changed: Added `docs/secops-business-hours-operating-model.md`; added `scripts/verify-secops-business-hours-operating-model-doc.sh` and `scripts/test-verify-secops-business-hours-operating-model-doc.sh`; updated `README.md` and `docs/documentation-ownership-map.md` to inventory and own the new baseline doc.
+- Current blocker: none
+- Next exact step: Stage the updated files, create a checkpoint commit on `codex/issue-96`, and leave the branch ready for draft PR or review.
+- Verification gap: Only focused verifier coverage was run for this documentation slice; no broader repository-wide verification was run because the change is scoped to the new operating-model artifact.
+- Files touched: .codex-supervisor/issues/96/issue-journal.md, README.md, docs/secops-business-hours-operating-model.md, docs/documentation-ownership-map.md, scripts/verify-secops-business-hours-operating-model-doc.sh, scripts/test-verify-secops-business-hours-operating-model-doc.sh
+- Rollback concern: low; change is additive documentation and verifier coverage with minimal inventory updates.
+- Last focused command: bash scripts/verify-secops-business-hours-operating-model-doc.sh .
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/sigma-to-opensearch-translation-strategy.md`
 - `docs/detection-lifecycle-and-rule-qa-framework.md`
 - `docs/secops-domain-model.md`
+- `docs/secops-business-hours-operating-model.md`
 - `docs/auth-baseline.md`
 - `docs/response-action-safety-model.md`
 - `docs/control-plane-state-model.md`

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -30,6 +30,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/sigma-to-opensearch-translation-strategy.md` | Sigma-to-OpenSearch translation strategy baseline | IT Operations, Information Systems Department |
 | `docs/detection-lifecycle-and-rule-qa-framework.md` | Detection lifecycle and rule QA framework baseline | IT Operations, Information Systems Department |
 | `docs/secops-domain-model.md` | SecOps domain model baseline | IT Operations, Information Systems Department |
+| `docs/secops-business-hours-operating-model.md` | Business-hours SecOps daily operating model baseline | IT Operations, Information Systems Department |
 | `docs/auth-baseline.md` | Authentication, authorization, and service account ownership baseline | IT Operations, Information Systems Department |
 | `docs/response-action-safety-model.md` | Response action safety and approval binding baseline | IT Operations, Information Systems Department |
 | `docs/control-plane-state-model.md` | Control-plane state and reconciliation baseline | IT Operations, Information Systems Department |
@@ -43,6 +44,8 @@ The requirements baseline owner recorded in `docs/requirements-baseline.md` rema
 ADR records under `docs/adr/` may identify specific document proposers or reviewers, but repository-level ownership for the ADR area remains assigned to IT Operations, Information Systems Department unless this map is updated explicitly.
 
 The SecOps domain model document remains the shared semantic reference for baseline object definitions and state boundaries and must stay aligned with the approved architecture and requirements baseline.
+
+The business-hours SecOps operating model remains the analyst-workflow reference for triage, case creation, approval timeout handling, after-hours escalation, and handoff expectations under the non-24x7 baseline.
 
 The auth baseline remains the policy reference for operator personas, least-privilege authorization boundaries, machine identity ownership, and secret lifecycle expectations across future monitors, workflows, approvals, and integrations.
 

--- a/docs/secops-business-hours-operating-model.md
+++ b/docs/secops-business-hours-operating-model.md
@@ -1,0 +1,148 @@
+# AegisOps Business-Hours SecOps Daily Operating Model
+
+## 1. Purpose
+
+This document defines the business-hours SecOps daily operating model for the AegisOps baseline.
+
+It supplements `docs/requirements-baseline.md`, `docs/secops-domain-model.md`, `docs/auth-baseline.md`, `docs/response-action-safety-model.md`, and `docs/runbook.md` by defining the analyst-facing review flow that future UI, workflow, and runbook work must support.
+
+This document defines operating expectations, records, and decision points only. It does not create runtime automation, commit AegisOps to specific staffing levels, or authorize destructive response without the separately approved approval model.
+
+## 2. Operating Assumptions
+
+This model assumes business-hours analyst coverage rather than 24x7 staffed monitoring.
+
+Finding or alert intake enters the analyst review queue for the next business-hours review cycle unless an explicitly defined escalation path applies.
+
+The default daily model assumes analysts review queued findings and alerts during scheduled working hours, with explicit prioritization rather than continuous around-the-clock watchstanding.
+
+Read-oriented enrichment, context collection, note-taking, and case updates may occur during business hours without separate approval as long as they do not cross into response execution or unauthorized changes.
+
+Write-oriented, destructive, or externally visible response actions remain approval-bound under the baseline even when the analyst believes the action is urgent.
+
+Business-hours operation does not mean low rigor. Analysts must still preserve record quality, escalation clarity, evidence capture, and auditability for every reviewed work item.
+
+## 3. Daily Analyst Workflow
+
+### 3.1 Intake and Queue Review
+
+The analyst begins by validating whether the incoming finding or alert is in scope, duplicated, or obviously explained by known benign context.
+
+Initial review should answer these questions before deeper investigation begins:
+
+- Is the item a valid routed work item rather than ingestion noise or a duplicate?
+- Does existing context already explain the activity as false positive, benign positive, expected administrative activity, duplicate, or accepted risk?
+- Does the item require immediate same-day handling, business-hours follow-up, or explicit after-hours escalation?
+
+If the item is clearly duplicated or otherwise already accounted for, the analyst closes or links it using the approved disposition and preserves the relationship to the existing alert or case.
+
+### 3.2 Investigation and Case Decision
+
+If the item requires investigation, the analyst collects read-oriented evidence, confirms affected assets or identities, reviews related findings, and documents the working hypothesis.
+
+A case is created when the work requires durable ownership, evidence capture, approval tracking, cross-shift visibility, or coordinated follow-up beyond the alert record itself.
+
+The alert may remain the only work record when review is self-contained, no approval-bound action is needed, and closure can be justified directly on the alert.
+
+When a case is opened, the analyst records at minimum:
+
+- current owner;
+- linked findings or alerts;
+- relevant assets, identities, and evidence;
+- current hypothesis and risk summary; and
+- next review or follow-up expectation.
+
+### 3.3 Recommendation and Approval Preparation
+
+If the analyst concludes that a response step may be required, the analyst defines the recommended action without executing it.
+
+The analyst records the recommended action, target scope, justification, and required approver before any approval-bound response is requested.
+
+The recommendation should also state:
+
+- why the action is needed;
+- what evidence supports the recommendation;
+- what could go wrong if the action is delayed or denied; and
+- whether the action remains valid if approval arrives after the current review window.
+
+### 3.4 Approval Outcome and Closure
+
+If approval is granted and the workflow path is available, execution proceeds through the approved execution path and the resulting execution state is recorded separately from the approval outcome.
+
+If approval is rejected, the analyst records the rejection outcome, updates the alert or case with the next planned step, and closes or re-routes the work according to the approver's decision and the remaining risk.
+
+If no response action is required, the analyst closes the alert or case with the appropriate disposition, records the rationale, and captures any tuning or follow-up work that should be tracked outside the immediate review item.
+
+Closure is not complete until the analyst can show what was reviewed, what was decided, what evidence was relied on, and whether any additional follow-up remains open.
+
+## 4. Approval, Timeout, and Manual Fallback Expectations
+
+Approval timeout must leave the action request in a non-executed state and force explicit analyst re-review during business hours before any later execution attempt.
+
+Timeout is not silent approval, and timeout is not silent cancellation. It is a decision point that requires the next analyst review to determine whether the action is still necessary, still correctly scoped, and still justified by current evidence.
+
+If the underlying facts changed while approval was pending, the prior request must be superseded or closed rather than reused without review.
+
+Manual fallback may be used when the approved workflow path is unavailable, but the same approval decision, execution record, and post-action evidence requirements still apply.
+
+Manual fallback is reserved for cases where an approved action must still be carried out but the normal orchestration path is impaired, unavailable, or unsuitable for the current boundary. It must not be used as a convenience path to bypass logging or policy controls.
+
+When manual fallback is used, the operator must record:
+
+- the original action request;
+- the approval decision authorizing the action;
+- why the standard workflow path was unavailable or inappropriate;
+- who performed the fallback action;
+- what was actually done; and
+- what verification evidence confirmed the outcome.
+
+## 5. After-Hours and Handoff Model
+
+After hours, AegisOps does not imply an always-on analyst at the console.
+
+After-hours handling must distinguish between work that can wait for the next business-hours review window and work that requires explicit escalation to an on-call or separately designated human owner.
+
+Items that can safely wait remain queued for the next business-hours review cycle with enough context recorded that the next analyst does not need to reconstruct intent from raw system outputs alone.
+
+Items that cannot safely wait require an explicit escalation decision. That decision must identify who is being contacted, why waiting until the next business-hours window is not acceptable, and what authority boundary applies if a response action may be required.
+
+Approved escalation paths may notify or wake a designated human owner, but they do not convert the platform into a 24x7 staffed SOC and do not authorize autonomous destructive response.
+
+Business-hours handoff must preserve queue state, open cases, pending approvals, expired approvals, and follow-up tasks so the next analyst can continue without reconstructing context from raw system logs.
+
+At minimum, handoff notes should identify:
+
+- which alerts or cases remain open;
+- which actions are waiting for approval, have expired, or were rejected;
+- which items were escalated after hours and to whom;
+- what evidence or links the next analyst must review first; and
+- what follow-up deadlines or business constraints still apply.
+
+## 6. Required Records and Decision Points
+
+The operating model depends on durable records that separate analytic intake, investigation, approval, execution, and closure.
+
+| Record | What future implementation must preserve | Key decision point |
+| ---- | ---- | ---- |
+| `Alert or Finding Record` | Intake source, triage state, analyst-visible context, severity, and links to related records. | Does the item need analyst attention, deduplication, closure, or escalation? |
+| `Case Record` | Durable ownership, evidence references, investigative notes, linked alerts, and follow-up tasks. | Does this work need a separate investigation record or can it remain inside the alert lifecycle? |
+| `Approval Decision Record` | Approver identity, action scope, approval outcome, time of decision, and any conditions or constraints. | Was the requested action approved, rejected, or allowed to expire? |
+| `Action Execution Record` | Execution path, executor identity, attempt/result state, target scope, and post-action verification evidence. | Did the action actually run, and if so, what happened? |
+| `Closure or Disposition Record` | Final outcome, rationale, tuning implications, remaining accepted risk, and any downstream follow-up reference. | Is the work item ready to close, and what should future reviewers learn from the outcome? |
+
+Future UI and workflow work must preserve, at minimum, these decision points:
+
+- intake triage versus duplicate or immediate closure;
+- alert-only handling versus case creation;
+- recommendation-only state versus approval request;
+- approved versus rejected versus expired approval outcome;
+- automated execution versus manual fallback execution; and
+- closure with clear rationale versus continued follow-up.
+
+## 7. Baseline Alignment Notes
+
+This operating model remains aligned to the baseline assumption that AegisOps supports business-hours-oriented security operations rather than a permanently staffed SOC.
+
+It preserves the requirement that approval-sensitive actions remain human-gated, keeps approval and execution as separate records, and treats manual fallback as an exception path that still preserves auditability.
+
+No part of this operating model creates a 24x7 staffing promise, an automatic destructive-action path, or a dependency on unsupported live-response coverage.

--- a/scripts/test-verify-secops-business-hours-operating-model-doc.sh
+++ b/scripts/test-verify-secops-business-hours-operating-model-doc.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-secops-business-hours-operating-model-doc.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_doc() {
+  local target="$1"
+  local doc_content="$2"
+
+  printf '%s\n' "${doc_content}" >"${target}/docs/secops-business-hours-operating-model.md"
+  git -C "${target}" add docs/secops-business-hours-operating-model.md
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_doc "${valid_repo}" '# AegisOps Business-Hours SecOps Daily Operating Model
+
+## 1. Purpose
+
+This document defines the business-hours SecOps daily operating model for the AegisOps baseline.
+
+## 2. Operating Assumptions
+
+This model assumes business-hours analyst coverage rather than 24x7 staffed monitoring.
+
+Finding or alert intake enters the analyst review queue for the next business-hours review cycle unless an explicitly defined escalation path applies.
+
+## 3. Daily Analyst Workflow
+
+The analyst begins by validating whether the incoming finding or alert is in scope, duplicated, or obviously explained by known benign context.
+
+A case is created when the work requires durable ownership, evidence capture, approval tracking, cross-shift visibility, or coordinated follow-up beyond the alert record itself.
+
+The analyst records the recommended action, target scope, justification, and required approver before any approval-bound response is requested.
+
+## 4. Approval, Timeout, and Manual Fallback Expectations
+
+Approval timeout must leave the action request in a non-executed state and force explicit analyst re-review during business hours before any later execution attempt.
+
+Manual fallback may be used when the approved workflow path is unavailable, but the same approval decision, execution record, and post-action evidence requirements still apply.
+
+## 5. After-Hours and Handoff Model
+
+After hours, AegisOps does not imply an always-on analyst at the console.
+
+After-hours handling must distinguish between work that can wait for the next business-hours review window and work that requires explicit escalation to an on-call or separately designated human owner.
+
+Business-hours handoff must preserve queue state, open cases, pending approvals, expired approvals, and follow-up tasks so the next analyst can continue without reconstructing context from raw system logs.
+
+## 6. Required Records and Decision Points
+
+| Record | Expectation |
+| ---- | ---- |
+| `Alert or Finding Record` | Intake and triage state stay reviewable. |
+| `Case Record` | Durable investigation ownership is explicit. |
+| `Approval Decision Record` | Authorization outcome is attributable. |
+| `Action Execution Record` | Execution attempt state is separate from approval. |
+| `Closure or Disposition Record` | Closure rationale remains reviewable. |
+
+## 7. Baseline Alignment Notes
+
+No part of this operating model creates a 24x7 staffing promise, an automatic destructive-action path, or a dependency on unsupported live-response coverage.'
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing business-hours operating model document:"
+
+missing_phrase_repo="${workdir}/missing-phrase"
+create_repo "${missing_phrase_repo}"
+write_doc "${missing_phrase_repo}" '# AegisOps Business-Hours SecOps Daily Operating Model
+
+## 1. Purpose
+
+This document defines the business-hours SecOps daily operating model for the AegisOps baseline.
+
+## 2. Operating Assumptions
+
+This model assumes business-hours analyst coverage rather than 24x7 staffed monitoring.
+
+Finding or alert intake enters the analyst review queue for the next business-hours review cycle unless an explicitly defined escalation path applies.
+
+## 3. Daily Analyst Workflow
+
+The analyst begins by validating whether the incoming finding or alert is in scope, duplicated, or obviously explained by known benign context.
+
+A case is created when the work requires durable ownership, evidence capture, approval tracking, cross-shift visibility, or coordinated follow-up beyond the alert record itself.
+
+## 4. Approval, Timeout, and Manual Fallback Expectations
+
+Approval timeout must leave the action request in a non-executed state and force explicit analyst re-review during business hours before any later execution attempt.
+
+Manual fallback may be used when the approved workflow path is unavailable, but the same approval decision, execution record, and post-action evidence requirements still apply.
+
+## 5. After-Hours and Handoff Model
+
+After hours, AegisOps does not imply an always-on analyst at the console.
+
+After-hours handling must distinguish between work that can wait for the next business-hours review window and work that requires explicit escalation to an on-call or separately designated human owner.
+
+Business-hours handoff must preserve queue state, open cases, pending approvals, expired approvals, and follow-up tasks so the next analyst can continue without reconstructing context from raw system logs.
+
+## 6. Required Records and Decision Points
+
+| Record | Expectation |
+| ---- | ---- |
+| `Alert or Finding Record` | Intake and triage state stay reviewable. |
+| `Case Record` | Durable investigation ownership is explicit. |
+| `Approval Decision Record` | Authorization outcome is attributable. |
+| `Action Execution Record` | Execution attempt state is separate from approval. |
+| `Closure or Disposition Record` | Closure rationale remains reviewable. |
+
+## 7. Baseline Alignment Notes
+
+No part of this operating model creates a 24x7 staffing promise, an automatic destructive-action path, or a dependency on unsupported live-response coverage.'
+commit_fixture "${missing_phrase_repo}"
+assert_fails_with "${missing_phrase_repo}" "Missing business-hours operating model statement: The analyst records the recommended action, target scope, justification, and required approver before any approval-bound response is requested."
+
+echo "Business-hours SecOps operating model verifier tests passed."

--- a/scripts/verify-secops-business-hours-operating-model-doc.sh
+++ b/scripts/verify-secops-business-hours-operating-model-doc.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/secops-business-hours-operating-model.md"
+
+required_headings=(
+  "# AegisOps Business-Hours SecOps Daily Operating Model"
+  "## 1. Purpose"
+  "## 2. Operating Assumptions"
+  "## 3. Daily Analyst Workflow"
+  "## 4. Approval, Timeout, and Manual Fallback Expectations"
+  "## 5. After-Hours and Handoff Model"
+  "## 6. Required Records and Decision Points"
+  "## 7. Baseline Alignment Notes"
+)
+
+required_phrases=(
+  "This document defines the business-hours SecOps daily operating model for the AegisOps baseline."
+  "This model assumes business-hours analyst coverage rather than 24x7 staffed monitoring."
+  "Finding or alert intake enters the analyst review queue for the next business-hours review cycle unless an explicitly defined escalation path applies."
+  "The analyst begins by validating whether the incoming finding or alert is in scope, duplicated, or obviously explained by known benign context."
+  "A case is created when the work requires durable ownership, evidence capture, approval tracking, cross-shift visibility, or coordinated follow-up beyond the alert record itself."
+  "The analyst records the recommended action, target scope, justification, and required approver before any approval-bound response is requested."
+  "Approval timeout must leave the action request in a non-executed state and force explicit analyst re-review during business hours before any later execution attempt."
+  "Manual fallback may be used when the approved workflow path is unavailable, but the same approval decision, execution record, and post-action evidence requirements still apply."
+  "After hours, AegisOps does not imply an always-on analyst at the console."
+  "After-hours handling must distinguish between work that can wait for the next business-hours review window and work that requires explicit escalation to an on-call or separately designated human owner."
+  "Business-hours handoff must preserve queue state, open cases, pending approvals, expired approvals, and follow-up tasks so the next analyst can continue without reconstructing context from raw system logs."
+  '| `Alert or Finding Record` |'
+  '| `Case Record` |'
+  '| `Approval Decision Record` |'
+  '| `Action Execution Record` |'
+  '| `Closure or Disposition Record` |'
+  "No part of this operating model creates a 24x7 staffing promise, an automatic destructive-action path, or a dependency on unsupported live-response coverage."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing business-hours operating model document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing business-hours operating model heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Missing business-hours operating model statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+echo "Business-hours SecOps operating model document is present and defines the required workflow, after-hours handling, and audit records."


### PR DESCRIPTION
## What changed
- added `docs/secops-business-hours-operating-model.md` to define the business-hours SecOps analyst workflow from intake through triage, case creation, approval handling, closure, after-hours escalation, manual fallback, and handoff
- added `scripts/verify-secops-business-hours-operating-model-doc.sh` plus `scripts/test-verify-secops-business-hours-operating-model-doc.sh` to enforce the required operating-model coverage
- updated the documentation inventory in `README.md` and `docs/documentation-ownership-map.md`

## Why it changed
Issue #96 requires a reviewable operating-model baseline so future UI, workflow, and runbook work stays aligned to the approved business-hours assumption instead of drifting into generic or 24x7-oriented behavior.

## Impact
This is a docs-and-verification checkpoint only. It does not add runtime automation, staffing commitments, or destructive-response behavior.

## Validation
- `bash scripts/verify-secops-business-hours-operating-model-doc.sh .`
- `bash scripts/test-verify-secops-business-hours-operating-model-doc.sh`

Closes #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added SecOps business-hours operating model documentation defining analyst workflow, approval handling, timeout procedures, after-hours escalation, and required audit records.
* Updated documentation maps and README to reflect the new operating model baseline.

## Tests
* Added verification scripts to validate documentation completeness and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->