### PR TITLE
[codex] Clarify telemetry required-field readiness semantics

### DIFF
--- a/docs/canonical-telemetry-schema-baseline.md
+++ b/docs/canonical-telemetry-schema-baseline.md
@@ -25,6 +25,8 @@ The normalized contract exists so downstream detections, findings, correlation l
 
 This baseline does not require every source to populate every field. It requires each source family to preserve the highest-fidelity values it has for the approved field groups and to avoid silent semantic drift during normalization.
 
+Required means normalization-required, not universally source-populated. When a source family cannot supply a required field group for some records, the gap must be documented as an explicit exception path rather than silently reclassifying the group as optional.
+
 ## 3. Normalization Model and Field Classes
 
 Normalized fields are grouped into three classes:
@@ -32,6 +34,11 @@ Normalized fields are grouped into three classes:
 - Required fields must exist on every normalized event in the initial approved families unless the source record is unusable.
 - Optional fields should be populated when the source or collector provides the necessary value without fabrication.
 - Derived fields may be added by AegisOps logic only when their origin remains explainable and the source-derived values remain distinguishable from derived context.
+
+Onboarding evidence may additionally mark a field group as unavailable or intentionally deferred for a source family review, but those are review states rather than field classes. They do not change a canonical required field group into an optional one.
+
+- `Unavailable` means the source cannot credibly provide the field group without fabrication for the reviewed scope. For shared required groups, that normally blocks normalization unless an explicit exception path is approved. For family baseline coverage, it normally blocks detection-ready status unless an explicit exception path says otherwise.
+- `Intentionally deferred` means the source family may support the field group later but the mapping, evidence, or parser work is not yet complete. Deferred required coverage blocks detection-ready status until the deferred gap is resolved or an explicit exception path is approved.
 
 Raw source payload preservation rules:
 
@@ -79,6 +86,12 @@ Raw source payload preservation rules:
 - Source and destination fields must preserve endpoint roles as reported by the source, especially for firewall, proxy, VPN, and SaaS access logs where observer perspective can differ from host-local semantics.
 
 ## 5. Initial Log Family Baselines
+
+Interpretation rule for the family baselines below:
+
+- Shared field groups marked `Required` in Section 4 are event-level normalization requirements.
+- Family sections marked "Required baseline coverage" are source-family readiness requirements for the listed semantic areas. They do not mean every representative field appears on every event; they mean the family must preserve that semantic area when the source exposes it and must document any approved exception path when it cannot.
+- A missing family baseline requirement must be classified during onboarding as either a normalization blocker, a detection-ready blocker, or an explicit exception path with allowed downstream usage.
 
 ### 5.1 Windows Security and Endpoint Telemetry
 

--- a/docs/source-onboarding-contract.md
+++ b/docs/source-onboarding-contract.md
@@ -44,6 +44,12 @@ Detection-ready status requires explicit evidence for canonical field coverage, 
 
 Field coverage evidence must map source fields into the canonical telemetry schema baseline and must identify required, optional, unavailable, and intentionally deferred fields without ambiguity.
 
+`Required` in this contract means the field group remains required by the canonical schema or family baseline even when a specific source family cannot currently supply it. Reviewers must not reinterpret required as optional merely because a source lacks the value.
+
+`Unavailable` means the source cannot credibly provide the field group for the reviewed scope without fabrication. `Intentionally deferred` means the source may support the field group later, but the mapping, parser, or evidence is not yet complete.
+
+Detection-ready review cannot treat a canonical required field group as satisfied by omission alone. A required field group may be unavailable or intentionally deferred only through an explicit documented exception path that states whether the gap blocks normalization, blocks detection readiness, or remains allowed for the current readiness state.
+
 Timestamp evidence must identify the source event time, any collector-created time, ingest arrival time, known clock-quality limitations, and the chosen mapping for `@timestamp`, `event.created`, and `event.ingested`.
 
 Identity and asset linkage evidence must show which principals, hosts, workloads, tenants, devices, or observers the source can represent and where that context is absent or unreliable.
@@ -55,7 +61,9 @@ A source family is not detection-ready until parser version evidence, field cove
 Detection-ready review must also confirm the following:
 
 - The normalization mapping uses canonical schema semantics first and reserves `aegisops.*` extensions for additive cases that ECS does not already cover.
-- Required field groups from the canonical telemetry schema are either populated, marked unavailable with justification, or explicitly deferred with a documented non-goal.
+- Required field groups from the canonical telemetry schema remain required even when a source family cannot yet satisfy them.
+- Shared required field groups that are unavailable block normalization unless the onboarding package documents an approved exception path.
+- Family required baseline coverage that is unavailable or intentionally deferred blocks detection-ready status unless the onboarding package documents an approved exception path and the resulting detector-use limits.
 - Timestamp quality limitations are preserved as evidence rather than hidden by silently rewriting source meaning.
 - Identity and asset linkage claims are supported by actual source fields, not by fabricated enrichment assumptions.
 - Detection authors can determine exactly which normalized fields are stable enough to depend on before activating rule content for the family.
@@ -83,7 +91,8 @@ State expectations:
 
 - `candidate` means the family is recognized, scoped, and documented enough to reserve a future onboarding path, but detection content must not depend on it.
 - `schema-reviewed` means the minimum onboarding package exists and the canonical mapping and evidence gaps have been reviewed, but detection activation remains blocked until readiness evidence is complete.
-- `detection-ready` means the family has completed the required evidence package and may be referenced by future detection content subject to separate detector and rollout review.
+- `detection-ready` means the family has completed the required evidence package, has no unresolved intentionally deferred required coverage, and may be referenced by future detection content subject to separate detector and rollout review.
+- `detection-ready` may rely on an explicit exception path only when the exception states which required coverage is missing, why the gap does not block the approved readiness scope, and which downstream detections remain prohibited.
 
 This contract is schema-driven and family-oriented. It must not become source-specific ad hoc guidance for individual products.
 

--- a/scripts/test-verify-canonical-telemetry-schema-doc.sh
+++ b/scripts/test-verify-canonical-telemetry-schema-doc.sh
@@ -80,9 +80,16 @@ A `Raw Event` is the source record exactly as received or as losslessly wrapped 
 
 A `Normalized Event` is the analytics-plane record after the source event has been mapped into the approved AegisOps field contract.
 
+Required means normalization-required, not universally source-populated. When a source family cannot supply a required field group for some records, the gap must be documented as an explicit exception path rather than silently reclassifying the group as optional.
+
 ## 3. Normalization Model and Field Classes
 
 Baseline classes are required, optional, and derived.
+
+Onboarding evidence may additionally mark a field group as unavailable or intentionally deferred for a source family review, but those are review states rather than field classes. They do not change a canonical required field group into an optional one.
+
+- `Unavailable` means the source cannot credibly provide the field group without fabrication for the reviewed scope. For shared required groups, that normally blocks normalization unless an explicit exception path is approved. For family baseline coverage, it normally blocks detection-ready status unless an explicit exception path says otherwise.
+- `Intentionally deferred` means the source family may support the field group later but the mapping, evidence, or parser work is not yet complete. Deferred required coverage blocks detection-ready status until the deferred gap is resolved or an explicit exception path is approved.
 
 ## 4. Shared Normalized Field Groups
 
@@ -98,6 +105,10 @@ Baseline classes are required, optional, and derived.
 | AegisOps derived context | `rule.*`, `tags`, `related.*`, `aegisops.*` | Derived |
 
 ## 5. Initial Log Family Baselines
+
+- Shared field groups marked `Required` in Section 4 are event-level normalization requirements.
+- Family sections marked "Required baseline coverage" are source-family readiness requirements for the listed semantic areas. They do not mean every representative field appears on every event; they mean the family must preserve that semantic area when the source exposes it and must document any approved exception path when it cannot.
+- A missing family baseline requirement must be classified during onboarding as either a normalization blocker, a detection-ready blocker, or an explicit exception path with allowed downstream usage.
 
 ### 5.1 Windows Security and Endpoint Telemetry
 
@@ -152,6 +163,72 @@ A `Raw Event` is the source record exactly as received or as losslessly wrapped 
 
 A `Normalized Event` is the analytics-plane record after the source event has been mapped into the approved AegisOps field contract.
 
+Required means normalization-required, not universally source-populated. When a source family cannot supply a required field group for some records, the gap must be documented as an explicit exception path rather than silently reclassifying the group as optional.
+
+## 3. Normalization Model and Field Classes
+
+Baseline classes are required, optional, and derived.
+
+Onboarding evidence may additionally mark a field group as unavailable or intentionally deferred for a source family review, but those are review states rather than field classes. They do not change a canonical required field group into an optional one.
+
+- `Unavailable` means the source cannot credibly provide the field group without fabrication for the reviewed scope. For shared required groups, that normally blocks normalization unless an explicit exception path is approved. For family baseline coverage, it normally blocks detection-ready status unless an explicit exception path says otherwise.
+- `Intentionally deferred` means the source family may support the field group later but the mapping, evidence, or parser work is not yet complete. Deferred required coverage blocks detection-ready status until the deferred gap is resolved or an explicit exception path is approved.
+
+## 4. Shared Normalized Field Groups
+
+| Field group | Representative fields | Class |
+| ---- | ---- | ---- |
+| Event classification | `event.*` | Required |
+| Time semantics | `@timestamp`, `event.created`, `event.ingested` | Required |
+| Source provenance | `observer.*`, `agent.*`, `event.provider`, `event.module`, `event.dataset`, `aegisops.provenance.*` | Required |
+| Identity references | `user.*`, `source.user.*`, `destination.user.*`, `related.user` | Optional |
+| Asset references | `host.*`, `observer.*`, `cloud.*`, `orchestrator.*`, `related.hosts` | Optional |
+| Network fields | `source.*`, `destination.*`, `network.*`, `url.*`, `dns.*`, `http.*`, `tls.*`, `related.ip` | Optional |
+| Process lineage | `process.*`, `process.parent.*`, `process.group_leader.*`, `related.process` | Optional |
+| AegisOps derived context | `rule.*`, `tags`, `related.*`, `aegisops.*` | Derived |
+
+## 5. Initial Log Family Baselines
+
+- Shared field groups marked `Required` in Section 4 are event-level normalization requirements.
+- Family sections marked "Required baseline coverage" are source-family readiness requirements for the listed semantic areas. They do not mean every representative field appears on every event; they mean the family must preserve that semantic area when the source exposes it and must document any approved exception path when it cannot.
+- A missing family baseline requirement must be classified during onboarding as either a normalization blocker, a detection-ready blocker, or an explicit exception path with allowed downstream usage.
+
+### 5.1 Windows Security and Endpoint Telemetry
+
+Normalized Windows telemetry must preserve actor identity, target identity when present, host identity, logon context, process lineage where available, and the original event channel or provider.
+
+## 6. ECS Alignment and AegisOps Extensions
+
+AegisOps adopts ECS as the baseline field naming and semantic contract for normalized events.
+
+AegisOps-specific fields are allowed only under the `aegisops.*` namespace.
+
+The baseline extension rule is additive: contributors may introduce `aegisops.*` fields when ECS lacks a stable home, but they must not redefine established ECS semantics or duplicate ECS fields with conflicting meaning.
+
+## 7. Baseline Guardrails
+
+This baseline is schema-first and runtime-neutral. A future issue may define mappings, pipelines, transforms, or storage policies, but this document does not approve those runtime behaviors.'
+commit_fixture "${missing_family_repo}"
+assert_fails_with "${missing_family_repo}" "### 5.2 Linux Operating System and Workload Telemetry"
+
+missing_required_semantics_repo="${workdir}/missing-required-semantics"
+create_repo "${missing_required_semantics_repo}"
+write_doc "${missing_required_semantics_repo}" '# AegisOps Canonical Telemetry Schema Baseline
+
+## 1. Purpose
+
+This document defines the canonical normalized telemetry schema baseline for the initial AegisOps log families.
+
+It establishes required, optional, and derived field expectations for future detection, correlation, enrichment, and case-oriented design work.
+
+This document defines schema semantics and preservation expectations only. It does not introduce live index mappings, ingestion pipelines, runtime transforms, or retention behavior.
+
+## 2. Baseline Scope and Non-Goals
+
+A `Raw Event` is the source record exactly as received or as losslessly wrapped by the ingest boundary before normalization.
+
+A `Normalized Event` is the analytics-plane record after the source event has been mapped into the approved AegisOps field contract.
+
 ## 3. Normalization Model and Field Classes
 
 Baseline classes are required, optional, and derived.
@@ -175,6 +252,18 @@ Baseline classes are required, optional, and derived.
 
 Normalized Windows telemetry must preserve actor identity, target identity when present, host identity, logon context, process lineage where available, and the original event channel or provider.
 
+### 5.2 Linux Operating System and Workload Telemetry
+
+Normalized Linux telemetry must preserve host identity, actor identity where present, process and parent process context where available, facility or collector provenance, and network endpoint context when the source record provides it.
+
+### 5.3 Network Device and Network Security Telemetry
+
+Normalized network telemetry must preserve observer identity, source and destination endpoint context, network transport and direction semantics, vendor or product provenance, and protocol-specific fields only when present in the original source.
+
+### 5.4 SaaS Audit and Control-Plane Telemetry
+
+Normalized SaaS telemetry must preserve tenant or organization context, actor identity, target identity when present, API or control-plane action semantics, source IP or access path context when present, and the originating provider metadata.
+
 ## 6. ECS Alignment and AegisOps Extensions
 
 AegisOps adopts ECS as the baseline field naming and semantic contract for normalized events.
@@ -186,7 +275,7 @@ The baseline extension rule is additive: contributors may introduce `aegisops.*`
 ## 7. Baseline Guardrails
 
 This baseline is schema-first and runtime-neutral. A future issue may define mappings, pipelines, transforms, or storage policies, but this document does not approve those runtime behaviors.'
-commit_fixture "${missing_family_repo}"
-assert_fails_with "${missing_family_repo}" "### 5.2 Linux Operating System and Workload Telemetry"
+commit_fixture "${missing_required_semantics_repo}"
+assert_fails_with "${missing_required_semantics_repo}" "Required means normalization-required, not universally source-populated."
 
 echo "verify-canonical-telemetry-schema-doc tests passed"

--- a/scripts/test-verify-source-onboarding-contract-doc.sh
+++ b/scripts/test-verify-source-onboarding-contract-doc.sh
@@ -94,6 +94,12 @@ Detection-ready status requires explicit evidence for canonical field coverage, 
 
 Field coverage evidence must map source fields into the canonical telemetry schema baseline and must identify required, optional, unavailable, and intentionally deferred fields without ambiguity.
 
+`Required` in this contract means the field group remains required by the canonical schema or family baseline even when a specific source family cannot currently supply it. Reviewers must not reinterpret required as optional merely because a source lacks the value.
+
+`Unavailable` means the source cannot credibly provide the field group for the reviewed scope without fabrication. `Intentionally deferred` means the source may support the field group later, but the mapping, parser, or evidence is not yet complete.
+
+Detection-ready review cannot treat a canonical required field group as satisfied by omission alone. A required field group may be unavailable or intentionally deferred only through an explicit documented exception path that states whether the gap blocks normalization, blocks detection readiness, or remains allowed for the current readiness state.
+
 Timestamp evidence must identify the source event time, any collector-created time, ingest arrival time, known clock-quality limitations, and the chosen mapping for `@timestamp`, `event.created`, and `event.ingested`.
 
 Identity and asset linkage evidence must show which principals, hosts, workloads, tenants, devices, or observers the source can represent and where that context is absent or unreliable.
@@ -101,6 +107,12 @@ Identity and asset linkage evidence must show which principals, hosts, workloads
 Provenance evidence must preserve source product, provider, module or dataset, collector path, and parser version details so normalized events remain traceable to their collection path.
 
 A source family is not detection-ready until parser version evidence, field coverage evidence, and provenance evidence are documented and reviewable.
+
+Required field groups from the canonical telemetry schema remain required even when a source family cannot yet satisfy them.
+
+Shared required field groups that are unavailable block normalization unless the onboarding package documents an approved exception path.
+
+Family required baseline coverage that is unavailable or intentionally deferred blocks detection-ready status unless the onboarding package documents an approved exception path and the resulting detector-use limits.
 
 ## 5. Replay and Sample Data Expectations
 
@@ -113,6 +125,10 @@ Sources that are not yet detection-ready must state their explicit non-goals, kn
 ## 6. Readiness States
 
 Readiness states must distinguish at least `candidate`, `schema-reviewed`, and `detection-ready` source families.
+
+`detection-ready` means the family has completed the required evidence package, has no unresolved intentionally deferred required coverage, and may be referenced by future detection content subject to separate detector and rollout review.
+
+`detection-ready` may rely on an explicit exception path only when the exception states which required coverage is missing, why the gap does not block the approved readiness scope, and which downstream detections remain prohibited.
 
 This contract is schema-driven and family-oriented. It must not become source-specific ad hoc guidance for individual products.
 
@@ -130,6 +146,80 @@ assert_fails_with "${missing_doc_repo}" "Missing source onboarding contract docu
 missing_state_repo="${workdir}/missing-state"
 create_repo "${missing_state_repo}"
 write_doc "${missing_state_repo}" '# AegisOps Source Onboarding Contract
+
+## 1. Purpose
+
+This document defines the minimum onboarding contract for any telemetry source family that seeks admission into the AegisOps normalized telemetry baseline.
+
+It establishes the required evidence, ownership, field coverage, provenance, and readiness checks that must exist before downstream detection content can rely on a source family.
+
+This contract governs documentation and validation expectations only. It does not approve live ingestion, parser deployment, source credentials, or runtime onboarding behavior.
+
+## 2. Contract Scope and Non-Goals
+
+Each source family onboarding package must identify the source family description, parser ownership, raw payload reference, normalization mapping, and sample data plan.
+
+## 3. Minimum Onboarding Package
+
+| Artifact | Expectation |
+| ---- | ---- |
+| Source family description | Required artifact |
+| Parser ownership and lifecycle | Required artifact |
+| Raw payload reference | Required artifact |
+| Normalization mapping | Required artifact |
+| Sample data and replay plan | Required artifact |
+
+## 4. Detection-Ready Evidence Requirements
+
+Detection-ready status requires explicit evidence for canonical field coverage, timestamp quality, identity linkage, asset linkage, provenance, and parser version traceability.
+
+Field coverage evidence must map source fields into the canonical telemetry schema baseline and must identify required, optional, unavailable, and intentionally deferred fields without ambiguity.
+
+`Required` in this contract means the field group remains required by the canonical schema or family baseline even when a specific source family cannot currently supply it. Reviewers must not reinterpret required as optional merely because a source lacks the value.
+
+`Unavailable` means the source cannot credibly provide the field group for the reviewed scope without fabrication. `Intentionally deferred` means the source may support the field group later, but the mapping, parser, or evidence is not yet complete.
+
+Detection-ready review cannot treat a canonical required field group as satisfied by omission alone. A required field group may be unavailable or intentionally deferred only through an explicit documented exception path that states whether the gap blocks normalization, blocks detection readiness, or remains allowed for the current readiness state.
+
+Timestamp evidence must identify the source event time, any collector-created time, ingest arrival time, known clock-quality limitations, and the chosen mapping for `@timestamp`, `event.created`, and `event.ingested`.
+
+Identity and asset linkage evidence must show which principals, hosts, workloads, tenants, devices, or observers the source can represent and where that context is absent or unreliable.
+
+Provenance evidence must preserve source product, provider, module or dataset, collector path, and parser version details so normalized events remain traceable to their collection path.
+
+A source family is not detection-ready until parser version evidence, field coverage evidence, and provenance evidence are documented and reviewable.
+
+Required field groups from the canonical telemetry schema remain required even when a source family cannot yet satisfy them.
+
+Shared required field groups that are unavailable block normalization unless the onboarding package documents an approved exception path.
+
+Family required baseline coverage that is unavailable or intentionally deferred blocks detection-ready status unless the onboarding package documents an approved exception path and the resulting detector-use limits.
+
+## 5. Replay and Sample Data Expectations
+
+Replay-capable sample data must be sufficient for future parser and mapping validation without implying that live source onboarding is approved.
+
+Sample datasets must preserve provenance, capture representative success and failure cases, and document any redaction or synthetic substitutions.
+
+Sources that are not yet detection-ready must state their explicit non-goals, known schema gaps, and why downstream detections must not depend on them yet.
+
+## 6. Readiness States
+
+`detection-ready` means the family has completed the required evidence package, has no unresolved intentionally deferred required coverage, and may be referenced by future detection content subject to separate detector and rollout review.
+
+`detection-ready` may rely on an explicit exception path only when the exception states which required coverage is missing, why the gap does not block the approved readiness scope, and which downstream detections remain prohibited.
+
+This contract is schema-driven and family-oriented. It must not become source-specific ad hoc guidance for individual products.
+ 
+## 7. Baseline Alignment Notes
+
+This contract remains aligned to `docs/canonical-telemetry-schema-baseline.md` and does not approve runtime parsers, ingest pipelines, or credential handling.'
+commit_fixture "${missing_state_repo}"
+assert_fails_with "${missing_state_repo}" 'Readiness states must distinguish at least `candidate`, `schema-reviewed`, and `detection-ready` source families.'
+
+missing_required_semantics_repo="${workdir}/missing-required-semantics"
+create_repo "${missing_required_semantics_repo}"
+write_doc "${missing_required_semantics_repo}" '# AegisOps Source Onboarding Contract
 
 ## 1. Purpose
 
@@ -177,12 +267,14 @@ Sources that are not yet detection-ready must state their explicit non-goals, kn
 
 ## 6. Readiness States
 
+Readiness states must distinguish at least `candidate`, `schema-reviewed`, and `detection-ready` source families.
+
 This contract is schema-driven and family-oriented. It must not become source-specific ad hoc guidance for individual products.
 
 ## 7. Baseline Alignment Notes
 
 This contract remains aligned to `docs/canonical-telemetry-schema-baseline.md` and does not approve runtime parsers, ingest pipelines, or credential handling.'
-commit_fixture "${missing_state_repo}"
-assert_fails_with "${missing_state_repo}" 'Readiness states must distinguish at least `candidate`, `schema-reviewed`, and `detection-ready` source families.'
+commit_fixture "${missing_required_semantics_repo}"
+assert_fails_with "${missing_required_semantics_repo}" '`Required` in this contract means the field group remains required by the canonical schema or family baseline even when a specific source family cannot currently supply it. Reviewers must not reinterpret required as optional merely because a source lacks the value.'
 
 echo "verify-source-onboarding-contract-doc tests passed"

--- a/scripts/verify-canonical-telemetry-schema-doc.sh
+++ b/scripts/verify-canonical-telemetry-schema-doc.sh
@@ -22,6 +22,10 @@ required_phrases=(
   'This document defines schema semantics and preservation expectations only. It does not introduce live index mappings, ingestion pipelines, runtime transforms, or retention behavior.'
   'A `Raw Event` is the source record exactly as received or as losslessly wrapped by the ingest boundary before normalization.'
   'A `Normalized Event` is the analytics-plane record after the source event has been mapped into the approved AegisOps field contract.'
+  'Required means normalization-required, not universally source-populated. When a source family cannot supply a required field group for some records, the gap must be documented as an explicit exception path rather than silently reclassifying the group as optional.'
+  'Onboarding evidence may additionally mark a field group as unavailable or intentionally deferred for a source family review, but those are review states rather than field classes. They do not change a canonical required field group into an optional one.'
+  '- `Unavailable` means the source cannot credibly provide the field group without fabrication for the reviewed scope. For shared required groups, that normally blocks normalization unless an explicit exception path is approved. For family baseline coverage, it normally blocks detection-ready status unless an explicit exception path says otherwise.'
+  '- `Intentionally deferred` means the source family may support the field group later but the mapping, evidence, or parser work is not yet complete. Deferred required coverage blocks detection-ready status until the deferred gap is resolved or an explicit exception path is approved.'
   '| Event classification | `event.*` | Required |'
   '| Time semantics | `@timestamp`, `event.created`, `event.ingested` | Required |'
   '| Source provenance | `observer.*`, `agent.*`, `event.provider`, `event.module`, `event.dataset`, `aegisops.provenance.*` | Required |'
@@ -34,6 +38,9 @@ required_phrases=(
   '### 5.2 Linux Operating System and Workload Telemetry'
   '### 5.3 Network Device and Network Security Telemetry'
   '### 5.4 SaaS Audit and Control-Plane Telemetry'
+  '- Shared field groups marked `Required` in Section 4 are event-level normalization requirements.'
+  '- Family sections marked "Required baseline coverage" are source-family readiness requirements for the listed semantic areas. They do not mean every representative field appears on every event; they mean the family must preserve that semantic area when the source exposes it and must document any approved exception path when it cannot.'
+  '- A missing family baseline requirement must be classified during onboarding as either a normalization blocker, a detection-ready blocker, or an explicit exception path with allowed downstream usage.'
   'Normalized Windows telemetry must preserve actor identity, target identity when present, host identity, logon context, process lineage where available, and the original event channel or provider.'
   'Normalized Linux telemetry must preserve host identity, actor identity where present, process and parent process context where available, facility or collector provenance, and network endpoint context when the source record provides it.'
   'Normalized network telemetry must preserve observer identity, source and destination endpoint context, network transport and direction semantics, vendor or product provenance, and protocol-specific fields only when present in the original source.'
@@ -57,7 +64,7 @@ for heading in "${required_headings[@]}"; do
 done
 
 for phrase in "${required_phrases[@]}"; do
-  if ! grep -Fq "${phrase}" "${doc_path}"; then
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
     echo "Missing canonical telemetry schema statement: ${phrase}" >&2
     exit 1
   fi

--- a/scripts/verify-source-onboarding-contract-doc.sh
+++ b/scripts/verify-source-onboarding-contract-doc.sh
@@ -28,14 +28,22 @@ required_phrases=(
   '| Sample data and replay plan | Required artifact |'
   "Detection-ready status requires explicit evidence for canonical field coverage, timestamp quality, identity linkage, asset linkage, provenance, and parser version traceability."
   "Field coverage evidence must map source fields into the canonical telemetry schema baseline and must identify required, optional, unavailable, and intentionally deferred fields without ambiguity."
+  '`Required` in this contract means the field group remains required by the canonical schema or family baseline even when a specific source family cannot currently supply it. Reviewers must not reinterpret required as optional merely because a source lacks the value.'
+  '`Unavailable` means the source cannot credibly provide the field group for the reviewed scope without fabrication. `Intentionally deferred` means the source may support the field group later, but the mapping, parser, or evidence is not yet complete.'
+  "Detection-ready review cannot treat a canonical required field group as satisfied by omission alone. A required field group may be unavailable or intentionally deferred only through an explicit documented exception path that states whether the gap blocks normalization, blocks detection readiness, or remains allowed for the current readiness state."
   'Timestamp evidence must identify the source event time, any collector-created time, ingest arrival time, known clock-quality limitations, and the chosen mapping for `@timestamp`, `event.created`, and `event.ingested`.'
   "Identity and asset linkage evidence must show which principals, hosts, workloads, tenants, devices, or observers the source can represent and where that context is absent or unreliable."
   "Provenance evidence must preserve source product, provider, module or dataset, collector path, and parser version details so normalized events remain traceable to their collection path."
   "A source family is not detection-ready until parser version evidence, field coverage evidence, and provenance evidence are documented and reviewable."
+  "Required field groups from the canonical telemetry schema remain required even when a source family cannot yet satisfy them."
+  "Shared required field groups that are unavailable block normalization unless the onboarding package documents an approved exception path."
+  "Family required baseline coverage that is unavailable or intentionally deferred blocks detection-ready status unless the onboarding package documents an approved exception path and the resulting detector-use limits."
   "Replay-capable sample data must be sufficient for future parser and mapping validation without implying that live source onboarding is approved."
   "Sample datasets must preserve provenance, capture representative success and failure cases, and document any redaction or synthetic substitutions."
   "Sources that are not yet detection-ready must state their explicit non-goals, known schema gaps, and why downstream detections must not depend on them yet."
   'Readiness states must distinguish at least `candidate`, `schema-reviewed`, and `detection-ready` source families.'
+  '`detection-ready` means the family has completed the required evidence package, has no unresolved intentionally deferred required coverage, and may be referenced by future detection content subject to separate detector and rollout review.'
+  '`detection-ready` may rely on an explicit exception path only when the exception states which required coverage is missing, why the gap does not block the approved readiness scope, and which downstream detections remain prohibited.'
   "This contract is schema-driven and family-oriented. It must not become source-specific ad hoc guidance for individual products."
   'This contract remains aligned to `docs/canonical-telemetry-schema-baseline.md` and does not approve runtime parsers, ingest pipelines, or credential handling.'
 )
@@ -53,7 +61,7 @@ for heading in "${required_headings[@]}"; do
 done
 
 for phrase in "${required_phrases[@]}"; do
-  if ! grep -Fq "${phrase}" "${doc_path}"; then
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
     echo "Missing source onboarding contract statement: ${phrase}" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- clarify the canonical telemetry schema wording so globally required normalized fields are defined as event-level normalization requirements
- align the source onboarding contract so `required`, `unavailable`, and `intentionally deferred` state whether a gap blocks normalization, detection readiness, or requires an explicit exception path
- tighten the narrow verifier scripts and reproducer tests so future edits preserve the clarified contract

## Why
The telemetry schema and source onboarding docs allowed an ambiguous reading where a source family could appear detection-ready while still lacking globally required normalized fields. This change makes the contract explicit for reviewers and doc verifiers.

## Validation
- `bash scripts/test-verify-canonical-telemetry-schema-doc.sh`
- `bash scripts/test-verify-source-onboarding-contract-doc.sh`
- `bash scripts/verify-canonical-telemetry-schema-doc.sh`
- `bash scripts/verify-source-onboarding-contract-doc.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified "Required" field semantics in telemetry schema baselines to distinguish normalization-required coverage from universal source availability.
  * Added onboarding review states—`Unavailable` and `Intentionally deferred`—with stricter rules for documenting exceptions to required field group coverage.

* **Tests**
  * Enhanced verification tests for schema and onboarding contract documentation with expanded fixture coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->