### PR TITLE
[codex] Add Phase 5 CI workflow coverage self-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           bash scripts/test-verify-compose-skeleton-validation.sh
           bash scripts/test-verify-compose-skeleton-overview-doc.sh
           bash scripts/test-verify-control-plane-state-model-doc.sh
+          bash scripts/test-verify-ci-phase-5-workflow-coverage.sh
           bash scripts/test-verify-detection-lifecycle-and-rule-qa-framework.sh
           bash scripts/test-verify-phase-5-semantic-contract-validation.sh
           bash scripts/test-verify-repository-skeleton.sh


### PR DESCRIPTION
## Summary
- add the existing Phase 5 workflow coverage guard to the CI focused shell test stage
- keep the CI change limited to wiring `bash scripts/test-verify-ci-phase-5-workflow-coverage.sh` into `.github/workflows/ci.yml`
- preserve the existing Phase 5 verifier and focused test command list enforced by the guard

## Why
The repository already had `scripts/test-verify-ci-phase-5-workflow-coverage.sh`, but the main CI workflow was not executing it. That meant CI would not automatically catch a future removal of required Phase 5 verifier or focused shell test commands from `.github/workflows/ci.yml`.

## Validation
- `bash scripts/test-verify-ci-phase-5-workflow-coverage.sh`
- `rg -n "test-verify-ci-phase-5-workflow-coverage\\.sh" .github/workflows/ci.yml`
- temporary negative check removing `bash scripts/test-verify-auth-baseline-doc.sh` from a copied workflow and rerunning the guard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI verification pipeline with automated workflow coverage checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->