### PR TITLE
[codex] Add Phase 6 initial telemetry slice baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/source-onboarding-contract.md`
 - `docs/sigma-to-opensearch-translation-strategy.md`
 - `docs/detection-lifecycle-and-rule-qa-framework.md`
+- `docs/phase-6-initial-telemetry-slice.md`
 - `docs/secops-domain-model.md`
 - `docs/secops-business-hours-operating-model.md`
 - `docs/auth-baseline.md`

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -29,6 +29,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/source-onboarding-contract.md` | Source onboarding contract baseline | IT Operations, Information Systems Department |
 | `docs/sigma-to-opensearch-translation-strategy.md` | Sigma-to-OpenSearch translation strategy baseline | IT Operations, Information Systems Department |
 | `docs/detection-lifecycle-and-rule-qa-framework.md` | Detection lifecycle and rule QA framework baseline | IT Operations, Information Systems Department |
+| `docs/phase-6-initial-telemetry-slice.md` | Phase 6 initial telemetry family and use-case selection baseline | IT Operations, Information Systems Department |
 | `docs/secops-domain-model.md` | SecOps domain model baseline | IT Operations, Information Systems Department |
 | `docs/secops-business-hours-operating-model.md` | Business-hours SecOps daily operating model baseline | IT Operations, Information Systems Department |
 | `docs/auth-baseline.md` | Authentication, authorization, and service account ownership baseline | IT Operations, Information Systems Department |
@@ -62,6 +63,8 @@ The source onboarding contract baseline remains the shared readiness reference f
 The Sigma-to-OpenSearch translation strategy baseline remains the approved boundary for what Sigma content is portable into future OpenSearch detector work, what must be deferred, and when detections must remain OpenSearch-native.
 
 The detection lifecycle and rule QA framework baseline remains the approval-readiness reference for moving reviewed detection content from proposal through activation, deprecation, and retirement without bypassing staging or evidence expectations.
+
+The Phase 6 initial telemetry slice document remains the narrow scoping reference for the first validated family and use-case set and must stay aligned with the business-hours operating model, replay-readiness assumptions, and Sigma translation boundaries.
 
 Parameter documents under `docs/parameters/` remain the authoritative human-readable home for parameter references, category explanations, ownership notes, and review guidance.
 

--- a/docs/phase-6-initial-telemetry-slice.md
+++ b/docs/phase-6-initial-telemetry-slice.md
@@ -1,0 +1,73 @@
+# AegisOps Phase 6 Initial Telemetry Slice
+
+## 1. Purpose
+
+This document selects the single initial telemetry family and first detection use cases for the Phase 6 validated slice.
+
+It supplements `docs/canonical-telemetry-schema-baseline.md`, `docs/source-onboarding-contract.md`, `docs/detection-lifecycle-and-rule-qa-framework.md`, `docs/secops-business-hours-operating-model.md`, `docs/retention-evidence-and-replay-readiness-baseline.md`, and `docs/sigma-to-opensearch-translation-strategy.md` by narrowing the first end-to-end validation target to one family and a small set of reviewable detections.
+
+This document selects scope only. It does not approve live onboarding, production detector activation, new response automation, or a broader Phase 6 implementation plan.
+
+## 2. Selected Initial Telemetry Family
+
+The selected initial telemetry family for the Phase 6 slice is Windows security and endpoint telemetry.
+
+Phase 6 starts with one telemetry family only.
+
+This family is the best initial fit for the first validated slice because the existing baseline already expects Windows telemetry to preserve event classification, timestamp semantics, source provenance, host identity, and actor or target identity when present.
+
+Those semantics are sufficient to validate the first end-to-end path from normalized event review, through single-event detection expression, into finding or alert handling without adding cross-family normalization ambiguity.
+
+## 3. Selected Initial Detection Use Cases
+
+The initial use cases below are intentionally limited to single-event detections that can be reviewed during business hours and exercised through replay.
+
+The Phase 6 slice is limited to these three initial detection use cases:
+
+1. Privileged group membership change
+   Detect a Windows event that records a user being added to a privileged local or domain group.
+   This is a high-signal administrative change with clear actor, target, and host context and does not require thresholding or multi-event correlation to be meaningful.
+2. Audit log cleared
+   Detect a Windows event that records clearing of the Windows audit log.
+   This is a direct single-event security signal that exercises provenance and timestamp handling while remaining reviewable as a standalone analyst work item.
+3. New local user created
+   Detect a Windows event that records creation of a new local account on a managed endpoint or server.
+   This is narrow enough for replay validation, often preserves actor and target identity, and fits business-hours triage as a review-first use case rather than an automatic action trigger.
+
+Each selected use case can be exercised with replayable Windows event samples and handled through read-only analyst workflow steps before any approval-bound response exists.
+
+The initial slice deliberately avoids detections that depend on threshold accumulation, sequence logic, cross-host correlation, or unresolved enrichment dependencies.
+
+## 4. Selection Rationale
+
+Windows telemetry is the best first proof of the Phase 5 contracts because it exercises actor identity, host identity, provenance, timestamp semantics, and Sigma-compatible single-event detection patterns in one family.
+
+The selected use cases are also small enough to validate the current contracts end to end:
+
+- They fit the source onboarding contract because representative Windows event samples can document raw payload shape, mapping assumptions, replay corpus needs, and parser provenance without having to solve multiple source families at once.
+- They fit the Sigma translation strategy because each use case can be expressed as a reviewable, single-rule, single-event hypothesis rather than a correlation story or a threshold rule.
+- They fit the detection lifecycle and rule QA framework because replay evidence, field coverage review, and expected-volume review can be evaluated for a narrow set of discrete administrative-security events.
+- They fit the business-hours operating model because they are plausible queue-driven review items that can be investigated through read-oriented evidence collection before any approval-bound response exists.
+- They fit the retention and replay baseline because normalized Windows event samples are a credible replay substrate for repeated detector validation and analyst workflow review.
+
+Windows is preferred over the other approved telemetry families for the first slice because the alternatives would broaden scope too early:
+
+Network telemetry is deferred because volume, directionality, and product variance would broaden parser and tuning scope too early.
+
+Linux telemetry is deferred because initial source heterogeneity would widen normalization and replay coverage before the first vertical slice is proven.
+
+SaaS audit telemetry is deferred because provider-specific action semantics would force early cross-provider narrowing inside a family that is still too broad for the first validated slice.
+
+## 5. Scope Guardrails
+
+No additional telemetry families, correlation logic, threshold-based analytics, response automation, or after-hours operating promises are included in this slice.
+
+The first Phase 6 validation target is limited to proving that one reviewed family can support:
+
+- replayable sample selection;
+- schema and provenance review for the required fields the chosen detections rely on;
+- up to three single-event detection definitions;
+- finding or alert handling that remains compatible with the current business-hours operating model; and
+- read-only investigation steps that do not assume write-capable response execution.
+
+If a proposed addition requires a second telemetry family, sequence or threshold analytics, cross-provider SaaS normalization, after-hours workflow guarantees, or automatic response behavior, it is outside this initial Phase 6 slice and should be handled by a later scoped issue.

--- a/scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
+++ b/scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-6-initial-telemetry-slice-doc.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_doc() {
+  local target="$1"
+  local doc_content="$2"
+
+  printf '%s\n' "${doc_content}" >"${target}/docs/phase-6-initial-telemetry-slice.md"
+  git -C "${target}" add docs/phase-6-initial-telemetry-slice.md
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_doc "${valid_repo}" '# AegisOps Phase 6 Initial Telemetry Slice
+
+## 1. Purpose
+
+This document selects the single initial telemetry family and first detection use cases for the Phase 6 validated slice.
+
+## 2. Selected Initial Telemetry Family
+
+The selected initial telemetry family for the Phase 6 slice is Windows security and endpoint telemetry.
+
+Phase 6 starts with one telemetry family only.
+
+## 3. Selected Initial Detection Use Cases
+
+The initial use cases below are intentionally limited to single-event detections that can be reviewed during business hours and exercised through replay.
+
+The Phase 6 slice is limited to these three initial detection use cases:
+
+1. Privileged group membership change
+2. Audit log cleared
+3. New local user created
+
+Each selected use case can be exercised with replayable Windows event samples and handled through read-only analyst workflow steps before any approval-bound response exists.
+
+## 4. Selection Rationale
+
+Windows telemetry is the best first proof of the Phase 5 contracts because it exercises actor identity, host identity, provenance, timestamp semantics, and Sigma-compatible single-event detection patterns in one family.
+
+Network telemetry is deferred because volume, directionality, and product variance would broaden parser and tuning scope too early.
+
+Linux telemetry is deferred because initial source heterogeneity would widen normalization and replay coverage before the first vertical slice is proven.
+
+SaaS audit telemetry is deferred because provider-specific action semantics would force early cross-provider narrowing inside a family that is still too broad for the first validated slice.
+
+## 5. Scope Guardrails
+
+No additional telemetry families, correlation logic, threshold-based analytics, response automation, or after-hours operating promises are included in this slice.'
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing Phase 6 initial telemetry slice document:"
+
+too_many_repo="${workdir}/too-many"
+create_repo "${too_many_repo}"
+write_doc "${too_many_repo}" '# AegisOps Phase 6 Initial Telemetry Slice
+
+## 1. Purpose
+
+This document selects the single initial telemetry family and first detection use cases for the Phase 6 validated slice.
+
+## 2. Selected Initial Telemetry Family
+
+The selected initial telemetry family for the Phase 6 slice is Windows security and endpoint telemetry.
+
+Phase 6 starts with one telemetry family only.
+
+## 3. Selected Initial Detection Use Cases
+
+The initial use cases below are intentionally limited to single-event detections that can be reviewed during business hours and exercised through replay.
+
+The Phase 6 slice is limited to these three initial detection use cases:
+
+1. Privileged group membership change
+2. Audit log cleared
+3. New local user created
+4. Extra use case
+
+Each selected use case can be exercised with replayable Windows event samples and handled through read-only analyst workflow steps before any approval-bound response exists.
+
+## 4. Selection Rationale
+
+Windows telemetry is the best first proof of the Phase 5 contracts because it exercises actor identity, host identity, provenance, timestamp semantics, and Sigma-compatible single-event detection patterns in one family.
+
+Network telemetry is deferred because volume, directionality, and product variance would broaden parser and tuning scope too early.
+
+Linux telemetry is deferred because initial source heterogeneity would widen normalization and replay coverage before the first vertical slice is proven.
+
+SaaS audit telemetry is deferred because provider-specific action semantics would force early cross-provider narrowing inside a family that is still too broad for the first validated slice.
+
+## 5. Scope Guardrails
+
+No additional telemetry families, correlation logic, threshold-based analytics, response automation, or after-hours operating promises are included in this slice.'
+commit_fixture "${too_many_repo}"
+assert_fails_with "${too_many_repo}" "Expected exactly three numbered initial detection use cases, found 4."
+
+echo "Phase 6 initial telemetry slice verifier tests passed."

--- a/scripts/verify-phase-6-initial-telemetry-slice-doc.sh
+++ b/scripts/verify-phase-6-initial-telemetry-slice-doc.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-6-initial-telemetry-slice.md"
+
+required_headings=(
+  "# AegisOps Phase 6 Initial Telemetry Slice"
+  "## 1. Purpose"
+  "## 2. Selected Initial Telemetry Family"
+  "## 3. Selected Initial Detection Use Cases"
+  "## 4. Selection Rationale"
+  "## 5. Scope Guardrails"
+)
+
+required_phrases=(
+  "This document selects the single initial telemetry family and first detection use cases for the Phase 6 validated slice."
+  "The selected initial telemetry family for the Phase 6 slice is Windows security and endpoint telemetry."
+  "Phase 6 starts with one telemetry family only."
+  "The initial use cases below are intentionally limited to single-event detections that can be reviewed during business hours and exercised through replay."
+  "The Phase 6 slice is limited to these three initial detection use cases:"
+  "Privileged group membership change"
+  "Audit log cleared"
+  "New local user created"
+  "Each selected use case can be exercised with replayable Windows event samples and handled through read-only analyst workflow steps before any approval-bound response exists."
+  "Windows telemetry is the best first proof of the Phase 5 contracts because it exercises actor identity, host identity, provenance, timestamp semantics, and Sigma-compatible single-event detection patterns in one family."
+  "Network telemetry is deferred because volume, directionality, and product variance would broaden parser and tuning scope too early."
+  "Linux telemetry is deferred because initial source heterogeneity would widen normalization and replay coverage before the first vertical slice is proven."
+  "SaaS audit telemetry is deferred because provider-specific action semantics would force early cross-provider narrowing inside a family that is still too broad for the first validated slice."
+  "No additional telemetry families, correlation logic, threshold-based analytics, response automation, or after-hours operating promises are included in this slice."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 6 initial telemetry slice document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing Phase 6 telemetry slice heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 6 telemetry slice statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+use_case_count="$(grep -Ec '^[[:space:]]*[0-9]+\. ' "${doc_path}")"
+if [[ "${use_case_count}" -ne 3 ]]; then
+  echo "Expected exactly three numbered initial detection use cases, found ${use_case_count}." >&2
+  exit 1
+fi
+
+echo "Phase 6 initial telemetry slice document is present and constrained to one family with three replayable, reviewable use cases."


### PR DESCRIPTION
## What changed
- added `docs/phase-6-initial-telemetry-slice.md` to select the first Phase 6 telemetry family and initial detection use cases
- selected Windows security and endpoint telemetry as the only initial family for the first validated slice
- limited the initial detection set to three replayable, single-event use cases: privileged group membership change, audit log cleared, and new local user created
- added a focused verifier and fixture test for the new Phase 6 slice document
- updated the README and documentation ownership map to inventory the new baseline artifact

## Why
Phase 6 needed an explicit first vertical slice that stays narrow enough to validate the Phase 5 contracts end to end without broadening scope into multiple telemetry families, correlation logic, or response automation.

## Impact
The repository now has a reviewable baseline decision for the first telemetry family and first detection use cases, plus a focused verifier that keeps the scope constrained.

## Validation
- `bash scripts/verify-phase-6-initial-telemetry-slice-doc.sh .`
- `bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh`
- `bash scripts/verify-documentation-ownership-map.sh .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 6 initial telemetry slice documentation defining validation scope and requirements.
  * Updated documentation index and ownership mappings.

* **Tests**
  * Added automated verification tests for Phase 6 documentation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->