### PR TITLE
[codex] Add Windows telemetry field coverage verification

### DIFF
--- a/.codex-supervisor/issues/125/issue-journal.md
+++ b/.codex-supervisor/issues/125/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #125: implementation: add normalized telemetry fixtures and field-coverage verification for the selected telemetry family
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/125
+- Branch: codex/issue-125
+- Workspace: .
+- Journal: .codex-supervisor/issues/125/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 4305a01bc128c81a2885e9332057f79d37a68efa
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-03T04:11:53.483Z
+
+## Latest Codex Summary
+- Added explicit Windows field-coverage verification for the selected Phase 6 telemetry family, tightened the focused verifier test to reproduce the missing coverage section first, and updated the Windows onboarding package plus verifier checks to validate required, optional, unavailable, deferred, and exception-path coverage against the normalized fixtures.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The Windows onboarding assets already contained representative replay fixtures, but the repository lacked a focused verifier that proved the reviewed normalized examples explicitly covered the Windows family field-coverage categories required by the source-onboarding contract.
+- What changed: Added a reproducing failure to `scripts/test-verify-windows-source-onboarding-assets.sh`, expanded `scripts/verify-windows-source-onboarding-assets.sh` to require a field-coverage verification section and concrete normalized-field evidence, and updated `docs/source-families/windows-security-and-endpoint/onboarding-package.md` with an explicit coverage matrix and exception-path language.
+- Current blocker: none
+- Next exact step: Commit the verified Windows field-coverage slice on `codex/issue-125` and continue only if follow-on supervisor work requests broader Phase 6 validation.
+- Verification gap: No broader Phase 6 detector or replay workflow checks were run in this turn; verification stayed limited to the Windows onboarding verifier plus the canonical schema and source-onboarding contract scripts.
+- Files touched: docs/source-families/windows-security-and-endpoint/onboarding-package.md; scripts/verify-windows-source-onboarding-assets.sh; scripts/test-verify-windows-source-onboarding-assets.sh
+- Rollback concern: Low; changes are limited to review documentation and shell verifiers for Windows onboarding assets.
+- Last focused command: bash scripts/verify-source-onboarding-contract-doc.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Reproduced the gap by adding a failing case that required `## 5. Field Coverage Verification`; the old verifier then failed before implementation updated section numbering and coverage checks.

--- a/docs/source-families/windows-security-and-endpoint/onboarding-package.md
+++ b/docs/source-families/windows-security-and-endpoint/onboarding-package.md
@@ -53,7 +53,25 @@ The mapping summary below aligns the reviewed Windows references to the canonica
 
 Shared required field groups remain required under `docs/canonical-telemetry-schema-baseline.md`, and this package does not reinterpret missing source values as optional.
 
-## 5. Replay Fixture Plan
+## 5. Field Coverage Verification
+
+The field coverage matrix below classifies the reviewed Windows semantic areas as required, optional, unavailable, intentionally deferred, or exception-path constrained without ambiguity.
+
+| Semantic area | Coverage status | Evidence or exception path |
+| ---- | ---- | ---- |
+| Event classification and timestamp semantics | Required | Covered by the reviewed normalized fixtures for `event.code`, `event.action`, `@timestamp`, `event.created`, and `event.ingested`. |
+| Source provenance including event channel, provider, and collector or agent identity | Required | Covered by `event.provider`, `event.module`, `event.dataset`, and `aegisops.provenance.ingest_path` in the reviewed normalized fixtures. |
+| Host identity and asset references | Required | Covered by `host.name`, `host.hostname`, and `related.hosts` in the reviewed normalized fixtures. |
+| Actor identity and target identity when present | Required with exception path | The missing-actor edge fixture documents that absent actor identity is a detection-ready blocker for actor-dependent detections but remains an allowed schema-reviewed exception path for fixture validation without fabricating `user.*` fields. |
+| Logon session context, token or integrity details, and group references | Optional | `group.name` is covered by the privileged-group-addition fixture, while logon and token details are not required for this narrow review set. |
+| Process lineage and command-line context | Intentionally deferred | Windows security records in this narrow fixture set do not yet provide reviewed process lineage evidence, so broader process-context validation remains future work before detection-ready approval. |
+| Source and destination network context for remote access or lateral movement records | Unavailable | The reviewed administrative-security fixture set does not credibly supply remote network context and therefore cannot claim it without fabrication. |
+| Related user, host, IP, and process correlation fields | Required derived coverage | `related.user` and `related.hosts` are present where supported, and `related.ip` or `related.process` are omitted because the reviewed source records do not credibly expose them. |
+| AegisOps-specific provenance annotations under `aegisops.*` | Required derived coverage | Covered by `aegisops.provenance.*` and `aegisops.validation.*` in the normalized fixtures. |
+
+This package remains `schema-reviewed`, so the classifications above are evidence for fixture and mapping review rather than a claim that all required detection-ready coverage is complete.
+
+## 6. Replay Fixture Plan
 
 Replay fixtures are stored under `ingest/replay/windows-security-and-endpoint/normalized/`.
 
@@ -70,7 +88,7 @@ The `edge.ndjson` corpus contains reviewed edge cases that future parser validat
 
 The raw and normalized fixtures together are sufficient for future parser and mapping validation without claiming that the family is already detection-ready.
 
-## 6. Known Gaps and Non-Goals
+## 7. Known Gaps and Non-Goals
 
 This package remains `schema-reviewed` rather than `detection-ready` because parser version evidence, field-by-field coverage sign-off across a broader Windows event range, and explicit detector-use approval remain future work.
 

--- a/scripts/test-verify-windows-source-onboarding-assets.sh
+++ b/scripts/test-verify-windows-source-onboarding-assets.sh
@@ -53,11 +53,27 @@ The reviewed edge-case references in this package cover missing actor identity a
 
 The mapping summary aligns raw Windows event fields to the canonical telemetry schema baseline.
 
-## 5. Replay Fixture Plan
+## 5. Field Coverage Verification
+
+The field coverage matrix below classifies the reviewed Windows semantic areas as required, optional, unavailable, intentionally deferred, or exception-path constrained without ambiguity.
+
+| Semantic area | Coverage status | Evidence or exception path |
+| ---- | ---- | ---- |
+| Event classification and timestamp semantics | Required | Covered by the reviewed normalized fixtures for event.code, event.action, @timestamp, event.created, and event.ingested. |
+| Source provenance including event channel, provider, and collector or agent identity | Required | Covered by event.provider, event.module, event.dataset, and aegisops.provenance.ingest_path in the reviewed normalized fixtures. |
+| Host identity and asset references | Required | Covered by host.name, host.hostname, and related.hosts in the reviewed normalized fixtures. |
+| Actor identity and target identity when present | Required with exception path | The missing-actor edge fixture documents that absent actor identity is a detection-ready blocker for actor-dependent detections but remains an allowed schema-reviewed exception path for fixture validation without fabricating user fields. |
+| Logon session context, token or integrity details, and group references | Optional | Group references are covered by group.name in the privileged-group-addition fixture, while logon and token details are not required for this narrow review set. |
+| Process lineage and command-line context | Intentionally deferred | Windows security records in this narrow fixture set do not yet provide reviewed process lineage evidence, so broader process-context validation remains future work before detection-ready approval. |
+| Source and destination network context for remote access or lateral movement records | Unavailable | The reviewed administrative-security fixture set does not credibly supply remote network context and therefore cannot claim it without fabrication. |
+| Related user, host, IP, and process correlation fields | Required derived coverage | related.user and related.hosts are present where supported, and related.ip or related.process are omitted because the reviewed source records do not credibly expose them. |
+| AegisOps-specific provenance annotations under aegisops.* | Required derived coverage | Covered by aegisops.provenance.* and aegisops.validation.* in the normalized fixtures. |
+
+## 6. Replay Fixture Plan
 
 Replay fixtures are stored under `ingest/replay/windows-security-and-endpoint/normalized/`.
 
-## 6. Known Gaps and Non-Goals
+## 7. Known Gaps and Non-Goals
 
 No live rollout is included in this review package.' >"${target}/docs/source-families/windows-security-and-endpoint/onboarding-package.md"
 
@@ -78,14 +94,14 @@ All fixtures in this directory are synthetic or redacted review examples and are
   printf '%s\n' '{"EventID":1102,"ForwardedTimeSkewSeconds":95}' >"${target}/ingest/replay/windows-security-and-endpoint/raw/audit-log-cleared-forwarded-time-anomaly.json"
 
   printf '%s\n' \
-    '{"event.code":"4732"}' \
-    '{"event.code":"1102"}' \
-    '{"event.code":"4720"}' \
+    '{"@timestamp":"2026-03-31T12:00:00Z","event.created":"2026-03-31T12:00:03Z","event.ingested":"2026-03-31T12:00:08Z","event.action":"member-added-to-local-group","event.code":"4732","event.provider":"Microsoft-Windows-Security-Auditing","event.module":"windows","event.dataset":"windows.security","host.name":"WS-ADMIN-01","host.hostname":"WS-ADMIN-01.corp.example.invalid","user.name":"svc_admin_ops","destination.user.name":"jdoe","group.name":"Administrators","related.user":["svc_admin_ops","jdoe"],"related.hosts":["WS-ADMIN-01"],"aegisops.provenance.ingest_path":"review/windows-forwarded-event","aegisops.provenance.parser_version":"review-fixture-v1"}' \
+    '{"@timestamp":"2026-03-31T12:05:00Z","event.created":"2026-03-31T12:05:02Z","event.ingested":"2026-03-31T12:05:06Z","event.action":"audit-log-cleared","event.code":"1102","event.provider":"Microsoft-Windows-Eventlog","event.module":"windows","event.dataset":"windows.security","host.name":"WS-SEC-02","host.hostname":"WS-SEC-02.corp.example.invalid","user.name":"secops.tier2","related.user":["secops.tier2"],"related.hosts":["WS-SEC-02"],"aegisops.provenance.ingest_path":"review/windows-eventlog","aegisops.provenance.parser_version":"review-fixture-v1"}' \
+    '{"@timestamp":"2026-03-31T12:10:00Z","event.created":"2026-03-31T12:10:04Z","event.ingested":"2026-03-31T12:10:08Z","event.action":"local-user-created","event.code":"4720","event.provider":"Microsoft-Windows-Security-Auditing","event.module":"windows","event.dataset":"windows.security","host.name":"WS-APP-07","host.hostname":"WS-APP-07.corp.example.invalid","user.name":"helpdesk_admin","destination.user.name":"svc_tempops","related.user":["helpdesk_admin","svc_tempops"],"related.hosts":["WS-APP-07"],"aegisops.provenance.ingest_path":"review/windows-eventlog","aegisops.provenance.parser_version":"review-fixture-v1"}' \
     >"${target}/ingest/replay/windows-security-and-endpoint/normalized/success.ndjson"
 
   printf '%s\n' \
-    '{"aegisops.validation.case":"missing-actor"}' \
-    '{"aegisops.validation.case":"forwarded-time-anomaly"}' \
+    '{"event.created":"2026-03-31T12:11:03Z","event.ingested":"2026-03-31T12:11:07Z","aegisops.validation.case":"missing-actor","aegisops.validation.note":"Actor identity unavailable in reviewed source payload.","event.original":"local-user-created-missing-actor.json"}' \
+    '{"event.created":"2026-03-31T12:00:15Z","event.ingested":"2026-03-31T12:00:45Z","aegisops.provenance.clock_quality":"forwarded-event-time-anomaly","aegisops.validation.case":"forwarded-time-anomaly","aegisops.validation.note":"Source event time and collector receipt time diverge materially.","event.original":"audit-log-cleared-forwarded-time-anomaly.json"}' \
     >"${target}/ingest/replay/windows-security-and-endpoint/normalized/edge.ndjson"
 
   git -C "${target}" add .
@@ -149,5 +165,22 @@ printf '%s\n' '{"aegisops.validation.case":"missing-actor"}' >"${missing_tag_rep
 git -C "${missing_tag_repo}" add .
 commit_fixture "${missing_tag_repo}"
 assert_fails_with "${missing_tag_repo}" "Missing edge fixture tagged for forwarded timestamp handling."
+
+missing_coverage_repo="${workdir}/missing-coverage"
+create_repo "${missing_coverage_repo}"
+write_valid_assets "${missing_coverage_repo}"
+python3 - <<'PY' "${missing_coverage_repo}/docs/source-families/windows-security-and-endpoint/onboarding-package.md"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+start = text.index("## 5. Field Coverage Verification")
+end = text.index("## 6. Replay Fixture Plan")
+path.write_text(text[:start] + text[end:])
+PY
+git -C "${missing_coverage_repo}" add .
+commit_fixture "${missing_coverage_repo}"
+assert_fails_with "${missing_coverage_repo}" "Missing Windows onboarding package heading: ## 5. Field Coverage Verification"
 
 echo "Windows source onboarding asset verifier tests passed."

--- a/scripts/verify-windows-source-onboarding-assets.sh
+++ b/scripts/verify-windows-source-onboarding-assets.sh
@@ -25,8 +25,9 @@ required_doc_headings=(
   "## 2. Parser Ownership and Lifecycle Boundary"
   "## 3. Raw Payload References"
   "## 4. Normalization Mapping Summary"
-  "## 5. Replay Fixture Plan"
-  "## 6. Known Gaps and Non-Goals"
+  "## 5. Field Coverage Verification"
+  "## 6. Replay Fixture Plan"
+  "## 7. Known Gaps and Non-Goals"
 )
 
 required_doc_phrases=(
@@ -38,6 +39,19 @@ required_doc_phrases=(
   'Replay fixtures are stored under `ingest/replay/windows-security-and-endpoint/normalized/`.'
   "The reviewed success-path references in this package cover privileged group membership change, audit log cleared, and new local user created records."
   "The reviewed edge-case references in this package cover missing actor identity and forwarded-event timestamp caveats."
+  "The field coverage matrix below classifies the reviewed Windows semantic areas as required, optional, unavailable, intentionally deferred, or exception-path constrained without ambiguity."
+  "| Event classification and timestamp semantics | Required |"
+  "| Source provenance including event channel, provider, and collector or agent identity | Required |"
+  "| Host identity and asset references | Required |"
+  "| Actor identity and target identity when present | Required with exception path |"
+  "| Logon session context, token or integrity details, and group references | Optional |"
+  "| Process lineage and command-line context | Intentionally deferred |"
+  "| Source and destination network context for remote access or lateral movement records | Unavailable |"
+  "| Related user, host, IP, and process correlation fields | Required derived coverage |"
+  "| AegisOps-specific provenance annotations under"
+  "The missing-actor edge fixture documents that absent actor identity is a detection-ready blocker for actor-dependent detections but remains an allowed schema-reviewed exception path for fixture validation"
+  "Windows security records in this narrow fixture set do not yet provide reviewed process lineage evidence, so broader process-context validation remains future work before detection-ready approval."
+  "The reviewed administrative-security fixture set does not credibly supply remote network context and therefore cannot claim it without fabrication."
 )
 
 required_replay_phrases=(
@@ -96,6 +110,42 @@ if ! grep -Fq '"event.code":"4720"' "${replay_root}/normalized/success.ndjson"; 
   exit 1
 fi
 
+for required_field in \
+  '"@timestamp"' \
+  '"event.created"' \
+  '"event.ingested"' \
+  '"event.action"' \
+  '"event.provider"' \
+  '"event.module":"windows"' \
+  '"event.dataset":"windows.security"' \
+  '"host.name"' \
+  '"host.hostname"' \
+  '"related.user"' \
+  '"related.hosts"' \
+  '"aegisops.provenance.ingest_path"' \
+  '"aegisops.provenance.parser_version"'
+do
+  if ! grep -Fq "${required_field}" "${replay_root}/normalized/success.ndjson"; then
+    echo "Missing required Windows success fixture field: ${required_field}" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Fq '"user.name"' "${replay_root}/normalized/success.ndjson"; then
+  echo 'Missing Windows success fixture actor identity field: "user.name".' >&2
+  exit 1
+fi
+
+if ! grep -Fq '"destination.user.name"' "${replay_root}/normalized/success.ndjson"; then
+  echo 'Missing Windows success fixture target identity field: "destination.user.name".' >&2
+  exit 1
+fi
+
+if ! grep -Fq '"group.name"' "${replay_root}/normalized/success.ndjson"; then
+  echo 'Missing Windows success fixture optional group reference field: "group.name".' >&2
+  exit 1
+fi
+
 if ! grep -Fq '"aegisops.validation.case":"missing-actor"' "${replay_root}/normalized/edge.ndjson"; then
   echo 'Missing edge fixture tagged for missing actor handling.' >&2
   exit 1
@@ -103,6 +153,23 @@ fi
 
 if ! grep -Fq '"aegisops.validation.case":"forwarded-time-anomaly"' "${replay_root}/normalized/edge.ndjson"; then
   echo 'Missing edge fixture tagged for forwarded timestamp handling.' >&2
+  exit 1
+fi
+
+for edge_field in \
+  '"event.created"' \
+  '"event.ingested"' \
+  '"aegisops.validation.note"' \
+  '"event.original"'
+do
+  if ! grep -Fq "${edge_field}" "${replay_root}/normalized/edge.ndjson"; then
+    echo "Missing Windows edge fixture field: ${edge_field}" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Fq '"aegisops.provenance.clock_quality":"forwarded-event-time-anomaly"' "${replay_root}/normalized/edge.ndjson"; then
+  echo 'Missing forwarded timestamp caveat provenance marker in Windows edge fixtures.' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add explicit Windows field-coverage verification for the selected Phase 6 telemetry family
- require the onboarding package to document required, optional, unavailable, deferred, and exception-path classifications with concrete normalized-field evidence
- tighten the focused Windows onboarding verifier test so the coverage section is required and reviewable

## Why
Issue #125 needs the selected telemetry family to prove canonical schema coverage against reviewed normalized examples without introducing live mappings or runtime transforms.

## Validation
- `bash scripts/test-verify-windows-source-onboarding-assets.sh`
- `bash scripts/verify-windows-source-onboarding-assets.sh`
- `bash scripts/verify-canonical-telemetry-schema-doc.sh`
- `bash scripts/verify-source-onboarding-contract-doc.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added field coverage verification matrix to Windows onboarding package documentation, clarifying coverage status for key telemetry fields.

* **Tests**
  * Enhanced Windows source onboarding validation tests with expanded fixture data and negative test cases for field coverage verification.

* **Chores**
  * Strengthened verification script to enforce comprehensive field coverage requirements for Windows telemetry sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->