### PR TITLE
[codex] add staging-only OpenSearch detector artifacts

### DIFF
--- a/docs/phase-6-opensearch-detector-artifact-validation.md
+++ b/docs/phase-6-opensearch-detector-artifact-validation.md
@@ -1,0 +1,22 @@
+# Phase 6 OpenSearch Detector Artifact Validation
+
+- Validation date: 2026-04-03
+- Validation status: PASS
+
+## Reviewed Artifacts
+
+- `opensearch/detectors/windows-security-and-endpoint/privileged-group-membership-change-staging.yaml`
+- `opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml`
+- `opensearch/detectors/windows-security-and-endpoint/new-local-user-created-staging.yaml`
+
+## Review Result
+
+The reviewed detector artifacts remain staging-only, preserve the selected Sigma rule identities, and limit validation to Windows staging indexes.
+
+Each artifact retains explicit Sigma traceability, Windows source prerequisites, normalized field dependencies, replay evidence references, and false-positive notes so the detector slice can be reviewed without implying automatic rollout.
+
+## Fallback Handling
+
+No OpenSearch-native fallback is required for the selected Phase 6 slice because all three use cases remain within the approved single-event Sigma translation subset.
+
+If a future detector for this family requires aggregation, temporal sequencing, unsupported modifiers, or hidden field remapping, it must stay OpenSearch-native and be documented separately under the fallback rules in `docs/sigma-to-opensearch-translation-strategy.md`.

--- a/opensearch/detectors/README.md
+++ b/opensearch/detectors/README.md
@@ -48,8 +48,13 @@ Future issues may expand this directory with detector definitions, validation no
 
 Any future addition here must keep runtime behavior unchanged unless the change explicitly includes approved activation and validation scope.
 
+The current Phase 6 slice adds staging-only detector artifacts for the selected Windows use cases under `opensearch/detectors/windows-security-and-endpoint/`.
+
+Those tracked artifacts preserve Sigma traceability and test-index scope only. They are reviewable detector materialization inputs, not production activation instructions.
+
 ## 6. Reference Documents
 
 - `docs/requirements-baseline.md`
 - `docs/repository-structure-baseline.md`
 - `opensearch/detectors/aegisops-detector-metadata-template.yaml`
+- `docs/phase-6-opensearch-detector-artifact-validation.md`

--- a/opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml
+++ b/opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml
@@ -1,0 +1,44 @@
+artifact_kind: aegisops-opensearch-detector
+artifact_version: v1
+detector_name: aegisops-windows-audit-log-cleared-high
+status: staging
+deployment_scope: staging-only
+production_eligible: false
+source_family: windows-security-and-endpoint
+source_of_truth: sigma
+sigma_rule_path: sigma/curated/windows-security-and-endpoint/audit-log-cleared.yml
+sigma_rule_id: 4f5b2a71-91d4-4d75-85a1-c0fc12276fea
+title: AegisOps Windows Audit Log Cleared
+owner: IT Operations, Information Systems Department
+purpose: Detect a reviewed Windows event that records clearing of the Windows audit log.
+expected_behavior: Create a reviewable finding when reviewed Windows telemetry records audit-log-cleared activity.
+severity: high
+mitre_attack_technique_tags:
+  - attack.defense-evasion
+  - attack.t1070.001
+field_dependencies:
+  - event.dataset
+  - event.code
+  - event.action
+  - host.name
+  - user.name
+source_prerequisites:
+  - Windows security and endpoint telemetry family remains schema-reviewed under docs/source-families/windows-security-and-endpoint/onboarding-package.md.
+  - Required normalized fields event.dataset, event.code, event.action, host.name, and user.name are preserved for reviewed success-path fixtures.
+index_patterns:
+  - aegisops-logs-windows-*
+validation_target_index:
+  - aegisops-logs-windows-staging-*
+query_language: lucene
+query: 'event.dataset:"windows.security" AND event.code:1102 AND event.action:"audit-log-cleared"'
+validation_evidence_reference: ingest/replay/windows-security-and-endpoint/normalized/success.ndjson#audit-log-cleared
+false_positive_considerations:
+  - Approved maintenance, forensic review, or controlled break-glass procedures can legitimately clear audit logs.
+fallback_handling: No OpenSearch-native fallback is required for this supported single-event Sigma translation.
+governance:
+  activation_guardrail: Staging or test-index validation only. Production activation is not approved by this artifact.
+  baseline_references:
+    - docs/phase-6-initial-telemetry-slice.md
+    - docs/sigma-to-opensearch-translation-strategy.md
+    - docs/detection-lifecycle-and-rule-qa-framework.md
+    - docs/source-families/windows-security-and-endpoint/onboarding-package.md

--- a/opensearch/detectors/windows-security-and-endpoint/new-local-user-created-staging.yaml
+++ b/opensearch/detectors/windows-security-and-endpoint/new-local-user-created-staging.yaml
@@ -1,0 +1,45 @@
+artifact_kind: aegisops-opensearch-detector
+artifact_version: v1
+detector_name: aegisops-windows-new-local-user-created-medium
+status: staging
+deployment_scope: staging-only
+production_eligible: false
+source_family: windows-security-and-endpoint
+source_of_truth: sigma
+sigma_rule_path: sigma/curated/windows-security-and-endpoint/new-local-user-created.yml
+sigma_rule_id: 91c9f67d-76f5-41f1-9ccf-66942a33df4f
+title: AegisOps Windows New Local User Created
+owner: IT Operations, Information Systems Department
+purpose: Detect a reviewed Windows event where a new local user account is created on a managed host.
+expected_behavior: Create a reviewable finding when reviewed Windows telemetry records local account creation.
+severity: medium
+mitre_attack_technique_tags:
+  - attack.persistence
+  - attack.t1136.001
+field_dependencies:
+  - event.dataset
+  - event.code
+  - event.action
+  - host.name
+  - user.name
+  - destination.user.name
+source_prerequisites:
+  - Windows security and endpoint telemetry family remains schema-reviewed under docs/source-families/windows-security-and-endpoint/onboarding-package.md.
+  - Required normalized fields event.dataset, event.code, event.action, host.name, user.name, and destination.user.name are preserved for reviewed success-path fixtures.
+index_patterns:
+  - aegisops-logs-windows-*
+validation_target_index:
+  - aegisops-logs-windows-staging-*
+query_language: lucene
+query: 'event.dataset:"windows.security" AND event.code:4720 AND event.action:"local-user-created"'
+validation_evidence_reference: ingest/replay/windows-security-and-endpoint/normalized/success.ndjson#new-local-user-created
+false_positive_considerations:
+  - Approved help desk provisioning, imaging workflows, or temporary break-glass account creation can legitimately match.
+fallback_handling: No OpenSearch-native fallback is required for this supported single-event Sigma translation.
+governance:
+  activation_guardrail: Staging or test-index validation only. Production activation is not approved by this artifact.
+  baseline_references:
+    - docs/phase-6-initial-telemetry-slice.md
+    - docs/sigma-to-opensearch-translation-strategy.md
+    - docs/detection-lifecycle-and-rule-qa-framework.md
+    - docs/source-families/windows-security-and-endpoint/onboarding-package.md

--- a/opensearch/detectors/windows-security-and-endpoint/privileged-group-membership-change-staging.yaml
+++ b/opensearch/detectors/windows-security-and-endpoint/privileged-group-membership-change-staging.yaml
@@ -1,0 +1,45 @@
+artifact_kind: aegisops-opensearch-detector
+artifact_version: v1
+detector_name: aegisops-windows-privileged-group-membership-change-high
+status: staging
+deployment_scope: staging-only
+production_eligible: false
+source_family: windows-security-and-endpoint
+source_of_truth: sigma
+sigma_rule_path: sigma/curated/windows-security-and-endpoint/privileged-group-membership-change.yml
+sigma_rule_id: 2b6d9ef3-0e1e-4e42-a0c2-9f4f7f0d4c81
+title: AegisOps Windows Privileged Group Membership Change
+owner: IT Operations, Information Systems Department
+purpose: Detect a reviewed Windows event where a user is added to a privileged local or domain group.
+expected_behavior: Create a reviewable finding when reviewed Windows telemetry records a membership change into a privileged group.
+severity: high
+mitre_attack_technique_tags:
+  - attack.persistence
+  - attack.privilege-escalation
+  - attack.t1098
+field_dependencies:
+  - event.dataset
+  - event.code
+  - group.name
+  - user.name
+  - destination.user.name
+source_prerequisites:
+  - Windows security and endpoint telemetry family remains schema-reviewed under docs/source-families/windows-security-and-endpoint/onboarding-package.md.
+  - Required normalized fields event.dataset, event.code, group.name, user.name, and destination.user.name are preserved for reviewed success-path fixtures.
+index_patterns:
+  - aegisops-logs-windows-*
+validation_target_index:
+  - aegisops-logs-windows-staging-*
+query_language: lucene
+query: 'event.dataset:"windows.security" AND event.code:(4728 OR 4732 OR 4756) AND group.name:("Administrators" OR "Domain Admins" OR "Enterprise Admins")'
+validation_evidence_reference: ingest/replay/windows-security-and-endpoint/normalized/success.ndjson#privileged-group-membership-change
+false_positive_considerations:
+  - Approved administrative group changes by endpoint engineering, identity administrators, or build automation can legitimately match.
+fallback_handling: No OpenSearch-native fallback is required for this supported single-event Sigma translation.
+governance:
+  activation_guardrail: Staging or test-index validation only. Production activation is not approved by this artifact.
+  baseline_references:
+    - docs/phase-6-initial-telemetry-slice.md
+    - docs/sigma-to-opensearch-translation-strategy.md
+    - docs/detection-lifecycle-and-rule-qa-framework.md
+    - docs/source-families/windows-security-and-endpoint/onboarding-package.md

--- a/scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
+++ b/scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-6-opensearch-detector-artifacts.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p \
+    "${target}/docs" \
+    "${target}/opensearch/detectors/windows-security-and-endpoint" \
+    "${target}/scripts" \
+    "${target}/sigma/curated/windows-security-and-endpoint"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+  cp "${verifier}" "${target}/scripts/"
+  chmod +x "${target}/scripts/verify-phase-6-opensearch-detector-artifacts.sh"
+}
+
+write_baseline_docs() {
+  local target="$1"
+
+  printf '%s\n' '# AegisOps Phase 6 Initial Telemetry Slice
+
+## 1. Purpose
+
+This document selects the single initial telemetry family and first detection use cases for the Phase 6 validated slice.
+
+## 2. Selected Initial Telemetry Family
+
+The selected initial telemetry family for the Phase 6 slice is Windows security and endpoint telemetry.
+
+Phase 6 starts with one telemetry family only.
+
+## 3. Selected Initial Detection Use Cases
+
+The Phase 6 slice is limited to these three initial detection use cases:
+
+1. Privileged group membership change
+2. Audit log cleared
+3. New local user created' >"${target}/docs/phase-6-initial-telemetry-slice.md"
+
+  printf '%s\n' '# AegisOps Sigma-to-OpenSearch Translation Strategy
+
+## 3. Supported Sigma Subset for the Approved Baseline
+
+AegisOps supports only single-rule, single-event Sigma detections whose logic can be translated into reviewable OpenSearch detector content without changing the rule'"'"'s meaning.
+
+## 6. OpenSearch-Native Fallback Path
+
+When a detection requirement cannot be translated safely from the approved Sigma subset, the detection must remain OpenSearch-native and carry explicit documentation that Sigma is not the source of truth for that rule.' >"${target}/docs/sigma-to-opensearch-translation-strategy.md"
+}
+
+write_sigma_rules() {
+  local target="$1"
+
+  printf '%s\n' 'title: AegisOps Windows Privileged Group Membership Change
+id: 2b6d9ef3-0e1e-4e42-a0c2-9f4f7f0d4c81
+source_of_truth: sigma
+severity: high' >"${target}/sigma/curated/windows-security-and-endpoint/privileged-group-membership-change.yml"
+
+  printf '%s\n' 'title: AegisOps Windows Audit Log Cleared
+id: 4f5b2a71-91d4-4d75-85a1-c0fc12276fea
+source_of_truth: sigma
+severity: high' >"${target}/sigma/curated/windows-security-and-endpoint/audit-log-cleared.yml"
+
+  printf '%s\n' 'title: AegisOps Windows New Local User Created
+id: 91c9f67d-76f5-41f1-9ccf-66942a33df4f
+source_of_truth: sigma
+severity: medium' >"${target}/sigma/curated/windows-security-and-endpoint/new-local-user-created.yml"
+}
+
+write_detector_artifact() {
+  local target="$1"
+  local path="$2"
+  local detector_name="$3"
+  local sigma_path="$4"
+  local sigma_rule_id="$5"
+  local severity="$6"
+  local query="$7"
+
+  printf '%s\n' "artifact_kind: aegisops-opensearch-detector
+artifact_version: v1
+detector_name: ${detector_name}
+status: staging
+deployment_scope: staging-only
+production_eligible: false
+source_family: windows-security-and-endpoint
+sigma_rule_path: ${sigma_path}
+sigma_rule_id: ${sigma_rule_id}
+source_of_truth: sigma
+index_patterns:
+  - aegisops-logs-windows-*
+validation_target_index:
+  - aegisops-logs-windows-staging-*
+severity: ${severity}
+query_language: lucene
+query: ${query}
+fallback_handling: No OpenSearch-native fallback is required for this supported single-event Sigma translation.
+" >"${target}/${path}"
+}
+
+write_validation_doc() {
+  local target="$1"
+
+  printf '%s\n' '# Phase 6 OpenSearch Detector Artifact Validation
+
+- Validation date: 2026-04-03
+- Validation status: PASS
+
+## Reviewed Artifacts
+
+- `opensearch/detectors/windows-security-and-endpoint/privileged-group-membership-change-staging.yaml`
+- `opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml`
+- `opensearch/detectors/windows-security-and-endpoint/new-local-user-created-staging.yaml`
+
+## Review Result
+
+The reviewed detector artifacts remain staging-only, preserve the selected Sigma rule identities, and limit validation to Windows staging indexes.
+
+## Fallback Handling
+
+No OpenSearch-native fallback is required for the selected Phase 6 slice because all three use cases remain within the approved single-event Sigma translation subset.' >"${target}/docs/phase-6-opensearch-detector-artifact-validation.md"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" add .
+  git -C "${target}" commit -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_baseline_docs "${valid_repo}"
+write_sigma_rules "${valid_repo}"
+write_detector_artifact \
+  "${valid_repo}" \
+  "opensearch/detectors/windows-security-and-endpoint/privileged-group-membership-change-staging.yaml" \
+  "aegisops-windows-privileged-group-membership-change-high" \
+  "sigma/curated/windows-security-and-endpoint/privileged-group-membership-change.yml" \
+  "2b6d9ef3-0e1e-4e42-a0c2-9f4f7f0d4c81" \
+  "high" \
+  "'event.dataset:\"windows.security\" AND event.code:(4728 OR 4732 OR 4756) AND group.name:(\"Administrators\" OR \"Domain Admins\" OR \"Enterprise Admins\")'"
+write_detector_artifact \
+  "${valid_repo}" \
+  "opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml" \
+  "aegisops-windows-audit-log-cleared-high" \
+  "sigma/curated/windows-security-and-endpoint/audit-log-cleared.yml" \
+  "4f5b2a71-91d4-4d75-85a1-c0fc12276fea" \
+  "high" \
+  "'event.dataset:\"windows.security\" AND event.code:1102 AND event.action:\"audit-log-cleared\"'"
+write_detector_artifact \
+  "${valid_repo}" \
+  "opensearch/detectors/windows-security-and-endpoint/new-local-user-created-staging.yaml" \
+  "aegisops-windows-new-local-user-created-medium" \
+  "sigma/curated/windows-security-and-endpoint/new-local-user-created.yml" \
+  "91c9f67d-76f5-41f1-9ccf-66942a33df4f" \
+  "medium" \
+  "'event.dataset:\"windows.security\" AND event.code:4720 AND event.action:\"local-user-created\"'"
+write_validation_doc "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_artifact_repo="${workdir}/missing-artifact"
+create_repo "${missing_artifact_repo}"
+write_baseline_docs "${missing_artifact_repo}"
+write_sigma_rules "${missing_artifact_repo}"
+write_validation_doc "${missing_artifact_repo}"
+commit_fixture "${missing_artifact_repo}"
+assert_fails_with \
+  "${missing_artifact_repo}" \
+  "Missing Phase 6 detector artifact: ${missing_artifact_repo}/opensearch/detectors/windows-security-and-endpoint/privileged-group-membership-change-staging.yaml"
+
+bad_scope_repo="${workdir}/bad-scope"
+create_repo "${bad_scope_repo}"
+write_baseline_docs "${bad_scope_repo}"
+write_sigma_rules "${bad_scope_repo}"
+write_detector_artifact \
+  "${bad_scope_repo}" \
+  "opensearch/detectors/windows-security-and-endpoint/privileged-group-membership-change-staging.yaml" \
+  "aegisops-windows-privileged-group-membership-change-high" \
+  "sigma/curated/windows-security-and-endpoint/privileged-group-membership-change.yml" \
+  "2b6d9ef3-0e1e-4e42-a0c2-9f4f7f0d4c81" \
+  "high" \
+  "'event.dataset:\"windows.security\" AND event.code:(4728 OR 4732 OR 4756) AND group.name:(\"Administrators\" OR \"Domain Admins\" OR \"Enterprise Admins\")'"
+write_detector_artifact \
+  "${bad_scope_repo}" \
+  "opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml" \
+  "aegisops-windows-audit-log-cleared-high" \
+  "sigma/curated/windows-security-and-endpoint/audit-log-cleared.yml" \
+  "4f5b2a71-91d4-4d75-85a1-c0fc12276fea" \
+  "high" \
+  "'event.dataset:\"windows.security\" AND event.code:1102 AND event.action:\"audit-log-cleared\"'"
+write_detector_artifact \
+  "${bad_scope_repo}" \
+  "opensearch/detectors/windows-security-and-endpoint/new-local-user-created-staging.yaml" \
+  "aegisops-windows-new-local-user-created-medium" \
+  "sigma/curated/windows-security-and-endpoint/new-local-user-created.yml" \
+  "91c9f67d-76f5-41f1-9ccf-66942a33df4f" \
+  "medium" \
+  "'event.dataset:\"windows.security\" AND event.code:4720 AND event.action:\"local-user-created\"'"
+write_validation_doc "${bad_scope_repo}"
+perl -0pi -e 's/deployment_scope: staging-only/deployment_scope: production/' \
+  "${bad_scope_repo}/opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml"
+git -C "${bad_scope_repo}" add .
+git -C "${bad_scope_repo}" commit -q -m "fixture"
+assert_fails_with \
+  "${bad_scope_repo}" \
+  "Detector artifact must remain staging-only: ${bad_scope_repo}/opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml"
+
+echo "verify-phase-6-opensearch-detector-artifacts tests passed"

--- a/scripts/verify-phase-6-opensearch-detector-artifacts.sh
+++ b/scripts/verify-phase-6-opensearch-detector-artifacts.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+artifact_dir="${repo_root}/opensearch/detectors/windows-security-and-endpoint"
+validation_doc="${repo_root}/docs/phase-6-opensearch-detector-artifact-validation.md"
+slice_doc="${repo_root}/docs/phase-6-initial-telemetry-slice.md"
+translation_doc="${repo_root}/docs/sigma-to-opensearch-translation-strategy.md"
+
+verify_artifact() {
+  local file_path="$1"
+  local detector_name="$2"
+  local sigma_rule_path="$3"
+  local sigma_rule_id="$4"
+  local severity="$5"
+  local query="$6"
+
+  if [[ ! -f "${file_path}" ]]; then
+    echo "Missing Phase 6 detector artifact: ${file_path}" >&2
+    exit 1
+  fi
+
+  local required_phrases=(
+    "artifact_kind: aegisops-opensearch-detector"
+    "artifact_version: v1"
+    "detector_name: ${detector_name}"
+    "status: staging"
+    "production_eligible: false"
+    "source_family: windows-security-and-endpoint"
+    "sigma_rule_path: ${sigma_rule_path}"
+    "sigma_rule_id: ${sigma_rule_id}"
+    "source_of_truth: sigma"
+    "  - aegisops-logs-windows-*"
+    "  - aegisops-logs-windows-staging-*"
+    "severity: ${severity}"
+    "query_language: lucene"
+    "query: ${query}"
+    "fallback_handling: No OpenSearch-native fallback is required for this supported single-event Sigma translation."
+  )
+
+  for phrase in "${required_phrases[@]}"; do
+    if ! grep -Fq -- "${phrase}" "${file_path}"; then
+      echo "Missing detector artifact statement in ${file_path}: ${phrase}" >&2
+      exit 1
+    fi
+  done
+
+  local deployment_scope_line
+  deployment_scope_line="$(grep -E '^deployment_scope:' "${file_path}" || true)"
+  if [[ "${deployment_scope_line}" != "deployment_scope: staging-only" ]]; then
+    echo "Detector artifact must remain staging-only: ${file_path}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -f "${slice_doc}" ]]; then
+  echo "Missing Phase 6 slice document required for detector verification: ${slice_doc}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${translation_doc}" ]]; then
+  echo "Missing Sigma-to-OpenSearch translation strategy document required for detector verification: ${translation_doc}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${artifact_dir}" ]]; then
+  echo "Missing Phase 6 detector artifact directory: ${artifact_dir}" >&2
+  exit 1
+fi
+
+verify_artifact \
+  "${artifact_dir}/privileged-group-membership-change-staging.yaml" \
+  "aegisops-windows-privileged-group-membership-change-high" \
+  "sigma/curated/windows-security-and-endpoint/privileged-group-membership-change.yml" \
+  "2b6d9ef3-0e1e-4e42-a0c2-9f4f7f0d4c81" \
+  "high" \
+  "'event.dataset:\"windows.security\" AND event.code:(4728 OR 4732 OR 4756) AND group.name:(\"Administrators\" OR \"Domain Admins\" OR \"Enterprise Admins\")'"
+
+verify_artifact \
+  "${artifact_dir}/audit-log-cleared-staging.yaml" \
+  "aegisops-windows-audit-log-cleared-high" \
+  "sigma/curated/windows-security-and-endpoint/audit-log-cleared.yml" \
+  "4f5b2a71-91d4-4d75-85a1-c0fc12276fea" \
+  "high" \
+  "'event.dataset:\"windows.security\" AND event.code:1102 AND event.action:\"audit-log-cleared\"'"
+
+verify_artifact \
+  "${artifact_dir}/new-local-user-created-staging.yaml" \
+  "aegisops-windows-new-local-user-created-medium" \
+  "sigma/curated/windows-security-and-endpoint/new-local-user-created.yml" \
+  "91c9f67d-76f5-41f1-9ccf-66942a33df4f" \
+  "medium" \
+  "'event.dataset:\"windows.security\" AND event.code:4720 AND event.action:\"local-user-created\"'"
+
+if [[ ! -f "${validation_doc}" ]]; then
+  echo "Missing Phase 6 detector validation document: ${validation_doc}" >&2
+  exit 1
+fi
+
+required_doc_phrases=(
+  "# Phase 6 OpenSearch Detector Artifact Validation"
+  "- Validation date: 2026-04-03"
+  "- Validation status: PASS"
+  "## Reviewed Artifacts"
+  "## Review Result"
+  "## Fallback Handling"
+  "The reviewed detector artifacts remain staging-only, preserve the selected Sigma rule identities, and limit validation to Windows staging indexes."
+  "No OpenSearch-native fallback is required for the selected Phase 6 slice because all three use cases remain within the approved single-event Sigma translation subset."
+)
+
+for phrase in "${required_doc_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${validation_doc}"; then
+    echo "Missing Phase 6 detector validation statement in ${validation_doc}: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+reviewed_artifacts=(
+  "opensearch/detectors/windows-security-and-endpoint/privileged-group-membership-change-staging.yaml"
+  "opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml"
+  "opensearch/detectors/windows-security-and-endpoint/new-local-user-created-staging.yaml"
+)
+
+for artifact in "${reviewed_artifacts[@]}"; do
+  if ! grep -Fqx -- "- \`${artifact}\`" "${validation_doc}"; then
+    echo "Validation document must list reviewed detector artifact: ${artifact}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 6 OpenSearch detector artifacts are present for the selected Sigma rules and remain staging-only."


### PR DESCRIPTION
## What changed
- added a focused Phase 6 verifier and test for staging-only OpenSearch detector artifacts
- added staging-only detector artifact YAMLs for the three selected Windows Sigma rules
- added a validation note and updated detector guidance to document the staged slice and lack of required OpenSearch-native fallback

## Why this changed
Issue #127 requires reviewable detector materialization for the selected Phase 6 Sigma rules without implying production activation. The repository had candidate Sigma rules and translation guidance, but no detector artifacts or verifier proving the staging-only translation path.

## Impact
- preserves Sigma traceability for the selected Windows slice
- keeps detector scope limited to staging or test-index validation
- gives reviewers a narrow script-backed contract for this translation slice

## Root cause
The Phase 6 slice had reviewed Sigma candidates and replay evidence, but the OpenSearch side stopped at metadata templates and did not yet materialize staging-only detector artifacts for the selected use cases.

## Validation
- `bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh`
- `bash scripts/verify-phase-6-opensearch-detector-artifacts.sh`
- `bash scripts/verify-opensearch-detector-metadata-template.sh`
- `bash scripts/verify-opensearch-placeholder-and-detector-validation.sh`
- `bash scripts/verify-sigma-curated-skeleton.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new staging detectors for Windows Security monitoring: audit log clearing detection, local user account creation detection, and privileged group membership change detection.
  * Introduced validation framework and verification tools for detector configurations.

* **Documentation**
  * Added Phase 6 detector artifact validation documentation and updated reference materials with configuration context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->