### PR TITLE
Issue #128: add Phase 6 read-only n8n workflow assets

### DIFF
--- a/docs/sigma-n8n-skeleton-validation.md
+++ b/docs/sigma-n8n-skeleton-validation.md
@@ -17,7 +17,9 @@
 - `n8n/workflows/aegisops_alert_ingest/.gitkeep`
 - `n8n/workflows/aegisops_approve/.gitkeep`
 - `n8n/workflows/aegisops_enrich/.gitkeep`
+- `n8n/workflows/aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json`
 - `n8n/workflows/aegisops_notify/.gitkeep`
+- `n8n/workflows/aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json`
 - `n8n/workflows/aegisops_response/.gitkeep`
 
 ## Sigma Review Result
@@ -28,15 +30,15 @@ The curated slice is limited to privileged group membership change, audit log cl
 
 ## n8n Workflow Category Review Result
 
-The tracked n8n workflow skeleton covers the approved alert ingest, enrich, approve, notify, and response categories.
+The tracked n8n workflow structure keeps the approved alert ingest, enrich, approve, notify, and response categories while limiting exported workflow assets to the selected Phase 6 read-only slice.
 
-Each category remains a placeholder-only directory with a `.gitkeep` marker, and no exported workflow, trigger, credential, or execution logic is present.
+Alert ingest, approve, and response remain placeholder-only with `.gitkeep` markers, while enrich and notify contain only the approved selected-detector workflow exports.
 
 ## Live Behavior Review Result
 
-No reviewed Sigma asset introduces runnable detection behavior, and no reviewed n8n asset introduces runnable workflow behavior.
+No reviewed Sigma asset introduces runnable detection behavior, and the reviewed n8n assets remain read-only workflow exports without approval-exempt write or response execution steps.
 
-The current tracked Sigma assets remain reviewed content only, and the n8n assets remain documentation and placeholder markers only.
+The current tracked Sigma assets remain reviewed content only, and the n8n workflow assets are limited to enrichment, routing, and notification payload preparation for the selected Windows detector outputs.
 
 ## Deviations
 

--- a/n8n/workflows/README.md
+++ b/n8n/workflows/README.md
@@ -18,11 +18,13 @@ The approved workflow categories are alert ingest, enrich, approve, notify, and 
 
 ## 3. Placeholder Boundary
 
-Placeholder directories and marker files under `n8n/workflows/` are not production workflows.
+Placeholder directories and marker files under `n8n/workflows/` remain non-production placeholders for categories that do not yet contain an explicitly approved exported workflow asset.
 
-They reserve approved homes for future workflow assets without claiming that exported workflows, credentials, triggers, or integrations are already implemented here.
+The approved Phase 6 exception is limited to `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json`.
 
-Do not infer live runtime behavior, integration coverage, or production-ready response logic from the current placeholders.
+Those two exported workflow assets are limited to the selected Windows detector outputs for privileged group membership change, audit log cleared, and new local user created.
+
+Do not infer broader live runtime behavior, integration coverage, or production-ready response logic beyond the approved Phase 6 read-only workflow assets.
 
 ## 4. Control vs Execution Alignment
 
@@ -32,9 +34,11 @@ This separation preserves the approved control-versus-execution model: alerts ar
 
 The guidance in this directory does not authorize direct destructive actions from raw inbound alerts, hidden write operations inside read-only workflows, or approval bypass by implementation detail.
 
+The approved Phase 6 workflow assets must remain read-only for enrichment and notify-only for analyst routing, without response execution, write-capable connectors, or uncontrolled downstream mutation.
+
 ## 5. Contributor Guidance
 
-Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline beyond the current Phase 6 read-only workflow assets.
 
 Keep future workflow additions within the approved category boundary and preserve explicit approval gates for write or destructive actions.
 

--- a/n8n/workflows/aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json
+++ b/n8n/workflows/aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json
@@ -1,0 +1,241 @@
+{
+  "name": "aegisops_enrich_windows_selected_detector_outputs",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "Phase 6 read-only enrich workflow for the selected Windows detector outputs. No write-capable or response-executing step is permitted here.",
+        "height": 260,
+        "width": 420
+      },
+      "id": "note-read-only-boundary",
+      "name": "Phase 6 Read-only Boundary",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -920,
+        -120
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -900,
+        140
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "selected-detector-outputs",
+              "name": "selected_detector_outputs",
+              "value": "privileged_group_membership_change,audit_log_cleared,new_local_user_created",
+              "type": "string"
+            },
+            {
+              "id": "read-only-boundary",
+              "name": "read_only_boundary",
+              "value": "true",
+              "type": "string"
+            },
+            {
+              "id": "notification-handoff-required",
+              "name": "notification_handoff_required",
+              "value": "true",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "normalize-selected-detector-output",
+      "name": "Normalize Selected Detector Output",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -620,
+        140
+      ]
+    },
+    {
+      "parameters": {
+        "dataType": "string",
+        "value1": "={{$json.detector_name}}",
+        "rules": {
+          "values": [
+            {
+              "operation": "equal",
+              "value2": "privileged_group_membership_change"
+            },
+            {
+              "operation": "equal",
+              "value2": "audit_log_cleared"
+            },
+            {
+              "operation": "equal",
+              "value2": "new_local_user_created"
+            }
+          ]
+        }
+      },
+      "id": "route-selected-detector-output",
+      "name": "Route Selected Detector Output",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [
+        -340,
+        140
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "detector-name-privileged-group-membership-change",
+              "name": "detector_name",
+              "value": "privileged_group_membership_change",
+              "type": "string"
+            },
+            {
+              "id": "enrichment-plan-privileged-group-membership-change",
+              "name": "enrichment_plan",
+              "value": "Confirm actor, target group, host, and change provenance from the finding payload only.",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "enrich-privileged-group-membership-change",
+      "name": "Build Read-only Enrichment Context",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -20,
+        -40
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "detector-name-audit-log-cleared",
+              "name": "detector_name",
+              "value": "audit_log_cleared",
+              "type": "string"
+            },
+            {
+              "id": "enrichment-plan-audit-log-cleared",
+              "name": "enrichment_plan",
+              "value": "Confirm actor, host, and event timing from the finding payload only.",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "enrich-audit-log-cleared",
+      "name": "Build Read-only Enrichment Context",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -20,
+        140
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "detector-name-new-local-user-created",
+              "name": "detector_name",
+              "value": "new_local_user_created",
+              "type": "string"
+            },
+            {
+              "id": "enrichment-plan-new-local-user-created",
+              "name": "enrichment_plan",
+              "value": "Confirm actor, created account, host, and source record context from the finding payload only.",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "enrich-new-local-user-created",
+      "name": "Build Read-only Enrichment Context",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -20,
+        320
+      ]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Normalize Selected Detector Output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Selected Detector Output": {
+      "main": [
+        [
+          {
+            "node": "Route Selected Detector Output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route Selected Detector Output": {
+      "main": [
+        [
+          {
+            "node": "Build Read-only Enrichment Context",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Read-only Enrichment Context",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Read-only Enrichment Context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "versionId": "phase-6-read-only-v1",
+  "tags": [
+    {
+      "name": "read_only"
+    },
+    {
+      "name": "phase_6"
+    }
+  ]
+}

--- a/n8n/workflows/aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json
+++ b/n8n/workflows/aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json
@@ -1,0 +1,97 @@
+{
+  "name": "aegisops_notify_windows_selected_detector_outputs",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "Phase 6 notify-only workflow for the selected Windows detector outputs. This workflow prepares analyst-routing payloads and must not perform response execution or write-capable downstream mutation.",
+        "height": 260,
+        "width": 420
+      },
+      "id": "note-notify-only-boundary",
+      "name": "Notify-only Boundary",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -860,
+        -120
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -820,
+        140
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "selected-detector-outputs",
+              "name": "selected_detector_outputs",
+              "value": "privileged_group_membership_change,audit_log_cleared,new_local_user_created",
+              "type": "string"
+            },
+            {
+              "id": "notify-only-boundary",
+              "name": "notify_only_boundary",
+              "value": "true",
+              "type": "string"
+            },
+            {
+              "id": "downstream-mutation-allowed",
+              "name": "downstream_mutation_allowed",
+              "value": "false",
+              "type": "string"
+            },
+            {
+              "id": "routing-destination",
+              "name": "routing_destination",
+              "value": "business-hours-analyst-queue",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "format-analyst-notification",
+      "name": "Format Analyst Notification",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -520,
+        140
+      ]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Format Analyst Notification",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "versionId": "phase-6-notify-v1",
+  "tags": [
+    {
+      "name": "notify_only"
+    },
+    {
+      "name": "phase_6"
+    }
+  ]
+}

--- a/scripts/test-verify-n8n-workflow-category-guidance.sh
+++ b/scripts/test-verify-n8n-workflow-category-guidance.sh
@@ -52,9 +52,11 @@ The approved workflow categories are alert ingest, enrich, approve, notify, and 
 
 ## 3. Placeholder Boundary
 
-Placeholder directories and marker files under `n8n/workflows/` are not production workflows.
+Placeholder directories and marker files under `n8n/workflows/` remain non-production placeholders for categories that do not yet contain an explicitly approved exported workflow asset.
 
-Do not infer live runtime behavior, integration coverage, or production-ready response logic from the current placeholders.
+The approved Phase 6 exception is limited to `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json`.
+
+Do not infer broader live runtime behavior, integration coverage, or production-ready response logic beyond the approved Phase 6 read-only workflow assets.
 
 ## 4. Control vs Execution Alignment
 
@@ -64,9 +66,11 @@ This separation preserves the approved control-versus-execution model and preven
 
 ## 5. Contributor Guidance
 
-Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline beyond the current Phase 6 read-only workflow assets.
 
 Keep future workflow additions within the approved category boundary and preserve explicit approval gates for write or destructive actions.
+
+The approved Phase 6 workflow assets must remain read-only for enrichment and notify-only for analyst routing, without response execution, write-capable connectors, or uncontrolled downstream mutation.
 
 ## 6. Reference Documents
 
@@ -137,7 +141,7 @@ The approved workflow categories are alert ingest, enrich, approve, notify, and 
 
 ## 3. Placeholder Boundary
 
-Placeholder directories and marker files under `n8n/workflows/` are not production workflows.
+Placeholder directories and marker files under `n8n/workflows/` remain non-production placeholders for categories that do not yet contain an explicitly approved exported workflow asset.
 
 ## 4. Control vs Execution Alignment
 
@@ -180,9 +184,11 @@ The approved workflow categories are alert ingest, enrich, approve, notify, and 
 
 ## 3. Placeholder Boundary
 
-Placeholder directories and marker files under `n8n/workflows/` are not production workflows.
+Placeholder directories and marker files under `n8n/workflows/` remain non-production placeholders for categories that do not yet contain an explicitly approved exported workflow asset.
 
-Do not infer live runtime behavior, integration coverage, or production-ready response logic from the current placeholders.
+The approved Phase 6 exception is limited to `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json`.
+
+Do not infer broader live runtime behavior, integration coverage, or production-ready response logic beyond the approved Phase 6 read-only workflow assets.
 
 ## 4. Control vs Execution Alignment
 
@@ -190,7 +196,9 @@ OpenSearch remains responsible for detection and analytics, while n8n is limited
 
 ## 5. Contributor Guidance
 
-Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline beyond the current Phase 6 read-only workflow assets.
+
+The approved Phase 6 workflow assets must remain read-only for enrichment and notify-only for analyst routing, without response execution, write-capable connectors, or uncontrolled downstream mutation.
 
 ## 6. Reference Documents
 

--- a/scripts/test-verify-n8n-workflow-skeleton.sh
+++ b/scripts/test-verify-n8n-workflow-skeleton.sh
@@ -45,6 +45,136 @@ create_workflow_skeleton() {
   : > "${target}/n8n/workflows/aegisops_response/.gitkeep"
 }
 
+create_phase_6_workflow_assets() {
+  local target="$1"
+
+  cat > "${target}/n8n/workflows/aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json" <<'EOF'
+{
+  "name": "aegisops_enrich_windows_selected_detector_outputs",
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Phase 6 Read-only Boundary",
+      "type": "n8n-nodes-base.stickyNote"
+    },
+    {
+      "parameters": {},
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "name": "selected_detector_outputs",
+              "value": "privileged_group_membership_change,audit_log_cleared,new_local_user_created",
+              "type": "string"
+            },
+            {
+              "name": "read_only_boundary",
+              "value": "true",
+              "type": "string"
+            },
+            {
+              "name": "notification_handoff_required",
+              "value": "true",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "name": "Normalize Selected Detector Output",
+      "type": "n8n-nodes-base.set"
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "value": "privileged_group_membership_change"
+            },
+            {
+              "value": "audit_log_cleared"
+            },
+            {
+              "value": "new_local_user_created"
+            }
+          ]
+        }
+      },
+      "name": "Route Selected Detector Output",
+      "type": "n8n-nodes-base.switch"
+    },
+    {
+      "parameters": {},
+      "name": "Build Read-only Enrichment Context",
+      "type": "n8n-nodes-base.set"
+    }
+  ],
+  "tags": [
+    {
+      "name": "read_only"
+    },
+    {
+      "name": "phase_6"
+    }
+  ]
+}
+EOF
+
+  cat > "${target}/n8n/workflows/aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json" <<'EOF'
+{
+  "name": "aegisops_notify_windows_selected_detector_outputs",
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Notify-only Boundary",
+      "type": "n8n-nodes-base.stickyNote"
+    },
+    {
+      "parameters": {},
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "name": "selected_detector_outputs",
+              "value": "privileged_group_membership_change,audit_log_cleared,new_local_user_created",
+              "type": "string"
+            },
+            {
+              "name": "notify_only_boundary",
+              "value": "true",
+              "type": "string"
+            },
+            {
+              "name": "downstream_mutation_allowed",
+              "value": "false",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "name": "Format Analyst Notification",
+      "type": "n8n-nodes-base.set"
+    }
+  ],
+  "tags": [
+    {
+      "name": "notify_only"
+    },
+    {
+      "name": "phase_6"
+    }
+  ]
+}
+EOF
+}
+
 assert_passes() {
   local target="$1"
 
@@ -74,8 +204,16 @@ assert_fails_with() {
 valid_repo="${workdir}/valid"
 create_repo "${valid_repo}"
 create_workflow_skeleton "${valid_repo}"
+create_phase_6_workflow_assets "${valid_repo}"
 commit_fixture "${valid_repo}"
 assert_passes "${valid_repo}"
+
+phase_6_read_only_repo="${workdir}/phase-6-read-only"
+create_repo "${phase_6_read_only_repo}"
+create_workflow_skeleton "${phase_6_read_only_repo}"
+create_phase_6_workflow_assets "${phase_6_read_only_repo}"
+commit_fixture "${phase_6_read_only_repo}"
+assert_passes "${phase_6_read_only_repo}"
 
 missing_root_repo="${workdir}/missing-root"
 create_repo "${missing_root_repo}"
@@ -95,7 +233,7 @@ create_workflow_skeleton "${logic_file_repo}"
 printf '%s\n' '{"name":"aegisops_response_host_isolation"}' > \
   "${logic_file_repo}/n8n/workflows/aegisops_response/bootstrap.json"
 commit_fixture "${logic_file_repo}"
-assert_fails_with "${logic_file_repo}" "must not introduce workflow logic"
+assert_fails_with "${logic_file_repo}" "includes an unapproved workflow asset"
 
 extra_directory_repo="${workdir}/extra-directory"
 create_repo "${extra_directory_repo}"
@@ -103,5 +241,11 @@ create_workflow_skeleton "${extra_directory_repo}"
 mkdir -p "${extra_directory_repo}/n8n/workflows/aegisops_notify/archive"
 commit_fixture "${extra_directory_repo}"
 assert_fails_with "${extra_directory_repo}" "Unexpected entries:"
+
+missing_asset_repo="${workdir}/missing-asset"
+create_repo "${missing_asset_repo}"
+create_workflow_skeleton "${missing_asset_repo}"
+commit_fixture "${missing_asset_repo}"
+assert_fails_with "${missing_asset_repo}" "Missing approved n8n workflow asset"
 
 echo "verify-n8n-workflow-skeleton tests passed"

--- a/scripts/test-verify-sigma-n8n-skeleton-validation.sh
+++ b/scripts/test-verify-sigma-n8n-skeleton-validation.sh
@@ -208,11 +208,11 @@ The approved workflow categories are alert ingest, enrich, approve, notify, and 
 
 ## 3. Placeholder Boundary
 
-Placeholder directories and marker files under `n8n/workflows/` are not production workflows.
+Placeholder directories and marker files under `n8n/workflows/` remain non-production placeholders for categories that do not yet contain an explicitly approved exported workflow asset.
 
-They reserve approved homes for future workflow assets without claiming that exported workflows, credentials, triggers, or integrations are already implemented here.
+The approved Phase 6 exception is limited to `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json`.
 
-Do not infer live runtime behavior, integration coverage, or production-ready response logic from the current placeholders.
+Do not infer broader live runtime behavior, integration coverage, or production-ready response logic beyond the approved Phase 6 read-only workflow assets.
 
 ## 4. Control vs Execution Alignment
 
@@ -224,9 +224,11 @@ The guidance in this directory does not authorize direct destructive actions fro
 
 ## 5. Contributor Guidance
 
-Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline.
+Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline beyond the current Phase 6 read-only workflow assets.
 
 Keep future workflow additions within the approved category boundary and preserve explicit approval gates for write or destructive actions.
+
+The approved Phase 6 workflow assets must remain read-only for enrichment and notify-only for analyst routing, without response execution, write-capable connectors, or uncontrolled downstream mutation.
 
 When real workflow assets are introduced in later approved work, they should remain auditable, clearly named, and explicit about whether a step is read-only, notify-only, approval-handling, or response-executing.
 
@@ -242,6 +244,127 @@ EOF
   : > "${target}/n8n/workflows/aegisops_enrich/.gitkeep"
   : > "${target}/n8n/workflows/aegisops_notify/.gitkeep"
   : > "${target}/n8n/workflows/aegisops_response/.gitkeep"
+
+  cat <<'EOF' > "${target}/n8n/workflows/aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json"
+{
+  "name": "aegisops_enrich_windows_selected_detector_outputs",
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Phase 6 Read-only Boundary",
+      "type": "n8n-nodes-base.stickyNote"
+    },
+    {
+      "parameters": {},
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "name": "selected_detector_outputs",
+              "value": "privileged_group_membership_change,audit_log_cleared,new_local_user_created",
+              "type": "string"
+            },
+            {
+              "name": "read_only_boundary",
+              "value": "true",
+              "type": "string"
+            },
+            {
+              "name": "notification_handoff_required",
+              "value": "true",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "name": "Normalize Selected Detector Output",
+      "type": "n8n-nodes-base.set"
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "value": "privileged_group_membership_change"
+            },
+            {
+              "value": "audit_log_cleared"
+            },
+            {
+              "value": "new_local_user_created"
+            }
+          ]
+        }
+      },
+      "name": "Route Selected Detector Output",
+      "type": "n8n-nodes-base.switch"
+    }
+  ],
+  "tags": [
+    {
+      "name": "read_only"
+    },
+    {
+      "name": "phase_6"
+    }
+  ]
+}
+EOF
+
+  cat <<'EOF' > "${target}/n8n/workflows/aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json"
+{
+  "name": "aegisops_notify_windows_selected_detector_outputs",
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Notify-only Boundary",
+      "type": "n8n-nodes-base.stickyNote"
+    },
+    {
+      "parameters": {},
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "name": "selected_detector_outputs",
+              "value": "privileged_group_membership_change,audit_log_cleared,new_local_user_created",
+              "type": "string"
+            },
+            {
+              "name": "notify_only_boundary",
+              "value": "true",
+              "type": "string"
+            },
+            {
+              "name": "downstream_mutation_allowed",
+              "value": "false",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "name": "Format Analyst Notification",
+      "type": "n8n-nodes-base.set"
+    }
+  ],
+  "tags": [
+    {
+      "name": "notify_only"
+    },
+    {
+      "name": "phase_6"
+    }
+  ]
+}
+EOF
 }
 
 write_validation_doc() {
@@ -267,7 +390,9 @@ write_validation_doc() {
 - `n8n/workflows/aegisops_alert_ingest/.gitkeep`
 - `n8n/workflows/aegisops_approve/.gitkeep`
 - `n8n/workflows/aegisops_enrich/.gitkeep`
+- `n8n/workflows/aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json`
 - `n8n/workflows/aegisops_notify/.gitkeep`
+- `n8n/workflows/aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json`
 - `n8n/workflows/aegisops_response/.gitkeep`
 
 ## Sigma Review Result
@@ -278,15 +403,15 @@ The curated slice is limited to privileged group membership change, audit log cl
 
 ## n8n Workflow Category Review Result
 
-The tracked n8n workflow skeleton covers the approved alert ingest, enrich, approve, notify, and response categories.
+The tracked n8n workflow structure keeps the approved alert ingest, enrich, approve, notify, and response categories while limiting exported workflow assets to the selected Phase 6 read-only slice.
 
-Each category remains a placeholder-only directory with a `.gitkeep` marker, and no exported workflow, trigger, credential, or execution logic is present.
+Alert ingest, approve, and response remain placeholder-only with `.gitkeep` markers, while enrich and notify contain only the approved selected-detector workflow exports.
 
 ## Live Behavior Review Result
 
-No reviewed Sigma asset introduces runnable detection behavior, and no reviewed n8n asset introduces runnable workflow behavior.
+No reviewed Sigma asset introduces runnable detection behavior, and the reviewed n8n assets remain read-only workflow exports without approval-exempt write or response execution steps.
 
-The current tracked Sigma assets remain reviewed content only, and the n8n assets remain documentation and placeholder markers only.
+The current tracked Sigma assets remain reviewed content only, and the n8n workflow assets are limited to enrichment, routing, and notification payload preparation for the selected Windows detector outputs.
 
 ## Deviations
 

--- a/scripts/verify-n8n-workflow-category-guidance.sh
+++ b/scripts/verify-n8n-workflow-category-guidance.sh
@@ -18,10 +18,11 @@ required_headings=(
 required_phrases=(
   "This directory exists to document the approved workflow-category boundaries for AegisOps n8n assets."
   "The approved workflow categories are alert ingest, enrich, approve, notify, and response."
-  'Placeholder directories and marker files under `n8n/workflows/` are not production workflows.'
+  'Placeholder directories and marker files under `n8n/workflows/` remain non-production placeholders for categories that do not yet contain an explicitly approved exported workflow asset.'
   "OpenSearch remains responsible for detection and analytics, while n8n is limited to approved orchestration, enrichment, approval handling, notification routing, and controlled downstream execution."
-  "Do not infer live runtime behavior, integration coverage, or production-ready response logic from the current placeholders."
-  "Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline."
+  'The approved Phase 6 exception is limited to `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json`.'
+  "The approved Phase 6 workflow assets must remain read-only for enrichment and notify-only for analyst routing, without response execution, write-capable connectors, or uncontrolled downstream mutation."
+  "Leave runtime behavior unchanged unless a separately approved issue or ADR expands the baseline beyond the current Phase 6 read-only workflow assets."
 )
 
 required_references=(
@@ -56,4 +57,4 @@ for reference in "${required_references[@]}"; do
   fi
 done
 
-echo "n8n workflow category guidance documents approved categories, placeholder limits, and control-versus-execution boundaries."
+echo "n8n workflow category guidance documents approved categories, the limited Phase 6 workflow exception, and control-versus-execution boundaries."

--- a/scripts/verify-n8n-workflow-skeleton.sh
+++ b/scripts/verify-n8n-workflow-skeleton.sh
@@ -14,6 +14,18 @@ expected_categories=(
   "aegisops_response"
 )
 
+required_workflow_assets=(
+  "aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json"
+  "aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json"
+)
+
+allowed_node_types=(
+  "n8n-nodes-base.manualTrigger"
+  "n8n-nodes-base.set"
+  "n8n-nodes-base.stickyNote"
+  "n8n-nodes-base.switch"
+)
+
 if [[ ! -d "${workflow_root}" ]]; then
   echo "Missing n8n workflow skeleton directory: ${workflow_root}" >&2
   exit 1
@@ -50,17 +62,93 @@ for category in "${expected_categories[@]}"; do
 
   unexpected_entries=()
   while IFS= read -r path; do
-    unexpected_entries+=("${path}")
+    relative_path="${path#${workflow_root}/}"
+    case "${relative_path}" in
+      "${category}/.gitkeep"|\
+      "aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json"|\
+      "aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json")
+        ;;
+      *)
+        unexpected_entries+=("${path}")
+        ;;
+    esac
   done < <(
-    find "${category_path}" -mindepth 1 ! -path "${category_path}/.gitkeep" | LC_ALL=C sort
+    find "${category_path}" -mindepth 1 | LC_ALL=C sort
   )
 
   if ((${#unexpected_entries[@]} > 0)); then
-    echo "n8n workflow category placeholders must not introduce workflow logic: ${category_path}" >&2
+    echo "n8n workflow structure includes an unapproved workflow asset: ${category_path}" >&2
     printf 'Unexpected entries:\n' >&2
     printf '  %s\n' "${unexpected_entries[@]}" >&2
     exit 1
   fi
+done
+
+for asset in "${required_workflow_assets[@]}"; do
+  asset_path="${workflow_root}/${asset}"
+
+  if [[ ! -f "${asset_path}" ]]; then
+    echo "Missing approved n8n workflow asset: ${asset_path}" >&2
+    exit 1
+  fi
+done
+
+enrich_workflow="${workflow_root}/aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json"
+notify_workflow="${workflow_root}/aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json"
+
+enrich_required_phrases=(
+  '"name": "aegisops_enrich_windows_selected_detector_outputs"'
+  '"value": "privileged_group_membership_change"'
+  '"value": "audit_log_cleared"'
+  '"value": "new_local_user_created"'
+  '"name": "read_only_boundary"'
+  '"name": "notification_handoff_required"'
+)
+
+notify_required_phrases=(
+  '"name": "aegisops_notify_windows_selected_detector_outputs"'
+  '"name": "notify_only_boundary"'
+  '"name": "downstream_mutation_allowed"'
+  '"name": "selected_detector_outputs"'
+)
+
+for phrase in "${enrich_required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${enrich_workflow}"; then
+    echo "Approved enrich workflow is missing required read-only structure text: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${notify_required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${notify_workflow}"; then
+    echo "Approved notify workflow is missing required notify-only structure text: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for asset_path in "${enrich_workflow}" "${notify_workflow}"; do
+  asset_name="${asset_path##*/}"
+  workflow_node_types=()
+  while IFS= read -r node_type; do
+    workflow_node_types+=("${node_type}")
+  done < <(
+    grep -o 'n8n-nodes-base\.[^"]*' "${asset_path}" | LC_ALL=C sort -u
+  )
+
+  for node_type in "${workflow_node_types[@]}"; do
+    is_allowed="false"
+    for allowed_node_type in "${allowed_node_types[@]}"; do
+      if [[ "${node_type}" == "${allowed_node_type}" ]]; then
+        is_allowed="true"
+        break
+      fi
+    done
+
+    if [[ "${is_allowed}" != "true" ]]; then
+      echo "Approved n8n workflow asset uses a non-read-only node type in ${asset_name}: ${node_type}" >&2
+      exit 1
+    fi
+  done
 done
 
 if [[ "${actual_categories[*]}" != "${expected_sorted[*]}" ]]; then
@@ -72,4 +160,4 @@ if [[ "${actual_categories[*]}" != "${expected_sorted[*]}" ]]; then
   exit 1
 fi
 
-echo "n8n workflow category skeleton matches the approved placeholder-safe structure."
+echo "n8n workflow structure matches the approved Phase 6 read-only enrich and notify asset boundaries."

--- a/scripts/verify-sigma-n8n-skeleton-validation.sh
+++ b/scripts/verify-sigma-n8n-skeleton-validation.sh
@@ -31,10 +31,10 @@ required_phrases=(
   "## Deviations"
   "The Sigma curated and suppressed directories preserve the approved distinction between reviewed onboarding candidates and documented future suppression decisions."
   "The curated slice is limited to privileged group membership change, audit log cleared, and new local user created, and the suppressed directory remains placeholder-only without live suppression entries."
-  "The tracked n8n workflow skeleton covers the approved alert ingest, enrich, approve, notify, and response categories."
-  "Each category remains a placeholder-only directory with a \`.gitkeep\` marker, and no exported workflow, trigger, credential, or execution logic is present."
-  "No reviewed Sigma asset introduces runnable detection behavior, and no reviewed n8n asset introduces runnable workflow behavior."
-  "The current tracked Sigma assets remain reviewed content only, and the n8n assets remain documentation and placeholder markers only."
+  "The tracked n8n workflow structure keeps the approved alert ingest, enrich, approve, notify, and response categories while limiting exported workflow assets to the selected Phase 6 read-only slice."
+  "Alert ingest, approve, and response remain placeholder-only with \`.gitkeep\` markers, while enrich and notify contain only the approved selected-detector workflow exports."
+  "No reviewed Sigma asset introduces runnable detection behavior, and the reviewed n8n assets remain read-only workflow exports without approval-exempt write or response execution steps."
+  "The current tracked Sigma assets remain reviewed content only, and the n8n workflow assets are limited to enrichment, routing, and notification payload preparation for the selected Windows detector outputs."
   "No deviations found."
 )
 
@@ -56,7 +56,9 @@ reviewed_artifacts=(
   "n8n/workflows/aegisops_alert_ingest/.gitkeep"
   "n8n/workflows/aegisops_approve/.gitkeep"
   "n8n/workflows/aegisops_enrich/.gitkeep"
+  "n8n/workflows/aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json"
   "n8n/workflows/aegisops_notify/.gitkeep"
+  "n8n/workflows/aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json"
   "n8n/workflows/aegisops_response/.gitkeep"
 )
 
@@ -67,4 +69,4 @@ for artifact in "${reviewed_artifacts[@]}"; do
   fi
 done
 
-echo "Sigma and n8n skeleton assets match the approved category structure and remain placeholder-safe."
+echo "Sigma assets remain reviewed content and n8n assets remain limited to the approved Phase 6 read-only workflow slice."


### PR DESCRIPTION
## Summary
- add read-only Phase 6 n8n enrich and notify workflow exports for the selected Windows detector outputs
- update n8n workflow guidance and structure verification to allow only the approved enrich/notify assets
- refresh the Sigma+n8n validation record and focused verifier tests for the new workflow state

## Verification
- `bash scripts/test-verify-n8n-workflow-skeleton.sh`
- `bash scripts/test-verify-n8n-workflow-category-guidance.sh`
- `bash scripts/test-verify-sigma-n8n-skeleton-validation.sh`
- `bash scripts/verify-n8n-workflow-category-guidance.sh`
- `bash scripts/verify-n8n-workflow-skeleton.sh`
- `bash scripts/verify-sigma-n8n-skeleton-validation.sh`