### PR TITLE
Document Phase 6 validation and rollback runbook

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -79,4 +79,68 @@ Future validation guidance should describe:
 - the conditions that require escalation instead of continued operation, and
 - the repository artifacts that define the expected state.
 
-Until those procedures exist, this section serves only as a placeholder for approved future validation content.
+The selected Phase 6 validation slice is limited to the Windows security and endpoint telemetry family and the three reviewed detector artifacts under `opensearch/detectors/windows-security-and-endpoint/`.
+
+This runbook section is limited to replay validation, staging-only detector review, and read-only or notify-only workflow review during business hours.
+
+### 6.1 Selected Slice and Preconditions
+
+The selected replay-to-detection-to-notify slice covers these reviewed use cases only:
+
+1. Privileged group membership change
+2. Audit log cleared
+3. New local user created
+
+The operator should treat the slice as ready for analyst validation only when all of the following repository artifacts remain present and internally consistent:
+
+- `docs/phase-6-initial-telemetry-slice.md`
+- `docs/source-families/windows-security-and-endpoint/onboarding-package.md`
+- `docs/phase-6-opensearch-detector-artifact-validation.md`
+- `opensearch/detectors/windows-security-and-endpoint/privileged-group-membership-change-staging.yaml`
+- `opensearch/detectors/windows-security-and-endpoint/audit-log-cleared-staging.yaml`
+- `opensearch/detectors/windows-security-and-endpoint/new-local-user-created-staging.yaml`
+- `n8n/workflows/aegisops_enrich/aegisops_enrich_windows_selected_detector_outputs.json`
+- `n8n/workflows/aegisops_notify/aegisops_notify_windows_selected_detector_outputs.json`
+- `ingest/replay/windows-security-and-endpoint/normalized/success.ndjson`
+
+This slice is not a production activation checklist. It does not authorize live source onboarding, detector enablement against production indexes, response execution, or after-hours operation promises.
+
+### 6.2 Analyst Validation Path
+
+The analyst validation path for this slice is review-first and replay-oriented:
+
+1. Confirm the replay corpus still represents only the three selected Windows use cases and remains synthetic or redacted review material.
+2. Confirm each detector artifact remains `staging` scoped, points to `aegisops-logs-windows-staging-*`, and preserves the expected field dependencies and replay evidence references.
+3. Confirm the enrich workflow remains read-only and the notify workflow remains notify-only, with no write-capable connector, response step, or approval-bypass behavior inferred from the asset content.
+4. Exercise the slice by replaying the reviewed success-path records into the approved staging validation path and verifying that the resulting detector outputs are suitable for analyst review rather than automated action.
+5. Review the resulting routed work item during business hours and confirm it can be handled as a queue-driven analyst task with evidence capture, hypothesis development, and escalation or closure decisions remaining human-owned.
+
+Validation is incomplete if the slice depends on missing actor attribution, forwarded-event timing ambiguity, hidden field remapping, threshold logic, or any workflow behavior beyond the approved read-only and notify-only boundaries.
+
+### 6.3 Required Evidence Review
+
+Operators must review replay evidence from `ingest/replay/windows-security-and-endpoint/normalized/success.ndjson`, the staging-only detector metadata, and the read-only or notify-only workflow assets before treating the slice as validated.
+
+The minimum evidence review for each exercise is:
+
+- replay evidence showing which of the three selected Windows scenarios was used;
+- detector metadata showing the expected validation target index, Sigma traceability, field dependencies, and false-positive notes;
+- workflow metadata showing the enrich asset remains read-oriented and the notify asset remains analyst-routing only; and
+- analyst-facing review notes showing whether the routed output was understandable, attributable to the replayed record, and compatible with the business-hours queue model.
+
+Any validation record should note whether the slice produced an explainable analyst work item, whether the evidence was sufficient for same-day review, and whether the output should stay staged, be revised, or be withdrawn.
+
+### 6.4 Disable and Rollback Path
+
+If validation fails, disable the selected slice by keeping the detector artifacts out of production activation and by withdrawing `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json` from the active workflow set until the issue is corrected and re-reviewed.
+
+Rollback for this slice means returning to the prior safe state where the reviewed artifacts remain version-controlled reference material only:
+
+- do not promote the detector artifacts beyond staging-only scope;
+- do not treat replay success as authority for production index coverage;
+- do not leave the selected enrich or notify assets available for uncontrolled live routing if their analyst-facing output is misleading or incomplete; and
+- document the failure reason, the affected use case, and the artifact set withdrawn from validation so the next review can confirm the rollback state deliberately.
+
+Escalate instead of continuing validation when the failure suggests missing provenance, ambiguous timestamps, missing identity fields required by the detector, or any behavior that would make the routed work item unreliable for analyst review.
+
+The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.

--- a/scripts/test-verify-runbook-doc.sh
+++ b/scripts/test-verify-runbook-doc.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-runbook-doc.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+}
+
+write_doc() {
+  local target="$1"
+  local doc_content="$2"
+
+  printf '%s\n' "${doc_content}" >"${target}/docs/runbook.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_doc "${valid_repo}" '# AegisOps Runbook Skeleton
+
+This runbook is an initial skeleton for approved future operational procedures.
+
+It supplements `docs/requirements-baseline.md` by reserving a structured home for startup, shutdown, restore, approval handling, and validation guidance as implementation artifacts mature.
+
+It does not claim production completeness and does not authorize environment-specific commands.
+
+## 1. Purpose and Status
+
+This document exists to define the minimum approved structure for future operator procedures without implying that those procedures are complete today.
+
+## 2. Startup
+
+Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+## 3. Shutdown
+
+Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+## 4. Restore
+
+Detailed restore steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+## 5. Approval Handling
+
+The approved baseline requires explicit approval for SOAR workflows that perform write or destructive actions by default.
+
+Approval handling procedures must preserve human review, auditability, and the separation between detection and execution.
+
+## 6. Validation
+
+Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure.
+
+The selected Phase 6 validation slice is limited to the Windows security and endpoint telemetry family and the three reviewed detector artifacts under `opensearch/detectors/windows-security-and-endpoint/`.
+
+This runbook section is limited to replay validation, staging-only detector review, and read-only or notify-only workflow review during business hours.
+
+### 6.1 Selected Slice and Preconditions
+
+Preconditions are documented for the selected slice only.
+
+### 6.2 Analyst Validation Path
+
+Analyst validation remains replay-oriented and business-hours only.
+
+### 6.3 Required Evidence Review
+
+Operators must review replay evidence from `ingest/replay/windows-security-and-endpoint/normalized/success.ndjson`, the staging-only detector metadata, and the read-only or notify-only workflow assets before treating the slice as validated.
+
+### 6.4 Disable and Rollback Path
+
+If validation fails, disable the selected slice by keeping the detector artifacts out of production activation and by withdrawing `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json` from the active workflow set until the issue is corrected and re-reviewed.
+
+The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.'
+assert_passes "${valid_repo}"
+
+missing_rollback_repo="${workdir}/missing-rollback"
+create_repo "${missing_rollback_repo}"
+write_doc "${missing_rollback_repo}" '# AegisOps Runbook Skeleton
+
+This runbook is an initial skeleton for approved future operational procedures.
+
+It supplements `docs/requirements-baseline.md` by reserving a structured home for startup, shutdown, restore, approval handling, and validation guidance as implementation artifacts mature.
+
+It does not claim production completeness and does not authorize environment-specific commands.
+
+## 1. Purpose and Status
+
+This document exists to define the minimum approved structure for future operator procedures without implying that those procedures are complete today.
+
+## 2. Startup
+
+Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+## 3. Shutdown
+
+Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+## 4. Restore
+
+Detailed restore steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+## 5. Approval Handling
+
+The approved baseline requires explicit approval for SOAR workflows that perform write or destructive actions by default.
+
+Approval handling procedures must preserve human review, auditability, and the separation between detection and execution.
+
+## 6. Validation
+
+Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure.
+
+The selected Phase 6 validation slice is limited to the Windows security and endpoint telemetry family and the three reviewed detector artifacts under `opensearch/detectors/windows-security-and-endpoint/`.
+
+This runbook section is limited to replay validation, staging-only detector review, and read-only or notify-only workflow review during business hours.
+
+### 6.1 Selected Slice and Preconditions
+
+Preconditions are documented for the selected slice only.
+
+### 6.2 Analyst Validation Path
+
+Analyst validation remains replay-oriented and business-hours only.
+
+### 6.3 Required Evidence Review
+
+Operators must review replay evidence from `ingest/replay/windows-security-and-endpoint/normalized/success.ndjson`, the staging-only detector metadata, and the read-only or notify-only workflow assets before treating the slice as validated.
+
+### 6.4 Disable and Rollback Path
+
+The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.'
+assert_fails_with "${missing_rollback_repo}" 'Missing runbook statement: If validation fails, disable the selected slice by keeping the detector artifacts out of production activation and by withdrawing `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json` from the active workflow set until the issue is corrected and re-reviewed.'
+
+echo "Runbook verifier tests passed."

--- a/scripts/verify-runbook-doc.sh
+++ b/scripts/verify-runbook-doc.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 doc_path="${repo_root}/docs/runbook.md"
 
 required_headings=(
@@ -12,6 +12,10 @@ required_headings=(
   "## 4. Restore"
   "## 5. Approval Handling"
   "## 6. Validation"
+  "### 6.1 Selected Slice and Preconditions"
+  "### 6.2 Analyst Validation Path"
+  "### 6.3 Required Evidence Review"
+  "### 6.4 Disable and Rollback Path"
 )
 
 required_phrases=(
@@ -23,6 +27,11 @@ required_phrases=(
   "Detailed restore steps are intentionally deferred until implementation artifacts and validation procedures exist."
   "Approval handling procedures must preserve human review, auditability, and the separation between detection and execution."
   "Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure."
+  'The selected Phase 6 validation slice is limited to the Windows security and endpoint telemetry family and the three reviewed detector artifacts under `opensearch/detectors/windows-security-and-endpoint/`.'
+  "This runbook section is limited to replay validation, staging-only detector review, and read-only or notify-only workflow review during business hours."
+  'Operators must review replay evidence from `ingest/replay/windows-security-and-endpoint/normalized/success.ndjson`, the staging-only detector metadata, and the read-only or notify-only workflow assets before treating the slice as validated.'
+  'If validation fails, disable the selected slice by keeping the detector artifacts out of production activation and by withdrawing `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json` from the active workflow set until the issue is corrected and re-reviewed.'
+  "The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation."
 )
 
 if [[ ! -f "${doc_path}" ]]; then
@@ -44,4 +53,4 @@ for phrase in "${required_phrases[@]}"; do
   fi
 done
 
-echo "Runbook document is present and limited to an approved skeleton."
+echo "Runbook document is present and covers the approved Phase 6 analyst validation and rollback slice."


### PR DESCRIPTION
## Summary
- document the selected Phase 6 Windows replay-to-detection-to-notify validation slice in the runbook
- add explicit evidence review and safe disable or rollback guidance that stays staging-only and business-hours-oriented
- tighten the runbook verifier and add a focused regression test for the new contract

## Verification
- bash scripts/test-verify-runbook-doc.sh
- bash scripts/verify-runbook-doc.sh
- bash scripts/verify-architecture-runbook-validation.sh

Closes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced runbook with Phase 6 analyst validation procedures, including replay validation flow, business-hours review guidelines, evidence review requirements, and rollback procedures for validation failures.

* **Tests**
  * Added test coverage for runbook documentation verification to ensure presence of required validation and rollback statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->