### PR TITLE
[codex] Add Phase 6 verifier coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           bash scripts/verify-parameter-category-docs.sh
           bash scripts/verify-parameter-config-files.sh
           bash scripts/verify-phase-5-semantic-contract-validation.sh
+          bash scripts/verify-phase-6-initial-telemetry-slice-doc.sh
+          bash scripts/verify-phase-6-opensearch-detector-artifacts.sh
+          bash scripts/verify-phase-6-replay-to-notify-validation.sh
           bash scripts/verify-postgres-compose-skeleton.sh
           bash scripts/verify-proxy-compose-skeleton.sh
           bash scripts/verify-response-action-safety-model-doc.sh
@@ -77,6 +80,9 @@ jobs:
           bash scripts/test-verify-ci-phase-5-workflow-coverage.sh
           bash scripts/test-verify-detection-lifecycle-and-rule-qa-framework.sh
           bash scripts/test-verify-phase-5-semantic-contract-validation.sh
+          bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
+          bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
+          bash scripts/test-verify-phase-6-replay-to-notify-validation.sh
           bash scripts/test-verify-repository-skeleton.sh
           bash scripts/test-verify-response-action-safety-model-doc.sh
           bash scripts/test-verify-retention-baseline-doc.sh

--- a/scripts/test-verify-ci-phase-6-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-6-workflow-coverage.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+required_verifiers=(
+  "bash scripts/verify-phase-6-initial-telemetry-slice-doc.sh"
+  "bash scripts/verify-phase-6-opensearch-detector-artifacts.sh"
+  "bash scripts/verify-phase-6-replay-to-notify-validation.sh"
+)
+
+required_tests=(
+  "bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh"
+  "bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh"
+  "bash scripts/test-verify-phase-6-replay-to-notify-validation.sh"
+)
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+for command in "${required_verifiers[@]}"; do
+  if ! grep -Fq "${command}" "${workflow_path}"; then
+    echo "Missing Phase 6 verifier command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_tests[@]}"; do
+  if ! grep -Fq "${command}" "${workflow_path}"; then
+    echo "Missing Phase 6 focused shell test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+echo "CI workflow includes the required Phase 6 verifier and focused shell test commands."


### PR DESCRIPTION
## Summary
- add the missing Phase 6 verifier commands to the CI workflow
- add the matching `test-verify-phase-6-*` commands to the focused shell test step
- add a focused Phase 6 CI workflow coverage test to prevent the wiring from drifting again

## Why
CI was not running the existing Phase 6 verifier/test scripts, so the approved Phase 6 slice could regress without workflow enforcement.

## Testing
- `bash scripts/test-verify-ci-phase-6-workflow-coverage.sh`
- `bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh`
- `bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh`
- `bash scripts/test-verify-phase-6-replay-to-notify-validation.sh`
- `bash scripts/verify-phase-6-initial-telemetry-slice-doc.sh`
- `bash scripts/verify-phase-6-opensearch-detector-artifacts.sh`
- `bash scripts/verify-phase-6-replay-to-notify-validation.sh`

Closes #139
