### PR TITLE
[codex] Add Phase 6 CI workflow coverage self-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           bash scripts/test-verify-compose-skeleton-overview-doc.sh
           bash scripts/test-verify-control-plane-state-model-doc.sh
           bash scripts/test-verify-ci-phase-5-workflow-coverage.sh
+          bash scripts/test-verify-ci-phase-6-workflow-coverage.sh
           bash scripts/test-verify-detection-lifecycle-and-rule-qa-framework.sh
           bash scripts/test-verify-phase-5-semantic-contract-validation.sh
           bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh


### PR DESCRIPTION
## Summary
- run the existing Phase 6 CI workflow coverage self-check from the focused shell test stage in `.github/workflows/ci.yml`
- keep the change limited to wiring the existing guard alongside the existing Phase 5 coverage self-check
- preserve the current Phase 6 verifier and focused test command list

## Root cause
The repository already had `scripts/test-verify-ci-phase-6-workflow-coverage.sh`, but the CI workflow never executed it. That meant CI would not fail if a required Phase 6 verifier or focused shell test command was later removed from `.github/workflows/ci.yml`.

## Verification
- `bash scripts/test-verify-ci-phase-5-workflow-coverage.sh`
- `bash scripts/test-verify-ci-phase-6-workflow-coverage.sh`
- temp negative check removing `bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh` from a copied workflow, which caused the Phase 6 guard to fail as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow testing infrastructure by adding additional workflow coverage verification to the test execution pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->