### PR TITLE
[codex] Add Phase 7 asset identity privilege baseline

### DIFF
--- a/.codex-supervisor/issues/149/issue-journal.md
+++ b/.codex-supervisor/issues/149/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #149: design: define the asset, identity, and privilege context baseline for AI-assisted threat hunting
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/149
+- Branch: codex/issue-149
+- Workspace: .
+- Journal: .codex-supervisor/issues/149/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 24337a6bee893e0779161476575fd604c628ea29
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-04T04:11:29.684Z
+
+## Latest Codex Summary
+- Added a dedicated Phase 7 asset, identity, and privilege context baseline document plus focused verifier/test and CI coverage updates.
+- Verified the new baseline alongside the existing SecOps domain model and auth baseline checks.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Issue #149 was missing a dedicated Phase 7 baseline for asset, identity, alias, ownership, criticality, group, service-account, and privilege context, and the narrowest reproducer was a new verifier failing because the document did not exist.
+- What changed: Added `docs/asset-identity-privilege-context-baseline.md`, added `scripts/verify-asset-identity-privilege-context-baseline.sh` and `scripts/test-verify-asset-identity-privilege-context-baseline.sh`, updated `.github/workflows/ci.yml`, `scripts/test-verify-ci-phase-7-workflow-coverage.sh`, `docs/documentation-ownership-map.md`, `scripts/verify-documentation-ownership-map.sh`, and `README.md`.
+- Current blocker: none
+- Next exact step: Commit the verified checkpoint on `codex/issue-149`.
+- Verification gap: Full CI has not been run end-to-end locally; focused verifiers and the required issue checks passed.
+- Files touched: `.github/workflows/ci.yml`, `README.md`, `docs/asset-identity-privilege-context-baseline.md`, `docs/documentation-ownership-map.md`, `scripts/test-verify-asset-identity-privilege-context-baseline.sh`, `scripts/test-verify-ci-phase-7-workflow-coverage.sh`, `scripts/verify-asset-identity-privilege-context-baseline.sh`, `scripts/verify-documentation-ownership-map.sh`
+- Rollback concern: Low; changes are documentation and shell verification only.
+- Last focused command: `bash scripts/verify-secops-domain-model-doc.sh && bash scripts/verify-auth-baseline-doc.sh && bash scripts/verify-asset-identity-privilege-context-baseline.sh && bash scripts/verify-documentation-ownership-map.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Run documentation and skeleton verifiers
         run: |
           bash scripts/verify-adr-review-path-doc.sh
+          bash scripts/verify-asset-identity-privilege-context-baseline.sh
           bash scripts/verify-ai-hunt-plane-adr.sh
           bash scripts/verify-architecture-doc.sh
           bash scripts/verify-architecture-runbook-validation.sh
@@ -66,6 +67,7 @@ jobs:
 
       - name: Run focused shell tests
         run: |
+          bash scripts/test-verify-asset-identity-privilege-context-baseline.sh
           bash scripts/test-verify-auth-baseline-doc.sh
           bash scripts/test-verify-ci-phase-7-workflow-coverage.sh
           bash scripts/test-verify-canonical-telemetry-schema-doc.sh

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/secops-domain-model.md`
 - `docs/secops-business-hours-operating-model.md`
 - `docs/auth-baseline.md`
+- `docs/asset-identity-privilege-context-baseline.md`
 - `docs/response-action-safety-model.md`
 - `docs/control-plane-state-model.md`
 - `docs/retention-evidence-and-replay-readiness-baseline.md`

--- a/docs/asset-identity-privilege-context-baseline.md
+++ b/docs/asset-identity-privilege-context-baseline.md
@@ -1,0 +1,114 @@
+# AegisOps Asset, Identity, and Privilege Context Baseline
+
+## 1. Purpose
+
+This document defines the minimum asset, identity, and privilege context baseline for Phase 7 AI-assisted threat hunting design work.
+
+It supplements `docs/secops-domain-model.md`, `docs/auth-baseline.md`, and `docs/adr/0001-phase-7-ai-hunt-plane-and-external-ai-data-boundary.md` by defining the smallest reviewed context model AegisOps may use when hunts reason about hosts, users, service accounts, groups, aliases, ownership, and criticality.
+
+This document defines baseline terms, ownership expectations, and bounded reasoning claims only. It does not approve live CMDB integration, IdP integration, or production privilege synchronization.
+
+## 2. First-Class Context Terms
+
+The following terms are first-class context entities for Phase 7 design work:
+
+| Term | Baseline definition |
+| ---- | ---- |
+| `Asset` | A host, workload, device, application instance, or other operational computing target that may produce telemetry, receive actions, or require ownership context. |
+| `Identity` | A human or machine principal that may authenticate, own activity, approve work, or operate automation relevant to hunt and triage context. |
+| `Group` | A named collection of identities used for access assignment, administrative delegation, or scoping of privilege-relevant relationships. |
+| `Service Account` | A non-human identity used by automation, integrations, monitors, or workflows rather than by an interactive person. |
+| `Alias` | A reviewed alternate identifier that may refer to the same asset, identity, or group without asserting hidden authority beyond the mapped context. |
+| `Ownership` | The accountable team or role expected to know why the asset or identity exists, what it supports, and who may authorize changes. |
+| `Criticality` | A bounded rating that explains how operationally or security-significant an asset, identity, or group is for triage and escalation decisions. |
+| `Privilege Context` | The reviewed description of why an identity, group, or asset is security-sensitive because of administrative capability, delegated authority, or access to high-impact systems. |
+
+These terms extend the existing `Asset` and `Identity` reference-entity model rather than replacing it.
+
+`Group`, `Service Account`, `Alias`, `Ownership`, `Criticality`, and `Privilege Context` exist to make threat-hunting explanations explicit before any live enterprise enrichment is introduced.
+
+## 3. Minimal Resolution and Alias Claims
+
+AegisOps may claim direct equality only when two records share the same stable identifier inside the same reviewed source boundary.
+
+AegisOps may claim probable alias linkage only when the relationship is explicitly supplied by reviewed documentation, curated mapping, or analyst-confirmed case context.
+
+AegisOps must not invent transitive identity, host, or group resolution from naming similarity alone.
+
+When resolution is incomplete, the baseline expectation is to preserve the ambiguity explicitly rather than fabricate a single authoritative entity.
+
+At this baseline, reviewed alias handling may support statements such as:
+
+- a hostname and inventory label refer to the same reviewed host;
+- a user principal name and directory short name refer to the same reviewed identity;
+- a privileged group has a reviewed alternate display name in a local platform; or
+- a service account has a stable integration-specific identifier that maps to one reviewed automation identity.
+
+This baseline does not authorize graph expansion, hidden transitive closure, or silent entity stitching across multiple systems just because identifiers appear similar.
+
+## 4. Ownership, Criticality, and Privilege Context Expectations
+
+Each tracked asset should have a named owning team or role, a stated operational purpose, and a criticality expectation when that context is available.
+
+Each tracked identity or service account should have a named owner, expected usage boundary, and whether the identity is interactive, shared, or automation-bound.
+
+Privilege-relevant groups must be treated as context-bearing entities even when live group membership synchronization is out of scope.
+
+Service accounts must remain distinct from human identities in hunt reasoning even if their names resemble individual user identifiers.
+
+The minimum expected context fields for Phase 7 design work are:
+
+| Entity family | Minimum context expectation | Why it matters |
+| ---- | ---- | ---- |
+| `Asset` | Owner, operational purpose, criticality, and known aliases when available | Lets hunts explain why a host or workload matters without pretending a CMDB is already integrated. |
+| `Identity` | Owner, identity type, known aliases, and whether the identity is interactive or machine-bound | Prevents hunts from collapsing people and automation into one ambiguous actor. |
+| `Group` | Owner, privilege relevance, and reviewed scope or purpose | Preserves why membership in the group is security-significant. |
+| `Service Account` | Owner, automation surface, privilege context, and criticality of the systems it can affect | Distinguishes bounded automation identities from generic usernames. |
+
+Host ownership, business purpose, service-account ownership, group sensitivity, and criticality may inform hunt prioritization and triage explanation, but they do not prove maliciousness by themselves.
+
+Privilege context may include statements such as local administrator scope, domain-adjacent delegated administration, approval authority, secrets access, or control over high-impact infrastructure, but each statement must remain bounded to reviewed source context.
+
+## 5. Hunt and Triage Usage Boundaries
+
+Phase 7 hunt workflows may use this baseline to explain why a host, user, service account, or group deserves additional scrutiny without claiming that AegisOps already has live enterprise authority over those records.
+
+This baseline permits bounded statements such as known owner, declared criticality, reviewed alias, and privilege-relevant group membership only when those statements come from approved internal reference data or analyst-reviewed case context.
+
+Approved Phase 7 reasoning may:
+
+- prioritize a hunt lead because the affected asset is marked critical;
+- explain that an identity is a service account rather than a human operator;
+- note that membership in a reviewed privileged group raises triage priority; and
+- preserve that multiple labels refer to one reviewed asset or identity when the alias mapping is explicit.
+
+Approved Phase 7 reasoning may not:
+
+- claim complete enterprise asset coverage;
+- claim complete identity or group coverage across all systems;
+- infer missing ownership, aliases, or entitlements from naming patterns alone; or
+- describe privilege context as authoritative proof of current access if the repository only holds reviewed design-time context.
+
+This baseline does not make CMDB data authoritative for all asset truth, does not make an IdP authoritative for every entitlement edge, and does not authorize production entitlement automation.
+
+## 6. Explicit Non-Goals
+
+Live CMDB integration is out of scope.
+
+IdP integration for live identity or group synchronization is out of scope.
+
+Production privilege sync, entitlement reconciliation, and automatic authorization changes are out of scope.
+
+This baseline does not define a production-ready schema for enterprise inventory ingestion, directory federation, entitlement graph computation, or continuously updated ownership reconciliation.
+
+This baseline also does not authorize AI-assisted hunts to treat undocumented spreadsheet data, ticket notes, or ad hoc operator memory as hidden authoritative enrichment.
+
+## 7. Baseline Alignment Notes
+
+This baseline keeps asset, identity, group, service-account, alias, ownership, criticality, and privilege context explicit for hunt design without creating a shadow source of truth.
+
+It aligns with the SecOps domain model by keeping contextual reference entities separate from findings, alerts, cases, and evidence.
+
+It aligns with the auth baseline by preserving distinct treatment for human identities, service accounts, approval roles, and least-privilege expectations.
+
+It aligns with the Phase 7 AI hunt ADR by allowing only bounded, reviewable context claims rather than silent live enrichment or externally hosted authority over internal identity and asset records.

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -33,6 +33,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/secops-domain-model.md` | SecOps domain model baseline | IT Operations, Information Systems Department |
 | `docs/secops-business-hours-operating-model.md` | Business-hours SecOps daily operating model baseline | IT Operations, Information Systems Department |
 | `docs/auth-baseline.md` | Authentication, authorization, and service account ownership baseline | IT Operations, Information Systems Department |
+| `docs/asset-identity-privilege-context-baseline.md` | Asset, identity, and privilege context baseline | IT Operations, Information Systems Department |
 | `docs/response-action-safety-model.md` | Response action safety and approval binding baseline | IT Operations, Information Systems Department |
 | `docs/control-plane-state-model.md` | Control-plane state and reconciliation baseline | IT Operations, Information Systems Department |
 | `docs/retention-evidence-and-replay-readiness-baseline.md` | Retention, evidence lifecycle, and replay readiness baseline | IT Operations, Information Systems Department |
@@ -49,6 +50,8 @@ The SecOps domain model document remains the shared semantic reference for basel
 The business-hours SecOps operating model remains the analyst-workflow reference for triage, case creation, approval timeout handling, after-hours escalation, and handoff expectations under the non-24x7 baseline.
 
 The auth baseline remains the policy reference for operator personas, least-privilege authorization boundaries, machine identity ownership, and secret lifecycle expectations across future monitors, workflows, approvals, and integrations.
+
+The asset, identity, and privilege context baseline remains the Phase 7 design reference for reviewed alias handling, ownership expectations, criticality context, and privilege-relevant entity reasoning without implying live CMDB or IdP authority.
 
 The response action safety model remains the baseline policy reference for action classes, approval binding, idempotency expectations, and post-approval drift protection for future response execution work.
 

--- a/scripts/test-verify-asset-identity-privilege-context-baseline.sh
+++ b/scripts/test-verify-asset-identity-privilege-context-baseline.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-asset-identity-privilege-context-baseline.sh"
+canonical_doc="${repo_root}/docs/asset-identity-privilege-context-baseline.md"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_canonical_doc() {
+  local target="$1"
+
+  cp "${canonical_doc}" "${target}/docs/asset-identity-privilege-context-baseline.md"
+  git -C "${target}" add docs/asset-identity-privilege-context-baseline.md
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local expected_text="$2"
+  local doc_path="${target}/docs/asset-identity-privilege-context-baseline.md"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${doc_path}"
+  git -C "${target}" add docs/asset-identity-privilege-context-baseline.md
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_canonical_doc "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing asset, identity, and privilege context baseline document:"
+
+missing_alias_repo="${workdir}/missing-alias"
+create_repo "${missing_alias_repo}"
+write_canonical_doc "${missing_alias_repo}"
+remove_text_from_doc "${missing_alias_repo}" "AegisOps may claim probable alias linkage only when the relationship is explicitly supplied by reviewed documentation, curated mapping, or analyst-confirmed case context."
+commit_fixture "${missing_alias_repo}"
+assert_fails_with "${missing_alias_repo}" "AegisOps may claim probable alias linkage only when the relationship is explicitly supplied by reviewed documentation, curated mapping, or analyst-confirmed case context."
+
+missing_non_goal_repo="${workdir}/missing-non-goal"
+create_repo "${missing_non_goal_repo}"
+write_canonical_doc "${missing_non_goal_repo}"
+remove_text_from_doc "${missing_non_goal_repo}" "Production privilege sync, entitlement reconciliation, and automatic authorization changes are out of scope."
+commit_fixture "${missing_non_goal_repo}"
+assert_fails_with "${missing_non_goal_repo}" "Production privilege sync, entitlement reconciliation, and automatic authorization changes are out of scope."
+
+echo "verify-asset-identity-privilege-context-baseline tests passed"

--- a/scripts/test-verify-ci-phase-7-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-7-workflow-coverage.sh
@@ -6,10 +6,12 @@ repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 workflow_path="${repo_root}/.github/workflows/ci.yml"
 
 required_verifiers=(
+  "bash scripts/verify-asset-identity-privilege-context-baseline.sh"
   "bash scripts/verify-ai-hunt-plane-adr.sh"
 )
 
 required_tests=(
+  "bash scripts/test-verify-asset-identity-privilege-context-baseline.sh"
   "bash scripts/test-verify-ci-phase-7-workflow-coverage.sh"
 )
 

--- a/scripts/verify-asset-identity-privilege-context-baseline.sh
+++ b/scripts/verify-asset-identity-privilege-context-baseline.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/asset-identity-privilege-context-baseline.md"
+
+required_headings=(
+  "# AegisOps Asset, Identity, and Privilege Context Baseline"
+  "## 1. Purpose"
+  "## 2. First-Class Context Terms"
+  "## 3. Minimal Resolution and Alias Claims"
+  "## 4. Ownership, Criticality, and Privilege Context Expectations"
+  "## 5. Hunt and Triage Usage Boundaries"
+  "## 6. Explicit Non-Goals"
+  "## 7. Baseline Alignment Notes"
+)
+
+required_phrases=(
+  "This document defines the minimum asset, identity, and privilege context baseline for Phase 7 AI-assisted threat hunting design work."
+  "This document defines baseline terms, ownership expectations, and bounded reasoning claims only. It does not approve live CMDB integration, IdP integration, or production privilege synchronization."
+  '| `Asset` | A host, workload, device, application instance, or other operational computing target that may produce telemetry, receive actions, or require ownership context. |'
+  '| `Identity` | A human or machine principal that may authenticate, own activity, approve work, or operate automation relevant to hunt and triage context. |'
+  '| `Group` | A named collection of identities used for access assignment, administrative delegation, or scoping of privilege-relevant relationships. |'
+  '| `Service Account` | A non-human identity used by automation, integrations, monitors, or workflows rather than by an interactive person. |'
+  '| `Alias` | A reviewed alternate identifier that may refer to the same asset, identity, or group without asserting hidden authority beyond the mapped context. |'
+  '| `Ownership` | The accountable team or role expected to know why the asset or identity exists, what it supports, and who may authorize changes. |'
+  '| `Criticality` | A bounded rating that explains how operationally or security-significant an asset, identity, or group is for triage and escalation decisions. |'
+  '| `Privilege Context` | The reviewed description of why an identity, group, or asset is security-sensitive because of administrative capability, delegated authority, or access to high-impact systems. |'
+  "AegisOps may claim direct equality only when two records share the same stable identifier inside the same reviewed source boundary."
+  "AegisOps may claim probable alias linkage only when the relationship is explicitly supplied by reviewed documentation, curated mapping, or analyst-confirmed case context."
+  "AegisOps must not invent transitive identity, host, or group resolution from naming similarity alone."
+  "When resolution is incomplete, the baseline expectation is to preserve the ambiguity explicitly rather than fabricate a single authoritative entity."
+  "Each tracked asset should have a named owning team or role, a stated operational purpose, and a criticality expectation when that context is available."
+  "Each tracked identity or service account should have a named owner, expected usage boundary, and whether the identity is interactive, shared, or automation-bound."
+  "Privilege-relevant groups must be treated as context-bearing entities even when live group membership synchronization is out of scope."
+  "Service accounts must remain distinct from human identities in hunt reasoning even if their names resemble individual user identifiers."
+  "Host ownership, business purpose, service-account ownership, group sensitivity, and criticality may inform hunt prioritization and triage explanation, but they do not prove maliciousness by themselves."
+  "Phase 7 hunt workflows may use this baseline to explain why a host, user, service account, or group deserves additional scrutiny without claiming that AegisOps already has live enterprise authority over those records."
+  "This baseline permits bounded statements such as known owner, declared criticality, reviewed alias, and privilege-relevant group membership only when those statements come from approved internal reference data or analyst-reviewed case context."
+  "This baseline does not make CMDB data authoritative for all asset truth, does not make an IdP authoritative for every entitlement edge, and does not authorize production entitlement automation."
+  "Live CMDB integration is out of scope."
+  "IdP integration for live identity or group synchronization is out of scope."
+  "Production privilege sync, entitlement reconciliation, and automatic authorization changes are out of scope."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing asset, identity, and privilege context baseline document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq "${heading}" "${doc_path}"; then
+    echo "Missing asset/identity/privilege baseline heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Missing asset/identity/privilege baseline statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+echo "Asset, identity, and privilege context baseline document is present and defines the required Phase 7 reasoning boundaries."

--- a/scripts/verify-documentation-ownership-map.sh
+++ b/scripts/verify-documentation-ownership-map.sh
@@ -23,12 +23,14 @@ required_phrases=(
   '| `docs/detection-lifecycle-and-rule-qa-framework.md` | Detection lifecycle and rule QA framework baseline | IT Operations, Information Systems Department |'
   '| `docs/secops-domain-model.md` | SecOps domain model baseline | IT Operations, Information Systems Department |'
   '| `docs/auth-baseline.md` | Authentication, authorization, and service account ownership baseline | IT Operations, Information Systems Department |'
+  '| `docs/asset-identity-privilege-context-baseline.md` | Asset, identity, and privilege context baseline | IT Operations, Information Systems Department |'
   '| `docs/response-action-safety-model.md` | Response action safety and approval binding baseline | IT Operations, Information Systems Department |'
   '| `docs/control-plane-state-model.md` | Control-plane state and reconciliation baseline | IT Operations, Information Systems Department |'
   '| `docs/retention-evidence-and-replay-readiness-baseline.md` | Retention, evidence lifecycle, and replay readiness baseline | IT Operations, Information Systems Department |'
   '| `docs/adr/` | Architecture Decision Records (ADRs) | IT Operations, Information Systems Department |'
   '| `docs/parameters/` | Parameter documentation | IT Operations, Information Systems Department |'
   '| `docs/runbook.md` | Runbooks | IT Operations, Information Systems Department |'
+  'The asset, identity, and privilege context baseline remains the Phase 7 design reference for reviewed alias handling, ownership expectations, criticality context, and privilege-relevant entity reasoning without implying live CMDB or IdP authority.'
   'The retention, evidence lifecycle, and replay readiness baseline remains the policy reference for record-family retention classes, evidence expiration constraints, replay dataset preservation, and restore-readiness assumptions.'
 )
 


### PR DESCRIPTION
## Summary
- add a dedicated Phase 7 baseline for asset, identity, group, service account, alias, ownership, criticality, and privilege context
- define the bounded claims AegisOps may make for alias handling and privilege-relevant hunt context without implying live CMDB or IdP integrations
- wire focused verification, shell tests, CI coverage, and ownership references for the new baseline

## Why
Issue #149 needs a reviewable baseline for AI-assisted threat hunting context so hunt and triage flows can reason about hosts, users, service accounts, groups, ownership, and criticality without inventing hidden enrichment or live enterprise authority.

## Validation
- `rg -n "asset|identity|privilege|criticality|alias|service account|group baseline|ownership" docs`
- `bash scripts/verify-secops-domain-model-doc.sh`
- `bash scripts/verify-auth-baseline-doc.sh`
- `bash scripts/verify-asset-identity-privilege-context-baseline.sh`
- `bash scripts/verify-documentation-ownership-map.sh`
- `bash scripts/test-verify-asset-identity-privilege-context-baseline.sh`
- `bash scripts/test-verify-ci-phase-7-workflow-coverage.sh`
