### PR TITLE
[codex] Tighten Phase 7 hunt semantics validation

### DIFF
--- a/.codex-supervisor/issues/162/issue-journal.md
+++ b/.codex-supervisor/issues/162/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #162: validation: include hunt semantics coverage in the Phase 7 design-set validation boundary
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/162
+- Branch: codex/issue-162
+- Workspace: .
+- Journal: .codex-supervisor/issues/162/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 52eceb64a995a6a25cf4766623118ece637a2c71
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-04T07:30:18.126Z
+
+## Latest Codex Summary
+- Reproduced the gap by adding a focused Phase 7 shell-test case showing that removing `docs/secops-domain-model.md` was not previously caught by the design-set verifier. Tightened the Phase 7 verifier and validation record to require `docs/secops-domain-model.md`, to run `verify-secops-domain-model-doc.sh`, and to fail when the asset/identity baseline loses its SecOps-domain-model hunt-semantics cross-link.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Phase 7 design-set validation was relying on broader repository checks for hunt semantics and needed an explicit dependency on `docs/secops-domain-model.md` plus a required cross-link from the Phase 7 context baseline back to the SecOps domain model.
+- What changed: Added focused shell-test coverage for missing domain-model artifact and missing hunt-semantics cross-link; updated `scripts/verify-phase-7-ai-hunt-design-validation.sh` to run `verify-secops-domain-model-doc.sh`, require `docs/secops-domain-model.md` in the design-set artifact list, and fail if `docs/asset-identity-privilege-context-baseline.md` loses its SecOps-domain-model supplement statement; updated `docs/phase-7-ai-hunt-design-validation.md` to record the new artifact, verification command, review outcome, and cross-link expectation.
+- Current blocker: none
+- Next exact step: Commit the Phase 7 validation tightening changes on `codex/issue-162`.
+- Verification gap: None in the focused Phase 7 path; the issue-specified verifier and focused shell tests pass locally.
+- Files touched: `.codex-supervisor/issues/162/issue-journal.md`, `docs/phase-7-ai-hunt-design-validation.md`, `scripts/verify-phase-7-ai-hunt-design-validation.sh`, `scripts/test-verify-phase-7-ai-hunt-design-validation.sh`
+- Rollback concern: Low; changes are limited to documentation-validation coverage and focused shell tests.
+- Last focused command: `bash scripts/test-verify-phase-7-ai-hunt-design-validation.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/phase-7-ai-hunt-design-validation.md
+++ b/docs/phase-7-ai-hunt-design-validation.md
@@ -2,8 +2,8 @@
 
 - Validation date: 2026-04-04
 - Validation scope: Phase 7 AI hunt and control-plane design-set review covering advisory-only AI boundaries, safe-query policy, bounded context terms, retention and replay constraints, and evaluation readiness guardrails
-- Baseline references: `docs/adr/0001-phase-7-ai-hunt-plane-and-external-ai-data-boundary.md`, `docs/control-plane-state-model.md`, `docs/safe-query-gateway-and-tool-policy.md`, `docs/asset-identity-privilege-context-baseline.md`, `docs/retention-evidence-and-replay-readiness-baseline.md`, `docs/phase-7-ai-hunt-evaluation-baseline.md`
-- Verification commands: `bash scripts/verify-ai-hunt-plane-adr.sh`, `bash scripts/verify-control-plane-state-model-doc.sh`, `bash scripts/verify-safe-query-gateway-doc.sh`, `bash scripts/verify-asset-identity-privilege-context-baseline.sh`, `bash scripts/verify-retention-baseline-doc.sh`, `bash scripts/verify-phase-7-ai-hunt-design-validation.sh`
+- Baseline references: `docs/adr/0001-phase-7-ai-hunt-plane-and-external-ai-data-boundary.md`, `docs/control-plane-state-model.md`, `docs/safe-query-gateway-and-tool-policy.md`, `docs/asset-identity-privilege-context-baseline.md`, `docs/secops-domain-model.md`, `docs/retention-evidence-and-replay-readiness-baseline.md`, `docs/phase-7-ai-hunt-evaluation-baseline.md`
+- Verification commands: `bash scripts/verify-ai-hunt-plane-adr.sh`, `bash scripts/verify-control-plane-state-model-doc.sh`, `bash scripts/verify-safe-query-gateway-doc.sh`, `bash scripts/verify-asset-identity-privilege-context-baseline.sh`, `bash scripts/verify-secops-domain-model-doc.sh`, `bash scripts/verify-retention-baseline-doc.sh`, `bash scripts/verify-phase-7-ai-hunt-design-validation.sh`
 - Validation status: PASS
 
 ## Required Design-Set Artifacts
@@ -12,6 +12,7 @@
 - `docs/control-plane-state-model.md`
 - `docs/safe-query-gateway-and-tool-policy.md`
 - `docs/asset-identity-privilege-context-baseline.md`
+- `docs/secops-domain-model.md`
 - `docs/retention-evidence-and-replay-readiness-baseline.md`
 - `docs/phase-7-ai-hunt-evaluation-baseline.md`
 
@@ -25,6 +26,8 @@ Confirmed the Safe Query Gateway policy requires structured query intent, determ
 
 Confirmed the asset, identity, and privilege context baseline limits Phase 7 reasoning to reviewed alias, ownership, criticality, and privilege context claims rather than live CMDB or IdP authority.
 
+Confirmed the SecOps domain model remains the hunt semantics source of truth for Hunt, Hunt Hypothesis, Hunt Run, Observation, Lead, Recommendation, and AI Trace records used by the Phase 7 design set.
+
 Confirmed the retention and replay baseline keeps evidence custody, approval lineage, and replay-ready normalized datasets explicit enough to review future AI-assisted hunt validation without relying on provider-side memory or dashboard history.
 
 Confirmed the Phase 7 evaluation baseline requires replay corpus coverage for benign noise, missing fields, locale variance, time skew, prompt injection, citation stress, scope-boundary pressure, and low-signal ambiguity before trust is granted.
@@ -34,6 +37,8 @@ Confirmed the Phase 7 evaluation baseline requires replay corpus coverage for be
 The Phase 7 ADR must remain cross-linked from the Safe Query Gateway policy, the asset and identity context baseline, and the evaluation baseline so the advisory-only authority ceiling stays reviewable from each design artifact.
 
 The control-plane state model must remain part of the required design set because Hunt, Hunt Run, and AI Trace records are control-plane records that keep AI assistance from becoming implicit workflow authority.
+
+The asset and identity context baseline must continue to cite `docs/secops-domain-model.md` so hunt terms, alias handling, and privilege-relevant context stay anchored to the reviewed SecOps vocabulary.
 
 The evaluation baseline must continue to cite the Safe Query Gateway policy, the asset and identity context baseline, and the retention and replay baseline so future review can trace trust-blocking failures back to the relevant design constraints.
 

--- a/scripts/test-verify-phase-7-ai-hunt-design-validation.sh
+++ b/scripts/test-verify-phase-7-ai-hunt-design-validation.sh
@@ -19,6 +19,7 @@ required_docs=(
   "docs/safe-query-gateway-and-tool-policy.md"
   "docs/asset-identity-privilege-context-baseline.md"
   "docs/retention-evidence-and-replay-readiness-baseline.md"
+  "docs/secops-domain-model.md"
   "docs/phase-7-ai-hunt-evaluation-baseline.md"
   "docs/phase-7-ai-hunt-design-validation.md"
 )
@@ -111,6 +112,20 @@ write_required_docs "${missing_cross_link_repo}"
 remove_text_from_doc "${missing_cross_link_repo}" "docs/phase-7-ai-hunt-evaluation-baseline.md" "It supplements \`docs/adr/0001-phase-7-ai-hunt-plane-and-external-ai-data-boundary.md\`, \`docs/safe-query-gateway-and-tool-policy.md\`, \`docs/asset-identity-privilege-context-baseline.md\`, and \`docs/retention-evidence-and-replay-readiness-baseline.md\` by defining how future AI hunt behavior must be challenged before any live AI-assisted path is treated as trustworthy."
 commit_fixture "${missing_cross_link_repo}"
 assert_fails_with "${missing_cross_link_repo}" "Missing Phase 7 evaluation baseline statement"
+
+missing_domain_model_repo="${workdir}/missing-domain-model"
+create_repo "${missing_domain_model_repo}"
+write_required_docs "${missing_domain_model_repo}"
+remove_doc "${missing_domain_model_repo}" "docs/secops-domain-model.md"
+commit_fixture "${missing_domain_model_repo}"
+assert_fails_with "${missing_domain_model_repo}" "Missing SecOps domain model document:"
+
+missing_hunt_semantics_cross_link_repo="${workdir}/missing-hunt-semantics-cross-link"
+create_repo "${missing_hunt_semantics_cross_link_repo}"
+write_required_docs "${missing_hunt_semantics_cross_link_repo}"
+remove_text_from_doc "${missing_hunt_semantics_cross_link_repo}" "docs/asset-identity-privilege-context-baseline.md" "It supplements \`docs/secops-domain-model.md\`, \`docs/auth-baseline.md\`, and \`docs/adr/0001-phase-7-ai-hunt-plane-and-external-ai-data-boundary.md\` by defining the smallest reviewed context model AegisOps may use when hunts reason about hosts, users, service accounts, groups, aliases, ownership, and criticality."
+commit_fixture "${missing_hunt_semantics_cross_link_repo}"
+assert_fails_with "${missing_hunt_semantics_cross_link_repo}" "Missing Phase 7 hunt semantics cross-link statement"
 
 missing_artifact_listing_repo="${workdir}/missing-artifact-listing"
 create_repo "${missing_artifact_listing_repo}"

--- a/scripts/verify-phase-7-ai-hunt-design-validation.sh
+++ b/scripts/verify-phase-7-ai-hunt-design-validation.sh
@@ -7,12 +7,14 @@ default_repo_root="$(cd "${script_dir}/.." && pwd)"
 repo_root="${1:-${default_repo_root}}"
 validation_doc="${repo_root}/docs/phase-7-ai-hunt-design-validation.md"
 evaluation_doc="${repo_root}/docs/phase-7-ai-hunt-evaluation-baseline.md"
+asset_context_doc="${repo_root}/docs/asset-identity-privilege-context-baseline.md"
 
 bash "${script_dir}/verify-ai-hunt-plane-adr.sh" "${repo_root}"
 bash "${script_dir}/verify-control-plane-state-model-doc.sh" "${repo_root}"
 bash "${script_dir}/verify-safe-query-gateway-doc.sh" "${repo_root}"
 bash "${script_dir}/verify-asset-identity-privilege-context-baseline.sh" "${repo_root}"
 bash "${script_dir}/verify-retention-baseline-doc.sh" "${repo_root}"
+bash "${script_dir}/verify-secops-domain-model-doc.sh" "${repo_root}"
 
 if [[ ! -f "${evaluation_doc}" ]]; then
   echo "Missing Phase 7 AI hunt evaluation baseline: ${evaluation_doc}" >&2
@@ -45,8 +47,8 @@ validation_required_phrases=(
   "# Phase 7 AI Hunt Design-Set Validation"
   "- Validation date: 2026-04-04"
   "- Validation scope: Phase 7 AI hunt and control-plane design-set review covering advisory-only AI boundaries, safe-query policy, bounded context terms, retention and replay constraints, and evaluation readiness guardrails"
-  "- Baseline references: \`docs/adr/0001-phase-7-ai-hunt-plane-and-external-ai-data-boundary.md\`, \`docs/control-plane-state-model.md\`, \`docs/safe-query-gateway-and-tool-policy.md\`, \`docs/asset-identity-privilege-context-baseline.md\`, \`docs/retention-evidence-and-replay-readiness-baseline.md\`, \`docs/phase-7-ai-hunt-evaluation-baseline.md\`"
-  "- Verification commands: \`bash scripts/verify-ai-hunt-plane-adr.sh\`, \`bash scripts/verify-control-plane-state-model-doc.sh\`, \`bash scripts/verify-safe-query-gateway-doc.sh\`, \`bash scripts/verify-asset-identity-privilege-context-baseline.sh\`, \`bash scripts/verify-retention-baseline-doc.sh\`, \`bash scripts/verify-phase-7-ai-hunt-design-validation.sh\`"
+  "- Baseline references: \`docs/adr/0001-phase-7-ai-hunt-plane-and-external-ai-data-boundary.md\`, \`docs/control-plane-state-model.md\`, \`docs/safe-query-gateway-and-tool-policy.md\`, \`docs/asset-identity-privilege-context-baseline.md\`, \`docs/secops-domain-model.md\`, \`docs/retention-evidence-and-replay-readiness-baseline.md\`, \`docs/phase-7-ai-hunt-evaluation-baseline.md\`"
+  "- Verification commands: \`bash scripts/verify-ai-hunt-plane-adr.sh\`, \`bash scripts/verify-control-plane-state-model-doc.sh\`, \`bash scripts/verify-safe-query-gateway-doc.sh\`, \`bash scripts/verify-asset-identity-privilege-context-baseline.sh\`, \`bash scripts/verify-secops-domain-model-doc.sh\`, \`bash scripts/verify-retention-baseline-doc.sh\`, \`bash scripts/verify-phase-7-ai-hunt-design-validation.sh\`"
   "- Validation status: PASS"
   "## Required Design-Set Artifacts"
   "## Review Outcome"
@@ -56,10 +58,12 @@ validation_required_phrases=(
   "Confirmed the approved design set preserves a bounded control-plane model for Hunt, Hunt Run, and AI Trace records without treating AI output, OpenSearch findings, or n8n execution history as the authoritative workflow state."
   "Confirmed the Safe Query Gateway policy requires structured query intent, deterministic query generation, bounded allowlists, and citation-bearing responses instead of direct execution of model-authored query text."
   "Confirmed the asset, identity, and privilege context baseline limits Phase 7 reasoning to reviewed alias, ownership, criticality, and privilege context claims rather than live CMDB or IdP authority."
+  "Confirmed the SecOps domain model remains the hunt semantics source of truth for Hunt, Hunt Hypothesis, Hunt Run, Observation, Lead, Recommendation, and AI Trace records used by the Phase 7 design set."
   "Confirmed the retention and replay baseline keeps evidence custody, approval lineage, and replay-ready normalized datasets explicit enough to review future AI-assisted hunt validation without relying on provider-side memory or dashboard history."
   "Confirmed the Phase 7 evaluation baseline requires replay corpus coverage for benign noise, missing fields, locale variance, time skew, prompt injection, citation stress, scope-boundary pressure, and low-signal ambiguity before trust is granted."
   "The Phase 7 ADR must remain cross-linked from the Safe Query Gateway policy, the asset and identity context baseline, and the evaluation baseline so the advisory-only authority ceiling stays reviewable from each design artifact."
   "The control-plane state model must remain part of the required design set because Hunt, Hunt Run, and AI Trace records are control-plane records that keep AI assistance from becoming implicit workflow authority."
+  "The asset and identity context baseline must continue to cite \`docs/secops-domain-model.md\` so hunt terms, alias handling, and privilege-relevant context stay anchored to the reviewed SecOps vocabulary."
   "The evaluation baseline must continue to cite the Safe Query Gateway policy, the asset and identity context baseline, and the retention and replay baseline so future review can trace trust-blocking failures back to the relevant design constraints."
   "This validation record must remain aligned with the reviewed design artifacts above and fail closed if any required artifact, required cross-link, or required Phase 7 guardrail statement is removed."
   "No deviations found."
@@ -77,6 +81,7 @@ required_artifacts=(
   "docs/control-plane-state-model.md"
   "docs/safe-query-gateway-and-tool-policy.md"
   "docs/asset-identity-privilege-context-baseline.md"
+  "docs/secops-domain-model.md"
   "docs/retention-evidence-and-replay-readiness-baseline.md"
   "docs/phase-7-ai-hunt-evaluation-baseline.md"
 )
@@ -92,5 +97,12 @@ for artifact in "${required_artifacts[@]}"; do
     exit 1
   fi
 done
+
+hunt_semantics_cross_link='It supplements `docs/secops-domain-model.md`, `docs/auth-baseline.md`, and `docs/adr/0001-phase-7-ai-hunt-plane-and-external-ai-data-boundary.md` by defining the smallest reviewed context model AegisOps may use when hunts reason about hosts, users, service accounts, groups, aliases, ownership, and criticality.'
+
+if ! grep -Fq -- "${hunt_semantics_cross_link}" "${asset_context_doc}"; then
+  echo "Missing Phase 7 hunt semantics cross-link statement in ${asset_context_doc}: ${hunt_semantics_cross_link}" >&2
+  exit 1
+fi
 
 echo "Phase 7 AI hunt design-set validation record and linked design artifacts remain reviewable and fail closed."


### PR DESCRIPTION
## What changed
- tightened the Phase 7 AI hunt design-set verifier so it explicitly depends on `docs/secops-domain-model.md`
- added focused shell-test coverage for a missing SecOps domain-model artifact and a missing hunt-semantics cross-link from the asset/identity context baseline
- updated the Phase 7 validation record to list the domain model as a required design artifact and to record the new cross-link expectation

## Why
Phase 7 hunt semantics were only being covered indirectly by broader repository validation. This change makes that dependency explicit inside the Phase 7 design-set boundary so drift fails closed in the focused verifier path.

## Impact
- Phase 7 validation now fails if `docs/secops-domain-model.md` is missing from the design set
- Phase 7 validation now fails if `docs/asset-identity-privilege-context-baseline.md` drops its SecOps-domain-model supplement statement
- CI continues to exercise the focused Phase 7 verifier path through the existing workflow coverage check

## Validation
- `bash scripts/verify-phase-7-ai-hunt-design-validation.sh`
- `bash scripts/test-verify-phase-7-ai-hunt-design-validation.sh`
- `bash scripts/test-verify-ci-phase-7-workflow-coverage.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Phase 7 validation now requires a SecOps domain model document as a required artifact.
  * Added cross-link validation to ensure asset and identity context documents properly reference hunt semantics.

* **Tests**
  * Extended test coverage with new fixtures validating required document presence and cross-link requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->