### PR TITLE
[codex] define finding-to-alert ingestion contract

### DIFF
--- a/.codex-supervisor/issues/166/issue-journal.md
+++ b/.codex-supervisor/issues/166/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #166: design: define the finding-to-alert ingestion and reconciliation contract for the control plane
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/166
+- Branch: codex/issue-166
+- Workspace: .
+- Journal: .codex-supervisor/issues/166/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 3027971aa02d483b1c87624088c460d4828d5624
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-04T09:27:05.036Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The docs already mentioned identifiers, but the finding-to-alert ingestion contract and duplicate/restatement boundary were still too implicit for future ingest work.
+- What changed: Tightened the two doc verification scripts with focused finding-to-alert contract assertions, fixed a verifier quoting bug caused by backticks in required phrases, and added explicit contract language to the control-plane and SecOps docs.
+- Current blocker: none
+- Next exact step: Commit the focused documentation and verification updates on `codex/issue-166`.
+- Verification gap: No broader repo-wide verification run; only the issue-targeted grep and document verification scripts were exercised.
+- Files touched: docs/control-plane-state-model.md; docs/secops-domain-model.md; scripts/verify-control-plane-state-model-doc.sh; scripts/verify-secops-domain-model-doc.sh
+- Rollback concern: Low; changes are documentation plus doc-specific verification only.
+- Last focused command: rg -n "finding_id|analytic_signal_id|alert_id|duplicate|restated|ingestion contract" docs/control-plane-state-model.md docs/secops-domain-model.md
+### Scratchpad
+- Reproduced gap by tightening verification first. Initial verifier patch failed because backticks in bash double-quoted array entries triggered command substitution; fixed by using single-quoted phrases before updating docs.

--- a/docs/control-plane-state-model.md
+++ b/docs/control-plane-state-model.md
@@ -82,6 +82,20 @@ OpenSearch is responsible for producing stable analytic identifiers and timestam
 
 n8n is responsible for exposing enough workflow-run identifiers, timestamps, execution outcomes, and step-level failure detail that a future control-plane layer can correlate approved intent to observed execution behavior.
 
+Finding-to-alert ingestion contract requirements:
+
+The ingestion boundary must treat `finding_id`, `analytic_signal_id`, and `alert_id` as related but non-interchangeable identifiers.
+
+A future ingest path must preserve the upstream `finding_id` as the durable analytic-origin reference, preserve `analytic_signal_id` when OpenSearch emits a distinct alerting or correlation artifact, and assign a separate control-plane `alert_id` for the analyst-facing record created or updated from that signal.
+
+The control plane must evaluate whether an incoming upstream signal creates a new alert, updates an existing alert, or is recorded only as a duplicate or restatement linked to an existing alert.
+
+Duplicate or restated upstream analytics signals must not mint a fresh `alert_id` when they do not represent materially new analyst work.
+
+The minimum reconciliation fields for that boundary are `finding_id`, `analytic_signal_id` when distinct, `alert_id`, the control-plane deduplication or correlation key, first-seen and last-seen timestamps for the linked upstream signal set, and explicit ingest disposition showing whether the signal created, updated, deduplicated against, or restated an existing alert.
+
+Reconciliation records must preserve which upstream findings or analytic signals were attached to an alert so later implementations can distinguish repeated analytics output from new analyst work.
+
 The minimum stable reconciliation key set for this baseline is:
 
 - `finding_id` for the upstream OpenSearch analytic record;

--- a/docs/secops-domain-model.md
+++ b/docs/secops-domain-model.md
@@ -138,6 +138,10 @@ OpenSearch findings, n8n workflow runs, and future case state must remain separa
 
 A finding promotes to an alert only when triage policy determines that analyst attention, tracking, notification, or downstream workflow handling is required.
 
+Finding-to-alert routing must preserve the distinction between the upstream finding, any distinct analytic signal emitted by OpenSearch alerting or correlation logic, and the downstream alert record created for analyst work.
+
+A finding identifier, an analytic signal identifier, and an alert identifier are related references, not interchangeable lifecycle keys.
+
 A finding may remain a finding without becoming an alert when the result is retained only for analytics, threshold accumulation, tuning review, or later correlation and does not yet require direct operator handling.
 
 A hunt may produce observations, leads, recommendations, or supporting context for findings, alerts, and cases, but hunt records do not replace those records.
@@ -163,6 +167,8 @@ A case must not be created for every alert by default.
 Grouping means related findings may be collected under one alert when they express the same operator-facing claim closely enough that one analyst work item can review them coherently.
 
 Deduplication means additional findings are attached to an existing alert or case when they restate the same analytic claim against materially the same operational target within the active review window.
+
+When upstream analytics restate the same claim without materially changing analyst work, the control plane must update or link the existing alert rather than minting a new alert identifier.
 
 A new alert must be created instead of deduplicating when severity, target scope, response owner, or review window changes enough that analyst handling would differ.
 

--- a/scripts/verify-control-plane-state-model-doc.sh
+++ b/scripts/verify-control-plane-state-model-doc.sh
@@ -49,6 +49,13 @@ required_phrases=(
   "The control plane is responsible for reconciling approved action intent against observed n8n execution outcomes and for recording when reconciliation is incomplete, stale, or failed."
   "Reconciliation must prefer deterministic correlation keys such as finding identifiers, action-request identifiers, approval identifiers, workflow identifiers, and idempotency keys rather than fuzzy time-window matching."
   "Stable reconciliation keys must allow operators to compare OpenSearch analytics output, control-plane records, and n8n execution outcomes without assuming those systems share one lifecycle or one authoritative identifier."
+  'Finding-to-alert ingestion contract requirements:'
+  'The ingestion boundary must treat `finding_id`, `analytic_signal_id`, and `alert_id` as related but non-interchangeable identifiers.'
+  'A future ingest path must preserve the upstream `finding_id` as the durable analytic-origin reference, preserve `analytic_signal_id` when OpenSearch emits a distinct alerting or correlation artifact, and assign a separate control-plane `alert_id` for the analyst-facing record created or updated from that signal.'
+  'The control plane must evaluate whether an incoming upstream signal creates a new alert, updates an existing alert, or is recorded only as a duplicate or restatement linked to an existing alert.'
+  'Duplicate or restated upstream analytics signals must not mint a fresh `alert_id` when they do not represent materially new analyst work.'
+  'The minimum reconciliation fields for that boundary are `finding_id`, `analytic_signal_id` when distinct, `alert_id`, the control-plane deduplication or correlation key, first-seen and last-seen timestamps for the linked upstream signal set, and explicit ingest disposition showing whether the signal created, updated, deduplicated against, or restated an existing alert.'
+  'Reconciliation records must preserve which upstream findings or analytic signals were attached to an alert so later implementations can distinguish repeated analytics output from new analyst work.'
   "The baseline must define immutable record-family identifiers and explicit lifecycle states for Alert, Case, Evidence, Observation, Lead, Recommendation, Hunt, Hunt Run, AI Trace, Approval Decision, and Action Request records before any live control-plane implementation exists."
   "These identifiers and states are minimum control-plane expectations. They must not be inferred from OpenSearch alert status, OpenSearch document updates, n8n execution status, or ad hoc analyst notes."
   '| `alert_id` | Immutable AegisOps control-plane identifier for one alert record. |'

--- a/scripts/verify-secops-domain-model-doc.sh
+++ b/scripts/verify-secops-domain-model-doc.sh
@@ -79,6 +79,8 @@ required_phrases=(
   '| `Approval Decision` | Future AegisOps approval control layer |'
   '| `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state |'
   "A finding promotes to an alert only when triage policy determines that analyst attention, tracking, notification, or downstream workflow handling is required."
+  "Finding-to-alert routing must preserve the distinction between the upstream finding, any distinct analytic signal emitted by OpenSearch alerting or correlation logic, and the downstream alert record created for analyst work."
+  "A finding identifier, an analytic signal identifier, and an alert identifier are related references, not interchangeable lifecycle keys."
   "A hunt may produce observations, leads, recommendations, or supporting context for findings, alerts, and cases, but hunt records do not replace those records."
   "A lead promotes to an alert only when triage decides the investigative signal requires durable analyst queueing or response handling."
   "A lead may be attached directly to an existing case when the signal materially advances an active investigation without requiring a separate alert lifecycle."
@@ -86,6 +88,7 @@ required_phrases=(
   "Correlation links records by shared context, but it does not by itself create an alert, open a case, or declare an incident."
   "A case must not be created for every alert by default."
   "Deduplication means additional findings are attached to an existing alert or case when they restate the same analytic claim against materially the same operational target within the active review window."
+  "When upstream analytics restate the same claim without materially changing analyst work, the control plane must update or link the existing alert rather than minting a new alert identifier."
   "A new alert must be created instead of deduplicating when severity, target scope, response owner, or review window changes enough that analyst handling would differ."
   "A case is created when analyst work requires durable ownership, evidence collection, note-taking, handoff, or coordinated response beyond the alert record itself."
   "An incident is declared only when one or more cases represent a material security event that requires coordinated operational handling beyond a single investigative work item."


### PR DESCRIPTION
## Summary
- define the finding-to-alert ingestion contract at the control-plane boundary
- state the minimum reconciliation fields that must survive future alert ingest
- require duplicate or restated upstream analytics signals to update or link existing alert work instead of minting a new alert by default

## Why
Issue #166 needs the repository to distinguish upstream finding identifiers, analytic signal identifiers, and future control-plane alert identifiers before alert queue runtime exists. The prior docs were too implicit for a later ingest implementation path.

## Validation
- `rg -n "finding_id|analytic_signal_id|alert_id|duplicate|restated|ingestion contract" docs/control-plane-state-model.md docs/secops-domain-model.md`
- `bash scripts/verify-control-plane-state-model-doc.sh`
- `bash scripts/verify-secops-domain-model-doc.sh`

Closes #166


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified identifier semantics and ingestion contracts for finding, signal, and alert records in control-plane and SecOps domain models to ensure distinct handling and proper deduplication behavior.

* **Tests**
  * Updated verification scripts to validate new documentation requirements around identifier management and ingestion boundary specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->