### PR TITLE
docs: align README with control-plane thesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ OpenSearch, Sigma, and n8n remain repository-tracked assets, but they are subord
 
 Current scope:
 
-- Approved control-plane baseline for alerts, cases, evidence, approvals, actions, and reconciliation
-- Wazuh as the initial standard detection substrate for upstream substrate detection records and analytic signals
-- Shuffle as the initial standard routine automation substrate for approved delegated automation
-- Transitional repository scaffolding for optional or experimental OpenSearch, Sigma, and n8n assets
-- Implementation guardrails for future AegisOps-owned runtime and AI-assisted development
+- Platform baseline definition
+- Architecture design and operating guidance
+- Repository scaffolding
+- Parameter catalog structure
+- Implementation guardrails for AI-assisted development
+
+Within that scope, Wazuh is the initial standard detection substrate, Shuffle is the initial standard routine automation substrate, and the AegisOps-owned control-plane runtime remains not yet live.
 
 ---
 


### PR DESCRIPTION
## Summary
- align the README status section with the accepted control-plane thesis and current runtime status
- replace the older OpenSearch/n8n-centric core-principles summary with the approved detection/control/automation/execution boundary
- preserve the transitional treatment of OpenSearch, Sigma, and n8n in the top-level project narrative

## Verification
- rg -n "foundation-building phase|OpenSearch detects; n8n orchestrates|control plane|Analytic Signal|Wazuh|Shuffle" README.md
- reviewed README.md against docs/adr/0002-wazuh-shuffle-control-plane-thesis.md, docs/requirements-baseline.md, and docs/architecture.md

Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated project status documentation to clarify control-plane approval state and runtime availability.
* Documented explicit substrate defaults: Wazuh for detection, Shuffle for automation.
* Refined core architectural principles to clearly delineate detection, control, automation, and execution functions with explicit ownership and delegation frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->