### PR TITLE
validation: reject stale Phase 10 thesis wording

### DIFF
--- a/.codex-supervisor/issues/221/issue-journal.md
+++ b/.codex-supervisor/issues/221/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #221: validation: make the Phase 10 thesis verifiers reject stale README and pre-runtime control-plane wording
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/221
+- Branch: codex/issue-221
+- Workspace: .
+- Journal: .codex-supervisor/issues/221/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: d0e32a4f6a2c24b711cbbbcde72bdef1ff7f33ef
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-06T04:29:52.980Z
+
+## Latest Codex Summary
+- Reproduced that the Phase 10 README, control-plane state-model, and top-level thesis verifiers all passed when stale foundation-phase README wording and pre-runtime control-plane wording were appended alongside the new required text.
+- Tightened the focused verifier tests first, then updated the README and control-plane verifier forbidden-phrase lists so those stale statements now fail closed and bubble through the top-level Phase 10 verifier.
+- Verified the focused test scripts, the three requested verifier scripts, and one explicit negative check that removed a required README thesis marker in a temporary repo copy and confirmed the README verifier failed.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The child verifiers required the new runtime-era wording but did not reject older contradictory README and control-plane state-model lines when those lines reappeared alongside the required text.
+- What changed: Added focused failing cases to the three Phase 10 verifier test scripts; extended `scripts/verify-readme-and-repository-structure-control-plane-thesis.sh` to reject stale foundation-phase and OpenSearch/n8n-centric README lines; extended `scripts/verify-control-plane-state-model-doc.sh` to reject pre-runtime "future control layer/control record" wording.
+- Current blocker: none
+- Next exact step: Review diff, commit the verifier/test changes on `codex/issue-221`, and leave the workspace ready for the next supervisor phase.
+- Verification gap: none for the scoped verifier changes; focused tests, direct verifier runs, and one explicit negative check all passed.
+- Files touched: .codex-supervisor/issues/221/issue-journal.md; scripts/test-verify-readme-and-repository-structure-control-plane-thesis.sh; scripts/test-verify-control-plane-state-model-doc.sh; scripts/test-verify-phase-10-thesis-consistency.sh; scripts/verify-readme-and-repository-structure-control-plane-thesis.sh; scripts/verify-control-plane-state-model-doc.sh
+- Rollback concern: Low; changes are isolated to Phase 10 thesis verifier deny-lists and their focused regression tests.
+- Last focused command: `tmpdir=$(mktemp -d) ... bash scripts/verify-readme-and-repository-structure-control-plane-thesis.sh "$tmpdir/repo"`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/scripts/test-verify-control-plane-state-model-doc.sh
+++ b/scripts/test-verify-control-plane-state-model-doc.sh
@@ -132,4 +132,20 @@ git -C "${stale_pre_runtime_repo}" add docs/control-plane-state-model.md
 commit_fixture "${stale_pre_runtime_repo}"
 assert_fails_with "${stale_pre_runtime_repo}" "Forbidden control-plane state model statement still present: This document defines the approved baseline control-plane state model for AegisOps before any dedicated control service or datastore is implemented."
 
+stale_future_control_layer_repo="${workdir}/stale-future-control-layer"
+create_repo "${stale_future_control_layer_repo}"
+write_canonical_doc "${stale_future_control_layer_repo}"
+printf '%s\n' "The future AegisOps control layer is responsible for:" >> "${stale_future_control_layer_repo}/docs/control-plane-state-model.md"
+git -C "${stale_future_control_layer_repo}" add docs/control-plane-state-model.md
+commit_fixture "${stale_future_control_layer_repo}"
+assert_fails_with "${stale_future_control_layer_repo}" "Forbidden control-plane state model statement still present: The future AegisOps control layer is responsible for:"
+
+stale_future_control_record_repo="${workdir}/stale-future-control-record"
+create_repo "${stale_future_control_record_repo}"
+write_canonical_doc "${stale_future_control_record_repo}"
+printf '%s\n' "Reconciliation must preserve auditable disagreement. When OpenSearch, n8n, and the future control record disagree, the platform must retain that mismatch as an explicit state that operators can inspect and resolve rather than overwriting one side to make the data look clean." >> "${stale_future_control_record_repo}/docs/control-plane-state-model.md"
+git -C "${stale_future_control_record_repo}" add docs/control-plane-state-model.md
+commit_fixture "${stale_future_control_record_repo}"
+assert_fails_with "${stale_future_control_record_repo}" "Forbidden control-plane state model statement still present: Reconciliation must preserve auditable disagreement. When OpenSearch, n8n, and the future control record disagree, the platform must retain that mismatch as an explicit state that operators can inspect and resolve rather than overwriting one side to make the data look clean."
+
 echo "Control-plane state model verifier enforces required policy statements."

--- a/scripts/test-verify-phase-10-thesis-consistency.sh
+++ b/scripts/test-verify-phase-10-thesis-consistency.sh
@@ -120,4 +120,18 @@ append_text_to_doc "${contradiction_repo}" "README.md" "**AegisOps** is primaril
 commit_fixture "${contradiction_repo}"
 assert_fails_with "${contradiction_repo}" "Forbidden thesis contradiction in README.md: **AegisOps** is primarily an OpenSearch-and-n8n product core."
 
+stale_child_verifier_repo="${workdir}/stale-child-verifier"
+create_repo "${stale_child_verifier_repo}"
+write_canonical_docs "${stale_child_verifier_repo}"
+append_text_to_doc "${stale_child_verifier_repo}" "README.md" "> This repository is currently in the foundation-building phase. It is **not yet a production-ready SOC platform**."
+commit_fixture "${stale_child_verifier_repo}"
+assert_fails_with "${stale_child_verifier_repo}" "Forbidden legacy README statement present: > This repository is currently in the foundation-building phase. It is **not yet a production-ready SOC platform**."
+
+stale_control_plane_child_repo="${workdir}/stale-control-plane-child"
+create_repo "${stale_control_plane_child_repo}"
+write_canonical_docs "${stale_control_plane_child_repo}"
+append_text_to_doc "${stale_control_plane_child_repo}" "docs/control-plane-state-model.md" "The future AegisOps control layer is responsible for:"
+commit_fixture "${stale_control_plane_child_repo}"
+assert_fails_with "${stale_control_plane_child_repo}" "Forbidden control-plane state model statement still present: The future AegisOps control layer is responsible for:"
+
 echo "Phase 10 thesis consistency verifier fails closed for missing artifacts and obvious thesis drift."

--- a/scripts/test-verify-readme-and-repository-structure-control-plane-thesis.sh
+++ b/scripts/test-verify-readme-and-repository-structure-control-plane-thesis.sh
@@ -141,6 +141,22 @@ replace_text_in_doc "${legacy_readme_repo}" "README.md" "**AegisOps** is a gover
 commit_fixture "${legacy_readme_repo}"
 assert_fails_with "${legacy_readme_repo}" "Forbidden legacy README statement present: **AegisOps** is an internal SOC + SOAR platform blueprint designed for flexible deployment across on-premise infrastructure and cloud environments, including AWS and other providers."
 
+stale_foundation_phase_repo="${workdir}/stale-foundation-phase"
+create_repo "${stale_foundation_phase_repo}"
+write_valid_docs "${stale_foundation_phase_repo}"
+printf '\n> This repository is currently in the foundation-building phase. It is **not yet a production-ready SOC platform**.\n' >> "${stale_foundation_phase_repo}/README.md"
+git -C "${stale_foundation_phase_repo}" add README.md
+commit_fixture "${stale_foundation_phase_repo}"
+assert_fails_with "${stale_foundation_phase_repo}" "Forbidden legacy README statement present: > This repository is currently in the foundation-building phase. It is **not yet a production-ready SOC platform**."
+
+stale_opensearch_n8n_principle_repo="${workdir}/stale-opensearch-n8n-principle"
+create_repo "${stale_opensearch_n8n_principle_repo}"
+write_valid_docs "${stale_opensearch_n8n_principle_repo}"
+printf '\n- **Detection and execution are separated** — OpenSearch detects; n8n orchestrates\n' >> "${stale_opensearch_n8n_principle_repo}/README.md"
+git -C "${stale_opensearch_n8n_principle_repo}" add README.md
+commit_fixture "${stale_opensearch_n8n_principle_repo}"
+assert_fails_with "${stale_opensearch_n8n_principle_repo}" "Forbidden legacy README statement present: - **Detection and execution are separated** — OpenSearch detects; n8n orchestrates"
+
 missing_structure_phrase_repo="${workdir}/missing-structure-phrase"
 create_repo "${missing_structure_phrase_repo}"
 write_valid_docs "${missing_structure_phrase_repo}"

--- a/scripts/verify-control-plane-state-model-doc.sh
+++ b/scripts/verify-control-plane-state-model-doc.sh
@@ -169,6 +169,8 @@ forbidden_phrases=(
   "Until a future implementation materializes a dedicated control schema or API boundary, this document is the normative definition of which component owns which state and what must later be reconciled across component boundaries."
   "The approved future persistence boundary for those platform-owned control records is an AegisOps-owned PostgreSQL-backed control-plane datastore boundary."
   "The approved ownership split for a future PostgreSQL-backed implementation is:"
+  "The future AegisOps control layer is responsible for:"
+  "Reconciliation must preserve auditable disagreement. When OpenSearch, n8n, and the future control record disagree, the platform must retain that mismatch as an explicit state that operators can inspect and resolve rather than overwriting one side to make the data look clean."
 )
 
 if [[ ! -f "${doc_path}" ]]; then

--- a/scripts/verify-readme-and-repository-structure-control-plane-thesis.sh
+++ b/scripts/verify-readme-and-repository-structure-control-plane-thesis.sh
@@ -24,6 +24,8 @@ readme_required_phrases=(
 
 readme_forbidden_phrases=(
   "**AegisOps** is an internal SOC + SOAR platform blueprint designed for flexible deployment across on-premise infrastructure and cloud environments, including AWS and other providers."
+  "> This repository is currently in the foundation-building phase. It is **not yet a production-ready SOC platform**."
+  "- **Detection and execution are separated** — OpenSearch detects; n8n orchestrates"
   "- **OpenSearch** — SIEM analytics and detection"
   "- **Sigma** — curated, reviewable detection logic"
   "- **n8n** — approval-gated orchestration, enrichment, and response"


### PR DESCRIPTION
## Summary
- reject stale foundation-phase and OpenSearch/n8n-core README wording in the Phase 10 README verifier
- reject pre-runtime control-plane state model wording in the control-plane verifier and keep the top-level Phase 10 verifier failing closed through the reviewed child verifiers
- add focused regression coverage for the README verifier, control-plane state-model verifier, and Phase 10 consistency verifier

## Verification
- bash scripts/test-verify-readme-and-repository-structure-control-plane-thesis.sh
- bash scripts/test-verify-control-plane-state-model-doc.sh
- bash scripts/test-verify-phase-10-thesis-consistency.sh
- bash scripts/verify-readme-and-repository-structure-control-plane-thesis.sh
- bash scripts/verify-control-plane-state-model-doc.sh
- bash scripts/verify-phase-10-thesis-consistency.sh
- focused negative check: temporary README authority-boundary marker removal in a repo copy confirmed verifier failure

Closes #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 10 thesis verifier update journal entry documenting verification improvements and test coverage.

* **Tests**
  * Expanded test coverage with new negative test scenarios to verify verifiers properly reject disallowed legacy and stale phrasing in documentation files.

* **Chores**
  * Extended verification logic to enforce stricter "fail closed" behavior by adding forbidden-phrase checks for outdated narrative patterns in key documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->