### PR TITLE
Make control-plane runtime use PostgreSQL authority store

### DIFF
--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -21,11 +21,10 @@ Current scaffold:
 
 Current persistence status:
 
-- The reviewed record families now have typed control-plane models plus runtime `save()` and `get()` behavior rooted under `control-plane/`.
-- The in-memory authoritative path fails closed against the reviewed v1 schema invariants in `postgres/control-plane/schema.sql` for lifecycle-state enums, required linkage fields, non-empty required tuple sets, and reconciliation timestamp ordering before records become inspectable runtime state.
+- The reviewed record families now have typed control-plane models plus PostgreSQL-backed runtime `save()`, `get()`, and `list()` behavior rooted under `control-plane/`.
+- The runtime adapter validates records against the reviewed v1 schema invariants in `postgres/control-plane/schema.sql` before writing them into the `aegisops_control` PostgreSQL boundary.
 - The approved reviewed local runtime path is the shipped CLI entrypoint: `python3 control-plane/main.py runtime`, `python3 control-plane/main.py inspect-records --family alert`, and `python3 control-plane/main.py inspect-reconciliation-status`.
-- Those inspection commands are explicitly read-only and run against the same process-local `persistence_mode="in_memory"` runtime used by the current local entrypoint, so they can render empty or locally-seeded inspection views without touching raw PostgreSQL tables directly.
-- The runtime snapshot reports `persistence_mode="in_memory"` to make clear that the current branch does not imply live PostgreSQL-backed storage, write-capable runtime authority, or production deployment readiness.
-- Live PostgreSQL persistence remains follow-up work and depends on adding explicit PostgreSQL client tooling to the runtime environment.
+- The runtime snapshot now reports `persistence_mode="postgresql"` so the reviewed control-plane runtime makes its authoritative store explicit.
+- Live read/write access still depends on PostgreSQL client tooling in the runtime environment, but the control-plane adapter no longer models the reviewed authority path as process-local in-memory state.
 
 This scaffold is intentionally minimal. It does not introduce real credentials, production deployment, analyst UI, or live detector execution.

--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Type, TypeVar
+from contextlib import contextmanager
+from dataclasses import dataclass, field, fields
+import importlib
+import json
+from typing import Any, Callable, Mapping, Protocol, Type, TypeVar
 
 from ..models import (
     AITraceRecord,
@@ -21,6 +24,56 @@ from ..models import (
 
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
+
+
+class CursorProtocol(Protocol):
+    description: object | None
+
+    def execute(self, query: str, params: tuple[object, ...] | None = None) -> None:
+        ...
+
+    def fetchone(self) -> object | None:
+        ...
+
+    def fetchall(self) -> list[object]:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+class ConnectionProtocol(Protocol):
+    def cursor(self) -> CursorProtocol:
+        ...
+
+    def commit(self) -> None:
+        ...
+
+    def rollback(self) -> None:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+ConnectionFactory = Callable[[str], ConnectionProtocol]
+
+
+@dataclass(frozen=True)
+class TableConfig:
+    record_type: Type[ControlPlaneRecord]
+    table_name: str
+    json_fields: frozenset[str] = frozenset()
+    array_fields: frozenset[str] = frozenset()
+
+    @property
+    def identifier_field(self) -> str:
+        return self.record_type.identifier_field
+
+    @property
+    def record_fields(self) -> tuple[str, ...]:
+        return tuple(field_info.name for field_info in fields(self.record_type))
+
 
 _LIFECYCLE_STATES_BY_FAMILY: dict[str, frozenset[str]] = {
     "alert": frozenset(
@@ -125,6 +178,48 @@ _RECONCILIATION_INGEST_DISPOSITIONS = frozenset(
     }
 )
 
+_TABLES_BY_RECORD_TYPE: dict[Type[ControlPlaneRecord], TableConfig] = {
+    AlertRecord: TableConfig(AlertRecord, "alert_records"),
+    CaseRecord: TableConfig(CaseRecord, "case_records", array_fields=frozenset({"evidence_ids"})),
+    EvidenceRecord: TableConfig(EvidenceRecord, "evidence_records"),
+    ObservationRecord: TableConfig(
+        ObservationRecord,
+        "observation_records",
+        array_fields=frozenset({"supporting_evidence_ids"}),
+    ),
+    LeadRecord: TableConfig(LeadRecord, "lead_records"),
+    RecommendationRecord: TableConfig(RecommendationRecord, "recommendation_records"),
+    ApprovalDecisionRecord: TableConfig(
+        ApprovalDecisionRecord,
+        "approval_decision_records",
+        json_fields=frozenset({"target_snapshot"}),
+        array_fields=frozenset({"approver_identities"}),
+    ),
+    ActionRequestRecord: TableConfig(
+        ActionRequestRecord,
+        "action_request_records",
+        json_fields=frozenset({"target_scope"}),
+    ),
+    HuntRecord: TableConfig(HuntRecord, "hunt_records"),
+    HuntRunRecord: TableConfig(
+        HuntRunRecord,
+        "hunt_run_records",
+        json_fields=frozenset({"scope_snapshot", "output_linkage"}),
+    ),
+    AITraceRecord: TableConfig(
+        AITraceRecord,
+        "ai_trace_records",
+        json_fields=frozenset({"subject_linkage"}),
+        array_fields=frozenset({"material_input_refs"}),
+    ),
+    ReconciliationRecord: TableConfig(
+        ReconciliationRecord,
+        "reconciliation_records",
+        json_fields=frozenset({"subject_linkage"}),
+        array_fields=frozenset({"linked_execution_ids"}),
+    ),
+}
+
 
 def _validate_lifecycle_state(record: ControlPlaneRecord) -> None:
     allowed_states = _LIFECYCLE_STATES_BY_FAMILY.get(record.record_family)
@@ -218,39 +313,202 @@ def _validate_record(record: ControlPlaneRecord) -> None:
     raise TypeError(f"Unsupported control-plane record type: {type(record).__name__}")
 
 
+def _load_default_connection_factory() -> ConnectionFactory:
+    for module_name in ("psycopg", "psycopg2"):
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        connector = getattr(module, "connect", None)
+        if callable(connector):
+            return connector
+    raise RuntimeError(
+        "PostgreSQL client tooling is not installed; inject a connection_factory or "
+        "install psycopg/psycopg2 for the reviewed control-plane store"
+    )
+
+
+def _json_ready(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    return value
+
+
+def _json_dump(value: object) -> str:
+    return json.dumps(_json_ready(value), separators=(",", ":"), sort_keys=True)
+
+
+def _row_to_mapping(cursor: CursorProtocol, row: object) -> Mapping[str, object]:
+    if isinstance(row, Mapping):
+        return row
+
+    description = getattr(cursor, "description", None)
+    if not description:
+        raise TypeError("Cursor description is required to map PostgreSQL rows")
+
+    column_names: list[str] = []
+    for column in description:
+        if isinstance(column, str):
+            column_names.append(column)
+        else:
+            column_names.append(column[0])
+
+    if not isinstance(row, (list, tuple)):
+        raise TypeError(f"Unsupported PostgreSQL row type: {type(row).__name__}")
+
+    return dict(zip(column_names, row))
+
+
+def _deserialize_json_value(value: object) -> object:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
 @dataclass
 class PostgresControlPlaneStore:
-    """In-process authoritative store for reviewed control-plane record families."""
+    """Reviewed PostgreSQL-backed authority store for control-plane record families."""
 
     dsn: str
-    persistence_mode: str = field(default="in_memory", init=False)
-    _records: dict[str, dict[str, ControlPlaneRecord]] = field(
-        default_factory=dict,
-        init=False,
-        repr=False,
-    )
+    connection_factory: ConnectionFactory | None = None
+    persistence_mode: str = field(default="postgresql", init=False)
+
+    @contextmanager
+    def _connection(self) -> Any:
+        connection_factory = self.connection_factory or _load_default_connection_factory()
+        connection = connection_factory(self.dsn)
+        try:
+            yield connection
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _table_config(record_type: Type[ControlPlaneRecord]) -> TableConfig:
+        try:
+            return _TABLES_BY_RECORD_TYPE[record_type]
+        except KeyError as exc:
+            raise TypeError(
+                f"Unsupported control-plane record type: {record_type.__name__}"
+            ) from exc
+
+    @staticmethod
+    def _serialize_field(table: TableConfig, field_name: str, value: object) -> object:
+        if field_name in table.json_fields:
+            return _json_dump(value)
+        if field_name in table.array_fields:
+            return list(value) if isinstance(value, tuple) else value
+        return value
+
+    @staticmethod
+    def _deserialize_field(table: TableConfig, field_name: str, value: object) -> object:
+        if field_name in table.json_fields:
+            return _deserialize_json_value(value)
+        if field_name in table.array_fields:
+            if value is None:
+                return ()
+            if isinstance(value, tuple):
+                return value
+            if isinstance(value, list):
+                return tuple(value)
+        return value
+
+    @staticmethod
+    def _placeholder(table: TableConfig, field_name: str) -> str:
+        if field_name in table.json_fields:
+            return "%s::jsonb"
+        if field_name in table.array_fields:
+            return "%s::text[]"
+        return "%s"
+
+    def _row_to_record(
+        self,
+        record_type: Type[RecordT],
+        row: Mapping[str, object],
+    ) -> RecordT:
+        table = self._table_config(record_type)
+        kwargs = {
+            field_name: self._deserialize_field(table, field_name, row[field_name])
+            for field_name in table.record_fields
+        }
+        return record_type(**kwargs)
 
     def save(self, record: RecordT) -> RecordT:
         _validate_record(record)
-        family_records = self._records.setdefault(record.record_family, {})
-        family_records[record.record_id] = record
+        table = self._table_config(type(record))
+        field_names = table.record_fields
+        placeholders = ", ".join(
+            self._placeholder(table, field_name) for field_name in field_names
+        )
+        assignments = ", ".join(
+            f"{field_name} = excluded.{field_name}"
+            for field_name in field_names
+            if field_name != table.identifier_field
+        )
+        params = tuple(
+            self._serialize_field(table, field_name, getattr(record, field_name))
+            for field_name in field_names
+        )
+        query = (
+            f"insert into aegisops_control.{table.table_name} "
+            f"({', '.join(field_names)}) values ({placeholders}) "
+            f"on conflict ({table.identifier_field}) do update set {assignments}"
+        )
+
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(query, params)
+            finally:
+                cursor.close()
         return record
 
     def get(self, record_type: Type[RecordT], record_id: str) -> RecordT | None:
-        family_records = self._records.get(record_type.record_family, {})
-        record = family_records.get(record_id)
-        if record is None:
+        table = self._table_config(record_type)
+        query = (
+            f"select {', '.join(table.record_fields)} "
+            f"from aegisops_control.{table.table_name} "
+            f"where {table.identifier_field} = %s"
+        )
+
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(query, (record_id,))
+                row = cursor.fetchone()
+            finally:
+                cursor.close()
+
+        if row is None:
             return None
-        if not isinstance(record, record_type):
-            raise TypeError(
-                f"Stored {record.record_family} record did not match requested type {record_type.__name__}"
-            )
-        return record
+        return self._row_to_record(record_type, _row_to_mapping(cursor, row))
 
     def list(self, record_type: Type[RecordT]) -> tuple[RecordT, ...]:
-        family_records = self._records.get(record_type.record_family, {})
+        table = self._table_config(record_type)
+        query = (
+            f"select {', '.join(table.record_fields)} "
+            f"from aegisops_control.{table.table_name} "
+            f"order by {table.identifier_field}"
+        )
+
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(query)
+                rows = cursor.fetchall()
+            finally:
+                cursor.close()
+
         return tuple(
-            record
-            for record in family_records.values()
-            if isinstance(record, record_type)
+            self._row_to_record(record_type, _row_to_mapping(cursor, row))
+            for row in rows
         )

--- a/control-plane/config/local.env.sample
+++ b/control-plane/config/local.env.sample
@@ -1,5 +1,5 @@
-# Current scaffold note: the runtime reports persistence_mode=in_memory until
-# explicit PostgreSQL client tooling is added for live adapter support.
+# Reviewed runtime note: the control-plane store reports persistence_mode=postgresql
+# and expects PostgreSQL client tooling in the runtime environment for live access.
 AEGISOPS_CONTROL_PLANE_HOST=127.0.0.1
 AEGISOPS_CONTROL_PLANE_PORT=8080
 AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=<set-me>

--- a/control-plane/postgres_test_support.py
+++ b/control-plane/postgres_test_support.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import re
+
+from aegisops_control_plane.adapters.postgres import PostgresControlPlaneStore
+
+
+_INSERT_RE = re.compile(
+    r"insert into aegisops_control\.(?P<table>\w+) "
+    r"\((?P<columns>[^)]+)\) values \((?P<placeholders>[^)]+)\) "
+    r"on conflict \((?P<identifier>\w+)\) do update set (?P<assignments>.+)",
+    re.IGNORECASE,
+)
+_SELECT_ONE_RE = re.compile(
+    r"select (?P<columns>.+) from aegisops_control\.(?P<table>\w+) "
+    r"where (?P<identifier>\w+) = %s",
+    re.IGNORECASE,
+)
+_SELECT_ALL_RE = re.compile(
+    r"select (?P<columns>.+) from aegisops_control\.(?P<table>\w+) "
+    r"order by (?P<identifier>\w+)",
+    re.IGNORECASE,
+)
+
+
+class FakePostgresBackend:
+    def __init__(self) -> None:
+        self.tables: dict[str, dict[str, dict[str, object]]] = {}
+        self.statements: list[tuple[str, tuple[object, ...] | None]] = []
+
+    def connect(self, dsn: str) -> "FakePostgresConnection":
+        return FakePostgresConnection(self, dsn)
+
+
+class FakePostgresConnection:
+    def __init__(self, backend: FakePostgresBackend, dsn: str) -> None:
+        self.backend = backend
+        self.dsn = dsn
+
+    def cursor(self) -> "FakePostgresCursor":
+        return FakePostgresCursor(self.backend)
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+class FakePostgresCursor:
+    def __init__(self, backend: FakePostgresBackend) -> None:
+        self.backend = backend
+        self.description: tuple[tuple[str], ...] | None = None
+        self._rows: list[dict[str, object]] = []
+
+    def execute(self, query: str, params: tuple[object, ...] | None = None) -> None:
+        normalized = " ".join(query.strip().split())
+        self.backend.statements.append((normalized, params))
+
+        insert_match = _INSERT_RE.fullmatch(normalized)
+        if insert_match is not None:
+            self._execute_insert(insert_match.group("table"), insert_match.group("columns"), params)
+            return
+
+        select_one_match = _SELECT_ONE_RE.fullmatch(normalized)
+        if select_one_match is not None:
+            self._execute_select_one(
+                select_one_match.group("table"),
+                select_one_match.group("columns"),
+                params,
+            )
+            return
+
+        select_all_match = _SELECT_ALL_RE.fullmatch(normalized)
+        if select_all_match is not None:
+            self._execute_select_all(
+                select_all_match.group("table"),
+                select_all_match.group("columns"),
+            )
+            return
+
+        raise AssertionError(f"Unsupported fake PostgreSQL query: {normalized}")
+
+    def _execute_insert(
+        self,
+        table: str,
+        columns: str,
+        params: tuple[object, ...] | None,
+    ) -> None:
+        column_names = [column.strip() for column in columns.split(",")]
+        row = dict(zip(column_names, params or ()))
+        identifier_field = column_names[0]
+        identifier_value = row[identifier_field]
+        table_rows = self.backend.tables.setdefault(table, {})
+        table_rows[str(identifier_value)] = row
+        self.description = None
+        self._rows = []
+
+    def _execute_select_one(
+        self,
+        table: str,
+        columns: str,
+        params: tuple[object, ...] | None,
+    ) -> None:
+        column_names = [column.strip() for column in columns.split(",")]
+        identifier_value = str((params or ("",))[0])
+        row = self.backend.tables.get(table, {}).get(identifier_value)
+        self.description = tuple((name,) for name in column_names)
+        self._rows = [self._project_row(row, column_names)] if row is not None else []
+
+    def _execute_select_all(
+        self,
+        table: str,
+        columns: str,
+    ) -> None:
+        column_names = [column.strip() for column in columns.split(",")]
+        rows = self.backend.tables.get(table, {})
+        self.description = tuple((name,) for name in column_names)
+        self._rows = [
+            self._project_row(rows[record_id], column_names)
+            for record_id in sorted(rows)
+        ]
+
+    @staticmethod
+    def _project_row(
+        row: dict[str, object] | None,
+        column_names: list[str],
+    ) -> dict[str, object]:
+        if row is None:
+            return {}
+        return {column_name: row[column_name] for column_name in column_names}
+
+    def fetchone(self) -> dict[str, object] | None:
+        if not self._rows:
+            return None
+        return self._rows[0]
+
+    def fetchall(self) -> list[dict[str, object]]:
+        return list(self._rows)
+
+    def close(self) -> None:
+        return None
+
+
+def make_store(
+    backend: FakePostgresBackend | None = None,
+) -> tuple[PostgresControlPlaneStore, FakePostgresBackend]:
+    backend = backend or FakePostgresBackend()
+    return (
+        PostgresControlPlaneStore(
+            "postgresql://control-plane.local/aegisops",
+            connection_factory=backend.connect,
+        ),
+        backend,
+    )

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -14,15 +14,15 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
 import main
-from aegisops_control_plane.adapters.postgres import PostgresControlPlaneStore
 from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.models import AlertRecord, ReconciliationRecord
 from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
 
 
 class ControlPlaneCliInspectionTests(unittest.TestCase):
     def test_runtime_command_honors_injected_service_snapshot(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 host="127.0.0.1",
@@ -41,10 +41,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(payload["bind_host"], "127.0.0.1")
         self.assertEqual(payload["bind_port"], 9411)
         self.assertEqual(payload["postgres_dsn"], "postgresql://control-plane.local/aegisops")
-        self.assertEqual(payload["persistence_mode"], "in_memory")
+        self.assertEqual(payload["persistence_mode"], "postgresql")
 
     def test_cli_renders_read_only_record_and_reconciliation_views(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
@@ -108,7 +108,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
 
     def test_cli_rejects_unknown_record_family_as_usage_error(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
@@ -125,12 +125,25 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(exc_info.exception.code, 2)
         self.assertIn("Unsupported control-plane record family", stderr.getvalue())
 
-    def test_cli_renders_standalone_inspection_views_against_in_memory_runtime(self) -> None:
+    def test_cli_renders_inspection_views_against_empty_postgresql_store(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
         records_stdout = io.StringIO()
         status_stdout = io.StringIO()
 
-        main.main(["inspect-records", "--family", "alert"], stdout=records_stdout)
-        main.main(["inspect-reconciliation-status"], stdout=status_stdout)
+        main.main(
+            ["inspect-records", "--family", "alert"],
+            stdout=records_stdout,
+            service=service,
+        )
+        main.main(
+            ["inspect-reconciliation-status"],
+            stdout=status_stdout,
+            service=service,
+        )
 
         records_payload = json.loads(records_stdout.getvalue())
         status_payload = json.loads(status_stdout.getvalue())

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -27,6 +27,7 @@ from aegisops_control_plane.models import (
     ReconciliationRecord,
     RecommendationRecord,
 )
+from postgres_test_support import FakePostgresBackend, make_store
 
 
 @dataclass(frozen=True)
@@ -39,14 +40,14 @@ class UnsupportedRecord(ControlPlaneRecord):
 
 
 class PostgresControlPlaneStoreTests(unittest.TestCase):
-    def test_store_reports_current_in_process_persistence_mode(self) -> None:
+    def test_store_reports_postgresql_authoritative_persistence_mode(self) -> None:
         store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
 
-        self.assertEqual(store.persistence_mode, "in_memory")
+        self.assertEqual(store.persistence_mode, "postgresql")
         self.assertEqual(store.dsn, "postgresql://control-plane.local/aegisops")
 
     def test_store_round_trips_reviewed_record_families_by_aegisops_ids(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         timestamp = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
 
         records = [
@@ -230,7 +231,7 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
             record.target_scope["asset_id"] = "asset-003"  # type: ignore[index]
 
     def test_store_lists_execution_reconciliation_records_separately(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
         compared_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
         records = (
@@ -299,7 +300,7 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
         )
 
     def test_store_rejects_schema_invalid_records_before_persistence(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         timestamp = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
 
         invalid_cases = (
@@ -379,7 +380,7 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
                 self.assertEqual(store.list(record_type), ())
 
     def test_store_rejects_unsupported_record_family_with_type_error(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
 
         with self.assertRaisesRegex(
             TypeError,
@@ -391,6 +392,24 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
                     lifecycle_state="new",
                 )
             )
+
+    def test_store_persists_records_across_store_instances_sharing_postgres_backend(
+        self,
+    ) -> None:
+        backend = FakePostgresBackend()
+        first_store, _ = make_store(backend)
+        second_store, _ = make_store(backend)
+        record = AlertRecord(
+            alert_id="alert-001",
+            finding_id="finding-001",
+            analytic_signal_id="signal-001",
+            case_id=None,
+            lifecycle_state="new",
+        )
+
+        first_store.save(record)
+
+        self.assertEqual(second_store.get(AlertRecord, "alert-001"), record)
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_runtime_skeleton.py
+++ b/control-plane/tests/test_runtime_skeleton.py
@@ -23,7 +23,7 @@ class RuntimeSkeletonTests(unittest.TestCase):
         self.assertEqual(snapshot.bind_host, "127.0.0.1")
         self.assertEqual(snapshot.bind_port, 8080)
         self.assertEqual(snapshot.postgres_dsn, "<set-me>")
-        self.assertEqual(snapshot.persistence_mode, "in_memory")
+        self.assertEqual(snapshot.persistence_mode, "postgresql")
         self.assertEqual(snapshot.opensearch_url, "<set-me>")
         self.assertEqual(snapshot.n8n_base_url, "<set-me>")
 

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -11,28 +11,28 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
 from aegisops_control_plane.config import RuntimeConfig
-from aegisops_control_plane.adapters.postgres import PostgresControlPlaneStore
 from aegisops_control_plane.models import (
     ActionRequestRecord,
     AlertRecord,
     ReconciliationRecord,
 )
 from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
 
 
 class ControlPlaneServicePersistenceTests(unittest.TestCase):
-    def test_runtime_snapshot_reports_current_in_process_persistence_mode(self) -> None:
+    def test_runtime_snapshot_reports_postgresql_authoritative_persistence_mode(self) -> None:
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops")
         )
 
         snapshot = service.describe_runtime()
 
-        self.assertEqual(snapshot.persistence_mode, "in_memory")
+        self.assertEqual(snapshot.persistence_mode, "postgresql")
         self.assertEqual(snapshot.postgres_dsn, "postgresql://control-plane.local/aegisops")
 
     def test_service_round_trips_records_by_control_plane_identifier(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
@@ -88,7 +88,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertIsNone(service.get_record(ReconciliationRecord, "n8n-exec-001"))
 
     def test_service_accepts_injected_store_for_runtime_snapshot(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://ignored.local/aegisops"),
             store=store,
@@ -97,10 +97,10 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         snapshot = service.describe_runtime()
 
         self.assertEqual(snapshot.postgres_dsn, "postgresql://control-plane.local/aegisops")
-        self.assertEqual(snapshot.persistence_mode, "in_memory")
+        self.assertEqual(snapshot.persistence_mode, "postgresql")
 
     def test_service_exposes_read_only_record_and_reconciliation_inspection(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
@@ -175,7 +175,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
     def test_service_rejects_schema_invalid_records_before_they_are_inspectable(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
@@ -226,7 +226,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
     def test_service_upserts_alert_lifecycle_from_upstream_signals(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
@@ -310,11 +310,11 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(restated_reconciliation.last_seen_at, restated_seen)
         self.assertEqual(
             restated_reconciliation.subject_linkage["finding_ids"],
-            ("finding-001", "finding-002"),
+            ["finding-001", "finding-002"],
         )
         self.assertEqual(
             restated_reconciliation.subject_linkage["analytic_signal_ids"],
-            ("signal-001", "signal-002"),
+            ["signal-001", "signal-002"],
         )
         self.assertEqual(updated_reconciliation.alert_id, created.alert.alert_id)
         self.assertEqual(updated_reconciliation.ingest_disposition, "updated")
@@ -322,11 +322,11 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(updated_reconciliation.last_seen_at, updated_seen)
         self.assertEqual(
             updated_reconciliation.subject_linkage["finding_ids"],
-            ("finding-001", "finding-002", "finding-003"),
+            ["finding-001", "finding-002", "finding-003"],
         )
         self.assertEqual(
             updated_reconciliation.subject_linkage["analytic_signal_ids"],
-            ("signal-001", "signal-002", "signal-003"),
+            ["signal-001", "signal-002", "signal-003"],
         )
         self.assertEqual(deduplicated_reconciliation.alert_id, created.alert.alert_id)
         self.assertEqual(
@@ -336,15 +336,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(deduplicated_reconciliation.last_seen_at, duplicate_seen)
         self.assertEqual(
             deduplicated_reconciliation.subject_linkage["finding_ids"],
-            ("finding-001", "finding-002", "finding-003"),
+            ["finding-001", "finding-002", "finding-003"],
         )
         self.assertEqual(
             deduplicated_reconciliation.subject_linkage["analytic_signal_ids"],
-            ("signal-001", "signal-002", "signal-003"),
+            ["signal-001", "signal-002", "signal-003"],
         )
 
     def test_service_records_execution_correlation_mismatch_states_separately(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
@@ -460,8 +460,8 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         stored_reconciliations = store.list(ReconciliationRecord)
         self.assertEqual(len(stored_reconciliations), 4)
         self.assertEqual(
-            [record.ingest_disposition for record in stored_reconciliations],
-            ["missing", "duplicate", "mismatch", "stale"],
+            sorted(record.ingest_disposition for record in stored_reconciliations),
+            ["duplicate", "mismatch", "missing", "stale"],
         )
         self.assertEqual(
             service.get_record(ActionRequestRecord, "action-request-001"),
@@ -469,7 +469,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
     def test_service_reconcile_action_execution_rejects_non_approved_requests(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
@@ -500,7 +500,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             )
 
     def test_service_reconcile_action_execution_requires_aware_datetimes(self) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
@@ -549,7 +549,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_reconcile_action_execution_ignores_repeated_polls_of_same_execution(
         self,
     ) -> None:
-        store = PostgresControlPlaneStore("postgresql://control-plane.local/aegisops")
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,


### PR DESCRIPTION
## Summary
- replace the reviewed runtime's in-memory authoritative path with a PostgreSQL-backed `PostgresControlPlaneStore`
- map reviewed control-plane record families onto the existing `aegisops_control` schema boundary and keep runtime snapshots on `persistence_mode="postgresql"`
- add injected PostgreSQL-style test support and update persistence, CLI, and runtime tests plus local docs/config wording

## Verification
- `python3 -m unittest control-plane/tests/test_postgres_store.py`
- `python3 -m unittest control-plane/tests/test_service_persistence.py`
- `python3 -m unittest control-plane.tests.test_postgres_store control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection control-plane.tests.test_runtime_skeleton`
- `rg -n "postgres/control-plane|authoritative|persistence_mode|control-plane" control-plane postgres`

Closes #226


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated control plane runtime documentation to reflect PostgreSQL-backed data persistence.

* **Refactor**
  * Control plane runtime now uses PostgreSQL for data persistence instead of in-memory storage.

* **Tests**
  * Updated test suite to support PostgreSQL-backed persistence model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->