### PR TITLE
Add Phase 11 control-plane CI validation (#231)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,14 @@ jobs:
       - name: Run Phase 10 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-10-workflow-coverage.sh
 
+      - name: Run Phase 11 workflow coverage guard
+        run: bash scripts/test-verify-ci-phase-11-workflow-coverage.sh
+
+      - name: Run Phase 11 control-plane validation
+        run: |
+          bash scripts/verify-phase-11-control-plane-ci-validation.sh
+          python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_postgres_store control-plane.tests.test_cli_inspection
+
       - name: Run control-plane runtime unit tests
         run: python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
 
@@ -107,12 +115,14 @@ jobs:
           bash scripts/test-verify-ci-phase-8-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-9-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-10-workflow-coverage.sh
+          bash scripts/test-verify-ci-phase-11-workflow-coverage.sh
           bash scripts/test-verify-detection-lifecycle-and-rule-qa-framework.sh
           bash scripts/test-verify-phase-5-semantic-contract-validation.sh
           bash scripts/test-verify-phase-7-ai-hunt-design-validation.sh
           bash scripts/test-verify-phase-8-control-plane-foundation-validation.sh
           bash scripts/test-verify-phase-9-control-plane-runtime-boundary-validation.sh
           bash scripts/test-verify-phase-10-thesis-consistency.sh
+          bash scripts/test-verify-phase-11-control-plane-ci-validation.sh
           bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
           bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
           bash scripts/test-verify-phase-6-replay-to-notify-validation.sh

--- a/docs/control-plane-state-model.md
+++ b/docs/control-plane-state-model.md
@@ -16,7 +16,7 @@ The design constraint is to prevent OpenSearch documents, OpenSearch alerting ar
 
 The repository already ships a dedicated control-plane runtime home, so this document is the normative definition of which component owns which state and what must be reconciled across runtime, persistence, analytics, and execution boundaries.
 
-No new live datastore rollout is approved in this phase. The current control-plane runtime remains `persistence_mode="in_memory"`, `postgres/control-plane/` remains the reviewed schema and migration home for future PostgreSQL-backed persistence work, and OpenSearch remains the analytics-plane store for telemetry and detection outputs.
+The reviewed local control-plane runtime now reports `persistence_mode="postgresql"` and treats the PostgreSQL-backed control-plane store as the authoritative persistence path for local runtime and inspection flows, while `postgres/control-plane/` remains the reviewed schema and migration home and OpenSearch remains the analytics-plane store for telemetry and detection outputs.
 
 ## 3. Baseline Ownership and Source of Truth
 

--- a/docs/phase-11-control-plane-ci-validation.md
+++ b/docs/phase-11-control-plane-ci-validation.md
@@ -1,0 +1,46 @@
+# Phase 11 Control-Plane Persistence and Vendor-Neutral CI Validation
+
+- Validation date: 2026-04-06
+- Validation scope: Phase 11 review of PostgreSQL-authoritative control-plane persistence, vendor-neutral analytic-signal and execution-surface coverage, and CI wiring for the reviewed local runtime and inspection paths
+- Baseline references: `docs/control-plane-state-model.md`, `control-plane/README.md`, `control-plane/tests/test_service_persistence.py`, `control-plane/tests/test_postgres_store.py`, `control-plane/tests/test_cli_inspection.py`, `.github/workflows/ci.yml`
+- Verification commands: `bash scripts/verify-control-plane-state-model-doc.sh`, `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_postgres_store control-plane.tests.test_cli_inspection`, `bash scripts/test-verify-ci-phase-11-workflow-coverage.sh`, `bash scripts/verify-phase-11-control-plane-ci-validation.sh`
+- Validation status: PASS
+
+## Required Boundary Artifacts
+
+- `docs/control-plane-state-model.md`
+- `control-plane/README.md`
+- `control-plane/tests/test_service_persistence.py`
+- `control-plane/tests/test_postgres_store.py`
+- `control-plane/tests/test_cli_inspection.py`
+- `.github/workflows/ci.yml`
+
+## Review Outcome
+
+Confirmed the reviewed runtime and inspection paths report `persistence_mode="postgresql"` and treat the PostgreSQL-backed control-plane store as the authoritative local persistence path.
+
+Confirmed analytic signals remain first-class control-plane records with durable `analytic_signal_id` and `substrate_detection_record_id` linkage instead of collapsing into alert-only state.
+
+Confirmed native detection intake remains constrained by explicit substrate-adapter boundaries and non-empty substrate-origin identifiers.
+
+Confirmed reconciliation coverage preserves vendor-neutral `execution_surface_type`, `execution_surface_id`, and `execution_run_id` assumptions so the reviewed tests do not hard-code one automation substrate implementation.
+
+Confirmed CI now runs a dedicated Phase 11 validation step and a workflow coverage guard so failures point to this reviewed boundary instead of only surfacing through broad unit-test discovery.
+
+## Cross-Link Review
+
+`docs/control-plane-state-model.md` must continue to describe the reviewed local runtime as `persistence_mode="postgresql"` and the PostgreSQL-backed control-plane store as the authoritative local persistence path.
+
+`control-plane/README.md` must continue to describe the reviewed runtime and inspection commands as the authoritative local operator flow while keeping injected in-memory stores limited to tests and local doubles.
+
+`control-plane/tests/test_postgres_store.py` must continue to guard authoritative PostgreSQL persistence mode reporting.
+
+`control-plane/tests/test_service_persistence.py` must continue to guard substrate-adapter intake boundaries, first-class analytic-signal handling, and vendor-neutral execution-surface reconciliation.
+
+`control-plane/tests/test_cli_inspection.py` must continue to guard the reviewed runtime and inspection paths against PostgreSQL-backed read-only control-plane views.
+
+`.github/workflows/ci.yml` must continue to run the dedicated Phase 11 validation step, the focused Phase 11 unit-test command, and the workflow coverage guard.
+
+## Deviations
+
+No deviations found.

--- a/scripts/test-verify-ci-phase-11-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-11-workflow-coverage.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+required_verifiers=(
+  "bash scripts/verify-phase-11-control-plane-ci-validation.sh"
+)
+
+required_tests=(
+  "bash scripts/test-verify-phase-11-control-plane-ci-validation.sh"
+)
+
+required_runtime_commands=(
+  "python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_postgres_store control-plane.tests.test_cli_inspection"
+)
+
+self_guard_step_name="Run Phase 11 workflow coverage guard"
+self_guard_command="bash scripts/test-verify-ci-phase-11-workflow-coverage.sh"
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+collect_active_run_commands() {
+  awk '
+    {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent > block_indent) {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          if (line != "" && line !~ /^#/) {
+            print line
+          }
+          next
+        }
+
+        in_block = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+        block_indent = match($0, /[^ ]/) - 1
+        in_block = 1
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[^|>]/) {
+        line = $0
+        sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+        if (line != "" && line !~ /^#/) {
+          print line
+        }
+      }
+    }
+  ' "${workflow_path}"
+}
+
+active_run_commands="$(collect_active_run_commands)"
+
+for command in "${required_verifiers[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 11 verifier command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_tests[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 11 focused shell test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_runtime_commands[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 11 focused control-plane runtime test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Eq "^[[:space:]]*- name: ${self_guard_step_name}\$" "${workflow_path}"; then
+  echo "Missing dedicated Phase 11 workflow coverage guard step in CI workflow: ${self_guard_step_name}" >&2
+  exit 1
+fi
+
+self_guard_count="$(grep -Fxc -- "${self_guard_command}" <<<"${active_run_commands}" || true)"
+if [[ "${self_guard_count}" -lt 2 ]]; then
+  echo "Phase 11 workflow coverage checker must run both as a dedicated guard and within focused shell tests." >&2
+  exit 1
+fi
+
+echo "CI workflow includes the required Phase 11 verifier, focused shell test, and focused control-plane runtime command."

--- a/scripts/test-verify-control-plane-state-model-doc.sh
+++ b/scripts/test-verify-control-plane-state-model-doc.sh
@@ -39,6 +39,16 @@ remove_text_from_doc() {
   git -C "${target}" add docs/control-plane-state-model.md
 }
 
+replace_text_in_doc() {
+  local target="$1"
+  local old_text="$2"
+  local new_text="$3"
+  local doc_path="${target}/docs/control-plane-state-model.md"
+
+  OLD_TEXT="${old_text}" NEW_TEXT="${new_text}" perl -0pi -e 's/\Q$ENV{OLD_TEXT}\E/$ENV{NEW_TEXT}/g' "${doc_path}"
+  git -C "${target}" add docs/control-plane-state-model.md
+}
+
 commit_fixture() {
   local target="$1"
 
@@ -76,6 +86,16 @@ create_repo "${valid_repo}"
 write_canonical_doc "${valid_repo}"
 commit_fixture "${valid_repo}"
 assert_passes "${valid_repo}"
+
+postgres_authoritative_repo="${workdir}/postgres-authoritative"
+create_repo "${postgres_authoritative_repo}"
+write_canonical_doc "${postgres_authoritative_repo}"
+replace_text_in_doc \
+  "${postgres_authoritative_repo}" \
+  'No new live datastore rollout is approved in this phase. The current control-plane runtime remains `persistence_mode="in_memory"`, `postgres/control-plane/` remains the reviewed schema and migration home for future PostgreSQL-backed persistence work, and OpenSearch remains the analytics-plane store for telemetry and detection outputs.' \
+  'The reviewed local control-plane runtime now reports `persistence_mode="postgresql"` and treats the PostgreSQL-backed control-plane store as the authoritative persistence path for local runtime and inspection flows, while `postgres/control-plane/` remains the reviewed schema and migration home and OpenSearch remains the analytics-plane store for telemetry and detection outputs.'
+commit_fixture "${postgres_authoritative_repo}"
+assert_passes "${postgres_authoritative_repo}"
 
 missing_doc_repo="${workdir}/missing-doc"
 create_repo "${missing_doc_repo}"

--- a/scripts/test-verify-phase-11-control-plane-ci-validation.sh
+++ b/scripts/test-verify-phase-11-control-plane-ci-validation.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-11-control-plane-ci-validation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+required_artifacts=(
+  "docs/control-plane-state-model.md"
+  "docs/phase-11-control-plane-ci-validation.md"
+  "control-plane/README.md"
+  "control-plane/tests/test_service_persistence.py"
+  "control-plane/tests/test_postgres_store.py"
+  "control-plane/tests/test_cli_inspection.py"
+  ".github/workflows/ci.yml"
+)
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs" "${target}/control-plane/tests" "${target}/.github/workflows" "${target}/control-plane"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_required_artifacts() {
+  local target="$1"
+  local artifact=""
+
+  for artifact in "${required_artifacts[@]}"; do
+    mkdir -p "${target}/$(dirname "${artifact}")"
+    cp "${repo_root}/${artifact}" "${target}/${artifact}"
+    git -C "${target}" add "${artifact}"
+  done
+}
+
+remove_text_from_file() {
+  local target="$1"
+  local path="$2"
+  local expected_text="$3"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+replace_text_in_file() {
+  local target="$1"
+  local path="$2"
+  local old_text="$3"
+  local new_text="$4"
+
+  OLD_TEXT="${old_text}" NEW_TEXT="${new_text}" perl -0pi -e 's/\Q$ENV{OLD_TEXT}\E/$ENV{NEW_TEXT}/g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_required_artifacts "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_validation_repo="${workdir}/missing-validation"
+create_repo "${missing_validation_repo}"
+write_required_artifacts "${missing_validation_repo}"
+rm "${missing_validation_repo}/docs/phase-11-control-plane-ci-validation.md"
+git -C "${missing_validation_repo}" add -u docs/phase-11-control-plane-ci-validation.md
+commit_fixture "${missing_validation_repo}"
+assert_fails_with "${missing_validation_repo}" "Missing Phase 11 control-plane CI validation record:"
+
+missing_test_repo="${workdir}/missing-test"
+create_repo "${missing_test_repo}"
+write_required_artifacts "${missing_test_repo}"
+remove_text_from_file "${missing_test_repo}" "control-plane/tests/test_service_persistence.py" "def test_service_reconcile_action_execution_supports_generic_execution_surfaces("
+commit_fixture "${missing_test_repo}"
+assert_fails_with "${missing_test_repo}" "Missing required Phase 11 test in ${missing_test_repo}/control-plane/tests/test_service_persistence.py: test_service_reconcile_action_execution_supports_generic_execution_surfaces"
+
+stale_state_model_repo="${workdir}/stale-state-model"
+create_repo "${stale_state_model_repo}"
+write_required_artifacts "${stale_state_model_repo}"
+replace_text_in_file \
+  "${stale_state_model_repo}" \
+  "docs/control-plane-state-model.md" \
+  'The reviewed local control-plane runtime now reports `persistence_mode="postgresql"` and treats the PostgreSQL-backed control-plane store as the authoritative persistence path for local runtime and inspection flows, while `postgres/control-plane/` remains the reviewed schema and migration home and OpenSearch remains the analytics-plane store for telemetry and detection outputs.' \
+  'No new live datastore rollout is approved in this phase. The current control-plane runtime remains `persistence_mode="in_memory"`, `postgres/control-plane/` remains the reviewed schema and migration home for future PostgreSQL-backed persistence work, and OpenSearch remains the analytics-plane store for telemetry and detection outputs.'
+commit_fixture "${stale_state_model_repo}"
+assert_fails_with "${stale_state_model_repo}" "Missing control-plane state model statement: The reviewed local control-plane runtime now reports \`persistence_mode=\"postgresql\"\` and treats the PostgreSQL-backed control-plane store as the authoritative persistence path for local runtime and inspection flows, while \`postgres/control-plane/\` remains the reviewed schema and migration home and OpenSearch remains the analytics-plane store for telemetry and detection outputs."
+
+missing_ci_step_repo="${workdir}/missing-ci-step"
+create_repo "${missing_ci_step_repo}"
+write_required_artifacts "${missing_ci_step_repo}"
+remove_text_from_file "${missing_ci_step_repo}" ".github/workflows/ci.yml" "      - name: Run Phase 11 control-plane validation"
+commit_fixture "${missing_ci_step_repo}"
+assert_fails_with "${missing_ci_step_repo}" "Missing required line in ${missing_ci_step_repo}/.github/workflows/ci.yml:       - name: Run Phase 11 control-plane validation"
+
+echo "Phase 11 control-plane CI validation verifier fails closed for missing reviewed coverage."

--- a/scripts/verify-control-plane-state-model-doc.sh
+++ b/scripts/verify-control-plane-state-model-doc.sh
@@ -23,7 +23,7 @@ required_phrases=(
   "This document defines ownership, source-of-truth expectations, and recovery responsibilities only. It does not introduce a live datastore, schema migration, API service, or runtime deployment in this phase."
   'The baseline must keep platform-owned control state explicit across the shipped `control-plane/` runtime boundary and the reviewed `postgres/control-plane/` persistence-contract home.'
   'The repository already ships a dedicated control-plane runtime home, so this document is the normative definition of which component owns which state and what must be reconciled across runtime, persistence, analytics, and execution boundaries.'
-  'No new live datastore rollout is approved in this phase. The current control-plane runtime remains `persistence_mode="in_memory"`, `postgres/control-plane/` remains the reviewed schema and migration home for future PostgreSQL-backed persistence work, and OpenSearch remains the analytics-plane store for telemetry and detection outputs.'
+  'The reviewed local control-plane runtime now reports `persistence_mode="postgresql"` and treats the PostgreSQL-backed control-plane store as the authoritative persistence path for local runtime and inspection flows, while `postgres/control-plane/` remains the reviewed schema and migration home and OpenSearch remains the analytics-plane store for telemetry and detection outputs.'
   '| `Substrate Detection Record` | Approved upstream detection substrate | The detection substrate remains the system of record for substrate-native detection, correlation, and alerting artifacts plus their native identifiers. |'
   '| `Analytic Signal` | AegisOps control-plane intake boundary referencing approved upstream detection substrates | Analytic signals are admitted upstream product inputs that preserve substrate-native linkage without becoming the durable analyst work-tracking record for the platform. |'
   '| `Finding` | Approved detection substrate or analytics plane | Findings remain upstream analytic assertions and must not be reused as downstream control-plane lifecycle state. |'
@@ -171,6 +171,7 @@ forbidden_phrases=(
   "The approved ownership split for a future PostgreSQL-backed implementation is:"
   "The future AegisOps control layer is responsible for:"
   "Reconciliation must preserve auditable disagreement. When OpenSearch, n8n, and the future control record disagree, the platform must retain that mismatch as an explicit state that operators can inspect and resolve rather than overwriting one side to make the data look clean."
+  'No new live datastore rollout is approved in this phase. The current control-plane runtime remains `persistence_mode="in_memory"`, `postgres/control-plane/` remains the reviewed schema and migration home for future PostgreSQL-backed persistence work, and OpenSearch remains the analytics-plane store for telemetry and detection outputs.'
 )
 
 if [[ ! -f "${doc_path}" ]]; then

--- a/scripts/verify-phase-11-control-plane-ci-validation.sh
+++ b/scripts/verify-phase-11-control-plane-ci-validation.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+default_repo_root="$(cd "${script_dir}/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+validation_doc="${repo_root}/docs/phase-11-control-plane-ci-validation.md"
+state_model_doc="${repo_root}/docs/control-plane-state-model.md"
+control_plane_readme="${repo_root}/control-plane/README.md"
+service_tests="${repo_root}/control-plane/tests/test_service_persistence.py"
+store_tests="${repo_root}/control-plane/tests/test_postgres_store.py"
+cli_tests="${repo_root}/control-plane/tests/test_cli_inspection.py"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+bash "${script_dir}/verify-control-plane-state-model-doc.sh" "${repo_root}"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_string() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required line in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_test_name() {
+  local file_path="$1"
+  local test_name="$2"
+
+  if ! grep -Fq -- "def ${test_name}" "${file_path}" >/dev/null; then
+    echo "Missing required Phase 11 test in ${file_path}: ${test_name}" >&2
+    exit 1
+  fi
+}
+
+require_file "${state_model_doc}" "Missing control-plane state model document"
+require_file "${control_plane_readme}" "Missing control-plane runtime README"
+require_file "${service_tests}" "Missing control-plane service persistence tests"
+require_file "${store_tests}" "Missing control-plane PostgreSQL store tests"
+require_file "${cli_tests}" "Missing control-plane CLI inspection tests"
+require_file "${workflow_path}" "Missing CI workflow"
+require_file "${validation_doc}" "Missing Phase 11 control-plane CI validation record"
+
+validation_required_phrases=(
+  "# Phase 11 Control-Plane Persistence and Vendor-Neutral CI Validation"
+  "- Validation date: 2026-04-06"
+  "- Validation scope: Phase 11 review of PostgreSQL-authoritative control-plane persistence, vendor-neutral analytic-signal and execution-surface coverage, and CI wiring for the reviewed local runtime and inspection paths"
+  "- Baseline references: \`docs/control-plane-state-model.md\`, \`control-plane/README.md\`, \`control-plane/tests/test_service_persistence.py\`, \`control-plane/tests/test_postgres_store.py\`, \`control-plane/tests/test_cli_inspection.py\`, \`.github/workflows/ci.yml\`"
+  "- Verification commands: \`bash scripts/verify-control-plane-state-model-doc.sh\`, \`python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_postgres_store control-plane.tests.test_cli_inspection\`, \`bash scripts/test-verify-ci-phase-11-workflow-coverage.sh\`, \`bash scripts/verify-phase-11-control-plane-ci-validation.sh\`"
+  "- Validation status: PASS"
+  "## Required Boundary Artifacts"
+  "## Review Outcome"
+  "## Cross-Link Review"
+  "## Deviations"
+  'Confirmed the reviewed runtime and inspection paths report `persistence_mode="postgresql"` and treat the PostgreSQL-backed control-plane store as the authoritative local persistence path.'
+  'Confirmed analytic signals remain first-class control-plane records with durable `analytic_signal_id` and `substrate_detection_record_id` linkage instead of collapsing into alert-only state.'
+  "Confirmed native detection intake remains constrained by explicit substrate-adapter boundaries and non-empty substrate-origin identifiers."
+  'Confirmed reconciliation coverage preserves vendor-neutral `execution_surface_type`, `execution_surface_id`, and `execution_run_id` assumptions so the reviewed tests do not hard-code one automation substrate implementation.'
+  "Confirmed CI now runs a dedicated Phase 11 validation step and a workflow coverage guard so failures point to this reviewed boundary instead of only surfacing through broad unit-test discovery."
+  '`docs/control-plane-state-model.md` must continue to describe the reviewed local runtime as `persistence_mode="postgresql"` and the PostgreSQL-backed control-plane store as the authoritative local persistence path.'
+  '`control-plane/README.md` must continue to describe the reviewed runtime and inspection commands as the authoritative local operator flow while keeping injected in-memory stores limited to tests and local doubles.'
+  '`control-plane/tests/test_postgres_store.py` must continue to guard authoritative PostgreSQL persistence mode reporting.'
+  '`control-plane/tests/test_service_persistence.py` must continue to guard substrate-adapter intake boundaries, first-class analytic-signal handling, and vendor-neutral execution-surface reconciliation.'
+  '`control-plane/tests/test_cli_inspection.py` must continue to guard the reviewed runtime and inspection paths against PostgreSQL-backed read-only control-plane views.'
+  '`.github/workflows/ci.yml` must continue to run the dedicated Phase 11 validation step, the focused Phase 11 unit-test command, and the workflow coverage guard.'
+  "No deviations found."
+)
+
+for phrase in "${validation_required_phrases[@]}"; do
+  require_fixed_string "${validation_doc}" "${phrase}"
+done
+
+required_artifacts=(
+  "docs/control-plane-state-model.md"
+  "control-plane/README.md"
+  "control-plane/tests/test_service_persistence.py"
+  "control-plane/tests/test_postgres_store.py"
+  "control-plane/tests/test_cli_inspection.py"
+  ".github/workflows/ci.yml"
+)
+
+for artifact in "${required_artifacts[@]}"; do
+  require_file "${repo_root}/${artifact}" "Missing required Phase 11 artifact"
+
+  if ! grep -Fqx -- "- \`${artifact}\`" "${validation_doc}" >/dev/null; then
+    echo "Phase 11 validation record must list required artifact: ${artifact}" >&2
+    exit 1
+  fi
+done
+
+require_fixed_string "${state_model_doc}" 'The reviewed local control-plane runtime now reports `persistence_mode="postgresql"` and treats the PostgreSQL-backed control-plane store as the authoritative persistence path for local runtime and inspection flows, while `postgres/control-plane/` remains the reviewed schema and migration home and OpenSearch remains the analytics-plane store for telemetry and detection outputs.'
+require_fixed_string "${control_plane_readme}" '- The runtime snapshot now reports `persistence_mode="postgresql"` so the reviewed control-plane runtime makes its authoritative store explicit.'
+require_fixed_string "${control_plane_readme}" '- Those runtime and inspection commands now construct the same reviewed control-plane service path, so PostgreSQL-backed runtime configuration remains the authoritative local operator flow while injected in-memory stores stay limited to tests and local doubles.'
+
+require_test_name "${store_tests}" "test_store_reports_postgresql_authoritative_persistence_mode"
+require_test_name "${service_tests}" "test_service_admits_native_detection_records_via_substrate_adapter_boundary"
+require_test_name "${service_tests}" "test_service_inspects_analytic_signal_records_as_first_class_records"
+require_test_name "${service_tests}" "test_service_reconcile_action_execution_supports_generic_execution_surfaces"
+require_test_name "${cli_tests}" "test_cli_renders_read_only_record_and_reconciliation_views"
+
+require_fixed_string "${workflow_path}" "      - name: Run Phase 11 workflow coverage guard"
+require_fixed_string "${workflow_path}" "      - name: Run Phase 11 control-plane validation"
+
+echo "Phase 11 control-plane persistence and vendor-neutral CI validation remains reviewable and fail closed."


### PR DESCRIPTION
Closes #231

## Summary
- update the control-plane state model and verifier to require the reviewed PostgreSQL-authoritative runtime wording
- add a dedicated Phase 11 validation record, verifier, shell test, and CI workflow coverage guard
- wire a focused Phase 11 control-plane unittest slice into CI so persistence and vendor-neutral control-plane assumptions fail closed

## Verification
- `bash scripts/test-verify-control-plane-state-model-doc.sh`
- `bash scripts/test-verify-phase-11-control-plane-ci-validation.sh`
- `bash scripts/test-verify-ci-phase-11-workflow-coverage.sh`
- `bash scripts/verify-phase-11-control-plane-ci-validation.sh`
- `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_postgres_store control-plane.tests.test_cli_inspection`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`

## Notes
- The issue text suggests `python3 -m unittest control-plane/tests`, but that is not a valid `unittest` module target in this repo; the discovery command above is the equivalent full-suite check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated control-plane persistence documentation to specify PostgreSQL-backed storage as the authoritative source for local runtime and inspection flows, replacing the previous in-memory persistence approach.

* **New Features**
  * Added comprehensive Phase 11 CI validation framework to verify control-plane consistency across unit tests, documentation, and deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->