### PR TITLE
Require first-class analytic-signal admission for ingest

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -363,6 +363,13 @@ class AegisOpsControlPlaneService:
             key=lambda record: record.compared_at,
             default=None,
         )
+        analytic_signal_id = self._resolve_analytic_signal_id(
+            analytic_signal_id=analytic_signal_id,
+            finding_id=finding_id,
+            correlation_key=correlation_key,
+            substrate_detection_record_id=substrate_detection_record_id,
+            latest_reconciliation=latest_reconciliation,
+        )
 
         if latest_reconciliation is None:
             alert = self.persist_record(
@@ -649,6 +656,51 @@ class AegisOpsControlPlaneService:
     @staticmethod
     def _linked_id_exists(existing_values: object, candidate: str) -> bool:
         return isinstance(existing_values, (list, tuple)) and candidate in existing_values
+
+    def _resolve_analytic_signal_id(
+        self,
+        *,
+        analytic_signal_id: str | None,
+        finding_id: str,
+        correlation_key: str,
+        substrate_detection_record_id: str | None,
+        latest_reconciliation: ReconciliationRecord | None,
+    ) -> str:
+        if analytic_signal_id is not None:
+            return analytic_signal_id
+
+        existing_signal_ids = self._merge_linked_ids(
+            (
+                latest_reconciliation.subject_linkage.get("analytic_signal_ids")
+                if latest_reconciliation is not None
+                else ()
+            ),
+            None,
+        )
+        if substrate_detection_record_id is not None:
+            for existing_signal_id in existing_signal_ids:
+                existing_signal = self._store.get(
+                    AnalyticSignalRecord,
+                    existing_signal_id,
+                )
+                if (
+                    existing_signal is not None
+                    and existing_signal.substrate_detection_record_id
+                    == substrate_detection_record_id
+                ):
+                    return existing_signal_id
+
+        if substrate_detection_record_id is None and len(existing_signal_ids) == 1:
+            return existing_signal_ids[0]
+
+        mint_material = "|".join(
+            (
+                finding_id,
+                correlation_key,
+                substrate_detection_record_id or "",
+            )
+        )
+        return f"analytic-signal-{uuid.uuid5(uuid.NAMESPACE_URL, mint_material)}"
 
     @staticmethod
     def _normalize_substrate_detection_record_id(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -125,10 +125,25 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         self.assertEqual(first.disposition, "created")
         self.assertEqual(second.disposition, "restated")
+        self.assertIsNotNone(first.reconciliation.analytic_signal_id)
+        self.assertIsNotNone(second.reconciliation.analytic_signal_id)
+        self.assertNotEqual(
+            first.reconciliation.analytic_signal_id,
+            second.reconciliation.analytic_signal_id,
+        )
         self.assertEqual(
             second.reconciliation.subject_linkage["substrate_detection_record_ids"],
             ("substrate-a:native-001", "substrate-b:native-001"),
         )
+        self.assertEqual(
+            second.reconciliation.subject_linkage["analytic_signal_ids"],
+            (
+                first.reconciliation.analytic_signal_id,
+                second.reconciliation.analytic_signal_id,
+            ),
+        )
+        signals = store.list(AnalyticSignalRecord)
+        self.assertEqual(len(signals), 2)
 
     def test_service_rejects_blank_substrate_keys_at_native_detection_boundary(self) -> None:
         @dataclass(frozen=True)
@@ -719,7 +734,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 last_seen_at=first_seen_at,
             )
 
-    def test_service_normalizes_blank_optional_admission_identities_to_none(self) -> None:
+    def test_service_mints_analytic_signal_identity_when_admission_leaves_it_blank(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
@@ -737,14 +752,26 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
         self.assertEqual(admitted.disposition, "created")
-        self.assertIsNone(admitted.alert.analytic_signal_id)
-        self.assertEqual(len(store.list(AnalyticSignalRecord)), 0)
+        self.assertIsNotNone(admitted.alert.analytic_signal_id)
+        self.assertTrue(admitted.alert.analytic_signal_id.startswith("analytic-signal-"))
+
+        signals = store.list(AnalyticSignalRecord)
+        self.assertEqual(len(signals), 1)
+        self.assertEqual(signals[0].analytic_signal_id, admitted.alert.analytic_signal_id)
+        self.assertIsNone(signals[0].substrate_detection_record_id)
+        self.assertEqual(signals[0].finding_id, "finding-001")
 
         reconciliation = service.get_record(
             ReconciliationRecord, admitted.reconciliation.reconciliation_id
         )
-        self.assertEqual(reconciliation.analytic_signal_id, None)
-        self.assertEqual(reconciliation.subject_linkage["analytic_signal_ids"], [])
+        self.assertEqual(
+            reconciliation.analytic_signal_id,
+            admitted.alert.analytic_signal_id,
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["analytic_signal_ids"],
+            [admitted.alert.analytic_signal_id],
+        )
         self.assertEqual(
             reconciliation.subject_linkage["substrate_detection_record_ids"],
             [],


### PR DESCRIPTION
## Summary
- require analytic-signal admission to preserve or mint a durable `analytic_signal_id` before alert and reconciliation persistence
- reuse linked analytic-signal identities when possible and otherwise mint deterministic IDs from finding/correlation/substrate linkage
- tighten focused persistence tests for blank direct admissions and native-detection fallback admissions

## Verification
- `python3 -m unittest control-plane.tests.test_service_persistence`
- `rg -n "analytic_signal_id|AnalyticSignalRecord|ingest_finding_alert|ingest_native_detection_record" control-plane docs scripts`

Closes #239