### PR TITLE
Harden nested JSON immutability after PostgreSQL round-trip

### DIFF
--- a/control-plane/aegisops_control_plane/models.py
+++ b/control-plane/aegisops_control_plane/models.py
@@ -6,8 +6,23 @@ from types import MappingProxyType
 from typing import ClassVar, Mapping, Union
 
 
+def _freeze_json_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {str(key): _freeze_json_value(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return tuple(_freeze_json_value(item) for item in value)
+    if isinstance(value, tuple):
+        return tuple(_freeze_json_value(item) for item in value)
+    return value
+
+
 def _freeze_mapping(value: Mapping[str, object]) -> Mapping[str, object]:
-    return MappingProxyType(dict(value))
+    frozen = _freeze_json_value(value)
+    if not isinstance(frozen, Mapping):
+        raise TypeError("Expected mapping-compatible control-plane field value")
+    return frozen
 
 
 @dataclass(frozen=True)

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -243,6 +243,38 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             record.target_scope["asset_id"] = "asset-003"  # type: ignore[index]
 
+    def test_store_freezes_nested_json_fields_after_round_trip(self) -> None:
+        store, _ = make_store()
+        timestamp = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        record = ReconciliationRecord(
+            reconciliation_id="reconciliation-immutable-001",
+            subject_linkage={
+                "action_request_ids": ["action-request-001"],
+                "targets": [{"asset_id": "asset-001"}],
+            },
+            alert_id=None,
+            finding_id="finding-001",
+            analytic_signal_id="signal-001",
+            execution_run_id="n8n-exec-001",
+            linked_execution_run_ids=("n8n-exec-001",),
+            correlation_key="action-request-001:automation_substrate:n8n:idempotency-001",
+            first_seen_at=timestamp,
+            last_seen_at=timestamp,
+            ingest_disposition="matched",
+            mismatch_summary="matched execution",
+            compared_at=timestamp,
+            lifecycle_state="matched",
+        )
+
+        store.save(record)
+        persisted = store.get(ReconciliationRecord, "reconciliation-immutable-001")
+
+        assert persisted is not None
+        with self.assertRaises(TypeError):
+            persisted.subject_linkage["action_request_ids"] += ("action-request-002",)
+        with self.assertRaises(TypeError):
+            persisted.subject_linkage["targets"][0]["asset_id"] = "asset-002"  # type: ignore[index]
+
     def test_store_lists_execution_reconciliation_records_separately(self) -> None:
         store, _ = make_store()
         requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -303,6 +303,42 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(snapshot.postgres_dsn, "postgresql://control-plane.local/aegisops")
         self.assertEqual(snapshot.persistence_mode, "postgresql")
 
+    def test_service_returns_nested_immutable_json_backed_records(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        timestamp = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+
+        record = ActionRequestRecord(
+            action_request_id="action-request-immutable-001",
+            approval_decision_id="approval-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+            idempotency_key="idempotency-001",
+            target_scope={
+                "asset_ids": ["asset-001"],
+                "filters": {"environment": "prod"},
+            },
+            payload_hash="payload-hash-001",
+            requested_at=timestamp,
+            expires_at=None,
+            lifecycle_state="approved",
+        )
+
+        service.persist_record(record)
+        persisted = service.get_record(
+            ActionRequestRecord, "action-request-immutable-001"
+        )
+
+        assert persisted is not None
+        with self.assertRaises(TypeError):
+            persisted.target_scope["asset_ids"] += ("asset-002",)
+        with self.assertRaises(TypeError):
+            persisted.target_scope["filters"]["environment"] = "dev"  # type: ignore[index]
+
     def test_service_exposes_read_only_record_and_reconciliation_inspection(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -523,15 +559,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(restated_reconciliation.last_seen_at, restated_seen)
         self.assertEqual(
             restated_reconciliation.subject_linkage["finding_ids"],
-            ["finding-001", "finding-002"],
+            ("finding-001", "finding-002"),
         )
         self.assertEqual(
             restated_reconciliation.subject_linkage["analytic_signal_ids"],
-            ["signal-001", "signal-002"],
+            ("signal-001", "signal-002"),
         )
         self.assertEqual(
             restated_reconciliation.subject_linkage["substrate_detection_record_ids"],
-            ["substrate-detection-001", "substrate-detection-002"],
+            ("substrate-detection-001", "substrate-detection-002"),
         )
         self.assertEqual(updated_reconciliation.alert_id, created.alert.alert_id)
         self.assertEqual(updated_reconciliation.ingest_disposition, "updated")
@@ -539,19 +575,19 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(updated_reconciliation.last_seen_at, updated_seen)
         self.assertEqual(
             updated_reconciliation.subject_linkage["finding_ids"],
-            ["finding-001", "finding-002", "finding-003"],
+            ("finding-001", "finding-002", "finding-003"),
         )
         self.assertEqual(
             updated_reconciliation.subject_linkage["analytic_signal_ids"],
-            ["signal-001", "signal-002", "signal-003"],
+            ("signal-001", "signal-002", "signal-003"),
         )
         self.assertEqual(
             updated_reconciliation.subject_linkage["substrate_detection_record_ids"],
-            [
+            (
                 "substrate-detection-001",
                 "substrate-detection-002",
                 "substrate-detection-003",
-            ],
+            ),
         )
         self.assertEqual(deduplicated_reconciliation.alert_id, created.alert.alert_id)
         self.assertEqual(
@@ -561,19 +597,19 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(deduplicated_reconciliation.last_seen_at, duplicate_seen)
         self.assertEqual(
             deduplicated_reconciliation.subject_linkage["finding_ids"],
-            ["finding-001", "finding-002", "finding-003"],
+            ("finding-001", "finding-002", "finding-003"),
         )
         self.assertEqual(
             deduplicated_reconciliation.subject_linkage["analytic_signal_ids"],
-            ["signal-001", "signal-002", "signal-003"],
+            ("signal-001", "signal-002", "signal-003"),
         )
         self.assertEqual(
             deduplicated_reconciliation.subject_linkage["substrate_detection_record_ids"],
-            [
+            (
                 "substrate-detection-001",
                 "substrate-detection-002",
                 "substrate-detection-003",
-            ],
+            ),
         )
 
         signal_one = service.get_record(AnalyticSignalRecord, "signal-001")
@@ -645,15 +681,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(reconciliation.ingest_disposition, "restated")
         self.assertEqual(
             reconciliation.subject_linkage["finding_ids"],
-            ["finding-001"],
+            ("finding-001",),
         )
         self.assertEqual(
             reconciliation.subject_linkage["analytic_signal_ids"],
-            ["signal-001", "signal-002"],
+            ("signal-001", "signal-002"),
         )
         self.assertEqual(
             reconciliation.subject_linkage["substrate_detection_record_ids"],
-            ["substrate-detection-001", "substrate-detection-002"],
+            ("substrate-detection-001", "substrate-detection-002"),
         )
 
     def test_service_rejects_naive_intake_timestamps(self) -> None:
@@ -770,11 +806,11 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
         self.assertEqual(
             reconciliation.subject_linkage["analytic_signal_ids"],
-            [admitted.alert.analytic_signal_id],
+            (admitted.alert.analytic_signal_id,),
         )
         self.assertEqual(
             reconciliation.subject_linkage["substrate_detection_record_ids"],
-            [],
+            (),
         )
 
     def test_service_inspects_analytic_signal_records_as_first_class_records(self) -> None:


### PR DESCRIPTION
## Summary
- recursively freeze nested JSON-backed control-plane fields so postgres round-trips preserve immutability semantics
- add focused postgres store coverage for nested linkage and scope payloads that used to come back mutable
- align service persistence expectations with immutable nested tuples/mappings after retrieval

## Testing
- python3 -m unittest control-plane.tests.test_postgres_store control-plane.tests.test_service_persistence
- rg -n "MappingProxyType|jsonb|_deserialize_field|subject_linkage|target_scope|target_snapshot" control-plane

Part of #238
Closes #240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation for data field compatibility with clearer error messages when invalid values are provided.
  * Enhanced data integrity by ensuring nested data structures remain immutable after storage and retrieval.

* **Tests**
  * Added comprehensive tests verifying nested data immutability is preserved through database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->