### PR TITLE
docs: align control-plane execution-surface contract

### DIFF
--- a/.codex-supervisor/issues/241/issue-journal.md
+++ b/.codex-supervisor/issues/241/issue-journal.md
@@ -1,0 +1,36 @@
+# Issue #241: documentation: align control-plane state-model and verifiers with the vendor-neutral execution-surface contract
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/241
+- Branch: codex/issue-241
+- Workspace: .
+- Journal: .codex-supervisor/issues/241/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 62bff1afa6487e64e9a862665943559f0601e95b
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-06T13:17:33.453Z
+
+## Latest Codex Summary
+- Reproduced the issue by tightening `scripts/test-verify-control-plane-state-model-doc.sh` to fail on stale n8n-only execution-surface wording before updating the docs or verifiers.
+- Updated `docs/control-plane-state-model.md` so `Action Execution` and related reconciliation language describe reviewed automation-substrate or executor surfaces instead of an n8n-only execution model, while preserving the control-plane versus downstream runtime ownership split.
+- Updated `scripts/verify-control-plane-state-model-doc.sh`, `scripts/verify-phase-11-control-plane-ci-validation.sh`, and their shell tests to fail closed on stale n8n-only wording in the reviewed boundary docs.
+- Verified with the focused shell guards plus the requested unit tests and verifier scripts.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The Phase 11 runtime and service tests already model vendor-neutral execution surfaces, but the reviewed control-plane state-model doc and shell verifiers still preserved stale n8n-only `Action Execution` and reconciliation wording.
+- What changed: Added a failing-first shell-test case for stale n8n-only wording, rewrote the state-model language to describe reviewed automation-substrate and executor surfaces, and tightened both verifier scripts plus both shell-test guards to require the new wording.
+- Current blocker: none
+- Next exact step: Stage the doc and verifier changes, commit the checkpoint on `codex/issue-241`, and leave the branch ready for PR creation or supervisor follow-up.
+- Verification gap: none for the updated docs and focused verifiers; broader repo-wide verification was not needed for this documentation-only scope.
+- Files touched: docs/control-plane-state-model.md; docs/phase-11-control-plane-ci-validation.md; scripts/verify-control-plane-state-model-doc.sh; scripts/test-verify-control-plane-state-model-doc.sh; scripts/verify-phase-11-control-plane-ci-validation.sh; scripts/test-verify-phase-11-control-plane-ci-validation.sh; .codex-supervisor/issues/241/issue-journal.md
+- Rollback concern: Low; changes are limited to reviewed documentation text and fail-closed verifier expectations around the same boundary.
+- Last focused command: python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection control-plane.tests.test_postgres_store
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/control-plane-state-model.md
+++ b/docs/control-plane-state-model.md
@@ -36,10 +36,10 @@ The reviewed local control-plane runtime now reports `persistence_mode="postgres
 | `Hunt` | AegisOps control-plane hunt record | Hunt lifecycle must remain analyst-directed and reviewable rather than inferred from ad hoc queries or downstream workflow runs. |
 | `Hunt Run` | AegisOps control-plane hunt-run record | Each hunt run must preserve bounded scope, execution context, and outcome for one hunt iteration without replacing alerts or cases. |
 | `AI Trace` | AegisOps control-plane AI-trace record | AI trace records must preserve prompt, model, review, and linkage context without mutating evidence custody or analyst-owned dispositions. |
-| `Reconciliation` | AegisOps control-plane reconciliation record | Cross-system linkage, mismatch tracking, and resolution state must not dissolve into alert fields, case notes, or n8n metadata. |
-| `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state | n8n owns execution-attempt state, step progress, and connector-specific runtime details. |
+| `Reconciliation` | AegisOps control-plane reconciliation record | Cross-system linkage, mismatch tracking, and resolution state must not dissolve into alert fields, case notes, or execution-surface metadata. |
+| `Action Execution` | Reviewed automation substrate or controlled executor surface | The execution surface owns execution-attempt state, step progress, and surface-specific runtime details for the reviewed automation-substrate or executor run. |
 
-n8n execution history must not become the implicit system of record for case state, approval state, or action-request intent.
+Execution-surface runtime history must not become the implicit system of record for case state, approval state, or action-request intent.
 
 Substrate-native detection records and admitted analytic signals remain upstream reconciliation inputs, but they do not own downstream case, approval, or execution-policy state.
 
@@ -51,7 +51,7 @@ At the approved baseline level, the source-of-truth expectations are:
 
 - substrate detection records and findings remain upstream substrate or analytics-plane facts, while analytic signals remain the admitted vendor-neutral intake primitive for control-plane routing and are preserved as first-class control-plane records;
 - analytic signals, alerts, cases, evidence, observations, leads, recommendations, approvals, action requests, hunts, hunt runs, AI traces, and reconciliation records are platform-owned control records whose authoritative home is the AegisOps control-plane runtime boundary with the reviewed PostgreSQL contract rooted under `postgres/control-plane/`;
-- action execution state remains execution-plane runtime state owned by n8n and backed by PostgreSQL; and
+- action execution state remains execution-surface runtime state owned by the reviewed automation substrate or executor surface and backed by that surface's runtime store; and
 - evidence links across those records must be explicit rather than reconstructed from whichever component happens to log the most detail.
 
 ## 4. Approved Persistence Boundary
@@ -78,15 +78,15 @@ The repository already materializes a version-controlled schema baseline for tha
 
 ## 5. Reconciliation Responsibilities
 
-The control plane is responsible for reconciling approved action intent against observed n8n execution outcomes and for recording when reconciliation is incomplete, stale, or failed.
+The control plane is responsible for reconciling approved action intent against observed execution-surface outcomes and for recording when reconciliation is incomplete, stale, or failed.
 
 Reconciliation must prefer deterministic correlation keys such as substrate detection record identifiers, analytic-signal identifiers, action-request identifiers, approval identifiers, workflow identifiers, and idempotency keys rather than fuzzy time-window matching.
 
-Stable reconciliation keys must allow operators to compare substrate-native detection output, admitted analytic signals, control-plane records, and n8n execution outcomes without assuming those systems share one lifecycle or one authoritative identifier.
+Stable reconciliation keys must allow operators to compare substrate-native detection output, admitted analytic signals, control-plane records, and execution-surface outcomes without assuming those systems share one lifecycle or one authoritative identifier.
 
 Approved detection substrates are responsible for producing stable substrate-native identifiers and timestamps for substrate detection records and related analytic outputs that downstream control-plane logic may reference.
 
-n8n is responsible for exposing enough workflow-run identifiers, timestamps, execution outcomes, and step-level failure detail that the control-plane runtime can correlate approved intent to observed execution behavior.
+The reviewed automation substrate or executor surface is responsible for exposing enough run identifiers, timestamps, execution outcomes, and step-level failure detail that the control-plane runtime can correlate approved intent to observed execution behavior.
 
 Substrate-record-to-alert ingestion contract requirements:
 
@@ -122,7 +122,7 @@ The AegisOps control-plane runtime is responsible for:
 - deciding how evidence, observations, leads, recommendations, hunts, hunt runs, and AI traces are attached to alerts, cases, or independent analyst workflows without collapsing their ownership boundaries;
 - deciding whether an action request is pending approval, approved, rejected, expired, canceled, superseded, executing, completed, failed, or unresolved;
 - binding approval decisions to exact request context before execution is allowed; and
-- marking reconciliation exceptions when upstream substrate records or findings disappear, duplicate workflow triggers arrive, or n8n reports an outcome that does not satisfy the approved intent record.
+- marking reconciliation exceptions when upstream substrate records or findings disappear, duplicate execution triggers arrive, or an execution surface reports an outcome that does not satisfy the approved intent record.
 
 Observation records must preserve scoped analyst assertions, timestamps, authorship, and linkage to supporting evidence without turning evidence custody into free-form narrative.
 
@@ -426,11 +426,11 @@ Reconciliation records provide the explicit cross-system home for mismatch track
 
 These lifecycle states establish the minimum reviewable transitions for later reconciliation, retry, expiry, duplicate suppression, and manual recovery work.
 
-No control-plane record family may silently inherit lifecycle from substrate-local alerts or n8n execution history. Cross-system state must be linked through explicit identifiers and reconciliation records instead.
+No control-plane record family may silently inherit lifecycle from substrate-local alerts or execution-surface runtime history. Cross-system state must be linked through explicit identifiers and reconciliation records instead.
 
 ## 7. Retry, Dead-Letter, and Manual Recovery Responsibilities
 
-Retry policy belongs to the control-plane intent record, while duplicate suppression and step-level retry behavior inside a running workflow belong to n8n.
+Retry policy belongs to the control-plane intent record, while duplicate suppression and step-level retry behavior inside a running automation-substrate or executor run belong to the execution surface.
 
 OpenSearch may re-emit or restate analytic signals according to its own alerting behavior, but deduplication of downstream analyst work belongs to the AegisOps control-plane runtime rather than to OpenSearch.
 
@@ -460,7 +460,7 @@ Auditability requires separate evidence for:
 - the control-plane record that tracked alert or case ownership,
 - the approval decision that authorized or rejected action,
 - the action request that defined exact execution intent, and
-- the n8n execution record that shows what actually ran and what outcome was observed.
+- the execution-surface record that shows what actually ran and what outcome was observed.
 
 No single component log should be treated as sufficient to reconstruct the entire decision chain when that would blur responsibility boundaries or allow silent loss of approval evidence.
 

--- a/docs/phase-11-control-plane-ci-validation.md
+++ b/docs/phase-11-control-plane-ci-validation.md
@@ -25,6 +25,8 @@ Confirmed native detection intake remains constrained by explicit substrate-adap
 
 Confirmed reconciliation coverage preserves vendor-neutral `execution_surface_type`, `execution_surface_id`, and `execution_run_id` assumptions so the reviewed tests do not hard-code one automation substrate implementation.
 
+Confirmed the control-plane state model describes `Action Execution` and reconciliation in terms of reviewed automation-substrate and executor surfaces rather than one named implementation.
+
 Confirmed CI now runs a dedicated Phase 11 validation step and a workflow coverage guard so failures point to this reviewed boundary instead of only surfacing through broad unit-test discovery.
 
 ## Cross-Link Review

--- a/scripts/test-verify-control-plane-state-model-doc.sh
+++ b/scripts/test-verify-control-plane-state-model-doc.sh
@@ -105,9 +105,9 @@ assert_fails_with "${missing_doc_repo}" "Missing control-plane state model docum
 missing_reconciliation_repo="${workdir}/missing-reconciliation"
 create_repo "${missing_reconciliation_repo}"
 write_canonical_doc "${missing_reconciliation_repo}"
-remove_text_from_doc "${missing_reconciliation_repo}" "The control plane is responsible for reconciling approved action intent against observed n8n execution outcomes and for recording when reconciliation is incomplete, stale, or failed."
+remove_text_from_doc "${missing_reconciliation_repo}" "The control plane is responsible for reconciling approved action intent against observed execution-surface outcomes and for recording when reconciliation is incomplete, stale, or failed."
 commit_fixture "${missing_reconciliation_repo}"
-assert_fails_with "${missing_reconciliation_repo}" "The control plane is responsible for reconciling approved action intent against observed n8n execution outcomes and for recording when reconciliation is incomplete, stale, or failed."
+assert_fails_with "${missing_reconciliation_repo}" "The control plane is responsible for reconciling approved action intent against observed execution-surface outcomes and for recording when reconciliation is incomplete, stale, or failed."
 
 missing_idempotency_repo="${workdir}/missing-idempotency"
 create_repo "${missing_idempotency_repo}"
@@ -133,9 +133,9 @@ assert_fails_with "${missing_evidence_withdrawn_state_repo}" '| `withdrawn` | Th
 missing_reconciliation_record_repo="${workdir}/missing-reconciliation-record"
 create_repo "${missing_reconciliation_record_repo}"
 write_canonical_doc "${missing_reconciliation_record_repo}"
-remove_text_from_doc "${missing_reconciliation_record_repo}" '| `Reconciliation` | AegisOps control-plane reconciliation record | Cross-system linkage, mismatch tracking, and resolution state must not dissolve into alert fields, case notes, or n8n metadata. |'
+remove_text_from_doc "${missing_reconciliation_record_repo}" '| `Reconciliation` | AegisOps control-plane reconciliation record | Cross-system linkage, mismatch tracking, and resolution state must not dissolve into alert fields, case notes, or execution-surface metadata. |'
 commit_fixture "${missing_reconciliation_record_repo}"
-assert_fails_with "${missing_reconciliation_record_repo}" '| `Reconciliation` | AegisOps control-plane reconciliation record | Cross-system linkage, mismatch tracking, and resolution state must not dissolve into alert fields, case notes, or n8n metadata. |'
+assert_fails_with "${missing_reconciliation_record_repo}" '| `Reconciliation` | AegisOps control-plane reconciliation record | Cross-system linkage, mismatch tracking, and resolution state must not dissolve into alert fields, case notes, or execution-surface metadata. |'
 
 missing_substrate_signal_repo="${workdir}/missing-substrate-signal"
 create_repo "${missing_substrate_signal_repo}"
@@ -167,5 +167,25 @@ printf '%s\n' "Reconciliation must preserve auditable disagreement. When OpenSea
 git -C "${stale_future_control_record_repo}" add docs/control-plane-state-model.md
 commit_fixture "${stale_future_control_record_repo}"
 assert_fails_with "${stale_future_control_record_repo}" "Forbidden control-plane state model statement still present: Reconciliation must preserve auditable disagreement. When OpenSearch, n8n, and the future control record disagree, the platform must retain that mismatch as an explicit state that operators can inspect and resolve rather than overwriting one side to make the data look clean."
+
+stale_n8n_execution_surface_repo="${workdir}/stale-n8n-execution-surface"
+create_repo "${stale_n8n_execution_surface_repo}"
+write_canonical_doc "${stale_n8n_execution_surface_repo}"
+replace_text_in_doc \
+  "${stale_n8n_execution_surface_repo}" \
+  '| `Action Execution` | Reviewed automation substrate or controlled executor surface | The execution surface owns execution-attempt state, step progress, and surface-specific runtime details for the reviewed automation-substrate or executor run. |' \
+  '| `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state | n8n owns execution-attempt state, step progress, and connector-specific runtime details. |'
+commit_fixture "${stale_n8n_execution_surface_repo}"
+assert_fails_with "${stale_n8n_execution_surface_repo}" "| \`Action Execution\` | Reviewed automation substrate or controlled executor surface | The execution surface owns execution-attempt state, step progress, and surface-specific runtime details for the reviewed automation-substrate or executor run. |"
+
+stale_n8n_reconciliation_repo="${workdir}/stale-n8n-reconciliation"
+create_repo "${stale_n8n_reconciliation_repo}"
+write_canonical_doc "${stale_n8n_reconciliation_repo}"
+replace_text_in_doc \
+  "${stale_n8n_reconciliation_repo}" \
+  "The control plane is responsible for reconciling approved action intent against observed execution-surface outcomes and for recording when reconciliation is incomplete, stale, or failed." \
+  "The control plane is responsible for reconciling approved action intent against observed n8n execution outcomes and for recording when reconciliation is incomplete, stale, or failed."
+commit_fixture "${stale_n8n_reconciliation_repo}"
+assert_fails_with "${stale_n8n_reconciliation_repo}" "The control plane is responsible for reconciling approved action intent against observed execution-surface outcomes and for recording when reconciliation is incomplete, stale, or failed."
 
 echo "Control-plane state model verifier enforces required policy statements."

--- a/scripts/test-verify-phase-11-control-plane-ci-validation.sh
+++ b/scripts/test-verify-phase-11-control-plane-ci-validation.sh
@@ -133,4 +133,14 @@ remove_text_from_file "${missing_ci_step_repo}" ".github/workflows/ci.yml" "    
 commit_fixture "${missing_ci_step_repo}"
 assert_fails_with "${missing_ci_step_repo}" "Missing required line in ${missing_ci_step_repo}/.github/workflows/ci.yml:       - name: Run Phase 11 control-plane validation"
 
+missing_vendor_neutral_review_repo="${workdir}/missing-vendor-neutral-review"
+create_repo "${missing_vendor_neutral_review_repo}"
+write_required_artifacts "${missing_vendor_neutral_review_repo}"
+remove_text_from_file \
+  "${missing_vendor_neutral_review_repo}" \
+  "docs/phase-11-control-plane-ci-validation.md" \
+  'Confirmed the control-plane state model describes `Action Execution` and reconciliation in terms of reviewed automation-substrate and executor surfaces rather than one named implementation.'
+commit_fixture "${missing_vendor_neutral_review_repo}"
+assert_fails_with "${missing_vendor_neutral_review_repo}" "Missing required line in ${missing_vendor_neutral_review_repo}/docs/phase-11-control-plane-ci-validation.md: Confirmed the control-plane state model describes \`Action Execution\` and reconciliation in terms of reviewed automation-substrate and executor surfaces rather than one named implementation."
+
 echo "Phase 11 control-plane CI validation verifier fails closed for missing reviewed coverage."

--- a/scripts/verify-control-plane-state-model-doc.sh
+++ b/scripts/verify-control-plane-state-model-doc.sh
@@ -37,11 +37,12 @@ required_phrases=(
   '| `Hunt` | AegisOps control-plane hunt record | Hunt lifecycle must remain analyst-directed and reviewable rather than inferred from ad hoc queries or downstream workflow runs. |'
   '| `Hunt Run` | AegisOps control-plane hunt-run record | Each hunt run must preserve bounded scope, execution context, and outcome for one hunt iteration without replacing alerts or cases. |'
   '| `AI Trace` | AegisOps control-plane AI-trace record | AI trace records must preserve prompt, model, review, and linkage context without mutating evidence custody or analyst-owned dispositions. |'
-  '| `Reconciliation` | AegisOps control-plane reconciliation record | Cross-system linkage, mismatch tracking, and resolution state must not dissolve into alert fields, case notes, or n8n metadata. |'
-  '| `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state | n8n owns execution-attempt state, step progress, and connector-specific runtime details. |'
-  "n8n execution history must not become the implicit system of record for case state, approval state, or action-request intent."
+  '| `Reconciliation` | AegisOps control-plane reconciliation record | Cross-system linkage, mismatch tracking, and resolution state must not dissolve into alert fields, case notes, or execution-surface metadata. |'
+  '| `Action Execution` | Reviewed automation substrate or controlled executor surface | The execution surface owns execution-attempt state, step progress, and surface-specific runtime details for the reviewed automation-substrate or executor run. |'
+  "Execution-surface runtime history must not become the implicit system of record for case state, approval state, or action-request intent."
   "Substrate-native detection records and admitted analytic signals remain upstream reconciliation inputs, but they do not own downstream case, approval, or execution-policy state."
   "The minimum control-plane record families for this baseline are Alert, Case, Evidence, Observation, Lead, Recommendation, Approval Decision, Action Request, Hunt, Hunt Run, AI Trace, Reconciliation, and the execution-plane Action Execution record that must later reconcile with them."
+  "- action execution state remains execution-surface runtime state owned by the reviewed automation substrate or executor surface and backed by that surface's runtime store; and"
   'The approved persistence boundary for those platform-owned control records is the AegisOps-owned PostgreSQL control-plane boundary reviewed under `postgres/control-plane/`.'
   "That reviewed PostgreSQL-backed boundary may share a PostgreSQL engine class with n8n, but it must not collapse control-plane ownership into n8n-owned metadata tables or runtime workflow state."
   "If a later deployment uses one PostgreSQL cluster for both concerns, it must still preserve an explicit ownership split through separate AegisOps-controlled schemas, tables, migration history, and access controls for control-plane records."
@@ -53,9 +54,10 @@ required_phrases=(
   "- OpenSearch owns telemetry, findings, and OpenSearch-native analytic or alerting artifacts that act as upstream signals rather than downstream control-plane truth."
   "This boundary approves where authoritative control-plane records belong for the live runtime boundary, but it does not approve live PostgreSQL provisioning, schema migrations, credentials, or runtime deployment changes in this phase."
   'The repository already materializes a version-controlled schema baseline for that boundary under `postgres/control-plane/`, including reviewed schema manifests and migration files that keep the approved record-family boundary explicit without authorizing live deployment, credentials, or production migration execution in this phase.'
-  "The control plane is responsible for reconciling approved action intent against observed n8n execution outcomes and for recording when reconciliation is incomplete, stale, or failed."
+  "The control plane is responsible for reconciling approved action intent against observed execution-surface outcomes and for recording when reconciliation is incomplete, stale, or failed."
   "Reconciliation must prefer deterministic correlation keys such as substrate detection record identifiers, analytic-signal identifiers, action-request identifiers, approval identifiers, workflow identifiers, and idempotency keys rather than fuzzy time-window matching."
-  "Stable reconciliation keys must allow operators to compare substrate-native detection output, admitted analytic signals, control-plane records, and n8n execution outcomes without assuming those systems share one lifecycle or one authoritative identifier."
+  "Stable reconciliation keys must allow operators to compare substrate-native detection output, admitted analytic signals, control-plane records, and execution-surface outcomes without assuming those systems share one lifecycle or one authoritative identifier."
+  "The reviewed automation substrate or executor surface is responsible for exposing enough run identifiers, timestamps, execution outcomes, and step-level failure detail that the control-plane runtime can correlate approved intent to observed execution behavior."
   'Substrate-record-to-alert ingestion contract requirements:'
   'The ingestion boundary must treat `substrate_detection_record_id`, `analytic_signal_id`, and `alert_id` as related but non-interchangeable identifiers.'
   'The ingest path must preserve the upstream `substrate_detection_record_id` as the durable substrate-origin reference, preserve `analytic_signal_id` for the admitted vendor-neutral signal created or updated from that substrate record set, and assign a separate control-plane `alert_id` for the analyst-facing record created or updated from that signal.'
@@ -123,7 +125,7 @@ required_phrases=(
   '| `failed` | Execution or required verification concluded unsuccessfully under the current approved request. |'
   '| `unresolved` | Operators cannot yet prove whether the request was executed correctly, failed partially, or needs manual recovery. |'
   "These lifecycle states establish the minimum reviewable transitions for later reconciliation, retry, expiry, duplicate suppression, and manual recovery work."
-  "No control-plane record family may silently inherit lifecycle from substrate-local alerts or n8n execution history. Cross-system state must be linked through explicit identifiers and reconciliation records instead."
+  "No control-plane record family may silently inherit lifecycle from substrate-local alerts or execution-surface runtime history. Cross-system state must be linked through explicit identifiers and reconciliation records instead."
   "Hunt records must preserve explicit lifecycle state, ownership, hypothesis linkage, and closure rationale even when no case is opened."
   "Observation records must preserve scoped analyst assertions, timestamps, authorship, and linkage to supporting evidence without turning evidence custody into free-form narrative."
   "Lead records must preserve investigative hypotheses, triage rationale, and disposition state without being treated as equivalent to alert state, case state, or recommendation text."
@@ -156,10 +158,12 @@ required_phrases=(
   "Promotion of a lead into alert or case work must create or update the destination alert or case record while preserving the original lead as a first-class control-plane record with explicit promotion linkage."
   "Observation records, recommendation records, AI trace records, and case notes may contribute context to promotion decisions, but none of them may become the sole system of record for lead state or lead promotion history."
   "Hunt, hunt-run, observation, lead, recommendation, and AI trace records may attach to alerts, cases, or stand-alone hunt workflows, but attachment alone does not transfer lifecycle ownership or collapse one record family into another."
-  "Retry policy belongs to the control-plane intent record, while duplicate suppression and step-level retry behavior inside a running workflow belong to n8n."
+  "- marking reconciliation exceptions when upstream substrate records or findings disappear, duplicate execution triggers arrive, or an execution surface reports an outcome that does not satisfy the approved intent record."
+  "Retry policy belongs to the control-plane intent record, while duplicate suppression and step-level retry behavior inside a running automation-substrate or executor run belong to the execution surface."
   "Dead-letter responsibility begins when the platform can no longer prove whether an approved intent was never executed, is still executing, or executed with an unknown result."
   "Manual recovery procedures must support re-drive, cancellation, supersession, and explicit operator annotation without rewriting historical approval or execution evidence."
   "Every action request and execution attempt must carry a stable idempotency key that survives retries, duplicate delivery, and reconciliation replays."
+  "- the execution-surface record that shows what actually ran and what outcome was observed."
   'This baseline already aligns to the shipped `control-plane/` runtime home and the reviewed `postgres/control-plane/` persistence contract. Later runtime and datastore work must preserve that authority boundary rather than redefine where authoritative control-plane truth lives.'
 )
 
@@ -172,6 +176,16 @@ forbidden_phrases=(
   "The future AegisOps control layer is responsible for:"
   "Reconciliation must preserve auditable disagreement. When OpenSearch, n8n, and the future control record disagree, the platform must retain that mismatch as an explicit state that operators can inspect and resolve rather than overwriting one side to make the data look clean."
   'No new live datastore rollout is approved in this phase. The current control-plane runtime remains `persistence_mode="in_memory"`, `postgres/control-plane/` remains the reviewed schema and migration home for future PostgreSQL-backed persistence work, and OpenSearch remains the analytics-plane store for telemetry and detection outputs.'
+  '| `Action Execution` | n8n execution plane with PostgreSQL-backed workflow state | n8n owns execution-attempt state, step progress, and connector-specific runtime details. |'
+  "n8n execution history must not become the implicit system of record for case state, approval state, or action-request intent."
+  "- action execution state remains execution-plane runtime state owned by n8n and backed by PostgreSQL; and"
+  "The control plane is responsible for reconciling approved action intent against observed n8n execution outcomes and for recording when reconciliation is incomplete, stale, or failed."
+  "Stable reconciliation keys must allow operators to compare substrate-native detection output, admitted analytic signals, control-plane records, and n8n execution outcomes without assuming those systems share one lifecycle or one authoritative identifier."
+  "n8n is responsible for exposing enough workflow-run identifiers, timestamps, execution outcomes, and step-level failure detail that the control-plane runtime can correlate approved intent to observed execution behavior."
+  "- marking reconciliation exceptions when upstream substrate records or findings disappear, duplicate workflow triggers arrive, or n8n reports an outcome that does not satisfy the approved intent record."
+  "No control-plane record family may silently inherit lifecycle from substrate-local alerts or n8n execution history. Cross-system state must be linked through explicit identifiers and reconciliation records instead."
+  "Retry policy belongs to the control-plane intent record, while duplicate suppression and step-level retry behavior inside a running workflow belong to n8n."
+  "- the n8n execution record that shows what actually ran and what outcome was observed."
 )
 
 if [[ ! -f "${doc_path}" ]]; then

--- a/scripts/verify-phase-11-control-plane-ci-validation.sh
+++ b/scripts/verify-phase-11-control-plane-ci-validation.sh
@@ -68,6 +68,7 @@ validation_required_phrases=(
   'Confirmed analytic signals remain first-class control-plane records with durable `analytic_signal_id` and `substrate_detection_record_id` linkage instead of collapsing into alert-only state.'
   "Confirmed native detection intake remains constrained by explicit substrate-adapter boundaries and non-empty substrate-origin identifiers."
   'Confirmed reconciliation coverage preserves vendor-neutral `execution_surface_type`, `execution_surface_id`, and `execution_run_id` assumptions so the reviewed tests do not hard-code one automation substrate implementation.'
+  'Confirmed the control-plane state model describes `Action Execution` and reconciliation in terms of reviewed automation-substrate and executor surfaces rather than one named implementation.'
   "Confirmed CI now runs a dedicated Phase 11 validation step and a workflow coverage guard so failures point to this reviewed boundary instead of only surfacing through broad unit-test discovery."
   '`docs/control-plane-state-model.md` must continue to describe the reviewed local runtime as `persistence_mode="postgresql"` and the PostgreSQL-backed control-plane store as the authoritative local persistence path.'
   '`control-plane/README.md` must continue to describe the reviewed runtime and inspection commands as the authoritative local operator flow while keeping injected in-memory stores limited to tests and local doubles.'


### PR DESCRIPTION
## Summary
- align the Phase 11 control-plane state model with the shipped vendor-neutral execution-surface contract
- tighten the Phase 11 verifier scripts and shell guards so stale n8n-only wording fails closed
- update the Phase 11 CI validation note to match the reviewed control-plane/runtime boundary

## Testing
- bash scripts/test-verify-control-plane-state-model-doc.sh
- bash scripts/verify-control-plane-state-model-doc.sh
- bash scripts/test-verify-phase-11-control-plane-ci-validation.sh
- bash scripts/verify-phase-11-control-plane-ci-validation.sh
- python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated control-plane state model documentation to use vendor-neutral "execution surface" terminology instead of vendor-specific language, generalizing concepts across different automation substrates.
  * Added confirmation that the control-plane documentation describes action execution and reconciliation in vendor-agnostic terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->