### PR TITLE
docs: define the Wazuh alert-ingest contract

### DIFF
--- a/.codex-supervisor/issues/246/issue-journal.md
+++ b/.codex-supervisor/issues/246/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #246: design: define the Wazuh alert-ingest contract and mapping into Analytic Signal
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/246
+- Branch: codex/issue-246
+- Workspace: .
+- Journal: .codex-supervisor/issues/246/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 6a7b0a8a55f51a4f52d35619071b0eb6bffe48c3
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-06T14:08:35.368Z
+
+## Latest Codex Summary
+- Added a focused documentation unittest that reproduced the missing Wazuh ingest-contract gap, then added `docs/wazuh-alert-ingest-contract.md` plus cross-links from the state-model and secops-domain docs.
+- Verified the new contract against the focused unittest and the issue-specified `rg` query.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The issue was a reviewed-documentation gap rather than a runtime bug; the repo had generic analytic-signal semantics but no Wazuh-specific intake contract that fixed required fields, provenance, and identifier mapping into first-class analytic signals.
+- What changed: Added `control-plane/tests/test_wazuh_alert_ingest_contract_docs.py` to reproduce the gap, created `docs/wazuh-alert-ingest-contract.md`, and cross-linked it from `docs/secops-domain-model.md` and `docs/control-plane-state-model.md`.
+- Current blocker: none
+- Next exact step: Stage the docs and focused test, commit the checkpoint, and leave the branch ready for local review or draft PR creation.
+- Verification gap: Focused docs verification passed; broader review is still manual and no broader automated doc lint suite exists in this repo.
+- Files touched: `.codex-supervisor/issues/246/issue-journal.md`, `control-plane/tests/test_wazuh_alert_ingest_contract_docs.py`, `docs/wazuh-alert-ingest-contract.md`, `docs/secops-domain-model.md`, `docs/control-plane-state-model.md`
+- Rollback concern: Low; changes are additive documentation plus a narrow unittest asserting the contract file and cross-links exist.
+- Last focused command: `rg -n "Wazuh|Analytic Signal|substrate_detection_record_id|analytic_signal_id|alert_id" docs control-plane`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/tests/test_wazuh_alert_ingest_contract_docs.py
+++ b/control-plane/tests/test_wazuh_alert_ingest_contract_docs.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CONTRACT_DOC = REPO_ROOT / "docs" / "wazuh-alert-ingest-contract.md"
+STATE_MODEL_DOC = REPO_ROOT / "docs" / "control-plane-state-model.md"
+DOMAIN_MODEL_DOC = REPO_ROOT / "docs" / "secops-domain-model.md"
+
+
+class WazuhAlertIngestContractDocsTests(unittest.TestCase):
+    def test_wazuh_contract_doc_defines_required_mapping_and_ownership_terms(self) -> None:
+        self.assertTrue(
+            CONTRACT_DOC.exists(),
+            f"expected reviewed Wazuh contract doc at {CONTRACT_DOC}",
+        )
+        text = CONTRACT_DOC.read_text(encoding="utf-8")
+
+        required_terms = (
+            "Wazuh Alert Ingest Contract",
+            "Required Fields",
+            "Optional Fields",
+            "substrate_detection_record_id",
+            "analytic_signal_id",
+            "alert_id",
+            "provenance",
+            "Substrate Detection Record",
+            "Analytic Signal",
+            "Alert",
+            "Case",
+            "Evidence",
+            "Wazuh-native",
+        )
+        for term in required_terms:
+            self.assertIn(term, text)
+
+    def test_shared_docs_cross_link_to_the_reviewed_wazuh_contract(self) -> None:
+        contract_path = "`docs/wazuh-alert-ingest-contract.md`"
+        self.assertIn(
+            contract_path,
+            STATE_MODEL_DOC.read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            contract_path,
+            DOMAIN_MODEL_DOC.read_text(encoding="utf-8"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/control-plane-state-model.md
+++ b/docs/control-plane-state-model.md
@@ -8,6 +8,8 @@ It supplements `docs/architecture.md`, `docs/secops-domain-model.md`, and `docs/
 
 This document defines ownership, source-of-truth expectations, and recovery responsibilities only. It does not introduce a live datastore, schema migration, API service, or runtime deployment in this phase.
 
+For the reviewed Wazuh-specific intake mapping into first-class analytic signals, see `docs/wazuh-alert-ingest-contract.md`.
+
 ## 2. Baseline Design Constraints
 
 The baseline must keep platform-owned control state explicit across the shipped `control-plane/` runtime boundary and the reviewed `postgres/control-plane/` persistence-contract home.
@@ -93,6 +95,8 @@ Substrate-record-to-alert ingestion contract requirements:
 The ingestion boundary must treat `substrate_detection_record_id`, `analytic_signal_id`, and `alert_id` as related but non-interchangeable identifiers.
 
 The ingest path must preserve the upstream `substrate_detection_record_id` as the durable substrate-origin reference, preserve `analytic_signal_id` for the admitted vendor-neutral signal created or updated from that substrate record set, and assign a separate control-plane `alert_id` for the analyst-facing record created or updated from that signal.
+
+For Wazuh-origin substrate alerts, `docs/wazuh-alert-ingest-contract.md` defines the reviewed input contract, the required Wazuh-native provenance set, and the mapping from Wazuh `id` and `timestamp` into this identifier boundary.
 
 The control plane must evaluate whether an incoming upstream signal creates a new alert, updates an existing alert, or is recorded only as a duplicate or restatement linked to an existing alert.
 

--- a/docs/secops-domain-model.md
+++ b/docs/secops-domain-model.md
@@ -8,6 +8,8 @@ It gives future implementation work a shared vocabulary for detection, investiga
 
 This document defines baseline semantics, ownership boundaries, and state transitions only. It does not introduce runtime behavior, workflow automation, or architecture changes.
 
+For the reviewed Wazuh-specific intake boundary, see `docs/wazuh-alert-ingest-contract.md`.
+
 ## 2. Core Domain Objects
 
 | Object | Definition |
@@ -50,6 +52,8 @@ A substrate detection record preserves the substrate's own identifiers, timestam
 An `Analytic Signal` is the vendor-neutral upstream SecOps primitive admitted by AegisOps from one or more substrate detection records.
 
 An analytic signal preserves durable references back to the originating substrate detection records, but it remains distinct from both those substrate-native records and the downstream alert or case lifecycle that AegisOps may create from it.
+
+For Wazuh-origin alerts, `docs/wazuh-alert-ingest-contract.md` defines the reviewed required fields, optional fields, provenance set, and mapping from the Wazuh-native alert into the admitted analytic-signal boundary.
 
 A finding is the normalized analytic assertion that detection logic matched relevant telemetry.
 

--- a/docs/wazuh-alert-ingest-contract.md
+++ b/docs/wazuh-alert-ingest-contract.md
@@ -1,0 +1,152 @@
+# Wazuh Alert Ingest Contract
+
+## 1. Purpose
+
+This document defines the reviewed Wazuh-specific intake contract for alerts entering the AegisOps control-plane boundary.
+
+It supplements `docs/secops-domain-model.md` and `docs/control-plane-state-model.md` by making the Wazuh-native alert shape, identifier mapping, provenance expectations, and downstream linkage rules explicit for future Phase 12 adapter work.
+
+This contract defines reviewed data-shape and ownership expectations only. It does not approve live adapter code, queue behavior, case-routing policy, or broader source-family expansion.
+
+## 2. Boundary and Ownership
+
+Wazuh remains the owner of the Wazuh-native alert record that it emits.
+
+AegisOps admits that Wazuh-native record through the intake boundary as one `Substrate Detection Record` and one vendor-neutral `Analytic Signal` candidate.
+
+The admitted analytic signal remains distinct from the downstream `Alert`, `Case`, and `Evidence` records that AegisOps may create later.
+
+The ownership split is:
+
+| Record or identifier | Owner | Boundary note |
+| ---- | ---- | ---- |
+| Wazuh-native alert payload | Wazuh | Preserves Wazuh-specific structure, rule metadata, agent metadata, and native record semantics. |
+| `substrate_detection_record_id` | AegisOps intake boundary with durable linkage back to Wazuh | Namespaced durable reference to the originating Wazuh-native alert record. |
+| `analytic_signal_id` | AegisOps | Identifier for the admitted vendor-neutral `Analytic Signal` created or updated from the Wazuh-origin input. |
+| `alert_id` | AegisOps | Identifier for analyst-facing alert work created from the analytic signal when routing policy decides tracked work is required. |
+| `case_id` | AegisOps | Identifier for durable investigation state when alert work is promoted into a case or opened directly from analytic intake. |
+| `evidence_id` and provenance records | AegisOps | Evidence custody and derivation links that preserve how Wazuh source material informed later analyst work. |
+
+Neither the Wazuh-native alert identifier nor the admitted `analytic_signal_id` may be reused as an `alert_id` or `case_id`.
+
+## 3. Reviewed Wazuh Input Contract
+
+The intake boundary accepts one Wazuh alert JSON object at a time.
+
+Wazuh documentation examples show stable top-level alert fields including `id`, `timestamp`, `rule`, `agent`, `manager`, `decoder`, `location`, and source-specific `data` payload sections. The contract below narrows which of those fields are required at the AegisOps boundary and which remain optional but preservable source context.
+
+### 3.1 Required Fields
+
+The following fields are required for a Wazuh alert to cross the AegisOps intake boundary:
+
+| Wazuh field | Required expectation | AegisOps mapping |
+| ---- | ---- | ---- |
+| `id` | Non-empty string. Unique only within Wazuh semantics and must be preserved exactly as emitted. | Source value for the Wazuh-native identifier and the suffix used to form `substrate_detection_record_id`. |
+| `timestamp` | Timezone-qualified event-emission timestamp string that can be parsed into an aware datetime. | Canonical upstream alert timestamp preserved in provenance and used as the baseline admitted-signal observation time. |
+| `rule.id` | Non-empty rule identifier string. | Preserved as native rule provenance and available to derive or review routing and correlation context. |
+| `rule.level` | Integer severity value as emitted by Wazuh. | Preserved as native severity provenance; it does not become an AegisOps lifecycle state by itself. |
+| `rule.description` | Non-empty descriptive string. | Preserved as human-readable native claim context for the admitted signal. |
+| `agent.id` or equivalent manager-local source identity for manager-origin alerts | At least one accountable source identity must exist. | Preserved in provenance and used in the bounded correlation input set. |
+| Raw alert payload | Full JSON object as received. | Preserved as source material for evidence and later review; intake normalization must not destroy the original Wazuh-native shape. |
+
+### 3.2 Optional Fields
+
+The following fields are optional at the intake boundary but must be preserved when present:
+
+| Wazuh field | Optional expectation | AegisOps handling |
+| ---- | ---- | ---- |
+| `agent.name` | Human-readable endpoint or source name. | Preserve as source context only. |
+| `agent.ip` | Source endpoint IP address. | Preserve as source context only. |
+| `manager.name` | Wazuh manager identity. | Preserve as provenance context showing which Wazuh control point emitted the record. |
+| `decoder.name` | Decoder family or parser name. | Preserve as native parsing provenance. |
+| `location` | Wazuh event location string. | Preserve as native routing and provenance context. |
+| `rule.groups` | Native Wazuh grouping tags. | Preserve as classification context; do not treat them as AegisOps queue state. |
+| `rule.mitre.*` | Native ATT&CK metadata when present. | Preserve as source analytic context. |
+| `data.*` | Source-family-specific structured payload. | Preserve as source evidence context and optional analytic enrichment input. |
+| Additional top-level fields | Any extra Wazuh-native fields present in a reviewed alert shape. | Preserve losslessly unless a separate reviewed contract forbids them. |
+
+## 4. Identifier Mapping
+
+The intake boundary must preserve the distinction between Wazuh-native identifiers, admitted analytic-signal identifiers, and downstream control-plane workflow identifiers.
+
+| Concern | Mapping rule |
+| ---- | ---- |
+| Wazuh-native record identity | Preserve Wazuh `id` exactly as the native alert identifier. |
+| `substrate_detection_record_id` | Set to `wazuh:<id>` unless the input is already namespaced as `wazuh:<id>`. This matches the shipped control-plane rule that substrate detection identifiers are namespaced by substrate key. |
+| `analytic_signal_id` | AegisOps-minted durable identifier for the admitted signal. It may be supplied by the intake adapter or deterministically derived by AegisOps from correlation context, but it remains an AegisOps-owned identifier rather than a Wazuh-native field. |
+| `alert_id` | AegisOps-minted analyst-work identifier created only if routing policy decides analyst queueing or tracked alert handling is required. |
+| `case_id` | AegisOps-minted investigation identifier created only when durable investigation tracking is required. |
+
+`substrate_detection_record_id`, `analytic_signal_id`, `alert_id`, and `case_id` are related references, not interchangeable lifecycle keys.
+
+## 5. Timestamp Mapping
+
+Wazuh `timestamp` is the required upstream record timestamp and must remain preserved in provenance.
+
+The admitted signal must populate its first-seen or last-seen timing from reviewed upstream timestamps rather than from when an analyst later opens an alert or case.
+
+When later intake logic distinguishes first observation from restatement or update time, it must preserve that distinction without rewriting the original Wazuh-native timestamp.
+
+## 6. Routing and Correlation Inputs
+
+The Wazuh alert contract does not define final analyst-queue behavior, but it does define the minimum native context that the `Analytic Signal` admission step must preserve for later routing and deduplication decisions.
+
+The admitted signal must preserve:
+
+- the namespaced `substrate_detection_record_id`;
+- the AegisOps `analytic_signal_id`;
+- the Wazuh-native severity and rule provenance from `rule.id`, `rule.level`, and `rule.description`;
+- accountable source identity from `agent.id` or the reviewed manager-local equivalent;
+- reviewed timing from Wazuh `timestamp`; and
+- enough preserved source context to explain why later alert or case routing happened.
+
+Correlation or deduplication inputs may additionally use Wazuh `rule.groups`, `agent.name`, `location`, selected `data.*` fields, and other reviewed source-family fields, but those fields remain correlation inputs rather than lifecycle identifiers.
+
+## 7. Provenance Expectations
+
+Every admitted Wazuh-origin `Analytic Signal` must preserve provenance sufficient to answer all of the following:
+
+- which exact Wazuh-native alert record was admitted;
+- which Wazuh manager or source context emitted it;
+- which Wazuh rule metadata described the native claim;
+- what native timestamp Wazuh attached to the alert; and
+- which later AegisOps alert, case, evidence, and reconciliation records were linked to that admitted signal.
+
+The minimum provenance set for Wazuh-origin intake is:
+
+| Provenance element | Minimum expectation |
+| ---- | ---- |
+| Native payload preservation | Retain the original Wazuh-native JSON payload as source material or evidence input. |
+| Source system marker | Preserve that the record originated from the `wazuh` detection substrate. |
+| Native identifier linkage | Preserve Wazuh `id` and the namespaced `substrate_detection_record_id`. |
+| Native timing | Preserve Wazuh `timestamp` and any later AegisOps ingest or comparison timestamps separately. |
+| Rule provenance | Preserve `rule.id`, `rule.level`, and `rule.description`; keep optional `rule.groups` and `rule.mitre.*` when present. |
+| Source provenance | Preserve `agent.*`, `manager.*`, `decoder.name`, and `location` when present. |
+
+## 8. Mapping into Analytic Signal and Downstream Records
+
+One Wazuh-native alert admission produces or updates one first-class `Analytic Signal` record, not a case by default.
+
+The reviewed mapping is:
+
+| Wazuh-origin input | AegisOps record or field | Mapping expectation |
+| ---- | ---- | ---- |
+| One Wazuh alert JSON object | `Substrate Detection Record` | The raw Wazuh-native record remains the upstream source fact. |
+| Wazuh `id` | `substrate_detection_record_id` | Namespaced durable linkage as `wazuh:<id>`. |
+| Wazuh `timestamp` | `Analytic Signal.first_seen_at` and `Analytic Signal.last_seen_at` baseline | Used as the upstream observation time unless later reviewed logic proves a restatement or update window. |
+| Wazuh rule and source context | `Analytic Signal` provenance and correlation context | Preserved without converting native fields into AegisOps workflow state. |
+| Admitted signal requiring analyst work | `alert_id` linkage on the analytic signal and alert record | AegisOps may create or update an `Alert` while keeping the `Analytic Signal` first-class and separately addressable. |
+| Alert promotion or direct investigation intake | `case_id` linkage | A case may link back to either the alert, the analytic signal, or both as defined in the control-plane state model. |
+| Preserved raw payload and source metadata | `Evidence` and reconciliation linkage | Later evidence and reconciliation records must point back to the Wazuh-origin signal chain rather than rewriting provenance into notes. |
+
+Downstream alert and case lifecycle state must remain AegisOps-owned even when the native Wazuh record is restated, updated, or disappears from the substrate view.
+
+## 9. Non-Goals
+
+This contract does not:
+
+- implement a live Wazuh adapter;
+- define the exact algorithm for `analytic_signal_id` generation;
+- approve concrete analyst-queue behavior;
+- expand the contract to all future detection substrates; or
+- redefine the control-plane ownership rules already established in `docs/control-plane-state-model.md`.


### PR DESCRIPTION
## Summary
- add a reviewed Wazuh alert-ingest contract for the control-plane intake boundary
- document mapping from Wazuh-native identifiers and timestamps into first-class Analytic Signal linkage
- cross-link the shared secops and control-plane state docs to the reviewed Wazuh contract

## Verification
- python3 -m unittest control-plane/tests/test_wazuh_alert_ingest_contract_docs.py
- rg -n "Wazuh|Analytic Signal|substrate_detection_record_id|analytic_signal_id|alert_id" docs control-plane

Closes #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Wazuh alert ingestion contract specification defining required fields, identifier mapping, and timestamp handling rules for control-plane intake.
  * Added cross-references to the new contract in related domain and state model documentation.

* **Tests**
  * Added validation tests ensuring documentation contract definitions and cross-references are present and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->