### PR TITLE
Add Wazuh alert adapter and fixtures

### DIFF
--- a/.codex-supervisor/issues/247/issue-journal.md
+++ b/.codex-supervisor/issues/247/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #247: implementation: add a Wazuh alert adapter, fixtures, and signal-admission path
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/247
+- Branch: codex/issue-247
+- Workspace: .
+- Journal: .codex-supervisor/issues/247/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 495abe3795aa0cdbb9e67f3fd0184a625ee914ef
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-06T14:26:16.609Z
+
+## Latest Codex Summary
+- Added a concrete `WazuhAlertAdapter`, reviewed Wazuh JSON fixtures, and fixture-backed tests proving Wazuh-origin intake persists first-class analytic signals through `ingest_native_detection_record`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Issue #247 was missing a concrete Wazuh-native adapter and fixture-backed proof that native Wazuh alerts flow through the substrate-adapter boundary into first-class `AnalyticSignalRecord` persistence plus linked alert/reconciliation records.
+- What changed: Added `control-plane/aegisops_control_plane/adapters/wazuh.py`, exported it from package init files, added two reviewed Wazuh alert fixtures, added focused adapter tests, and added a fixture-backed service persistence test that admits a Wazuh-origin record through `ingest_native_detection_record`.
+- Current blocker: none
+- Next exact step: Review diff, then push branch or open/update the draft PR if the supervisor wants the checkpoint published.
+- Verification gap: Did not run the entire repository test suite; verification is scoped to the new adapter tests, `test_service_persistence`, and the requested `rg` inspection.
+- Files touched: control-plane/aegisops_control_plane/__init__.py; control-plane/aegisops_control_plane/adapters/__init__.py; control-plane/aegisops_control_plane/adapters/wazuh.py; control-plane/tests/test_service_persistence.py; control-plane/tests/test_wazuh_adapter.py; control-plane/tests/fixtures/wazuh/agent-origin-alert.json; control-plane/tests/fixtures/wazuh/manager-origin-alert.json
+- Rollback concern: Correlation and finding ID derivation are deterministic and currently scoped to reviewed Wazuh fixtures; future broader Wazuh contracts may want different minting semantics without affecting the persistence boundary added here.
+- Last focused command: python3 -m unittest control-plane.tests.test_service_persistence
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Focused commands run: `python3 -m unittest control-plane.tests.test_wazuh_adapter`; `python3 -m unittest control-plane.tests.test_service_persistence`; `rg -n "Wazuh|wazuh|AnalyticSignal|NativeDetectionRecordAdapter|fixture" control-plane docs`.

--- a/control-plane/aegisops_control_plane/__init__.py
+++ b/control-plane/aegisops_control_plane/__init__.py
@@ -1,5 +1,6 @@
 """AegisOps control-plane runtime scaffold."""
 
+from .adapters import WazuhAlertAdapter
 from .config import RuntimeConfig
 from .models import (
     AITraceRecord,
@@ -52,6 +53,7 @@ __all__ = [
     "RecordInspectionSnapshot",
     "RuntimeConfig",
     "RuntimeSnapshot",
+    "WazuhAlertAdapter",
     "build_runtime_service",
     "build_runtime_snapshot",
 ]

--- a/control-plane/aegisops_control_plane/adapters/__init__.py
+++ b/control-plane/aegisops_control_plane/adapters/__init__.py
@@ -3,9 +3,11 @@
 from .n8n import N8NReconciliationAdapter
 from .opensearch import OpenSearchSignalAdapter
 from .postgres import PostgresControlPlaneStore
+from .wazuh import WazuhAlertAdapter
 
 __all__ = [
     "N8NReconciliationAdapter",
     "OpenSearchSignalAdapter",
     "PostgresControlPlaneStore",
+    "WazuhAlertAdapter",
 ]

--- a/control-plane/aegisops_control_plane/adapters/wazuh.py
+++ b/control-plane/aegisops_control_plane/adapters/wazuh.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping
+
+from ..models import AnalyticSignalAdmission, NativeDetectionRecord
+
+
+def _require_mapping(value: object, field_name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field_name} must be a mapping")
+    return value
+
+
+def _require_non_empty_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _optional_mapping(value: object) -> Mapping[str, object] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _optional_string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str) and item.strip())
+
+
+@dataclass(frozen=True)
+class WazuhAlertAdapter:
+    substrate_key: str = "wazuh"
+
+    def build_native_detection_record(
+        self,
+        alert: Mapping[str, object],
+    ) -> NativeDetectionRecord:
+        native_alert = _require_mapping(alert, "alert")
+        native_record_id = _require_non_empty_string(native_alert.get("id"), "id")
+        timestamp = self._parse_timestamp(
+            _require_non_empty_string(native_alert.get("timestamp"), "timestamp")
+        )
+        rule = _require_mapping(native_alert.get("rule"), "rule")
+        rule_id = _require_non_empty_string(rule.get("id"), "rule.id")
+        rule_level = rule.get("level")
+        if not isinstance(rule_level, int):
+            raise ValueError("rule.level must be an integer")
+        rule_description = _require_non_empty_string(
+            rule.get("description"),
+            "rule.description",
+        )
+
+        agent = _optional_mapping(native_alert.get("agent"))
+        manager = _optional_mapping(native_alert.get("manager"))
+        accountable_source_identity = self._resolve_accountable_source_identity(
+            agent,
+            manager,
+        )
+        correlation_key = (
+            f"wazuh:rule:{rule_id}:source:{accountable_source_identity}"
+        )
+
+        metadata = {
+            "raw_alert": dict(native_alert),
+            "source_system": self.substrate_key,
+            "native_rule": {
+                "id": rule_id,
+                "level": rule_level,
+                "description": rule_description,
+                "groups": _optional_string_tuple(rule.get("groups")),
+                "mitre": dict(_optional_mapping(rule.get("mitre")) or {}),
+            },
+            "source_provenance": {
+                "accountable_source_identity": accountable_source_identity,
+                "agent": dict(agent or {}),
+                "manager": dict(manager or {}),
+                "decoder_name": _optional_string(
+                    (_optional_mapping(native_alert.get("decoder")) or {}).get("name")
+                ),
+                "location": _optional_string(native_alert.get("location")),
+            },
+        }
+
+        return NativeDetectionRecord(
+            substrate_key=self.substrate_key,
+            native_record_id=native_record_id,
+            record_kind="alert",
+            correlation_key=correlation_key,
+            first_seen_at=timestamp,
+            last_seen_at=timestamp,
+            metadata=metadata,
+        )
+
+    def build_analytic_signal_admission(
+        self,
+        record: NativeDetectionRecord,
+    ) -> AnalyticSignalAdmission:
+        native_rule = _require_mapping(record.metadata.get("native_rule"), "native_rule")
+        accountable_source_identity = _require_non_empty_string(
+            _require_mapping(
+                record.metadata.get("source_provenance"),
+                "source_provenance",
+            ).get("accountable_source_identity"),
+            "source_provenance.accountable_source_identity",
+        )
+        finding_id = (
+            "finding:"
+            f"{self.substrate_key}:"
+            f"rule:{_require_non_empty_string(native_rule.get('id'), 'native_rule.id')}:"
+            f"source:{accountable_source_identity}:"
+            f"alert:{record.native_record_id}"
+        )
+        return AnalyticSignalAdmission(
+            finding_id=finding_id,
+            analytic_signal_id=None,
+            substrate_detection_record_id=record.native_record_id,
+            correlation_key=record.correlation_key,
+            first_seen_at=record.first_seen_at,
+            last_seen_at=record.last_seen_at,
+        )
+
+    @staticmethod
+    def _parse_timestamp(value: str) -> datetime:
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            raise ValueError("timestamp must be timezone-aware")
+        return parsed
+
+    @staticmethod
+    def _resolve_accountable_source_identity(
+        agent: Mapping[str, object] | None,
+        manager: Mapping[str, object] | None,
+    ) -> str:
+        agent_id = _optional_string((agent or {}).get("id"))
+        if agent_id is not None:
+            return f"agent:{agent_id}"
+
+        manager_name = _optional_string((manager or {}).get("name"))
+        if manager_name is not None:
+            return f"manager:{manager_name}"
+
+        raise ValueError(
+            "agent.id or manager.name must provide an accountable source identity"
+        )

--- a/control-plane/tests/fixtures/wazuh/agent-origin-alert.json
+++ b/control-plane/tests/fixtures/wazuh/agent-origin-alert.json
@@ -1,0 +1,40 @@
+{
+  "id": "1731594986.4931506",
+  "timestamp": "2026-04-05T12:00:00+00:00",
+  "rule": {
+    "id": "5710",
+    "level": 10,
+    "description": "SSH brute force attempt",
+    "groups": [
+      "sshd",
+      "authentication_failures"
+    ],
+    "mitre": {
+      "id": [
+        "T1110"
+      ],
+      "tactic": [
+        "Credential Access"
+      ],
+      "technique": [
+        "Brute Force"
+      ]
+    }
+  },
+  "agent": {
+    "id": "007",
+    "name": "db-01",
+    "ip": "10.0.0.7"
+  },
+  "manager": {
+    "name": "wazuh-manager-1"
+  },
+  "decoder": {
+    "name": "sshd"
+  },
+  "location": "/var/log/auth.log",
+  "data": {
+    "srcip": "198.51.100.24",
+    "srcuser": "invalid-user"
+  }
+}

--- a/control-plane/tests/fixtures/wazuh/manager-origin-alert.json
+++ b/control-plane/tests/fixtures/wazuh/manager-origin-alert.json
@@ -1,0 +1,24 @@
+{
+  "id": "1731594999.4931507",
+  "timestamp": "2026-04-05T12:05:00+00:00",
+  "rule": {
+    "id": "100001",
+    "level": 7,
+    "description": "Manager-side integration warning",
+    "groups": [
+      "wazuh",
+      "integration"
+    ]
+  },
+  "manager": {
+    "name": "wazuh-manager-2"
+  },
+  "decoder": {
+    "name": "json"
+  },
+  "location": "manager/integrations",
+  "data": {
+    "integration": "virustotal",
+    "event_type": "warning"
+  }
+}

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import json
 import pathlib
 import sys
 import unittest
@@ -20,6 +21,7 @@ from aegisops_control_plane.models import (
     NativeDetectionRecord,
     ReconciliationRecord,
 )
+from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
 from aegisops_control_plane.service import (
     AegisOpsControlPlaneService,
     NativeDetectionRecordAdapter,
@@ -27,7 +29,71 @@ from aegisops_control_plane.service import (
 from postgres_test_support import make_store
 
 
+FIXTURES_ROOT = pathlib.Path(__file__).resolve().parent / "fixtures" / "wazuh"
+
+
+def _load_wazuh_fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+
+
 class ControlPlaneServicePersistenceTests(unittest.TestCase):
+    def test_service_admits_wazuh_fixture_through_substrate_adapter_boundary(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+        native_record = adapter.build_native_detection_record(
+            _load_wazuh_fixture("agent-origin-alert.json")
+        )
+
+        admitted = service.ingest_native_detection_record(adapter, native_record)
+
+        self.assertEqual(admitted.disposition, "created")
+        self.assertIsNotNone(admitted.alert.analytic_signal_id)
+        self.assertEqual(
+            admitted.alert.finding_id,
+            "finding:wazuh:rule:5710:source:agent:007:alert:1731594986.4931506",
+        )
+        self.assertTrue(
+            admitted.alert.analytic_signal_id.startswith("analytic-signal-")
+        )
+
+        signals = store.list(AnalyticSignalRecord)
+        self.assertEqual(len(signals), 1)
+        self.assertEqual(
+            signals[0].substrate_detection_record_id,
+            "wazuh:1731594986.4931506",
+        )
+        self.assertEqual(
+            signals[0].correlation_key,
+            "wazuh:rule:5710:source:agent:007",
+        )
+        self.assertEqual(
+            signals[0].first_seen_at,
+            datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            signals[0].last_seen_at,
+            datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(signals[0].alert_ids, (admitted.alert.alert_id,))
+
+        reconciliation = service.get_record(
+            ReconciliationRecord,
+            admitted.reconciliation.reconciliation_id,
+        )
+        self.assertEqual(reconciliation.ingest_disposition, "created")
+        self.assertEqual(
+            reconciliation.subject_linkage["substrate_detection_record_ids"],
+            ("wazuh:1731594986.4931506",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["analytic_signal_ids"],
+            (admitted.alert.analytic_signal_id,),
+        )
+
     def test_service_admits_native_detection_records_via_substrate_adapter_boundary(self) -> None:
         @dataclass(frozen=True)
         class TestNativeRecordAdapter(NativeDetectionRecordAdapter):

--- a/control-plane/tests/test_wazuh_adapter.py
+++ b/control-plane/tests/test_wazuh_adapter.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import pathlib
+import sys
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
+
+
+FIXTURES_ROOT = pathlib.Path(__file__).resolve().parent / "fixtures" / "wazuh"
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+
+
+class WazuhAlertAdapterTests(unittest.TestCase):
+    def test_adapter_builds_native_detection_record_from_agent_origin_fixture(self) -> None:
+        adapter = WazuhAlertAdapter()
+
+        record = adapter.build_native_detection_record(
+            _load_fixture("agent-origin-alert.json")
+        )
+
+        self.assertEqual(record.substrate_key, "wazuh")
+        self.assertEqual(record.native_record_id, "1731594986.4931506")
+        self.assertEqual(record.record_kind, "alert")
+        self.assertEqual(record.correlation_key, "wazuh:rule:5710:source:agent:007")
+        self.assertEqual(
+            record.first_seen_at,
+            datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(record.last_seen_at, record.first_seen_at)
+        self.assertEqual(record.metadata["source_system"], "wazuh")
+        self.assertEqual(record.metadata["native_rule"]["level"], 10)
+        self.assertEqual(record.metadata["native_rule"]["description"], "SSH brute force attempt")
+        self.assertEqual(
+            record.metadata["source_provenance"]["accountable_source_identity"],
+            "agent:007",
+        )
+        self.assertEqual(
+            record.metadata["source_provenance"]["decoder_name"],
+            "sshd",
+        )
+        self.assertEqual(
+            record.metadata["source_provenance"]["location"],
+            "/var/log/auth.log",
+        )
+
+    def test_adapter_accepts_manager_origin_fixture_when_agent_identity_is_absent(self) -> None:
+        adapter = WazuhAlertAdapter()
+
+        record = adapter.build_native_detection_record(
+            _load_fixture("manager-origin-alert.json")
+        )
+        admission = adapter.build_analytic_signal_admission(record)
+
+        self.assertEqual(
+            record.correlation_key,
+            "wazuh:rule:100001:source:manager:wazuh-manager-2",
+        )
+        self.assertEqual(
+            record.metadata["source_provenance"]["accountable_source_identity"],
+            "manager:wazuh-manager-2",
+        )
+        self.assertEqual(
+            admission.finding_id,
+            "finding:wazuh:rule:100001:source:manager:wazuh-manager-2:alert:1731594999.4931507",
+        )
+        self.assertIsNone(admission.analytic_signal_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reviewed `WazuhAlertAdapter` for Wazuh-native alert intake
- add reviewed Wazuh alert fixtures for agent-origin and manager-origin records
- prove fixture-backed Wazuh admission persists first-class analytic signals through the substrate-adapter boundary

## Verification
- `python3 -m unittest control-plane.tests.test_wazuh_adapter`
- `python3 -m unittest control-plane.tests.test_service_persistence`
- `python3 -m unittest control-plane.tests.test_wazuh_alert_ingest_contract_docs`
- `rg -n "Wazuh|wazuh|AnalyticSignal|NativeDetectionRecordAdapter|fixture" control-plane docs`

## Scope
- adapter, fixtures, and admission behavior only
- no dedupe refinement, queue policy, or live Wazuh deployment changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wazuh alert ingestion support enabling processing of both agent-origin and manager-origin alerts
  * Extracts comprehensive metadata including rule information, source identity, decoder details, and location data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->