### PR TITLE
[codex] Propagate case linkage across Wazuh signal restatements

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -390,6 +390,7 @@ class AegisOpsControlPlaneService:
                 (),
                 substrate_detection_record_id,
             )
+            linked_case_ids = self._merge_linked_ids((), alert.case_id)
             persisted_first_seen = first_seen_at
             persisted_last_seen = last_seen_at
         else:
@@ -405,6 +406,7 @@ class AegisOpsControlPlaneService:
             existing_substrate_detection_ids = latest_reconciliation.subject_linkage.get(
                 "substrate_detection_record_ids"
             )
+            existing_case_ids = latest_reconciliation.subject_linkage.get("case_ids")
             linked_finding_ids = self._merge_linked_ids(
                 existing_finding_ids,
                 finding_id,
@@ -416,6 +418,10 @@ class AegisOpsControlPlaneService:
             linked_substrate_detection_ids = self._merge_linked_ids(
                 existing_substrate_detection_ids,
                 substrate_detection_record_id,
+            )
+            linked_case_ids = self._merge_linked_ids(
+                existing_case_ids,
+                alert.case_id,
             )
             persisted_first_seen = min(
                 latest_reconciliation.first_seen_at or first_seen_at,
@@ -493,11 +499,14 @@ class AegisOpsControlPlaneService:
                 )
             )
 
+        self._link_case_to_analytic_signals(linked_signal_ids, alert.case_id)
+
         reconciliation = self.persist_record(
             ReconciliationRecord(
                 reconciliation_id=self._next_identifier("reconciliation"),
                 subject_linkage={
                     "alert_ids": (alert.alert_id,),
+                    "case_ids": linked_case_ids,
                     "substrate_detection_record_ids": linked_substrate_detection_ids,
                     "finding_ids": linked_finding_ids,
                     "analytic_signal_ids": linked_signal_ids,
@@ -656,6 +665,37 @@ class AegisOpsControlPlaneService:
     @staticmethod
     def _linked_id_exists(existing_values: object, candidate: str) -> bool:
         return isinstance(existing_values, (list, tuple)) and candidate in existing_values
+
+    def _link_case_to_analytic_signals(
+        self,
+        analytic_signal_ids: tuple[str, ...],
+        case_id: str | None,
+    ) -> None:
+        if case_id is None:
+            return
+
+        for analytic_signal_id in analytic_signal_ids:
+            existing_signal = self._store.get(AnalyticSignalRecord, analytic_signal_id)
+            if existing_signal is None:
+                continue
+            linked_case_ids = self._merge_linked_ids(existing_signal.case_ids, case_id)
+            if linked_case_ids == existing_signal.case_ids:
+                continue
+            self.persist_record(
+                AnalyticSignalRecord(
+                    analytic_signal_id=existing_signal.analytic_signal_id,
+                    substrate_detection_record_id=(
+                        existing_signal.substrate_detection_record_id
+                    ),
+                    finding_id=existing_signal.finding_id,
+                    alert_ids=existing_signal.alert_ids,
+                    case_ids=linked_case_ids,
+                    correlation_key=existing_signal.correlation_key,
+                    first_seen_at=existing_signal.first_seen_at,
+                    last_seen_at=existing_signal.last_seen_at,
+                    lifecycle_state=existing_signal.lifecycle_state,
+                )
+            )
 
     def _resolve_analytic_signal_id(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -18,6 +18,7 @@ from aegisops_control_plane.models import (
     AnalyticSignalAdmission,
     AnalyticSignalRecord,
     AlertRecord,
+    CaseRecord,
     NativeDetectionRecord,
     ReconciliationRecord,
 )
@@ -93,6 +94,63 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             reconciliation.subject_linkage["analytic_signal_ids"],
             (admitted.alert.analytic_signal_id,),
         )
+
+    def test_service_extends_promoted_wazuh_alert_with_existing_case_linkage(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+        created = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("agent-origin-alert.json")
+            ),
+        )
+        service.persist_record(
+            AlertRecord(
+                alert_id=created.alert.alert_id,
+                finding_id=created.alert.finding_id,
+                analytic_signal_id=created.alert.analytic_signal_id,
+                case_id="case-001",
+                lifecycle_state="escalated_to_case",
+            )
+        )
+        service.persist_record(
+            CaseRecord(
+                case_id="case-001",
+                alert_id=created.alert.alert_id,
+                finding_id=created.alert.finding_id,
+                evidence_ids=("evidence-001",),
+                lifecycle_state="investigating",
+            )
+        )
+
+        restated_payload = _load_wazuh_fixture("agent-origin-alert.json")
+        restated_payload["id"] = "1731595888.5000001"
+        restated_payload["timestamp"] = "2026-04-05T12:15:00+00:00"
+        restated = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(restated_payload),
+        )
+
+        restated_signal = service.get_record(
+            AnalyticSignalRecord,
+            restated.alert.analytic_signal_id,
+        )
+        reconciliation = service.get_record(
+            ReconciliationRecord,
+            restated.reconciliation.reconciliation_id,
+        )
+
+        self.assertEqual(restated.disposition, "restated")
+        self.assertEqual(restated.alert.alert_id, created.alert.alert_id)
+        self.assertEqual(restated.alert.case_id, "case-001")
+        self.assertIsNotNone(restated_signal)
+        self.assertEqual(restated_signal.case_ids, ("case-001",))
+        self.assertIsNotNone(reconciliation)
+        self.assertEqual(reconciliation.subject_linkage["case_ids"], ("case-001",))
 
     def test_service_admits_native_detection_records_via_substrate_adapter_boundary(self) -> None:
         @dataclass(frozen=True)


### PR DESCRIPTION
## What changed
- propagated `case_id` linkage onto Wazuh-linked analytic signals when a repeated or restated signal lands on an alert already promoted into a case
- included linked `case_ids` in reconciliation subject linkage for the resulting restatement record
- added a focused persistence test covering a Wazuh restatement against an alert already escalated into a case

## Why
Repeated Wazuh-origin signals were preserving the alert linkage but could drop the promoted case linkage from the analytic-signal chain and reconciliation record. That broke the stable lineage expected from dedupe/restatement handling once an alert had already moved into case workflow.

## Impact
This keeps Wazuh-driven restatements on one reviewed dedupe path with stable alert and case linkage, preserving lineage for downstream case-promotion behavior.

## Verification
- `python3 -m unittest control-plane.tests.test_service_persistence`
- `rg -n "dedupe|restated|case-promotion|Wazuh|wazuh" control-plane docs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced case association tracking to preserve case linkage across reconciliation records and analytic signals during ingestion and updates.

* **Tests**
  * Added comprehensive test coverage for case linkage preservation when signals are restated or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->