### PR TITLE
[codex] Add Phase 12 Wazuh CI validation coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,18 @@ jobs:
       - name: Run Phase 11 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-11-workflow-coverage.sh
 
+      - name: Run Phase 12 workflow coverage guard
+        run: bash scripts/test-verify-ci-phase-12-workflow-coverage.sh
+
       - name: Run Phase 11 control-plane validation
         run: |
           bash scripts/verify-phase-11-control-plane-ci-validation.sh
           python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_postgres_store control-plane.tests.test_cli_inspection
+
+      - name: Run Phase 12 Wazuh validation
+        run: |
+          bash scripts/verify-phase-12-wazuh-ci-validation.sh
+          python3 -m unittest control-plane.tests.test_wazuh_alert_ingest_contract_docs control-plane.tests.test_wazuh_adapter control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection
 
       - name: Run control-plane runtime unit tests
         run: python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
@@ -117,6 +125,7 @@ jobs:
           bash scripts/test-verify-ci-phase-9-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-10-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-11-workflow-coverage.sh
+          bash scripts/test-verify-ci-phase-12-workflow-coverage.sh
           bash scripts/test-verify-detection-lifecycle-and-rule-qa-framework.sh
           bash scripts/test-verify-phase-5-semantic-contract-validation.sh
           bash scripts/test-verify-phase-7-ai-hunt-design-validation.sh
@@ -124,6 +133,7 @@ jobs:
           bash scripts/test-verify-phase-9-control-plane-runtime-boundary-validation.sh
           bash scripts/test-verify-phase-10-thesis-consistency.sh
           bash scripts/test-verify-phase-11-control-plane-ci-validation.sh
+          bash scripts/test-verify-phase-12-wazuh-ci-validation.sh
           bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
           bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
           bash scripts/test-verify-phase-6-replay-to-notify-validation.sh

--- a/docs/phase-12-wazuh-ci-validation.md
+++ b/docs/phase-12-wazuh-ci-validation.md
@@ -1,0 +1,51 @@
+# Phase 12 Wazuh Ingest and Workflow CI Validation
+
+- Validation date: 2026-04-07
+- Validation scope: Phase 12 review of Wazuh ingest contract coverage, fixture-backed admissions, alert and case lifecycle behavior, analyst queue invariants, and CI wiring for the reviewed Wazuh control-plane path
+- Baseline references: `docs/wazuh-alert-ingest-contract.md`, `docs/wazuh-rule-lifecycle-runbook.md`, `control-plane/tests/test_wazuh_alert_ingest_contract_docs.py`, `control-plane/tests/test_wazuh_adapter.py`, `control-plane/tests/test_service_persistence.py`, `control-plane/tests/test_cli_inspection.py`, `.github/workflows/ci.yml`
+- Verification commands: `bash scripts/verify-wazuh-rule-lifecycle-runbook.sh`, `python3 -m unittest control-plane.tests.test_wazuh_alert_ingest_contract_docs control-plane.tests.test_wazuh_adapter control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection`, `bash scripts/test-verify-ci-phase-12-workflow-coverage.sh`, `bash scripts/verify-phase-12-wazuh-ci-validation.sh`
+- Validation status: PASS
+
+## Required Boundary Artifacts
+
+- `docs/wazuh-alert-ingest-contract.md`
+- `docs/wazuh-rule-lifecycle-runbook.md`
+- `control-plane/tests/test_wazuh_alert_ingest_contract_docs.py`
+- `control-plane/tests/test_wazuh_adapter.py`
+- `control-plane/tests/test_service_persistence.py`
+- `control-plane/tests/test_cli_inspection.py`
+- `.github/workflows/ci.yml`
+
+## Review Outcome
+
+Confirmed the reviewed Wazuh ingest contract remains explicit about native identifier preservation, namespaced `substrate_detection_record_id` linkage, native timing preservation, and accountable source provenance.
+
+Confirmed fixture-backed Wazuh adapter coverage still admits both agent-origin and manager-origin alerts through the reviewed substrate-adapter boundary.
+
+Confirmed the reviewed service persistence path still admits Wazuh-origin analytic signals, preserves restated case linkage, and exposes analyst queue records with Wazuh-native rule and accountable source context.
+
+Confirmed analyst queue review keeps Wazuh-specific source precedence when multi-source linkage is present so queue routing does not drift away from the reviewed Phase 12 ingest path.
+
+Confirmed the CLI inspection path still renders the read-only Wazuh business-hours analyst queue view from the same reviewed control-plane state.
+
+Confirmed CI now runs a dedicated Phase 12 validation step and a workflow coverage guard so failures point to the reviewed Wazuh ingest and workflow boundary instead of only surfacing through broad suite discovery.
+
+## Cross-Link Review
+
+`docs/wazuh-alert-ingest-contract.md` must continue to define the reviewed Wazuh-native required fields, provenance set, and identifier mapping that the Phase 12 intake path preserves.
+
+`docs/wazuh-rule-lifecycle-runbook.md` must continue to require fixture refresh and aligned adapter and persistence tests before downstream workflow logic relies on a Wazuh rule change.
+
+`control-plane/tests/test_wazuh_alert_ingest_contract_docs.py` must continue to guard the reviewed Wazuh contract document and its required cross-links.
+
+`control-plane/tests/test_wazuh_adapter.py` must continue to guard fixture-backed Wazuh native-record and source-identity admission behavior.
+
+`control-plane/tests/test_service_persistence.py` must continue to guard Wazuh ingest admission, alert and case lifecycle linkage, and analyst queue invariants.
+
+`control-plane/tests/test_cli_inspection.py` must continue to guard the read-only Wazuh analyst queue inspection path.
+
+`.github/workflows/ci.yml` must continue to run the dedicated Phase 12 validation step, the focused Wazuh unit-test command, and the workflow coverage guard.
+
+## Deviations
+
+No deviations found.

--- a/scripts/test-verify-ci-phase-12-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-12-workflow-coverage.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+required_verifiers=(
+  "bash scripts/verify-phase-12-wazuh-ci-validation.sh"
+)
+
+required_tests=(
+  "bash scripts/test-verify-phase-12-wazuh-ci-validation.sh"
+)
+
+required_runtime_commands=(
+  "python3 -m unittest control-plane.tests.test_wazuh_alert_ingest_contract_docs control-plane.tests.test_wazuh_adapter control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection"
+)
+
+self_guard_step_name="Run Phase 12 workflow coverage guard"
+self_guard_command="bash scripts/test-verify-ci-phase-12-workflow-coverage.sh"
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+collect_active_run_commands() {
+  awk '
+    {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent > block_indent) {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          if (line != "" && line !~ /^#/) {
+            print line
+          }
+          next
+        }
+
+        in_block = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+        block_indent = match($0, /[^ ]/) - 1
+        in_block = 1
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[^|>]/) {
+        line = $0
+        sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+        if (line != "" && line !~ /^#/) {
+          print line
+        }
+      }
+    }
+  ' "${workflow_path}"
+}
+
+active_run_commands="$(collect_active_run_commands)"
+
+for command in "${required_verifiers[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 12 verifier command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_tests[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 12 focused shell test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_runtime_commands[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 12 focused Wazuh runtime test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Eq "^[[:space:]]*- name: ${self_guard_step_name}\$" "${workflow_path}"; then
+  echo "Missing dedicated Phase 12 workflow coverage guard step in CI workflow: ${self_guard_step_name}" >&2
+  exit 1
+fi
+
+self_guard_count="$(grep -Fxc -- "${self_guard_command}" <<<"${active_run_commands}" || true)"
+if [[ "${self_guard_count}" -lt 2 ]]; then
+  echo "Phase 12 workflow coverage checker must run both as a dedicated guard and within focused shell tests." >&2
+  exit 1
+fi
+
+echo "CI workflow includes the required Phase 12 verifier, focused shell test, and focused Wazuh runtime command."

--- a/scripts/test-verify-phase-12-wazuh-ci-validation.sh
+++ b/scripts/test-verify-phase-12-wazuh-ci-validation.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-12-wazuh-ci-validation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+required_artifacts=(
+  "docs/wazuh-alert-ingest-contract.md"
+  "docs/wazuh-rule-lifecycle-runbook.md"
+  "docs/phase-12-wazuh-ci-validation.md"
+  "control-plane/tests/test_wazuh_alert_ingest_contract_docs.py"
+  "control-plane/tests/test_wazuh_adapter.py"
+  "control-plane/tests/test_service_persistence.py"
+  "control-plane/tests/test_cli_inspection.py"
+  ".github/workflows/ci.yml"
+)
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs" "${target}/control-plane/tests" "${target}/.github/workflows"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_required_artifacts() {
+  local target="$1"
+  local artifact=""
+
+  for artifact in "${required_artifacts[@]}"; do
+    mkdir -p "${target}/$(dirname "${artifact}")"
+    cp "${repo_root}/${artifact}" "${target}/${artifact}"
+    git -C "${target}" add "${artifact}"
+  done
+}
+
+remove_text_from_file() {
+  local target="$1"
+  local path="$2"
+  local expected_text="$3"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+replace_text_in_file() {
+  local target="$1"
+  local path="$2"
+  local old_text="$3"
+  local new_text="$4"
+
+  OLD_TEXT="${old_text}" NEW_TEXT="${new_text}" perl -0pi -e 's/\Q$ENV{OLD_TEXT}\E/$ENV{NEW_TEXT}/g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_required_artifacts "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_validation_repo="${workdir}/missing-validation"
+create_repo "${missing_validation_repo}"
+write_required_artifacts "${missing_validation_repo}"
+rm "${missing_validation_repo}/docs/phase-12-wazuh-ci-validation.md"
+git -C "${missing_validation_repo}" add -u docs/phase-12-wazuh-ci-validation.md
+commit_fixture "${missing_validation_repo}"
+assert_fails_with "${missing_validation_repo}" "Missing Phase 12 Wazuh CI validation record:"
+
+missing_queue_test_repo="${workdir}/missing-queue-test"
+create_repo "${missing_queue_test_repo}"
+write_required_artifacts "${missing_queue_test_repo}"
+remove_text_from_file "${missing_queue_test_repo}" "control-plane/tests/test_service_persistence.py" "def test_service_exposes_wazuh_origin_alerts_in_business_hours_analyst_queue(self) -> None:"
+commit_fixture "${missing_queue_test_repo}"
+assert_fails_with "${missing_queue_test_repo}" "Missing required Phase 12 test in ${missing_queue_test_repo}/control-plane/tests/test_service_persistence.py: test_service_exposes_wazuh_origin_alerts_in_business_hours_analyst_queue"
+
+stale_contract_repo="${workdir}/stale-contract"
+create_repo "${stale_contract_repo}"
+write_required_artifacts "${stale_contract_repo}"
+replace_text_in_file \
+  "${stale_contract_repo}" \
+  "docs/wazuh-alert-ingest-contract.md" \
+  '| `substrate_detection_record_id` | Set to `wazuh:<id>` unless the input is already namespaced as `wazuh:<id>`. This matches the shipped control-plane rule that substrate detection identifiers are namespaced by substrate key. |' \
+  '| `substrate_detection_record_id` | May mirror any upstream identifier shape. |'
+commit_fixture "${stale_contract_repo}"
+assert_fails_with "${stale_contract_repo}" "Missing required line in ${stale_contract_repo}/docs/wazuh-alert-ingest-contract.md: | \`substrate_detection_record_id\` | Set to \`wazuh:<id>\` unless the input is already namespaced as \`wazuh:<id>\`. This matches the shipped control-plane rule that substrate detection identifiers are namespaced by substrate key. |"
+
+missing_ci_step_repo="${workdir}/missing-ci-step"
+create_repo "${missing_ci_step_repo}"
+write_required_artifacts "${missing_ci_step_repo}"
+remove_text_from_file "${missing_ci_step_repo}" ".github/workflows/ci.yml" "      - name: Run Phase 12 Wazuh validation"
+commit_fixture "${missing_ci_step_repo}"
+assert_fails_with "${missing_ci_step_repo}" "Missing required line in ${missing_ci_step_repo}/.github/workflows/ci.yml:       - name: Run Phase 12 Wazuh validation"
+
+missing_review_repo="${workdir}/missing-review"
+create_repo "${missing_review_repo}"
+write_required_artifacts "${missing_review_repo}"
+remove_text_from_file \
+  "${missing_review_repo}" \
+  "docs/phase-12-wazuh-ci-validation.md" \
+  "Confirmed analyst queue review keeps Wazuh-specific source precedence when multi-source linkage is present so queue routing does not drift away from the reviewed Phase 12 ingest path."
+commit_fixture "${missing_review_repo}"
+assert_fails_with "${missing_review_repo}" "Missing required line in ${missing_review_repo}/docs/phase-12-wazuh-ci-validation.md: Confirmed analyst queue review keeps Wazuh-specific source precedence when multi-source linkage is present so queue routing does not drift away from the reviewed Phase 12 ingest path."
+
+echo "Phase 12 Wazuh CI validation verifier fails closed for missing reviewed coverage."

--- a/scripts/verify-phase-12-wazuh-ci-validation.sh
+++ b/scripts/verify-phase-12-wazuh-ci-validation.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+default_repo_root="$(cd "${script_dir}/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+validation_doc="${repo_root}/docs/phase-12-wazuh-ci-validation.md"
+contract_doc="${repo_root}/docs/wazuh-alert-ingest-contract.md"
+runbook_doc="${repo_root}/docs/wazuh-rule-lifecycle-runbook.md"
+contract_doc_tests="${repo_root}/control-plane/tests/test_wazuh_alert_ingest_contract_docs.py"
+adapter_tests="${repo_root}/control-plane/tests/test_wazuh_adapter.py"
+service_tests="${repo_root}/control-plane/tests/test_service_persistence.py"
+cli_tests="${repo_root}/control-plane/tests/test_cli_inspection.py"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+bash "${script_dir}/verify-wazuh-rule-lifecycle-runbook.sh" "${repo_root}"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_string() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required line in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_test_name() {
+  local file_path="$1"
+  local test_name="$2"
+
+  if ! grep -Fq -- "def ${test_name}" "${file_path}" >/dev/null; then
+    echo "Missing required Phase 12 test in ${file_path}: ${test_name}" >&2
+    exit 1
+  fi
+}
+
+require_file "${validation_doc}" "Missing Phase 12 Wazuh CI validation record"
+require_file "${contract_doc}" "Missing Wazuh alert ingest contract document"
+require_file "${runbook_doc}" "Missing Wazuh rule lifecycle runbook"
+require_file "${contract_doc_tests}" "Missing Wazuh contract documentation tests"
+require_file "${adapter_tests}" "Missing Wazuh adapter tests"
+require_file "${service_tests}" "Missing control-plane service persistence tests"
+require_file "${cli_tests}" "Missing control-plane CLI inspection tests"
+require_file "${workflow_path}" "Missing CI workflow"
+
+validation_required_phrases=(
+  "# Phase 12 Wazuh Ingest and Workflow CI Validation"
+  "- Validation date: 2026-04-07"
+  "- Validation scope: Phase 12 review of Wazuh ingest contract coverage, fixture-backed admissions, alert and case lifecycle behavior, analyst queue invariants, and CI wiring for the reviewed Wazuh control-plane path"
+  "- Baseline references: \`docs/wazuh-alert-ingest-contract.md\`, \`docs/wazuh-rule-lifecycle-runbook.md\`, \`control-plane/tests/test_wazuh_alert_ingest_contract_docs.py\`, \`control-plane/tests/test_wazuh_adapter.py\`, \`control-plane/tests/test_service_persistence.py\`, \`control-plane/tests/test_cli_inspection.py\`, \`.github/workflows/ci.yml\`"
+  "- Verification commands: \`bash scripts/verify-wazuh-rule-lifecycle-runbook.sh\`, \`python3 -m unittest control-plane.tests.test_wazuh_alert_ingest_contract_docs control-plane.tests.test_wazuh_adapter control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection\`, \`bash scripts/test-verify-ci-phase-12-workflow-coverage.sh\`, \`bash scripts/verify-phase-12-wazuh-ci-validation.sh\`"
+  "- Validation status: PASS"
+  "## Required Boundary Artifacts"
+  "## Review Outcome"
+  "## Cross-Link Review"
+  "## Deviations"
+  'Confirmed the reviewed Wazuh ingest contract remains explicit about native identifier preservation, namespaced `substrate_detection_record_id` linkage, native timing preservation, and accountable source provenance.'
+  "Confirmed fixture-backed Wazuh adapter coverage still admits both agent-origin and manager-origin alerts through the reviewed substrate-adapter boundary."
+  "Confirmed the reviewed service persistence path still admits Wazuh-origin analytic signals, preserves restated case linkage, and exposes analyst queue records with Wazuh-native rule and accountable source context."
+  "Confirmed analyst queue review keeps Wazuh-specific source precedence when multi-source linkage is present so queue routing does not drift away from the reviewed Phase 12 ingest path."
+  "Confirmed the CLI inspection path still renders the read-only Wazuh business-hours analyst queue view from the same reviewed control-plane state."
+  "Confirmed CI now runs a dedicated Phase 12 validation step and a workflow coverage guard so failures point to the reviewed Wazuh ingest and workflow boundary instead of only surfacing through broad suite discovery."
+  '`docs/wazuh-alert-ingest-contract.md` must continue to define the reviewed Wazuh-native required fields, provenance set, and identifier mapping that the Phase 12 intake path preserves.'
+  '`docs/wazuh-rule-lifecycle-runbook.md` must continue to require fixture refresh and aligned adapter and persistence tests before downstream workflow logic relies on a Wazuh rule change.'
+  '`control-plane/tests/test_wazuh_alert_ingest_contract_docs.py` must continue to guard the reviewed Wazuh contract document and its required cross-links.'
+  '`control-plane/tests/test_wazuh_adapter.py` must continue to guard fixture-backed Wazuh native-record and source-identity admission behavior.'
+  '`control-plane/tests/test_service_persistence.py` must continue to guard Wazuh ingest admission, alert and case lifecycle linkage, and analyst queue invariants.'
+  '`control-plane/tests/test_cli_inspection.py` must continue to guard the read-only Wazuh analyst queue inspection path.'
+  '`.github/workflows/ci.yml` must continue to run the dedicated Phase 12 validation step, the focused Wazuh unit-test command, and the workflow coverage guard.'
+  "No deviations found."
+)
+
+for phrase in "${validation_required_phrases[@]}"; do
+  require_fixed_string "${validation_doc}" "${phrase}"
+done
+
+required_artifacts=(
+  "docs/wazuh-alert-ingest-contract.md"
+  "docs/wazuh-rule-lifecycle-runbook.md"
+  "control-plane/tests/test_wazuh_alert_ingest_contract_docs.py"
+  "control-plane/tests/test_wazuh_adapter.py"
+  "control-plane/tests/test_service_persistence.py"
+  "control-plane/tests/test_cli_inspection.py"
+  ".github/workflows/ci.yml"
+)
+
+for artifact in "${required_artifacts[@]}"; do
+  require_file "${repo_root}/${artifact}" "Missing required Phase 12 artifact"
+
+  if ! grep -Fqx -- "- \`${artifact}\`" "${validation_doc}" >/dev/null; then
+    echo "Phase 12 validation record must list required artifact: ${artifact}" >&2
+    exit 1
+  fi
+done
+
+require_fixed_string "${contract_doc}" '| `substrate_detection_record_id` | Set to `wazuh:<id>` unless the input is already namespaced as `wazuh:<id>`. This matches the shipped control-plane rule that substrate detection identifiers are namespaced by substrate key. |'
+require_fixed_string "${runbook_doc}" 'At minimum, the fixture-backed review path must keep `control-plane/tests/test_wazuh_adapter.py` and `control-plane/tests/test_service_persistence.py` aligned with the reviewed rule behavior before downstream workflow logic can rely on it.'
+
+require_test_name "${contract_doc_tests}" "test_wazuh_contract_doc_defines_required_mapping_and_ownership_terms"
+require_test_name "${adapter_tests}" "test_adapter_builds_native_detection_record_from_agent_origin_fixture"
+require_test_name "${adapter_tests}" "test_adapter_accepts_manager_origin_fixture_when_agent_identity_is_absent"
+require_test_name "${service_tests}" "test_service_admits_wazuh_fixture_through_substrate_adapter_boundary"
+require_test_name "${service_tests}" "test_service_extends_promoted_wazuh_alert_with_existing_case_linkage"
+require_test_name "${service_tests}" "test_service_exposes_wazuh_origin_alerts_in_business_hours_analyst_queue"
+require_test_name "${service_tests}" "test_service_analyst_queue_prefers_explicit_wazuh_source_for_multi_source_linkage"
+require_test_name "${cli_tests}" "test_cli_renders_wazuh_business_hours_analyst_queue_view"
+
+require_fixed_string "${workflow_path}" "      - name: Run Phase 12 workflow coverage guard"
+require_fixed_string "${workflow_path}" "      - name: Run Phase 12 Wazuh validation"
+
+echo "Phase 12 Wazuh ingest and workflow CI validation remains reviewable and fail closed."


### PR DESCRIPTION
## Summary
- add a dedicated Phase 12 Wazuh CI validation record and fail-closed verifier
- add a workflow coverage guard so CI fails if the focused Phase 12 validation steps drift
- wire the CI workflow to run the Phase 12 Wazuh validation and focused shell coverage checks

## Why
Phase 12 Wazuh ingest and analyst workflow behavior already had reviewed runtime coverage, but the repository lacked a dedicated CI validation surface to keep those guarantees reviewable and fail closed.

## Validation
- bash scripts/test-verify-ci-phase-12-workflow-coverage.sh
- bash scripts/verify-phase-12-wazuh-ci-validation.sh
- bash scripts/test-verify-phase-12-wazuh-ci-validation.sh
- python3 -m unittest control-plane.tests.test_wazuh_alert_ingest_contract_docs control-plane.tests.test_wazuh_adapter control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection
- python3 -m unittest discover -s control-plane/tests -p 'test_*.py'

## Notes
- `python3 -m unittest control-plane.tests` reports `NO TESTS RAN` in this workspace, so validation uses explicit Wazuh targets plus unittest discovery instead.
