### PR TITLE
[codex] Harden Wazuh correlation boundaries

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/wazuh.py
+++ b/control-plane/aegisops_control_plane/adapters/wazuh.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Mapping
+from urllib.parse import quote
 
 from ..models import AnalyticSignalAdmission, NativeDetectionRecord
 
@@ -36,6 +37,13 @@ def _optional_string_tuple(value: object) -> tuple[str, ...]:
 @dataclass(frozen=True)
 class WazuhAlertAdapter:
     substrate_key: str = "wazuh"
+    reviewed_correlation_fields: tuple[str, ...] = (
+        "location",
+        "data.srcip",
+        "data.srcuser",
+        "data.integration",
+        "data.event_type",
+    )
 
     def build_native_detection_record(
         self,
@@ -62,8 +70,13 @@ class WazuhAlertAdapter:
             agent,
             manager,
         )
-        correlation_key = (
-            f"wazuh:rule:{rule_id}:source:{accountable_source_identity}"
+        reviewed_correlation_context = self._build_reviewed_correlation_context(
+            native_alert
+        )
+        correlation_key = self._build_correlation_key(
+            rule_id,
+            accountable_source_identity,
+            reviewed_correlation_context,
         )
 
         metadata = {
@@ -85,6 +98,7 @@ class WazuhAlertAdapter:
                 ),
                 "location": _optional_string(native_alert.get("location")),
             },
+            "reviewed_correlation_context": dict(reviewed_correlation_context),
         }
 
         return NativeDetectionRecord(
@@ -148,3 +162,39 @@ class WazuhAlertAdapter:
         raise ValueError(
             "agent.id or manager.name must provide an accountable source identity"
         )
+
+    def _build_reviewed_correlation_context(
+        self,
+        alert: Mapping[str, object],
+    ) -> tuple[tuple[str, str], ...]:
+        context: list[tuple[str, str]] = []
+        for field_path in self.reviewed_correlation_fields:
+            value = self._extract_reviewed_correlation_value(alert, field_path)
+            if value is not None:
+                context.append((field_path, value))
+        return tuple(context)
+
+    def _build_correlation_key(
+        self,
+        rule_id: str,
+        accountable_source_identity: str,
+        reviewed_correlation_context: tuple[tuple[str, str], ...],
+    ) -> str:
+        correlation_key = (
+            f"wazuh:rule:{rule_id}:source:{accountable_source_identity}"
+        )
+        for field_path, value in reviewed_correlation_context:
+            correlation_key += f":{field_path}={quote(value, safe='')}"
+        return correlation_key
+
+    @staticmethod
+    def _extract_reviewed_correlation_value(
+        alert: Mapping[str, object],
+        field_path: str,
+    ) -> str | None:
+        current: object = alert
+        for segment in field_path.split("."):
+            if not isinstance(current, Mapping):
+                return None
+            current = current.get(segment)
+        return _optional_string(current)

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -757,6 +757,14 @@ class AegisOpsControlPlaneService:
                 "description": native_rule_description,
             }
 
+        reviewed_correlation_context = record.metadata.get("reviewed_correlation_context")
+        if isinstance(reviewed_correlation_context, Mapping):
+            subject_linkage["reviewed_correlation_context"] = {
+                str(field_name): field_value
+                for field_name, field_value in reviewed_correlation_context.items()
+                if isinstance(field_value, str) and field_value.strip()
+            }
+
         raw_alert = record.metadata.get("raw_alert")
         if isinstance(raw_alert, Mapping):
             subject_linkage["latest_native_payload"] = dict(raw_alert)

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -70,7 +70,12 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
         self.assertEqual(
             signals[0].correlation_key,
-            "wazuh:rule:5710:source:agent:007",
+            (
+                "wazuh:rule:5710:source:agent:007"
+                ":location=%2Fvar%2Flog%2Fauth.log"
+                ":data.srcip=198.51.100.24"
+                ":data.srcuser=invalid-user"
+            ),
         )
         self.assertEqual(
             signals[0].first_seen_at,
@@ -94,6 +99,14 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(
             reconciliation.subject_linkage["analytic_signal_ids"],
             (admitted.alert.analytic_signal_id,),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["reviewed_correlation_context"],
+            {
+                "location": "/var/log/auth.log",
+                "data.srcip": "198.51.100.24",
+                "data.srcuser": "invalid-user",
+            },
         )
 
     def test_service_extends_promoted_wazuh_alert_with_existing_case_linkage(self) -> None:
@@ -152,6 +165,62 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(restated_signal.case_ids, ("case-001",))
         self.assertIsNotNone(reconciliation)
         self.assertEqual(reconciliation.subject_linkage["case_ids"], ("case-001",))
+
+    def test_service_keeps_distinct_wazuh_incidents_separate_when_native_context_differs(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+
+        first_payload = _load_wazuh_fixture("agent-origin-alert.json")
+        second_payload = _load_wazuh_fixture("agent-origin-alert.json")
+        second_payload["id"] = "1731595888.5000001"
+        second_payload["timestamp"] = "2026-04-05T12:15:00+00:00"
+        second_payload["location"] = "/var/log/secure"
+        second_payload["data"] = {
+            "srcip": "203.0.113.77",
+            "srcuser": "invalid-user",
+        }
+
+        created = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(first_payload),
+        )
+        distinct = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(second_payload),
+        )
+
+        self.assertEqual(created.disposition, "created")
+        self.assertEqual(distinct.disposition, "created")
+        self.assertNotEqual(distinct.alert.alert_id, created.alert.alert_id)
+
+        alerts = store.list(AlertRecord)
+        self.assertEqual(len(alerts), 2)
+
+        first_reconciliation = service.get_record(
+            ReconciliationRecord,
+            created.reconciliation.reconciliation_id,
+        )
+        second_reconciliation = service.get_record(
+            ReconciliationRecord,
+            distinct.reconciliation.reconciliation_id,
+        )
+
+        self.assertIsNotNone(first_reconciliation)
+        self.assertIsNotNone(second_reconciliation)
+        self.assertEqual(
+            first_reconciliation.subject_linkage["substrate_detection_record_ids"],
+            ("wazuh:1731594986.4931506",),
+        )
+        self.assertEqual(
+            second_reconciliation.subject_linkage["substrate_detection_record_ids"],
+            ("wazuh:1731595888.5000001",),
+        )
 
     def test_service_admits_native_detection_records_via_substrate_adapter_boundary(self) -> None:
         @dataclass(frozen=True)

--- a/control-plane/tests/test_wazuh_adapter.py
+++ b/control-plane/tests/test_wazuh_adapter.py
@@ -32,7 +32,15 @@ class WazuhAlertAdapterTests(unittest.TestCase):
         self.assertEqual(record.substrate_key, "wazuh")
         self.assertEqual(record.native_record_id, "1731594986.4931506")
         self.assertEqual(record.record_kind, "alert")
-        self.assertEqual(record.correlation_key, "wazuh:rule:5710:source:agent:007")
+        self.assertEqual(
+            record.correlation_key,
+            (
+                "wazuh:rule:5710:source:agent:007"
+                ":location=%2Fvar%2Flog%2Fauth.log"
+                ":data.srcip=198.51.100.24"
+                ":data.srcuser=invalid-user"
+            ),
+        )
         self.assertEqual(
             record.first_seen_at,
             datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
@@ -53,6 +61,14 @@ class WazuhAlertAdapterTests(unittest.TestCase):
             record.metadata["source_provenance"]["location"],
             "/var/log/auth.log",
         )
+        self.assertEqual(
+            record.metadata["reviewed_correlation_context"],
+            {
+                "location": "/var/log/auth.log",
+                "data.srcip": "198.51.100.24",
+                "data.srcuser": "invalid-user",
+            },
+        )
 
     def test_adapter_accepts_manager_origin_fixture_when_agent_identity_is_absent(self) -> None:
         adapter = WazuhAlertAdapter()
@@ -64,7 +80,12 @@ class WazuhAlertAdapterTests(unittest.TestCase):
 
         self.assertEqual(
             record.correlation_key,
-            "wazuh:rule:100001:source:manager:wazuh-manager-2",
+            (
+                "wazuh:rule:100001:source:manager:wazuh-manager-2"
+                ":location=manager%2Fintegrations"
+                ":data.integration=virustotal"
+                ":data.event_type=warning"
+            ),
         )
         self.assertEqual(
             record.metadata["source_provenance"]["accountable_source_identity"],
@@ -75,6 +96,23 @@ class WazuhAlertAdapterTests(unittest.TestCase):
             "finding:wazuh:rule:100001:source:manager:wazuh-manager-2:alert:1731594999.4931507",
         )
         self.assertIsNone(admission.analytic_signal_id)
+
+    def test_adapter_distinguishes_same_rule_and_source_when_reviewed_context_changes(
+        self,
+    ) -> None:
+        adapter = WazuhAlertAdapter()
+        first_alert = _load_fixture("agent-origin-alert.json")
+        second_alert = _load_fixture("agent-origin-alert.json")
+        second_alert["location"] = "/var/log/secure"
+        second_alert["data"] = {
+            "srcip": "203.0.113.77",
+            "srcuser": "invalid-user",
+        }
+
+        first_record = adapter.build_native_detection_record(first_alert)
+        second_record = adapter.build_native_detection_record(second_alert)
+
+        self.assertNotEqual(first_record.correlation_key, second_record.correlation_key)
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_wazuh_alert_ingest_contract_docs.py
+++ b/control-plane/tests/test_wazuh_alert_ingest_contract_docs.py
@@ -47,6 +47,25 @@ class WazuhAlertIngestContractDocsTests(unittest.TestCase):
             DOMAIN_MODEL_DOC.read_text(encoding="utf-8"),
         )
 
+    def test_wazuh_contract_doc_names_reviewed_correlation_allowlist_and_provenance_only_fields(
+        self,
+    ) -> None:
+        text = CONTRACT_DOC.read_text(encoding="utf-8")
+
+        required_terms = (
+            "current reviewed Wazuh correlation boundary uses the following native fields",
+            "`location`",
+            "`data.srcip`",
+            "`data.srcuser`",
+            "`data.integration`",
+            "`data.event_type`",
+            "provenance-only context",
+            "`rule.groups`",
+            "`decoder.name`",
+        )
+        for term in required_terms:
+            self.assertIn(term, text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/wazuh-alert-ingest-contract.md
+++ b/docs/wazuh-alert-ingest-contract.md
@@ -100,7 +100,27 @@ The admitted signal must preserve:
 - reviewed timing from Wazuh `timestamp`; and
 - enough preserved source context to explain why later alert or case routing happened.
 
-Correlation or deduplication inputs may additionally use Wazuh `rule.groups`, `agent.name`, `location`, selected `data.*` fields, and other reviewed source-family fields, but those fields remain correlation inputs rather than lifecycle identifiers.
+The current reviewed Wazuh correlation boundary uses the following native fields in addition to `rule.id` and accountable source identity:
+
+- `location`
+- `data.srcip`
+- `data.srcuser`
+- `data.integration`
+- `data.event_type`
+
+Those fields may separate distinct incidents during deduplication or restatement decisions, but they still remain reviewed correlation inputs rather than lifecycle identifiers.
+
+The following preserved native fields remain provenance-only context in the shipped adapter and must not change alert lineage by themselves:
+
+- `rule.level`
+- `rule.description`
+- `rule.groups`
+- `rule.mitre.*`
+- `agent.name`
+- `agent.ip`
+- `manager.name` beyond its accountable-source role when no agent identity is present
+- `decoder.name`
+- additional `data.*` fields outside the reviewed correlation allowlist above
 
 ## 7. Provenance Expectations
 


### PR DESCRIPTION
## Summary
- harden the Wazuh correlation boundary so reviewed native context distinguishes materially different incidents instead of collapsing them into one alert lineage
- persist the reviewed Wazuh correlation context through reconciliation linkage and document which native fields drive correlation versus provenance-only handling
- add focused adapter, service, and contract-doc tests for both the positive restatement path and the distinct-incident path

## Root cause
The prior Wazuh correlation key effectively grouped alerts by `rule.id` plus accountable source identity, which was too broad for reviewed Wazuh incidents that shared a rule and source but differed in meaningful native context such as `location` or selected `data.*` fields.

## Validation
- `python3 -m unittest control-plane.tests.test_wazuh_adapter control-plane.tests.test_service_persistence`
- `python3 -m unittest control-plane.tests.test_wazuh_alert_ingest_contract_docs`
- `rg -n "correlation_key|location|rule\.groups|data\.|restated|deduplicated|Wazuh" control-plane docs`

Closes #259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Wazuh alert correlation and deduplication now incorporates additional context fields—location, source IP, source user, integration type, and event type—enabling more accurate incident separation and alert grouping.

* **Documentation**
  * Updated alert ingestion contract documentation to specify correlation and provenance field boundaries.

* **Tests**
  * Added test coverage for enhanced alert correlation behavior and incident distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->