### PR TITLE
Fix Wazuh restatement case evidence linkage

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -828,12 +828,13 @@ class AegisOpsControlPlaneService:
             "metadata.source_system",
         ) or record.substrate_key
         evidence_id = f"evidence-{uuid.uuid5(uuid.NAMESPACE_URL, substrate_detection_record_id)}"
+        case_id = ingest_result.alert.case_id
         evidence = self.persist_record(
             EvidenceRecord(
                 evidence_id=evidence_id,
                 source_record_id=substrate_detection_record_id,
                 alert_id=ingest_result.alert.alert_id,
-                case_id=ingest_result.alert.case_id,
+                case_id=case_id,
                 source_system=source_system,
                 collector_identity=f"{record.substrate_key}-native-detection-adapter",
                 acquired_at=self._require_aware_datetime(
@@ -841,9 +842,27 @@ class AegisOpsControlPlaneService:
                     "record.first_seen_at",
                 ),
                 derivation_relationship="native_detection_record",
-                lifecycle_state="collected",
+                lifecycle_state="linked" if case_id is not None else "collected",
             )
         )
+
+        if case_id is not None:
+            existing_case = self._store.get(CaseRecord, case_id)
+            if existing_case is not None:
+                merged_case_evidence_ids = self._merge_linked_ids(
+                    existing_case.evidence_ids,
+                    evidence.evidence_id,
+                )
+                if merged_case_evidence_ids != existing_case.evidence_ids:
+                    self.persist_record(
+                        CaseRecord(
+                            case_id=existing_case.case_id,
+                            alert_id=existing_case.alert_id,
+                            finding_id=existing_case.finding_id,
+                            evidence_ids=merged_case_evidence_ids,
+                            lifecycle_state=existing_case.lifecycle_state,
+                        )
+                    )
 
         subject_linkage = dict(ingest_result.reconciliation.subject_linkage)
         subject_linkage["evidence_ids"] = self._merge_linked_ids(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -160,7 +160,23 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(persisted_case.alert_id, created.alert.alert_id)
         self.assertEqual(persisted_case.finding_id, created.alert.finding_id)
         self.assertEqual(persisted_case.lifecycle_state, "open")
-        self.assertGreaterEqual(len(persisted_case.evidence_ids), 1)
+        evidence_records = sorted(
+            (
+                evidence
+                for evidence in store.list(EvidenceRecord)
+                if evidence.alert_id == created.alert.alert_id
+            ),
+            key=lambda evidence: evidence.evidence_id,
+        )
+        self.assertEqual(len(evidence_records), 2)
+        self.assertEqual(
+            sorted(evidence.evidence_id for evidence in evidence_records),
+            sorted(persisted_case.evidence_ids),
+        )
+        self.assertEqual(
+            tuple(evidence.case_id for evidence in evidence_records),
+            (promoted_case.case_id, promoted_case.case_id),
+        )
 
     def test_service_keeps_distinct_wazuh_incidents_separate_when_native_context_differs(
         self,


### PR DESCRIPTION
## Summary
- keep `CaseRecord.evidence_ids` synchronized when Wazuh-origin restatements collect new native evidence for an already promoted case
- persist newly collected native evidence as linked when it is created against an existing case
- add a focused regression test for promoted Wazuh alerts that receive a restated native record

## Testing
- python3 -m unittest control-plane.tests.test_service_persistence
- python3 -m unittest control-plane.tests.test_postgres_store
- rg -n "evidence_ids|EvidenceRecord|CaseRecord|latest_native_payload|Wazuh" control-plane docs