### PR TITLE
[codex] Add isolated executor delegation boundary

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/__init__.py
+++ b/control-plane/aegisops_control_plane/adapters/__init__.py
@@ -1,5 +1,6 @@
 """Adapter placeholders for the first control-plane service boundary."""
 
+from .executor import IsolatedExecutorAdapter
 from .n8n import N8NReconciliationAdapter
 from .opensearch import OpenSearchSignalAdapter
 from .postgres import PostgresControlPlaneStore
@@ -7,6 +8,7 @@ from .shuffle import ShuffleActionAdapter
 from .wazuh import WazuhAlertAdapter
 
 __all__ = [
+    "IsolatedExecutorAdapter",
     "N8NReconciliationAdapter",
     "OpenSearchSignalAdapter",
     "PostgresControlPlaneStore",

--- a/control-plane/aegisops_control_plane/adapters/executor.py
+++ b/control-plane/aegisops_control_plane/adapters/executor.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class IsolatedExecutorDelegationReceipt:
+    execution_surface_type: str
+    execution_surface_id: str
+    execution_run_id: str
+    adapter: str
+    base_url: str
+
+
+@dataclass(frozen=True)
+class IsolatedExecutorAdapter:
+    """Reviewed isolated execution boundary for high-risk approved actions."""
+
+    base_url: str
+    execution_surface_type: str = "executor"
+    execution_surface_id: str = "isolated-executor"
+
+    def dispatch_approved_action(
+        self,
+        *,
+        delegation_id: str,
+        action_request_id: str,
+        approval_decision_id: str,
+        payload_hash: str,
+        idempotency_key: str,
+        approved_payload: Mapping[str, object],
+        delegated_at: datetime,
+    ) -> IsolatedExecutorDelegationReceipt:
+        del action_request_id
+        del approval_decision_id
+        del payload_hash
+        del idempotency_key
+        del approved_payload
+        del delegated_at
+        return IsolatedExecutorDelegationReceipt(
+            execution_surface_type=self.execution_surface_type,
+            execution_surface_id=self.execution_surface_id,
+            execution_run_id=f"executor-run-{delegation_id}",
+            adapter=self.execution_surface_id,
+            base_url=self.base_url,
+        )

--- a/control-plane/aegisops_control_plane/config.py
+++ b/control-plane/aegisops_control_plane/config.py
@@ -13,6 +13,7 @@ class RuntimeConfig:
     opensearch_url: str = "<set-me>"
     n8n_base_url: str = "<set-me>"
     shuffle_base_url: str = "<set-me>"
+    isolated_executor_base_url: str = "<set-me>"
 
     @classmethod
     def from_env(cls, environ: Mapping[str, str] | None = None) -> "RuntimeConfig":
@@ -41,5 +42,9 @@ class RuntimeConfig:
             shuffle_base_url=source.get(
                 "AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL",
                 cls.shuffle_base_url,
+            ),
+            isolated_executor_base_url=source.get(
+                "AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL",
+                cls.isolated_executor_base_url,
             ),
         )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import uuid
 from typing import Mapping, Protocol, Type, TypeVar
 
+from .adapters.executor import IsolatedExecutorAdapter
 from .adapters.n8n import N8NReconciliationAdapter
 from .adapters.postgres import PostgresControlPlaneStore
 from .adapters.shuffle import ShuffleActionAdapter
@@ -72,6 +73,7 @@ class RuntimeSnapshot:
     opensearch_url: str
     n8n_base_url: str
     shuffle_base_url: str
+    isolated_executor_base_url: str
     ownership_boundary: dict[str, str]
 
     def to_dict(self) -> dict[str, object]:
@@ -232,6 +234,9 @@ class AegisOpsControlPlaneService:
         self._store = store or PostgresControlPlaneStore(config.postgres_dsn)
         self._reconciliation = N8NReconciliationAdapter(config.n8n_base_url)
         self._shuffle = ShuffleActionAdapter(config.shuffle_base_url)
+        self._isolated_executor = IsolatedExecutorAdapter(
+            config.isolated_executor_base_url
+        )
 
     def describe_runtime(self) -> RuntimeSnapshot:
         return RuntimeSnapshot(
@@ -243,12 +248,14 @@ class AegisOpsControlPlaneService:
             opensearch_url=self._config.opensearch_url,
             n8n_base_url=self._reconciliation.base_url,
             shuffle_base_url=self._shuffle.base_url,
+            isolated_executor_base_url=self._isolated_executor.base_url,
             ownership_boundary={
                 "runtime_root": "control-plane/",
                 "postgres_contract_root": "postgres/control-plane/",
                 "native_detection_intake": "substrate-adapters/",
                 "admitted_signal_model": "control-plane/analytic-signals",
-                "execution_plane": "shuffle/",
+                "routine_automation_substrate": "shuffle/",
+                "controlled_execution_surface": "executor/isolated-executor",
             },
         )
 
@@ -330,6 +337,114 @@ class AegisOpsControlPlaneService:
 
             delegation_id = self._next_identifier("delegation")
             receipt = self._shuffle.dispatch_approved_action(
+                delegation_id=delegation_id,
+                action_request_id=action_request.action_request_id,
+                approval_decision_id=approval_decision_id,
+                payload_hash=action_request.payload_hash,
+                idempotency_key=action_request.idempotency_key,
+                approved_payload=normalized_payload,
+                delegated_at=delegated_at,
+            )
+            provenance: dict[str, object] = {
+                "delegation_issuer": delegation_issuer,
+                "evidence_ids": evidence_ids,
+                "adapter": receipt.adapter,
+            }
+            if receipt.base_url.strip() and receipt.base_url != "<set-me>":
+                provenance["adapter_base_url"] = receipt.base_url
+
+            return self.persist_record(
+                ActionExecutionRecord(
+                    action_execution_id=self._next_identifier("action-execution"),
+                    action_request_id=action_request.action_request_id,
+                    approval_decision_id=approval_decision_id,
+                    delegation_id=delegation_id,
+                    execution_surface_type=receipt.execution_surface_type,
+                    execution_surface_id=receipt.execution_surface_id,
+                    execution_run_id=receipt.execution_run_id,
+                    idempotency_key=action_request.idempotency_key,
+                    target_scope=action_request.target_scope,
+                    approved_payload=normalized_payload,
+                    payload_hash=action_request.payload_hash,
+                    delegated_at=delegated_at,
+                    expires_at=action_request.expires_at,
+                    provenance=provenance,
+                    lifecycle_state="queued",
+                )
+            )
+
+    def delegate_approved_action_to_isolated_executor(
+        self,
+        *,
+        action_request_id: str,
+        approved_payload: Mapping[str, object],
+        delegated_at: datetime,
+        delegation_issuer: str,
+        evidence_ids: tuple[str, ...] = (),
+    ) -> ActionExecutionRecord:
+        delegated_at = self._require_aware_datetime(delegated_at, "delegated_at")
+        action_request_id = self._require_non_empty_string(
+            action_request_id,
+            "action_request_id",
+        )
+        delegation_issuer = self._require_non_empty_string(
+            delegation_issuer,
+            "delegation_issuer",
+        )
+        normalized_payload = self._require_mapping(approved_payload, "approved_payload")
+        action_request = self._store.get(ActionRequestRecord, action_request_id)
+        if action_request is None:
+            raise LookupError(f"Missing action request {action_request_id!r}")
+        if action_request.lifecycle_state != "approved":
+            raise ValueError(
+                f"Action request {action_request_id!r} is not approved "
+                f"(state={action_request.lifecycle_state!r})"
+            )
+        approval_decision_id = self._require_non_empty_string(
+            action_request.approval_decision_id,
+            "action_request.approval_decision_id",
+        )
+        approval_decision = self._store.get(ApprovalDecisionRecord, approval_decision_id)
+        if approval_decision is None:
+            raise LookupError(
+                f"Missing approval decision {approval_decision_id!r} for action request "
+                f"{action_request_id!r}"
+            )
+        if approval_decision.lifecycle_state != "approved":
+            raise ValueError(
+                f"Approval decision {approval_decision_id!r} is not approved "
+                f"(state={approval_decision.lifecycle_state!r})"
+            )
+        if approval_decision.payload_hash != action_request.payload_hash:
+            raise ValueError(
+                "approval decision payload_hash does not match action request payload_hash"
+            )
+        policy_evaluation = action_request.policy_evaluation
+        if policy_evaluation.get("execution_surface_type") != "executor":
+            raise ValueError(
+                "approved action request is not delegated through the isolated executor path"
+            )
+        if policy_evaluation.get("execution_surface_id") != "isolated-executor":
+            raise ValueError(
+                "approved action request is not routed to the reviewed isolated executor"
+            )
+        if action_request.expires_at is not None and delegated_at > action_request.expires_at:
+            raise ValueError(
+                f"Action request {action_request_id!r} expired before isolated executor delegation"
+            )
+
+        with self._store.transaction():
+            for existing in self._store.list(ActionExecutionRecord):
+                if (
+                    existing.action_request_id == action_request.action_request_id
+                    and existing.execution_surface_type == "executor"
+                    and existing.execution_surface_id == "isolated-executor"
+                    and existing.idempotency_key == action_request.idempotency_key
+                ):
+                    return existing
+
+            delegation_id = self._next_identifier("delegation")
+            receipt = self._isolated_executor.dispatch_approved_action(
                 delegation_id=delegation_id,
                 action_request_id=action_request.action_request_id,
                 approval_decision_id=approval_decision_id,

--- a/control-plane/tests/test_runtime_skeleton.py
+++ b/control-plane/tests/test_runtime_skeleton.py
@@ -27,6 +27,7 @@ class RuntimeSkeletonTests(unittest.TestCase):
         self.assertEqual(snapshot.opensearch_url, "<set-me>")
         self.assertEqual(snapshot.n8n_base_url, "<set-me>")
         self.assertEqual(snapshot.shuffle_base_url, "<set-me>")
+        self.assertEqual(snapshot.isolated_executor_base_url, "<set-me>")
 
     def test_runtime_snapshot_uses_default_port_when_env_is_empty(self) -> None:
         snapshot = build_runtime_snapshot({"AEGISOPS_CONTROL_PLANE_PORT": ""})
@@ -40,6 +41,7 @@ class RuntimeSkeletonTests(unittest.TestCase):
                 "AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL": "https://opensearch.internal",
                 "AEGISOPS_CONTROL_PLANE_N8N_BASE_URL": "https://n8n.internal",
                 "AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL": "https://shuffle.internal",
+                "AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL": "https://executor.internal",
             }
         )
 
@@ -54,7 +56,14 @@ class RuntimeSkeletonTests(unittest.TestCase):
             snapshot.ownership_boundary["admitted_signal_model"],
             "control-plane/analytic-signals",
         )
-        self.assertEqual(snapshot.ownership_boundary["execution_plane"], "shuffle/")
+        self.assertEqual(
+            snapshot.ownership_boundary["routine_automation_substrate"],
+            "shuffle/",
+        )
+        self.assertEqual(
+            snapshot.ownership_boundary["controlled_execution_surface"],
+            "executor/isolated-executor",
+        )
 
     def test_runtime_snapshot_rejects_non_integer_port(self) -> None:
         with self.assertRaisesRegex(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -1924,6 +1924,99 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 delegation_issuer="control-plane-service",
             )
 
+    def test_service_delegates_approved_high_risk_action_through_isolated_executor(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        expires_at = datetime(2026, 4, 5, 13, 0, tzinfo=timezone.utc)
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-executor-002",
+                action_request_id="action-request-executor-002",
+                approver_identities=("approver-001",),
+                target_snapshot={"asset_id": "critical-host-002"},
+                payload_hash="payload-hash-executor-002",
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-executor-002",
+                approval_decision_id="approval-executor-002",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-executor-002",
+                target_scope={"asset_id": "critical-host-002"},
+                payload_hash="payload-hash-executor-002",
+                requested_at=requested_at,
+                expires_at=expires_at,
+                lifecycle_state="approved",
+                policy_basis={
+                    "severity": "critical",
+                    "target_scope": "single_asset",
+                    "action_reversibility": "irreversible",
+                    "asset_criticality": "critical",
+                    "identity_criticality": "high",
+                    "blast_radius": "organization",
+                    "execution_constraint": "requires_isolated_executor",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "executor",
+                    "execution_surface_id": "isolated-executor",
+                },
+            )
+        )
+
+        execution = service.delegate_approved_action_to_isolated_executor(
+            action_request_id="action-request-executor-002",
+            approved_payload={
+                "action_type": "disable_identity",
+                "asset_id": "critical-host-002",
+            },
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-002",),
+        )
+
+        self.assertEqual(execution.action_request_id, "action-request-executor-002")
+        self.assertEqual(execution.approval_decision_id, "approval-executor-002")
+        self.assertEqual(execution.execution_surface_type, "executor")
+        self.assertEqual(execution.execution_surface_id, "isolated-executor")
+        self.assertEqual(execution.idempotency_key, "idempotency-executor-002")
+        self.assertEqual(execution.payload_hash, "payload-hash-executor-002")
+        self.assertEqual(
+            execution.approved_payload,
+            {
+                "action_type": "disable_identity",
+                "asset_id": "critical-host-002",
+            },
+        )
+        self.assertEqual(
+            execution.provenance,
+            {
+                "delegation_issuer": "control-plane-service",
+                "evidence_ids": ("evidence-002",),
+                "adapter": "isolated-executor",
+            },
+        )
+        self.assertEqual(execution.lifecycle_state, "queued")
+        self.assertTrue(execution.delegation_id.startswith("delegation-"))
+        self.assertTrue(execution.execution_run_id.startswith("executor-run-"))
+        self.assertEqual(
+            service.get_record(ActionExecutionRecord, execution.action_execution_id),
+            execution,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a reviewed isolated-executor adapter and service boundary for approved high-risk actions
- keep executor-local run metadata subordinate to AegisOps-owned approval, action intent, and reconciliation records
- expose isolated executor runtime/config settings and cover the boundary with focused control-plane tests

## Why
Issue #269 requires a distinct execution surface for high-risk or high-blast-radius actions so they do not share the same execution path or trust assumptions as routine Shuffle automation.

## Verification
- `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_postgres_store`
- `rg -n "executor|high-risk|blast-radius|execution_surface|Action Execution|reconciliation" control-plane docs postgres`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for isolated executor as a new execution surface and adapter.
  * Added routing capability for approved actions to the isolated executor with integrated policy validation.
  * Updated runtime ownership boundary metadata to reflect new execution surfaces.

* **Configuration**
  * Added configurable isolated executor base URL via environment variable.

* **Tests**
  * Added tests for isolated executor integration and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->