### PR TITLE
[codex] Align baseline with action execution ownership

### DIFF
--- a/.codex-supervisor/issues/282/issue-journal.md
+++ b/.codex-supervisor/issues/282/issue-journal.md
@@ -1,42 +1,47 @@
-# Issue #282: Follow-up: Follow-up: design: define the approved automation substrate contract and approval-binding model (#266) - The new delegation contract makes `Action Execution` an AegisOps-owned record by stating that execution-surface receipts ...
+# Issue #282: Follow-up: design: define the approved automation substrate contract and approval-binding model (#266) - The new delegation contract makes `Action Execution` an AegisOps-owned record by stating that execution-surface receipts ...
 
 ## Supervisor Snapshot
 - Issue URL: https://github.com/TommyKammy/AegisOps/issues/282
 - Branch: codex/issue-282
 - Workspace: .
 - Journal: .codex-supervisor/issues/282/issue-journal.md
-- Current phase: stabilizing
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: ba64661415b1e02455c050e5655fce01b89ae967
+- Current phase: addressing_review
+- Attempt count: 4 (implementation=2, repair=2)
+- Last head SHA: 39c1eed8f14032636139f4191196e0ac4331d71e
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-07T10:09:27.959Z
+- Last failure signature: PRRT_kwDOR2iDUc55Pq04|PRRT_kwDOR2iDUc55Pq1J
+- Repeated failure signature count: 1
+- Updated at: 2026-04-07T10:23:58.353Z
 
 ## Latest Codex Summary
-Aligned `docs/requirements-baseline.md` with the approved `Action Execution` ownership model and tightened the focused requirements-baseline verifier to fail if that ownership entry disappears.
+Validated the two unresolved CodeRabbit review threads on PR #286, confirmed both findings were still valid on the branch, and applied the requested fixes locally.
 
-Focused verification passed with `bash scripts/test-verify-requirements-baseline-control-plane-thesis.sh`, the branch was pushed as `origin/codex/issue-282`, and draft PR #286 was opened: https://github.com/TommyKammy/AegisOps/pull/286
+The baseline now includes `Action Execution` consistently in the Section 4.1 ownership summary and in the later control-vs-execution ownership sentence, the focused verifier now guards both phrases, and the issue journal heading no longer repeats `Follow-up:`.
 
-Summary: Baseline wording, focused verifier coverage, and draft PR are in place for the residual `Action Execution` ownership follow-up.
-State hint: draft_pr
+Summary: Addressed the two active review-thread findings locally, added focused guardrails for the ownership-summary regression, and refreshed the journal handoff.
+State hint: addressing_review
 Blocked reason: none
-Tests: `bash scripts/test-verify-requirements-baseline-control-plane-thesis.sh`
-Next action: Monitor PR #286 for review or CI feedback and address any follow-up if it appears.
+Tests: `python3 .../fetch_comments.py`; `gh pr view 286 --json number,url,title,state,isDraft,reviewDecision,mergeStateStatus,headRefName,baseRefName`; `bash scripts/test-verify-requirements-baseline-control-plane-thesis.sh`; `bash scripts/verify-requirements-baseline-control-plane-thesis.sh`; `rg -n "Action Request|Approval Decision|Action Execution|reconciliation|Shuffle|executor|idempotency" docs control-plane postgres`
+Next action: Commit the review-fix checkpoint, push `codex/issue-282`, and refresh PR #286 review state.
 Failure signature: none
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: The two previously unresolved automated review findings were reproduced against the local branch and patched; remote threads remain open until the updated branch is pushed and re-evaluated.
+- Reference: https://github.com/TommyKammy/AegisOps/pull/286#discussion_r3044353507
+- Details:
+  - .codex-supervisor/issues/282/issue-journal.md:1 duplicate `Follow-up:` heading fixed locally.
+  - docs/requirements-baseline.md:147 and docs/requirements-baseline.md:161 now explicitly include `Action Execution` ownership/action-execution truth to keep the baseline internally consistent.
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The residual finding is resolved by aligning the top-level requirements baseline with the already-approved domain and control-plane state model language that treats `Action Execution` as an AegisOps-owned authoritative record.
-- What changed: Added `Action Execution` to the authoritative record list in `docs/requirements-baseline.md`; updated the analytic-signal non-authority sentence to include action-execution state; tightened the baseline verifier and added a focused failing fixture for missing `Action Execution`; pushed branch `codex/issue-282`; opened draft PR #286.
+- What changed: Fixed the duplicated `Follow-up:` wording in the issue journal heading; added `action-execution` ownership to the Section 4.1 control-plane summary in `docs/requirements-baseline.md`; updated the Section 4.2 control-vs-execution sentence to include action-execution truth; tightened the baseline verifier to require both ownership-alignment phrases; added focused failing fixtures for removing either phrase.
 - Current blocker: none
-- Next exact step: Wait for PR #286 feedback or CI, and address any review or verification follow-up if one appears.
-- Verification gap: Did not change or re-verify `docs/architecture.md`; current issue scope stayed constrained to `docs/requirements-baseline.md` plus the baseline verifier guardrail.
-- Files touched: `docs/requirements-baseline.md`, `scripts/verify-requirements-baseline-control-plane-thesis.sh`, `scripts/test-verify-requirements-baseline-control-plane-thesis.sh`
-- Rollback concern: low; change is limited to baseline wording plus its focused documentation guardrail.
-- Last focused command: `gh pr create --draft --base main --head codex/issue-282 --title "[codex] Align baseline with action execution ownership" --body-file <tempfile>`
+- Next exact step: Commit and push the review-fix patch, then refresh PR #286 to confirm the unresolved-thread set clears.
+- Verification gap: Did not change `docs/architecture.md`; this follow-up remains intentionally limited to the baseline doc, its focused verifier, and the issue journal heading called out by review.
+- Files touched: `.codex-supervisor/issues/282/issue-journal.md`, `docs/requirements-baseline.md`, `scripts/verify-requirements-baseline-control-plane-thesis.sh`, `scripts/test-verify-requirements-baseline-control-plane-thesis.sh`
+- Rollback concern: low; change is limited to review-driven documentation wording plus its focused guardrail.
+- Last focused command: `bash scripts/test-verify-requirements-baseline-control-plane-thesis.sh`
 ### Scratchpad
-- Keep this section short. The supervisor may compact older notes automatically.
+- Live PR state checked with `gh pr view 286 --json ...` and `fetch_comments.py`; branch is open, non-draft, clean, with exactly two unresolved CodeRabbit threads.

--- a/docs/requirements-baseline.md
+++ b/docs/requirements-baseline.md
@@ -9,7 +9,7 @@
 - **Version**: 0.4.0
 - **Status**: Draft
 - **Owner**: IT Operations, Information Systems Department
-- **Last Updated**: 6 April 2026
+- **Last Updated**: 7 April 2026
 
 This document defines the **non-negotiable implementation baseline** for **AegisOps** as a **governed control plane above commodity detection and automation substrates**.
 
@@ -144,7 +144,7 @@ The following constraints are **mandatory** and non-negotiable.
 
 | Component / Boundary | Responsibility |
 | -------------------- | -------------- |
-| AegisOps control plane | Alert, case, evidence, observation, lead, recommendation, approval, action-request, hunt, AI-trace, and reconciliation ownership |
+| AegisOps control plane | Alert, case, evidence, observation, lead, recommendation, approval, action-request, action-execution, hunt, AI-trace, and reconciliation ownership |
 | Upstream Analytic Signal substrates | Detection, correlation, and substrate-native alerting artifacts that feed AegisOps without becoming downstream workflow truth |
 | Downstream execution substrates | Approved automation execution within the scope delegated by AegisOps |
 | PostgreSQL | n8n metadata and execution state, plus the future control-plane persistence boundary under separate governance |
@@ -158,7 +158,7 @@ No component should silently absorb another component’s responsibility without
 
 - **Detection, control, and execution MUST remain explicitly separated**
 - Upstream Analytic Signal substrates perform detection or correlation only and MUST NOT directly define AegisOps-owned approval, case, or reconciliation truth
-- AegisOps owns approval decisions, action intent, evidence linkage, and reconciliation
+- AegisOps owns approval decisions, action intent, action-execution truth, evidence linkage, and reconciliation
 - Optional execution substrates execute approved workflows only after validation and approval requirements are satisfied
 - External systems MUST NOT directly trigger unrestricted execution logic
 - High-risk response actions are prohibited without human oversight

--- a/scripts/test-verify-requirements-baseline-control-plane-thesis.sh
+++ b/scripts/test-verify-requirements-baseline-control-plane-thesis.sh
@@ -113,12 +113,32 @@ remove_text_from_doc "${missing_action_execution_repo}" "- Action Execution"
 commit_fixture "${missing_action_execution_repo}"
 assert_fails_with "${missing_action_execution_repo}" "- Action Execution"
 
+missing_action_execution_summary_repo="${workdir}/missing-action-execution-summary"
+create_repo "${missing_action_execution_summary_repo}"
+write_canonical_doc "${missing_action_execution_summary_repo}"
+replace_text_in_doc \
+  "${missing_action_execution_summary_repo}" \
+  "| AegisOps control plane | Alert, case, evidence, observation, lead, recommendation, approval, action-request, action-execution, hunt, AI-trace, and reconciliation ownership |" \
+  "| AegisOps control plane | Alert, case, evidence, observation, lead, recommendation, approval, action-request, hunt, AI-trace, and reconciliation ownership |"
+commit_fixture "${missing_action_execution_summary_repo}"
+assert_fails_with "${missing_action_execution_summary_repo}" "action-request, action-execution, hunt, AI-trace, and reconciliation ownership"
+
 missing_non_goal_repo="${workdir}/missing-non-goal"
 create_repo "${missing_non_goal_repo}"
 write_canonical_doc "${missing_non_goal_repo}"
 remove_text_from_doc "${missing_non_goal_repo}" "AegisOps will **not** rebuild Shuffle-class routine automation breadth in-house."
 commit_fixture "${missing_non_goal_repo}"
 assert_fails_with "${missing_non_goal_repo}" "AegisOps will **not** rebuild Shuffle-class routine automation breadth in-house."
+
+missing_action_execution_truth_repo="${workdir}/missing-action-execution-truth"
+create_repo "${missing_action_execution_truth_repo}"
+write_canonical_doc "${missing_action_execution_truth_repo}"
+replace_text_in_doc \
+  "${missing_action_execution_truth_repo}" \
+  "AegisOps owns approval decisions, action intent, action-execution truth, evidence linkage, and reconciliation" \
+  "AegisOps owns approval decisions, action intent, evidence linkage, and reconciliation"
+commit_fixture "${missing_action_execution_truth_repo}"
+assert_fails_with "${missing_action_execution_truth_repo}" "AegisOps owns approval decisions, action intent, action-execution truth, evidence linkage, and reconciliation"
 
 legacy_phrase_repo="${workdir}/legacy-phrase"
 create_repo "${legacy_phrase_repo}"

--- a/scripts/verify-requirements-baseline-control-plane-thesis.sh
+++ b/scripts/verify-requirements-baseline-control-plane-thesis.sh
@@ -18,6 +18,8 @@ required_phrases=(
   "- Action Request"
   "- Action Execution"
   "- Reconciliation"
+  "| AegisOps control plane | Alert, case, evidence, observation, lead, recommendation, approval, action-request, action-execution, hunt, AI-trace, and reconciliation ownership |"
+  "AegisOps owns approval decisions, action intent, action-execution truth, evidence linkage, and reconciliation"
   "Analytic Signals are upstream inputs to AegisOps, not the durable system of record for analyst workflow, approval state, evidence custody, action-execution state, or reconciliation."
   "Upstream detections, findings, correlations, and product-native alerting artifacts from external substrates are treated as **Analytic Signals**."
   "OpenSearch, Sigma, and n8n are **not** co-equal product cores for AegisOps."


### PR DESCRIPTION
## Summary
- align `docs/requirements-baseline.md` with the approved ownership model by adding `Action Execution` to the authoritative AegisOps record set
- make the baseline analytic-signal boundary explicit for action-execution state as well as approval, evidence, and reconciliation state
- tighten the focused requirements-baseline verifier and add a regression fixture so this drift fails locally if reintroduced

## Why
Issue #282 follows up the residual finding from #273 / PR #281: the detailed state and domain docs already made `Action Execution` authoritative inside the AegisOps control-plane boundary, but the top-level requirements baseline still omitted it. This left two incompatible approved contracts.

## Verification
- `bash scripts/test-verify-requirements-baseline-control-plane-thesis.sh`

## Traceability
- Closes #282
- Follow-up to residual finding from #273


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated requirements baseline: added "Action Execution" as an AegisOps authoritative responsibility and clarified Analytic Signals are non-authoritative for action-execution state.
* **Tests**
  * Added negative fixtures and strengthened verifier checks to enforce presence of Action Execution-related wording.
* **Chores**
  * Added an issue journal entry capturing current review tracking, verification steps, and next monitoring actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->