### PR TITLE
[codex] add identity context to analyst queue

### DIFF
--- a/.codex-supervisor/issues/304/issue-journal.md
+++ b/.codex-supervisor/issues/304/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #304: implementation: add cross-signal correlation and enrichment paths for identity-rich alerts and cases
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/304
+- Branch: codex/issue-304
+- Workspace: .
+- Journal: .codex-supervisor/issues/304/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 9b0be86002c00aa016ad91c4417085192c9b38e4
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-08T17:09:29.030Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: the analyst queue was omitting the normalized `reviewed_context`, so identity-rich Wazuh-backed alerts were still surfaced through reconciliation metadata but not through the shared control-plane vocabulary on the queue view.
+- What changed: added `reviewed_context` to analyst queue records, and added focused service/CLI tests that assert Microsoft 365 audit alerts expose the normalized identity profile through `inspect_analyst_queue`.
+- Current blocker: none.
+- Next exact step: commit the service and test updates on `codex/issue-304`.
+- Verification gap: focused unit coverage is green; no full repo sweep was run.
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_service_persistence.py`, `control-plane/tests/test_cli_inspection.py`.
+- Rollback concern: low; the queue payload change is additive and the tests only assert the new field is present and populated.
+- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection` and `python3 -m unittest control-plane.tests.test_postgres_store`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -612,6 +612,7 @@ class AegisOpsControlPlaneService:
                         ),
                         None,
                     ),
+                    "reviewed_context": dict(alert.reviewed_context),
                     "native_rule": reconciliation.subject_linkage.get(
                         "latest_native_rule"
                     ),

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -206,12 +206,47 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             ["agent:007"],
         )
         self.assertEqual(
+            payload["records"][0]["reviewed_context"]["location"],
+            "/var/log/auth.log",
+        )
+        self.assertEqual(
             payload["records"][0]["native_rule"]["description"],
             "SSH brute force attempt",
         )
         self.assertEqual(
             payload["records"][0]["substrate_detection_record_ids"],
             ["wazuh:1731594986.4931506"],
+        )
+
+    def test_cli_renders_identity_rich_analyst_queue_view_with_reviewed_context(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("microsoft-365-audit-alert.json")
+            ),
+        )
+        service.promote_alert_to_case(admitted.alert.alert_id)
+
+        stdout = io.StringIO()
+        main.main(["inspect-analyst-queue"], stdout=stdout, service=service)
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["total_records"], 1)
+        self.assertEqual(
+            payload["records"][0]["reviewed_context"]["source"]["source_family"],
+            "microsoft_365_audit",
+        )
+        self.assertEqual(
+            payload["records"][0]["reviewed_context"]["identity"]["actor"]["identity_id"],
+            "alex@contoso.com",
         )
 
     def test_cli_rejects_unknown_record_family_as_usage_error(self) -> None:

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -1318,6 +1318,38 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
         self.assertEqual(len(queue_view.records[0]["evidence_ids"]), 1)
 
+    def test_service_exposes_reviewed_context_in_analyst_queue_for_identity_rich_alerts(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("microsoft-365-audit-alert.json")
+            ),
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+
+        queue_view = service.inspect_analyst_queue()
+
+        self.assertEqual(queue_view.total_records, 1)
+        self.assertEqual(queue_view.records[0]["alert_id"], admitted.alert.alert_id)
+        self.assertEqual(queue_view.records[0]["case_id"], promoted_case.case_id)
+        self.assertEqual(
+            queue_view.records[0]["reviewed_context"],
+            admitted.alert.reviewed_context,
+        )
+        self.assertEqual(
+            queue_view.records[0]["reviewed_context"]["source"]["source_family"],
+            "microsoft_365_audit",
+        )
+
     def test_service_analyst_queue_prefers_explicit_wazuh_source_for_multi_source_linkage(
         self,
     ) -> None:


### PR DESCRIPTION
## What changed
- Added `reviewed_context` to analyst queue records so the queue view carries the normalized identity-centric profile already stored on admitted alerts.
- Added focused tests for the service and CLI inspection paths using the Microsoft 365 audit fixture.

## Why
- Identity-rich Phase 14 signals were already being admitted and reconciled, but the analyst queue did not expose the canonical reviewed context that the control plane uses for alert and case triage.
- Surfacing the normalized context keeps the queue aligned with the control-plane vocabulary instead of forcing analysts to infer identity semantics from vendor-native metadata.

## Validation
- `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection`
- `python3 -m unittest control-plane.tests.test_postgres_store`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Analyst queue inspection now exposes reviewed context data, including source information and identity details from security alerts for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->