### PR TITLE
[codex] docs: add phase 14 triage runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/control-plane-runtime-service-boundary.md`
 - `docs/retention-evidence-and-replay-readiness-baseline.md`
 - `docs/runbook.md`
+- `docs/source-families/`
 - `docs/repository-structure-baseline.md`
 - `docs/network-exposure-and-access-path-policy.md`
 - `docs/storage-layout-and-mount-policy.md`

--- a/control-plane/tests/test_phase14_identity_rich_source_profile_docs.py
+++ b/control-plane/tests/test_phase14_identity_rich_source_profile_docs.py
@@ -27,6 +27,28 @@ class Phase14IdentityRichSourceProfileDocsTests(unittest.TestCase):
         for doc_path in (microsoft_doc, entra_doc):
             self.assertTrue(doc_path.exists(), f"expected reviewed onboarding package at {doc_path}")
 
+    def test_phase14_family_triage_runbooks_exist(self) -> None:
+        runbook_paths = (
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "github-audit"
+            / "analyst-triage-runbook.md",
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "microsoft-365-audit"
+            / "analyst-triage-runbook.md",
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "entra-id"
+            / "analyst-triage-runbook.md",
+        )
+
+        for doc_path in runbook_paths:
+            self.assertTrue(doc_path.exists(), f"expected reviewed triage runbook at {doc_path}")
+
     def test_microsoft_365_onboarding_package_defines_the_reviewed_wazuh_profile(
         self,
     ) -> None:
@@ -74,6 +96,62 @@ class Phase14IdentityRichSourceProfileDocsTests(unittest.TestCase):
             "Non-audit Entra ID telemetry families",
         ):
             self.assertIn(term, text)
+
+    def test_phase14_family_triage_runbooks_define_the_reviewed_posture(self) -> None:
+        github_text = (
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "github-audit"
+            / "analyst-triage-runbook.md"
+        ).read_text(encoding="utf-8")
+        microsoft_text = (
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "microsoft-365-audit"
+            / "analyst-triage-runbook.md"
+        ).read_text(encoding="utf-8")
+        entra_text = (
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "entra-id"
+            / "analyst-triage-runbook.md"
+        ).read_text(encoding="utf-8")
+
+        shared_terms = (
+            "Business-hours SecOps daily operating model",
+            "AegisOps Source Onboarding Contract",
+            "Wazuh Rule Lifecycle and Validation Runbook",
+            "control-plane-first analyst workflow",
+            "false-positive expectations",
+            "read-oriented evidence",
+        )
+        family_specific_terms = {
+            github_text: (
+                "GitHub audit",
+                "repository or organization context",
+                "accountable source identity",
+                "Direct GitHub API actioning",
+            ),
+            microsoft_text: (
+                "Microsoft 365 audit",
+                "tenant context",
+                "authentication context",
+                "Direct Microsoft 365 actioning",
+            ),
+            entra_text: (
+                "Entra ID",
+                "directory boundary",
+                "authentication context",
+                "Direct Entra ID actioning",
+            ),
+        }
+
+        for text, terms in family_specific_terms.items():
+            for term in shared_terms + terms:
+                self.assertIn(term, text)
 
 
 if __name__ == "__main__":

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -40,6 +40,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/control-plane-runtime-service-boundary.md` | Live control-plane runtime service boundary and repository placement baseline | IT Operations, Information Systems Department |
 | `docs/retention-evidence-and-replay-readiness-baseline.md` | Retention, evidence lifecycle, and replay readiness baseline | IT Operations, Information Systems Department |
 | `docs/phase-7-ai-hunt-evaluation-baseline.md` | Phase 7 AI hunt evaluation baseline | IT Operations, Information Systems Department |
+| `docs/source-families/` | Approved source-family onboarding and analyst triage runbooks | IT Operations, Information Systems Department |
 | `docs/adr/` | Architecture Decision Records (ADRs) | IT Operations, Information Systems Department |
 | `docs/parameters/` | Parameter documentation | IT Operations, Information Systems Department |
 | `docs/runbook.md` | Runbooks | IT Operations, Information Systems Department |

--- a/docs/phase-14-identity-rich-source-family-design.md
+++ b/docs/phase-14-identity-rich-source-family-design.md
@@ -40,6 +40,8 @@ Wazuh remains the reviewed ingestion and normalization path for the approved Pha
 
 GitHub audit signals are expected to be high-value approval-context inputs because repository and workflow changes often map directly to access, release, and approval boundaries.
 
+The reviewed GitHub audit onboarding package lives at `docs/source-families/github-audit/onboarding-package.md`, and the reviewed analyst triage runbook lives at `docs/source-families/github-audit/analyst-triage-runbook.md`.
+
 ### 4.2 Entra ID
 
 | Aspect | Review expectation |
@@ -52,6 +54,8 @@ GitHub audit signals are expected to be high-value approval-context inputs becau
 
 Entra ID signals are expected to provide the strongest directory and privilege context for analyst triage and approval review.
 
+The reviewed Entra ID onboarding package lives at `docs/source-families/entra-id/onboarding-package.md`, and the reviewed analyst triage runbook lives at `docs/source-families/entra-id/analyst-triage-runbook.md`.
+
 ### 4.3 Microsoft 365 audit
 
 | Aspect | Review expectation |
@@ -63,6 +67,8 @@ Entra ID signals are expected to provide the strongest directory and privilege c
 | Provenance | Workload, operation, record type, actor id, target id, and event time must remain preserved. |
 
 Microsoft 365 audit signals are expected to broaden approval-context coverage without becoming a generic platform-wide telemetry grab bag.
+
+The reviewed Microsoft 365 audit onboarding package lives at `docs/source-families/microsoft-365-audit/onboarding-package.md`, and the reviewed analyst triage runbook lives at `docs/source-families/microsoft-365-audit/analyst-triage-runbook.md`.
 
 ## 5. Explicit Non-Goals
 

--- a/docs/source-families/entra-id/analyst-triage-runbook.md
+++ b/docs/source-families/entra-id/analyst-triage-runbook.md
@@ -1,0 +1,86 @@
+# Entra ID Analyst Triage Runbook
+
+## 1. Purpose
+
+This runbook defines the reviewed analyst triage posture for the approved Entra ID family.
+
+It complements the AegisOps Source Onboarding Contract, the Wazuh Rule Lifecycle and Validation Runbook, `docs/source-families/entra-id/onboarding-package.md`, `docs/source-onboarding-contract.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
+
+The runbook keeps Entra ID handling inside the control-plane-first analyst workflow and makes the family-specific false-positive expectations, evidence requirements, and business-hours handling explicit.
+
+## 2. Scope and Non-Goals
+
+This runbook applies to reviewed Entra ID alerts and cases that enter AegisOps through the Wazuh-backed intake boundary.
+
+It covers read-oriented triage, evidence capture, disposition decisions, and fixture refresh expectations for the reviewed Entra ID source profile.
+
+Direct Entra ID actioning remains out of scope. This runbook does not authorize directory changes, credential changes, source-side credentials, or any unsupported source family.
+
+It also does not replace the source onboarding contract or the Wazuh rule lifecycle runbook. Those documents remain authoritative for onboarding evidence and rule-change validation.
+
+## 3. Reviewed Triage Posture
+
+Entra ID items are triaged as queue-driven work items rather than as autonomous response triggers.
+
+The analyst first determines whether the item is a reviewed Entra ID audit event, a duplicate, an expected administrative change, or a potentially interesting privilege, directory, or authentication change.
+
+If the item is already explained by known directory administration, approved identity operations, a reviewed service identity, or an approved change window, the analyst records the benign explanation and closes or links the item according to the current case state.
+
+If the item is not clearly benign, the analyst gathers read-oriented evidence, preserves the reviewed source identity, and decides whether the work item should remain an alert, promote to a case, or wait for the next business-hours review cycle.
+
+The control-plane-first analyst workflow remains the decision boundary. Entra ID output informs triage, but it does not become the source of truth for case state, approval state, or action execution.
+
+## 4. Family Assumptions and False-Positive Expectations
+
+The reviewed Entra ID family preserves tenant context, actor identity, target identity, authentication context, privilege-change metadata, and directory provenance.
+
+The directory boundary stays explicit so the reviewed triage path does not collapse into a generic identity provider assumption.
+
+False-positive expectations are centered on routine directory administration, approved identity operations, reviewed service identity activity, role assignment maintenance, and changes that were already reviewed in a separate change-management path.
+
+Expected benign examples include role assignment updates, group membership maintenance, app registration changes, credential lifecycle work, or other reviewed administrative activity that remains within the approved boundary.
+
+Analysts must not assume that every Entra ID alert indicates malicious activity. The triage posture requires explicit evidence before escalation, especially when the event can be explained by a normal maintenance task or a reviewed automation path.
+
+Unsupported Entra ID telemetry families remain out of scope. Direct vendor-local actioning remains out of scope even when a directory event looks urgent.
+
+## 5. Evidence to Collect
+
+The analyst captures read-oriented evidence that answers what changed, who or what changed it, which target object was affected, and why the item is or is not interesting.
+
+At minimum, the analyst records:
+
+- the reviewed Entra ID event summary;
+- the accountable source identity and delivery path;
+- the actor identity, including whether it was a human, service principal, managed identity, or other automation identity when present;
+- the target object, user, group, role assignment, app registration, credential object, or policy context;
+- the tenant, directory, authentication, and correlation context;
+- the privilege or access change context, if any;
+- the raw payload or fixture reference used for review; and
+- the reason the event is benign, escalated, or deferred.
+
+The reviewer should keep evidence aligned with `docs/source-onboarding-contract.md` and the reviewed Entra ID onboarding package. If a new reviewed alert shape appears, the corresponding fixture under `control-plane/tests/fixtures/wazuh/entra-id-alert.json` and the related Wazuh rule lifecycle evidence must be refreshed before downstream workflow assumptions change.
+
+## 6. Business-Hours Handling
+
+This runbook follows the Business-hours SecOps daily operating model.
+
+Entra ID alerts that do not require immediate same-day handling remain queued for the next business-hours review cycle with enough context recorded that the next analyst does not need to reconstruct intent from raw system output.
+
+If an item appears to require escalation, the analyst records the reason, the affected scope, and the review context before requesting any human follow-up.
+
+After-hours handling remains explicit and bounded. The reviewed path does not imply 24x7 analyst watchstanding, and it does not authorize vendor-local actioning or automatic enforcement.
+
+## 7. Validation and Fixture Expectations
+
+The reviewer treats the reviewed Entra ID fixture as the canonical replay reference for this family.
+
+Any new reviewed Entra ID rule shape, provenance expectation, or identity branch must be validated against `docs/wazuh-rule-lifecycle-runbook.md` before it is treated as stable for triage.
+
+The analyst triage record should note whether the current fixture set still explains the alert clearly, whether the event remains compatible with the control-plane-first analyst workflow, and whether a new fixture or mapping update is required.
+
+## 8. Baseline Alignment Notes
+
+This runbook remains aligned with `docs/source-onboarding-contract.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
+
+It preserves the Wazuh-backed source boundary, keeps false-positive expectations explicit, and avoids any promise of production expansion beyond the reviewed Entra ID family.

--- a/docs/source-families/github-audit/analyst-triage-runbook.md
+++ b/docs/source-families/github-audit/analyst-triage-runbook.md
@@ -1,0 +1,83 @@
+# GitHub Audit Analyst Triage Runbook
+
+## 1. Purpose
+
+This runbook defines the reviewed analyst triage posture for the approved GitHub audit family.
+
+It complements the AegisOps Source Onboarding Contract, the Wazuh Rule Lifecycle and Validation Runbook, `docs/source-families/github-audit/onboarding-package.md`, `docs/source-onboarding-contract.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
+
+The runbook keeps GitHub audit handling inside the control-plane-first analyst workflow and makes the family-specific false-positive expectations, evidence requirements, and business-hours handling explicit.
+
+## 2. Scope and Non-Goals
+
+This runbook applies to reviewed GitHub audit alerts and cases that enter AegisOps through the Wazuh-backed intake boundary.
+
+It covers read-oriented triage, evidence capture, disposition decisions, and fixture refresh expectations for the reviewed GitHub audit source profile.
+
+Direct GitHub API actioning remains out of scope. This runbook does not authorize repository changes, secret rotation, privilege enforcement, or any unsupported source family.
+
+It also does not replace the source onboarding contract or the Wazuh rule lifecycle runbook. Those documents remain authoritative for onboarding evidence and rule-change validation.
+
+## 3. Reviewed Triage Posture
+
+GitHub audit items are triaged as queue-driven work items rather than as autonomous response triggers.
+
+The analyst first determines whether the item is a reviewed GitHub audit event, a duplicate, an expected administrative change, or a potentially interesting privilege or access change.
+
+If the item is already explained by known repository administration, maintainer activity, a reviewed automation identity, or an approved change window, the analyst records the benign explanation and closes or links the item according to the current case state.
+
+If the item is not clearly benign, the analyst gathers read-oriented evidence, preserves the reviewed source identity, and decides whether the work item should remain an alert, promote to a case, or wait for the next business-hours review cycle.
+
+The control-plane-first analyst workflow remains the decision boundary. GitHub audit output informs triage, but it does not become the source of truth for case state, approval state, or action execution.
+
+## 4. Family Assumptions and False-Positive Expectations
+
+The reviewed GitHub audit family preserves accountable source identity, actor identity, target identity, repository or organization context, and privilege-change metadata.
+
+False-positive expectations are centered on routine repository administration, approved maintainer activity, automation identity activity, and changes that were already reviewed in a change-management path outside the alert.
+
+Expected benign examples include repository setting updates, workflow maintenance, bot-driven changes, access review cleanup, or other reviewed administrative activity that remains within the approved boundary.
+
+Analysts must not assume that every GitHub audit alert indicates malicious activity. The triage posture requires explicit evidence before escalation, especially when the event can be explained by a normal maintenance task or a reviewed automation path.
+
+Unsupported GitHub telemetry families remain out of scope. Direct vendor-local actioning remains out of scope even when a repository event looks urgent.
+
+## 5. Evidence to Collect
+
+The analyst captures read-oriented evidence that answers what changed, who or what changed it, which target object was affected, and why the item is or is not interesting.
+
+At minimum, the analyst records:
+
+- the reviewed GitHub audit event summary;
+- the accountable source identity and delivery path;
+- the actor identity, including whether it was a human, app, bot, or other automation identity when present;
+- the target object, repository, organization, or membership context;
+- the privilege or access change context, if any;
+- the raw payload or fixture reference used for review; and
+- the reason the event is benign, escalated, or deferred.
+
+The reviewer should keep evidence aligned with `docs/source-onboarding-contract.md` and the reviewed GitHub audit onboarding package. If a new reviewed alert shape appears, the corresponding fixture under `control-plane/tests/fixtures/wazuh/github-audit-alert.json` and the related Wazuh rule lifecycle evidence must be refreshed before downstream workflow assumptions change.
+
+## 6. Business-Hours Handling
+
+This runbook follows the Business-hours SecOps daily operating model.
+
+GitHub audit alerts that do not require immediate same-day handling remain queued for the next business-hours review cycle with enough context recorded that the next analyst does not need to reconstruct intent from raw system output.
+
+If an item appears to require escalation, the analyst records the reason, the affected scope, and the review context before requesting any human follow-up.
+
+After-hours handling remains explicit and bounded. The reviewed path does not imply 24x7 analyst watchstanding, and it does not authorize vendor-local actioning or automatic enforcement.
+
+## 7. Validation and Fixture Expectations
+
+The reviewer treats the reviewed GitHub audit fixture as the canonical replay reference for this family.
+
+Any new reviewed GitHub audit rule shape, provenance expectation, or identity branch must be validated against `docs/wazuh-rule-lifecycle-runbook.md` before it is treated as stable for triage.
+
+The analyst triage record should note whether the current fixture set still explains the alert clearly, whether the event remains compatible with the control-plane-first analyst workflow, and whether a new fixture or mapping update is required.
+
+## 8. Baseline Alignment Notes
+
+This runbook remains aligned with `docs/source-onboarding-contract.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
+
+It preserves the Wazuh-backed source boundary, keeps false-positive expectations explicit, and avoids any promise of production expansion beyond the reviewed GitHub audit family.

--- a/docs/source-families/microsoft-365-audit/analyst-triage-runbook.md
+++ b/docs/source-families/microsoft-365-audit/analyst-triage-runbook.md
@@ -1,0 +1,84 @@
+# Microsoft 365 Audit Analyst Triage Runbook
+
+## 1. Purpose
+
+This runbook defines the reviewed analyst triage posture for the approved Microsoft 365 audit family.
+
+It complements the AegisOps Source Onboarding Contract, the Wazuh Rule Lifecycle and Validation Runbook, `docs/source-families/microsoft-365-audit/onboarding-package.md`, `docs/source-onboarding-contract.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
+
+The runbook keeps Microsoft 365 audit handling inside the control-plane-first analyst workflow and makes the family-specific false-positive expectations, evidence requirements, and business-hours handling explicit.
+
+## 2. Scope and Non-Goals
+
+This runbook applies to reviewed Microsoft 365 audit alerts and cases that enter AegisOps through the Wazuh-backed intake boundary.
+
+It covers read-oriented triage, evidence capture, disposition decisions, and fixture refresh expectations for the reviewed Microsoft 365 audit source profile.
+
+Direct Microsoft 365 actioning remains out of scope. This runbook does not authorize mailbox or tenant changes, privileged delegation changes, source-side credentials, or any unsupported source family.
+
+It also does not replace the source onboarding contract or the Wazuh rule lifecycle runbook. Those documents remain authoritative for onboarding evidence and rule-change validation.
+
+## 3. Reviewed Triage Posture
+
+Microsoft 365 audit items are triaged as queue-driven work items rather than as autonomous response triggers.
+
+The analyst first determines whether the item is a reviewed Microsoft 365 audit event, a duplicate, an expected administrative change, or a potentially interesting privilege, mailbox, or policy change.
+
+If the item is already explained by known tenant administration, approved workload maintenance, a reviewed service identity, or an approved change window, the analyst records the benign explanation and closes or links the item according to the current case state.
+
+If the item is not clearly benign, the analyst gathers read-oriented evidence, preserves the reviewed source identity, and decides whether the work item should remain an alert, promote to a case, or wait for the next business-hours review cycle.
+
+The control-plane-first analyst workflow remains the decision boundary. Microsoft 365 audit output informs triage, but it does not become the source of truth for case state, approval state, or action execution.
+
+## 4. Family Assumptions and False-Positive Expectations
+
+The reviewed Microsoft 365 audit family preserves tenant context, actor identity, target identity, authentication context, privilege-change metadata, and workload provenance.
+
+False-positive expectations are centered on routine tenant administration, approved admin activity, reviewed service identity activity, mailbox or site maintenance, and changes that were already reviewed in a separate change-management path.
+
+Expected benign examples include mailbox permission updates, policy changes, sharing adjustments, compliance or retention maintenance, or other reviewed administrative activity that remains within the approved boundary.
+
+Analysts must not assume that every Microsoft 365 audit alert indicates malicious activity. The triage posture requires explicit evidence before escalation, especially when the event can be explained by a normal maintenance task or a reviewed automation path.
+
+Unsupported Microsoft 365 telemetry families remain out of scope. Direct vendor-local actioning remains out of scope even when a tenant event looks urgent.
+
+## 5. Evidence to Collect
+
+The analyst captures read-oriented evidence that answers what changed, who or what changed it, which target object was affected, and why the item is or is not interesting.
+
+At minimum, the analyst records:
+
+- the reviewed Microsoft 365 audit event summary;
+- the accountable source identity and delivery path;
+- the actor identity, including whether it was a human, service principal, or other automation identity when present;
+- the target object, mailbox, site, document, team, policy, or message context;
+- the tenant, workload, and authentication context;
+- the privilege or access change context, if any;
+- the raw payload or fixture reference used for review; and
+- the reason the event is benign, escalated, or deferred.
+
+The reviewer should keep evidence aligned with `docs/source-onboarding-contract.md` and the reviewed Microsoft 365 audit onboarding package. If a new reviewed alert shape appears, the corresponding fixture under `control-plane/tests/fixtures/wazuh/microsoft-365-audit-alert.json` and the related Wazuh rule lifecycle evidence must be refreshed before downstream workflow assumptions change.
+
+## 6. Business-Hours Handling
+
+This runbook follows the Business-hours SecOps daily operating model.
+
+Microsoft 365 audit alerts that do not require immediate same-day handling remain queued for the next business-hours review cycle with enough context recorded that the next analyst does not need to reconstruct intent from raw system output.
+
+If an item appears to require escalation, the analyst records the reason, the affected scope, and the review context before requesting any human follow-up.
+
+After-hours handling remains explicit and bounded. The reviewed path does not imply 24x7 analyst watchstanding, and it does not authorize vendor-local actioning or automatic enforcement.
+
+## 7. Validation and Fixture Expectations
+
+The reviewer treats the reviewed Microsoft 365 audit fixture as the canonical replay reference for this family.
+
+Any new reviewed Microsoft 365 audit rule shape, provenance expectation, or identity branch must be validated against `docs/wazuh-rule-lifecycle-runbook.md` before it is treated as stable for triage.
+
+The analyst triage record should note whether the current fixture set still explains the alert clearly, whether the event remains compatible with the control-plane-first analyst workflow, and whether a new fixture or mapping update is required.
+
+## 8. Baseline Alignment Notes
+
+This runbook remains aligned with `docs/source-onboarding-contract.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
+
+It preserves the Wazuh-backed source boundary, keeps false-positive expectations explicit, and avoids any promise of production expansion beyond the reviewed Microsoft 365 audit family.


### PR DESCRIPTION
This PR adds the reviewed Phase 14 analyst triage runbooks for GitHub audit, Microsoft 365 audit, and Entra ID, then cross-links them from the Phase 14 design and ownership docs.
 
Why:
The approved identity-rich source families had onboarding packages, but the analyst triage path was not yet published as explicit runbook guidance.
 
Impact:
Analysts now have family-specific false-positive expectations, evidence expectations, and business-hours handling for the Wazuh-backed intake boundary without expanding scope to unsupported families or direct vendor actioning.
 
Checks:
- python3 -m unittest control-plane.tests.test_phase14_identity_rich_source_profile_docs
- bash scripts/test-verify-source-onboarding-contract-doc.sh
- bash scripts/test-verify-secops-business-hours-operating-model-doc.sh
- bash scripts/test-verify-wazuh-rule-lifecycle-runbook.sh
- bash scripts/test-verify-phase-14-identity-rich-source-family-design.sh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added analyst triage runbooks for Entra ID, GitHub audit, and Microsoft 365 audit source families, defining reviewed postures for alert classification, evidence collection, business-hours handling, and escalation workflows.
  * Established documentation governance and ownership assignments for source-family materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->