### PR TITLE
[codex] Add Phase 16 first-boot bootstrap skeletons

### DIFF
--- a/.codex-supervisor/issues/351/issue-journal.md
+++ b/.codex-supervisor/issues/351/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #351: implementation: add first-boot bootstrap artifacts and deployment-entrypoint skeletons for the approved scope
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/351
+- Branch: codex/issue-351
+- Workspace: .
+- Journal: .codex-supervisor/issues/351/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: a7ddd4c956ec25a1355c7e4b51c654b2a03eec9c
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-09T15:02:56.173Z
+
+## Latest Codex Summary
+- Added repository-local Phase 16 first-boot bootstrap artifacts and deployment-entrypoint skeletons under `control-plane/deployment/first-boot/`, and tightened the focused Phase 16 contract test to require them and keep deferred components explicit.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The current Phase 16 gap is not runtime behavior but missing repository-local first-boot artifacts, so the narrowest reproducible failure is a contract test that expects a bootstrap sample and entrypoint skeletons under the approved `control-plane/` runtime home.
+- What changed: Added a focused failing test in `control-plane/tests/test_phase16_bootstrap_contract_docs.py`, reproduced the failure for the missing bootstrap sample, then added `control-plane/deployment/first-boot/bootstrap.env.sample`, `control-plane/deployment/first-boot/docker-compose.yml`, `control-plane/deployment/first-boot/control-plane-entrypoint.sh`, and a small `control-plane/README.md` note documenting the new scaffold home.
+- Current blocker: none
+- Next exact step: Stage the focused Phase 16 artifact changes, create a checkpoint commit on `codex/issue-351`, and leave the branch ready for local review or draft PR creation.
+- Verification gap: No live container bring-up was attempted because the approved scope is skeletal and explicitly excludes real runtime image implementation and live secret distribution.
+- Files touched: `control-plane/tests/test_phase16_bootstrap_contract_docs.py`, `control-plane/README.md`, `control-plane/deployment/first-boot/bootstrap.env.sample`, `control-plane/deployment/first-boot/docker-compose.yml`, `control-plane/deployment/first-boot/control-plane-entrypoint.sh`
+- Rollback concern: Low; new files are additive skeleton assets and the only existing-file changes are a README note and a focused repository-contract test.
+- Last focused command: `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Reproduced initial failure with `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py` before adding artifacts; missing path was `control-plane/deployment/first-boot/bootstrap.env.sample`.

--- a/.codex-supervisor/issues/351/issue-journal.md
+++ b/.codex-supervisor/issues/351/issue-journal.md
@@ -7,22 +7,22 @@
 - Journal: .codex-supervisor/issues/351/issue-journal.md
 - Current phase: addressing_review
 - Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: 3e540e892da33cf25d39f4ac973f95fb720d3358
+- Last head SHA: a98f39c7efc3bd120cf13979d6c74bb77d57f8e9
 - Blocked reason: none
 - Last failure signature: PRRT_kwDOR2iDUc555N_l|PRRT_kwDOR2iDUc555N_y
 - Repeated failure signature count: 1
-- Updated at: 2026-04-09T15:25:58Z
+- Updated at: 2026-04-09T15:27:16Z
 
 ## Latest Codex Summary
 Validated the two unresolved CodeRabbit review threads on PR `#356`, confirmed both were actionable, and applied the narrow local fixes without widening Phase 16 scope. The first-boot entrypoint now fails closed on missing `AEGISOPS_CONTROL_PLANE_HOST` and malformed non-PostgreSQL DSNs, and the focused contract test now enforces the deferred `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL` line while also executing the skeleton entrypoint under valid and invalid bootstrap inputs.
 
 Focused verification passed across the touched surfaces, including the entrypoint execution checks, the runtime skeleton tests, and the Phase 16 verifier scripts. The branch still has unrelated untracked supervisor scratch paths under `.codex-supervisor/`, which I left untouched.
 
-Summary: Addressed the two unresolved PR `#356` review findings locally with stricter first-boot validation and focused test coverage
+Summary: Pushed commit `a98f39c` to `codex/issue-351` with the two PR `#356` review fixes and focused validation coverage
 State hint: addressing_review
 Blocked reason: none
 Tests: `gh auth status`; `python3 /Users/jp.infra/.codex/plugins/cache/openai-curated/github/b4940fd0a222022ecd7852e20a4c89ed36b9e9de/skills/gh-address-comments/scripts/fetch_comments.py --repo TommyKammy/AegisOps --pr 356`; `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py`; `python3 -m unittest control-plane/tests/test_runtime_skeleton.py`; `bash scripts/verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/verify-control-plane-runtime-skeleton.sh`
-Next action: Commit and push the review-fix checkpoint to `codex/issue-351`, then wait for PR `#356` to refresh
+Next action: Re-check PR `#356` after review automation refreshes and address any remaining actionable feedback without widening Phase 16 scope
 Failure signature: none
 
 ## Active Failure Context
@@ -31,13 +31,13 @@ Failure signature: none
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The two automated review findings were valid contract gaps, and tightening the entrypoint plus executing the skeleton in tests is sufficient to close them without broadening the first-boot runtime slice.
-- What changed: Verified the live unresolved review threads with the bundled GitHub GraphQL helper, added `AEGISOPS_CONTROL_PLANE_HOST` and PostgreSQL-DSN fail-closed validation to the first-boot entrypoint, added the missing `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL` contract assertion, and extended the focused test module to execute the entrypoint under missing-host, malformed-DSN, and valid bootstrap inputs.
+- What changed: Verified the live unresolved review threads with the bundled GitHub GraphQL helper, added `AEGISOPS_CONTROL_PLANE_HOST` and PostgreSQL-DSN fail-closed validation to the first-boot entrypoint, added the missing `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL` contract assertion, extended the focused test module to execute the entrypoint under missing-host, malformed-DSN, and valid bootstrap inputs, committed the fix as `a98f39c`, and pushed `codex/issue-351` to `origin`.
 - Current blocker: none
-- Next exact step: Commit and push the current review-fix checkpoint to `codex/issue-351`, then re-check PR `#356` for any remaining actionable review state.
+- Next exact step: Re-check PR `#356` after the pushed head `a98f39c` is indexed, then handle any remaining actionable review state if new threads appear.
 - Verification gap: No live container bring-up was attempted because the approved scope is skeletal and explicitly excludes real runtime image implementation, live secret distribution, and Phase 17 readiness behavior.
 - Files touched: `control-plane/tests/test_phase16_bootstrap_contract_docs.py`, `control-plane/deployment/first-boot/control-plane-entrypoint.sh`, `.codex-supervisor/issues/351/issue-journal.md`
 - Rollback concern: Low; the changes are limited to stricter bootstrap validation and focused contract tests around additive first-boot skeleton assets.
-- Last focused command: `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`
+- Last focused command: `git push origin codex/issue-351`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Reproduced initial failure with `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py` before adding artifacts; missing path was `control-plane/deployment/first-boot/bootstrap.env.sample`.

--- a/.codex-supervisor/issues/351/issue-journal.md
+++ b/.codex-supervisor/issues/351/issue-journal.md
@@ -5,30 +5,40 @@
 - Branch: codex/issue-351
 - Workspace: .
 - Journal: .codex-supervisor/issues/351/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: a7ddd4c956ec25a1355c7e4b51c654b2a03eec9c
+- Current phase: stabilizing
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: 9c0ad3e2bc3a2fe32b61b6943f7e7b5bc15e3457
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-09T15:02:56.173Z
+- Updated at: 2026-04-09T15:10:40.566Z
 
 ## Latest Codex Summary
-- Added repository-local Phase 16 first-boot bootstrap artifacts and deployment-entrypoint skeletons under `control-plane/deployment/first-boot/`, and tightened the focused Phase 16 contract test to require them and keep deferred components explicit.
+Added the Phase 16 first-boot artifact slice under [control-plane/deployment/first-boot/bootstrap.env.sample](control-plane/deployment/first-boot/bootstrap.env.sample), [control-plane/deployment/first-boot/docker-compose.yml](control-plane/deployment/first-boot/docker-compose.yml), and [control-plane/deployment/first-boot/control-plane-entrypoint.sh](control-plane/deployment/first-boot/control-plane-entrypoint.sh). The sample keeps `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` explicit, the compose skeleton stays limited to control-plane/PostgreSQL/proxy, and the entrypoint validates only the required first-boot contract while marking OpenSearch, n8n, assistant UI, and executor wiring as deferred.
+
+I tightened [control-plane/tests/test_phase16_bootstrap_contract_docs.py](control-plane/tests/test_phase16_bootstrap_contract_docs.py) to reproduce the missing-artifact failure first, then verified the new skeletons. I also added a short pointer in [control-plane/README.md](control-plane/README.md), pushed branch `codex/issue-351`, and opened draft PR `#356` at `https://github.com/TommyKammy/AegisOps/pull/356`. PR creation through the GitHub app connector failed with `Resource not accessible by integration`, so the PR was opened via `gh pr create --draft` instead.
+
+Summary: Added Phase 16 first-boot bootstrap sample and deployment-entrypoint skeletons under `control-plane/deployment/first-boot/`, tightened the focused contract test, and committed the checkpoint as `9c0ad3e`.
+State hint: local_review
+Blocked reason: none
+Tests: `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py`; `python3 -m unittest control-plane/tests/test_runtime_skeleton.py`; `bash scripts/verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/verify-control-plane-runtime-skeleton.sh`
+Next action: Review the committed skeleton artifacts, then open or update the draft PR for issue #351 if this checkpoint is acceptable
+Failure signature: none
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The current Phase 16 gap is not runtime behavior but missing repository-local first-boot artifacts, so the narrowest reproducible failure is a contract test that expects a bootstrap sample and entrypoint skeletons under the approved `control-plane/` runtime home.
-- What changed: Added a focused failing test in `control-plane/tests/test_phase16_bootstrap_contract_docs.py`, reproduced the failure for the missing bootstrap sample, then added `control-plane/deployment/first-boot/bootstrap.env.sample`, `control-plane/deployment/first-boot/docker-compose.yml`, `control-plane/deployment/first-boot/control-plane-entrypoint.sh`, and a small `control-plane/README.md` note documenting the new scaffold home.
+- Hypothesis: The implementation is stable and the remaining work is review-driven; no broader runtime expansion is needed unless PR feedback identifies a real contract gap.
+- What changed: Pushed `codex/issue-351` to `origin`, confirmed no existing PR, attempted connector-based PR creation, then opened draft PR `#356` via `gh` after the GitHub app returned `Resource not accessible by integration`.
 - Current blocker: none
-- Next exact step: Stage the focused Phase 16 artifact changes, create a checkpoint commit on `codex/issue-351`, and leave the branch ready for local review or draft PR creation.
-- Verification gap: No live container bring-up was attempted because the approved scope is skeletal and explicitly excludes real runtime image implementation and live secret distribution.
-- Files touched: `control-plane/tests/test_phase16_bootstrap_contract_docs.py`, `control-plane/README.md`, `control-plane/deployment/first-boot/bootstrap.env.sample`, `control-plane/deployment/first-boot/docker-compose.yml`, `control-plane/deployment/first-boot/control-plane-entrypoint.sh`
+- Next exact step: Keep PR `#356` in draft for local review and address any feedback without widening beyond the approved Phase 16 skeletal scope.
+- Verification gap: No live container bring-up was attempted because the approved scope is skeletal and explicitly excludes real runtime image implementation and live secret distribution; PR creation required `gh` fallback because the GitHub app lacked permission to create PRs here.
+- Files touched: `control-plane/tests/test_phase16_bootstrap_contract_docs.py`, `control-plane/README.md`, `control-plane/deployment/first-boot/bootstrap.env.sample`, `control-plane/deployment/first-boot/docker-compose.yml`, `control-plane/deployment/first-boot/control-plane-entrypoint.sh`, `.codex-supervisor/issues/351/issue-journal.md`
 - Rollback concern: Low; new files are additive skeleton assets and the only existing-file changes are a README note and a focused repository-contract test.
-- Last focused command: `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`
+- Last focused command: `gh pr create --draft --base main --head codex/issue-351 --title "[codex] Add Phase 16 first-boot bootstrap skeletons" --body-file "$tmp_body"`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Reproduced initial failure with `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py` before adding artifacts; missing path was `control-plane/deployment/first-boot/bootstrap.env.sample`.
+- Draft PR URL: `https://github.com/TommyKammy/AegisOps/pull/356`

--- a/.codex-supervisor/issues/351/issue-journal.md
+++ b/.codex-supervisor/issues/351/issue-journal.md
@@ -5,40 +5,41 @@
 - Branch: codex/issue-351
 - Workspace: .
 - Journal: .codex-supervisor/issues/351/issue-journal.md
-- Current phase: stabilizing
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: 9c0ad3e2bc3a2fe32b61b6943f7e7b5bc15e3457
+- Current phase: addressing_review
+- Attempt count: 3 (implementation=2, repair=1)
+- Last head SHA: 3e540e892da33cf25d39f4ac973f95fb720d3358
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-09T15:10:40.566Z
+- Last failure signature: PRRT_kwDOR2iDUc555N_l|PRRT_kwDOR2iDUc555N_y
+- Repeated failure signature count: 1
+- Updated at: 2026-04-09T15:25:58Z
 
 ## Latest Codex Summary
-Added the Phase 16 first-boot artifact slice under [control-plane/deployment/first-boot/bootstrap.env.sample](control-plane/deployment/first-boot/bootstrap.env.sample), [control-plane/deployment/first-boot/docker-compose.yml](control-plane/deployment/first-boot/docker-compose.yml), and [control-plane/deployment/first-boot/control-plane-entrypoint.sh](control-plane/deployment/first-boot/control-plane-entrypoint.sh). The sample keeps `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` explicit, the compose skeleton stays limited to control-plane/PostgreSQL/proxy, and the entrypoint validates only the required first-boot contract while marking OpenSearch, n8n, assistant UI, and executor wiring as deferred.
+Validated the two unresolved CodeRabbit review threads on PR `#356`, confirmed both were actionable, and applied the narrow local fixes without widening Phase 16 scope. The first-boot entrypoint now fails closed on missing `AEGISOPS_CONTROL_PLANE_HOST` and malformed non-PostgreSQL DSNs, and the focused contract test now enforces the deferred `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL` line while also executing the skeleton entrypoint under valid and invalid bootstrap inputs.
 
-I tightened [control-plane/tests/test_phase16_bootstrap_contract_docs.py](control-plane/tests/test_phase16_bootstrap_contract_docs.py) to reproduce the missing-artifact failure first, then verified the new skeletons. I also added a short pointer in [control-plane/README.md](control-plane/README.md), pushed branch `codex/issue-351`, and opened draft PR `#356` at `https://github.com/TommyKammy/AegisOps/pull/356`. PR creation through the GitHub app connector failed with `Resource not accessible by integration`, so the PR was opened via `gh pr create --draft` instead.
+Focused verification passed across the touched surfaces, including the entrypoint execution checks, the runtime skeleton tests, and the Phase 16 verifier scripts. The branch still has unrelated untracked supervisor scratch paths under `.codex-supervisor/`, which I left untouched.
 
-Summary: Added Phase 16 first-boot bootstrap sample and deployment-entrypoint skeletons under `control-plane/deployment/first-boot/`, tightened the focused contract test, and committed the checkpoint as `9c0ad3e`.
-State hint: local_review
+Summary: Addressed the two unresolved PR `#356` review findings locally with stricter first-boot validation and focused test coverage
+State hint: addressing_review
 Blocked reason: none
-Tests: `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py`; `python3 -m unittest control-plane/tests/test_runtime_skeleton.py`; `bash scripts/verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/verify-control-plane-runtime-skeleton.sh`
-Next action: Review the committed skeleton artifacts, then open or update the draft PR for issue #351 if this checkpoint is acceptable
+Tests: `gh auth status`; `python3 /Users/jp.infra/.codex/plugins/cache/openai-curated/github/b4940fd0a222022ecd7852e20a4c89ed36b9e9de/skills/gh-address-comments/scripts/fetch_comments.py --repo TommyKammy/AegisOps --pr 356`; `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py`; `python3 -m unittest control-plane/tests/test_runtime_skeleton.py`; `bash scripts/verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/verify-control-plane-runtime-skeleton.sh`
+Next action: Commit and push the review-fix checkpoint to `codex/issue-351`, then wait for PR `#356` to refresh
 Failure signature: none
 
 ## Active Failure Context
-- None recorded.
+- None recorded after the local review-fix verification pass.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The implementation is stable and the remaining work is review-driven; no broader runtime expansion is needed unless PR feedback identifies a real contract gap.
-- What changed: Pushed `codex/issue-351` to `origin`, confirmed no existing PR, attempted connector-based PR creation, then opened draft PR `#356` via `gh` after the GitHub app returned `Resource not accessible by integration`.
+- Hypothesis: The two automated review findings were valid contract gaps, and tightening the entrypoint plus executing the skeleton in tests is sufficient to close them without broadening the first-boot runtime slice.
+- What changed: Verified the live unresolved review threads with the bundled GitHub GraphQL helper, added `AEGISOPS_CONTROL_PLANE_HOST` and PostgreSQL-DSN fail-closed validation to the first-boot entrypoint, added the missing `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL` contract assertion, and extended the focused test module to execute the entrypoint under missing-host, malformed-DSN, and valid bootstrap inputs.
 - Current blocker: none
-- Next exact step: Keep PR `#356` in draft for local review and address any feedback without widening beyond the approved Phase 16 skeletal scope.
-- Verification gap: No live container bring-up was attempted because the approved scope is skeletal and explicitly excludes real runtime image implementation and live secret distribution; PR creation required `gh` fallback because the GitHub app lacked permission to create PRs here.
-- Files touched: `control-plane/tests/test_phase16_bootstrap_contract_docs.py`, `control-plane/README.md`, `control-plane/deployment/first-boot/bootstrap.env.sample`, `control-plane/deployment/first-boot/docker-compose.yml`, `control-plane/deployment/first-boot/control-plane-entrypoint.sh`, `.codex-supervisor/issues/351/issue-journal.md`
-- Rollback concern: Low; new files are additive skeleton assets and the only existing-file changes are a README note and a focused repository-contract test.
-- Last focused command: `gh pr create --draft --base main --head codex/issue-351 --title "[codex] Add Phase 16 first-boot bootstrap skeletons" --body-file "$tmp_body"`
+- Next exact step: Commit and push the current review-fix checkpoint to `codex/issue-351`, then re-check PR `#356` for any remaining actionable review state.
+- Verification gap: No live container bring-up was attempted because the approved scope is skeletal and explicitly excludes real runtime image implementation, live secret distribution, and Phase 17 readiness behavior.
+- Files touched: `control-plane/tests/test_phase16_bootstrap_contract_docs.py`, `control-plane/deployment/first-boot/control-plane-entrypoint.sh`, `.codex-supervisor/issues/351/issue-journal.md`
+- Rollback concern: Low; the changes are limited to stricter bootstrap validation and focused contract tests around additive first-boot skeleton assets.
+- Last focused command: `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Reproduced initial failure with `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py` before adding artifacts; missing path was `control-plane/deployment/first-boot/bootstrap.env.sample`.
 - Draft PR URL: `https://github.com/TommyKammy/AegisOps/pull/356`
+- Review threads validated locally via `fetch_comments.py`; both were unresolved and actionable before the fix pass.

--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -19,6 +19,7 @@ Current scaffold:
 - `aegisops_control_plane/` contains the initial service module, boundary-aware adapters, and environment-backed runtime config.
 - `tests/` contains focused service-root tests for the local runtime skeleton.
 - `config/local.env.sample` defines non-secret local placeholders for PostgreSQL, OpenSearch, and n8n integration boundaries.
+- `deployment/first-boot/` contains reviewed Phase 16 bootstrap and entrypoint skeletons for the narrow first-boot control-plane, PostgreSQL, and reverse-proxy contract.
 
 Current persistence status:
 

--- a/control-plane/deployment/first-boot/bootstrap.env.sample
+++ b/control-plane/deployment/first-boot/bootstrap.env.sample
@@ -1,0 +1,13 @@
+# Reviewed bootstrap sample for the Phase 16 first-boot skeleton only.
+# Copy reviewed values into an untracked runtime env file before use.
+# Do not commit live credentials, DSNs, or secret material to this repository.
+
+AEGISOPS_CONTROL_PLANE_HOST=127.0.0.1
+AEGISOPS_CONTROL_PLANE_PORT=8080
+AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=postgresql://<user>:<password>@postgres:5432/aegisops_control_plane
+
+# Optional and deferred components below must remain non-blocking for first boot.
+AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL=
+AEGISOPS_CONTROL_PLANE_N8N_BASE_URL=
+AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL=
+AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL=

--- a/control-plane/deployment/first-boot/control-plane-entrypoint.sh
+++ b/control-plane/deployment/first-boot/control-plane-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+set -eu
+
+# Phase 16 first-boot skeleton only.
+# This entrypoint validates the reviewed required bootstrap contract,
+# reserves a hook point for migration bootstrap, and then hands off to
+# the runtime command. Live health endpoints and production image
+# implementation remain out of scope for this repository skeleton.
+
+require_non_empty() {
+  var_name="$1"
+  var_value="${2:-}"
+
+  if [ -z "${var_value}" ] || [ "${var_value}" = "<set-me>" ]; then
+    echo "Missing required first-boot setting: ${var_name}" >&2
+    exit 1
+  fi
+}
+
+require_non_empty "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN" "${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:-}"
+
+port_value="${AEGISOPS_CONTROL_PLANE_PORT:-8080}"
+case "${port_value}" in
+  ''|*[!0-9]*)
+    echo "AEGISOPS_CONTROL_PLANE_PORT must be an integer for the first-boot skeleton." >&2
+    exit 1
+    ;;
+esac
+
+# migration bootstrap remains skeletal here: reviewed migrations stay under
+# postgres/control-plane/migrations/ and later runtime work must replace this
+# placeholder with real forward-only migration execution before readiness is
+# allowed to succeed.
+
+# readiness remains a later-phase runtime concern. This skeleton only enforces
+# that required bootstrap state exists before the control-plane process starts.
+
+# OpenSearch, n8n, the full analyst-assistant surface, and executor wiring remain deferred.
+
+exec "$@"

--- a/control-plane/deployment/first-boot/control-plane-entrypoint.sh
+++ b/control-plane/deployment/first-boot/control-plane-entrypoint.sh
@@ -18,7 +18,18 @@ require_non_empty() {
   fi
 }
 
+require_non_empty "AEGISOPS_CONTROL_PLANE_HOST" "${AEGISOPS_CONTROL_PLANE_HOST:-}"
 require_non_empty "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN" "${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:-}"
+
+dsn_value="${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:-}"
+case "${dsn_value}" in
+  postgresql://*|postgres://*)
+    ;;
+  *)
+    echo "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN must be a PostgreSQL DSN for the first-boot skeleton." >&2
+    exit 1
+    ;;
+esac
 
 port_value="${AEGISOPS_CONTROL_PLANE_PORT:-8080}"
 case "${port_value}" in

--- a/control-plane/deployment/first-boot/docker-compose.yml
+++ b/control-plane/deployment/first-boot/docker-compose.yml
@@ -1,0 +1,51 @@
+name: aegisops-first-boot
+
+services:
+  control-plane:
+    image: alpine:3.22.1
+    working_dir: /workspace/control-plane
+    entrypoint:
+      - /opt/aegisops/bin/first-boot-entrypoint.sh
+    command:
+      - python3
+      - main.py
+      - runtime
+    environment:
+      AEGISOPS_CONTROL_PLANE_HOST: ${AEGISOPS_CONTROL_PLANE_HOST:-127.0.0.1}
+      AEGISOPS_CONTROL_PLANE_PORT: ${AEGISOPS_CONTROL_PLANE_PORT:-8080}
+      AEGISOPS_CONTROL_PLANE_POSTGRES_DSN: ${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:?set-in-untracked-runtime-env}
+      AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL: ${AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL:-}
+      AEGISOPS_CONTROL_PLANE_N8N_BASE_URL: ${AEGISOPS_CONTROL_PLANE_N8N_BASE_URL:-}
+      AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL: ${AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL:-}
+      AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL: ${AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL:-}
+    volumes:
+      - ../../../:/workspace:ro
+      - ./control-plane-entrypoint.sh:/opt/aegisops/bin/first-boot-entrypoint.sh:ro
+      - ../../../postgres/control-plane/migrations:/opt/aegisops/postgres-migrations:ro
+    depends_on:
+      - postgres
+    # control-plane first-boot contract only; runtime image implementation remains out of scope
+    # optional extensions remain out of scope for this first-boot skeleton
+    # do not add OpenSearch, n8n, analyst-assistant UI, or executor services here
+
+  postgres:
+    image: postgres:16.4
+    environment:
+      POSTGRES_DB: ${AEGISOPS_CONTROL_PLANE_POSTGRES_DB:-aegisops_control_plane}
+      POSTGRES_USER: ${AEGISOPS_CONTROL_PLANE_POSTGRES_USER:-aegisops_control_plane}
+      POSTGRES_PASSWORD: ${AEGISOPS_CONTROL_PLANE_POSTGRES_PASSWORD:?set-in-untracked-runtime-secret-source}
+    volumes:
+      - /srv/aegisops/postgres-control-plane-data-placeholder:/var/lib/postgresql/data
+    # reviewed first-boot persistence dependency only
+    # live secret distribution and backup automation remain out of scope here
+
+  proxy:
+    image: nginx:1.27.0
+    depends_on:
+      - control-plane
+    volumes:
+      - ../../../proxy/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../../../proxy/nginx/conf.d-placeholder:/etc/nginx/conf.d:ro
+      - /srv/aegisops/proxy-certs-placeholder:/etc/nginx/certs:ro
+    # approved reverse-proxy boundary only; backend services remain internal
+    # user-facing route implementation and live publication remain out of scope here

--- a/control-plane/tests/test_phase16_bootstrap_contract_docs.py
+++ b/control-plane/tests/test_phase16_bootstrap_contract_docs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+import subprocess
 import unittest
 
 
@@ -56,6 +57,7 @@ class Phase16BootstrapContractDocsTests(unittest.TestCase):
             "Optional and deferred components below must remain non-blocking for first boot.",
             "AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL=",
             "AEGISOPS_CONTROL_PLANE_N8N_BASE_URL=",
+            "AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL=",
             "AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL=",
         ):
             self.assertIn(term, bootstrap_text)
@@ -82,6 +84,60 @@ class Phase16BootstrapContractDocsTests(unittest.TestCase):
             "exec \"$@\"",
         ):
             self.assertIn(term, entrypoint_text)
+
+    def test_first_boot_entrypoint_requires_control_plane_host(self) -> None:
+        result = self._run_entrypoint(
+            {
+                "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "postgresql://user:pass@postgres:5432/aegisops",
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Missing required first-boot setting: AEGISOPS_CONTROL_PLANE_HOST", result.stderr)
+
+    def test_first_boot_entrypoint_rejects_non_postgres_dsn(self) -> None:
+        result = self._run_entrypoint(
+            {
+                "AEGISOPS_CONTROL_PLANE_HOST": "127.0.0.1",
+                "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "mysql://user:pass@postgres:3306/aegisops",
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN must be a PostgreSQL DSN for the first-boot skeleton.",
+            result.stderr,
+        )
+
+    def test_first_boot_entrypoint_executes_command_when_contract_is_valid(self) -> None:
+        result = self._run_entrypoint(
+            {
+                "AEGISOPS_CONTROL_PLANE_HOST": "127.0.0.1",
+                "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "postgresql://user:pass@postgres:5432/aegisops",
+            }
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "ok")
+        self.assertEqual(result.stderr, "")
+
+    @staticmethod
+    def _run_entrypoint(env_overrides: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        entrypoint = (
+            REPO_ROOT / "control-plane" / "deployment" / "first-boot" / "control-plane-entrypoint.sh"
+        )
+        env = {
+            "PATH": "/usr/bin:/bin",
+            **env_overrides,
+        }
+
+        return subprocess.run(
+            ["sh", str(entrypoint), "printf", "ok"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_phase16_bootstrap_contract_docs.py
+++ b/control-plane/tests/test_phase16_bootstrap_contract_docs.py
@@ -36,6 +36,53 @@ class Phase16BootstrapContractDocsTests(unittest.TestCase):
         ):
             self.assertIn(term, text)
 
+    def test_first_boot_bootstrap_artifacts_exist_and_stay_narrow(self) -> None:
+        bootstrap_sample = REPO_ROOT / "control-plane" / "deployment" / "first-boot" / "bootstrap.env.sample"
+        compose_skeleton = (
+            REPO_ROOT / "control-plane" / "deployment" / "first-boot" / "docker-compose.yml"
+        )
+        entrypoint_skeleton = (
+            REPO_ROOT / "control-plane" / "deployment" / "first-boot" / "control-plane-entrypoint.sh"
+        )
+
+        for path in (bootstrap_sample, compose_skeleton, entrypoint_skeleton):
+            self.assertTrue(path.exists(), f"expected first-boot artifact at {path}")
+
+        bootstrap_text = bootstrap_sample.read_text(encoding="utf-8")
+        for term in (
+            "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=",
+            "AEGISOPS_CONTROL_PLANE_HOST=",
+            "AEGISOPS_CONTROL_PLANE_PORT=",
+            "Optional and deferred components below must remain non-blocking for first boot.",
+            "AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL=",
+            "AEGISOPS_CONTROL_PLANE_N8N_BASE_URL=",
+            "AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL=",
+        ):
+            self.assertIn(term, bootstrap_text)
+
+        compose_text = compose_skeleton.read_text(encoding="utf-8")
+        for term in (
+            "name: aegisops-first-boot",
+            "control-plane:",
+            "postgres:",
+            "proxy:",
+            "control-plane-entrypoint.sh:/opt/aegisops/bin/first-boot-entrypoint.sh:ro",
+            "optional extensions remain out of scope for this first-boot skeleton",
+            "do not add OpenSearch, n8n, analyst-assistant UI, or executor services here",
+        ):
+            self.assertIn(term, compose_text)
+
+        entrypoint_text = entrypoint_skeleton.read_text(encoding="utf-8")
+        for term in (
+            "Phase 16 first-boot skeleton only",
+            "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN",
+            "migration bootstrap",
+            "readiness",
+            "OpenSearch, n8n, the full analyst-assistant surface, and executor wiring remain deferred",
+            "exec \"$@\"",
+        ):
+            self.assertIn(term, entrypoint_text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed
Add the first repository-local Phase 16 first-boot artifacts under `control-plane/deployment/first-boot/`.

This PR adds:
- a reviewed bootstrap sample for the narrow first-boot contract
- a skeletal Compose entrypoint surface limited to control-plane, PostgreSQL, and proxy
- a skeletal control-plane entrypoint script that validates required bootstrap state and keeps deferred components explicit
- a focused contract test that reproduces the missing-artifact gap and now enforces the new files
- a small control-plane README note pointing to the new scaffold home

## Why
Phase 16 already documented the approved first-boot scope, but the repository did not yet contain concrete bootstrap artifacts or deployment-entrypoint skeletons for that narrow runtime target. That left the scope documented but not instantiated in the repo.

## Impact
This stays intentionally skeletal. It does not introduce real container image implementation, live secret distribution, automatic migration execution, or broader runtime bring-up. It makes the approved first-boot floor explicit while keeping OpenSearch, n8n, the full analyst-assistant surface, and executor wiring visibly deferred.

## Validation
- `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py`
- `python3 -m unittest control-plane/tests/test_runtime_skeleton.py`
- `bash scripts/verify-phase-16-release-state-and-first-boot-scope.sh`
- `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`
- `bash scripts/verify-control-plane-runtime-skeleton.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-boot deployment stack (core service, DB, proxy) and a first-boot entrypoint that validates required startup configuration.
  * Added sample environment template for initial bootstrap parameters.

* **Documentation**
  * Updated deployment docs to include the new first-boot deployment structure and guidance for bootstrap configuration.

* **Tests**
  * Added verification tests that assert presence of first-boot artifacts and exercise the entrypoint’s contract validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->