### PR TITLE
[codex] Add Phase 16 first-boot verifier coverage

### DIFF
--- a/.codex-supervisor/issues/351/issue-journal.md
+++ b/.codex-supervisor/issues/351/issue-journal.md
@@ -21,7 +21,7 @@ Focused verification passed across the touched surfaces, including the entrypoin
 Summary: Pushed commit `a98f39c` to `codex/issue-351` with the two PR `#356` review fixes and focused validation coverage
 State hint: addressing_review
 Blocked reason: none
-Tests: `gh auth status`; `python3 /Users/jp.infra/.codex/plugins/cache/openai-curated/github/b4940fd0a222022ecd7852e20a4c89ed36b9e9de/skills/gh-address-comments/scripts/fetch_comments.py --repo TommyKammy/AegisOps --pr 356`; `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py`; `python3 -m unittest control-plane/tests/test_runtime_skeleton.py`; `bash scripts/verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/verify-control-plane-runtime-skeleton.sh`
+Tests: `gh auth status`; `python3 <redacted-local-path> --repo TommyKammy/AegisOps --pr 356`; `python3 -m unittest control-plane/tests/test_phase16_bootstrap_contract_docs.py`; `python3 -m unittest control-plane/tests/test_runtime_skeleton.py`; `bash scripts/verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`; `bash scripts/verify-control-plane-runtime-skeleton.sh`
 Next action: Re-check PR `#356` after review automation refreshes and address any remaining actionable feedback without widening Phase 16 scope
 Failure signature: none
 

--- a/.codex-supervisor/issues/352/issue-journal.md
+++ b/.codex-supervisor/issues/352/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #352: validation: add release-state and bootstrap-contract verification coverage for the Phase 16 first-boot path
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/352
+- Branch: codex/issue-352
+- Workspace: .
+- Journal: .codex-supervisor/issues/352/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: b179719c1bd2bc39716f5b2449e95bb7b57a8ae2
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-09T15:38:01.342Z
+
+## Latest Codex Summary
+- Added repository-local Phase 16 first-boot verification coverage for cross-document release-state drift and bootstrap-contract artifacts.
+- Reproduced the gap with a new focused unit test that initially failed because `scripts/verify-phase-16-first-boot-contract.sh` did not exist.
+- Implemented the verifier plus a shell fixture test and reran the full `control-plane/tests` unit suite successfully.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Phase 16 already had doc-presence and entrypoint checks, but it lacked repository-local validation for release-state drift across README, requirements, runtime-boundary, and runbook artifacts, plus fail-closed checks for first-boot bootstrap-contract drift.
+- What changed: Added `control-plane/tests/test_phase16_first_boot_verifier.py`, implemented `scripts/verify-phase-16-first-boot-contract.sh`, and added `scripts/test-verify-phase-16-first-boot-contract.sh` to exercise passing and failing fixture repos.
+- Current blocker: none
+- Next exact step: Commit the verifier coverage changes on `codex/issue-352`.
+- Verification gap: none for the requested Phase 16 repository-local verification slice; full `control-plane/tests` discovery now passes after the change.
+- Files touched: `.codex-supervisor/issues/352/issue-journal.md`, `control-plane/tests/test_phase16_first_boot_verifier.py`, `scripts/verify-phase-16-first-boot-contract.sh`, `scripts/test-verify-phase-16-first-boot-contract.sh`
+- Rollback concern: low; the change adds validation-only coverage and does not alter runtime behavior.
+- Last focused command: `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/tests/test_phase16_first_boot_verifier.py
+++ b/control-plane/tests/test_phase16_first_boot_verifier.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase16FirstBootVerifierTests(unittest.TestCase):
+    def test_phase16_first_boot_verifier_exists(self) -> None:
+        verifier = REPO_ROOT / "scripts" / "verify-phase-16-first-boot-contract.sh"
+
+        self.assertTrue(verifier.exists(), f"expected Phase 16 verifier at {verifier}")
+
+    def test_phase16_first_boot_verifier_fails_closed_on_release_state_and_bootstrap_drift(
+        self,
+    ) -> None:
+        verifier = REPO_ROOT / "scripts" / "verify-phase-16-first-boot-contract.sh"
+        self.assertTrue(verifier.exists(), f"expected Phase 16 verifier at {verifier}")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fixture_root = pathlib.Path(tmpdir) / "repo"
+            self._create_repo_fixture(fixture_root)
+
+            self._assert_verifier_passes(verifier, fixture_root)
+
+            self._remove_text(
+                fixture_root / "README.md",
+                (
+                    "That first-boot target is limited to the AegisOps control-plane service, "
+                    "PostgreSQL for control-plane state, the approved reverse proxy boundary, "
+                    "and reviewed Wazuh-facing analytic-signal intake expectations.\n"
+                ),
+            )
+            self._assert_verifier_fails_with(
+                verifier,
+                fixture_root,
+                "README.md",
+            )
+
+            self._create_repo_fixture(fixture_root)
+            compose_path = (
+                fixture_root / "control-plane" / "deployment" / "first-boot" / "docker-compose.yml"
+            )
+            compose_path.write_text(
+                compose_path.read_text(encoding="utf-8")
+                + "\n  opensearch:\n    image: opensearchproject/opensearch:2\n",
+                encoding="utf-8",
+            )
+            self._assert_verifier_fails_with(
+                verifier,
+                fixture_root,
+                "must not define first-boot service: opensearch",
+            )
+
+            self._create_repo_fixture(fixture_root)
+            self._remove_text(
+                fixture_root
+                / "control-plane"
+                / "deployment"
+                / "first-boot"
+                / "control-plane-entrypoint.sh",
+                'exec "$@"\n',
+            )
+            self._assert_verifier_fails_with(
+                verifier,
+                fixture_root,
+                'Missing required line in control-plane/deployment/first-boot/control-plane-entrypoint.sh: exec "$@"',
+            )
+
+    @staticmethod
+    def _create_repo_fixture(target: pathlib.Path) -> None:
+        if target.exists():
+            shutil.rmtree(target)
+
+        required_files = (
+            "README.md",
+            "docs/phase-16-release-state-and-first-boot-scope.md",
+            "docs/requirements-baseline.md",
+            "docs/control-plane-runtime-service-boundary.md",
+            "docs/runbook.md",
+            "control-plane/deployment/first-boot/bootstrap.env.sample",
+            "control-plane/deployment/first-boot/docker-compose.yml",
+            "control-plane/deployment/first-boot/control-plane-entrypoint.sh",
+            "postgres/control-plane/README.md",
+            "postgres/control-plane/schema.sql",
+            "postgres/control-plane/migrations/0001_control_plane_schema_skeleton.sql",
+            "postgres/control-plane/migrations/0002_phase_14_reviewed_context_columns.sql",
+            "postgres/control-plane/migrations/0003_phase_15_assistant_advisory_draft_columns.sql",
+        )
+
+        for relative_path in required_files:
+            source = REPO_ROOT / relative_path
+            destination = target / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+
+    @staticmethod
+    def _remove_text(path: pathlib.Path, text: str) -> None:
+        content = path.read_text(encoding="utf-8")
+        if text not in content:
+            raise AssertionError(f"expected to remove text from {path}: {text!r}")
+        path.write_text(content.replace(text, "", 1), encoding="utf-8")
+
+    @staticmethod
+    def _assert_verifier_passes(verifier: pathlib.Path, repo_root: pathlib.Path) -> None:
+        result = subprocess.run(
+            ["bash", str(verifier), str(repo_root)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            raise AssertionError(
+                "expected verifier to pass\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+
+    @staticmethod
+    def _assert_verifier_fails_with(
+        verifier: pathlib.Path,
+        repo_root: pathlib.Path,
+        expected_stderr: str,
+    ) -> None:
+        result = subprocess.run(
+            ["bash", str(verifier), str(repo_root)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode == 0:
+            raise AssertionError(
+                "expected verifier to fail\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+
+        if expected_stderr not in result.stderr:
+            raise AssertionError(
+                "expected verifier stderr to contain\n"
+                f"{expected_stderr!r}\n"
+                f"actual stderr:\n{result.stderr}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-verify-phase-16-first-boot-contract.sh
+++ b/scripts/test-verify-phase-16-first-boot-contract.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-16-first-boot-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p \
+    "${target}/docs" \
+    "${target}/control-plane/deployment/first-boot" \
+    "${target}/postgres/control-plane/migrations"
+}
+
+copy_fixture() {
+  local target="$1"
+
+  cp "${repo_root}/README.md" "${target}/README.md"
+  cp "${repo_root}/docs/phase-16-release-state-and-first-boot-scope.md" "${target}/docs/phase-16-release-state-and-first-boot-scope.md"
+  cp "${repo_root}/docs/requirements-baseline.md" "${target}/docs/requirements-baseline.md"
+  cp "${repo_root}/docs/control-plane-runtime-service-boundary.md" "${target}/docs/control-plane-runtime-service-boundary.md"
+  cp "${repo_root}/docs/runbook.md" "${target}/docs/runbook.md"
+  cp "${repo_root}/control-plane/deployment/first-boot/bootstrap.env.sample" "${target}/control-plane/deployment/first-boot/bootstrap.env.sample"
+  cp "${repo_root}/control-plane/deployment/first-boot/docker-compose.yml" "${target}/control-plane/deployment/first-boot/docker-compose.yml"
+  cp "${repo_root}/control-plane/deployment/first-boot/control-plane-entrypoint.sh" "${target}/control-plane/deployment/first-boot/control-plane-entrypoint.sh"
+  cp "${repo_root}/postgres/control-plane/README.md" "${target}/postgres/control-plane/README.md"
+  cp "${repo_root}/postgres/control-plane/schema.sql" "${target}/postgres/control-plane/schema.sql"
+  cp "${repo_root}/postgres/control-plane/migrations/0001_control_plane_schema_skeleton.sql" "${target}/postgres/control-plane/migrations/0001_control_plane_schema_skeleton.sql"
+  cp "${repo_root}/postgres/control-plane/migrations/0002_phase_14_reviewed_context_columns.sql" "${target}/postgres/control-plane/migrations/0002_phase_14_reviewed_context_columns.sql"
+  cp "${repo_root}/postgres/control-plane/migrations/0003_phase_15_assistant_advisory_draft_columns.sql" "${target}/postgres/control-plane/migrations/0003_phase_15_assistant_advisory_draft_columns.sql"
+}
+
+remove_text() {
+  local path="$1"
+  local text="$2"
+
+  REMOVE_TEXT="${text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${path}"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >/dev/null 2>"${workdir}/stderr"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${workdir}/stderr" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >/dev/null 2>"${workdir}/stderr"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${workdir}/stderr" >/dev/null; then
+    echo "Expected verifier stderr to contain: ${expected}" >&2
+    cat "${workdir}/stderr" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+copy_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+readme_drift_repo="${workdir}/readme-drift"
+create_repo "${readme_drift_repo}"
+copy_fixture "${readme_drift_repo}"
+remove_text "${readme_drift_repo}/README.md" \
+  'That first-boot target is limited to the AegisOps control-plane service, PostgreSQL for control-plane state, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.'
+assert_fails_with "${readme_drift_repo}" 'Missing required line in README.md: That first-boot target is limited to the AegisOps control-plane service, PostgreSQL for control-plane state, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.'
+
+optional_blocker_repo="${workdir}/optional-blocker"
+create_repo "${optional_blocker_repo}"
+copy_fixture "${optional_blocker_repo}"
+cat <<'EOF' >>"${optional_blocker_repo}/control-plane/deployment/first-boot/docker-compose.yml"
+  opensearch:
+    image: opensearchproject/opensearch:2
+EOF
+assert_fails_with "${optional_blocker_repo}" 'First-boot compose must not define first-boot service: opensearch'
+
+entrypoint_drift_repo="${workdir}/entrypoint-drift"
+create_repo "${entrypoint_drift_repo}"
+copy_fixture "${entrypoint_drift_repo}"
+remove_text "${entrypoint_drift_repo}/control-plane/deployment/first-boot/control-plane-entrypoint.sh" \
+  'exec "$@"'
+assert_fails_with "${entrypoint_drift_repo}" 'Missing required line in control-plane/deployment/first-boot/control-plane-entrypoint.sh: exec "$@"'
+
+echo "Phase 16 first-boot verifier catches release-state drift and optional boot blockers."

--- a/scripts/verify-phase-16-first-boot-contract.sh
+++ b/scripts/verify-phase-16-first-boot-contract.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+default_repo_root="$(cd "${script_dir}/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+scope_doc="${repo_root}/docs/phase-16-release-state-and-first-boot-scope.md"
+requirements_doc="${repo_root}/docs/requirements-baseline.md"
+runtime_boundary_doc="${repo_root}/docs/control-plane-runtime-service-boundary.md"
+runbook_doc="${repo_root}/docs/runbook.md"
+readme_doc="${repo_root}/README.md"
+bootstrap_env_sample="${repo_root}/control-plane/deployment/first-boot/bootstrap.env.sample"
+compose_file="${repo_root}/control-plane/deployment/first-boot/docker-compose.yml"
+entrypoint_file="${repo_root}/control-plane/deployment/first-boot/control-plane-entrypoint.sh"
+migration_home="${repo_root}/postgres/control-plane/migrations"
+postgres_readme="${repo_root}/postgres/control-plane/README.md"
+postgres_schema="${repo_root}/postgres/control-plane/schema.sql"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_dir() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -d "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_string() {
+  local file_path="$1"
+  local expected="$2"
+  local relative_path
+
+  relative_path="${file_path#"${repo_root}/"}"
+  if [[ "${relative_path}" == "${file_path}" ]]; then
+    relative_path="${file_path}"
+  fi
+
+  if ! grep -Fqx -- "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required line in ${relative_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_absent_string() {
+  local file_path="$1"
+  local forbidden="$2"
+  local message="$3"
+
+  if grep -F -- "${forbidden}" "${file_path}" >/dev/null; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+require_file "${scope_doc}" "Missing Phase 16 scope document"
+require_file "${requirements_doc}" "Missing requirements baseline doc"
+require_file "${runtime_boundary_doc}" "Missing control-plane runtime boundary doc"
+require_file "${runbook_doc}" "Missing runbook doc"
+require_file "${readme_doc}" "Missing repository README"
+require_file "${bootstrap_env_sample}" "Missing first-boot bootstrap env sample"
+require_file "${compose_file}" "Missing first-boot compose skeleton"
+require_file "${entrypoint_file}" "Missing first-boot entrypoint"
+require_dir "${migration_home}" "Missing control-plane migration home"
+require_file "${postgres_readme}" "Missing control-plane postgres README"
+require_file "${postgres_schema}" "Missing control-plane schema baseline"
+
+release_state_lines=(
+  'That first-boot target is limited to the AegisOps control-plane service, PostgreSQL for control-plane state, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.'
+  'OpenSearch, n8n, the full analyst-assistant surface, and the high-risk executor path remain optional, deferred, or non-blocking for first boot.'
+)
+for line in "${release_state_lines[@]}"; do
+  require_fixed_string "${readme_doc}" "${line}"
+done
+
+requirements_lines=(
+  'The approved Phase 16 first-boot target is limited to the AegisOps control-plane service, PostgreSQL for AegisOps-owned state, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.'
+  'OpenSearch, n8n, the full analyst-assistant surface, the high-risk executor path, and broad source expansion remain optional, deferred, or non-blocking for first boot unless a later ADR approves a broader runtime floor.'
+)
+for line in "${requirements_lines[@]}"; do
+  require_fixed_string "${requirements_doc}" "${line}"
+done
+
+runtime_boundary_lines=(
+  'Within the approved Phase 16 release-state, the first-boot runtime target for this boundary is limited to the control-plane service, the reviewed PostgreSQL persistence dependency, the approved reverse proxy ingress boundary, and reviewed Wazuh-facing analytic-signal intake expectations.'
+  'That first-boot target does not make OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path mandatory startup blockers.'
+)
+for line in "${runtime_boundary_lines[@]}"; do
+  require_fixed_string "${runtime_boundary_doc}" "${line}"
+done
+
+runbook_lines=(
+  'Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.'
+  'Operators must not treat optional OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path as first-boot prerequisites.'
+)
+for line in "${runbook_lines[@]}"; do
+  require_fixed_string "${runbook_doc}" "${line}"
+done
+
+scope_lines=(
+  '- `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` for the authoritative PostgreSQL connection string used by the control-plane runtime; and'
+  'Optional environment variables such as `AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL`, `AEGISOPS_CONTROL_PLANE_N8N_BASE_URL`, `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL`, and `AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL` must not become first-boot prerequisites.'
+  'The reviewed migration asset home remains `postgres/control-plane/migrations/`.'
+  'Readiness success means the control-plane runtime has loaded valid required bootstrap environment, can reach PostgreSQL through `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`, and has confirmed migration bootstrap success for the approved first-boot schema state.'
+  'Compose or other repository-local boot surfaces may orchestrate startup order, but they must not redefine first-boot success to require OpenSearch, n8n, the analyst-assistant surface, or executor availability.'
+)
+for line in "${scope_lines[@]}"; do
+  require_fixed_string "${scope_doc}" "${line}"
+done
+
+bootstrap_lines=(
+  'AEGISOPS_CONTROL_PLANE_HOST=127.0.0.1'
+  'AEGISOPS_CONTROL_PLANE_PORT=8080'
+  'AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=postgresql://<user>:<password>@postgres:5432/aegisops_control_plane'
+  '# Optional and deferred components below must remain non-blocking for first boot.'
+  'AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL='
+  'AEGISOPS_CONTROL_PLANE_N8N_BASE_URL='
+  'AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL='
+  'AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL='
+)
+for line in "${bootstrap_lines[@]}"; do
+  require_fixed_string "${bootstrap_env_sample}" "${line}"
+done
+
+compose_lines=(
+  'name: aegisops-first-boot'
+  '  control-plane:'
+  '  postgres:'
+  '  proxy:'
+  '      AEGISOPS_CONTROL_PLANE_POSTGRES_DSN: ${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:?set-in-untracked-runtime-env}'
+  '      AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL: ${AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL:-}'
+  '      AEGISOPS_CONTROL_PLANE_N8N_BASE_URL: ${AEGISOPS_CONTROL_PLANE_N8N_BASE_URL:-}'
+  '      AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL: ${AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL:-}'
+  '      AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL: ${AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL:-}'
+  '      - ../../../postgres/control-plane/migrations:/opt/aegisops/postgres-migrations:ro'
+  '    # optional extensions remain out of scope for this first-boot skeleton'
+  '    # do not add OpenSearch, n8n, analyst-assistant UI, or executor services here'
+)
+for line in "${compose_lines[@]}"; do
+  require_fixed_string "${compose_file}" "${line}"
+done
+
+require_absent_string "${compose_file}" '  opensearch:' \
+  'First-boot compose must not define first-boot service: opensearch'
+require_absent_string "${compose_file}" '  n8n:' \
+  'First-boot compose must not define first-boot service: n8n'
+require_absent_string "${compose_file}" '  analyst-assistant:' \
+  'First-boot compose must not define first-boot service: analyst-assistant'
+require_absent_string "${compose_file}" '  executor:' \
+  'First-boot compose must not define first-boot service: executor'
+
+entrypoint_lines=(
+  '# Phase 16 first-boot skeleton only.'
+  'require_non_empty "AEGISOPS_CONTROL_PLANE_HOST" "${AEGISOPS_CONTROL_PLANE_HOST:-}"'
+  'require_non_empty "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN" "${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:-}"'
+  '    echo "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN must be a PostgreSQL DSN for the first-boot skeleton." >&2'
+  '    echo "AEGISOPS_CONTROL_PLANE_PORT must be an integer for the first-boot skeleton." >&2'
+  '# migration bootstrap remains skeletal here: reviewed migrations stay under'
+  '# readiness remains a later-phase runtime concern. This skeleton only enforces'
+  '# OpenSearch, n8n, the full analyst-assistant surface, and executor wiring remain deferred.'
+  'exec "$@"'
+)
+for line in "${entrypoint_lines[@]}"; do
+  require_fixed_string "${entrypoint_file}" "${line}"
+done
+
+postgres_lines=(
+  'This directory reserves the reviewed repository home for future AegisOps-owned control-plane schema and migration assets.'
+  'These repository assets do not authorize live deployment, production data migration, or credentials.'
+)
+for line in "${postgres_lines[@]}"; do
+  require_fixed_string "${postgres_readme}" "${line}"
+done
+
+for migration_file in \
+  "0001_control_plane_schema_skeleton.sql" \
+  "0002_phase_14_reviewed_context_columns.sql" \
+  "0003_phase_15_assistant_advisory_draft_columns.sql"; do
+  require_file "${migration_home}/${migration_file}" "Missing reviewed control-plane migration asset"
+done
+
+echo "Phase 16 release-state and first-boot contract remain aligned."


### PR DESCRIPTION
## Summary
Adds repository-local Phase 16 first-boot verification so release-state drift and bootstrap-contract drift are caught before Phase 17 runtime bring-up work.

## What changed
- add a focused Python test that requires a dedicated Phase 16 first-boot verifier script
- add `scripts/verify-phase-16-first-boot-contract.sh` to validate release-state consistency across the approved documentation and runtime-boundary artifacts
- add shell fixture coverage that fails closed when optional or deferred components creep into the first-boot path or entrypoint/bootstrap contracts drift

## Impact
This keeps the approved Phase 16 first-boot scope explicit and reviewable in-repo, without introducing live boot execution or external deployment testing.

## Verification
- `python3 -m unittest control-plane.tests.test_phase16_first_boot_verifier`
- `bash scripts/test-verify-phase-16-first-boot-contract.sh`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated verification system to ensure Phase 16 first-boot deployment configuration aligns with documentation and enforces required scope contracts.

* **Tests**
  * Added test coverage for the first-boot deployment verifier, validating detection of configuration drift and documentation inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->