### PR TITLE
[codex] Align first-boot control-plane service command

### DIFF
--- a/.codex-supervisor/issues/360/issue-journal.md
+++ b/.codex-supervisor/issues/360/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #360: implementation: align the first-boot control-plane service command with the approved live runtime boundary
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/360
+- Branch: codex/issue-360
+- Workspace: .
+- Journal: .codex-supervisor/issues/360/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: aa68f66070a2d9b00909162c39d577cd66693cee
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T00:31:22.923Z
+
+## Latest Codex Summary
+- Replaced the first-boot control-plane compose command with the long-running `python3 main.py serve` runtime surface, kept `python3 main.py runtime` as a read-only snapshot CLI, and tightened Phase 16 regression coverage so first boot fails closed if compose points back at the one-shot renderer.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The first-boot compose surface drifted to the read-only `runtime` snapshot CLI, so the boot contract could claim a live control-plane service while launching a process that prints JSON and exits.
+- What changed: Added a long-running `serve` command in `control-plane/main.py` with `/healthz`, `/readyz`, and `/runtime` HTTP endpoints; switched `control-plane/deployment/first-boot/docker-compose.yml` to `python3 main.py serve`; updated `scripts/verify-phase-16-first-boot-contract.sh`; expanded CLI and Phase 16 verifier regression tests; refreshed `control-plane/README.md` to distinguish `serve` from `runtime`.
+- Current blocker: none
+- Next exact step: Commit the checkpoint, then leave the branch ready for supervisor review or follow-up verification.
+- Verification gap: Did not exercise the long-running server against live Docker Compose or a live PostgreSQL-backed first-boot environment; coverage is unit-level plus repository contract verification.
+- Files touched: .codex-supervisor/issues/360/issue-journal.md; control-plane/README.md; control-plane/deployment/first-boot/docker-compose.yml; control-plane/main.py; control-plane/tests/test_cli_inspection.py; control-plane/tests/test_phase16_first_boot_verifier.py; scripts/verify-phase-16-first-boot-contract.sh
+- Rollback concern: Reverting only the compose command without also reverting the verifier and CLI changes would restore the false-positive first-boot service claim.
+- Last focused command: python3 -m unittest control-plane.tests.test_phase16_first_boot_verifier control-plane.tests.test_cli_inspection
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -14,7 +14,7 @@ Future implementation may add service source code, adapters, tests, and service-
 
 Current scaffold:
 
-- `main.py` is the local entrypoint for rendering read-only runtime, record-family, and reconciliation inspection views without assuming deployment tooling.
+- `main.py` is the local entrypoint for the reviewed long-running control-plane runtime service plus read-only runtime, record-family, and reconciliation inspection views without assuming deployment tooling.
 - `main.py` also exposes read-only analyst-assistant context inspection for control-plane records, reviewed context, and linked evidence.
 - `aegisops_control_plane/` contains the initial service module, boundary-aware adapters, and environment-backed runtime config.
 - `tests/` contains focused service-root tests for the local runtime skeleton.
@@ -25,7 +25,8 @@ Current persistence status:
 
 - The reviewed record families now have typed control-plane models plus PostgreSQL-backed runtime `save()`, `get()`, and `list()` behavior rooted under `control-plane/`.
 - The runtime adapter validates records against the reviewed v1 schema invariants in `postgres/control-plane/schema.sql` before writing them into the `aegisops_control` PostgreSQL boundary.
-- The approved reviewed local runtime path is the shipped CLI entrypoint: `python3 control-plane/main.py runtime`, `python3 control-plane/main.py inspect-records --family alert`, `python3 control-plane/main.py inspect-reconciliation-status`, and `python3 control-plane/main.py inspect-assistant-context --family case --record-id <id>`.
+- The approved reviewed local runtime path is the shipped CLI entrypoint: `python3 control-plane/main.py serve`, `python3 control-plane/main.py runtime`, `python3 control-plane/main.py inspect-records --family alert`, `python3 control-plane/main.py inspect-reconciliation-status`, and `python3 control-plane/main.py inspect-assistant-context --family case --record-id <id>`.
+- `python3 control-plane/main.py serve` is the reviewed long-running runtime surface for first boot; `python3 control-plane/main.py runtime` remains the read-only snapshot renderer for inspection and verification.
 - Those runtime and inspection commands now construct the same reviewed control-plane service path, so PostgreSQL-backed runtime configuration remains the authoritative local operator flow while injected in-memory stores stay limited to tests and local doubles.
 - The runtime snapshot now reports `persistence_mode="postgresql"` so the reviewed control-plane runtime makes its authoritative store explicit.
 - Live read/write access still depends on PostgreSQL client tooling in the runtime environment, but the control-plane adapter no longer models the reviewed authority path as process-local in-memory state.

--- a/control-plane/deployment/first-boot/docker-compose.yml
+++ b/control-plane/deployment/first-boot/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     command:
       - python3
       - main.py
-      - runtime
+      - serve
     environment:
       AEGISOPS_CONTROL_PLANE_HOST: ${AEGISOPS_CONTROL_PLANE_HOST:-127.0.0.1}
       AEGISOPS_CONTROL_PLANE_PORT: ${AEGISOPS_CONTROL_PLANE_PORT:-8080}

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import sys
 from typing import Sequence, TextIO
@@ -16,12 +18,16 @@ from aegisops_control_plane.service import (
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Render read-only control-plane runtime, record, and reconciliation "
-            "inspection views."
+            "Run the reviewed control-plane runtime service or render read-only "
+            "runtime, record, and reconciliation inspection views."
         )
     )
     subparsers = parser.add_subparsers(dest="command")
 
+    subparsers.add_parser(
+        "serve",
+        help="Run the reviewed long-running control-plane runtime service.",
+    )
     subparsers.add_parser("runtime", help="Render the current runtime snapshot.")
 
     inspect_records = subparsers.add_parser(
@@ -87,19 +93,101 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def run_control_plane_service(
+    service: AegisOpsControlPlaneService,
+    *,
+    stderr: TextIO | None = None,
+) -> int:
+    runtime_snapshot = service.describe_runtime().to_dict()
+    stderr = stderr or sys.stderr
+
+    class _RequestHandler(BaseHTTPRequestHandler):
+        server_version = "AegisOpsControlPlane/1.0"
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path == "/healthz":
+                self._write_json(
+                    HTTPStatus.OK,
+                    {
+                        "service_name": runtime_snapshot["service_name"],
+                        "status": "ok",
+                    },
+                )
+                return
+
+            if self.path == "/readyz":
+                self._write_json(
+                    HTTPStatus.OK,
+                    {
+                        "service_name": runtime_snapshot["service_name"],
+                        "status": "ready",
+                        "persistence_mode": runtime_snapshot["persistence_mode"],
+                    },
+                )
+                return
+
+            if self.path == "/runtime":
+                self._write_json(HTTPStatus.OK, runtime_snapshot)
+                return
+
+            self._write_json(
+                HTTPStatus.NOT_FOUND,
+                {
+                    "error": "not_found",
+                    "path": self.path,
+                },
+            )
+
+        def log_message(self, format: str, *args: object) -> None:
+            print(
+                "%s - - [%s] %s"
+                % (
+                    self.address_string(),
+                    self.log_date_time_string(),
+                    format % args,
+                ),
+                file=stderr,
+            )
+
+        def _write_json(self, status: HTTPStatus, payload: dict[str, object]) -> None:
+            body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(
+        (str(runtime_snapshot["bind_host"]), int(runtime_snapshot["bind_port"])),
+        _RequestHandler,
+    )
+
+    try:
+        server.serve_forever()
+        return 0
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        server.server_close()
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
     stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
     service: AegisOpsControlPlaneService | None = None,
 ) -> int:
     parser = _build_parser()
     parsed = parser.parse_args(list(argv) if argv is not None else None)
     command = parsed.command or "runtime"
     stdout = stdout or sys.stdout
+    stderr = stderr or sys.stderr
 
     service = service or build_runtime_service()
 
+    if command == "serve":
+        return run_control_plane_service(service, stderr=stderr)
     if command == "runtime":
         payload = service.describe_runtime().to_dict()
     else:

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -77,6 +77,49 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(payload["postgres_dsn"], "postgresql://control-plane.local/aegisops")
         self.assertEqual(payload["persistence_mode"], "postgresql")
 
+    def test_serve_command_uses_long_running_runtime_surface(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        with mock.patch.object(
+            main,
+            "build_runtime_service",
+            return_value=service,
+        ) as build_runtime_service, mock.patch.object(
+            main,
+            "run_control_plane_service",
+            return_value=0,
+        ) as run_control_plane_service:
+            exit_code = main.main(["serve"])
+
+        self.assertEqual(exit_code, 0)
+        build_runtime_service.assert_called_once_with()
+        run_control_plane_service.assert_called_once_with(service, stderr=mock.ANY)
+
+    def test_long_running_runtime_surface_starts_http_server(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=8089,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+            ),
+            store=store,
+        )
+
+        with mock.patch.object(main, "ThreadingHTTPServer") as server_cls:
+            server = server_cls.return_value
+
+            exit_code = main.run_control_plane_service(service)
+
+        self.assertEqual(exit_code, 0)
+        server_cls.assert_called_once_with(("127.0.0.1", 8089), mock.ANY)
+        server.serve_forever.assert_called_once_with()
+        server.server_close.assert_called_once_with()
+
     def test_cli_renders_read_only_record_and_reconciliation_views(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_phase16_first_boot_verifier.py
+++ b/control-plane/tests/test_phase16_first_boot_verifier.py
@@ -46,6 +46,21 @@ class Phase16FirstBootVerifierTests(unittest.TestCase):
             compose_path = (
                 fixture_root / "control-plane" / "deployment" / "first-boot" / "docker-compose.yml"
             )
+            self._insert_text_after(
+                compose_path,
+                "      - serve\n",
+                "      - runtime\n",
+            )
+            self._assert_verifier_fails_with(
+                verifier,
+                fixture_root,
+                "First-boot compose must not launch the one-shot runtime snapshot renderer.",
+            )
+
+            self._create_repo_fixture(fixture_root)
+            compose_path = (
+                fixture_root / "control-plane" / "deployment" / "first-boot" / "docker-compose.yml"
+            )
             compose_path.write_text(
                 compose_path.read_text(encoding="utf-8")
                 + "\n  opensearch:\n    image: opensearchproject/opensearch:2\n",
@@ -105,6 +120,13 @@ class Phase16FirstBootVerifierTests(unittest.TestCase):
         if text not in content:
             raise AssertionError(f"expected to remove text from {path}: {text!r}")
         path.write_text(content.replace(text, "", 1), encoding="utf-8")
+
+    @staticmethod
+    def _insert_text_after(path: pathlib.Path, anchor: str, inserted: str) -> None:
+        content = path.read_text(encoding="utf-8")
+        if anchor not in content:
+            raise AssertionError(f"expected to insert text in {path} after: {anchor!r}")
+        path.write_text(content.replace(anchor, anchor + inserted, 1), encoding="utf-8")
 
     @staticmethod
     def _assert_verifier_passes(verifier: pathlib.Path, repo_root: pathlib.Path) -> None:

--- a/scripts/verify-phase-16-first-boot-contract.sh
+++ b/scripts/verify-phase-16-first-boot-contract.sh
@@ -139,6 +139,7 @@ compose_lines=(
   '  control-plane:'
   '  postgres:'
   '  proxy:'
+  '      - serve'
   '      AEGISOPS_CONTROL_PLANE_POSTGRES_DSN: ${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:?set-in-untracked-runtime-env}'
   '      AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL: ${AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL:-}'
   '      AEGISOPS_CONTROL_PLANE_N8N_BASE_URL: ${AEGISOPS_CONTROL_PLANE_N8N_BASE_URL:-}'
@@ -160,6 +161,8 @@ require_absent_string "${compose_file}" '  analyst-assistant:' \
   'First-boot compose must not define first-boot service: analyst-assistant'
 require_absent_string "${compose_file}" '  executor:' \
   'First-boot compose must not define first-boot service: executor'
+require_absent_string "${compose_file}" '      - runtime' \
+  'First-boot compose must not launch the one-shot runtime snapshot renderer.'
 
 entrypoint_lines=(
   '# Phase 16 first-boot skeleton only.'


### PR DESCRIPTION
## Summary
- add a long-running `python3 main.py serve` control-plane runtime surface with `/healthz`, `/readyz`, and `/runtime`
- switch the first-boot compose service away from the one-shot `runtime` snapshot command to the approved live-service boundary
- fail closed in the Phase 16 first-boot contract verifier and add regression coverage for CLI and verifier drift

## Why
The first-boot control-plane service previously claimed a live runtime boundary while actually resolving to a one-shot inspection renderer that printed JSON and exited. This change aligns the boot surface with the approved Phase 16 live-service contract and prevents drift back to the snapshot CLI.

## Validation
- `python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence`
- `python3 -m unittest control-plane.tests.test_phase16_first_boot_verifier`
- `bash scripts/test-verify-phase-16-release-state-and-first-boot-scope.sh`
- `bash scripts/verify-phase-16-first-boot-contract.sh`

## Notes
- Validation is focused on unit and repository-contract coverage; this does not exercise a live Docker Compose or PostgreSQL-backed first-boot environment.
- Supervisor scratch files and journal updates are intentionally excluded from the PR scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new long-running HTTP server mode for the control-plane service with health check, readiness, and runtime snapshot endpoints.

* **Documentation**
  * Updated documentation to reflect the new long-running service mode and startup commands.

* **Tests**
  * Added test coverage for the new HTTP server functionality and first-boot deployment mode validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->