### PR TITLE
[codex] Define Phase 17 runtime config contract

### DIFF
--- a/.codex-supervisor/issues/364/issue-journal.md
+++ b/.codex-supervisor/issues/364/issue-journal.md
@@ -38,10 +38,11 @@ Failure signature: none
 - Hypothesis: The Phase 17 contract doc is present and tested, but the checkpoint still benefits from a repo-level verifier and validation snapshot so reviewers can confirm the runtime contract without relying only on a single Python doc test.
 - What changed: Added `docs/phase-17-runtime-config-contract-validation.md`, `scripts/verify-phase-17-runtime-config-contract.sh`, and `scripts/test-verify-phase-17-runtime-config-contract.sh`, then linked the validation doc from `README.md` and `docs/documentation-ownership-map.md`.
 - Current blocker: none
-- Next exact step: Commit the Phase 17 verifier/validation checkpoint on `codex/issue-364`, push the branch, and open a draft PR from that checkpoint.
+- Next exact step: Monitor draft PR `#369` for review feedback and keep the Phase 17 verifier aligned with any wording changes to the contract docs.
 - Verification gap: The requested `Phase 16-21 Epic Roadmap.md` comparison target is still unavailable in the local worktree, so the validation snapshot records that deviation instead of claiming roadmap review was completed.
 - Files touched: `docs/phase-17-runtime-config-contract-validation.md`, `scripts/verify-phase-17-runtime-config-contract.sh`, `scripts/test-verify-phase-17-runtime-config-contract.sh`, `README.md`, `docs/documentation-ownership-map.md`, `.codex-supervisor/issues/364/issue-journal.md`
 - Rollback concern: Low; changes remain documentation and verification only, but the new verifier now treats direct backend publication, widened startup prerequisites, and missing fail-closed contract language as review failures.
-- Last focused command: `bash scripts/verify-phase-17-runtime-config-contract.sh && bash scripts/test-verify-phase-17-runtime-config-contract.sh && python3 -m unittest control-plane.tests.test_phase17_runtime_config_contract_docs control-plane.tests.test_phase16_bootstrap_contract_docs control-plane.tests.test_phase16_first_boot_verifier && bash scripts/verify-phase-16-first-boot-contract.sh`
+- Last focused command: `gh pr create --draft --base main --head codex/issue-364 --title "[codex] Define Phase 17 runtime config contract" --body-file <tempfile>`
 ### Scratchpad
+- Draft PR opened: `https://github.com/TommyKammy/AegisOps/pull/369`
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/364/issue-journal.md
+++ b/.codex-supervisor/issues/364/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #364: design: define the concrete Phase 17 runtime config contract and boot command expectations
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/364
+- Branch: codex/issue-364
+- Workspace: .
+- Journal: .codex-supervisor/issues/364/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 70dab8746bea43e64b0fe4c951bd8f00c5043aa2
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T02:33:57.788Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The Phase 16 first-boot floor is already defined and verified locally, but the repository has no Phase 17 artifact that turns that floor into an explicit runtime config contract and boot command expectation for real bring-up work.
+- What changed: Added a focused reproducing test for the missing Phase 17 contract doc, confirmed the failure, then added `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md` plus README and documentation-ownership references.
+- Current blocker: none
+- Next exact step: Commit the Phase 17 contract doc checkpoint on `codex/issue-364`, then decide whether to add a repository verifier script or open a draft PR from this checkpoint.
+- Verification gap: No repo-level shell verifier or validation snapshot was added for the new Phase 17 doc in this turn; verification currently relies on focused Python doc tests and adjacent Phase 16 first-boot tests.
+- Files touched: `control-plane/tests/test_phase17_runtime_config_contract_docs.py`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `README.md`, `docs/documentation-ownership-map.md`, `.codex-supervisor/issues/364/issue-journal.md`
+- Rollback concern: Low; changes are documentation and test coverage only, but the new contract explicitly rejects direct backend publication and broadening first-boot prerequisites, so later runtime implementation must follow those constraints.
+- Last focused command: `python3 -m unittest control-plane.tests.test_phase17_runtime_config_contract_docs control-plane.tests.test_phase16_bootstrap_contract_docs control-plane.tests.test_phase16_first_boot_verifier`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/364/issue-journal.md
+++ b/.codex-supervisor/issues/364/issue-journal.md
@@ -5,29 +5,43 @@
 - Branch: codex/issue-364
 - Workspace: .
 - Journal: .codex-supervisor/issues/364/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 70dab8746bea43e64b0fe4c951bd8f00c5043aa2
+- Current phase: stabilizing
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: b993d1bb99faeed48b35cebd9f71d2b767c9f4ac
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-10T02:33:57.788Z
+- Updated at: 2026-04-10T02:39:49.555Z
 
 ## Latest Codex Summary
-- None yet.
+Added the Phase 17 contract doc at [docs/phase-17-runtime-config-contract-and-boot-command-expectations.md](docs/phase-17-runtime-config-contract-and-boot-command-expectations.md), plus a focused reproducing test at [control-plane/tests/test_phase17_runtime_config_contract_docs.py](control-plane/tests/test_phase17_runtime_config_contract_docs.py). The doc makes the first-boot runtime keys, reviewed defaults, fail-closed rules, migration bootstrap sequence, and reverse-proxy-only exposure model explicit, and it calls out which Phase 16 placeholders are now concrete versus still deferred.
+
+I also added the new contract to [README.md](README.md) and [docs/documentation-ownership-map.md](docs/documentation-ownership-map.md), updated the issue journal at [.codex-supervisor/issues/364/issue-journal.md](.codex-supervisor/issues/364/issue-journal.md), and committed the checkpoint as `b993d1b` with message `Define Phase 17 runtime config contract`.
+
+Verification ran clean:
+`python3 -m unittest control-plane.tests.test_phase17_runtime_config_contract_docs`
+`python3 -m unittest control-plane.tests.test_phase16_bootstrap_contract_docs`
+`python3 -m unittest control-plane.tests.test_phase16_first_boot_verifier`
+
+Summary: Added and verified the missing Phase 17 runtime config and boot-command contract, anchored to the existing Phase 16 first-boot floor.
+State hint: implementing
+Blocked reason: none
+Tests: `python3 -m unittest control-plane.tests.test_phase17_runtime_config_contract_docs`; `python3 -m unittest control-plane.tests.test_phase16_bootstrap_contract_docs`; `python3 -m unittest control-plane.tests.test_phase16_first_boot_verifier`
+Next action: Decide whether to add a repo-level verifier/validation snapshot for the new Phase 17 contract and open a draft PR from commit `b993d1b`.
+Failure signature: none
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The Phase 16 first-boot floor is already defined and verified locally, but the repository has no Phase 17 artifact that turns that floor into an explicit runtime config contract and boot command expectation for real bring-up work.
-- What changed: Added a focused reproducing test for the missing Phase 17 contract doc, confirmed the failure, then added `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md` plus README and documentation-ownership references.
+- Hypothesis: The Phase 17 contract doc is present and tested, but the checkpoint still benefits from a repo-level verifier and validation snapshot so reviewers can confirm the runtime contract without relying only on a single Python doc test.
+- What changed: Added `docs/phase-17-runtime-config-contract-validation.md`, `scripts/verify-phase-17-runtime-config-contract.sh`, and `scripts/test-verify-phase-17-runtime-config-contract.sh`, then linked the validation doc from `README.md` and `docs/documentation-ownership-map.md`.
 - Current blocker: none
-- Next exact step: Commit the Phase 17 contract doc checkpoint on `codex/issue-364`, then decide whether to add a repository verifier script or open a draft PR from this checkpoint.
-- Verification gap: No repo-level shell verifier or validation snapshot was added for the new Phase 17 doc in this turn; verification currently relies on focused Python doc tests and adjacent Phase 16 first-boot tests.
-- Files touched: `control-plane/tests/test_phase17_runtime_config_contract_docs.py`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `README.md`, `docs/documentation-ownership-map.md`, `.codex-supervisor/issues/364/issue-journal.md`
-- Rollback concern: Low; changes are documentation and test coverage only, but the new contract explicitly rejects direct backend publication and broadening first-boot prerequisites, so later runtime implementation must follow those constraints.
-- Last focused command: `python3 -m unittest control-plane.tests.test_phase17_runtime_config_contract_docs control-plane.tests.test_phase16_bootstrap_contract_docs control-plane.tests.test_phase16_first_boot_verifier`
+- Next exact step: Commit the Phase 17 verifier/validation checkpoint on `codex/issue-364`, push the branch, and open a draft PR from that checkpoint.
+- Verification gap: The requested `Phase 16-21 Epic Roadmap.md` comparison target is still unavailable in the local worktree, so the validation snapshot records that deviation instead of claiming roadmap review was completed.
+- Files touched: `docs/phase-17-runtime-config-contract-validation.md`, `scripts/verify-phase-17-runtime-config-contract.sh`, `scripts/test-verify-phase-17-runtime-config-contract.sh`, `README.md`, `docs/documentation-ownership-map.md`, `.codex-supervisor/issues/364/issue-journal.md`
+- Rollback concern: Low; changes remain documentation and verification only, but the new verifier now treats direct backend publication, widened startup prerequisites, and missing fail-closed contract language as review failures.
+- Last focused command: `bash scripts/verify-phase-17-runtime-config-contract.sh && bash scripts/test-verify-phase-17-runtime-config-contract.sh && python3 -m unittest control-plane.tests.test_phase17_runtime_config_contract_docs control-plane.tests.test_phase16_bootstrap_contract_docs control-plane.tests.test_phase16_first_boot_verifier && bash scripts/verify-phase-16-first-boot-contract.sh`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/phase-16-release-state-and-first-boot-scope.md`
 - `docs/phase-16-release-state-and-first-boot-validation.md`
 - `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`
+- `docs/phase-17-runtime-config-contract-validation.md`
 - `docs/phase-15-identity-grounded-analyst-assistant-operating-guidance.md`
 - `docs/retention-evidence-and-replay-readiness-baseline.md`
 - `docs/runbook.md`

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/control-plane-runtime-service-boundary.md`
 - `docs/phase-16-release-state-and-first-boot-scope.md`
 - `docs/phase-16-release-state-and-first-boot-validation.md`
+- `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`
 - `docs/phase-15-identity-grounded-analyst-assistant-operating-guidance.md`
 - `docs/retention-evidence-and-replay-readiness-baseline.md`
 - `docs/runbook.md`

--- a/control-plane/tests/test_phase17_runtime_config_contract_docs.py
+++ b/control-plane/tests/test_phase17_runtime_config_contract_docs.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase17RuntimeConfigContractDocsTests(unittest.TestCase):
+    @staticmethod
+    def _contract_doc() -> pathlib.Path:
+        return REPO_ROOT / "docs" / "phase-17-runtime-config-contract-and-boot-command-expectations.md"
+
+    def test_phase17_contract_doc_exists(self) -> None:
+        contract_doc = self._contract_doc()
+
+        self.assertTrue(contract_doc.exists(), f"expected Phase 17 contract doc at {contract_doc}")
+
+    def test_phase17_contract_doc_defines_runtime_config_and_boot_expectations(self) -> None:
+        contract_doc = self._contract_doc()
+        self.assertTrue(contract_doc.exists(), f"expected Phase 17 contract doc at {contract_doc}")
+        text = contract_doc.read_text(encoding="utf-8")
+
+        for term in (
+            "Runtime Config Contract",
+            "Boot Command Expectations",
+            "Approved Required Runtime Environment Keys",
+            "Approved Optional and Deferred Environment Keys",
+            "AEGISOPS_CONTROL_PLANE_HOST",
+            "AEGISOPS_CONTROL_PLANE_PORT",
+            "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN",
+            "AEGISOPS_CONTROL_PLANE_BOOT_MODE",
+            "AEGISOPS_CONTROL_PLANE_LOG_LEVEL",
+            "control-plane service process",
+            "migration bootstrap",
+            "reverse proxy",
+            "must fail closed",
+            "must not publish the control-plane backend port directly",
+            "Phase 16 placeholders become concrete runtime expectations",
+            "remain deferred",
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -40,6 +40,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/control-plane-runtime-service-boundary.md` | Live control-plane runtime service boundary and repository placement baseline | IT Operations, Information Systems Department |
 | `docs/phase-16-release-state-and-first-boot-scope.md` | Approved Phase 16 release-state, first-boot runtime boundary, and definition of done | IT Operations, Information Systems Department |
 | `docs/phase-16-release-state-and-first-boot-validation.md` | Review record for the approved Phase 16 first-boot scope and bootability target | IT Operations, Information Systems Department |
+| `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md` | Concrete Phase 17 first-boot runtime config contract and boot command expectations | IT Operations, Information Systems Department |
 | `docs/retention-evidence-and-replay-readiness-baseline.md` | Retention, evidence lifecycle, and replay readiness baseline | IT Operations, Information Systems Department |
 | `docs/phase-7-ai-hunt-evaluation-baseline.md` | Phase 7 AI hunt evaluation baseline | IT Operations, Information Systems Department |
 | `docs/source-families/` | Approved source-family onboarding and analyst triage runbooks | IT Operations, Information Systems Department |

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -41,6 +41,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/phase-16-release-state-and-first-boot-scope.md` | Approved Phase 16 release-state, first-boot runtime boundary, and definition of done | IT Operations, Information Systems Department |
 | `docs/phase-16-release-state-and-first-boot-validation.md` | Review record for the approved Phase 16 first-boot scope and bootability target | IT Operations, Information Systems Department |
 | `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md` | Concrete Phase 17 first-boot runtime config contract and boot command expectations | IT Operations, Information Systems Department |
+| `docs/phase-17-runtime-config-contract-validation.md` | Review record for the Phase 17 runtime config contract and boot command expectations | IT Operations, Information Systems Department |
 | `docs/retention-evidence-and-replay-readiness-baseline.md` | Retention, evidence lifecycle, and replay readiness baseline | IT Operations, Information Systems Department |
 | `docs/phase-7-ai-hunt-evaluation-baseline.md` | Phase 7 AI hunt evaluation baseline | IT Operations, Information Systems Department |
 | `docs/source-families/` | Approved source-family onboarding and analyst triage runbooks | IT Operations, Information Systems Department |

--- a/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md
+++ b/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md
@@ -1,0 +1,165 @@
+# AegisOps Phase 17 Runtime Config Contract and Boot Command Expectations
+
+## 1. Purpose
+
+This document defines the concrete runtime config contract and boot command expectations for the Phase 17 first-boot bring-up path.
+
+It supplements `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/control-plane-runtime-service-boundary.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/storage-layout-and-mount-policy.md`, and `control-plane/deployment/first-boot/`.
+
+This document turns the approved Phase 16 floor into a concrete implementation contract for image, Compose, and entrypoint work without broadening first-boot scope.
+
+It does not approve live Wazuh integration wiring, a thin operator UI, optional OpenSearch extension wiring, or the high-risk executor path.
+
+## 2. Phase 17 Contract Goal
+
+Phase 17 exists to make the approved first-boot target bootable as a real control-plane runtime service.
+
+That means the repository must now be explicit about:
+
+- which runtime environment keys are required to start the control-plane service process;
+- which keys may use reviewed defaults;
+- which optional keys remain non-blocking and deferred;
+- which boot command shape is approved for the control-plane service process;
+- how migration bootstrap is sequenced before normal service readiness; and
+- how the reverse proxy remains the only approved user-facing exposure path.
+
+Phase 17 therefore defines implementation expectations for the approved first-boot runtime.
+
+It does not reopen which components count as the runtime floor.
+
+## 3. Runtime Config Contract
+
+### 3.1 Approved Required Runtime Environment Keys
+
+The approved required runtime environment keys for Phase 17 first boot are:
+
+- `AEGISOPS_CONTROL_PLANE_HOST`
+- `AEGISOPS_CONTROL_PLANE_PORT`
+- `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`
+- `AEGISOPS_CONTROL_PLANE_BOOT_MODE`
+- `AEGISOPS_CONTROL_PLANE_LOG_LEVEL`
+
+`AEGISOPS_CONTROL_PLANE_HOST` is required runtime input because the service must bind intentionally to the approved internal interface rather than to an inferred convenience default.
+
+`AEGISOPS_CONTROL_PLANE_PORT` is required runtime input for the reviewed listen port, even when repository-local boot surfaces provide a reviewed default.
+
+`AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` is required authoritative persistence configuration and must identify the reviewed PostgreSQL control-plane datastore.
+
+`AEGISOPS_CONTROL_PLANE_BOOT_MODE` is required so the boot command can distinguish first-boot migration-and-serve behavior from unsupported ad hoc startup modes.
+
+`AEGISOPS_CONTROL_PLANE_LOG_LEVEL` is required so runtime observability is explicit and reviewable instead of being hidden inside framework defaults.
+
+If any required key is absent, empty, malformed, contradictory, or would violate the approved reverse-proxy-first exposure model, startup must fail closed.
+
+### 3.2 Approved Defaults and Fail-Closed Rules
+
+The following reviewed local defaults are allowed only where they preserve the approved first-boot boundary:
+
+- `AEGISOPS_CONTROL_PLANE_HOST=127.0.0.1`
+- `AEGISOPS_CONTROL_PLANE_PORT=8080`
+- `AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot`
+- `AEGISOPS_CONTROL_PLANE_LOG_LEVEL=INFO`
+
+`AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` has no approved repository default and must come from an untracked runtime secret source or operator-provided runtime env file.
+
+`AEGISOPS_CONTROL_PLANE_HOST` must fail closed if set to a wildcard or convenience value that would bypass the approved proxy boundary, including `0.0.0.0` for direct user-network publication in the first-boot path.
+
+`AEGISOPS_CONTROL_PLANE_PORT` must fail closed if it is non-numeric, empty, or outside the reviewed application listen-port expectation.
+
+`AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` must fail closed unless it is a PostgreSQL DSN for the AegisOps-owned control-plane datastore boundary.
+
+`AEGISOPS_CONTROL_PLANE_BOOT_MODE` must fail closed unless it is the reviewed first-boot mode expected by the repository-local entrypoint and service command path.
+
+`AEGISOPS_CONTROL_PLANE_LOG_LEVEL` must fail closed unless it is one of the reviewed service levels `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`.
+
+### 3.3 Approved Optional and Deferred Environment Keys
+
+The approved optional and deferred environment keys remain:
+
+- `AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL`
+- `AEGISOPS_CONTROL_PLANE_N8N_BASE_URL`
+- `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL`
+- `AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL`
+
+These keys may be present in runtime env files or Compose wiring for future compatibility, but they must not become first-boot prerequisites.
+
+Their absence must not block control-plane startup, migration bootstrap, liveness, or readiness for the reviewed Phase 17 first-boot path.
+
+## 4. Boot Command Expectations
+
+### 4.1 Control-Plane Service Process
+
+The approved control-plane boot path is a reviewed entrypoint that validates runtime config, runs migration bootstrap, proves readiness prerequisites, and then starts the control-plane service process.
+
+The control-plane service process must be started as the final foreground process for the container or runtime unit.
+
+The reviewed boot command shape is:
+
+1. validate required runtime config
+2. validate the reviewed migration asset set
+3. prove PostgreSQL reachability
+4. apply the required forward migration bootstrap set
+5. verify the expected first-boot schema state
+6. exec the control-plane service process
+
+The boot command must not background the control-plane service process, split migration bootstrap into an undocumented sidecar, or report readiness before migration bootstrap succeeds.
+
+### 4.2 Migration Bootstrap Expectations
+
+Migration bootstrap remains part of the approved normal boot sequence for `AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot`.
+
+The reviewed migration asset home remains `postgres/control-plane/migrations/`.
+
+Migration bootstrap must execute before the control-plane service process is treated as ready for authoritative writes.
+
+Migration bootstrap failure includes:
+
+- missing reviewed migration assets;
+- PostgreSQL connection failure;
+- a failed forward migration;
+- partially applied required migrations; or
+- inability to prove the expected reviewed schema state after migration execution.
+
+Any such failure must fail closed and stop the boot command before normal service admission.
+
+### 4.3 Reverse-Proxy Exposure Model
+
+Phase 17 keeps the approved reverse proxy as the only reviewed user-facing ingress path.
+
+The control-plane backend port must remain an internal service port.
+
+Repository-local boot surfaces must not publish the control-plane backend port directly to user networks or the public internet.
+
+The contract therefore must not publish the control-plane backend port directly as a substitute for approved reverse-proxy routing.
+
+Compose, container, or service-unit examples may expose the reverse proxy front door, but they must keep the control-plane service on an internal network path behind that proxy.
+
+## 5. Phase 16 Placeholders That Become Concrete Runtime Expectations
+
+Phase 16 placeholders become concrete runtime expectations in Phase 17 as follows:
+
+- the reviewed first-boot skeleton environment keys now become the approved runtime environment contract for first boot;
+- the reviewed first-boot entrypoint pattern now becomes the approved boot sequencing contract for real bring-up work;
+- the reviewed migration asset location now becomes the required runtime migration-bootstrap input;
+- the reviewed distinction between liveness and readiness now becomes a concrete startup gate for implementation; and
+- the reviewed reverse-proxy-first access model now becomes a concrete exposure rule for image and Compose work.
+
+The following items remain deferred and must stay visibly out of the initial bring-up contract:
+
+- live Wazuh integration wiring;
+- optional OpenSearch extension wiring or OpenSearch-dependent readiness;
+- n8n, Shuffle, or executor connectivity as startup blockers;
+- the thin operator UI or analyst-assistant surface; and
+- destructive schema repair, downgrade logic, or ad hoc bootstrap shortcuts.
+
+## 6. Alignment and Non-Expansion Rules
+
+This Phase 17 contract is aligned to the Phase 16 first-boot scope and must be read as a concrete implementation contract for that already-approved floor.
+
+If an image, Compose definition, runtime env file, or service unit conflicts with this document by adding new required dependencies, direct backend publication, or broader first-boot success criteria, that implementation is out of contract and must fail review.
+
+`docs/phase-16-release-state-and-first-boot-scope.md` remains the normative source for the approved runtime floor.
+
+`docs/network-exposure-and-access-path-policy.md` remains the normative source for the reverse proxy and internal exposure rules.
+
+`docs/control-plane-runtime-service-boundary.md` remains the normative source for the ownership split and the `control-plane/` runtime home.

--- a/docs/phase-17-runtime-config-contract-validation.md
+++ b/docs/phase-17-runtime-config-contract-validation.md
@@ -1,0 +1,55 @@
+# Phase 17 Runtime Config Contract and Boot Command Validation
+
+- Validation date: 2026-04-10
+- Validation scope: Phase 17 review of the approved first-boot runtime config contract, required and optional environment keys, reviewed defaults, fail-closed boot behavior, migration-bootstrap sequencing, reverse-proxy-only exposure expectations, and explicit Phase 16-to-Phase 17 carry-forward boundaries
+- Baseline references: `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/control-plane-runtime-service-boundary.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/storage-layout-and-mount-policy.md`, `README.md`
+- Verification commands: `bash scripts/verify-phase-17-runtime-config-contract.sh`, `bash scripts/test-verify-phase-17-runtime-config-contract.sh`
+- Validation status: PASS
+
+## Required Boundary Artifacts
+
+- `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`
+- `docs/phase-17-runtime-config-contract-validation.md`
+- `docs/phase-16-release-state-and-first-boot-scope.md`
+- `docs/control-plane-runtime-service-boundary.md`
+- `docs/network-exposure-and-access-path-policy.md`
+- `docs/storage-layout-and-mount-policy.md`
+- `README.md`
+- `scripts/verify-phase-17-runtime-config-contract.sh`
+- `scripts/test-verify-phase-17-runtime-config-contract.sh`
+
+## Review Outcome
+
+Confirmed the Phase 17 contract makes the approved first-boot runtime environment keys explicit enough to drive image, Compose, and entrypoint implementation without reopening the approved runtime floor.
+
+Confirmed `AEGISOPS_CONTROL_PLANE_HOST`, `AEGISOPS_CONTROL_PLANE_PORT`, `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`, `AEGISOPS_CONTROL_PLANE_BOOT_MODE`, and `AEGISOPS_CONTROL_PLANE_LOG_LEVEL` are the approved required first-boot runtime keys and that startup must fail closed when they are absent, empty, malformed, contradictory, or exposure-bypassing.
+
+Confirmed the reviewed local defaults stay narrow by allowing `127.0.0.1`, `8080`, `first-boot`, and `INFO` while keeping `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` without a repository default.
+
+Confirmed the Phase 17 contract keeps `AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL`, `AEGISOPS_CONTROL_PLANE_N8N_BASE_URL`, `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL`, and `AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL` explicitly optional and non-blocking for the first-boot path.
+
+Confirmed the approved boot command shape keeps migration bootstrap in the normal first-boot path by requiring runtime-config validation, migration-asset validation, PostgreSQL reachability proof, forward migration application, schema-state verification, and only then `exec` of the control-plane service process.
+
+Confirmed migration bootstrap failure remains fail-closed when reviewed migration assets are missing, PostgreSQL is unreachable, a forward migration fails, required migrations are only partially applied, or the expected reviewed schema state cannot be proven after execution.
+
+Confirmed the reverse proxy remains the only approved user-facing ingress path and that repository-local boot surfaces must not publish the control-plane backend port directly to user networks or the public internet.
+
+Confirmed the Phase 17 contract turns the reviewed Phase 16 first-boot skeleton environment keys, entrypoint sequencing, migration-home requirement, liveness-versus-readiness distinction, and reverse-proxy-first access model into concrete runtime expectations without making OpenSearch, n8n, Shuffle, executor wiring, thin UI work, or destructive schema shortcuts part of initial bring-up.
+
+The issue requested review against `Phase 16-21 Epic Roadmap.md`, but that roadmap file was not present in the local worktree and could not be located via repository search during this turn.
+
+## Cross-Link Review
+
+`docs/phase-16-release-state-and-first-boot-scope.md` must continue to define the approved first-boot runtime floor that Phase 17 implements concretely rather than broadening.
+
+`docs/control-plane-runtime-service-boundary.md` must continue to keep the control-plane service as the AegisOps-owned runtime authority boundary for image and entrypoint work.
+
+`docs/network-exposure-and-access-path-policy.md` must continue to keep the reverse proxy as the approved ingress boundary and disallow direct backend publication as a substitute.
+
+`docs/storage-layout-and-mount-policy.md` must continue to keep PostgreSQL state ownership and reviewed mount expectations distinct from optional substrate storage.
+
+`README.md` must continue to describe the Phase 16 first-boot target as the approved floor for Phase 17 bring-up and keep optional substrates out of the product-core runtime baseline.
+
+## Deviations
+
+- Requested comparison target `Phase 16-21 Epic Roadmap.md` was unavailable in the local worktree during this validation snapshot.

--- a/scripts/test-verify-phase-17-runtime-config-contract.sh
+++ b/scripts/test-verify-phase-17-runtime-config-contract.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-17-runtime-config-contract.sh"
+canonical_contract_doc="${repo_root}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md"
+canonical_validation_doc="${repo_root}/docs/phase-17-runtime-config-contract-validation.md"
+canonical_phase16_scope_doc="${repo_root}/docs/phase-16-release-state-and-first-boot-scope.md"
+canonical_runtime_boundary_doc="${repo_root}/docs/control-plane-runtime-service-boundary.md"
+canonical_network_doc="${repo_root}/docs/network-exposure-and-access-path-policy.md"
+canonical_storage_doc="${repo_root}/docs/storage-layout-and-mount-policy.md"
+canonical_readme="${repo_root}/README.md"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs" "${target}/scripts"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_canonical_artifacts() {
+  local target="$1"
+
+  cp "${canonical_contract_doc}" "${target}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md"
+  cp "${canonical_validation_doc}" "${target}/docs/phase-17-runtime-config-contract-validation.md"
+  cp "${canonical_phase16_scope_doc}" "${target}/docs/phase-16-release-state-and-first-boot-scope.md"
+  cp "${canonical_runtime_boundary_doc}" "${target}/docs/control-plane-runtime-service-boundary.md"
+  cp "${canonical_network_doc}" "${target}/docs/network-exposure-and-access-path-policy.md"
+  cp "${canonical_storage_doc}" "${target}/docs/storage-layout-and-mount-policy.md"
+  cp "${canonical_readme}" "${target}/README.md"
+  cp "${verifier}" "${target}/scripts/verify-phase-17-runtime-config-contract.sh"
+  cp "${repo_root}/scripts/test-verify-phase-17-runtime-config-contract.sh" "${target}/scripts/test-verify-phase-17-runtime-config-contract.sh"
+  git -C "${target}" add .
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local doc_path="$2"
+  local expected_text="$3"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${doc_path}"
+  git -C "${target}" add "${doc_path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_canonical_artifacts "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_repo "${missing_contract_repo}"
+write_canonical_artifacts "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md"
+git -C "${missing_contract_repo}" add -u
+commit_fixture "${missing_contract_repo}"
+assert_fails_with "${missing_contract_repo}" "Missing Phase 17 runtime config contract doc:"
+
+missing_required_key_repo="${workdir}/missing-required-key"
+create_repo "${missing_required_key_repo}"
+write_canonical_artifacts "${missing_required_key_repo}"
+remove_text_from_doc "${missing_required_key_repo}" "${missing_required_key_repo}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md" '- `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`'
+commit_fixture "${missing_required_key_repo}"
+assert_fails_with "${missing_required_key_repo}" '- `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`'
+
+missing_fail_closed_repo="${workdir}/missing-fail-closed"
+create_repo "${missing_fail_closed_repo}"
+write_canonical_artifacts "${missing_fail_closed_repo}"
+remove_text_from_doc "${missing_fail_closed_repo}" "${missing_fail_closed_repo}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md" 'If any required key is absent, empty, malformed, contradictory, or would violate the approved reverse-proxy-first exposure model, startup must fail closed.'
+commit_fixture "${missing_fail_closed_repo}"
+assert_fails_with "${missing_fail_closed_repo}" 'If any required key is absent, empty, malformed, contradictory, or would violate the approved reverse-proxy-first exposure model, startup must fail closed.'
+
+missing_boot_sequence_repo="${workdir}/missing-boot-sequence"
+create_repo "${missing_boot_sequence_repo}"
+write_canonical_artifacts "${missing_boot_sequence_repo}"
+remove_text_from_doc "${missing_boot_sequence_repo}" "${missing_boot_sequence_repo}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md" '4. apply the required forward migration bootstrap set'
+commit_fixture "${missing_boot_sequence_repo}"
+assert_fails_with "${missing_boot_sequence_repo}" '4. apply the required forward migration bootstrap set'
+
+missing_validation_note_repo="${workdir}/missing-validation-note"
+create_repo "${missing_validation_note_repo}"
+write_canonical_artifacts "${missing_validation_note_repo}"
+remove_text_from_doc "${missing_validation_note_repo}" "${missing_validation_note_repo}/docs/phase-17-runtime-config-contract-validation.md" 'Confirmed the reverse proxy remains the only approved user-facing ingress path and that repository-local boot surfaces must not publish the control-plane backend port directly to user networks or the public internet.'
+commit_fixture "${missing_validation_note_repo}"
+assert_fails_with "${missing_validation_note_repo}" 'Confirmed the reverse proxy remains the only approved user-facing ingress path and that repository-local boot surfaces must not publish the control-plane backend port directly to user networks or the public internet.'
+
+missing_deviation_repo="${workdir}/missing-deviation"
+create_repo "${missing_deviation_repo}"
+write_canonical_artifacts "${missing_deviation_repo}"
+remove_text_from_doc "${missing_deviation_repo}" "${missing_deviation_repo}/docs/phase-17-runtime-config-contract-validation.md" '- Requested comparison target `Phase 16-21 Epic Roadmap.md` was unavailable in the local worktree during this validation snapshot.'
+commit_fixture "${missing_deviation_repo}"
+assert_fails_with "${missing_deviation_repo}" '- Requested comparison target `Phase 16-21 Epic Roadmap.md` was unavailable in the local worktree during this validation snapshot.'
+
+echo "Phase 17 runtime config verifier enforces required contract and validation statements."

--- a/scripts/verify-phase-17-runtime-config-contract.sh
+++ b/scripts/verify-phase-17-runtime-config-contract.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+default_repo_root="$(cd "${script_dir}/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+contract_doc="${repo_root}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md"
+validation_doc="${repo_root}/docs/phase-17-runtime-config-contract-validation.md"
+phase16_scope_doc="${repo_root}/docs/phase-16-release-state-and-first-boot-scope.md"
+runtime_boundary_doc="${repo_root}/docs/control-plane-runtime-service-boundary.md"
+network_doc="${repo_root}/docs/network-exposure-and-access-path-policy.md"
+storage_doc="${repo_root}/docs/storage-layout-and-mount-policy.md"
+readme_doc="${repo_root}/README.md"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_string() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required line in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${contract_doc}" "Missing Phase 17 runtime config contract doc"
+require_file "${validation_doc}" "Missing Phase 17 validation record"
+require_file "${phase16_scope_doc}" "Missing Phase 16 first-boot scope doc"
+require_file "${runtime_boundary_doc}" "Missing control-plane runtime boundary doc"
+require_file "${network_doc}" "Missing network exposure policy doc"
+require_file "${storage_doc}" "Missing storage layout policy doc"
+require_file "${readme_doc}" "Missing repository README"
+
+contract_required_lines=(
+  '# AegisOps Phase 17 Runtime Config Contract and Boot Command Expectations'
+  '## 1. Purpose'
+  '## 2. Phase 17 Contract Goal'
+  '## 3. Runtime Config Contract'
+  '### 3.1 Approved Required Runtime Environment Keys'
+  '### 3.2 Approved Defaults and Fail-Closed Rules'
+  '### 3.3 Approved Optional and Deferred Environment Keys'
+  '## 4. Boot Command Expectations'
+  '### 4.1 Control-Plane Service Process'
+  '### 4.2 Migration Bootstrap Expectations'
+  '### 4.3 Reverse-Proxy Exposure Model'
+  '## 5. Phase 16 Placeholders That Become Concrete Runtime Expectations'
+  '## 6. Alignment and Non-Expansion Rules'
+  'The approved required runtime environment keys for Phase 17 first boot are:'
+  '- `AEGISOPS_CONTROL_PLANE_HOST`'
+  '- `AEGISOPS_CONTROL_PLANE_PORT`'
+  '- `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`'
+  '- `AEGISOPS_CONTROL_PLANE_BOOT_MODE`'
+  '- `AEGISOPS_CONTROL_PLANE_LOG_LEVEL`'
+  'If any required key is absent, empty, malformed, contradictory, or would violate the approved reverse-proxy-first exposure model, startup must fail closed.'
+  '- `AEGISOPS_CONTROL_PLANE_HOST=127.0.0.1`'
+  '- `AEGISOPS_CONTROL_PLANE_PORT=8080`'
+  '- `AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot`'
+  '- `AEGISOPS_CONTROL_PLANE_LOG_LEVEL=INFO`'
+  '`AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` has no approved repository default and must come from an untracked runtime secret source or operator-provided runtime env file.'
+  '`AEGISOPS_CONTROL_PLANE_HOST` must fail closed if set to a wildcard or convenience value that would bypass the approved proxy boundary, including `0.0.0.0` for direct user-network publication in the first-boot path.'
+  '`AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` must fail closed unless it is a PostgreSQL DSN for the AegisOps-owned control-plane datastore boundary.'
+  'The approved optional and deferred environment keys remain:'
+  '- `AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL`'
+  '- `AEGISOPS_CONTROL_PLANE_N8N_BASE_URL`'
+  '- `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL`'
+  '- `AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL`'
+  'Their absence must not block control-plane startup, migration bootstrap, liveness, or readiness for the reviewed Phase 17 first-boot path.'
+  'The reviewed boot command shape is:'
+  '1. validate required runtime config'
+  '2. validate the reviewed migration asset set'
+  '3. prove PostgreSQL reachability'
+  '4. apply the required forward migration bootstrap set'
+  '5. verify the expected first-boot schema state'
+  '6. exec the control-plane service process'
+  'The boot command must not background the control-plane service process, split migration bootstrap into an undocumented sidecar, or report readiness before migration bootstrap succeeds.'
+  'Migration bootstrap remains part of the approved normal boot sequence for `AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot`.'
+  'The reviewed migration asset home remains `postgres/control-plane/migrations/`.'
+  'Any such failure must fail closed and stop the boot command before normal service admission.'
+  'Phase 17 keeps the approved reverse proxy as the only reviewed user-facing ingress path.'
+  'Repository-local boot surfaces must not publish the control-plane backend port directly to user networks or the public internet.'
+  'The control-plane backend port must remain an internal service port.'
+  'The following items remain deferred and must stay visibly out of the initial bring-up contract:'
+  '- live Wazuh integration wiring;'
+  '- optional OpenSearch extension wiring or OpenSearch-dependent readiness;'
+  '- n8n, Shuffle, or executor connectivity as startup blockers;'
+  '- the thin operator UI or analyst-assistant surface; and'
+  '- destructive schema repair, downgrade logic, or ad hoc bootstrap shortcuts.'
+  '`docs/phase-16-release-state-and-first-boot-scope.md` remains the normative source for the approved runtime floor.'
+)
+
+for line in "${contract_required_lines[@]}"; do
+  require_fixed_string "${contract_doc}" "${line}"
+done
+
+validation_required_lines=(
+  '# Phase 17 Runtime Config Contract and Boot Command Validation'
+  '- Validation date: 2026-04-10'
+  '- Validation scope: Phase 17 review of the approved first-boot runtime config contract, required and optional environment keys, reviewed defaults, fail-closed boot behavior, migration-bootstrap sequencing, reverse-proxy-only exposure expectations, and explicit Phase 16-to-Phase 17 carry-forward boundaries'
+  "- Baseline references: \`docs/phase-17-runtime-config-contract-and-boot-command-expectations.md\`, \`docs/phase-16-release-state-and-first-boot-scope.md\`, \`docs/control-plane-runtime-service-boundary.md\`, \`docs/network-exposure-and-access-path-policy.md\`, \`docs/storage-layout-and-mount-policy.md\`, \`README.md\`"
+  "- Verification commands: \`bash scripts/verify-phase-17-runtime-config-contract.sh\`, \`bash scripts/test-verify-phase-17-runtime-config-contract.sh\`"
+  '- Validation status: PASS'
+  '## Required Boundary Artifacts'
+  '## Review Outcome'
+  '## Cross-Link Review'
+  '## Deviations'
+  'Confirmed the Phase 17 contract makes the approved first-boot runtime environment keys explicit enough to drive image, Compose, and entrypoint implementation without reopening the approved runtime floor.'
+  'Confirmed `AEGISOPS_CONTROL_PLANE_HOST`, `AEGISOPS_CONTROL_PLANE_PORT`, `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`, `AEGISOPS_CONTROL_PLANE_BOOT_MODE`, and `AEGISOPS_CONTROL_PLANE_LOG_LEVEL` are the approved required first-boot runtime keys and that startup must fail closed when they are absent, empty, malformed, contradictory, or exposure-bypassing.'
+  'Confirmed the reviewed local defaults stay narrow by allowing `127.0.0.1`, `8080`, `first-boot`, and `INFO` while keeping `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN` without a repository default.'
+  'Confirmed the Phase 17 contract keeps `AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL`, `AEGISOPS_CONTROL_PLANE_N8N_BASE_URL`, `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL`, and `AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL` explicitly optional and non-blocking for the first-boot path.'
+  'Confirmed the approved boot command shape keeps migration bootstrap in the normal first-boot path by requiring runtime-config validation, migration-asset validation, PostgreSQL reachability proof, forward migration application, schema-state verification, and only then `exec` of the control-plane service process.'
+  'Confirmed migration bootstrap failure remains fail-closed when reviewed migration assets are missing, PostgreSQL is unreachable, a forward migration fails, required migrations are only partially applied, or the expected reviewed schema state cannot be proven after execution.'
+  'Confirmed the reverse proxy remains the only approved user-facing ingress path and that repository-local boot surfaces must not publish the control-plane backend port directly to user networks or the public internet.'
+  'Confirmed the Phase 17 contract turns the reviewed Phase 16 first-boot skeleton environment keys, entrypoint sequencing, migration-home requirement, liveness-versus-readiness distinction, and reverse-proxy-first access model into concrete runtime expectations without making OpenSearch, n8n, Shuffle, executor wiring, thin UI work, or destructive schema shortcuts part of initial bring-up.'
+  "The issue requested review against \`Phase 16-21 Epic Roadmap.md\`, but that roadmap file was not present in the local worktree and could not be located via repository search during this turn."
+  '`docs/network-exposure-and-access-path-policy.md` must continue to keep the reverse proxy as the approved ingress boundary and disallow direct backend publication as a substitute.'
+  "- Requested comparison target \`Phase 16-21 Epic Roadmap.md\` was unavailable in the local worktree during this validation snapshot."
+)
+
+for line in "${validation_required_lines[@]}"; do
+  require_fixed_string "${validation_doc}" "${line}"
+done
+
+required_artifacts=(
+  "docs/phase-17-runtime-config-contract-and-boot-command-expectations.md"
+  "docs/phase-17-runtime-config-contract-validation.md"
+  "docs/phase-16-release-state-and-first-boot-scope.md"
+  "docs/control-plane-runtime-service-boundary.md"
+  "docs/network-exposure-and-access-path-policy.md"
+  "docs/storage-layout-and-mount-policy.md"
+  "README.md"
+  "scripts/verify-phase-17-runtime-config-contract.sh"
+  "scripts/test-verify-phase-17-runtime-config-contract.sh"
+)
+
+for artifact in "${required_artifacts[@]}"; do
+  require_file "${repo_root}/${artifact}" "Missing required Phase 17 artifact"
+
+  if ! grep -Fqx -- "- \`${artifact}\`" "${validation_doc}" >/dev/null; then
+    echo "Phase 17 validation record must list required artifact: ${artifact}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 17 runtime config contract remains explicit and reviewable."


### PR DESCRIPTION
## Summary
- add the Phase 17 runtime config contract and boot command validation snapshot
- add a repository-level verifier and self-test for the Phase 17 contract
- link the validation record from the documentation indexes used by reviewers

## Why
Phase 17 already had the concrete contract document on this branch, but the checkpoint still relied mostly on focused doc tests. This adds a repo-level verification path so reviewers can detect drift in the required runtime keys, fail-closed boot expectations, migration sequencing, reverse-proxy-only exposure model, and explicit deferred items.

## Impact
The branch now contains a reviewable Phase 17 contract plus a matching validation record and verifier. It stays scoped to docs and tests only and does not expand runtime implementation or reopen the approved first-boot floor.

## Notes
- The requested comparison target `Phase 16-21 Epic Roadmap.md` was not present in the local worktree, so the validation record captures that as a deviation instead of claiming the comparison was completed.

## Validation
- `bash scripts/verify-phase-17-runtime-config-contract.sh`
- `bash scripts/test-verify-phase-17-runtime-config-contract.sh`
- `python3 -m unittest control-plane.tests.test_phase17_runtime_config_contract_docs control-plane.tests.test_phase16_bootstrap_contract_docs control-plane.tests.test_phase16_first_boot_verifier`
- `bash scripts/verify-phase-16-first-boot-contract.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Phase 17 runtime configuration contract and boot command expectations documentation, defining required environment variables, fail-closed validation rules, and approved boot sequences.
  * Added Phase 17 runtime configuration contract validation record documenting verification scope and outcomes.

* **Tests**
  * Added automated test suite validating Phase 17 documentation presence and required content.
  * Added verification scripts enforcing runtime configuration documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->