### PR TITLE
Make the control-plane first-boot path image-backed

### DIFF
--- a/.codex-supervisor/issues/365/issue-journal.md
+++ b/.codex-supervisor/issues/365/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #365: implementation: make the control-plane runtime bootable through a reviewed image and compose-backed service path
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/365
+- Branch: codex/issue-365
+- Workspace: .
+- Journal: .codex-supervisor/issues/365/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 9f49fcd9806b5256edee8e64b6f1ea62f5e7ff12
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T02:53:37.620Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The first-boot control-plane path was still only nominally bootable because Compose relied on `alpine`, repo bind mounts, and a mounted entrypoint instead of a reviewed runtime image artifact.
+- What changed: Added a reviewed first-boot `Dockerfile`, switched the control-plane Compose service to `build` plus a tagged image, copied the runtime code and reviewed migrations into the image, added `AEGISOPS_CONTROL_PLANE_BOOT_MODE` and `AEGISOPS_CONTROL_PLANE_LOG_LEVEL` to the env contract, tightened entrypoint fail-closed validation, and added focused tests for the image-backed boot path.
+- Current blocker: none
+- Next exact step: Stage the reviewed artifact/test changes, create a checkpoint commit, and open or prepare a draft PR for branch `codex/issue-365`.
+- Verification gap: No live `docker compose up` against a real PostgreSQL instance was run; validation covered unit tests, contract verifiers, compose rendering, and image build only.
+- Files touched: control-plane/deployment/first-boot/Dockerfile; control-plane/deployment/first-boot/docker-compose.yml; control-plane/deployment/first-boot/control-plane-entrypoint.sh; control-plane/deployment/first-boot/bootstrap.env.sample; control-plane/tests/test_phase17_first_boot_runtime_artifacts.py; control-plane/tests/test_phase16_bootstrap_contract_docs.py; control-plane/tests/test_phase16_first_boot_verifier.py; scripts/verify-phase-16-first-boot-contract.sh
+- Rollback concern: Reverting to the prior placeholder Compose path would restore repo bind-mount assumptions and drop the reviewed image artifact and stricter startup validation.
+- Last focused command: docker build -f control-plane/deployment/first-boot/Dockerfile -t aegisops-control-plane:first-boot .
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/365/issue-journal.md
+++ b/.codex-supervisor/issues/365/issue-journal.md
@@ -14,7 +14,7 @@
 - Updated at: 2026-04-10T02:53:37.620Z
 
 ## Latest Codex Summary
-- None yet.
+- Added a reviewed image-backed first-boot control-plane runtime path, removed the placeholder repo-mount boot assumption from the control-plane Compose service, tightened the entrypoint env validation to include boot mode and log level, and opened draft PR #370.
 
 ## Active Failure Context
 - None recorded.
@@ -22,12 +22,12 @@
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The first-boot control-plane path was still only nominally bootable because Compose relied on `alpine`, repo bind mounts, and a mounted entrypoint instead of a reviewed runtime image artifact.
-- What changed: Added a reviewed first-boot `Dockerfile`, switched the control-plane Compose service to `build` plus a tagged image, copied the runtime code and reviewed migrations into the image, added `AEGISOPS_CONTROL_PLANE_BOOT_MODE` and `AEGISOPS_CONTROL_PLANE_LOG_LEVEL` to the env contract, tightened entrypoint fail-closed validation, and added focused tests for the image-backed boot path.
+- What changed: Added a reviewed first-boot `Dockerfile`, switched the control-plane Compose service to `build` plus a tagged image, copied the runtime code and reviewed migrations into the image, added `AEGISOPS_CONTROL_PLANE_BOOT_MODE` and `AEGISOPS_CONTROL_PLANE_LOG_LEVEL` to the env contract, tightened entrypoint fail-closed validation, added focused tests for the image-backed boot path, committed the slice as `f5ec925`, pushed `codex/issue-365`, and opened draft PR #370.
 - Current blocker: none
-- Next exact step: Stage the reviewed artifact/test changes, create a checkpoint commit, and open or prepare a draft PR for branch `codex/issue-365`.
+- Next exact step: Await review on PR #370 or, if requested, extend verification to a live `docker compose up` run against a disposable PostgreSQL instance.
 - Verification gap: No live `docker compose up` against a real PostgreSQL instance was run; validation covered unit tests, contract verifiers, compose rendering, and image build only.
 - Files touched: control-plane/deployment/first-boot/Dockerfile; control-plane/deployment/first-boot/docker-compose.yml; control-plane/deployment/first-boot/control-plane-entrypoint.sh; control-plane/deployment/first-boot/bootstrap.env.sample; control-plane/tests/test_phase17_first_boot_runtime_artifacts.py; control-plane/tests/test_phase16_bootstrap_contract_docs.py; control-plane/tests/test_phase16_first_boot_verifier.py; scripts/verify-phase-16-first-boot-contract.sh
 - Rollback concern: Reverting to the prior placeholder Compose path would restore repo bind-mount assumptions and drop the reviewed image artifact and stricter startup validation.
-- Last focused command: docker build -f control-plane/deployment/first-boot/Dockerfile -t aegisops-control-plane:first-boot .
+- Last focused command: gh pr create --draft --base main --head codex/issue-365 --title "Make the control-plane first-boot path image-backed" --body "<summary omitted>"
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/deployment/first-boot/Dockerfile
+++ b/control-plane/deployment/first-boot/Dockerfile
@@ -8,14 +8,19 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir "psycopg[binary]>=3.2,<3.3"
+RUN groupadd --system aegisops \
+    && useradd --system --create-home --gid aegisops --home-dir /home/aegisops --shell /usr/sbin/nologin aegisops \
+    && mkdir -p /opt/aegisops/bin /opt/aegisops/control-plane /opt/aegisops/postgres-migrations \
+    && chown -R aegisops:aegisops /opt/aegisops
 
 WORKDIR /opt/aegisops/control-plane
 
-COPY control-plane /opt/aegisops/control-plane
-COPY postgres/control-plane/migrations /opt/aegisops/postgres-migrations
-COPY control-plane/deployment/first-boot/control-plane-entrypoint.sh /opt/aegisops/bin/first-boot-entrypoint.sh
+COPY --chown=aegisops:aegisops control-plane /opt/aegisops/control-plane
+COPY --chown=aegisops:aegisops postgres/control-plane/migrations /opt/aegisops/postgres-migrations
+COPY --chown=aegisops:aegisops control-plane/deployment/first-boot/control-plane-entrypoint.sh /opt/aegisops/bin/first-boot-entrypoint.sh
 
 RUN chmod 0555 /opt/aegisops/bin/first-boot-entrypoint.sh
+USER aegisops:aegisops
 
 ENTRYPOINT ["/opt/aegisops/bin/first-boot-entrypoint.sh"]
 CMD ["python3", "main.py", "serve"]

--- a/control-plane/deployment/first-boot/Dockerfile
+++ b/control-plane/deployment/first-boot/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir "psycopg[binary]>=3.2,<3.3"
+
+WORKDIR /opt/aegisops/control-plane
+
+COPY control-plane /opt/aegisops/control-plane
+COPY postgres/control-plane/migrations /opt/aegisops/postgres-migrations
+COPY control-plane/deployment/first-boot/control-plane-entrypoint.sh /opt/aegisops/bin/first-boot-entrypoint.sh
+
+RUN chmod 0555 /opt/aegisops/bin/first-boot-entrypoint.sh
+
+ENTRYPOINT ["/opt/aegisops/bin/first-boot-entrypoint.sh"]
+CMD ["python3", "main.py", "serve"]

--- a/control-plane/deployment/first-boot/bootstrap.env.sample
+++ b/control-plane/deployment/first-boot/bootstrap.env.sample
@@ -5,6 +5,8 @@
 AEGISOPS_CONTROL_PLANE_HOST=127.0.0.1
 AEGISOPS_CONTROL_PLANE_PORT=8080
 AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=postgresql://<user>:<password>@postgres:5432/aegisops_control_plane
+AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot
+AEGISOPS_CONTROL_PLANE_LOG_LEVEL=INFO
 
 # Optional and deferred components below must remain non-blocking for first boot.
 AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL=

--- a/control-plane/deployment/first-boot/control-plane-entrypoint.sh
+++ b/control-plane/deployment/first-boot/control-plane-entrypoint.sh
@@ -2,11 +2,10 @@
 
 set -eu
 
-# Phase 16 first-boot skeleton only.
-# This entrypoint validates the reviewed required bootstrap contract,
-# reserves a hook point for migration bootstrap, and then hands off to
-# the runtime command. Live health endpoints and production image
-# implementation remain out of scope for this repository skeleton.
+# Reviewed first-boot control-plane entrypoint.
+# This entrypoint validates the approved runtime contract, proves
+# migration bootstrap success, and then hands off to the runtime
+# service process as the final foreground command.
 
 require_non_empty() {
   var_name="$1"
@@ -21,12 +20,22 @@ require_non_empty() {
 require_non_empty "AEGISOPS_CONTROL_PLANE_HOST" "${AEGISOPS_CONTROL_PLANE_HOST:-}"
 require_non_empty "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN" "${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:-}"
 
+host_value="${AEGISOPS_CONTROL_PLANE_HOST:-}"
+case "${host_value}" in
+  0.0.0.0|::|*)
+    if [ "${host_value}" = "0.0.0.0" ] || [ "${host_value}" = "::" ] || [ "${host_value}" = "*" ]; then
+      echo "AEGISOPS_CONTROL_PLANE_HOST must not publish the control-plane backend directly." >&2
+      exit 1
+    fi
+    ;;
+esac
+
 dsn_value="${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:-}"
 case "${dsn_value}" in
   postgresql://*|postgres://*)
     ;;
   *)
-    echo "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN must be a PostgreSQL DSN for the first-boot skeleton." >&2
+    echo "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN must be a PostgreSQL DSN for the first-boot runtime." >&2
     exit 1
     ;;
 esac
@@ -34,7 +43,32 @@ esac
 port_value="${AEGISOPS_CONTROL_PLANE_PORT:-8080}"
 case "${port_value}" in
   ''|*[!0-9]*)
-    echo "AEGISOPS_CONTROL_PLANE_PORT must be an integer for the first-boot skeleton." >&2
+    echo "AEGISOPS_CONTROL_PLANE_PORT must be an integer for the first-boot runtime." >&2
+    exit 1
+    ;;
+esac
+
+if [ "${port_value}" -lt 1 ] || [ "${port_value}" -gt 65535 ]; then
+  echo "AEGISOPS_CONTROL_PLANE_PORT must stay within the reviewed listen-port range." >&2
+  exit 1
+fi
+
+boot_mode_value="${AEGISOPS_CONTROL_PLANE_BOOT_MODE:-first-boot}"
+case "${boot_mode_value}" in
+  first-boot)
+    ;;
+  *)
+    echo "AEGISOPS_CONTROL_PLANE_BOOT_MODE must remain first-boot for the reviewed startup path." >&2
+    exit 1
+    ;;
+esac
+
+log_level_value="${AEGISOPS_CONTROL_PLANE_LOG_LEVEL:-INFO}"
+case "${log_level_value}" in
+  DEBUG|INFO|WARNING|ERROR|CRITICAL)
+    ;;
+  *)
+    echo "AEGISOPS_CONTROL_PLANE_LOG_LEVEL must be one of DEBUG, INFO, WARNING, ERROR, or CRITICAL." >&2
     exit 1
     ;;
 esac

--- a/control-plane/deployment/first-boot/docker-compose.yml
+++ b/control-plane/deployment/first-boot/docker-compose.yml
@@ -2,30 +2,24 @@ name: aegisops-first-boot
 
 services:
   control-plane:
-    image: alpine:3.22.1
-    working_dir: /workspace/control-plane
-    entrypoint:
-      - /opt/aegisops/bin/first-boot-entrypoint.sh
-    command:
-      - python3
-      - main.py
-      - serve
+    build:
+      context: ../../..
+      dockerfile: control-plane/deployment/first-boot/Dockerfile
+    image: aegisops-control-plane:first-boot
     environment:
       AEGISOPS_CONTROL_PLANE_HOST: ${AEGISOPS_CONTROL_PLANE_HOST:-127.0.0.1}
       AEGISOPS_CONTROL_PLANE_PORT: ${AEGISOPS_CONTROL_PLANE_PORT:-8080}
       AEGISOPS_CONTROL_PLANE_POSTGRES_DSN: ${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:?set-in-untracked-runtime-env}
+      AEGISOPS_CONTROL_PLANE_BOOT_MODE: ${AEGISOPS_CONTROL_PLANE_BOOT_MODE:-first-boot}
+      AEGISOPS_CONTROL_PLANE_LOG_LEVEL: ${AEGISOPS_CONTROL_PLANE_LOG_LEVEL:-INFO}
       AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL: ${AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL:-}
       AEGISOPS_CONTROL_PLANE_N8N_BASE_URL: ${AEGISOPS_CONTROL_PLANE_N8N_BASE_URL:-}
       AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL: ${AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL:-}
       AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL: ${AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL:-}
-    volumes:
-      - ../../../:/workspace:ro
-      - ./control-plane-entrypoint.sh:/opt/aegisops/bin/first-boot-entrypoint.sh:ro
-      - ../../../postgres/control-plane/migrations:/opt/aegisops/postgres-migrations:ro
     depends_on:
       - postgres
-    # control-plane first-boot contract only; runtime image implementation remains out of scope
-    # optional extensions remain out of scope for this first-boot skeleton
+    # reviewed image-backed first-boot control-plane runtime only
+    # optional extensions remain out of scope for this first-boot path
     # do not add OpenSearch, n8n, analyst-assistant UI, or executor services here
 
   postgres:

--- a/control-plane/tests/test_phase16_bootstrap_contract_docs.py
+++ b/control-plane/tests/test_phase16_bootstrap_contract_docs.py
@@ -118,18 +118,22 @@ class Phase16BootstrapContractDocsTests(unittest.TestCase):
         )
 
     def test_first_boot_entrypoint_rejects_direct_backend_publication_host(self) -> None:
-        result = self._run_entrypoint(
-            {
-                "AEGISOPS_CONTROL_PLANE_HOST": "0.0.0.0",
-                "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "postgresql://user:pass@postgres:5432/aegisops",
-            }
-        )
+        for host_value in ("0.0.0.0", "::", "*"):
+            with self.subTest(host_value=host_value):
+                result = self._run_entrypoint(
+                    {
+                        "AEGISOPS_CONTROL_PLANE_HOST": host_value,
+                        "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": (
+                            "postgresql://user:pass@postgres:5432/aegisops"
+                        ),
+                    }
+                )
 
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn(
-            "AEGISOPS_CONTROL_PLANE_HOST must not publish the control-plane backend directly.",
-            result.stderr,
-        )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "AEGISOPS_CONTROL_PLANE_HOST must not publish the control-plane backend directly.",
+                    result.stderr,
+                )
 
     def test_first_boot_entrypoint_rejects_invalid_boot_mode(self) -> None:
         result = self._run_entrypoint(

--- a/control-plane/tests/test_phase16_bootstrap_contract_docs.py
+++ b/control-plane/tests/test_phase16_bootstrap_contract_docs.py
@@ -56,6 +56,8 @@ class Phase16BootstrapContractDocsTests(unittest.TestCase):
             "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=",
             "AEGISOPS_CONTROL_PLANE_HOST=",
             "AEGISOPS_CONTROL_PLANE_PORT=",
+            "AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot",
+            "AEGISOPS_CONTROL_PLANE_LOG_LEVEL=INFO",
             "Optional and deferred components below must remain non-blocking for first boot.",
             "AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL=",
             "AEGISOPS_CONTROL_PLANE_N8N_BASE_URL=",
@@ -70,15 +72,19 @@ class Phase16BootstrapContractDocsTests(unittest.TestCase):
             "control-plane:",
             "postgres:",
             "proxy:",
-            "control-plane-entrypoint.sh:/opt/aegisops/bin/first-boot-entrypoint.sh:ro",
-            "optional extensions remain out of scope for this first-boot skeleton",
+            "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN: ${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:?set-in-untracked-runtime-env}",
+            "AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL: ${AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL:-}",
+            "AEGISOPS_CONTROL_PLANE_N8N_BASE_URL: ${AEGISOPS_CONTROL_PLANE_N8N_BASE_URL:-}",
+            "AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL: ${AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL:-}",
+            "AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL: ${AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL:-}",
             "do not add OpenSearch, n8n, analyst-assistant UI, or executor services here",
         ):
             self.assertIn(term, compose_text)
 
         entrypoint_text = entrypoint_skeleton.read_text(encoding="utf-8")
         for term in (
-            "Phase 16 first-boot skeleton only",
+            "AEGISOPS_CONTROL_PLANE_BOOT_MODE",
+            "AEGISOPS_CONTROL_PLANE_LOG_LEVEL",
             "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN",
             "migration bootstrap",
             "readiness",
@@ -107,7 +113,51 @@ class Phase16BootstrapContractDocsTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn(
-            "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN must be a PostgreSQL DSN for the first-boot skeleton.",
+            "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN must be a PostgreSQL DSN for the first-boot runtime.",
+            result.stderr,
+        )
+
+    def test_first_boot_entrypoint_rejects_direct_backend_publication_host(self) -> None:
+        result = self._run_entrypoint(
+            {
+                "AEGISOPS_CONTROL_PLANE_HOST": "0.0.0.0",
+                "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "postgresql://user:pass@postgres:5432/aegisops",
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "AEGISOPS_CONTROL_PLANE_HOST must not publish the control-plane backend directly.",
+            result.stderr,
+        )
+
+    def test_first_boot_entrypoint_rejects_invalid_boot_mode(self) -> None:
+        result = self._run_entrypoint(
+            {
+                "AEGISOPS_CONTROL_PLANE_HOST": "127.0.0.1",
+                "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "postgresql://user:pass@postgres:5432/aegisops",
+                "AEGISOPS_CONTROL_PLANE_BOOT_MODE": "serve-now",
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "AEGISOPS_CONTROL_PLANE_BOOT_MODE must remain first-boot for the reviewed startup path.",
+            result.stderr,
+        )
+
+    def test_first_boot_entrypoint_rejects_invalid_log_level(self) -> None:
+        result = self._run_entrypoint(
+            {
+                "AEGISOPS_CONTROL_PLANE_HOST": "127.0.0.1",
+                "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "postgresql://user:pass@postgres:5432/aegisops",
+                "AEGISOPS_CONTROL_PLANE_LOG_LEVEL": "TRACE",
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "AEGISOPS_CONTROL_PLANE_LOG_LEVEL must be one of DEBUG, INFO, WARNING, ERROR, or CRITICAL.",
             result.stderr,
         )
 
@@ -183,6 +233,8 @@ exit 1
                 {
                     "AEGISOPS_CONTROL_PLANE_HOST": "127.0.0.1",
                     "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "postgresql://user:pass@postgres:5432/aegisops",
+                    "AEGISOPS_CONTROL_PLANE_BOOT_MODE": "first-boot",
+                    "AEGISOPS_CONTROL_PLANE_LOG_LEVEL": "INFO",
                     "AEGISOPS_FIRST_BOOT_MIGRATIONS_DIR": str(migrations_dir),
                     "AEGISOPS_FIRST_BOOT_PSQL_BIN": str(psql_path),
                     "AEGISOPS_TEST_PSQL_LOG": str(psql_log),

--- a/control-plane/tests/test_phase16_first_boot_verifier.py
+++ b/control-plane/tests/test_phase16_first_boot_verifier.py
@@ -46,15 +46,11 @@ class Phase16FirstBootVerifierTests(unittest.TestCase):
             compose_path = (
                 fixture_root / "control-plane" / "deployment" / "first-boot" / "docker-compose.yml"
             )
-            self._insert_text_after(
-                compose_path,
-                "      - serve\n",
-                "      - runtime\n",
-            )
+            self._insert_text_after(compose_path, "    image: aegisops-control-plane:first-boot\n", "    volumes:\n      - ../../../:/workspace:ro\n")
             self._assert_verifier_fails_with(
                 verifier,
                 fixture_root,
-                "First-boot compose must not launch the one-shot runtime snapshot renderer.",
+                "First-boot compose must not depend on repository-local runtime bind mounts.",
             )
 
             self._create_repo_fixture(fixture_root)

--- a/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
+++ b/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import pathlib
+import re
 import unittest
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+APPROVED_FIRST_BOOT_BASE_IMAGE = "python:3.12-slim-bookworm"
 
 
 class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
@@ -17,12 +19,13 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
 
         text = dockerfile.read_text(encoding="utf-8")
         for term in (
-            "FROM python:",
+            f"FROM {APPROVED_FIRST_BOOT_BASE_IMAGE}",
             "postgresql-client",
             "psycopg[binary]",
-            "COPY control-plane /opt/aegisops/control-plane",
-            "COPY postgres/control-plane/migrations /opt/aegisops/postgres-migrations",
-            "COPY control-plane/deployment/first-boot/control-plane-entrypoint.sh /opt/aegisops/bin/first-boot-entrypoint.sh",
+            "COPY --chown=aegisops:aegisops control-plane /opt/aegisops/control-plane",
+            "COPY --chown=aegisops:aegisops postgres/control-plane/migrations /opt/aegisops/postgres-migrations",
+            "COPY --chown=aegisops:aegisops control-plane/deployment/first-boot/control-plane-entrypoint.sh /opt/aegisops/bin/first-boot-entrypoint.sh",
+            "USER aegisops:aegisops",
             'ENTRYPOINT ["/opt/aegisops/bin/first-boot-entrypoint.sh"]',
             'CMD ["python3", "main.py", "serve"]',
         ):
@@ -37,6 +40,7 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
         self.assertTrue(compose_path.exists(), f"expected first-boot compose at {compose_path}")
 
         text = compose_path.read_text(encoding="utf-8")
+        control_plane_block = self._control_plane_service_block(text)
         for term in (
             "build:",
             "dockerfile: control-plane/deployment/first-boot/Dockerfile",
@@ -44,7 +48,7 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
             "AEGISOPS_CONTROL_PLANE_BOOT_MODE: ${AEGISOPS_CONTROL_PLANE_BOOT_MODE:-first-boot}",
             "AEGISOPS_CONTROL_PLANE_LOG_LEVEL: ${AEGISOPS_CONTROL_PLANE_LOG_LEVEL:-INFO}",
         ):
-            self.assertIn(term, text)
+            self.assertIn(term, control_plane_block)
 
         for forbidden in (
             "image: alpine:3.22.1",
@@ -53,7 +57,20 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
             "./control-plane-entrypoint.sh:/opt/aegisops/bin/first-boot-entrypoint.sh:ro",
             "../../../postgres/control-plane/migrations:/opt/aegisops/postgres-migrations:ro",
         ):
-            self.assertNotIn(forbidden, text)
+            self.assertNotIn(forbidden, control_plane_block)
+
+        self.assertNotIn("volumes:", control_plane_block)
+        self.assertNotIn("working_dir:", control_plane_block)
+
+    @staticmethod
+    def _control_plane_service_block(compose_text: str) -> str:
+        match = re.search(
+            r"(?ms)^  control-plane:\n(.*?)(?=^  [a-z0-9-]+:\n|\Z)",
+            compose_text,
+        )
+        if match is None:
+            raise AssertionError("expected control-plane service block in first-boot compose file")
+        return match.group(0)
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
+++ b/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
+    def test_reviewed_runtime_image_artifact_exists(self) -> None:
+        dockerfile = (
+            REPO_ROOT / "control-plane" / "deployment" / "first-boot" / "Dockerfile"
+        )
+
+        self.assertTrue(dockerfile.exists(), f"expected first-boot runtime image at {dockerfile}")
+
+        text = dockerfile.read_text(encoding="utf-8")
+        for term in (
+            "FROM python:",
+            "postgresql-client",
+            "psycopg[binary]",
+            "COPY control-plane /opt/aegisops/control-plane",
+            "COPY postgres/control-plane/migrations /opt/aegisops/postgres-migrations",
+            "COPY control-plane/deployment/first-boot/control-plane-entrypoint.sh /opt/aegisops/bin/first-boot-entrypoint.sh",
+            'ENTRYPOINT ["/opt/aegisops/bin/first-boot-entrypoint.sh"]',
+            'CMD ["python3", "main.py", "serve"]',
+        ):
+            self.assertIn(term, text)
+
+    def test_first_boot_compose_uses_reviewed_image_path_instead_of_repo_local_runtime_mounts(
+        self,
+    ) -> None:
+        compose_path = (
+            REPO_ROOT / "control-plane" / "deployment" / "first-boot" / "docker-compose.yml"
+        )
+        self.assertTrue(compose_path.exists(), f"expected first-boot compose at {compose_path}")
+
+        text = compose_path.read_text(encoding="utf-8")
+        for term in (
+            "build:",
+            "dockerfile: control-plane/deployment/first-boot/Dockerfile",
+            "image: aegisops-control-plane:first-boot",
+            "AEGISOPS_CONTROL_PLANE_BOOT_MODE: ${AEGISOPS_CONTROL_PLANE_BOOT_MODE:-first-boot}",
+            "AEGISOPS_CONTROL_PLANE_LOG_LEVEL: ${AEGISOPS_CONTROL_PLANE_LOG_LEVEL:-INFO}",
+        ):
+            self.assertIn(term, text)
+
+        for forbidden in (
+            "image: alpine:3.22.1",
+            "working_dir: /workspace/control-plane",
+            "../../../:/workspace:ro",
+            "./control-plane-entrypoint.sh:/opt/aegisops/bin/first-boot-entrypoint.sh:ro",
+            "../../../postgres/control-plane/migrations:/opt/aegisops/postgres-migrations:ro",
+        ):
+            self.assertNotIn(forbidden, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-phase-16-first-boot-contract.sh
+++ b/scripts/verify-phase-16-first-boot-contract.sh
@@ -71,7 +71,7 @@ require_file "${runtime_boundary_doc}" "Missing control-plane runtime boundary d
 require_file "${runbook_doc}" "Missing runbook doc"
 require_file "${readme_doc}" "Missing repository README"
 require_file "${bootstrap_env_sample}" "Missing first-boot bootstrap env sample"
-require_file "${compose_file}" "Missing first-boot compose skeleton"
+require_file "${compose_file}" "Missing first-boot compose path"
 require_file "${entrypoint_file}" "Missing first-boot entrypoint"
 require_dir "${migration_home}" "Missing control-plane migration home"
 require_file "${postgres_readme}" "Missing control-plane postgres README"
@@ -124,6 +124,8 @@ bootstrap_lines=(
   'AEGISOPS_CONTROL_PLANE_HOST=127.0.0.1'
   'AEGISOPS_CONTROL_PLANE_PORT=8080'
   'AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=postgresql://<user>:<password>@postgres:5432/aegisops_control_plane'
+  'AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot'
+  'AEGISOPS_CONTROL_PLANE_LOG_LEVEL=INFO'
   '# Optional and deferred components below must remain non-blocking for first boot.'
   'AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL='
   'AEGISOPS_CONTROL_PLANE_N8N_BASE_URL='
@@ -139,14 +141,18 @@ compose_lines=(
   '  control-plane:'
   '  postgres:'
   '  proxy:'
-  '      - serve'
+  '    build:'
+  '      dockerfile: control-plane/deployment/first-boot/Dockerfile'
+  '    image: aegisops-control-plane:first-boot'
   '      AEGISOPS_CONTROL_PLANE_POSTGRES_DSN: ${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:?set-in-untracked-runtime-env}'
+  '      AEGISOPS_CONTROL_PLANE_BOOT_MODE: ${AEGISOPS_CONTROL_PLANE_BOOT_MODE:-first-boot}'
+  '      AEGISOPS_CONTROL_PLANE_LOG_LEVEL: ${AEGISOPS_CONTROL_PLANE_LOG_LEVEL:-INFO}'
   '      AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL: ${AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL:-}'
   '      AEGISOPS_CONTROL_PLANE_N8N_BASE_URL: ${AEGISOPS_CONTROL_PLANE_N8N_BASE_URL:-}'
   '      AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL: ${AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL:-}'
   '      AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL: ${AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL:-}'
-  '      - ../../../postgres/control-plane/migrations:/opt/aegisops/postgres-migrations:ro'
-  '    # optional extensions remain out of scope for this first-boot skeleton'
+  '    # reviewed image-backed first-boot control-plane runtime only'
+  '    # optional extensions remain out of scope for this first-boot path'
   '    # do not add OpenSearch, n8n, analyst-assistant UI, or executor services here'
 )
 for line in "${compose_lines[@]}"; do
@@ -161,15 +167,23 @@ require_absent_string "${compose_file}" '  analyst-assistant:' \
   'First-boot compose must not define first-boot service: analyst-assistant'
 require_absent_string "${compose_file}" '  executor:' \
   'First-boot compose must not define first-boot service: executor'
-require_absent_string "${compose_file}" '      - runtime' \
-  'First-boot compose must not launch the one-shot runtime snapshot renderer.'
+require_absent_string "${compose_file}" '../../../:/workspace:ro' \
+  'First-boot compose must not depend on repository-local runtime bind mounts.'
+require_absent_string "${compose_file}" './control-plane-entrypoint.sh:/opt/aegisops/bin/first-boot-entrypoint.sh:ro' \
+  'First-boot compose must not depend on a bind-mounted entrypoint script.'
+require_absent_string "${compose_file}" '../../../postgres/control-plane/migrations:/opt/aegisops/postgres-migrations:ro' \
+  'First-boot compose must not depend on bind-mounted migration assets.'
+require_absent_string "${compose_file}" 'image: alpine:3.22.1' \
+  'First-boot compose must not use the placeholder Alpine control-plane image.'
 
 entrypoint_lines=(
-  '# Phase 16 first-boot skeleton only.'
+  '# Reviewed first-boot control-plane entrypoint.'
   'require_non_empty "AEGISOPS_CONTROL_PLANE_HOST" "${AEGISOPS_CONTROL_PLANE_HOST:-}"'
   'require_non_empty "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN" "${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN:-}"'
-  '    echo "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN must be a PostgreSQL DSN for the first-boot skeleton." >&2'
-  '    echo "AEGISOPS_CONTROL_PLANE_PORT must be an integer for the first-boot skeleton." >&2'
+  'boot_mode_value="${AEGISOPS_CONTROL_PLANE_BOOT_MODE:-first-boot}"'
+  'log_level_value="${AEGISOPS_CONTROL_PLANE_LOG_LEVEL:-INFO}"'
+  '    echo "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN must be a PostgreSQL DSN for the first-boot runtime." >&2'
+  '    echo "AEGISOPS_CONTROL_PLANE_PORT must be an integer for the first-boot runtime." >&2'
   'MIGRATIONS_DIR="${AEGISOPS_FIRST_BOOT_MIGRATIONS_DIR:-/opt/aegisops/postgres-migrations}"'
   'PSQL_BIN="${AEGISOPS_FIRST_BOOT_PSQL_BIN:-psql}"'
   '        fail_closed "First-boot migration bootstrap requires psql to prove PostgreSQL reachability and readiness."'


### PR DESCRIPTION
## Summary
- replace the placeholder Alpine plus bind-mounted control-plane first-boot path with a reviewed image artifact
- wire the Compose control-plane service through the approved Phase 17 boot env contract, including boot mode and log level
- tighten the first-boot verifier/tests so the compose path stays image-backed and narrow

## Testing
- python3 -m unittest control-plane.tests.test_phase17_first_boot_runtime_artifacts control-plane.tests.test_phase16_bootstrap_contract_docs control-plane.tests.test_phase16_first_boot_verifier control-plane.tests.test_phase17_runtime_config_contract_docs
- bash scripts/verify-phase-16-first-boot-contract.sh
- bash scripts/test-verify-phase-16-first-boot-contract.sh
- bash scripts/test-verify-phase-17-runtime-config-contract.sh
- AEGISOPS_CONTROL_PLANE_POSTGRES_DSN='postgresql://user:pass@postgres:5432/aegisops_control_plane' AEGISOPS_CONTROL_PLANE_POSTGRES_PASSWORD='placeholder-secret' docker compose -f control-plane/deployment/first-boot/docker-compose.yml config
- docker build -f control-plane/deployment/first-boot/Dockerfile -t aegisops-control-plane:first-boot .

Closes #365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image-backed first-boot control-plane runtime introduced, removing repo-mount runtime dependencies
  * New config vars: AEGISOPS_CONTROL_PLANE_BOOT_MODE and AEGISOPS_CONTROL_PLANE_LOG_LEVEL

* **Improvements**
  * Stronger runtime validation for host binding, port ranges, boot mode, and log level
  * Entrypoint contract tightened and error messages clarified

* **Tests**
  * Added/expanded tests validating first-boot runtime artifacts and compose/contract compliance

* **Documentation**
  * Supervisor journal entry documenting status, hypotheses, and verification gaps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->