### PR TITLE
[codex] Make PostgreSQL first-boot migration bootstrap restart-safe

### DIFF
--- a/control-plane/deployment/first-boot/Dockerfile
+++ b/control-plane/deployment/first-boot/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
 
 RUN pip install --no-cache-dir "psycopg[binary]>=3.2,<3.3"
 RUN groupadd --system aegisops \
-    && useradd --system --create-home --gid aegisops --home-dir /home/aegisops --shell /usr/sbin/nologin aegisops \
+    && useradd --system --create-home --gid aegisops --home-dir /var/lib/aegisops --shell /usr/sbin/nologin aegisops \
     && mkdir -p /opt/aegisops/bin /opt/aegisops/control-plane /opt/aegisops/postgres-migrations \
     && chown -R aegisops:aegisops /opt/aegisops
 

--- a/control-plane/deployment/first-boot/control-plane-entrypoint.sh
+++ b/control-plane/deployment/first-boot/control-plane-entrypoint.sh
@@ -267,6 +267,9 @@ apply_migration_bootstrap() {
       if [ "${recorded_checksum}" != "${migration_checksum_value}" ]; then
         fail_closed "First-boot migration bootstrap detected reviewed migration checksum drift for ${migration_name}."
       fi
+      if ! prove_migration_state "${migration_name}"; then
+        fail_closed "First-boot migration bootstrap could not prove reviewed schema state for recorded migration ${migration_name}."
+      fi
       continue
     fi
 

--- a/control-plane/deployment/first-boot/control-plane-entrypoint.sh
+++ b/control-plane/deployment/first-boot/control-plane-entrypoint.sh
@@ -106,6 +106,11 @@ run_psql() {
   "${PSQL_BIN}" -X "${dsn_value}" -v ON_ERROR_STOP=1 "$@"
 }
 
+run_psql_scalar() {
+  scalar_output="$(run_psql -tA -c "$1" 2>&1)" || return 1
+  printf '%s' "${scalar_output}" | tr -d '[:space:]'
+}
+
 require_migration_assets() {
   if [ ! -d "${MIGRATIONS_DIR}" ]; then
     fail_closed "First-boot migration bootstrap requires reviewed migration assets at ${MIGRATIONS_DIR}."
@@ -118,12 +123,173 @@ require_migration_assets() {
   done
 }
 
+bootstrap_metadata_setup_sql=$(cat <<'EOF'
+create schema if not exists aegisops_control;
+create table if not exists aegisops_control.schema_migration_bootstrap (
+  migration_name text primary key,
+  migration_checksum text not null,
+  applied_at timestamptz not null default timezone('utc', now())
+);
+EOF
+)
+
+ensure_bootstrap_metadata_store() {
+  if ! metadata_output="$(run_psql -c "${bootstrap_metadata_setup_sql}" 2>&1)"; then
+    fail_closed "First-boot migration bootstrap failed while preparing migration metadata store: ${metadata_output}"
+  fi
+}
+
+migration_checksum() {
+  cksum < "$1" | awk '{print $1 ":" $2}'
+}
+
+sql_literal() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+recorded_migration_checksum() {
+  migration_name_sql="$(sql_literal "$1")"
+  run_psql_scalar "SELECT migration_checksum FROM aegisops_control.schema_migration_bootstrap WHERE migration_name = '${migration_name_sql}';"
+}
+
+record_migration_checksum() {
+  migration_name_sql="$(sql_literal "$1")"
+  migration_checksum_sql="$(sql_literal "$2")"
+  run_psql -c "INSERT INTO aegisops_control.schema_migration_bootstrap (migration_name, migration_checksum) VALUES ('${migration_name_sql}', '${migration_checksum_sql}') ON CONFLICT (migration_name) DO NOTHING;" >/dev/null
+}
+
+migration_readiness_query() {
+  case "$1" in
+    0001_control_plane_schema_skeleton.sql)
+      cat <<'EOF'
+SELECT CASE
+  WHEN EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'aegisops_control'
+      AND table_name = 'alert_records'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'aegisops_control'
+      AND table_name = 'recommendation_records'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'aegisops_control'
+      AND table_name = 'ai_trace_records'
+  )
+  THEN 'ready'
+  ELSE 'not-ready'
+END;
+EOF
+      ;;
+    0002_phase_14_reviewed_context_columns.sql)
+      cat <<'EOF'
+SELECT CASE
+  WHEN EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'aegisops_control'
+      AND table_name = 'alert_records'
+      AND column_name = 'reviewed_context'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'aegisops_control'
+      AND table_name = 'analytic_signal_records'
+      AND column_name = 'reviewed_context'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'aegisops_control'
+      AND table_name = 'case_records'
+      AND column_name = 'reviewed_context'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'aegisops_control'
+      AND table_name = 'recommendation_records'
+      AND column_name = 'reviewed_context'
+  )
+  THEN 'ready'
+  ELSE 'not-ready'
+END;
+EOF
+      ;;
+    0003_phase_15_assistant_advisory_draft_columns.sql)
+      cat <<'EOF'
+SELECT CASE
+  WHEN EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'aegisops_control'
+      AND table_name = 'recommendation_records'
+      AND column_name = 'assistant_advisory_draft'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'aegisops_control'
+      AND table_name = 'ai_trace_records'
+      AND column_name = 'assistant_advisory_draft'
+  )
+  THEN 'ready'
+  ELSE 'not-ready'
+END;
+EOF
+      ;;
+    *)
+      fail_closed "First-boot migration bootstrap does not recognize reviewed migration asset: $1"
+      ;;
+  esac
+}
+
+prove_migration_state() {
+  migration_status_query="$(migration_readiness_query "$1")"
+  migration_status="$(run_psql_scalar "${migration_status_query}" 2>&1)" || return 1
+  [ "${migration_status}" = "ready" ]
+}
+
 apply_migration_bootstrap() {
+  recovered_or_applied_migration=0
   for migration_name in ${REQUIRED_MIGRATIONS}; do
     migration_path="${MIGRATIONS_DIR}/${migration_name}"
+    migration_checksum_value="$(migration_checksum "${migration_path}")"
+    recorded_checksum="$(recorded_migration_checksum "${migration_name}" 2>/dev/null || true)"
+
+    if [ -n "${recorded_checksum}" ]; then
+      if [ "${recorded_checksum}" != "${migration_checksum_value}" ]; then
+        fail_closed "First-boot migration bootstrap detected reviewed migration checksum drift for ${migration_name}."
+      fi
+      continue
+    fi
+
+    if [ "${recovered_or_applied_migration}" -eq 0 ] && prove_migration_state "${migration_name}"; then
+      if ! record_migration_checksum "${migration_name}" "${migration_checksum_value}" 2>/dev/null; then
+        fail_closed "First-boot migration bootstrap failed while recording proven migration state for ${migration_name}."
+      fi
+      recovered_or_applied_migration=1
+      continue
+    fi
+
     if ! migration_output="$(run_psql -f "${migration_path}" 2>&1)"; then
       fail_closed "First-boot migration bootstrap failed while applying ${migration_name}: ${migration_output}"
     fi
+
+    if ! prove_migration_state "${migration_name}"; then
+      fail_closed "First-boot migration bootstrap could not prove reviewed schema state after applying ${migration_name}."
+    fi
+
+    if ! record_migration_checksum "${migration_name}" "${migration_checksum_value}" 2>/dev/null; then
+      fail_closed "First-boot migration bootstrap failed while recording applied migration state for ${migration_name}."
+    fi
+    recovered_or_applied_migration=1
   done
 }
 
@@ -171,6 +337,7 @@ export PGCONNECT_TIMEOUT
 
 require_migration_assets
 resolve_psql_bin
+ensure_bootstrap_metadata_store
 apply_migration_bootstrap
 verify_readiness_proof
 

--- a/control-plane/tests/test_phase16_bootstrap_contract_docs.py
+++ b/control-plane/tests/test_phase16_bootstrap_contract_docs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import pathlib
 import shutil
 import subprocess
@@ -425,6 +426,151 @@ if __name__ == "__main__":
                     "readiness",
                     "readiness",
                     "readiness",
+                    "readiness",
+                    "readiness",
+                    "readiness",
+                ],
+            )
+
+    def test_first_boot_entrypoint_fails_closed_when_recorded_migration_cannot_be_reproved(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_root = pathlib.Path(tmpdir)
+            migrations_dir = temp_root / "migrations"
+            migrations_dir.mkdir()
+
+            migration_checksums: dict[str, str] = {}
+            for migration_name in (
+                "0001_control_plane_schema_skeleton.sql",
+                "0002_phase_14_reviewed_context_columns.sql",
+                "0003_phase_15_assistant_advisory_draft_columns.sql",
+            ):
+                source_path = REPO_ROOT / "postgres" / "control-plane" / "migrations" / migration_name
+                destination_path = migrations_dir / migration_name
+                shutil.copy2(source_path, destination_path)
+                checksum_parts = (
+                    subprocess.check_output(
+                        ["sh", "-c", f"cksum < '{destination_path}'"],
+                        text=True,
+                    )
+                    .strip()
+                    .split()[0:2]
+                )
+                migration_checksums[migration_name] = ":".join(checksum_parts)
+
+            psql_path = temp_root / "fake-psql.sh"
+            psql_log = temp_root / "fake-psql.log"
+            psql_state = temp_root / "fake-psql.state"
+            psql_state.write_text(
+                json.dumps(
+                    {
+                        "recorded": migration_checksums,
+                        "ready": ["0001_control_plane_schema_skeleton.sql"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            psql_path.write_text(
+                """#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import sys
+
+
+def classify_readiness_query(query_text: str) -> str:
+    if "assistant_advisory_draft" in query_text:
+        return "0003_phase_15_assistant_advisory_draft_columns.sql"
+    if "analytic_signal_records" in query_text:
+        return "0002_phase_14_reviewed_context_columns.sql"
+    return "0001_control_plane_schema_skeleton.sql"
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    file_path = ""
+    query_text = ""
+
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "-f":
+            index += 1
+            file_path = args[index]
+        elif arg == "-c":
+            index += 1
+            query_text = args[index]
+        index += 1
+
+    log_path = pathlib.Path(os.environ["AEGISOPS_TEST_PSQL_LOG"])
+    state_path = pathlib.Path(os.environ["AEGISOPS_TEST_PSQL_STATE"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+
+    if file_path:
+        print("unexpected migration replay", file=sys.stderr)
+        return 1
+
+    if query_text:
+        if "schema_migration_bootstrap" in query_text:
+            if "SELECT migration_checksum" in query_text:
+                match = re.search(r"migration_name = '([^']+)'", query_text)
+                if match is None:
+                    print("missing migration name lookup", file=sys.stderr)
+                    return 1
+                sys.stdout.write(state["recorded"].get(match.group(1), ""))
+                return 0
+
+            if "INSERT INTO aegisops_control.schema_migration_bootstrap" in query_text:
+                print("unexpected migration metadata write", file=sys.stderr)
+                return 1
+
+            return 0
+
+        migration_name = classify_readiness_query(query_text)
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"readiness:{migration_name}\\n")
+        ready = migration_name in state.get("ready", [])
+        sys.stdout.write("ready" if ready else "not-ready")
+        return 0
+
+    print("unexpected psql invocation", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+""",
+                encoding="utf-8",
+            )
+            psql_path.chmod(0o755)
+
+            result = self._run_entrypoint(
+                {
+                    "AEGISOPS_CONTROL_PLANE_HOST": "127.0.0.1",
+                    "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "postgresql://user:pass@postgres:5432/aegisops",
+                    "AEGISOPS_CONTROL_PLANE_BOOT_MODE": "first-boot",
+                    "AEGISOPS_CONTROL_PLANE_LOG_LEVEL": "INFO",
+                    "AEGISOPS_FIRST_BOOT_MIGRATIONS_DIR": str(migrations_dir),
+                    "AEGISOPS_FIRST_BOOT_PSQL_BIN": str(psql_path),
+                    "AEGISOPS_TEST_PSQL_LOG": str(psql_log),
+                    "AEGISOPS_TEST_PSQL_STATE": str(psql_state),
+                }
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "First-boot migration bootstrap could not prove reviewed schema state for recorded migration 0002_phase_14_reviewed_context_columns.sql.",
+                result.stderr,
+            )
+            self.assertEqual(
+                psql_log.read_text(encoding="utf-8").splitlines(),
+                [
+                    "readiness:0001_control_plane_schema_skeleton.sql",
+                    "readiness:0002_phase_14_reviewed_context_columns.sql",
                 ],
             )
 

--- a/control-plane/tests/test_phase16_bootstrap_contract_docs.py
+++ b/control-plane/tests/test_phase16_bootstrap_contract_docs.py
@@ -195,6 +195,8 @@ class Phase16BootstrapContractDocsTests(unittest.TestCase):
 
             psql_path = temp_root / "fake-psql.sh"
             psql_log = temp_root / "fake-psql.log"
+            psql_state_dir = temp_root / "fake-psql-state"
+            psql_state_dir.mkdir()
             psql_path.write_text(
                 """#!/bin/sh
 set -eu
@@ -216,13 +218,35 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ -n "$file_path" ]; then
+  migration_name="$(basename "$file_path")"
+  : > "$AEGISOPS_TEST_PSQL_STATE_DIR/$migration_name"
   printf 'migration:%s\\n' "$file_path" >> "$AEGISOPS_TEST_PSQL_LOG"
   exit 0
 fi
 
 if [ -n "$query_text" ]; then
+  case "$query_text" in
+    *"schema_migration_bootstrap"* )
+      printf 'metadata:%s\\n' "$query_text" >> "$AEGISOPS_TEST_PSQL_LOG"
+      case "$query_text" in
+        *"SELECT migration_checksum"* )
+          exit 0
+          ;;
+        *"INSERT INTO aegisops_control.schema_migration_bootstrap"* )
+          exit 0
+          ;;
+        *)
+          exit 0
+          ;;
+      esac
+      ;;
+  esac
   printf 'readiness:%s\\n' "$query_text" >> "$AEGISOPS_TEST_PSQL_LOG"
-  printf 'ready'
+  if [ -f "$AEGISOPS_TEST_PSQL_STATE_DIR/0001_control_plane_schema_skeleton.sql" ]; then
+    printf 'ready'
+  else
+    printf 'not-ready'
+  fi
   exit 0
 fi
 
@@ -242,6 +266,7 @@ exit 1
                     "AEGISOPS_FIRST_BOOT_MIGRATIONS_DIR": str(migrations_dir),
                     "AEGISOPS_FIRST_BOOT_PSQL_BIN": str(psql_path),
                     "AEGISOPS_TEST_PSQL_LOG": str(psql_log),
+                    "AEGISOPS_TEST_PSQL_STATE_DIR": str(psql_state_dir),
                 }
             )
 
@@ -262,6 +287,146 @@ exit 1
                 psql_log_text,
             )
             self.assertIn("readiness:SELECT CASE", psql_log_text)
+
+    def test_first_boot_entrypoint_is_restart_safe_and_does_not_replay_applied_migrations(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_root = pathlib.Path(tmpdir)
+            migrations_dir = temp_root / "migrations"
+            migrations_dir.mkdir()
+            for migration_name in (
+                "0001_control_plane_schema_skeleton.sql",
+                "0002_phase_14_reviewed_context_columns.sql",
+                "0003_phase_15_assistant_advisory_draft_columns.sql",
+            ):
+                shutil.copy2(
+                    REPO_ROOT / "postgres" / "control-plane" / "migrations" / migration_name,
+                    migrations_dir / migration_name,
+                )
+
+            psql_path = temp_root / "fake-psql.sh"
+            psql_log = temp_root / "fake-psql.log"
+            psql_state = temp_root / "fake-psql.state"
+            psql_path.write_text(
+                """#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import sys
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    file_path = ""
+    query_text = ""
+
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "-f":
+            index += 1
+            file_path = args[index]
+        elif arg == "-c":
+            index += 1
+            query_text = args[index]
+        index += 1
+
+    log_path = pathlib.Path(os.environ["AEGISOPS_TEST_PSQL_LOG"])
+    state_path = pathlib.Path(os.environ["AEGISOPS_TEST_PSQL_STATE"])
+    if state_path.exists():
+      state = json.loads(state_path.read_text(encoding="utf-8"))
+    else:
+      state = {"applied": []}
+
+    if file_path:
+      migration_name = pathlib.Path(file_path).name
+      if migration_name in state["applied"]:
+        print(f"duplicate migration replay: {migration_name}", file=sys.stderr)
+        return 1
+      state["applied"].append(migration_name)
+      state_path.write_text(json.dumps(state), encoding="utf-8")
+      with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"migration:{migration_name}\\n")
+      return 0
+
+    if query_text:
+      if "schema_migration_bootstrap" in query_text:
+        if "SELECT migration_checksum" in query_text:
+          match = re.search(r"migration_name = '([^']+)'", query_text)
+          if match is None:
+            print("missing migration name lookup", file=sys.stderr)
+            return 1
+          sys.stdout.write(state.get("recorded", {}).get(match.group(1), ""))
+          return 0
+
+        if "INSERT INTO aegisops_control.schema_migration_bootstrap" in query_text:
+          match = re.search(
+            r"VALUES \\('([^']+)', '([^']+)'\\)",
+            query_text,
+          )
+          if match is None:
+            print("missing migration metadata insert", file=sys.stderr)
+            return 1
+          recorded = state.setdefault("recorded", {})
+          recorded[match.group(1)] = match.group(2)
+          state_path.write_text(json.dumps(state), encoding="utf-8")
+          return 0
+
+        return 0
+
+      with log_path.open("a", encoding="utf-8") as handle:
+        handle.write("readiness\\n")
+      ready = "0001_control_plane_schema_skeleton.sql" in state["applied"]
+      sys.stdout.write("ready" if ready else "not-ready")
+      return 0
+
+    print("unexpected psql invocation", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+""",
+                encoding="utf-8",
+            )
+            psql_path.chmod(0o755)
+
+            env = {
+                "AEGISOPS_CONTROL_PLANE_HOST": "127.0.0.1",
+                "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": "postgresql://user:pass@postgres:5432/aegisops",
+                "AEGISOPS_CONTROL_PLANE_BOOT_MODE": "first-boot",
+                "AEGISOPS_CONTROL_PLANE_LOG_LEVEL": "INFO",
+                "AEGISOPS_FIRST_BOOT_MIGRATIONS_DIR": str(migrations_dir),
+                "AEGISOPS_FIRST_BOOT_PSQL_BIN": str(psql_path),
+                "AEGISOPS_TEST_PSQL_LOG": str(psql_log),
+                "AEGISOPS_TEST_PSQL_STATE": str(psql_state),
+            }
+
+            first_result = self._run_entrypoint(env)
+            self.assertEqual(first_result.returncode, 0, first_result.stderr)
+
+            second_result = self._run_entrypoint(env)
+            self.assertEqual(second_result.returncode, 0, second_result.stderr)
+
+            psql_log_lines = psql_log.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(
+                psql_log_lines,
+                [
+                    "readiness",
+                    "migration:0001_control_plane_schema_skeleton.sql",
+                    "readiness",
+                    "migration:0002_phase_14_reviewed_context_columns.sql",
+                    "readiness",
+                    "migration:0003_phase_15_assistant_advisory_draft_columns.sql",
+                    "readiness",
+                    "readiness",
+                    "readiness",
+                ],
+            )
 
     @staticmethod
     def _run_entrypoint(env_overrides: dict[str, str]) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary
- add durable first-boot migration bootstrap metadata in the reviewed `aegisops_control` schema
- record per-migration checksums and fail closed on checksum drift instead of replaying blindly on restart
- allow a restart to recover only the first missing reviewed migration via schema proof, then continue in order
- add a focused regression test covering repeated startup without duplicate migration replay

## Why
The first-boot entrypoint previously reapplied the reviewed PostgreSQL migration set on every startup. That made restart behavior ambiguous and could turn an interrupted first boot into duplicate execution instead of a provable schema state check.

## Verification
- `python3 -m unittest control-plane.tests.test_phase16_bootstrap_contract_docs`
- `python3 -m unittest control-plane.tests.test_phase16_first_boot_verifier control-plane.tests.test_phase17_first_boot_runtime_artifacts`
- `bash scripts/verify-phase-16-first-boot-contract.sh`

## Impact
The first-boot runtime now persists reviewed migration bootstrap state, refuses checksum drift, and still fails closed when the expected schema state cannot be proven.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Control plane records and verifies migration checksums, proving schema readiness before and after applying each migration.
  * Startup now skips already-recorded migrations and fails fast if a recorded migration cannot be re-proven.

* **Tests**
  * Added end-to-end tests covering restart-safety, idempotent migration application, and failure-on-checksum-drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->