### PR TITLE
[codex] Add Phase 18 Wazuh lab topology contract

### DIFF
--- a/.codex-supervisor/issues/378/issue-journal.md
+++ b/.codex-supervisor/issues/378/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #378: design: define the Phase 18 Wazuh lab topology, first live source family, and live ingest contract
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/378
+- Branch: codex/issue-378
+- Workspace: .
+- Journal: .codex-supervisor/issues/378/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 87af17f9b140424545b1680f6a02d9bb1626d024
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T13:34:25.777Z
+
+## Latest Codex Summary
+- Added a focused Phase 18 doc test to reproduce the missing-artifact failure, then defined the Phase 18 Wazuh lab topology, first live source family, validation record, and verifier scripts around one narrow `Wazuh -> AegisOps` live path.
+
+## Active Failure Context
+- Reproduced initial failure: `python3 -m unittest control-plane.tests.test_phase18_wazuh_lab_topology_docs` failed because `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md` and `docs/phase-18-wazuh-lab-topology-validation.md` did not exist.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Phase 18 needed the same artifact pattern as prior phases: focused doc guard, design doc, validation record, and shell verifier anchored to the Phase 16/17 boot boundary and existing Wazuh/source-family contracts.
+- What changed: Added `control-plane/tests/test_phase18_wazuh_lab_topology_docs.py`; added `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md` and `docs/phase-18-wazuh-lab-topology-validation.md`; added `scripts/verify-phase-18-wazuh-lab-topology.sh` and `scripts/test-verify-phase-18-wazuh-lab-topology.sh`; updated `README.md` and `docs/documentation-ownership-map.md` to reference the new Phase 18 artifacts.
+- Current blocker: none
+- Next exact step: commit the coherent Phase 18 docs/test/verifier checkpoint on `codex/issue-378`.
+- Verification gap: focused Phase 18 checks passed; no broader suite run because this slice is documentation/verifier scoped.
+- Files touched: `control-plane/tests/test_phase18_wazuh_lab_topology_docs.py`, `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md`, `docs/phase-18-wazuh-lab-topology-validation.md`, `scripts/verify-phase-18-wazuh-lab-topology.sh`, `scripts/test-verify-phase-18-wazuh-lab-topology.sh`, `README.md`, `docs/documentation-ownership-map.md`
+- Rollback concern: low; changes are additive documentation and focused verification only.
+- Last focused command: `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Key documents that serve as the source of truth for implementation decisions:
 - `docs/phase-16-release-state-and-first-boot-validation.md`
 - `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`
 - `docs/phase-17-runtime-config-contract-validation.md`
+- `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md`
+- `docs/phase-18-wazuh-lab-topology-validation.md`
 - `docs/phase-15-identity-grounded-analyst-assistant-operating-guidance.md`
 - `docs/retention-evidence-and-replay-readiness-baseline.md`
 - `docs/runbook.md`

--- a/control-plane/tests/test_phase18_wazuh_lab_topology_docs.py
+++ b/control-plane/tests/test_phase18_wazuh_lab_topology_docs.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase18WazuhLabTopologyDocsTests(unittest.TestCase):
+    @staticmethod
+    def _design_doc() -> pathlib.Path:
+        return REPO_ROOT / "docs" / "phase-18-wazuh-lab-topology-and-live-ingest-contract.md"
+
+    @staticmethod
+    def _validation_doc() -> pathlib.Path:
+        return REPO_ROOT / "docs" / "phase-18-wazuh-lab-topology-validation.md"
+
+    def test_phase18_design_doc_exists(self) -> None:
+        design_doc = self._design_doc()
+
+        self.assertTrue(design_doc.exists(), f"expected Phase 18 design doc at {design_doc}")
+
+    def test_phase18_design_doc_defines_topology_source_family_and_ingest_contract(self) -> None:
+        design_doc = self._design_doc()
+        self.assertTrue(design_doc.exists(), f"expected Phase 18 design doc at {design_doc}")
+        text = design_doc.read_text(encoding="utf-8")
+
+        for term in (
+            "Approved Phase 18 Lab Topology",
+            "single-node Wazuh",
+            "bootable AegisOps control-plane runtime boundary",
+            "Approved First Live Source Family",
+            "GitHub audit",
+            "reviewed Wazuh custom integration",
+            "HTTPS POST",
+            "Authorization: Bearer",
+            "shared secret",
+            "must fail closed",
+            "Wazuh -> AegisOps",
+            "must not make `Wazuh -> Shuffle` part of the first live slice",
+            "OpenSearch runtime enrichment",
+            "thin operator UI",
+            "guarded automation live wiring",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase18_validation_doc_exists_and_records_deferred_scope(self) -> None:
+        validation_doc = self._validation_doc()
+        self.assertTrue(
+            validation_doc.exists(),
+            f"expected Phase 18 validation doc at {validation_doc}",
+        )
+        text = validation_doc.read_text(encoding="utf-8")
+
+        for term in (
+            "Phase 18 Wazuh Lab Topology and Live Ingest Contract Validation",
+            "Validation status: PASS",
+            "single-node Wazuh lab target",
+            "GitHub audit as the approved first live source family",
+            "Wazuh -> AegisOps as the mainline live path",
+            "fail-closed expectations for transport, authentication, and payload admission",
+            "OpenSearch runtime enrichment, thin operator UI, and guarded automation live wiring remain deferred",
+            "Phase 16-21 Epic Roadmap.md",
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -42,6 +42,8 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/phase-16-release-state-and-first-boot-validation.md` | Review record for the approved Phase 16 first-boot scope and bootability target | IT Operations, Information Systems Department |
 | `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md` | Concrete Phase 17 first-boot runtime config contract and boot command expectations | IT Operations, Information Systems Department |
 | `docs/phase-17-runtime-config-contract-validation.md` | Review record for the Phase 17 runtime config contract and boot command expectations | IT Operations, Information Systems Department |
+| `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md` | Approved Phase 18 single-node Wazuh lab topology, first live source family, and reviewed live ingest contract | IT Operations, Information Systems Department |
+| `docs/phase-18-wazuh-lab-topology-validation.md` | Review record for the Phase 18 Wazuh lab topology and live ingest contract | IT Operations, Information Systems Department |
 | `docs/retention-evidence-and-replay-readiness-baseline.md` | Retention, evidence lifecycle, and replay readiness baseline | IT Operations, Information Systems Department |
 | `docs/phase-7-ai-hunt-evaluation-baseline.md` | Phase 7 AI hunt evaluation baseline | IT Operations, Information Systems Department |
 | `docs/source-families/` | Approved source-family onboarding and analyst triage runbooks | IT Operations, Information Systems Department |

--- a/docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md
+++ b/docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md
@@ -1,0 +1,126 @@
+# AegisOps Phase 18 Wazuh Lab Topology and Live Ingest Contract
+
+## 1. Purpose
+
+This document defines the approved Phase 18 lab topology, first live source family, and reviewed live ingest contract for the first narrow Wazuh-backed runtime slice.
+
+It supplements `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/wazuh-alert-ingest-contract.md`, `docs/source-onboarding-contract.md`, `docs/architecture.md`, and `docs/source-families/github-audit/onboarding-package.md`.
+
+This document defines reviewed topology and ingest-contract scope only. It does not approve broader source-family rollout, OpenSearch runtime enrichment, a thin operator UI, guarded automation live wiring, or production-scale Wazuh deployment topologies.
+
+## 2. Approved Phase 18 Lab Topology
+
+The approved Phase 18 lab topology is one single-node Wazuh lab target connected to one bootable AegisOps control-plane runtime boundary.
+
+The approved topology components are:
+
+- one single-node Wazuh manager as the upstream detection substrate and reviewed webhook sender;
+- one reviewed reverse proxy as the only approved external ingress path into AegisOps;
+- one bootable AegisOps control-plane runtime boundary rooted under `control-plane/`; and
+- one PostgreSQL datastore for AegisOps-owned control-plane state.
+
+The approved Phase 18 live path is:
+
+`single-node Wazuh -> reviewed reverse proxy -> bootable AegisOps control-plane runtime boundary -> PostgreSQL`
+
+Phase 18 therefore turns the Phase 17 boot path into one reviewed live substrate path without broadening the first-boot runtime floor.
+
+The control-plane backend port remains internal-only behind the reverse proxy.
+
+The approved topology must not publish the control-plane backend port directly to user networks or the public internet.
+
+The approved topology must not require OpenSearch, Shuffle, n8n, the thin operator UI, or the guarded executor path to count as the first live slice.
+
+## 3. Approved First Live Source Family
+
+The Approved First Live Source Family for the initial Phase 18 slice is GitHub audit.
+
+GitHub audit remains the first priority family from the reviewed Phase 14 ordering and is the narrowest identity-rich family that already preserves actor, target, repository or organization context, privilege-change metadata, and provenance detail through the reviewed Wazuh path.
+
+Phase 18 approves GitHub audit as the first live source family because it keeps the first live ingest path reviewable without reopening the broader source-family problem.
+
+The Phase 18 live-family decision does not make GitHub a direct actioning substrate and does not authorize non-audit GitHub telemetry families.
+
+The following remain explicitly deferred source families for this slice:
+
+- Entra ID;
+- Microsoft 365 audit; and
+- any broader endpoint, network, SaaS, or generic cross-platform telemetry family.
+
+## 4. Reviewed Wazuh Custom Integration Live Ingest Contract
+
+### 4.1 Transport and Path
+
+The reviewed Wazuh custom integration must send one Wazuh alert JSON object at a time to AegisOps using HTTPS POST.
+
+The approved external ingress target is the reviewed reverse proxy path for the AegisOps intake boundary, not a directly exposed control-plane backend port.
+
+The approved live path is Wazuh -> AegisOps.
+
+Phase 18 must not make `Wazuh -> Shuffle` part of the first live slice.
+
+The custom integration must not route the first live slice through Shuffle, n8n, OpenSearch, or any sidecar relay before the AegisOps control-plane boundary admits the payload.
+
+### 4.2 Authentication
+
+The reviewed request authentication contract is `Authorization: Bearer <shared secret>`.
+
+The shared secret is an AegisOps-owned runtime secret and must come from an untracked secret source or reviewed operator-provided runtime secret file.
+
+Wazuh and the AegisOps reverse proxy must share the same reviewed bearer secret for this live path.
+
+Alternate authentication schemes, query-string secrets, anonymous webhook access, or substrate-local trust-by-network-location are out of contract for the first live slice.
+
+### 4.3 Payload Admission Boundary
+
+The payload shape remains the reviewed Wazuh alert contract from `docs/wazuh-alert-ingest-contract.md`.
+
+Phase 18 does not redefine the Wazuh-native field contract. It applies that contract to one reviewed live path.
+
+For the first live slice, the admitted payload family is GitHub audit carried inside the reviewed Wazuh alert envelope.
+
+The control-plane boundary must preserve the full raw Wazuh payload, Wazuh-native identifier, upstream timestamp, rule provenance, and accountable source identity exactly as required by the Wazuh ingest contract.
+
+### 4.4 Fail-Closed Expectations
+
+The live ingest path must fail closed.
+
+Ingress must reject the request when any of the following conditions hold:
+
+- the request is not HTTPS at the approved ingress boundary;
+- the request does not use HTTPS POST;
+- the `Authorization: Bearer` header is missing, empty, malformed, or does not match the reviewed shared secret;
+- the request attempts to bypass the approved reverse proxy and reach the control-plane backend directly;
+- the payload is not valid JSON;
+- the payload does not satisfy the reviewed Wazuh required fields including `id`, `timestamp`, `rule.id`, `rule.level`, `rule.description`, accountable source identity, and raw payload preservation expectations; or
+- the payload represents a family other than the approved GitHub audit first live source family.
+
+Fail closed in this phase means the request is rejected, downstream alert or case truth is not minted from the invalid payload, and no fallback automation route is used as a substitute for the rejected control-plane admission.
+
+The live ingest path must not silently downgrade to HTTP, accept missing authentication, bypass the reviewed Wazuh contract, or treat `Wazuh -> Shuffle` as a fallback route.
+
+## 5. Deferred Runtime Surfaces and Non-Goals
+
+The following remain visibly deferred and out of scope for the Phase 18 first live slice:
+
+- broader source-family rollout beyond GitHub audit;
+- OpenSearch runtime enrichment or OpenSearch-dependent success criteria;
+- thin operator UI work;
+- guarded automation live wiring;
+- direct GitHub API actioning or response execution;
+- multi-node, HA, or production-scale Wazuh topologies; and
+- any topology that makes Wazuh, Shuffle, or another substrate the authority for alert, case, approval, evidence, or reconciliation truth.
+
+## 6. Alignment and Non-Expansion Rules
+
+Phase 18 is aligned to the reviewed Phase 16 and Phase 17 baseline by keeping the bootable AegisOps control-plane runtime boundary narrow and by adding only one reviewed live intake path.
+
+`docs/phase-16-release-state-and-first-boot-scope.md` remains the normative source for the approved first-boot runtime floor.
+
+`docs/phase-17-runtime-config-contract-and-boot-command-expectations.md` remains the normative source for the bootable runtime contract that this live topology connects to.
+
+`docs/wazuh-alert-ingest-contract.md` remains the normative source for the Wazuh payload contract.
+
+`docs/source-onboarding-contract.md` and `docs/source-families/github-audit/onboarding-package.md` remain the normative source-family review references for why GitHub audit is the first live family.
+
+Any implementation that adds alternate live routing, broader source admission, direct backend publication, or optional-surface startup blockers is out of contract for Phase 18.

--- a/docs/phase-18-wazuh-lab-topology-validation.md
+++ b/docs/phase-18-wazuh-lab-topology-validation.md
@@ -1,0 +1,54 @@
+# Phase 18 Wazuh Lab Topology and Live Ingest Contract Validation
+
+- Validation date: 2026-04-10
+- Validation scope: Phase 18 review of the approved single-node Wazuh lab target, the bootable AegisOps control-plane runtime boundary it connects to, GitHub audit as the approved first live source family, Wazuh -> AegisOps as the mainline live path, fail-closed expectations for transport, authentication, and payload admission, and confirmation that OpenSearch runtime enrichment, thin operator UI, and guarded automation live wiring remain deferred
+- Baseline references: `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/wazuh-alert-ingest-contract.md`, `docs/source-onboarding-contract.md`, `docs/source-families/github-audit/onboarding-package.md`, `docs/architecture.md`
+- Verification commands: `python3 -m unittest control-plane.tests.test_phase18_wazuh_lab_topology_docs`, `bash scripts/verify-phase-18-wazuh-lab-topology.sh`, `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`
+- Validation status: PASS
+
+## Required Boundary Artifacts
+
+- `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md`
+- `docs/phase-18-wazuh-lab-topology-validation.md`
+- `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`
+- `docs/phase-16-release-state-and-first-boot-scope.md`
+- `docs/wazuh-alert-ingest-contract.md`
+- `docs/source-onboarding-contract.md`
+- `docs/source-families/github-audit/onboarding-package.md`
+- `docs/architecture.md`
+- `scripts/verify-phase-18-wazuh-lab-topology.sh`
+- `scripts/test-verify-phase-18-wazuh-lab-topology.sh`
+
+## Review Outcome
+
+Confirmed the approved topology is limited to one single-node Wazuh lab target feeding one bootable AegisOps control-plane runtime boundary through the reviewed reverse proxy and into PostgreSQL-backed control-plane state.
+
+Confirmed the Phase 18 live path keeps Wazuh -> AegisOps as the mainline live path and does not broaden the first live slice into `Wazuh -> Shuffle`, n8n relay routing, or OpenSearch-first runtime dependence.
+
+Confirmed GitHub audit is the approved first live source family because it preserves the narrowest identity-rich source context already prioritized by the reviewed Phase 14 family order and GitHub audit onboarding package.
+
+Confirmed the reviewed Wazuh custom integration contract requires HTTPS POST to the approved reverse-proxy ingress boundary plus `Authorization: Bearer <shared secret>` authentication sourced from an untracked runtime secret.
+
+Confirmed the Phase 18 contract applies the existing Wazuh payload-admission rules rather than redefining them, and limits first live admission to GitHub audit carried inside the reviewed Wazuh alert envelope.
+
+Confirmed the live ingest path remains fail-closed by rejecting non-HTTPS requests, non-POST requests, missing or invalid bearer credentials, direct backend bypass attempts, invalid JSON payloads, Wazuh payloads that violate required field expectations, and payloads outside the approved first live family.
+
+Confirmed OpenSearch runtime enrichment, thin operator UI, guarded automation live wiring, broader source-family rollout, direct GitHub API actioning, and production-scale Wazuh topologies remain deferred and out of scope for this slice.
+
+The issue requested review against `Phase 16-21 Epic Roadmap.md`, but that roadmap file was not present in the local worktree and could not be located via repository search during this turn.
+
+## Cross-Link Review
+
+`docs/phase-17-runtime-config-contract-and-boot-command-expectations.md` must continue to define the bootable runtime contract that the first live topology connects to without adding new startup blockers.
+
+`docs/phase-16-release-state-and-first-boot-scope.md` must continue to define the narrow first-boot floor so Phase 18 live wiring does not silently broaden the required runtime.
+
+`docs/wazuh-alert-ingest-contract.md` must continue to define the reviewed Wazuh-native required fields, provenance expectations, and identifier mapping that the live path preserves.
+
+`docs/source-onboarding-contract.md` and `docs/source-families/github-audit/onboarding-package.md` must continue to keep GitHub audit scoped as a reviewed source-family baseline rather than a blanket approval for broad live source rollout.
+
+`docs/architecture.md` must continue to keep AegisOps as the authority boundary and forbid detection-substrate or automation-substrate shortcuts from becoming the policy-sensitive system-of-record path.
+
+## Deviations
+
+- Requested comparison target `Phase 16-21 Epic Roadmap.md` was unavailable in the local worktree during this validation snapshot.

--- a/scripts/test-verify-phase-18-wazuh-lab-topology.sh
+++ b/scripts/test-verify-phase-18-wazuh-lab-topology.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-18-wazuh-lab-topology.sh"
+canonical_design_doc="${repo_root}/docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md"
+canonical_validation_doc="${repo_root}/docs/phase-18-wazuh-lab-topology-validation.md"
+canonical_phase17_doc="${repo_root}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md"
+canonical_phase16_doc="${repo_root}/docs/phase-16-release-state-and-first-boot-scope.md"
+canonical_wazuh_contract_doc="${repo_root}/docs/wazuh-alert-ingest-contract.md"
+canonical_source_contract_doc="${repo_root}/docs/source-onboarding-contract.md"
+canonical_github_audit_doc="${repo_root}/docs/source-families/github-audit/onboarding-package.md"
+canonical_architecture_doc="${repo_root}/docs/architecture.md"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/source-families/github-audit" "${target}/scripts"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_canonical_artifacts() {
+  local target="$1"
+
+  cp "${canonical_design_doc}" "${target}/docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md"
+  cp "${canonical_validation_doc}" "${target}/docs/phase-18-wazuh-lab-topology-validation.md"
+  cp "${canonical_phase17_doc}" "${target}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md"
+  cp "${canonical_phase16_doc}" "${target}/docs/phase-16-release-state-and-first-boot-scope.md"
+  cp "${canonical_wazuh_contract_doc}" "${target}/docs/wazuh-alert-ingest-contract.md"
+  cp "${canonical_source_contract_doc}" "${target}/docs/source-onboarding-contract.md"
+  cp "${canonical_github_audit_doc}" "${target}/docs/source-families/github-audit/onboarding-package.md"
+  cp "${canonical_architecture_doc}" "${target}/docs/architecture.md"
+  cp "${verifier}" "${target}/scripts/verify-phase-18-wazuh-lab-topology.sh"
+  cp "${repo_root}/scripts/test-verify-phase-18-wazuh-lab-topology.sh" "${target}/scripts/test-verify-phase-18-wazuh-lab-topology.sh"
+  git -C "${target}" add .
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local doc_path="$2"
+  local expected_text="$3"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${doc_path}"
+  git -C "${target}" add "${doc_path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_canonical_artifacts "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_design_repo="${workdir}/missing-design"
+create_repo "${missing_design_repo}"
+write_canonical_artifacts "${missing_design_repo}"
+rm "${missing_design_repo}/docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md"
+git -C "${missing_design_repo}" add -u
+commit_fixture "${missing_design_repo}"
+assert_fails_with "${missing_design_repo}" "Missing Phase 18 Wazuh lab topology doc:"
+
+missing_live_path_repo="${workdir}/missing-live-path"
+create_repo "${missing_live_path_repo}"
+write_canonical_artifacts "${missing_live_path_repo}"
+remove_text_from_doc "${missing_live_path_repo}" "${missing_live_path_repo}/docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md" 'The approved live path is Wazuh -> AegisOps.'
+commit_fixture "${missing_live_path_repo}"
+assert_fails_with "${missing_live_path_repo}" 'The approved live path is Wazuh -> AegisOps.'
+
+missing_auth_repo="${workdir}/missing-auth"
+create_repo "${missing_auth_repo}"
+write_canonical_artifacts "${missing_auth_repo}"
+remove_text_from_doc "${missing_auth_repo}" "${missing_auth_repo}/docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md" 'The reviewed request authentication contract is `Authorization: Bearer <shared secret>`.'
+commit_fixture "${missing_auth_repo}"
+assert_fails_with "${missing_auth_repo}" 'The reviewed request authentication contract is `Authorization: Bearer <shared secret>`.'
+
+missing_deferred_scope_repo="${workdir}/missing-deferred-scope"
+create_repo "${missing_deferred_scope_repo}"
+write_canonical_artifacts "${missing_deferred_scope_repo}"
+remove_text_from_doc "${missing_deferred_scope_repo}" "${missing_deferred_scope_repo}/docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md" '- guarded automation live wiring;'
+commit_fixture "${missing_deferred_scope_repo}"
+assert_fails_with "${missing_deferred_scope_repo}" '- guarded automation live wiring;'
+
+missing_validation_note_repo="${workdir}/missing-validation-note"
+create_repo "${missing_validation_note_repo}"
+write_canonical_artifacts "${missing_validation_note_repo}"
+remove_text_from_doc "${missing_validation_note_repo}" "${missing_validation_note_repo}/docs/phase-18-wazuh-lab-topology-validation.md" 'Confirmed the live ingest path remains fail-closed by rejecting non-HTTPS requests, non-POST requests, missing or invalid bearer credentials, direct backend bypass attempts, invalid JSON payloads, Wazuh payloads that violate required field expectations, and payloads outside the approved first live family.'
+commit_fixture "${missing_validation_note_repo}"
+assert_fails_with "${missing_validation_note_repo}" 'Confirmed the live ingest path remains fail-closed by rejecting non-HTTPS requests, non-POST requests, missing or invalid bearer credentials, direct backend bypass attempts, invalid JSON payloads, Wazuh payloads that violate required field expectations, and payloads outside the approved first live family.'
+
+missing_deviation_repo="${workdir}/missing-deviation"
+create_repo "${missing_deviation_repo}"
+write_canonical_artifacts "${missing_deviation_repo}"
+remove_text_from_doc "${missing_deviation_repo}" "${missing_deviation_repo}/docs/phase-18-wazuh-lab-topology-validation.md" '- Requested comparison target `Phase 16-21 Epic Roadmap.md` was unavailable in the local worktree during this validation snapshot.'
+commit_fixture "${missing_deviation_repo}"
+assert_fails_with "${missing_deviation_repo}" '- Requested comparison target `Phase 16-21 Epic Roadmap.md` was unavailable in the local worktree during this validation snapshot.'
+
+echo "Phase 18 Wazuh lab topology verifier enforces the reviewed live-path contract and deferred-scope boundaries."

--- a/scripts/verify-phase-18-wazuh-lab-topology.sh
+++ b/scripts/verify-phase-18-wazuh-lab-topology.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+default_repo_root="$(cd "${script_dir}/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+design_doc="${repo_root}/docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md"
+validation_doc="${repo_root}/docs/phase-18-wazuh-lab-topology-validation.md"
+phase17_doc="${repo_root}/docs/phase-17-runtime-config-contract-and-boot-command-expectations.md"
+phase16_doc="${repo_root}/docs/phase-16-release-state-and-first-boot-scope.md"
+wazuh_contract_doc="${repo_root}/docs/wazuh-alert-ingest-contract.md"
+source_contract_doc="${repo_root}/docs/source-onboarding-contract.md"
+github_audit_doc="${repo_root}/docs/source-families/github-audit/onboarding-package.md"
+architecture_doc="${repo_root}/docs/architecture.md"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_string() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required line in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${design_doc}" "Missing Phase 18 Wazuh lab topology doc"
+require_file "${validation_doc}" "Missing Phase 18 Wazuh lab topology validation doc"
+require_file "${phase17_doc}" "Missing Phase 17 runtime config contract doc"
+require_file "${phase16_doc}" "Missing Phase 16 first-boot scope doc"
+require_file "${wazuh_contract_doc}" "Missing Wazuh alert ingest contract doc"
+require_file "${source_contract_doc}" "Missing source onboarding contract doc"
+require_file "${github_audit_doc}" "Missing GitHub audit onboarding package doc"
+require_file "${architecture_doc}" "Missing architecture overview doc"
+
+design_required_lines=(
+  '# AegisOps Phase 18 Wazuh Lab Topology and Live Ingest Contract'
+  '## 1. Purpose'
+  '## 2. Approved Phase 18 Lab Topology'
+  '## 3. Approved First Live Source Family'
+  '## 4. Reviewed Wazuh Custom Integration Live Ingest Contract'
+  '### 4.1 Transport and Path'
+  '### 4.2 Authentication'
+  '### 4.3 Payload Admission Boundary'
+  '### 4.4 Fail-Closed Expectations'
+  '## 5. Deferred Runtime Surfaces and Non-Goals'
+  '## 6. Alignment and Non-Expansion Rules'
+  'The approved Phase 18 lab topology is one single-node Wazuh lab target connected to one bootable AegisOps control-plane runtime boundary.'
+  '`single-node Wazuh -> reviewed reverse proxy -> bootable AegisOps control-plane runtime boundary -> PostgreSQL`'
+  'The control-plane backend port remains internal-only behind the reverse proxy.'
+  'The Approved First Live Source Family for the initial Phase 18 slice is GitHub audit.'
+  'The reviewed Wazuh custom integration must send one Wazuh alert JSON object at a time to AegisOps using HTTPS POST.'
+  'The approved live path is Wazuh -> AegisOps.'
+  'Phase 18 must not make `Wazuh -> Shuffle` part of the first live slice.'
+  'The reviewed request authentication contract is `Authorization: Bearer <shared secret>`.'
+  'The shared secret is an AegisOps-owned runtime secret and must come from an untracked secret source or reviewed operator-provided runtime secret file.'
+  'The payload shape remains the reviewed Wazuh alert contract from `docs/wazuh-alert-ingest-contract.md`.'
+  'The live ingest path must fail closed.'
+  '- the request is not HTTPS at the approved ingress boundary;'
+  '- the request does not use HTTPS POST;'
+  '- the `Authorization: Bearer` header is missing, empty, malformed, or does not match the reviewed shared secret;'
+  '- the request attempts to bypass the approved reverse proxy and reach the control-plane backend directly;'
+  '- the payload is not valid JSON;'
+  '- the payload represents a family other than the approved GitHub audit first live source family.'
+  'The live ingest path must not silently downgrade to HTTP, accept missing authentication, bypass the reviewed Wazuh contract, or treat `Wazuh -> Shuffle` as a fallback route.'
+  '- OpenSearch runtime enrichment or OpenSearch-dependent success criteria;'
+  '- thin operator UI work;'
+  '- guarded automation live wiring;'
+)
+
+for line in "${design_required_lines[@]}"; do
+  require_fixed_string "${design_doc}" "${line}"
+done
+
+validation_required_lines=(
+  '# Phase 18 Wazuh Lab Topology and Live Ingest Contract Validation'
+  '- Validation date: 2026-04-10'
+  '- Validation status: PASS'
+  '## Required Boundary Artifacts'
+  '## Review Outcome'
+  '## Cross-Link Review'
+  '## Deviations'
+  'Confirmed the approved topology is limited to one single-node Wazuh lab target feeding one bootable AegisOps control-plane runtime boundary through the reviewed reverse proxy and into PostgreSQL-backed control-plane state.'
+  'Confirmed the Phase 18 live path keeps Wazuh -> AegisOps as the mainline live path and does not broaden the first live slice into `Wazuh -> Shuffle`, n8n relay routing, or OpenSearch-first runtime dependence.'
+  'Confirmed GitHub audit is the approved first live source family because it preserves the narrowest identity-rich source context already prioritized by the reviewed Phase 14 family order and GitHub audit onboarding package.'
+  'Confirmed the reviewed Wazuh custom integration contract requires HTTPS POST to the approved reverse-proxy ingress boundary plus `Authorization: Bearer <shared secret>` authentication sourced from an untracked runtime secret.'
+  'Confirmed the Phase 18 contract applies the existing Wazuh payload-admission rules rather than redefining them, and limits first live admission to GitHub audit carried inside the reviewed Wazuh alert envelope.'
+  'Confirmed the live ingest path remains fail-closed by rejecting non-HTTPS requests, non-POST requests, missing or invalid bearer credentials, direct backend bypass attempts, invalid JSON payloads, Wazuh payloads that violate required field expectations, and payloads outside the approved first live family.'
+  'Confirmed OpenSearch runtime enrichment, thin operator UI, guarded automation live wiring, broader source-family rollout, direct GitHub API actioning, and production-scale Wazuh topologies remain deferred and out of scope for this slice.'
+  "The issue requested review against \`Phase 16-21 Epic Roadmap.md\`, but that roadmap file was not present in the local worktree and could not be located via repository search during this turn."
+  '- Requested comparison target `Phase 16-21 Epic Roadmap.md` was unavailable in the local worktree during this validation snapshot.'
+)
+
+for line in "${validation_required_lines[@]}"; do
+  require_fixed_string "${validation_doc}" "${line}"
+done
+
+required_artifacts=(
+  "docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md"
+  "docs/phase-18-wazuh-lab-topology-validation.md"
+  "docs/phase-17-runtime-config-contract-and-boot-command-expectations.md"
+  "docs/phase-16-release-state-and-first-boot-scope.md"
+  "docs/wazuh-alert-ingest-contract.md"
+  "docs/source-onboarding-contract.md"
+  "docs/source-families/github-audit/onboarding-package.md"
+  "docs/architecture.md"
+  "scripts/verify-phase-18-wazuh-lab-topology.sh"
+  "scripts/test-verify-phase-18-wazuh-lab-topology.sh"
+)
+
+for artifact in "${required_artifacts[@]}"; do
+  require_file "${repo_root}/${artifact}" "Missing required Phase 18 artifact"
+
+  if ! grep -Fqx -- "- \`${artifact}\`" "${validation_doc}" >/dev/null; then
+    echo "Phase 18 validation record must list required artifact: ${artifact}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 18 Wazuh lab topology and live ingest contract remain explicit and reviewable."


### PR DESCRIPTION
## What changed
- add the Phase 18 design document that defines the approved Wazuh single-node lab topology, first live source family, and reviewed `Wazuh -> AegisOps` ingest contract
- add the Phase 18 validation record and shell verifier for the approved topology and deferred-scope boundaries
- add a focused test for the Phase 18 documentation contract and link the new artifacts from the repository docs index

## Why it changed
Phase 18 needs an explicit, reviewable contract for the first live substrate slice so implementation can wire the narrow Wazuh lab path into AegisOps without reopening broader topology, source-family, or routing scope.

## Impact
- reviewers get a concrete approved topology and ingest contract tied to the existing Phase 16/17 boot-path baseline
- implementation work can proceed on the mainline `Wazuh -> AegisOps` path without pulling in Shuffle routing, broader source rollout, or optional runtime enrichment
- the verifier and focused test guard the intended deferred-scope boundaries for later phases

## Validation
- `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 18 Wazuh lab topology and live ingest contract specifications
  * Added Phase 18 Wazuh lab topology validation documentation
  * Updated documentation ownership map with new Phase 18 entries

* **Tests**
  * Added automated validation tests for Phase 18 documentation integrity

* **Chores**
  * Added verification scripts for Phase 18 Wazuh lab topology compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->