### PR TITLE
Implement authenticated Wazuh ingest endpoint

### DIFF
--- a/control-plane/aegisops_control_plane/config.py
+++ b/control-plane/aegisops_control_plane/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 from typing import Mapping
 
@@ -14,7 +14,8 @@ class RuntimeConfig:
     n8n_base_url: str = "<set-me>"
     shuffle_base_url: str = "<set-me>"
     isolated_executor_base_url: str = "<set-me>"
-    wazuh_ingest_shared_secret: str = ""
+    wazuh_ingest_shared_secret: str = field(default="", repr=False)
+    wazuh_ingest_trusted_proxy_cidrs: tuple[str, ...] = ()
 
     @classmethod
     def from_env(cls, environ: Mapping[str, str] | None = None) -> "RuntimeConfig":
@@ -34,6 +35,15 @@ class RuntimeConfig:
                     f"AEGISOPS_CONTROL_PLANE_PORT must be between 1 and 65535, got: {port}"
                 )
 
+        trusted_proxy_cidrs = tuple(
+            item.strip()
+            for item in source.get(
+                "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_TRUSTED_PROXY_CIDRS",
+                "",
+            ).split(",")
+            if item.strip()
+        )
+
         return cls(
             host=source.get("AEGISOPS_CONTROL_PLANE_HOST", cls.host),
             port=port,
@@ -52,4 +62,5 @@ class RuntimeConfig:
                 "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET",
                 cls.wazuh_ingest_shared_secret,
             ),
+            wazuh_ingest_trusted_proxy_cidrs=trusted_proxy_cidrs,
         )

--- a/control-plane/aegisops_control_plane/config.py
+++ b/control-plane/aegisops_control_plane/config.py
@@ -14,6 +14,7 @@ class RuntimeConfig:
     n8n_base_url: str = "<set-me>"
     shuffle_base_url: str = "<set-me>"
     isolated_executor_base_url: str = "<set-me>"
+    wazuh_ingest_shared_secret: str = ""
 
     @classmethod
     def from_env(cls, environ: Mapping[str, str] | None = None) -> "RuntimeConfig":
@@ -46,5 +47,9 @@ class RuntimeConfig:
             isolated_executor_base_url=source.get(
                 "AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL",
                 cls.isolated_executor_base_url,
+            ),
+            wazuh_ingest_shared_secret=source.get(
+                "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET",
+                cls.wazuh_ingest_shared_secret,
             ),
         )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -5,6 +5,7 @@ from collections import Counter
 from dataclasses import asdict, dataclass, fields, replace
 from datetime import datetime, timezone
 import hashlib
+import hmac
 import json
 import re
 import uuid
@@ -14,6 +15,7 @@ from .adapters.executor import IsolatedExecutorAdapter
 from .adapters.n8n import N8NReconciliationAdapter
 from .adapters.postgres import PostgresControlPlaneStore
 from .adapters.shuffle import ShuffleActionAdapter
+from .adapters.wazuh import WazuhAlertAdapter
 from .config import RuntimeConfig
 from .models import (
     AITraceRecord,
@@ -864,6 +866,59 @@ class AegisOpsControlPlaneService:
 
     def get_record(self, record_type: Type[RecordT], record_id: str) -> RecordT | None:
         return self._store.get(record_type, record_id)
+
+    def validate_wazuh_ingest_runtime(self) -> None:
+        if self._config.wazuh_ingest_shared_secret.strip() == "":
+            raise ValueError(
+                "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET must be set "
+                "before starting the live Wazuh ingest runtime"
+            )
+
+    def ingest_wazuh_alert(
+        self,
+        *,
+        raw_alert: Mapping[str, object],
+        authorization_header: str | None,
+        forwarded_proto: str | None,
+    ) -> FindingAlertIngestResult:
+        self.validate_wazuh_ingest_runtime()
+
+        if (forwarded_proto or "").strip().lower() != "https":
+            raise PermissionError(
+                "live Wazuh ingest requires the reviewed reverse proxy HTTPS boundary"
+            )
+
+        scheme, separator, supplied_secret = (authorization_header or "").partition(" ")
+        if separator == "" or scheme != "Bearer" or supplied_secret.strip() == "":
+            raise PermissionError(
+                "live Wazuh ingest requires Authorization: Bearer <shared secret>"
+            )
+        if not hmac.compare_digest(
+            supplied_secret.strip(),
+            self._config.wazuh_ingest_shared_secret,
+        ):
+            raise PermissionError(
+                "live Wazuh ingest bearer credential did not match the reviewed shared secret"
+            )
+
+        native_alert = self._require_mapping(raw_alert, "alert")
+        source_family = self._normalize_optional_string(
+            (
+                self._require_mapping(
+                    native_alert.get("data"),
+                    "data",
+                )
+            ).get("source_family"),
+            "data.source_family",
+        )
+        if source_family != "github_audit":
+            raise ValueError(
+                "live Wazuh ingest only admits the reviewed github_audit first live source family"
+            )
+
+        adapter = WazuhAlertAdapter()
+        native_record = adapter.build_native_detection_record(native_alert)
+        return self.ingest_native_detection_record(adapter, native_record)
 
     def delegate_approved_action_to_shuffle(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -6,6 +6,7 @@ from dataclasses import asdict, dataclass, fields, replace
 from datetime import datetime, timezone
 import hashlib
 import hmac
+import ipaddress
 import json
 import re
 import uuid
@@ -873,6 +874,22 @@ class AegisOpsControlPlaneService:
                 "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET must be set "
                 "before starting the live Wazuh ingest runtime"
             )
+        for cidr in self._config.wazuh_ingest_trusted_proxy_cidrs:
+            try:
+                ipaddress.ip_network(cidr, strict=False)
+            except ValueError as exc:
+                raise ValueError(
+                    "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_TRUSTED_PROXY_CIDRS must contain "
+                    f"only valid IP networks, got: {cidr!r}"
+                ) from exc
+        if (
+            not self._wazuh_ingest_listener_is_loopback()
+            and not self._config.wazuh_ingest_trusted_proxy_cidrs
+        ):
+            raise ValueError(
+                "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_TRUSTED_PROXY_CIDRS must be set "
+                "before starting the live Wazuh ingest runtime on a non-loopback interface"
+            )
 
     def ingest_wazuh_alert(
         self,
@@ -880,8 +897,14 @@ class AegisOpsControlPlaneService:
         raw_alert: Mapping[str, object],
         authorization_header: str | None,
         forwarded_proto: str | None,
+        peer_addr: str | None,
     ) -> FindingAlertIngestResult:
         self.validate_wazuh_ingest_runtime()
+
+        if not self._is_trusted_wazuh_ingest_peer(peer_addr):
+            raise PermissionError(
+                "live Wazuh ingest rejects requests that bypass the reviewed reverse proxy peer boundary"
+            )
 
         if (forwarded_proto or "").strip().lower() != "https":
             raise PermissionError(
@@ -919,6 +942,29 @@ class AegisOpsControlPlaneService:
         adapter = WazuhAlertAdapter()
         native_record = adapter.build_native_detection_record(native_alert)
         return self.ingest_native_detection_record(adapter, native_record)
+
+    def _wazuh_ingest_listener_is_loopback(self) -> bool:
+        host = self._config.host.strip()
+        if host.lower() == "localhost":
+            return True
+        try:
+            return ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            return False
+
+    def _is_trusted_wazuh_ingest_peer(self, peer_addr: str | None) -> bool:
+        if self._wazuh_ingest_listener_is_loopback():
+            return True
+        if peer_addr is None or peer_addr.strip() == "":
+            return False
+        try:
+            peer_ip = ipaddress.ip_address(peer_addr)
+        except ValueError:
+            return False
+        for cidr in self._config.wazuh_ingest_trusted_proxy_cidrs:
+            if peer_ip in ipaddress.ip_network(cidr, strict=False):
+                return True
+        return False
 
     def delegate_approved_action_to_shuffle(
         self,

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import fields, is_dataclass
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import sys
-from typing import Sequence, TextIO
+from typing import Mapping, Sequence, TextIO
 from urllib.parse import parse_qs, urlsplit
 
 from aegisops_control_plane.service import (
@@ -99,6 +100,7 @@ def run_control_plane_service(
     *,
     stderr: TextIO | None = None,
 ) -> int:
+    service.validate_wazuh_ingest_runtime()
     runtime_snapshot = service.describe_runtime().to_dict()
     stderr = stderr or sys.stderr
 
@@ -175,6 +177,100 @@ def run_control_plane_service(
                 },
             )
 
+        def do_POST(self) -> None:  # noqa: N802
+            request_target = urlsplit(self.path)
+            request_path = request_target.path
+
+            if request_path != "/intake/wazuh":
+                self._write_json(
+                    HTTPStatus.NOT_FOUND,
+                    {
+                        "error": "not_found",
+                        "path": request_path,
+                    },
+                )
+                return
+
+            try:
+                content_length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {
+                        "error": "invalid_request",
+                        "message": "Content-Length must be an integer",
+                    },
+                )
+                return
+            if content_length <= 0:
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {
+                        "error": "invalid_request",
+                        "message": "request body is required",
+                    },
+                )
+                return
+
+            try:
+                raw_payload = self.rfile.read(content_length).decode("utf-8")
+            except UnicodeDecodeError:
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {
+                        "error": "invalid_request",
+                        "message": "request body must be valid UTF-8 JSON",
+                    },
+                )
+                return
+
+            try:
+                alert = json.loads(raw_payload)
+            except json.JSONDecodeError as exc:
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {
+                        "error": "invalid_request",
+                        "message": f"request body must be valid JSON: {exc.msg}",
+                    },
+                )
+                return
+
+            try:
+                ingest_result = service.ingest_wazuh_alert(
+                    raw_alert=alert,
+                    authorization_header=self.headers.get("Authorization"),
+                    forwarded_proto=self.headers.get("X-Forwarded-Proto"),
+                )
+            except PermissionError as exc:
+                self._write_json(
+                    HTTPStatus.FORBIDDEN,
+                    {
+                        "error": "forbidden",
+                        "message": str(exc),
+                    },
+                )
+                return
+            except ValueError as exc:
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {
+                        "error": "invalid_request",
+                        "message": str(exc),
+                    },
+                )
+                return
+
+            self._write_json(
+                HTTPStatus.ACCEPTED,
+                {
+                    "disposition": ingest_result.disposition,
+                    "finding_id": ingest_result.alert.finding_id,
+                    "alert": _json_ready(ingest_result.alert),
+                    "reconciliation": _json_ready(ingest_result.reconciliation),
+                },
+            )
+
         def log_message(self, format: str, *args: object) -> None:
             print(
                 "%s - - [%s] %s"
@@ -206,6 +302,32 @@ def run_control_plane_service(
         return 0
     finally:
         server.server_close()
+
+
+def _json_ready(value: object) -> object:
+    if is_dataclass(value):
+        raw = {
+            field.name: getattr(value, field.name)
+            for field in fields(value)
+        }
+    else:
+        raw = value
+    if isinstance(raw, Mapping):
+        return {str(key): _json_ready(item) for key, item in raw.items()}
+    if isinstance(raw, dict):
+        return {key: _json_ready(item) for key, item in raw.items()}
+    if isinstance(raw, tuple):
+        return [_json_ready(item) for item in raw]
+    if isinstance(raw, list):
+        return [_json_ready(item) for item in raw]
+    if hasattr(raw, "isoformat"):
+        try:
+            return raw.isoformat()
+        except TypeError:
+            return raw
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return value.to_dict()
+    return raw
 
 
 def main(

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -16,6 +16,8 @@ from aegisops_control_plane.service import (
     build_runtime_service,
 )
 
+MAX_WAZUH_INGEST_BODY_BYTES = 1_048_576
+
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -211,6 +213,15 @@ def run_control_plane_service(
                     },
                 )
                 return
+            if content_length > MAX_WAZUH_INGEST_BODY_BYTES:
+                self._write_json(
+                    HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                    {
+                        "error": "request_too_large",
+                        "message": "request body exceeds the reviewed Wazuh ingest size limit",
+                    },
+                )
+                return
 
             try:
                 raw_payload = self.rfile.read(content_length).decode("utf-8")
@@ -241,6 +252,7 @@ def run_control_plane_service(
                     raw_alert=alert,
                     authorization_header=self.headers.get("Authorization"),
                     forwarded_proto=self.headers.get("X-Forwarded-Proto"),
+                    peer_addr=self.client_address[0] if self.client_address else None,
                 )
             except PermissionError as exc:
                 self._write_json(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from datetime import datetime, timezone
+import http.client
 import io
 import json
 import pathlib
@@ -596,23 +597,25 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     thread.join(0.01)
                 self.assertTrue(servers, "expected test HTTP server to start")
 
-                oversized_payload = b"x" * (main.MAX_WAZUH_INGEST_BODY_BYTES + 1)
-                ingest_request = request.Request(
-                    f"http://127.0.0.1:{servers[0].server_port}/intake/wazuh",
-                    data=oversized_payload,
-                    method="POST",
-                    headers={
-                        "Authorization": "Bearer reviewed-shared-secret",
-                        "Content-Type": "application/json",
-                        "X-Forwarded-Proto": "https",
-                    },
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1",
+                    servers[0].server_port,
+                    timeout=2,
                 )
+                connection.putrequest("POST", "/intake/wazuh")
+                connection.putheader("Authorization", "Bearer reviewed-shared-secret")
+                connection.putheader("Content-Type", "application/json")
+                connection.putheader("X-Forwarded-Proto", "https")
+                connection.putheader(
+                    "Content-Length",
+                    str(main.MAX_WAZUH_INGEST_BODY_BYTES + 1),
+                )
+                connection.endheaders()
 
-                with self.assertRaises(error.HTTPError) as exc_info:
-                    request.urlopen(ingest_request, timeout=2)
-
-                self.assertEqual(exc_info.exception.code, 413)
-                response_body = json.loads(exc_info.exception.read().decode("utf-8"))
+                response = connection.getresponse()
+                self.assertEqual(response.status, 413)
+                response_body = json.loads(response.read().decode("utf-8"))
+                connection.close()
                 self.assertEqual(response_body["error"], "request_too_large")
                 self.assertEqual(store.list(AlertRecord), ())
                 self.assertEqual(store.list(AnalyticSignalRecord), ())

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -288,6 +288,26 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         ):
             main.run_control_plane_service(service)
 
+    def test_long_running_runtime_surface_rejects_non_loopback_wazuh_ingest_without_trusted_proxies(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="0.0.0.0",
+                port=8089,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+            ),
+            store=store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_TRUSTED_PROXY_CIDRS must be set",
+        ):
+            main.run_control_plane_service(service)
+
     def test_long_running_runtime_surface_rejects_wazuh_ingest_without_bearer_auth(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -491,6 +511,109 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 with self.assertRaisesRegex(error.HTTPError, "400"):
                     request.urlopen(ingest_request, timeout=2)
 
+                self.assertEqual(store.list(AlertRecord), ())
+                self.assertEqual(store.list(AnalyticSignalRecord), ())
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="0.0.0.0",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
+            ),
+            store=store,
+        )
+
+        with self.assertRaisesRegex(
+            PermissionError,
+            "reviewed reverse proxy peer boundary",
+        ):
+            service.ingest_wazuh_alert(
+                raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+                authorization_header="Bearer reviewed-shared-secret",
+                forwarded_proto="https",
+                peer_addr="10.10.0.6",
+            )
+
+    def test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="0.0.0.0",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
+            ),
+            store=store,
+        )
+
+        ingest_result = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            peer_addr="10.10.0.5",
+        )
+
+        self.assertEqual(ingest_result.disposition, "created")
+        self.assertEqual(len(store.list(AlertRecord)), 1)
+        self.assertEqual(len(store.list(AnalyticSignalRecord)), 1)
+
+    def test_long_running_runtime_surface_rejects_oversized_wazuh_ingest_body(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+            ),
+            store=store,
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                oversized_payload = b"x" * (main.MAX_WAZUH_INGEST_BODY_BYTES + 1)
+                ingest_request = request.Request(
+                    f"http://127.0.0.1:{servers[0].server_port}/intake/wazuh",
+                    data=oversized_payload,
+                    method="POST",
+                    headers={
+                        "Authorization": "Bearer reviewed-shared-secret",
+                        "Content-Type": "application/json",
+                        "X-Forwarded-Proto": "https",
+                    },
+                )
+
+                with self.assertRaises(error.HTTPError) as exc_info:
+                    request.urlopen(ingest_request, timeout=2)
+
+                self.assertEqual(exc_info.exception.code, 413)
+                response_body = json.loads(exc_info.exception.read().decode("utf-8"))
+                self.assertEqual(response_body["error"], "request_too_large")
                 self.assertEqual(store.list(AlertRecord), ())
                 self.assertEqual(store.list(AnalyticSignalRecord), ())
             finally:

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -8,7 +8,7 @@ import pathlib
 import sys
 import threading
 import unittest
-from urllib import request
+from urllib import error, request
 from unittest import mock
 
 
@@ -108,6 +108,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 host="127.0.0.1",
                 port=8089,
                 postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
             ),
             store=store,
         )
@@ -129,6 +130,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 host="127.0.0.1",
                 port=0,
                 postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
             ),
             store=store,
         )
@@ -203,6 +205,294 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 self.assertEqual(records_payload["record_family"], "alert")
                 self.assertEqual(records_payload["records"][0]["alert_id"], "alert-http-001")
                 self.assertEqual(status_payload["by_ingest_disposition"], {"created": 1})
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_long_running_runtime_surface_admits_authenticated_wazuh_ingest(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+            ),
+            store=store,
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                alert = _load_wazuh_fixture("github-audit-alert.json")
+                request_body = json.dumps(alert).encode("utf-8")
+                ingest_request = request.Request(
+                    f"http://127.0.0.1:{servers[0].server_port}/intake/wazuh",
+                    data=request_body,
+                    method="POST",
+                    headers={
+                        "Authorization": "Bearer reviewed-shared-secret",
+                        "Content-Type": "application/json",
+                        "X-Forwarded-Proto": "https",
+                    },
+                )
+
+                with request.urlopen(ingest_request, timeout=2) as response:
+                    response_body = json.loads(response.read().decode("utf-8"))
+
+                self.assertEqual(response.status, 202)
+                self.assertEqual(response_body["disposition"], "created")
+                self.assertEqual(response_body["finding_id"], response_body["alert"]["finding_id"])
+                self.assertEqual(store.list(AlertRecord)[0].finding_id, response_body["finding_id"])
+                self.assertEqual(
+                    store.list(AnalyticSignalRecord)[0].substrate_detection_record_id,
+                    "wazuh:1731595300.1234567",
+                )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_long_running_runtime_surface_rejects_missing_wazuh_shared_secret(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=8089,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+            ),
+            store=store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET must be set",
+        ):
+            main.run_control_plane_service(service)
+
+    def test_long_running_runtime_surface_rejects_wazuh_ingest_without_bearer_auth(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+            ),
+            store=store,
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                ingest_request = request.Request(
+                    f"http://127.0.0.1:{servers[0].server_port}/intake/wazuh",
+                    data=json.dumps(_load_wazuh_fixture("github-audit-alert.json")).encode("utf-8"),
+                    method="POST",
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Forwarded-Proto": "https",
+                    },
+                )
+
+                with self.assertRaisesRegex(error.HTTPError, "403"):
+                    request.urlopen(ingest_request, timeout=2)
+
+                self.assertEqual(store.list(AlertRecord), ())
+                self.assertEqual(store.list(AnalyticSignalRecord), ())
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_long_running_runtime_surface_rejects_wazuh_ingest_with_wrong_bearer_secret(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+            ),
+            store=store,
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                ingest_request = request.Request(
+                    f"http://127.0.0.1:{servers[0].server_port}/intake/wazuh",
+                    data=json.dumps(_load_wazuh_fixture("github-audit-alert.json")).encode("utf-8"),
+                    method="POST",
+                    headers={
+                        "Authorization": "Bearer wrong-secret",
+                        "Content-Type": "application/json",
+                        "X-Forwarded-Proto": "https",
+                    },
+                )
+
+                with self.assertRaisesRegex(error.HTTPError, "403"):
+                    request.urlopen(ingest_request, timeout=2)
+
+                self.assertEqual(store.list(AlertRecord), ())
+                self.assertEqual(store.list(AnalyticSignalRecord), ())
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_long_running_runtime_surface_rejects_wazuh_ingest_without_https_forwarding(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+            ),
+            store=store,
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                ingest_request = request.Request(
+                    f"http://127.0.0.1:{servers[0].server_port}/intake/wazuh",
+                    data=json.dumps(_load_wazuh_fixture("github-audit-alert.json")).encode("utf-8"),
+                    method="POST",
+                    headers={
+                        "Authorization": "Bearer reviewed-shared-secret",
+                        "Content-Type": "application/json",
+                    },
+                )
+
+                with self.assertRaisesRegex(error.HTTPError, "403"):
+                    request.urlopen(ingest_request, timeout=2)
+
+                self.assertEqual(store.list(AlertRecord), ())
+                self.assertEqual(store.list(AnalyticSignalRecord), ())
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_long_running_runtime_surface_rejects_non_github_wazuh_family(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+            ),
+            store=store,
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                ingest_request = request.Request(
+                    f"http://127.0.0.1:{servers[0].server_port}/intake/wazuh",
+                    data=json.dumps(_load_wazuh_fixture("microsoft-365-audit-alert.json")).encode("utf-8"),
+                    method="POST",
+                    headers={
+                        "Authorization": "Bearer reviewed-shared-secret",
+                        "Content-Type": "application/json",
+                        "X-Forwarded-Proto": "https",
+                    },
+                )
+
+                with self.assertRaisesRegex(error.HTTPError, "400"):
+                    request.urlopen(ingest_request, timeout=2)
+
+                self.assertEqual(store.list(AlertRecord), ())
+                self.assertEqual(store.list(AnalyticSignalRecord), ())
             finally:
                 if servers:
                     servers[0].shutdown()

--- a/control-plane/tests/test_runtime_skeleton.py
+++ b/control-plane/tests/test_runtime_skeleton.py
@@ -10,6 +10,7 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
 from aegisops_control_plane import AlertRecord, ControlPlaneRecord
+from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.service import build_runtime_snapshot
 
 
@@ -78,6 +79,28 @@ class RuntimeSkeletonTests(unittest.TestCase):
             r"AEGISOPS_CONTROL_PLANE_PORT must be between 1 and 65535, got: 70000",
         ):
             build_runtime_snapshot({"AEGISOPS_CONTROL_PLANE_PORT": "70000"})
+
+    def test_runtime_config_repr_hides_wazuh_shared_secret(self) -> None:
+        config = RuntimeConfig(
+            postgres_dsn="postgresql://control-plane.local/aegisops",
+            wazuh_ingest_shared_secret="reviewed-shared-secret",
+        )
+
+        self.assertNotIn("reviewed-shared-secret", repr(config))
+
+    def test_runtime_config_parses_trusted_proxy_cidrs_from_env(self) -> None:
+        config = RuntimeConfig.from_env(
+            {
+                "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_TRUSTED_PROXY_CIDRS": (
+                    "10.10.0.5/32, 10.10.0.0/24 ,,2001:db8::/32"
+                ),
+            }
+        )
+
+        self.assertEqual(
+            config.wazuh_ingest_trusted_proxy_cidrs,
+            ("10.10.0.5/32", "10.10.0.0/24", "2001:db8::/32"),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add the reviewed live `POST /intake/wazuh` runtime path for Wazuh custom integration payloads
- enforce fail-closed startup and request validation with the configured shared bearer secret, reverse-proxy HTTPS forwarding, and GitHub-audit-only admission
- cover the live path with focused CLI HTTP tests for both successful admission and fail-closed rejects

## Verification
- `python3 -m unittest control-plane.tests.test_cli_inspection`
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile`
- `python3 -m unittest control-plane.tests.test_wazuh_adapter`
- `python3 -m unittest control-plane.tests.test_runtime_skeleton`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Wazuh security alert ingestion via HTTP POST with bearer-token auth, HTTPS enforcement, request size limits, and pre-start runtime validation.
  * Ingest returns structured acceptance responses (disposition, finding_id) and maps errors to proper HTTP status codes.

* **Configuration**
  * New env vars to set shared secret and trusted-proxy CIDRs; secret is kept out of object representation.

* **Tests**
  * Added comprehensive HTTP and service tests covering success and multiple failure scenarios (auth, proxy, payload, size).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->