### PR TITLE
[codex] Preserve live-vs-replay Wazuh admission provenance

### DIFF
--- a/.codex-supervisor/issues/381/issue-journal.md
+++ b/.codex-supervisor/issues/381/issue-journal.md
@@ -5,18 +5,25 @@
 - Branch: codex/issue-381
 - Workspace: .
 - Journal: .codex-supervisor/issues/381/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 4715b7deeb1c546b3497779f2584c7c373c81fdd
+- Current phase: stabilizing
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: e7801be93ccfcebd74cec073f729683586bbf374
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-10T22:30:33.132Z
+- Updated at: 2026-04-10T22:38:53.899Z
 
 ## Latest Codex Summary
-- Reproduced that GitHub-audit live Wazuh intake and fixture/native-record replay produced the same reviewed source profile without any admission marker, leaving replay-versus-live provenance ambiguous on the runtime path.
-- Added focused persistence coverage for replay-versus-live admission provenance, then updated native-detection intake to stamp replay defaults, stamp live Wazuh webhook provenance, merge that provenance into reviewed context, and persist it into reconciliation subject linkage.
-- Focused verification passed for the new provenance test, the GitHub/Microsoft 365/Entra reviewed-source-profile persistence tests, the trusted/untrusted live Wazuh ingress service tests, and existing restatement/case-linkage coverage.
+Extended the focused provenance checkpoint with explicit live webhook persistence coverage for the approved GitHub-audit family. The branch now proves that live `ingest_wazuh_alert()` keeps `live_wazuh_webhook` / `live` provenance visible while restatements mint a new analytic signal for the new substrate detection record, preserve the existing alert and case linkage, and exact repeats deduplicate on the reviewed runtime path.
+
+The implementation remains in [service.py](control-plane/aegisops_control_plane/service.py); this turn tightened [test_service_persistence.py](control-plane/tests/test_service_persistence.py) and reran the adjacent live-ingest checks.
+
+Summary: Added focused live GitHub-audit restatement and deduplication persistence coverage on top of the live-vs-replay Wazuh admission provenance fix.
+State hint: stabilizing
+Blocked reason: none
+Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_extends_promoted_wazuh_alert_with_existing_case_linkage`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_extends_promoted_wazuh_alert_with_existing_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_upserts_alert_lifecycle_from_upstream_signals`
+Next action: commit the live restatement/deduplication coverage checkpoint and, if a PR is opened next, summarize the reviewed runtime-path guarantees now covered
+Failure signature: none
 
 ## Active Failure Context
 - None recorded.
@@ -24,13 +31,13 @@
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: Issue #381 was not blocked on first-family live admission itself; the missing behavior was provenance capture. Live `ingest_wazuh_alert()` already admitted reviewed GitHub-audit payloads, but replay/native-record intake and live webhook intake produced indistinguishable reviewed context and evidence linkage.
-- What changed: Added a failing test for replay-versus-live provenance, then taught `AegisOpsControlPlaneService` to stamp native-detection admission provenance (`fixture_replay` vs `live_wazuh_webhook`), merge it into reviewed-context provenance, and persist it under reconciliation `subject_linkage["admission_provenance"]`. Updated reviewed-context expectations for replay-backed source-profile tests.
+- What changed: Added a focused live-path persistence test for GitHub-audit webhook intake that creates, promotes, restates, and deduplicates the same reviewed incident. The test asserts that live provenance remains visible, restatements add a second substrate detection record and analytic signal under the same alert/case, and exact repeats deduplicate without collapsing live lineage.
 - Current blocker: none
-- Next exact step: commit the provenance fix checkpoint on `codex/issue-381`, then consider whether to extend focused live-path verification to explicit dedupe/restatement behavior for GitHub-audit webhook intake.
-- Verification gap: No end-to-end live webhook restatement/deduplication test exists yet; current verification relies on the shared ingest path plus existing upstream restatement/case-linkage tests.
-- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_service_persistence.py`, `.codex-supervisor/issues/381/issue-journal.md`
+- Next exact step: commit the test-only checkpoint on `codex/issue-381` so the branch captures the new live restatement/deduplication guarantee in a reviewable state.
+- Verification gap: No broader end-to-end HTTP runtime scenario was added this turn; coverage remains at service-level persistence plus the existing trusted/untrusted live-ingest service checks.
+- Files touched: `control-plane/tests/test_service_persistence.py`, `.codex-supervisor/issues/381/issue-journal.md`
 - Rollback concern: The new admission provenance is merged into reviewed-context `provenance.*` for native-detection admission, so any callers or consumers that assumed the provenance block was source-native only may need to tolerate the added `admission_kind`/`admission_channel` keys.
-- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`
+- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Failure signature reproduced before fix: `KeyError: 'admission_channel'` from `test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance`

--- a/.codex-supervisor/issues/381/issue-journal.md
+++ b/.codex-supervisor/issues/381/issue-journal.md
@@ -6,24 +6,32 @@
 - Workspace: .
 - Journal: .codex-supervisor/issues/381/issue-journal.md
 - Current phase: stabilizing
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: e7801be93ccfcebd74cec073f729683586bbf374
+- Attempt count: 3 (implementation=3, repair=0)
+- Last head SHA: 9d9d1567ab8ddba86eabb6f1b91cf377f0f2d41e
 - Blocked reason: none
-- Last failure signature: none
+- Last failure signature: stale-stabilizing-no-pr-recovery-loop
 - Repeated failure signature count: 0
-- Updated at: 2026-04-10T22:38:53.899Z
+- Updated at: 2026-04-10T22:50:47Z
 
 ## Latest Codex Summary
-Extended the focused provenance checkpoint with explicit live webhook persistence coverage for the approved GitHub-audit family. The branch now proves that live `ingest_wazuh_alert()` keeps `live_wazuh_webhook` / `live` provenance visible while restatements mint a new analytic signal for the new substrate detection record, preserve the existing alert and case linkage, and exact repeats deduplicate on the reviewed runtime path.
+Published the existing issue branch state for review, then fixed the first CI regression exposed by PR `#386`. The failing `verify` job showed that `test_service_admits_wazuh_fixture_through_substrate_adapter_boundary` still expected the pre-provenance reviewed context. I updated that legacy assertion to include explicit replay admission provenance in both reviewed context and reconciliation linkage.
 
-The implementation remains in [service.py](control-plane/aegisops_control_plane/service.py); this turn tightened [test_service_persistence.py](control-plane/tests/test_service_persistence.py) and reran the adjacent live-ingest checks.
+Verification run:
+`python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`
+`python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_wazuh_fixture_through_substrate_adapter_boundary`
+`bash scripts/verify-phase-11-control-plane-ci-validation.sh`
 
-Summary: Added focused live GitHub-audit restatement and deduplication persistence coverage on top of the live-vs-replay Wazuh admission provenance fix.
-State hint: stabilizing
+Publish notes:
+- `git push -u origin codex/issue-381`
+- GitHub app PR creation returned `403 Resource not accessible by integration`
+- fallback succeeded with `gh pr create --draft --base main --head codex/issue-381 --title "[codex] Preserve live-vs-replay Wazuh admission provenance" --body-file <tempfile>`
+- `gh pr checks 386` showed `verify` failing in `Run Phase 11 control-plane validation`
+
+Summary: Opened draft PR #386, reproduced the failing CI expectation locally, and fixed the stale substrate-boundary test to match the new replay provenance contract
+State hint: repairing_ci
 Blocked reason: none
-Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_extends_promoted_wazuh_alert_with_existing_case_linkage`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_extends_promoted_wazuh_alert_with_existing_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_upserts_alert_lifecycle_from_upstream_signals`
-Next action: commit the live restatement/deduplication coverage checkpoint and, if a PR is opened next, summarize the reviewed runtime-path guarantees now covered
-Failure signature: none
+Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_wazuh_fixture_through_substrate_adapter_boundary`; `bash scripts/verify-phase-11-control-plane-ci-validation.sh`
+Failure signature: ci-stale-replay-provenance-expectation
 
 ## Active Failure Context
 - None recorded.
@@ -31,13 +39,14 @@ Failure signature: none
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: Issue #381 was not blocked on first-family live admission itself; the missing behavior was provenance capture. Live `ingest_wazuh_alert()` already admitted reviewed GitHub-audit payloads, but replay/native-record intake and live webhook intake produced indistinguishable reviewed context and evidence linkage.
-- What changed: Added a focused live-path persistence test for GitHub-audit webhook intake that creates, promotes, restates, and deduplicates the same reviewed incident. The test asserts that live provenance remains visible, restatements add a second substrate detection record and analytic signal under the same alert/case, and exact repeats deduplicate without collapsing live lineage.
+- What changed: The branch now contains the provenance merge in `service.py` plus focused regression coverage proving replay-vs-live distinction, reviewed runtime-path preservation, and case-linked live restatement/deduplication for the approved GitHub-audit family. This turn pushed `codex/issue-381`, opened draft PR `#386`, reproduced the failing `verify` job locally, and updated the older Wazuh substrate-boundary test so it asserts the explicit replay provenance contract instead of the pre-fix reviewed context.
 - Current blocker: none
-- Next exact step: commit the test-only checkpoint on `codex/issue-381` so the branch captures the new live restatement/deduplication guarantee in a reviewable state.
+- Next exact step: commit the CI expectation fix, push it to `codex/issue-381`, and confirm PR `#386` requeues green or identify any remaining failing checks.
 - Verification gap: No broader end-to-end HTTP runtime scenario was added this turn; coverage remains at service-level persistence plus the existing trusted/untrusted live-ingest service checks.
 - Files touched: `control-plane/tests/test_service_persistence.py`, `.codex-supervisor/issues/381/issue-journal.md`
 - Rollback concern: The new admission provenance is merged into reviewed-context `provenance.*` for native-detection admission, so any callers or consumers that assumed the provenance block was source-native only may need to tolerate the added `admission_kind`/`admission_channel` keys.
-- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`
+- Last focused command: `bash scripts/verify-phase-11-control-plane-ci-validation.sh`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Failure signature reproduced before fix: `KeyError: 'admission_channel'` from `test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance`
+- CI failure reproduced from PR `#386`: `test_service_admits_wazuh_fixture_through_substrate_adapter_boundary` still expected the old reviewed context without replay provenance

--- a/.codex-supervisor/issues/381/issue-journal.md
+++ b/.codex-supervisor/issues/381/issue-journal.md
@@ -1,0 +1,36 @@
+# Issue #381: implementation: make live substrate admission and replay-versus-live evidence capture work for the first source family
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/381
+- Branch: codex/issue-381
+- Workspace: .
+- Journal: .codex-supervisor/issues/381/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 4715b7deeb1c546b3497779f2584c7c373c81fdd
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T22:30:33.132Z
+
+## Latest Codex Summary
+- Reproduced that GitHub-audit live Wazuh intake and fixture/native-record replay produced the same reviewed source profile without any admission marker, leaving replay-versus-live provenance ambiguous on the runtime path.
+- Added focused persistence coverage for replay-versus-live admission provenance, then updated native-detection intake to stamp replay defaults, stamp live Wazuh webhook provenance, merge that provenance into reviewed context, and persist it into reconciliation subject linkage.
+- Focused verification passed for the new provenance test, the GitHub/Microsoft 365/Entra reviewed-source-profile persistence tests, the trusted/untrusted live Wazuh ingress service tests, and existing restatement/case-linkage coverage.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Issue #381 was not blocked on first-family live admission itself; the missing behavior was provenance capture. Live `ingest_wazuh_alert()` already admitted reviewed GitHub-audit payloads, but replay/native-record intake and live webhook intake produced indistinguishable reviewed context and evidence linkage.
+- What changed: Added a failing test for replay-versus-live provenance, then taught `AegisOpsControlPlaneService` to stamp native-detection admission provenance (`fixture_replay` vs `live_wazuh_webhook`), merge it into reviewed-context provenance, and persist it under reconciliation `subject_linkage["admission_provenance"]`. Updated reviewed-context expectations for replay-backed source-profile tests.
+- Current blocker: none
+- Next exact step: commit the provenance fix checkpoint on `codex/issue-381`, then consider whether to extend focused live-path verification to explicit dedupe/restatement behavior for GitHub-audit webhook intake.
+- Verification gap: No end-to-end live webhook restatement/deduplication test exists yet; current verification relies on the shared ingest path plus existing upstream restatement/case-linkage tests.
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_service_persistence.py`, `.codex-supervisor/issues/381/issue-journal.md`
+- Rollback concern: The new admission provenance is merged into reviewed-context `provenance.*` for native-detection admission, so any callers or consumers that assumed the provenance block was source-native only may need to tolerate the added `admission_kind`/`admission_channel` keys.
+- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Failure signature reproduced before fix: `KeyError: 'admission_channel'` from `test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance`

--- a/.codex-supervisor/issues/381/issue-journal.md
+++ b/.codex-supervisor/issues/381/issue-journal.md
@@ -5,48 +5,53 @@
 - Branch: codex/issue-381
 - Workspace: .
 - Journal: .codex-supervisor/issues/381/issue-journal.md
-- Current phase: stabilizing
-- Attempt count: 3 (implementation=3, repair=0)
-- Last head SHA: 9d9d1567ab8ddba86eabb6f1b91cf377f0f2d41e
+- Current phase: addressing_review
+- Attempt count: 4 (implementation=3, repair=1)
+- Last head SHA: 23103806f6566565b2245848f2a0263f0012c7fc
 - Blocked reason: none
-- Last failure signature: stale-stabilizing-no-pr-recovery-loop
-- Repeated failure signature count: 0
-- Updated at: 2026-04-10T22:50:47Z
+- Last failure signature: PRRT_kwDOR2iDUc56QSw1|PRRT_kwDOR2iDUc56QSw5
+- Repeated failure signature count: 1
+- Updated at: 2026-04-10T23:01:43.197Z
 
 ## Latest Codex Summary
-Published the existing issue branch state for review, then fixed the first CI regression exposed by PR `#386`. The failing `verify` job showed that `test_service_admits_wazuh_fixture_through_substrate_adapter_boundary` still expected the pre-provenance reviewed context. I updated that legacy assertion to include explicit replay admission provenance in both reviewed context and reconciliation linkage.
+Draft PR is open at `https://github.com/TommyKammy/AegisOps/pull/386` on `codex/issue-381`. After opening it, CI exposed one stale test expectation: [control-plane/tests/test_service_persistence.py](control-plane/tests/test_service_persistence.py) still expected the old Wazuh reviewed context without replay admission provenance. I fixed that assertion to match the new contract and pushed commit `2310380` (`Fix Wazuh provenance CI expectation`).
 
-Verification run:
-`python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`
-`python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_wazuh_fixture_through_substrate_adapter_boundary`
-`bash scripts/verify-phase-11-control-plane-ci-validation.sh`
+Local verification passed with the targeted regression and the repo’s CI-equivalent Phase 11 script:
+- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_substrate_adapter_boundary`
+- `bash scripts/verify-phase-11-control-plane-ci-validation.sh`
 
-Publish notes:
-- `git push -u origin codex/issue-381`
-- GitHub app PR creation returned `403 Resource not accessible by integration`
-- fallback succeeded with `gh pr create --draft --base main --head codex/issue-381 --title "[codex] Preserve live-vs-replay Wazuh admission provenance" --body-file <tempfile>`
-- `gh pr checks 386` showed `verify` failing in `Run Phase 11 control-plane validation`
+The issue journal was updated in [.codex-supervisor/issues/381/issue-journal.md](.codex-supervisor/issues/381/issue-journal.md). Current PR status shows `verify` requeued and `IN_PROGRESS` on head `23103806f6566565b2245848f2a0263f0012c7fc`.
 
-Summary: Opened draft PR #386, reproduced the failing CI expectation locally, and fixed the stale substrate-boundary test to match the new replay provenance contract
-State hint: repairing_ci
+Summary: Opened draft PR #386, fixed the CI-revealed stale Wazuh replay-provenance test expectation, and pushed commit `2310380`
+State hint: waiting_ci
 Blocked reason: none
-Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_wazuh_fixture_through_substrate_adapter_boundary`; `bash scripts/verify-phase-11-control-plane-ci-validation.sh`
-Failure signature: ci-stale-replay-provenance-expectation
+Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_substrate_adapter_boundary`; `bash scripts/verify-phase-11-control-plane-ci-validation.sh`; earlier focused Wazuh provenance/runtime tests also passed
+Next action: Monitor PR #386 `verify` completion and address any remaining CI or review feedback without broadening scope
+Failure signature: PRRT_kwDOR2iDUc56QSw1|PRRT_kwDOR2iDUc56QSw5
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 2 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/AegisOps/pull/386#discussion_r3067075914
+- Details:
+  - control-plane/aegisops_control_plane/service.py:486 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Normalize provenance values after trimming whitespace.** Validation uses `strip()`, but the stored value keeps original whitespace. url=https://github.com/TommyKammy/AegisOps/pull/386#discussion_r3067075914
+  - control-plane/tests/test_service_persistence.py:2818 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Assert `admission_kind` in live reviewed context as well.** These checks only pin `provenance.admission_channel` on the live path. url=https://github.com/TommyKammy/AegisOps/pull/386#discussion_r3067075919
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: Issue #381 was not blocked on first-family live admission itself; the missing behavior was provenance capture. Live `ingest_wazuh_alert()` already admitted reviewed GitHub-audit payloads, but replay/native-record intake and live webhook intake produced indistinguishable reviewed context and evidence linkage.
-- What changed: The branch now contains the provenance merge in `service.py` plus focused regression coverage proving replay-vs-live distinction, reviewed runtime-path preservation, and case-linked live restatement/deduplication for the approved GitHub-audit family. This turn pushed `codex/issue-381`, opened draft PR `#386`, reproduced the failing `verify` job locally, and updated the older Wazuh substrate-boundary test so it asserts the explicit replay provenance contract instead of the pre-fix reviewed context.
+- What changed: The branch now also trims stored `admission_provenance` values in `_normalize_admission_provenance()` so reviewed-context provenance and reconciliation linkage cannot retain stray whitespace, and the Wazuh runtime-path persistence tests now assert `admission_kind` alongside `admission_channel` for replay, live, restated, deduplicated, and case-linked reviewed context. A focused native-admission regression was added to prove whitespace-normalized provenance persists consistently into both reviewed context and reconciliation linkage.
 - Current blocker: none
-- Next exact step: commit the CI expectation fix, push it to `codex/issue-381`, and confirm PR `#386` requeues green or identify any remaining failing checks.
+- Next exact step: commit and push the local review-thread fixes on `codex/issue-381`, then confirm PR `#386` clears the two remaining CodeRabbit threads and stays green.
 - Verification gap: No broader end-to-end HTTP runtime scenario was added this turn; coverage remains at service-level persistence plus the existing trusted/untrusted live-ingest service checks.
-- Files touched: `control-plane/tests/test_service_persistence.py`, `.codex-supervisor/issues/381/issue-journal.md`
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_service_persistence.py`, `.codex-supervisor/issues/381/issue-journal.md`
 - Rollback concern: The new admission provenance is merged into reviewed-context `provenance.*` for native-detection admission, so any callers or consumers that assumed the provenance block was source-native only may need to tolerate the added `admission_kind`/`admission_channel` keys.
-- Last focused command: `bash scripts/verify-phase-11-control-plane-ci-validation.sh`
+- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_trims_native_admission_provenance_before_persisting_reviewed_context`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Failure signature reproduced before fix: `KeyError: 'admission_channel'` from `test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance`
 - CI failure reproduced from PR `#386`: `test_service_admits_wazuh_fixture_through_substrate_adapter_boundary` still expected the old reviewed context without replay provenance
+- Review fixes verified locally:
+  - `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance`
+  - `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage`
+  - `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_trims_native_admission_provenance_before_persisting_reviewed_context`

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -482,8 +482,10 @@ def _normalize_admission_provenance(
     normalized: dict[str, str] = {}
     for field_name in ("admission_kind", "admission_channel"):
         field_value = value.get(field_name)
-        if isinstance(field_value, str) and field_value.strip():
-            normalized[field_name] = field_value
+        if isinstance(field_value, str):
+            normalized_value = field_value.strip()
+            if normalized_value:
+                normalized[field_name] = normalized_value
     if len(normalized) != 2:
         return None
     return normalized

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -474,6 +474,21 @@ def _reviewed_identity_is_alias_only(reviewed_context: Mapping[str, object]) -> 
     return any(identity.get(key) for key in alias_like_keys)
 
 
+def _normalize_admission_provenance(
+    value: object,
+) -> dict[str, str] | None:
+    if not isinstance(value, Mapping):
+        return None
+    normalized: dict[str, str] = {}
+    for field_name in ("admission_kind", "admission_channel"):
+        field_value = value.get(field_name)
+        if isinstance(field_value, str) and field_value.strip():
+            normalized[field_name] = field_value
+    if len(normalized) != 2:
+        return None
+    return normalized
+
+
 def _recommendation_draft_review_summary(
     record_family: str,
     record_id: str,
@@ -940,7 +955,11 @@ class AegisOpsControlPlaneService:
             )
 
         adapter = WazuhAlertAdapter()
-        native_record = adapter.build_native_detection_record(native_alert)
+        native_record = self._with_native_detection_admission_provenance(
+            adapter.build_native_detection_record(native_alert),
+            admission_kind="live",
+            admission_channel="live_wazuh_webhook",
+        )
         return self.ingest_native_detection_record(adapter, native_record)
 
     def _wazuh_ingest_listener_is_loopback(self) -> bool:
@@ -2373,6 +2392,11 @@ class AegisOpsControlPlaneService:
         adapter: NativeDetectionRecordAdapter,
         record: NativeDetectionRecord,
     ) -> FindingAlertIngestResult:
+        record = self._with_native_detection_admission_provenance(
+            record,
+            admission_kind="replay",
+            admission_channel="fixture_replay",
+        )
         adapter_substrate_key = self._require_non_empty_string(
             adapter.substrate_key,
             "adapter.substrate_key",
@@ -2387,6 +2411,23 @@ class AegisOpsControlPlaneService:
                 f"({record_substrate_key!r} != {adapter_substrate_key!r})"
             )
         admission = adapter.build_analytic_signal_admission(record)
+        admission_provenance = _normalize_admission_provenance(
+            record.metadata.get("admission_provenance")
+        )
+        if admission_provenance is not None:
+            admission = AnalyticSignalAdmission(
+                finding_id=admission.finding_id,
+                analytic_signal_id=admission.analytic_signal_id,
+                substrate_detection_record_id=admission.substrate_detection_record_id,
+                correlation_key=admission.correlation_key,
+                first_seen_at=admission.first_seen_at,
+                last_seen_at=admission.last_seen_at,
+                materially_new_work=admission.materially_new_work,
+                reviewed_context=_merge_reviewed_context(
+                    admission.reviewed_context,
+                    {"provenance": admission_provenance},
+                ),
+            )
         raw_substrate_detection_record_id = self._require_non_empty_string(
             admission.substrate_detection_record_id or record.native_record_id,
             "substrate_detection_record_id/native_record_id",
@@ -2782,6 +2823,12 @@ class AegisOpsControlPlaneService:
         if isinstance(raw_alert, Mapping):
             subject_linkage["latest_native_payload"] = dict(raw_alert)
 
+        admission_provenance = _normalize_admission_provenance(
+            record.metadata.get("admission_provenance")
+        )
+        if admission_provenance is not None:
+            subject_linkage["admission_provenance"] = admission_provenance
+
         reconciliation = self.persist_record(
             ReconciliationRecord(
                 reconciliation_id=ingest_result.reconciliation.reconciliation_id,
@@ -2807,6 +2854,22 @@ class AegisOpsControlPlaneService:
             reconciliation=reconciliation,
             disposition=ingest_result.disposition,
         )
+
+    def _with_native_detection_admission_provenance(
+        self,
+        record: NativeDetectionRecord,
+        *,
+        admission_kind: str,
+        admission_channel: str,
+    ) -> NativeDetectionRecord:
+        if _normalize_admission_provenance(record.metadata.get("admission_provenance")) is not None:
+            return record
+        metadata = dict(record.metadata)
+        metadata["admission_provenance"] = {
+            "admission_kind": admission_kind,
+            "admission_channel": admission_channel,
+        }
+        return replace(record, metadata=metadata)
 
     def reconcile_action_execution(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -165,11 +165,22 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             },
         )
         self.assertEqual(
+            reconciliation.subject_linkage["admission_provenance"],
+            {
+                "admission_channel": "fixture_replay",
+                "admission_kind": "replay",
+            },
+        )
+        self.assertEqual(
             admitted.alert.reviewed_context,
             {
                 "location": "/var/log/auth.log",
                 "data.srcip": "198.51.100.24",
                 "data.srcuser": "invalid-user",
+                "provenance": {
+                    "admission_kind": "replay",
+                    "admission_channel": "fixture_replay",
+                },
             },
         )
 

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -2715,16 +2715,24 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 "location": "github/orgs/TommyKammy/repos/AegisOps/audit",
             },
         }
+        expected_reviewed_context = {
+            **expected_profile,
+            "provenance": {
+                **expected_profile["provenance"],
+                "admission_kind": "replay",
+                "admission_channel": "fixture_replay",
+            },
+        }
 
         self.assertEqual(admitted.disposition, "created")
-        self.assertEqual(admitted.alert.reviewed_context, expected_profile)
+        self.assertEqual(admitted.alert.reviewed_context, expected_reviewed_context)
         self.assertEqual(
             service.get_record(AnalyticSignalRecord, admitted.alert.analytic_signal_id).reviewed_context,
-            expected_profile,
+            expected_reviewed_context,
         )
         self.assertEqual(
             service.get_record(AlertRecord, admitted.alert.alert_id).reviewed_context,
-            expected_profile,
+            expected_reviewed_context,
         )
         reconciliation = service.get_record(
             ReconciliationRecord,
@@ -2756,6 +2764,65 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 "data.privilege.scope": "repository_admin",
                 "data.privilege.permission": "admin",
                 "data.privilege.role": "maintainer",
+            },
+        )
+
+    def test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance(
+        self,
+    ) -> None:
+        replay_store, _ = make_store()
+        replay_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=replay_store,
+        )
+        live_store, _ = make_store()
+        live_service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+            ),
+            store=live_store,
+        )
+        adapter = WazuhAlertAdapter()
+        payload = _load_wazuh_fixture("github-audit-alert.json")
+
+        replay_result = replay_service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(payload),
+        )
+        live_result = live_service.ingest_wazuh_alert(
+            raw_alert=payload,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            peer_addr="127.0.0.1",
+        )
+
+        self.assertEqual(
+            replay_result.alert.reviewed_context["provenance"]["admission_channel"],
+            "fixture_replay",
+        )
+        self.assertEqual(
+            live_result.alert.reviewed_context["provenance"]["admission_channel"],
+            "live_wazuh_webhook",
+        )
+        self.assertEqual(
+            replay_service.get_record(
+                ReconciliationRecord,
+                replay_result.reconciliation.reconciliation_id,
+            ).subject_linkage["admission_provenance"],
+            {
+                "admission_channel": "fixture_replay",
+                "admission_kind": "replay",
+            },
+        )
+        self.assertEqual(
+            live_service.get_record(
+                ReconciliationRecord,
+                live_result.reconciliation.reconciliation_id,
+            ).subject_linkage["admission_provenance"],
+            {
+                "admission_channel": "live_wazuh_webhook",
+                "admission_kind": "live",
             },
         )
 
@@ -2827,16 +2894,24 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 "location": "microsoft365/contoso/exchange",
             },
         }
+        expected_reviewed_context = {
+            **expected_profile,
+            "provenance": {
+                **expected_profile["provenance"],
+                "admission_kind": "replay",
+                "admission_channel": "fixture_replay",
+            },
+        }
 
         self.assertEqual(admitted.disposition, "created")
-        self.assertEqual(admitted.alert.reviewed_context, expected_profile)
+        self.assertEqual(admitted.alert.reviewed_context, expected_reviewed_context)
         self.assertEqual(
             service.get_record(AnalyticSignalRecord, admitted.alert.analytic_signal_id).reviewed_context,
-            expected_profile,
+            expected_reviewed_context,
         )
         self.assertEqual(
             service.get_record(AlertRecord, admitted.alert.alert_id).reviewed_context,
-            expected_profile,
+            expected_reviewed_context,
         )
         reconciliation = service.get_record(
             ReconciliationRecord,
@@ -2941,16 +3016,24 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 "location": "entra/contoso/directory",
             },
         }
+        expected_reviewed_context = {
+            **expected_profile,
+            "provenance": {
+                **expected_profile["provenance"],
+                "admission_kind": "replay",
+                "admission_channel": "fixture_replay",
+            },
+        }
 
         self.assertEqual(admitted.disposition, "created")
-        self.assertEqual(admitted.alert.reviewed_context, expected_profile)
+        self.assertEqual(admitted.alert.reviewed_context, expected_reviewed_context)
         self.assertEqual(
             service.get_record(AnalyticSignalRecord, admitted.alert.analytic_signal_id).reviewed_context,
-            expected_profile,
+            expected_reviewed_context,
         )
         self.assertEqual(
             service.get_record(AlertRecord, admitted.alert.alert_id).reviewed_context,
-            expected_profile,
+            expected_reviewed_context,
         )
         reconciliation = service.get_record(
             ReconciliationRecord,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -2813,8 +2813,16 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "fixture_replay",
         )
         self.assertEqual(
+            replay_result.alert.reviewed_context["provenance"]["admission_kind"],
+            "replay",
+        )
+        self.assertEqual(
             live_result.alert.reviewed_context["provenance"]["admission_channel"],
             "live_wazuh_webhook",
+        )
+        self.assertEqual(
+            live_result.alert.reviewed_context["provenance"]["admission_kind"],
+            "live",
         )
         self.assertEqual(
             replay_service.get_record(
@@ -2905,8 +2913,16 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "live_wazuh_webhook",
         )
         self.assertEqual(
+            restated.alert.reviewed_context["provenance"]["admission_kind"],
+            "live",
+        )
+        self.assertEqual(
             deduplicated.alert.reviewed_context["provenance"]["admission_channel"],
             "live_wazuh_webhook",
+        )
+        self.assertEqual(
+            deduplicated.alert.reviewed_context["provenance"]["admission_kind"],
+            "live",
         )
 
         self.assertIsNotNone(created_signal)
@@ -2988,6 +3004,10 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(
             persisted_case.reviewed_context["provenance"]["admission_channel"],
             "live_wazuh_webhook",
+        )
+        self.assertEqual(
+            persisted_case.reviewed_context["provenance"]["admission_kind"],
+            "live",
         )
         evidence_records = sorted(
             (
@@ -3291,6 +3311,67 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(
             signals[0].substrate_detection_record_id,
             "test-substrate:native-001",
+        )
+
+    def test_service_trims_native_admission_provenance_before_persisting_reviewed_context(
+        self,
+    ) -> None:
+        @dataclass(frozen=True)
+        class TestNativeRecordAdapter(NativeDetectionRecordAdapter):
+            substrate_key: str = "test-substrate"
+
+            def build_analytic_signal_admission(
+                self, record: NativeDetectionRecord
+            ) -> AnalyticSignalAdmission:
+                return AnalyticSignalAdmission(
+                    finding_id=f"finding::{record.native_record_id}",
+                    analytic_signal_id=f"signal::{record.native_record_id}",
+                    substrate_detection_record_id=record.native_record_id,
+                    correlation_key=record.correlation_key,
+                    first_seen_at=record.first_seen_at,
+                    last_seen_at=record.last_seen_at,
+                )
+
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        admitted = service.ingest_native_detection_record(
+            TestNativeRecordAdapter(),
+            NativeDetectionRecord(
+                substrate_key="test-substrate",
+                native_record_id="native-001",
+                record_kind="alert",
+                correlation_key="claim:host-001:privilege-escalation",
+                first_seen_at=datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
+                last_seen_at=datetime(2026, 4, 5, 12, 15, tzinfo=timezone.utc),
+                metadata={
+                    "admission_provenance": {
+                        "admission_kind": " replay ",
+                        "admission_channel": " fixture_replay ",
+                    }
+                },
+            ),
+        )
+
+        self.assertEqual(
+            admitted.alert.reviewed_context["provenance"],
+            {
+                "admission_kind": "replay",
+                "admission_channel": "fixture_replay",
+            },
+        )
+        self.assertEqual(
+            service.get_record(
+                ReconciliationRecord,
+                admitted.reconciliation.reconciliation_id,
+            ).subject_linkage["admission_provenance"],
+            {
+                "admission_kind": "replay",
+                "admission_channel": "fixture_replay",
+            },
         )
 
     def test_service_rolls_back_native_ingest_when_evidence_timestamp_is_naive(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -2472,7 +2472,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         restated_signal = service.get_record(
             AnalyticSignalRecord,
-            restated.alert.analytic_signal_id,
+            restated.reconciliation.analytic_signal_id,
         )
         reconciliation = service.get_record(
             ReconciliationRecord,
@@ -2824,6 +2824,172 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 "admission_channel": "live_wazuh_webhook",
                 "admission_kind": "live",
             },
+        )
+
+    def test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+            ),
+            store=store,
+        )
+        payload = _load_wazuh_fixture("github-audit-alert.json")
+
+        created = service.ingest_wazuh_alert(
+            raw_alert=payload,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(created.alert.alert_id)
+
+        restated_payload = _load_wazuh_fixture("github-audit-alert.json")
+        restated_payload["id"] = "1731595300.7654321"
+        restated_payload["timestamp"] = "2026-04-05T12:25:00+00:00"
+        restated = service.ingest_wazuh_alert(
+            raw_alert=restated_payload,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            peer_addr="127.0.0.1",
+        )
+        deduplicated = service.ingest_wazuh_alert(
+            raw_alert=restated_payload,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            peer_addr="127.0.0.1",
+        )
+
+        created_signal = service.get_record(
+            AnalyticSignalRecord,
+            created.alert.analytic_signal_id,
+        )
+        restated_signal = service.get_record(
+            AnalyticSignalRecord,
+            restated.reconciliation.analytic_signal_id,
+        )
+        restated_reconciliation = service.get_record(
+            ReconciliationRecord,
+            restated.reconciliation.reconciliation_id,
+        )
+        deduplicated_reconciliation = service.get_record(
+            ReconciliationRecord,
+            deduplicated.reconciliation.reconciliation_id,
+        )
+
+        self.assertEqual(created.disposition, "created")
+        self.assertEqual(restated.disposition, "restated")
+        self.assertEqual(deduplicated.disposition, "deduplicated")
+        self.assertEqual(restated.alert.alert_id, created.alert.alert_id)
+        self.assertEqual(deduplicated.alert.alert_id, created.alert.alert_id)
+        self.assertEqual(restated.alert.case_id, promoted_case.case_id)
+        self.assertEqual(deduplicated.alert.case_id, promoted_case.case_id)
+        self.assertEqual(restated.alert.lifecycle_state, "escalated_to_case")
+        self.assertEqual(deduplicated.alert.lifecycle_state, "escalated_to_case")
+        self.assertEqual(
+            restated.alert.reviewed_context["provenance"]["admission_channel"],
+            "live_wazuh_webhook",
+        )
+        self.assertEqual(
+            deduplicated.alert.reviewed_context["provenance"]["admission_channel"],
+            "live_wazuh_webhook",
+        )
+
+        self.assertIsNotNone(created_signal)
+        self.assertEqual(created_signal.case_ids, (promoted_case.case_id,))
+        self.assertEqual(
+            created_signal.substrate_detection_record_id,
+            "wazuh:1731595300.1234567",
+        )
+        self.assertEqual(
+            created_signal.last_seen_at,
+            datetime(2026, 4, 5, 12, 20, tzinfo=timezone.utc),
+        )
+
+        self.assertIsNotNone(restated_signal)
+        self.assertEqual(restated_signal.case_ids, (promoted_case.case_id,))
+        self.assertEqual(
+            restated_signal.substrate_detection_record_id,
+            "wazuh:1731595300.7654321",
+        )
+        self.assertEqual(
+            restated_signal.last_seen_at,
+            datetime(2026, 4, 5, 12, 25, tzinfo=timezone.utc),
+        )
+
+        self.assertIsNotNone(restated_reconciliation)
+        self.assertEqual(restated_reconciliation.ingest_disposition, "restated")
+        self.assertEqual(
+            restated_reconciliation.subject_linkage["case_ids"],
+            (promoted_case.case_id,),
+        )
+        self.assertEqual(
+            restated_reconciliation.subject_linkage["substrate_detection_record_ids"],
+            ("wazuh:1731595300.1234567", "wazuh:1731595300.7654321"),
+        )
+        self.assertEqual(
+            restated_reconciliation.subject_linkage["analytic_signal_ids"],
+            (created.alert.analytic_signal_id, restated.reconciliation.analytic_signal_id),
+        )
+        self.assertEqual(
+            restated_reconciliation.subject_linkage["admission_provenance"],
+            {
+                "admission_channel": "live_wazuh_webhook",
+                "admission_kind": "live",
+            },
+        )
+        self.assertEqual(
+            restated_reconciliation.last_seen_at,
+            datetime(2026, 4, 5, 12, 25, tzinfo=timezone.utc),
+        )
+
+        self.assertIsNotNone(deduplicated_reconciliation)
+        self.assertEqual(
+            deduplicated_reconciliation.ingest_disposition,
+            "deduplicated",
+        )
+        self.assertEqual(
+            deduplicated_reconciliation.subject_linkage["case_ids"],
+            (promoted_case.case_id,),
+        )
+        self.assertEqual(
+            deduplicated_reconciliation.subject_linkage[
+                "substrate_detection_record_ids"
+            ],
+            ("wazuh:1731595300.1234567", "wazuh:1731595300.7654321"),
+        )
+        self.assertEqual(
+            deduplicated_reconciliation.subject_linkage["admission_provenance"],
+            {
+                "admission_channel": "live_wazuh_webhook",
+                "admission_kind": "live",
+            },
+        )
+
+        persisted_case = service.get_record(CaseRecord, promoted_case.case_id)
+        self.assertIsNotNone(persisted_case)
+        self.assertEqual(persisted_case.alert_id, created.alert.alert_id)
+        self.assertEqual(persisted_case.finding_id, created.alert.finding_id)
+        self.assertEqual(persisted_case.lifecycle_state, "open")
+        self.assertEqual(
+            persisted_case.reviewed_context["provenance"]["admission_channel"],
+            "live_wazuh_webhook",
+        )
+        evidence_records = sorted(
+            (
+                evidence
+                for evidence in store.list(EvidenceRecord)
+                if evidence.alert_id == created.alert.alert_id
+            ),
+            key=lambda evidence: evidence.evidence_id,
+        )
+        self.assertEqual(len(evidence_records), 2)
+        self.assertEqual(
+            tuple(evidence.case_id for evidence in evidence_records),
+            (promoted_case.case_id, promoted_case.case_id),
         )
 
     def test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile(


### PR DESCRIPTION
## What changed
- preserve admission provenance when native detection records are admitted so replay fixtures carry `fixture_replay` / `replay` and live Wazuh webhook intake carries `live_wazuh_webhook` / `live`
- merge that provenance into reviewed analytic-signal context and reconciliation subject linkage so operators can distinguish replay from live lineage without breaking the reviewed runtime path
- add focused persistence regression coverage for the approved GitHub-audit first source family, including live create/restatement/deduplication behavior with existing case linkage
- update existing Wazuh source-profile tests to assert replay provenance is now explicit in reviewed context

## Why
Issue #381 requires the first approved source family to continue flowing through the reviewed `substrate_detection_record_id -> analytic_signal_id -> alert_id` path for live Wazuh intake while keeping replay-versus-live provenance visible. Before this change, replay and live native-record admission produced indistinguishable reviewed provenance.

## Impact
- live Wazuh GitHub-audit alerts keep the reviewed runtime path and case-linkage behavior intact
- replay fixtures remain distinguishable from live webhook admissions in reviewed context and reconciliation evidence/linkage
- restatements add new reviewed lineage without collapsing exact deduplication behavior

## Validation
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_github_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_admits_non_loopback_wazuh_ingest_from_trusted_proxy_peer control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_rejects_non_loopback_wazuh_ingest_from_untrusted_proxy_peer`
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_distinguishes_live_wazuh_github_audit_ingest_from_replay_provenance control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_restates_and_deduplicates_live_wazuh_github_audit_ingest_with_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_extends_promoted_wazuh_alert_with_existing_case_linkage`
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_extends_promoted_wazuh_alert_with_existing_case_linkage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_upserts_alert_lifecycle_from_upstream_signals`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced provenance tracking to capture admission source (live vs. replay) for detection records.

* **Bug Fixes**
  * Improved validation and normalization of admission metadata to prevent malformed provenance.

* **Tests**
  * Added and extended tests to verify provenance persistence and behavior across live/replay ingestion paths.

* **Documentation**
  * Added an investigation journal entry documenting the issue investigation, verification steps, and CI status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->