### PR TITLE
[codex] Add Phase 18 live Wazuh queue validation

### DIFF
--- a/.codex-supervisor/issues/382/issue-journal.md
+++ b/.codex-supervisor/issues/382/issue-journal.md
@@ -5,18 +5,25 @@
 - Branch: codex/issue-382
 - Workspace: .
 - Journal: .codex-supervisor/issues/382/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 8e3d883d74368ff33ca98443cfda7e689c2b9502
+- Current phase: stabilizing
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: f4c3993b11fbe06fc9bd68db9901be0f0bc7230b
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-10T23:14:07.507Z
+- Updated at: 2026-04-10T23:21:46.107Z
 
 ## Latest Codex Summary
-- Added repository-local Phase 18 validation for authenticated live `ingest_wazuh_alert` delivery into the analyst queue, covering GitHub audit admission, repeat live delivery restatement/deduplication, and preserved case linkage.
-- Extended the Phase 18 validation record and shell verifier so the new live queue validator is required alongside the existing topology and asset guards.
-- Verified with the focused Phase 18 unit test, the Phase 18 shell verifier and self-test, and full `control-plane/tests` discovery.
+Added a dedicated Phase 18 repository-local validator for the live Wazuh webhook path into the analyst queue. The new test drives authenticated `ingest_wazuh_alert` delivery for the approved `github_audit` family through `created`, `restated`, and `deduplicated` outcomes, then asserts the queue still exposes a single Wazuh-origin record with preserved case linkage, merged substrate IDs, live admission provenance, and the expected business-hours routing.
+
+I also wired that validator into the existing Phase 18 validation record and shell verifier so the slice fails closed if the live queue coverage disappears. The checkpoint is committed on `codex/issue-382` as `f4c3993` with message `Add Phase 18 live Wazuh queue validation`.
+
+Summary: Added Phase 18 end-to-end live Wazuh queue validation and verifier coverage; committed as `f4c3993`
+State hint: implementing
+Blocked reason: none
+Tests: `python3 -m unittest control-plane.tests.test_phase18_live_wazuh_queue_validation`; `bash scripts/verify-phase-18-wazuh-lab-topology.sh`; `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`; `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+Next action: Open or update a draft PR for the committed Phase 18 validation slice if supervisor flow wants an early checkpoint published
+Failure signature: none
 
 ## Active Failure Context
 - None recorded.
@@ -26,11 +33,12 @@
 - Hypothesis: The missing Phase 18 coverage was a dedicated repository-local validator for the reviewed live Wazuh webhook path into the analyst queue, not a broad service bug.
 - What changed: Added `control-plane/tests/test_phase18_live_wazuh_queue_validation.py`; updated `docs/phase-18-wazuh-lab-topology-validation.md`; extended `scripts/verify-phase-18-wazuh-lab-topology.sh` and `scripts/test-verify-phase-18-wazuh-lab-topology.sh` to require the new validator.
 - Current blocker: none
-- Next exact step: Commit the Phase 18 validation slice on `codex/issue-382`.
+- Next exact step: Push `codex/issue-382` and open a draft PR for the verified Phase 18 validation slice.
 - Verification gap: none for the requested repository-local validation slice; broader Phase 19 operator-surface coverage remains intentionally out of scope.
 - Files touched: `.codex-supervisor/issues/382/issue-journal.md`, `control-plane/tests/test_phase18_live_wazuh_queue_validation.py`, `docs/phase-18-wazuh-lab-topology-validation.md`, `scripts/verify-phase-18-wazuh-lab-topology.sh`, `scripts/test-verify-phase-18-wazuh-lab-topology.sh`
 - Rollback concern: Low; changes are additive validation/doc/verifier updates and do not alter runtime service logic.
-- Last focused command: `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+- Last focused commands: `python3 -m unittest control-plane.tests.test_phase18_live_wazuh_queue_validation`; `bash scripts/verify-phase-18-wazuh-lab-topology.sh`; `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`; `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Focused reproducer note: the first draft of the new test intentionally changed `data.request_id`, which exercised `updated` reviewed-context behavior instead of `restated`; the final test now changes only native id/timestamp to isolate repeat live-delivery semantics.
+- Stabilization note: Re-ran the dedicated Phase 18 validator, both shell verifier paths, and the full `control-plane/tests` unittest discovery sweep on 2026-04-11; all passed without additional code changes.

--- a/.codex-supervisor/issues/382/issue-journal.md
+++ b/.codex-supervisor/issues/382/issue-journal.md
@@ -1,0 +1,36 @@
+# Issue #382: validation: add end-to-end Phase 18 coverage for live Wazuh alert intake into the AegisOps analyst queue
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/382
+- Branch: codex/issue-382
+- Workspace: .
+- Journal: .codex-supervisor/issues/382/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 8e3d883d74368ff33ca98443cfda7e689c2b9502
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T23:14:07.507Z
+
+## Latest Codex Summary
+- Added repository-local Phase 18 validation for authenticated live `ingest_wazuh_alert` delivery into the analyst queue, covering GitHub audit admission, repeat live delivery restatement/deduplication, and preserved case linkage.
+- Extended the Phase 18 validation record and shell verifier so the new live queue validator is required alongside the existing topology and asset guards.
+- Verified with the focused Phase 18 unit test, the Phase 18 shell verifier and self-test, and full `control-plane/tests` discovery.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The missing Phase 18 coverage was a dedicated repository-local validator for the reviewed live Wazuh webhook path into the analyst queue, not a broad service bug.
+- What changed: Added `control-plane/tests/test_phase18_live_wazuh_queue_validation.py`; updated `docs/phase-18-wazuh-lab-topology-validation.md`; extended `scripts/verify-phase-18-wazuh-lab-topology.sh` and `scripts/test-verify-phase-18-wazuh-lab-topology.sh` to require the new validator.
+- Current blocker: none
+- Next exact step: Commit the Phase 18 validation slice on `codex/issue-382`.
+- Verification gap: none for the requested repository-local validation slice; broader Phase 19 operator-surface coverage remains intentionally out of scope.
+- Files touched: `.codex-supervisor/issues/382/issue-journal.md`, `control-plane/tests/test_phase18_live_wazuh_queue_validation.py`, `docs/phase-18-wazuh-lab-topology-validation.md`, `scripts/verify-phase-18-wazuh-lab-topology.sh`, `scripts/test-verify-phase-18-wazuh-lab-topology.sh`
+- Rollback concern: Low; changes are additive validation/doc/verifier updates and do not alter runtime service logic.
+- Last focused command: `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Focused reproducer note: the first draft of the new test intentionally changed `data.request_id`, which exercised `updated` reviewed-context behavior instead of `restated`; the final test now changes only native id/timestamp to isolate repeat live-delivery semantics.

--- a/.codex-supervisor/issues/382/issue-journal.md
+++ b/.codex-supervisor/issues/382/issue-journal.md
@@ -33,7 +33,7 @@ Failure signature: none
 - Hypothesis: The missing Phase 18 coverage was a dedicated repository-local validator for the reviewed live Wazuh webhook path into the analyst queue, not a broad service bug.
 - What changed: Added `control-plane/tests/test_phase18_live_wazuh_queue_validation.py`; updated `docs/phase-18-wazuh-lab-topology-validation.md`; extended `scripts/verify-phase-18-wazuh-lab-topology.sh` and `scripts/test-verify-phase-18-wazuh-lab-topology.sh` to require the new validator.
 - Current blocker: none
-- Next exact step: Push `codex/issue-382` and open a draft PR for the verified Phase 18 validation slice.
+- Next exact step: Monitor draft PR `#387` for review or CI feedback and address only focused validation regressions if they appear.
 - Verification gap: none for the requested repository-local validation slice; broader Phase 19 operator-surface coverage remains intentionally out of scope.
 - Files touched: `.codex-supervisor/issues/382/issue-journal.md`, `control-plane/tests/test_phase18_live_wazuh_queue_validation.py`, `docs/phase-18-wazuh-lab-topology-validation.md`, `scripts/verify-phase-18-wazuh-lab-topology.sh`, `scripts/test-verify-phase-18-wazuh-lab-topology.sh`
 - Rollback concern: Low; changes are additive validation/doc/verifier updates and do not alter runtime service logic.
@@ -42,3 +42,4 @@ Failure signature: none
 - Keep this section short. The supervisor may compact older notes automatically.
 - Focused reproducer note: the first draft of the new test intentionally changed `data.request_id`, which exercised `updated` reviewed-context behavior instead of `restated`; the final test now changes only native id/timestamp to isolate repeat live-delivery semantics.
 - Stabilization note: Re-ran the dedicated Phase 18 validator, both shell verifier paths, and the full `control-plane/tests` unittest discovery sweep on 2026-04-11; all passed without additional code changes.
+- Publish note: Pushed `codex/issue-382` and opened draft PR `#387` (`[codex] Add Phase 18 live Wazuh queue validation`) against `main`.

--- a/control-plane/tests/test_phase18_live_wazuh_queue_validation.py
+++ b/control-plane/tests/test_phase18_live_wazuh_queue_validation.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import pathlib
+import sys
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.models import ReconciliationRecord
+from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
+
+
+FIXTURES_ROOT = pathlib.Path(__file__).resolve().parent / "fixtures" / "wazuh"
+
+
+def _load_wazuh_fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+
+
+class Phase18LiveWazuhQueueValidationTests(unittest.TestCase):
+    def test_live_github_audit_ingest_restates_and_deduplicates_into_case_linked_queue_record(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="0.0.0.0",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
+            ),
+            store=store,
+        )
+
+        created_alert = _load_wazuh_fixture("github-audit-alert.json")
+        restated_alert = deepcopy(created_alert)
+        restated_alert["id"] = "1731596200.1234568"
+        restated_alert["timestamp"] = "2026-04-05T12:35:00+00:00"
+        deduplicated_alert = deepcopy(restated_alert)
+
+        created = service.ingest_wazuh_alert(
+            raw_alert=created_alert,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            peer_addr="10.10.0.5",
+        )
+        promoted_case = service.promote_alert_to_case(created.alert.alert_id)
+        restated = service.ingest_wazuh_alert(
+            raw_alert=restated_alert,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            peer_addr="10.10.0.5",
+        )
+        deduplicated = service.ingest_wazuh_alert(
+            raw_alert=deduplicated_alert,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            peer_addr="10.10.0.5",
+        )
+
+        self.assertEqual(created.disposition, "created")
+        self.assertEqual(restated.disposition, "restated")
+        self.assertEqual(deduplicated.disposition, "deduplicated")
+        self.assertEqual(restated.alert.alert_id, created.alert.alert_id)
+        self.assertEqual(deduplicated.alert.alert_id, created.alert.alert_id)
+        self.assertEqual(restated.alert.case_id, promoted_case.case_id)
+        self.assertEqual(deduplicated.alert.case_id, promoted_case.case_id)
+
+        restated_reconciliation = service.get_record(
+            ReconciliationRecord,
+            restated.reconciliation.reconciliation_id,
+        )
+        deduplicated_reconciliation = service.get_record(
+            ReconciliationRecord,
+            deduplicated.reconciliation.reconciliation_id,
+        )
+        self.assertEqual(
+            restated_reconciliation.subject_linkage["admission_provenance"],
+            {
+                "admission_kind": "live",
+                "admission_channel": "live_wazuh_webhook",
+            },
+        )
+        self.assertEqual(
+            deduplicated_reconciliation.subject_linkage["admission_provenance"],
+            {
+                "admission_kind": "live",
+                "admission_channel": "live_wazuh_webhook",
+            },
+        )
+
+        queue_view = service.inspect_analyst_queue()
+
+        self.assertTrue(queue_view.read_only)
+        self.assertEqual(queue_view.queue_name, "analyst_review")
+        self.assertEqual(queue_view.total_records, 1)
+        self.assertEqual(queue_view.records[0]["alert_id"], created.alert.alert_id)
+        self.assertEqual(queue_view.records[0]["case_id"], promoted_case.case_id)
+        self.assertEqual(queue_view.records[0]["case_lifecycle_state"], "open")
+        self.assertEqual(queue_view.records[0]["queue_selection"], "business_hours_triage")
+        self.assertEqual(queue_view.records[0]["review_state"], "case_required")
+        self.assertEqual(queue_view.records[0]["source_system"], "wazuh")
+        self.assertEqual(
+            queue_view.records[0]["substrate_detection_record_ids"],
+            (
+                "wazuh:1731595300.1234567",
+                "wazuh:1731596200.1234568",
+            ),
+        )
+        self.assertEqual(
+            queue_view.records[0]["accountable_source_identities"],
+            ("manager:wazuh-manager-github-1",),
+        )
+        self.assertEqual(
+            queue_view.records[0]["reviewed_context"]["source"]["source_family"],
+            "github_audit",
+        )
+        self.assertEqual(
+            queue_view.records[0]["correlation_key"],
+            created.reconciliation.correlation_key,
+        )
+        self.assertEqual(
+            queue_view.records[0]["last_seen_at"].isoformat(),
+            "2026-04-05T12:35:00+00:00",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-18-wazuh-lab-topology-validation.md
+++ b/docs/phase-18-wazuh-lab-topology-validation.md
@@ -3,7 +3,7 @@
 - Validation date: 2026-04-10
 - Validation scope: Phase 18 review of the approved single-node Wazuh lab target, the bootable AegisOps control-plane runtime boundary it connects to, the reviewed repository-local Wazuh lab deployment assets, GitHub audit as the approved first live source family, Wazuh -> AegisOps as the mainline live path, fail-closed expectations for transport, authentication, and payload admission, and confirmation that OpenSearch runtime enrichment, thin operator UI, and guarded automation live wiring remain deferred
 - Baseline references: `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md`, `docs/phase-18-wazuh-single-node-lab-assets.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/wazuh-alert-ingest-contract.md`, `docs/source-onboarding-contract.md`, `docs/source-families/github-audit/onboarding-package.md`, `docs/architecture.md`
-- Verification commands: `python3 -m unittest control-plane.tests.test_phase18_wazuh_lab_topology_docs`, `python3 -m unittest control-plane.tests.test_phase18_wazuh_single_node_lab_assets`, `bash scripts/verify-phase-18-wazuh-lab-topology.sh`, `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`
+- Verification commands: `python3 -m unittest control-plane.tests.test_phase18_wazuh_lab_topology_docs`, `python3 -m unittest control-plane.tests.test_phase18_wazuh_single_node_lab_assets`, `python3 -m unittest control-plane.tests.test_phase18_live_wazuh_queue_validation`, `bash scripts/verify-phase-18-wazuh-lab-topology.sh`, `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`
 - Validation status: PASS
 
 ## Required Boundary Artifacts
@@ -17,6 +17,7 @@
 - `docs/source-onboarding-contract.md`
 - `docs/source-families/github-audit/onboarding-package.md`
 - `docs/architecture.md`
+- `control-plane/tests/test_phase18_live_wazuh_queue_validation.py`
 - `ingest/wazuh/single-node-lab/README.md`
 - `ingest/wazuh/single-node-lab/bootstrap.env.sample`
 - `ingest/wazuh/single-node-lab/docker-compose.yml`
@@ -36,6 +37,8 @@ Confirmed GitHub audit is the approved first live source family because it prese
 Confirmed the reviewed Wazuh custom integration contract requires HTTPS POST to the approved reverse-proxy ingress boundary plus `Authorization: Bearer <shared secret>` authentication sourced from an untracked runtime secret.
 
 Confirmed the Phase 18 contract applies the existing Wazuh payload-admission rules rather than redefining them, and limits first live admission to GitHub audit carried inside the reviewed Wazuh alert envelope.
+
+Confirmed the repository-local Phase 18 live-ingest validator now exercises authenticated `ingest_wazuh_alert` runtime admission, repeat live GitHub audit delivery, and analyst-queue appearance so restatement, dedupe, and case-linkage drift fail closed before later operator-surface phases build on the slice.
 
 Confirmed the reviewed repository-local asset bundle under `ingest/wazuh/single-node-lab/` makes the first live substrate target explicit with placeholder-safe compose, bootstrap, and integration artifacts while keeping secrets untracked and production hardening out of scope.
 

--- a/scripts/test-verify-phase-18-wazuh-lab-topology.sh
+++ b/scripts/test-verify-phase-18-wazuh-lab-topology.sh
@@ -13,6 +13,7 @@ canonical_wazuh_contract_doc="${repo_root}/docs/wazuh-alert-ingest-contract.md"
 canonical_source_contract_doc="${repo_root}/docs/source-onboarding-contract.md"
 canonical_github_audit_doc="${repo_root}/docs/source-families/github-audit/onboarding-package.md"
 canonical_architecture_doc="${repo_root}/docs/architecture.md"
+canonical_phase18_live_queue_test="${repo_root}/control-plane/tests/test_phase18_live_wazuh_queue_validation.py"
 canonical_asset_readme="${repo_root}/ingest/wazuh/single-node-lab/README.md"
 canonical_asset_bootstrap="${repo_root}/ingest/wazuh/single-node-lab/bootstrap.env.sample"
 canonical_asset_compose="${repo_root}/ingest/wazuh/single-node-lab/docker-compose.yml"
@@ -30,7 +31,7 @@ fail_stderr="${workdir}/fail.err"
 create_repo() {
   local target="$1"
 
-  mkdir -p "${target}/docs/source-families/github-audit" "${target}/scripts" "${target}/ingest/wazuh/single-node-lab"
+  mkdir -p "${target}/docs/source-families/github-audit" "${target}/scripts" "${target}/ingest/wazuh/single-node-lab" "${target}/control-plane/tests"
   git -C "${target}" init -q
   git -C "${target}" config user.name "Codex Test"
   git -C "${target}" config user.email "codex@example.com"
@@ -48,6 +49,7 @@ write_canonical_artifacts() {
   cp "${canonical_source_contract_doc}" "${target}/docs/source-onboarding-contract.md"
   cp "${canonical_github_audit_doc}" "${target}/docs/source-families/github-audit/onboarding-package.md"
   cp "${canonical_architecture_doc}" "${target}/docs/architecture.md"
+  cp "${canonical_phase18_live_queue_test}" "${target}/control-plane/tests/test_phase18_live_wazuh_queue_validation.py"
   cp "${canonical_asset_readme}" "${target}/ingest/wazuh/single-node-lab/README.md"
   cp "${canonical_asset_bootstrap}" "${target}/ingest/wazuh/single-node-lab/bootstrap.env.sample"
   cp "${canonical_asset_compose}" "${target}/ingest/wazuh/single-node-lab/docker-compose.yml"
@@ -177,5 +179,13 @@ write_canonical_artifacts "${missing_deviation_repo}"
 remove_text_from_doc "${missing_deviation_repo}" "${missing_deviation_repo}/docs/phase-18-wazuh-lab-topology-validation.md" '- Requested comparison target `Phase 16-21 Epic Roadmap.md` was unavailable in the local worktree during this validation snapshot.'
 commit_fixture "${missing_deviation_repo}"
 assert_fails_with "${missing_deviation_repo}" '- Requested comparison target `Phase 16-21 Epic Roadmap.md` was unavailable in the local worktree during this validation snapshot.'
+
+missing_live_queue_test_repo="${workdir}/missing-live-queue-test"
+create_repo "${missing_live_queue_test_repo}"
+write_canonical_artifacts "${missing_live_queue_test_repo}"
+rm "${missing_live_queue_test_repo}/control-plane/tests/test_phase18_live_wazuh_queue_validation.py"
+git -C "${missing_live_queue_test_repo}" add -u
+commit_fixture "${missing_live_queue_test_repo}"
+assert_fails_with "${missing_live_queue_test_repo}" 'Missing Phase 18 live Wazuh queue validation test:'
 
 echo "Phase 18 Wazuh lab topology verifier enforces the reviewed live-path contract and deferred-scope boundaries."

--- a/scripts/verify-phase-18-wazuh-lab-topology.sh
+++ b/scripts/verify-phase-18-wazuh-lab-topology.sh
@@ -14,6 +14,7 @@ wazuh_contract_doc="${repo_root}/docs/wazuh-alert-ingest-contract.md"
 source_contract_doc="${repo_root}/docs/source-onboarding-contract.md"
 github_audit_doc="${repo_root}/docs/source-families/github-audit/onboarding-package.md"
 architecture_doc="${repo_root}/docs/architecture.md"
+phase18_live_queue_test="${repo_root}/control-plane/tests/test_phase18_live_wazuh_queue_validation.py"
 asset_dir="${repo_root}/ingest/wazuh/single-node-lab"
 asset_readme="${asset_dir}/README.md"
 asset_bootstrap="${asset_dir}/bootstrap.env.sample"
@@ -50,6 +51,7 @@ require_file "${wazuh_contract_doc}" "Missing Wazuh alert ingest contract doc"
 require_file "${source_contract_doc}" "Missing source onboarding contract doc"
 require_file "${github_audit_doc}" "Missing GitHub audit onboarding package doc"
 require_file "${architecture_doc}" "Missing architecture overview doc"
+require_file "${phase18_live_queue_test}" "Missing Phase 18 live Wazuh queue validation test"
 require_file "${asset_readme}" "Missing Phase 18 Wazuh lab README"
 require_file "${asset_bootstrap}" "Missing Phase 18 Wazuh lab bootstrap sample"
 require_file "${asset_compose}" "Missing Phase 18 Wazuh lab compose asset"
@@ -139,6 +141,7 @@ validation_required_lines=(
   'Confirmed GitHub audit is the approved first live source family because it preserves the narrowest identity-rich source context already prioritized by the reviewed Phase 14 family order and GitHub audit onboarding package.'
   'Confirmed the reviewed Wazuh custom integration contract requires HTTPS POST to the approved reverse-proxy ingress boundary plus `Authorization: Bearer <shared secret>` authentication sourced from an untracked runtime secret.'
   'Confirmed the Phase 18 contract applies the existing Wazuh payload-admission rules rather than redefining them, and limits first live admission to GitHub audit carried inside the reviewed Wazuh alert envelope.'
+  'Confirmed the repository-local Phase 18 live-ingest validator now exercises authenticated `ingest_wazuh_alert` runtime admission, repeat live GitHub audit delivery, and analyst-queue appearance so restatement, dedupe, and case-linkage drift fail closed before later operator-surface phases build on the slice.'
   'Confirmed the live ingest path remains fail-closed by rejecting non-HTTPS requests, non-POST requests, missing or invalid bearer credentials, direct backend bypass attempts, invalid JSON payloads, Wazuh payloads that violate required field expectations, and payloads outside the approved first live family.'
   'Confirmed OpenSearch runtime enrichment, thin operator UI, guarded automation live wiring, broader source-family rollout, direct GitHub API actioning, and production-scale Wazuh topologies remain deferred and out of scope for this slice.'
   "The issue requested review against \`Phase 16-21 Epic Roadmap.md\`, but that roadmap file was not present in the local worktree and could not be located via repository search during this turn."
@@ -159,6 +162,7 @@ required_artifacts=(
   "docs/source-onboarding-contract.md"
   "docs/source-families/github-audit/onboarding-package.md"
   "docs/architecture.md"
+  "control-plane/tests/test_phase18_live_wazuh_queue_validation.py"
   "ingest/wazuh/single-node-lab/README.md"
   "ingest/wazuh/single-node-lab/bootstrap.env.sample"
   "ingest/wazuh/single-node-lab/docker-compose.yml"
@@ -176,6 +180,15 @@ for artifact in "${required_artifacts[@]}"; do
     exit 1
   fi
 done
+
+require_fixed_string "${validation_doc}" '- Verification commands: `python3 -m unittest control-plane.tests.test_phase18_wazuh_lab_topology_docs`, `python3 -m unittest control-plane.tests.test_phase18_wazuh_single_node_lab_assets`, `python3 -m unittest control-plane.tests.test_phase18_live_wazuh_queue_validation`, `bash scripts/verify-phase-18-wazuh-lab-topology.sh`, `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`'
+require_fixed_string "${phase18_live_queue_test}" 'class Phase18LiveWazuhQueueValidationTests(unittest.TestCase):'
+require_fixed_string "${phase18_live_queue_test}" '    def test_live_github_audit_ingest_restates_and_deduplicates_into_case_linked_queue_record('
+require_fixed_string "${phase18_live_queue_test}" '        self.assertEqual(created.disposition, "created")'
+require_fixed_string "${phase18_live_queue_test}" '        self.assertEqual(restated.disposition, "restated")'
+require_fixed_string "${phase18_live_queue_test}" '        self.assertEqual(deduplicated.disposition, "deduplicated")'
+require_fixed_string "${phase18_live_queue_test}" '        self.assertEqual(queue_view.records[0]["queue_selection"], "business_hours_triage")'
+require_fixed_string "${phase18_live_queue_test}" '            "github_audit",'
 
 asset_compose_required_lines=(
   'name: aegisops-wazuh-single-node-lab'


### PR DESCRIPTION
## What changed
- added a dedicated Phase 18 end-to-end validator for authenticated live Wazuh ingest of the approved `github_audit` family into the AegisOps analyst queue
- extended the Phase 18 validation record and shell verifier coverage so the live-path contract now fails closed if the queue validation disappears
- refreshed the issue journal with the stabilization verification results for this checkpoint

## Why
Phase 18 needed repository-local verification that the first live Wazuh slice reaches the reviewed AegisOps analyst queue with the expected restatement, dedupe, and case-linkage behavior before later operator-surface phases build on that path.

## Impact
- catches drift in the live ingest contract, source-family admission boundary, and analyst-queue appearance for the first live Wazuh path
- keeps the scope narrow to backend validation, docs, and tests without changing runtime service behavior
- gives Phase 19 a stable first-live-slice baseline for operator-facing work

## Validation
- `python3 -m unittest control-plane.tests.test_phase18_live_wazuh_queue_validation`
- `bash scripts/verify-phase-18-wazuh-lab-topology.sh`
- `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end validation for live Wazuh alert ingestion into the analyst queue, verifying authenticated delivery, queue state handling, and case linkage across deduplication and restatement scenarios.

* **Documentation**
  * Updated Phase 18 validation documentation with new test coverage and verification commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->