### PR TITLE
[codex] Harden Wazuh integration render output handling

### DIFF
--- a/.codex-supervisor/issues/390/issue-journal.md
+++ b/.codex-supervisor/issues/390/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #390: Phase 18 follow-up: make Wazuh integration render output secret-safe by default
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/390
+- Branch: codex/issue-390
+- Workspace: .
+- Journal: .codex-supervisor/issues/390/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 3da085b867906428f7179ad14746d5577ad68968
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T05:04:39.495Z
+
+## Latest Codex Summary
+- Reproduced that `ingest/wazuh/single-node-lab/render-ossec-integration.sh` defaulted to `./ossec.integration.rendered.xml` and would write a secret-bearing rendered integration file from repo root with no explicit output argument.
+- Hardened the helper to require an explicit output path, print a reviewed safe temp-location example, and added `.gitignore` coverage for rendered `ossec.integration.rendered.xml` artifacts.
+- Updated the Phase 18 lab asset test, asset documentation, asset README, and Phase 18 verifier to enforce the secret-safe render workflow.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The unsafe default came from `render-ossec-integration.sh` using an implicit current-directory output path (`./ossec.integration.rendered.xml`), which allows secret-bearing output to land in tracked worktree locations during repo-root usage.
+- What changed: Added a focused failing unittest for the no-argument render path, changed the helper to reject implicit output paths and print `\${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml` as the reviewed safe example, added rendered-artifact ignore patterns to `.gitignore`, and updated Phase 18 asset docs/README/verifier expectations to match.
+- Current blocker: none
+- Next exact step: Commit the verified secret-safe render-flow hardening on `codex/issue-390`.
+- Verification gap: none for the requested local scope; PR/CI is still absent because no PR exists yet.
+- Files touched: `.gitignore`, `control-plane/tests/test_phase18_wazuh_single_node_lab_assets.py`, `docs/phase-18-wazuh-single-node-lab-assets.md`, `ingest/wazuh/single-node-lab/README.md`, `ingest/wazuh/single-node-lab/render-ossec-integration.sh`, `scripts/verify-phase-18-wazuh-lab-topology.sh`
+- Rollback concern: Low; the behavioral change is intentionally narrow but operators now must pass an explicit output path when rendering the Wazuh integration block.
+- Last focused command: `git check-ignore -v ingest/wazuh/single-node-lab/ossec.integration.rendered.xml`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/390/issue-journal.md
+++ b/.codex-supervisor/issues/390/issue-journal.md
@@ -5,31 +5,43 @@
 - Branch: codex/issue-390
 - Workspace: .
 - Journal: .codex-supervisor/issues/390/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 3da085b867906428f7179ad14746d5577ad68968
+- Current phase: addressing_review
+- Attempt count: 4 (implementation=3, repair=1)
+- Last head SHA: 4b2b203e12ca7bc65bdc49aab2d134356bdf511b
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-11T05:04:39.495Z
+- Last failure signature: PRRT_kwDOR2iDUc56R6X0
+- Repeated failure signature count: 2
+- Updated at: 2026-04-11T05:26:53.366Z
 
 ## Latest Codex Summary
-- Reproduced that `ingest/wazuh/single-node-lab/render-ossec-integration.sh` defaulted to `./ossec.integration.rendered.xml` and would write a secret-bearing rendered integration file from repo root with no explicit output argument.
-- Hardened the helper to require an explicit output path, print a reviewed safe temp-location example, and added `.gitignore` coverage for rendered `ossec.integration.rendered.xml` artifacts.
-- Updated the Phase 18 lab asset test, asset documentation, asset README, and Phase 18 verifier to enforce the secret-safe render workflow.
+The checkpoint is published and reviewable. I pushed `codex/issue-390` to `origin` and opened draft PR [#392](https://github.com/TommyKammy/AegisOps/pull/392) against `main` for commit `4b2b203` (`Harden Wazuh integration render output handling`). The GitHub app could not create the PR because of a `403 Resource not accessible by integration`, so I used `gh pr create` as the fallback.
+
+Focused verification was rerun before opening the PR and passed: `python3 -m unittest control-plane.tests.test_phase18_wazuh_single_node_lab_assets control-plane.tests.test_runtime_skeleton`, `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`, and `git check-ignore -v -- ossec.integration.rendered.xml ingest/wazuh/single-node-lab/ossec.integration.rendered.xml foo.ossec.integration.rendered.xml`. I also updated the Codex Working Notes in [issue-journal.md](.codex-supervisor/issues/390/issue-journal.md:1) with the PR link, fresh verification, and next step.
+
+Summary: Pushed `codex/issue-390`, opened draft PR `#392`, reran the requested local verification, and updated the issue journal working notes.
+State hint: draft_pr
+Blocked reason: none
+Tests: `python3 -m unittest control-plane.tests.test_phase18_wazuh_single_node_lab_assets control-plane.tests.test_runtime_skeleton`; `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`; `git check-ignore -v -- ossec.integration.rendered.xml ingest/wazuh/single-node-lab/ossec.integration.rendered.xml foo.ossec.integration.rendered.xml`
+Next action: Monitor draft PR `#392` for CI/manual review feedback and address any follow-up if checks or comments arrive.
+Failure signature: PRRT_kwDOR2iDUc56R6X0
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/AegisOps/pull/392#discussion_r3067639173
+- Details:
+  - control-plane/tests/test_phase18_wazuh_single_node_lab_assets.py:215 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Avoid pre-existing-file flakiness in the repo-root negative test.** At Line 214, the test can fail if `REPO_ROOT/ossec.integration.rendered.x... url=https://github.com/TommyKammy/AegisOps/pull/392#discussion_r3067639173
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The unsafe default came from `render-ossec-integration.sh` using an implicit current-directory output path (`./ossec.integration.rendered.xml`), which allows secret-bearing output to land in tracked worktree locations during repo-root usage.
-- What changed: Added a focused failing unittest for the no-argument render path, changed the helper to reject implicit output paths and print `\${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml` as the reviewed safe example, added rendered-artifact ignore patterns to `.gitignore`, and updated Phase 18 asset docs/README/verifier expectations to match.
+- What changed: Kept the reviewed Phase 18 hardening intact and addressed the remaining PR thread by making the repo-root negative unittest preserve pre-existing `REPO_ROOT/ossec.integration.rendered.xml` state. The test now records existence plus `st_mtime_ns` before invoking the helper and asserts the helper did not create or modify that path on failure.
 - Current blocker: none
-- Next exact step: Commit the verified secret-safe render-flow hardening on `codex/issue-390`.
-- Verification gap: none for the requested local scope; PR/CI is still absent because no PR exists yet.
+- Next exact step: Commit the review-thread fix, push `codex/issue-390`, and update PR `#392`.
+- Verification gap: none for the requested local scope after rerunning the focused Phase 18 verification set on the review-fix diff.
 - Files touched: `.gitignore`, `control-plane/tests/test_phase18_wazuh_single_node_lab_assets.py`, `docs/phase-18-wazuh-single-node-lab-assets.md`, `ingest/wazuh/single-node-lab/README.md`, `ingest/wazuh/single-node-lab/render-ossec-integration.sh`, `scripts/verify-phase-18-wazuh-lab-topology.sh`
 - Rollback concern: Low; the behavioral change is intentionally narrow but operators now must pass an explicit output path when rendering the Wazuh integration block.
-- Last focused command: `git check-ignore -v ingest/wazuh/single-node-lab/ossec.integration.rendered.xml`
+- Last focused command:
+- Last focused commands: `python3 -m unittest control-plane.tests.test_phase18_wazuh_single_node_lab_assets control-plane.tests.test_runtime_skeleton`; `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`; `git check-ignore -v -- ossec.integration.rendered.xml ingest/wazuh/single-node-lab/ossec.integration.rendered.xml foo.ossec.integration.rendered.xml`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ Thumbs.db
 # Local override files
 docker-compose.override.yml
 docker-compose.local.yml
+
+# Rendered Wazuh integration artifacts may contain live bearer material
+ossec.integration.rendered.xml
+*.ossec.integration.rendered.xml

--- a/control-plane/tests/test_phase18_wazuh_single_node_lab_assets.py
+++ b/control-plane/tests/test_phase18_wazuh_single_node_lab_assets.py
@@ -186,6 +186,9 @@ class Phase18WazuhSingleNodeLabAssetsTests(unittest.TestCase):
             temp_path = pathlib.Path(temp_dir)
             secret_path = temp_path / "shared-secret.txt"
             secret_path.write_text("reviewed-secret\n", encoding="utf-8")
+            repo_rendered_path = REPO_ROOT / "ossec.integration.rendered.xml"
+            existed_before = repo_rendered_path.exists()
+            mtime_before = repo_rendered_path.stat().st_mtime_ns if existed_before else None
 
             env = {
                 **os.environ,
@@ -211,7 +214,9 @@ class Phase18WazuhSingleNodeLabAssetsTests(unittest.TestCase):
                 "Suggested safe location: /tmp/aegisops-wazuh/ossec.integration.rendered.xml",
                 completed.stderr,
             )
-            self.assertFalse((REPO_ROOT / "ossec.integration.rendered.xml").exists())
+            self.assertEqual(repo_rendered_path.exists(), existed_before)
+            if existed_before:
+                self.assertEqual(repo_rendered_path.stat().st_mtime_ns, mtime_before)
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_phase18_wazuh_single_node_lab_assets.py
+++ b/control-plane/tests/test_phase18_wazuh_single_node_lab_assets.py
@@ -38,6 +38,8 @@ class Phase18WazuhSingleNodeLabAssetsTests(unittest.TestCase):
             "Wazuh -> AegisOps",
             "Authorization: Bearer <shared secret>",
             "must remain untracked",
+            "must not default to a tracked repository output path",
+            "safe output example is `${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml`",
             "OpenSearch runtime extension",
             "multi-node or production-scale Wazuh",
         ):
@@ -105,6 +107,11 @@ class Phase18WazuhSingleNodeLabAssetsTests(unittest.TestCase):
 
         render_helper_text = render_helper_path.read_text(encoding="utf-8")
         for term in (
+            'safe_output_example="${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml"',
+            'require_explicit_output_path() {',
+            'echo "Explicit output path required. Refusing to write rendered integration content to an implicit worktree path." >&2',
+            'echo "Suggested safe location: ${safe_output_example}" >&2',
+            'require_explicit_output_path "$@"',
             'require_env "AEGISOPS_WAZUH_AEGISOPS_INGEST_URL"',
             'require_env "AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE"',
             'template_path="${script_dir}/ossec.integration.sample.xml"',
@@ -128,8 +135,18 @@ class Phase18WazuhSingleNodeLabAssetsTests(unittest.TestCase):
             "must not publish the control-plane backend port directly",
             "render-ossec-integration.sh",
             "Wazuh config",
+            "requires an explicit output path",
+            "reviewed safe example is `${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml`",
+            "repository ignore coverage for `ossec.integration.rendered.xml` artifacts",
         ):
             self.assertIn(term, readme_text)
+
+        gitignore_text = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+        for term in (
+            "ossec.integration.rendered.xml",
+            "*.ossec.integration.rendered.xml",
+        ):
+            self.assertIn(term, gitignore_text)
 
     def test_render_helper_materializes_literal_integration_values(self) -> None:
         render_helper_path = self._asset_dir() / "render-ossec-integration.sh"
@@ -160,6 +177,41 @@ class Phase18WazuhSingleNodeLabAssetsTests(unittest.TestCase):
             self.assertIn("<hook_url>https://aegisops.example.internal/intake/wazuh?channel=github&amp;mode=lab</hook_url>", rendered_text)
             self.assertIn("<api_key>reviewed&lt;&amp;&gt;secret</api_key>", rendered_text)
             self.assertIn("<group>github_audit</group>", rendered_text)
+
+    def test_render_helper_requires_explicit_output_path_when_run_from_repo_root(self) -> None:
+        render_helper_path = self._asset_dir() / "render-ossec-integration.sh"
+        self.assertTrue(render_helper_path.exists(), f"expected Phase 18 render helper at {render_helper_path}")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = pathlib.Path(temp_dir)
+            secret_path = temp_path / "shared-secret.txt"
+            secret_path.write_text("reviewed-secret\n", encoding="utf-8")
+
+            env = {
+                **os.environ,
+                "TMPDIR": "/tmp",
+                "AEGISOPS_WAZUH_AEGISOPS_INGEST_URL": "https://aegisops.example.internal/intake/wazuh",
+                "AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE": str(secret_path),
+            }
+            completed = subprocess.run(
+                ["bash", str(render_helper_path)],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertNotEqual(
+                completed.returncode,
+                0,
+                "expected render helper to reject the implicit repo-root output path",
+            )
+            self.assertIn("Explicit output path required", completed.stderr)
+            self.assertIn(
+                "Suggested safe location: /tmp/aegisops-wazuh/ossec.integration.rendered.xml",
+                completed.stderr,
+            )
+            self.assertFalse((REPO_ROOT / "ossec.integration.rendered.xml").exists())
 
 
 if __name__ == "__main__":

--- a/docs/phase-18-wazuh-single-node-lab-assets.md
+++ b/docs/phase-18-wazuh-single-node-lab-assets.md
@@ -17,7 +17,7 @@ The reviewed bundle contains:
 - `docker-compose.yml` for the placeholder-safe single-node Wazuh manager, indexer, and dashboard lab stack with internal-only service exposure and no direct host port publication;
 - `bootstrap.env.sample` for reviewed non-secret bootstrap inputs;
 - `ossec.integration.sample.xml` for the reviewed custom integration shape that preserves `Wazuh -> AegisOps` as the only approved first live routing path;
-- `render-ossec-integration.sh` for rendering the reviewed sample into literal Wazuh integration values before operator use; and
+- `render-ossec-integration.sh` for rendering the reviewed sample into literal Wazuh integration values before operator use with an explicit output path requirement; and
 - `README.md` for operator expectations, deferred-scope reminders, and path-local usage notes.
 
 These artifacts exist so the repository contains one explicit substrate target for the first live ingest path without implying a broader Wazuh rollout.
@@ -45,6 +45,12 @@ Wazuh does not expand the sample `${...}` placeholders inside the integration bl
 
 The reviewed render helper reads `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE`, materializes `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET` from that mounted file, and then replaces both reviewed placeholders in `ossec.integration.sample.xml` before writing the rendered output.
 
+The reviewed render helper must not default to a tracked repository output path. Operators must provide the destination path explicitly so the render step stays intentional when live bearer material is present.
+
+The reviewed safe output example is `${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml`.
+
+If an operator intentionally writes a rendered integration file inside a local worktree for short-lived review, the file path must stay under repository ignore coverage for rendered `ossec.integration.rendered.xml` artifacts and must not be staged.
+
 Do not commit live secrets, enrolled certificates, real IP addresses, or production host paths into this repository.
 
 ## 4. Operator Expectations
@@ -58,6 +64,10 @@ Operators must keep GitHub audit as the only approved first live source family f
 Operators must keep the Wazuh manager, indexer, and dashboard interfaces internal to the lab compose network or another separately reviewed lab access path rather than publishing host ports from this bundle.
 
 Operators must run `render-ossec-integration.sh` in the manager container or another shell where `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE` resolves to the mounted secret path before copying the reviewed integration block into active Wazuh configuration.
+
+Operators must pass an explicit output path to `render-ossec-integration.sh` rather than relying on an implicit current-directory default.
+
+Operators should prefer `${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml` or another reviewed untracked location outside the repository when rendering the live integration block.
 
 Operators must not use these assets to publish the control-plane backend port directly, to insert Shuffle or n8n into the first live path, or to imply that OpenSearch runtime extension work is required for first live success.
 

--- a/ingest/wazuh/single-node-lab/README.md
+++ b/ingest/wazuh/single-node-lab/README.md
@@ -15,13 +15,15 @@ Use the files here as reviewed scaffolding only:
 - `docker-compose.yml` keeps the Wazuh manager, indexer, and dashboard topology explicit for lab review while leaving service interfaces internal-only.
 - `bootstrap.env.sample` lists the reviewed non-secret inputs that operators must supply in an untracked env file.
 - `ossec.integration.sample.xml` keeps the reviewed custom integration template shape for `Wazuh -> AegisOps`.
-- `render-ossec-integration.sh` reads `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE`, materializes `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET`, and renders literal `<hook_url>` and `<api_key>` values before operators load the integration into Wazuh.
+- `render-ossec-integration.sh` reads `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE`, materializes `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET`, requires an explicit output path, and renders literal `<hook_url>` and `<api_key>` values before operators load the integration into Wazuh.
 
 Operator expectations:
 
 - Keep the AegisOps ingress target on the reviewed reverse proxy HTTPS path.
 - Keep the shared bearer secret in an untracked secret file.
 - Run `render-ossec-integration.sh` in the manager container or another shell where `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE` resolves to the mounted secret path so the helper can populate the template’s `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET` placeholder before copying the integration block into active Wazuh config.
+- Pass an explicit output path every time. The reviewed safe example is `${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml`, not a tracked repository path.
+- If an operator still renders into a local worktree path for review, keep the output under the repository ignore coverage for `ossec.integration.rendered.xml` artifacts and do not stage it.
 - Keep GitHub audit as the only approved first live family.
 - Keep service interfaces internal-only unless a separate reviewed lab access path is supplied.
 - Keep the bundle narrow and reviewable.

--- a/ingest/wazuh/single-node-lab/render-ossec-integration.sh
+++ b/ingest/wazuh/single-node-lab/render-ossec-integration.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 template_path="${script_dir}/ossec.integration.sample.xml"
-output_path="${1:-./ossec.integration.rendered.xml}"
+safe_output_example="${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml"
 
 require_env() {
   local name="$1"
@@ -29,6 +29,17 @@ xml_escape() {
 escape_sed_replacement() {
   printf '%s' "${1}" | sed -e 's/[&|\\]/\\&/g'
 }
+
+require_explicit_output_path() {
+  if [[ $# -lt 1 || -z "${1}" ]]; then
+    echo "Explicit output path required. Refusing to write rendered integration content to an implicit worktree path." >&2
+    echo "Suggested safe location: ${safe_output_example}" >&2
+    exit 1
+  fi
+}
+
+require_explicit_output_path "$@"
+output_path="$1"
 
 require_env "AEGISOPS_WAZUH_AEGISOPS_INGEST_URL"
 require_env "AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE"

--- a/scripts/verify-phase-18-wazuh-lab-topology.sh
+++ b/scripts/verify-phase-18-wazuh-lab-topology.sh
@@ -115,13 +115,18 @@ asset_doc_required_lines=(
   '- `docker-compose.yml` for the placeholder-safe single-node Wazuh manager, indexer, and dashboard lab stack with internal-only service exposure and no direct host port publication;'
   '- `bootstrap.env.sample` for reviewed non-secret bootstrap inputs;'
   '- `ossec.integration.sample.xml` for the reviewed custom integration shape that preserves `Wazuh -> AegisOps` as the only approved first live routing path;'
-  '- `render-ossec-integration.sh` for rendering the reviewed sample into literal Wazuh integration values before operator use; and'
+  '- `render-ossec-integration.sh` for rendering the reviewed sample into literal Wazuh integration values before operator use with an explicit output path requirement; and'
   'The reviewed custom integration shape uses `Authorization: Bearer <shared secret>` at runtime.'
   'The shared secret must remain untracked and must come from an operator-provided runtime secret file or another reviewed untracked secret source.'
   'Wazuh does not expand the sample `${...}` placeholders inside the integration block. Operators must render literal `<hook_url>` and `<api_key>` values with `render-ossec-integration.sh` before loading the reviewed integration into active Wazuh configuration.'
+  'The reviewed render helper must not default to a tracked repository output path. Operators must provide the destination path explicitly so the render step stays intentional when live bearer material is present.'
+  'The reviewed safe output example is `${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml`.'
+  'If an operator intentionally writes a rendered integration file inside a local worktree for short-lived review, the file path must stay under repository ignore coverage for rendered `ossec.integration.rendered.xml` artifacts and must not be staged.'
   'Operators must keep GitHub audit as the only approved first live source family for this slice.'
   'Operators must keep the Wazuh manager, indexer, and dashboard interfaces internal to the lab compose network or another separately reviewed lab access path rather than publishing host ports from this bundle.'
   'Operators must run `render-ossec-integration.sh` in the manager container or another shell where `AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE` resolves to the mounted secret path before copying the reviewed integration block into active Wazuh configuration.'
+  'Operators must pass an explicit output path to `render-ossec-integration.sh` rather than relying on an implicit current-directory default.'
+  'Operators should prefer `${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml` or another reviewed untracked location outside the repository when rendering the live integration block.'
   '- multi-node or production-scale Wazuh;'
   '- the optional OpenSearch runtime extension;'
 )
@@ -252,6 +257,11 @@ for line in "${asset_integration_required_lines[@]}"; do
 done
 
 render_helper_required_lines=(
+  'safe_output_example="${TMPDIR:-/tmp}/aegisops-wazuh/ossec.integration.rendered.xml"'
+  'require_explicit_output_path() {'
+  '    echo "Explicit output path required. Refusing to write rendered integration content to an implicit worktree path." >&2'
+  '    echo "Suggested safe location: ${safe_output_example}" >&2'
+  'require_explicit_output_path "$@"'
   'require_env "AEGISOPS_WAZUH_AEGISOPS_INGEST_URL"'
   'require_env "AEGISOPS_WAZUH_AEGISOPS_SHARED_SECRET_FILE"'
   'template_path="${script_dir}/ossec.integration.sample.xml"'


### PR DESCRIPTION
## What changed
- require an explicit output path when rendering the reviewed Phase 18 Wazuh integration block instead of defaulting to `./ossec.integration.rendered.xml`
- point operators to a safe default example under `${TMPDIR:-/tmp}/aegisops-wazuh/` and add repository ignore coverage for rendered `ossec.integration.rendered.xml` artifacts
- update the Phase 18 lab asset documentation, README guidance, topology verifier, and focused tests to reflect the secret-safe render flow

## Why
The reviewed render helper previously allowed secret-bearing output to land in tracked worktree paths when operators ran it from the repository root. This hardens the reviewed lab flow without changing the live ingest contract itself.

## Operator impact
Operators now must pass an explicit destination path to `render-ossec-integration.sh`. The documented reviewed example keeps the rendered integration outside the worktree by default, and if someone still chooses a repository path the added ignore patterns make accidental staging harder.

## Validation
- `python3 -m unittest control-plane.tests.test_phase18_wazuh_single_node_lab_assets control-plane.tests.test_runtime_skeleton`
- `bash scripts/test-verify-phase-18-wazuh-lab-topology.sh`
- `git check-ignore -v -- ossec.integration.rendered.xml ingest/wazuh/single-node-lab/ossec.integration.rendered.xml foo.ossec.integration.rendered.xml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rendering Wazuh integration now requires an explicit output path to avoid writing sensitive data to tracked repository locations.

* **Documentation**
  * Added safe output examples and clarified operator requirements to keep rendered artifacts out of the repo tree and un-staged.

* **Tests**
  * Strengthened tests to enforce explicit-output behavior and to verify ignored rendered artifacts are not created or staged.

* **Chores**
  * Added a journal entry recording the work and updated ignore rules for rendered integration artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->