### PR TITLE
[codex] Expose reviewed Wazuh alert detail surface

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1961,6 +1961,7 @@ class AegisOpsControlPlaneService:
             if (
                 record.alert_id != alert_id
                 or not self._reconciliation_has_detection_lineage(record)
+                or not self._reconciliation_is_wazuh_origin(record)
             ):
                 continue
             if latest is None or (
@@ -1981,6 +1982,7 @@ class AegisOpsControlPlaneService:
             if (
                 record.alert_id is None
                 or not self._reconciliation_has_detection_lineage(record)
+                or not self._reconciliation_is_wazuh_origin(record)
             ):
                 continue
             current = latest_by_alert_id.get(record.alert_id)

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -152,6 +152,44 @@ class AnalystQueueSnapshot:
 
 
 @dataclass(frozen=True)
+class AlertDetailSnapshot:
+    read_only: bool
+    alert_id: str
+    alert: dict[str, object]
+    case_record: dict[str, object] | None
+    analytic_signal_record: dict[str, object] | None
+    latest_reconciliation: dict[str, object]
+    linked_evidence_records: tuple[dict[str, object], ...]
+    reviewed_context: dict[str, object]
+    review_state: str
+    escalation_boundary: str
+    source_system: str
+    native_rule: dict[str, object] | None
+    provenance: dict[str, str] | None
+    lineage: dict[str, object]
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(
+            {
+                "read_only": self.read_only,
+                "alert_id": self.alert_id,
+                "alert": self.alert,
+                "case_record": self.case_record,
+                "analytic_signal_record": self.analytic_signal_record,
+                "latest_reconciliation": self.latest_reconciliation,
+                "linked_evidence_records": self.linked_evidence_records,
+                "reviewed_context": self.reviewed_context,
+                "review_state": self.review_state,
+                "escalation_boundary": self.escalation_boundary,
+                "source_system": self.source_system,
+                "native_rule": self.native_rule,
+                "provenance": self.provenance,
+                "lineage": self.lineage,
+            }
+        )
+
+
+@dataclass(frozen=True)
 class AnalystAssistantContextSnapshot:
     read_only: bool
     record_family: str
@@ -1235,17 +1273,6 @@ class AegisOpsControlPlaneService:
         )
 
     def inspect_analyst_queue(self) -> AnalystQueueSnapshot:
-        latest_reconciliation_by_alert_id: dict[str, ReconciliationRecord] = {}
-        for record in self._store.list(ReconciliationRecord):
-            if (
-                record.alert_id is None
-                or not self._reconciliation_has_detection_lineage(record)
-            ):
-                continue
-            current = latest_reconciliation_by_alert_id.get(record.alert_id)
-            if current is None or record.compared_at > current.compared_at:
-                latest_reconciliation_by_alert_id[record.alert_id] = record
-
         active_alert_states = {
             "new",
             "triaged",
@@ -1257,8 +1284,11 @@ class AegisOpsControlPlaneService:
         for alert in self._store.list(AlertRecord):
             if alert.lifecycle_state not in active_alert_states:
                 continue
-            reconciliation = latest_reconciliation_by_alert_id.get(alert.alert_id)
+            reconciliation = self._latest_detection_reconciliation_for_alert(alert.alert_id)
             if reconciliation is None:
+                continue
+
+            if not self._reconciliation_is_wazuh_origin(reconciliation):
                 continue
 
             source_systems = self._merge_linked_ids(
@@ -1269,13 +1299,6 @@ class AegisOpsControlPlaneService:
                 reconciliation.subject_linkage.get("substrate_detection_record_ids"),
                 None,
             )
-            is_wazuh_origin = "wazuh" in source_systems or any(
-                detection_id.startswith("wazuh:")
-                for detection_id in substrate_detection_record_ids
-            )
-            if not is_wazuh_origin:
-                continue
-
             case_record = (
                 self._store.get(CaseRecord, alert.case_id)
                 if alert.case_id is not None
@@ -1296,7 +1319,7 @@ class AegisOpsControlPlaneService:
                     "escalation_boundary": self._alert_escalation_boundary(alert),
                     "source_system": (
                         "wazuh"
-                        if is_wazuh_origin
+                        if self._reconciliation_is_wazuh_origin(reconciliation)
                         else (source_systems[0] if source_systems else "wazuh")
                     ),
                     "substrate_detection_record_ids": substrate_detection_record_ids,
@@ -1333,6 +1356,93 @@ class AegisOpsControlPlaneService:
             queue_name="analyst_review",
             total_records=len(queue_records),
             records=tuple(queue_records),
+        )
+
+    def inspect_alert_detail(self, alert_id: str) -> AlertDetailSnapshot:
+        alert_id = self._require_non_empty_string(alert_id, "alert_id")
+        alert = self._store.get(AlertRecord, alert_id)
+        if alert is None:
+            raise LookupError(f"Missing alert record {alert_id!r} for detail inspection")
+
+        reconciliation = self._latest_detection_reconciliation_for_alert(alert.alert_id)
+        if reconciliation is None or not self._reconciliation_is_wazuh_origin(reconciliation):
+            raise LookupError(
+                f"Missing reviewed Wazuh-backed reconciliation for alert {alert_id!r}"
+            )
+
+        case_record = (
+            self._store.get(CaseRecord, alert.case_id)
+            if alert.case_id is not None
+            else None
+        )
+        analytic_signal_record = (
+            self._store.get(AnalyticSignalRecord, alert.analytic_signal_id)
+            if alert.analytic_signal_id is not None
+            else None
+        )
+        evidence_records = self._assistant_evidence_records_for_context(
+            alert_ids=(alert.alert_id,),
+            case_ids=self._assistant_ids_from_value(alert.case_id),
+            evidence_ids=self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "evidence_ids",
+            ),
+            exclude_evidence_id=None,
+        )
+        source_systems = self._merge_linked_ids(
+            reconciliation.subject_linkage.get("source_systems"),
+            None,
+        )
+        source_system = (
+            "wazuh" if "wazuh" in source_systems else (source_systems[0] if source_systems else "wazuh")
+        )
+        lineage = {
+            "finding_id": alert.finding_id,
+            "analytic_signal_id": alert.analytic_signal_id,
+            "case_id": alert.case_id,
+            "reconciliation_id": reconciliation.reconciliation_id,
+            "correlation_key": reconciliation.correlation_key,
+            "source_systems": source_systems,
+            "substrate_detection_record_ids": self._merge_linked_ids(
+                reconciliation.subject_linkage.get("substrate_detection_record_ids"),
+                None,
+            ),
+            "accountable_source_identities": self._merge_linked_ids(
+                reconciliation.subject_linkage.get("accountable_source_identities"),
+                None,
+            ),
+            "evidence_ids": tuple(evidence.evidence_id for evidence in evidence_records),
+            "first_seen_at": reconciliation.first_seen_at,
+            "last_seen_at": reconciliation.last_seen_at,
+        }
+
+        return AlertDetailSnapshot(
+            read_only=True,
+            alert_id=alert.alert_id,
+            alert=_record_to_dict(alert),
+            case_record=_record_to_dict(case_record) if case_record is not None else None,
+            analytic_signal_record=(
+                _record_to_dict(analytic_signal_record)
+                if analytic_signal_record is not None
+                else None
+            ),
+            latest_reconciliation=_record_to_dict(reconciliation),
+            linked_evidence_records=tuple(
+                _record_to_dict(evidence) for evidence in evidence_records
+            ),
+            reviewed_context=dict(alert.reviewed_context),
+            review_state=self._alert_review_state(alert),
+            escalation_boundary=self._alert_escalation_boundary(alert),
+            source_system=source_system,
+            native_rule=(
+                dict(reconciliation.subject_linkage.get("latest_native_rule"))
+                if isinstance(reconciliation.subject_linkage.get("latest_native_rule"), Mapping)
+                else None
+            ),
+            provenance=_normalize_admission_provenance(
+                reconciliation.subject_linkage.get("admission_provenance")
+            ),
+            lineage=lineage,
         )
 
     def inspect_assistant_context(
@@ -1824,6 +1934,32 @@ class AegisOpsControlPlaneService:
                     )
                 ),
             )
+        )
+
+    def _latest_detection_reconciliation_for_alert(
+        self,
+        alert_id: str,
+    ) -> ReconciliationRecord | None:
+        latest: ReconciliationRecord | None = None
+        for record in self._store.list(ReconciliationRecord):
+            if record.alert_id != alert_id or not self._reconciliation_has_detection_lineage(record):
+                continue
+            if latest is None or record.compared_at > latest.compared_at:
+                latest = record
+        return latest
+
+    def _reconciliation_is_wazuh_origin(self, record: ReconciliationRecord) -> bool:
+        source_systems = self._merge_linked_ids(
+            record.subject_linkage.get("source_systems"),
+            None,
+        )
+        substrate_detection_record_ids = self._merge_linked_ids(
+            record.subject_linkage.get("substrate_detection_record_ids"),
+            None,
+        )
+        return "wazuh" in source_systems or any(
+            detection_id.startswith("wazuh:")
+            for detection_id in substrate_detection_record_ids
         )
 
     @staticmethod

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1280,11 +1280,14 @@ class AegisOpsControlPlaneService:
             "escalated_to_case",
             "reopened",
         }
+        latest_reconciliation_by_alert_id = (
+            self._latest_detection_reconciliations_by_alert_id()
+        )
         queue_records: list[dict[str, object]] = []
         for alert in self._store.list(AlertRecord):
             if alert.lifecycle_state not in active_alert_states:
                 continue
-            reconciliation = self._latest_detection_reconciliation_for_alert(alert.alert_id)
+            reconciliation = latest_reconciliation_by_alert_id.get(alert.alert_id)
             if reconciliation is None:
                 continue
 
@@ -1942,11 +1945,29 @@ class AegisOpsControlPlaneService:
     ) -> ReconciliationRecord | None:
         latest: ReconciliationRecord | None = None
         for record in self._store.list(ReconciliationRecord):
-            if record.alert_id != alert_id or not self._reconciliation_has_detection_lineage(record):
+            if (
+                record.alert_id != alert_id
+                or not self._reconciliation_has_detection_lineage(record)
+            ):
                 continue
             if latest is None or record.compared_at > latest.compared_at:
                 latest = record
         return latest
+
+    def _latest_detection_reconciliations_by_alert_id(
+        self,
+    ) -> dict[str, ReconciliationRecord]:
+        latest_by_alert_id: dict[str, ReconciliationRecord] = {}
+        for record in self._store.list(ReconciliationRecord):
+            if (
+                record.alert_id is None
+                or not self._reconciliation_has_detection_lineage(record)
+            ):
+                continue
+            current = latest_by_alert_id.get(record.alert_id)
+            if current is None or record.compared_at > current.compared_at:
+                latest_by_alert_id[record.alert_id] = record
+        return latest_by_alert_id
 
     def _reconciliation_is_wazuh_origin(self, record: ReconciliationRecord) -> bool:
         source_systems = self._merge_linked_ids(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1396,9 +1396,25 @@ class AegisOpsControlPlaneService:
             reconciliation.subject_linkage.get("source_systems"),
             None,
         )
-        source_system = (
-            "wazuh" if "wazuh" in source_systems else (source_systems[0] if source_systems else "wazuh")
+        substrate_detection_record_ids = self._merge_linked_ids(
+            reconciliation.subject_linkage.get("substrate_detection_record_ids"),
+            None,
         )
+        source_system = (
+            "wazuh"
+            if self._reconciliation_is_wazuh_origin(reconciliation)
+            else (
+                "wazuh"
+                if "wazuh" in source_systems
+                else (source_systems[0] if source_systems else "wazuh")
+            )
+        )
+        latest_reconciliation_payload = _record_to_dict(reconciliation)
+        subject_linkage_payload = latest_reconciliation_payload.get("subject_linkage")
+        if isinstance(subject_linkage_payload, Mapping):
+            redacted_subject_linkage = dict(subject_linkage_payload)
+            redacted_subject_linkage.pop("latest_native_payload", None)
+            latest_reconciliation_payload["subject_linkage"] = redacted_subject_linkage
         lineage = {
             "finding_id": alert.finding_id,
             "analytic_signal_id": alert.analytic_signal_id,
@@ -1406,10 +1422,7 @@ class AegisOpsControlPlaneService:
             "reconciliation_id": reconciliation.reconciliation_id,
             "correlation_key": reconciliation.correlation_key,
             "source_systems": source_systems,
-            "substrate_detection_record_ids": self._merge_linked_ids(
-                reconciliation.subject_linkage.get("substrate_detection_record_ids"),
-                None,
-            ),
+            "substrate_detection_record_ids": substrate_detection_record_ids,
             "accountable_source_identities": self._merge_linked_ids(
                 reconciliation.subject_linkage.get("accountable_source_identities"),
                 None,
@@ -1429,7 +1442,7 @@ class AegisOpsControlPlaneService:
                 if analytic_signal_record is not None
                 else None
             ),
-            latest_reconciliation=_record_to_dict(reconciliation),
+            latest_reconciliation=latest_reconciliation_payload,
             linked_evidence_records=tuple(
                 _record_to_dict(evidence) for evidence in evidence_records
             ),

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1385,7 +1385,7 @@ class AegisOpsControlPlaneService:
         )
         evidence_records = self._assistant_evidence_records_for_context(
             alert_ids=(alert.alert_id,),
-            case_ids=self._assistant_ids_from_value(alert.case_id),
+            case_ids=(),
             evidence_ids=self._assistant_ids_from_mapping(
                 reconciliation.subject_linkage,
                 "evidence_ids",

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1963,7 +1963,13 @@ class AegisOpsControlPlaneService:
                 or not self._reconciliation_has_detection_lineage(record)
             ):
                 continue
-            if latest is None or record.compared_at > latest.compared_at:
+            if latest is None or (
+                record.compared_at,
+                record.reconciliation_id,
+            ) > (
+                latest.compared_at,
+                latest.reconciliation_id,
+            ):
                 latest = record
         return latest
 
@@ -1978,7 +1984,13 @@ class AegisOpsControlPlaneService:
             ):
                 continue
             current = latest_by_alert_id.get(record.alert_id)
-            if current is None or record.compared_at > current.compared_at:
+            if current is None or (
+                record.compared_at,
+                record.reconciliation_id,
+            ) > (
+                current.compared_at,
+                current.reconciliation_id,
+            ):
                 latest_by_alert_id[record.alert_id] = record
         return latest_by_alert_id
 
@@ -1991,9 +2003,16 @@ class AegisOpsControlPlaneService:
             record.subject_linkage.get("substrate_detection_record_ids"),
             None,
         )
-        return "wazuh" in source_systems or any(
-            detection_id.startswith("wazuh:")
+        normalized_source_systems = tuple(
+            source_system.strip().lower() for source_system in source_systems
+        )
+        normalized_substrate_detection_record_ids = tuple(
+            detection_id.strip().lower()
             for detection_id in substrate_detection_record_ids
+        )
+        return "wazuh" in normalized_source_systems or any(
+            detection_id.startswith("wazuh:")
+            for detection_id in normalized_substrate_detection_record_ids
         )
 
     @staticmethod

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -52,6 +52,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "inspect-analyst-queue",
         help="Render the business-hours analyst review queue view.",
     )
+    inspect_alert_detail = subparsers.add_parser(
+        "inspect-alert-detail",
+        help="Render the reviewed Wazuh-backed alert detail view for one alert.",
+    )
+    inspect_alert_detail.add_argument(
+        "--alert-id",
+        required=True,
+        help="Control-plane alert identifier to inspect.",
+    )
     inspect_assistant_context = subparsers.add_parser(
         "inspect-assistant-context",
         help="Render a read-only analyst-assistant context view for one record.",
@@ -169,6 +178,35 @@ def run_control_plane_service(
                     HTTPStatus.OK,
                     service.inspect_reconciliation_status().to_dict(),
                 )
+                return
+
+            if request_path == "/inspect-analyst-queue":
+                self._write_json(HTTPStatus.OK, service.inspect_analyst_queue().to_dict())
+                return
+
+            if request_path == "/inspect-alert-detail":
+                alert_id = parse_qs(request_target.query).get("alert_id", [""])[0]
+                if not alert_id:
+                    self._write_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {
+                            "error": "invalid_request",
+                            "message": "alert_id query parameter is required",
+                        },
+                    )
+                    return
+                try:
+                    payload = service.inspect_alert_detail(alert_id).to_dict()
+                except LookupError as exc:
+                    self._write_json(
+                        HTTPStatus.NOT_FOUND,
+                        {
+                            "error": "not_found",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, payload)
                 return
 
             self._write_json(
@@ -398,6 +436,11 @@ def main(
             payload = service.inspect_reconciliation_status().to_dict()
         elif command == "inspect-analyst-queue":
             payload = service.inspect_analyst_queue().to_dict()
+        elif command == "inspect-alert-detail":
+            try:
+                payload = service.inspect_alert_detail(parsed.alert_id).to_dict()
+            except LookupError as exc:
+                parser.error(str(exc))
         else:
             raise AssertionError(f"Unhandled command: {command}")
 

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -19,6 +19,10 @@ from aegisops_control_plane.service import (
 MAX_WAZUH_INGEST_BODY_BYTES = 1_048_576
 
 
+def _normalize_alert_id(value: str) -> str:
+    return value.strip()
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -185,7 +189,9 @@ def run_control_plane_service(
                 return
 
             if request_path == "/inspect-alert-detail":
-                alert_id = parse_qs(request_target.query).get("alert_id", [""])[0]
+                alert_id = _normalize_alert_id(
+                    parse_qs(request_target.query).get("alert_id", [""])[0]
+                )
                 if not alert_id:
                     self._write_json(
                         HTTPStatus.BAD_REQUEST,
@@ -197,6 +203,15 @@ def run_control_plane_service(
                     return
                 try:
                     payload = service.inspect_alert_detail(alert_id).to_dict()
+                except ValueError as exc:
+                    self._write_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {
+                            "error": "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
                 except LookupError as exc:
                     self._write_json(
                         HTTPStatus.NOT_FOUND,
@@ -437,9 +452,12 @@ def main(
         elif command == "inspect-analyst-queue":
             payload = service.inspect_analyst_queue().to_dict()
         elif command == "inspect-alert-detail":
+            alert_id = _normalize_alert_id(parsed.alert_id)
+            if not alert_id:
+                parser.error("alert_id must be a non-empty string")
             try:
-                payload = service.inspect_alert_detail(parsed.alert_id).to_dict()
-            except LookupError as exc:
+                payload = service.inspect_alert_detail(alert_id).to_dict()
+            except (LookupError, ValueError) as exc:
                 parser.error(str(exc))
         else:
             raise AssertionError(f"Unhandled command: {command}")

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -213,6 +213,108 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     servers[0].shutdown()
                 thread.join(timeout=2)
 
+    def test_long_running_runtime_surface_exposes_analyst_queue_and_alert_detail_http_views(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+        alert = _load_wazuh_fixture("github-audit-alert.json")
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=alert,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+                queue_payload = json.loads(
+                    request.urlopen(
+                        f"{base_url}/inspect-analyst-queue",
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+                detail_payload = json.loads(
+                    request.urlopen(
+                        (
+                            f"{base_url}/inspect-alert-detail"
+                            f"?alert_id={admitted.alert.alert_id}"
+                        ),
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+
+                self.assertTrue(queue_payload["read_only"])
+                self.assertEqual(queue_payload["queue_name"], "analyst_review")
+                self.assertEqual(queue_payload["total_records"], 1)
+                self.assertEqual(
+                    queue_payload["records"][0]["alert_id"],
+                    admitted.alert.alert_id,
+                )
+
+                self.assertTrue(detail_payload["read_only"])
+                self.assertEqual(detail_payload["alert_id"], admitted.alert.alert_id)
+                self.assertEqual(detail_payload["alert"]["alert_id"], admitted.alert.alert_id)
+                self.assertEqual(detail_payload["case_record"]["case_id"], promoted_case.case_id)
+                self.assertEqual(
+                    detail_payload["latest_reconciliation"]["reconciliation_id"],
+                    admitted.reconciliation.reconciliation_id,
+                )
+                self.assertEqual(
+                    detail_payload["provenance"],
+                    {
+                        "admission_kind": "live",
+                        "admission_channel": "live_wazuh_webhook",
+                    },
+                )
+                self.assertEqual(
+                    detail_payload["lineage"]["substrate_detection_record_ids"],
+                    ["wazuh:1731595300.1234567"],
+                )
+                self.assertEqual(
+                    detail_payload["lineage"]["accountable_source_identities"],
+                    ["manager:wazuh-manager-github-1"],
+                )
+                self.assertEqual(
+                    detail_payload["reviewed_context"]["source"]["source_family"],
+                    "github_audit",
+                )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
     def test_long_running_runtime_surface_rejects_direct_backend_wazuh_ingest_bypass(
         self,
     ) -> None:
@@ -799,6 +901,61 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(
             payload["records"][0]["substrate_detection_record_ids"],
             ["wazuh:1731594986.4931506"],
+        )
+
+    def test_cli_renders_reviewed_wazuh_alert_detail_view(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-alert-detail", "--alert-id", admitted.alert.alert_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["read_only"])
+        self.assertEqual(payload["alert_id"], admitted.alert.alert_id)
+        self.assertEqual(payload["alert"]["alert_id"], admitted.alert.alert_id)
+        self.assertEqual(payload["case_record"]["case_id"], promoted_case.case_id)
+        self.assertEqual(
+            payload["latest_reconciliation"]["reconciliation_id"],
+            admitted.reconciliation.reconciliation_id,
+        )
+        self.assertEqual(
+            payload["provenance"],
+            {
+                "admission_channel": "live_wazuh_webhook",
+                "admission_kind": "live",
+            },
+        )
+        self.assertEqual(
+            payload["lineage"]["substrate_detection_record_ids"],
+            ["wazuh:1731595300.1234567"],
+        )
+        self.assertEqual(
+            payload["lineage"]["accountable_source_identities"],
+            ["manager:wazuh-manager-github-1"],
+        )
+        self.assertEqual(
+            payload["reviewed_context"]["source"]["source_family"],
+            "github_audit",
         )
 
     def test_cli_renders_analyst_assistant_context_view_for_a_case(self) -> None:

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -315,6 +315,60 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     servers[0].shutdown()
                 thread.join(timeout=2)
 
+    def test_long_running_runtime_surface_rejects_blank_alert_detail_query(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                with self.assertRaises(error.HTTPError) as exc_info:
+                    request.urlopen(
+                        (
+                            "http://127.0.0.1:"
+                            f"{servers[0].server_port}/inspect-alert-detail?alert_id=%20%20"
+                        ),
+                        timeout=2,
+                    )
+
+                self.assertEqual(exc_info.exception.code, 400)
+                error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
+                self.assertEqual(error_payload["error"], "invalid_request")
+                self.assertEqual(
+                    error_payload["message"],
+                    "alert_id query parameter is required",
+                )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
     def test_long_running_runtime_surface_rejects_direct_backend_wazuh_ingest_bypass(
         self,
     ) -> None:
@@ -1370,6 +1424,24 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
 
         self.assertEqual(exc_info.exception.code, 2)
         self.assertIn("Unsupported control-plane record family", stderr.getvalue())
+
+    def test_cli_rejects_blank_alert_detail_identifier_as_usage_error(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as exc_info:
+                main.main(
+                    ["inspect-alert-detail", "--alert-id", "   "],
+                    service=service,
+                )
+
+        self.assertEqual(exc_info.exception.code, 2)
+        self.assertIn("alert_id must be a non-empty string", stderr.getvalue())
 
     def test_cli_renders_inspection_views_against_empty_postgresql_store(self) -> None:
         store, _ = make_store()

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -3928,6 +3928,97 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(queue_view.total_records, 1)
         self.assertEqual(queue_view.records[0]["source_system"], "wazuh")
 
+    def test_service_alert_detail_reports_wazuh_when_origin_is_inferred_from_detection_ids(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("agent-origin-alert.json")
+            ),
+        )
+        reconciliation = service.get_record(
+            ReconciliationRecord,
+            admitted.reconciliation.reconciliation_id,
+        )
+        self.assertIsNotNone(reconciliation)
+
+        subject_linkage = dict(reconciliation.subject_linkage)
+        subject_linkage["source_systems"] = ("opensearch",)
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id=reconciliation.reconciliation_id,
+                subject_linkage=subject_linkage,
+                alert_id=reconciliation.alert_id,
+                finding_id=reconciliation.finding_id,
+                analytic_signal_id=reconciliation.analytic_signal_id,
+                execution_run_id=reconciliation.execution_run_id,
+                linked_execution_run_ids=reconciliation.linked_execution_run_ids,
+                correlation_key=reconciliation.correlation_key,
+                first_seen_at=reconciliation.first_seen_at,
+                last_seen_at=reconciliation.last_seen_at,
+                ingest_disposition=reconciliation.ingest_disposition,
+                mismatch_summary=reconciliation.mismatch_summary,
+                compared_at=reconciliation.compared_at,
+                lifecycle_state=reconciliation.lifecycle_state,
+            )
+        )
+
+        detail = service.inspect_alert_detail(admitted.alert.alert_id)
+
+        self.assertEqual(detail.source_system, "wazuh")
+        self.assertEqual(
+            detail.lineage["substrate_detection_record_ids"],
+            ("wazuh:1731594986.4931506",),
+        )
+
+    def test_service_alert_detail_redacts_raw_native_payload_from_latest_reconciliation(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
+        )
+        stored_reconciliation = service.get_record(
+            ReconciliationRecord,
+            admitted.reconciliation.reconciliation_id,
+        )
+        self.assertIsNotNone(stored_reconciliation)
+        self.assertIn("latest_native_payload", stored_reconciliation.subject_linkage)
+
+        detail = service.inspect_alert_detail(admitted.alert.alert_id)
+        detail_subject_linkage = detail.latest_reconciliation["subject_linkage"]
+
+        self.assertIsInstance(detail_subject_linkage, dict)
+        self.assertNotIn("latest_native_payload", detail_subject_linkage)
+        self.assertEqual(
+            detail_subject_linkage["admission_provenance"],
+            {
+                "admission_channel": "live_wazuh_webhook",
+                "admission_kind": "live",
+            },
+        )
+
     def test_service_analyst_queue_ignores_newer_action_execution_reconciliation(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 import pathlib
@@ -3974,6 +3974,107 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(
             detail.lineage["reconciliation_id"],
             preferred_reconciliation.reconciliation_id,
+        )
+
+    def _persist_newer_non_wazuh_detection_reconciliation(
+        self,
+    ) -> tuple[
+        AegisOpsControlPlaneService,
+        object,
+        ReconciliationRecord,
+        ReconciliationRecord,
+    ]:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("agent-origin-alert.json")
+            ),
+        )
+        reconciliation = service.get_record(
+            ReconciliationRecord,
+            admitted.reconciliation.reconciliation_id,
+        )
+        self.assertIsNotNone(reconciliation)
+
+        subject_linkage = dict(reconciliation.subject_linkage)
+        subject_linkage["source_systems"] = ("opensearch",)
+        subject_linkage["substrate_detection_record_ids"] = (
+            "opensearch:1731594986.4931506",
+        )
+        newer_non_wazuh_reconciliation = replace(
+            reconciliation,
+            reconciliation_id=f"{reconciliation.reconciliation_id}-opensearch",
+            correlation_key=f"{reconciliation.correlation_key}:opensearch",
+            compared_at=reconciliation.compared_at + timedelta(minutes=5),
+            last_seen_at=(
+                reconciliation.last_seen_at + timedelta(minutes=5)
+                if reconciliation.last_seen_at is not None
+                else None
+            ),
+            subject_linkage=subject_linkage,
+        )
+        service.persist_record(newer_non_wazuh_reconciliation)
+
+        return (
+            service,
+            admitted,
+            reconciliation,
+            newer_non_wazuh_reconciliation,
+        )
+
+    def test_service_analyst_queue_keeps_latest_wazuh_detection_when_newer_non_wazuh_detection_exists(
+        self,
+    ) -> None:
+        (
+            service,
+            admitted,
+            reviewed_wazuh_reconciliation,
+            newer_non_wazuh_reconciliation,
+        ) = self._persist_newer_non_wazuh_detection_reconciliation()
+
+        queue_view = service.inspect_analyst_queue()
+
+        self.assertEqual(queue_view.total_records, 1)
+        self.assertEqual(queue_view.records[0]["alert_id"], admitted.alert.alert_id)
+        self.assertEqual(
+            queue_view.records[0]["correlation_key"],
+            reviewed_wazuh_reconciliation.correlation_key,
+        )
+        self.assertNotEqual(
+            queue_view.records[0]["correlation_key"],
+            newer_non_wazuh_reconciliation.correlation_key,
+        )
+
+    def test_service_alert_detail_keeps_latest_wazuh_detection_when_newer_non_wazuh_detection_exists(
+        self,
+    ) -> None:
+        (
+            service,
+            admitted,
+            reviewed_wazuh_reconciliation,
+            newer_non_wazuh_reconciliation,
+        ) = self._persist_newer_non_wazuh_detection_reconciliation()
+
+        detail = service.inspect_alert_detail(admitted.alert.alert_id)
+
+        self.assertEqual(
+            detail.latest_reconciliation["reconciliation_id"],
+            reviewed_wazuh_reconciliation.reconciliation_id,
+        )
+        self.assertEqual(
+            detail.lineage["reconciliation_id"],
+            reviewed_wazuh_reconciliation.reconciliation_id,
+        )
+        self.assertNotEqual(
+            detail.latest_reconciliation["reconciliation_id"],
+            newer_non_wazuh_reconciliation.reconciliation_id,
         )
 
     def test_service_alert_detail_reports_wazuh_when_origin_is_inferred_from_detection_ids(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -3881,8 +3881,10 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "microsoft_365_audit",
         )
 
-    def test_service_analyst_queue_accepts_mixed_case_wazuh_source_for_multi_source_linkage(
+    def _assert_service_analyst_queue_prefers_wazuh_source_for_multi_source_linkage(
         self,
+        *,
+        wazuh_source_system: str,
     ) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -3904,7 +3906,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertIsNotNone(reconciliation)
 
         subject_linkage = dict(reconciliation.subject_linkage)
-        subject_linkage["source_systems"] = ("opensearch", "WaZuH")
+        subject_linkage["source_systems"] = ("opensearch", wazuh_source_system)
         service.persist_record(
             replace(reconciliation, subject_linkage=subject_linkage)
         )
@@ -3913,6 +3915,20 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         self.assertEqual(queue_view.total_records, 1)
         self.assertEqual(queue_view.records[0]["source_system"], "wazuh")
+
+    def test_service_analyst_queue_prefers_explicit_wazuh_source_for_multi_source_linkage(
+        self,
+    ) -> None:
+        self._assert_service_analyst_queue_prefers_wazuh_source_for_multi_source_linkage(
+            wazuh_source_system="wazuh"
+        )
+
+    def test_service_analyst_queue_accepts_mixed_case_wazuh_source_for_multi_source_linkage(
+        self,
+    ) -> None:
+        self._assert_service_analyst_queue_prefers_wazuh_source_for_multi_source_linkage(
+            wazuh_source_system="WaZuH"
+        )
 
     def test_service_alert_detail_prefers_higher_reconciliation_id_when_compared_at_ties(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -3881,7 +3881,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "microsoft_365_audit",
         )
 
-    def test_service_analyst_queue_prefers_explicit_wazuh_source_for_multi_source_linkage(
+    def test_service_analyst_queue_accepts_mixed_case_wazuh_source_for_multi_source_linkage(
         self,
     ) -> None:
         store, _ = make_store()
@@ -3904,30 +3904,61 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertIsNotNone(reconciliation)
 
         subject_linkage = dict(reconciliation.subject_linkage)
-        subject_linkage["source_systems"] = ("opensearch", "wazuh")
+        subject_linkage["source_systems"] = ("opensearch", "WaZuH")
         service.persist_record(
-            ReconciliationRecord(
-                reconciliation_id=reconciliation.reconciliation_id,
-                subject_linkage=subject_linkage,
-                alert_id=reconciliation.alert_id,
-                finding_id=reconciliation.finding_id,
-                analytic_signal_id=reconciliation.analytic_signal_id,
-                execution_run_id=reconciliation.execution_run_id,
-                linked_execution_run_ids=reconciliation.linked_execution_run_ids,
-                correlation_key=reconciliation.correlation_key,
-                first_seen_at=reconciliation.first_seen_at,
-                last_seen_at=reconciliation.last_seen_at,
-                ingest_disposition=reconciliation.ingest_disposition,
-                mismatch_summary=reconciliation.mismatch_summary,
-                compared_at=reconciliation.compared_at,
-                lifecycle_state=reconciliation.lifecycle_state,
-            )
+            replace(reconciliation, subject_linkage=subject_linkage)
         )
 
         queue_view = service.inspect_analyst_queue()
 
         self.assertEqual(queue_view.total_records, 1)
         self.assertEqual(queue_view.records[0]["source_system"], "wazuh")
+
+    def test_service_alert_detail_prefers_higher_reconciliation_id_when_compared_at_ties(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("agent-origin-alert.json")
+            ),
+        )
+        reconciliation = service.get_record(
+            ReconciliationRecord,
+            admitted.reconciliation.reconciliation_id,
+        )
+        self.assertIsNotNone(reconciliation)
+
+        preferred_reconciliation = replace(
+            reconciliation,
+            reconciliation_id=f"{reconciliation.reconciliation_id}-z",
+            correlation_key=f"{reconciliation.correlation_key}:z",
+        )
+        service.persist_record(preferred_reconciliation)
+
+        queue_view = service.inspect_analyst_queue()
+        detail = service.inspect_alert_detail(admitted.alert.alert_id)
+
+        self.assertEqual(queue_view.total_records, 1)
+        self.assertEqual(
+            queue_view.records[0]["correlation_key"],
+            preferred_reconciliation.correlation_key,
+        )
+        self.assertEqual(
+            detail.latest_reconciliation["reconciliation_id"],
+            preferred_reconciliation.reconciliation_id,
+        )
+        self.assertEqual(
+            detail.lineage["reconciliation_id"],
+            preferred_reconciliation.reconciliation_id,
+        )
 
     def test_service_alert_detail_reports_wazuh_when_origin_is_inferred_from_detection_ids(
         self,
@@ -3953,23 +3984,11 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         subject_linkage = dict(reconciliation.subject_linkage)
         subject_linkage["source_systems"] = ("opensearch",)
+        subject_linkage["substrate_detection_record_ids"] = (
+            "WaZuH:1731594986.4931506",
+        )
         service.persist_record(
-            ReconciliationRecord(
-                reconciliation_id=reconciliation.reconciliation_id,
-                subject_linkage=subject_linkage,
-                alert_id=reconciliation.alert_id,
-                finding_id=reconciliation.finding_id,
-                analytic_signal_id=reconciliation.analytic_signal_id,
-                execution_run_id=reconciliation.execution_run_id,
-                linked_execution_run_ids=reconciliation.linked_execution_run_ids,
-                correlation_key=reconciliation.correlation_key,
-                first_seen_at=reconciliation.first_seen_at,
-                last_seen_at=reconciliation.last_seen_at,
-                ingest_disposition=reconciliation.ingest_disposition,
-                mismatch_summary=reconciliation.mismatch_summary,
-                compared_at=reconciliation.compared_at,
-                lifecycle_state=reconciliation.lifecycle_state,
-            )
+            replace(reconciliation, subject_linkage=subject_linkage)
         )
 
         detail = service.inspect_alert_detail(admitted.alert.alert_id)
@@ -3977,7 +3996,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(detail.source_system, "wazuh")
         self.assertEqual(
             detail.lineage["substrate_detection_record_ids"],
-            ("wazuh:1731594986.4931506",),
+            ("WaZuH:1731594986.4931506",),
         )
 
     def test_service_alert_detail_redacts_raw_native_payload_from_latest_reconciliation(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import hashlib
 import json
 import pathlib
+import secrets
 import sys
 from typing import Callable, Iterator
 import unittest
@@ -3983,20 +3984,22 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self,
     ) -> None:
         store, _ = make_store()
+        shared_secret = secrets.token_urlsafe(24)
+        reverse_proxy_secret = secrets.token_urlsafe(24)
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret=shared_secret,
+                wazuh_ingest_reverse_proxy_secret=reverse_proxy_secret,
             ),
             store=store,
         )
 
         admitted = service.ingest_wazuh_alert(
             raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
-            authorization_header="Bearer reviewed-shared-secret",
+            authorization_header=f"Bearer {shared_secret}",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header=reverse_proxy_secret,
             peer_addr="127.0.0.1",
         )
         stored_reconciliation = service.get_record(
@@ -4016,6 +4019,51 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             {
                 "admission_channel": "live_wazuh_webhook",
                 "admission_kind": "live",
+            },
+        )
+
+    def test_service_alert_detail_excludes_case_only_sibling_evidence(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("agent-origin-alert.json")
+            ),
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        sibling_evidence = EvidenceRecord(
+            evidence_id="evidence-case-sibling-001",
+            source_record_id="case-sibling-source-001",
+            alert_id="alert-sibling-001",
+            case_id=promoted_case.case_id,
+            source_system="wazuh",
+            collector_identity="collector://wazuh/live",
+            acquired_at=datetime(2026, 4, 11, 14, 0, tzinfo=timezone.utc),
+            derivation_relationship="correlated_case_context",
+            lifecycle_state="linked",
+        )
+        service.persist_record(sibling_evidence)
+
+        detail = service.inspect_alert_detail(admitted.alert.alert_id)
+
+        linked_evidence_ids = {
+            record["evidence_id"] for record in detail.linked_evidence_records
+        }
+
+        self.assertNotIn(sibling_evidence.evidence_id, linked_evidence_ids)
+        self.assertNotIn(sibling_evidence.evidence_id, detail.lineage["evidence_ids"])
+        self.assertEqual(
+            linked_evidence_ids,
+            {
+                evidence.evidence_id
+                for evidence in store.list(EvidenceRecord)
+                if evidence.alert_id == admitted.alert.alert_id
             },
         )
 

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -94,6 +94,36 @@ class _TransactionMutationStore:
             yield
 
 
+@dataclass
+class _ListCountingStore:
+    inner: object
+    reconciliation_list_calls: int = 0
+
+    @property
+    def dsn(self) -> str:
+        return self.inner.dsn
+
+    @property
+    def persistence_mode(self) -> str:
+        return self.inner.persistence_mode
+
+    def save(self, record: object) -> object:
+        return self.inner.save(record)
+
+    def get(self, record_type: object, record_id: str) -> object | None:
+        return self.inner.get(record_type, record_id)
+
+    def list(self, record_type: object) -> tuple[object, ...]:
+        if record_type is ReconciliationRecord:
+            self.reconciliation_list_calls += 1
+        return self.inner.list(record_type)
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        with self.inner.transaction():
+            yield
+
+
 class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_admits_wazuh_fixture_through_substrate_adapter_boundary(self) -> None:
         store, _ = make_store()
@@ -3952,6 +3982,34 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             admitted.reconciliation.correlation_key,
         )
         self.assertEqual(queue_view.records[0]["source_system"], "wazuh")
+
+    def test_service_analyst_queue_scans_reconciliations_once_for_multiple_alerts(self) -> None:
+        inner_store, _ = make_store()
+        store = _ListCountingStore(inner=inner_store)
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+
+        service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("agent-origin-alert.json")
+            ),
+        )
+        service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("github-audit-alert.json")
+            ),
+        )
+
+        store.reconciliation_list_calls = 0
+        queue_view = service.inspect_analyst_queue()
+
+        self.assertEqual(queue_view.total_records, 2)
+        self.assertEqual(store.reconciliation_list_calls, 1)
 
     def test_service_analyst_queue_sorts_unknown_last_seen_after_real_timestamps(
         self,


### PR DESCRIPTION
## What changed
- exposed the reviewed analyst queue runtime endpoint for the live Wazuh slice at `/inspect-analyst-queue`
- added a read-only reviewed alert-detail surface at `/inspect-alert-detail?alert_id=...` and the matching `inspect-alert-detail --alert-id ...` CLI command
- kept the detail view constrained to reviewed control-plane records, including linked case, signal, reconciliation, evidence, native rule, and live/replay provenance plus lineage summaries
- added focused CLI and long-running runtime tests covering the reviewed queue and alert-detail paths

## Why
Phase 19 needed a narrow AegisOps-native daily review path for the approved live Wazuh slice. Before this change, operators could inspect the reviewed queue snapshot but lacked the corresponding reviewed runtime alert-detail surface, which pushed first-pass review back toward substrate dashboards or CLI-only inspection.

## Impact
Operators can now review the approved live Wazuh analyst queue and open the minimum alert detail needed for first-pass triage without leaving the reviewed runtime surface.

## Validation
- `python3 -m unittest control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_reviewed_wazuh_alert_detail_view control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_long_running_runtime_surface_exposes_analyst_queue_and_alert_detail_http_views control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_wazuh_business_hours_analyst_queue_view control-plane.tests.test_phase18_live_wazuh_queue_validation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added alert-detail inspection via CLI and HTTP endpoint; returns read-only alert metadata, linked case/signal/evidence, provenance, latest reviewed detection reconciliation (raw native payload redacted), computed lineage, and inferred source_system (e.g., Wazuh); rejects blank alert IDs.
  * Analyst-queue inspection now ensures only detection-backed (Wazuh-origin) reconciliations are surfaced and derives queue source_system accordingly.

* **Tests**
  * Added integration and unit tests for endpoints/CLI validation, payload redaction, source-system inference, exclusion of case-only evidence, reconciliation selection/tiebreaking, and queue scanning efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->