### PR TITLE
Add bounded operator casework actions

### DIFF
--- a/.codex-supervisor/issues/397/issue-journal.md
+++ b/.codex-supervisor/issues/397/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #397: implementation: add bounded operator actions for case promotion, triage annotations, disposition, and handoff
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/397
+- Branch: codex/issue-397
+- Workspace: .
+- Journal: .codex-supervisor/issues/397/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 880ce696c0c989360b9ee4213ab694a9f23a2421
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T22:29:28.416Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Phase 19 was missing bounded service-layer operator actions for durable casework entry after alert promotion; raw `persist_record` existed, but there was no reviewed API or case-detail surface for observations, leads, disposition, and business-hours handoff metadata.
+- What changed: Added focused reproducing tests first, then implemented `record_case_observation`, `record_case_lead`, `record_case_recommendation`, `record_case_handoff`, and `record_case_disposition` on the control-plane service. Extended `inspect_case_detail` to return linked observation and lead identifiers/records alongside triage and handoff context merged into the case reviewed context. Tightened the CLI case-detail test to verify the new surface contract.
+- Current blocker: none
+- Next exact step: Commit this coherent checkpoint, then decide whether a follow-up is needed to expose bounded operator writes through an explicit runtime/API surface beyond the service layer.
+- Verification gap: Full `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` has not been run yet; verified the related service and CLI modules instead.
+- Files touched: control-plane/aegisops_control_plane/service.py; control-plane/tests/test_service_persistence.py; control-plane/tests/test_cli_inspection.py
+- Rollback concern: The implementation stores triage and handoff semantics inside `CaseRecord.reviewed_context`; if later issues formalize first-class fields for those semantics, this slice may need migration or reshaping.
+- Last focused command: python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/397/issue-journal.md
+++ b/.codex-supervisor/issues/397/issue-journal.md
@@ -5,29 +5,43 @@
 - Branch: codex/issue-397
 - Workspace: .
 - Journal: .codex-supervisor/issues/397/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 880ce696c0c989360b9ee4213ab694a9f23a2421
+- Current phase: stabilizing
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: dc9e027a779274703198b9af8bdb98872b9ebc2d
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-11T22:29:28.416Z
+- Updated at: 2026-04-11T22:38:53.361Z
 
 ## Latest Codex Summary
-- None yet.
+Implemented a bounded Phase 19 casework slice in the control-plane service and checkpointed it in `dc9e027` (`Add bounded operator casework actions`).
+
+The service now has explicit bounded operator actions for `record_case_observation`, `record_case_lead`, `record_case_recommendation`, `record_case_handoff`, and `record_case_disposition`, instead of relying on raw `persist_record`. `inspect_case_detail` now surfaces linked observations and leads, and the case reviewed context now carries reviewed triage and business-hours handoff metadata. I added a focused reproducer first, then tightened the CLI case-detail coverage so the reviewed surface proves the new artifacts show up.
+
+Verification ran clean on the related slice:
+`python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff`
+`python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_case_detail_with_evidence_provenance_and_cited_advisory_output`
+`python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence`
+
+Summary: Added bounded operator casework actions and exposed their outputs on the reviewed case-detail surface; committed as `dc9e027`.
+State hint: implementing
+Blocked reason: none
+Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_case_detail_with_evidence_provenance_and_cited_advisory_output`; `python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence`
+Next action: Decide whether to expose these bounded casework writes through an explicit runtime/API surface beyond the service layer, then run the full `control-plane/tests` discovery sweep if needed.
+Failure signature: none
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Phase 19 was missing bounded service-layer operator actions for durable casework entry after alert promotion; raw `persist_record` existed, but there was no reviewed API or case-detail surface for observations, leads, disposition, and business-hours handoff metadata.
-- What changed: Added focused reproducing tests first, then implemented `record_case_observation`, `record_case_lead`, `record_case_recommendation`, `record_case_handoff`, and `record_case_disposition` on the control-plane service. Extended `inspect_case_detail` to return linked observation and lead identifiers/records alongside triage and handoff context merged into the case reviewed context. Tightened the CLI case-detail test to verify the new surface contract.
+- Hypothesis: The remaining Phase 19 gap was not in the service layer anymore; it was the reviewed operator surface itself. Operators could inspect alert and case detail, but could not yet promote alerts or record bounded casework actions through the CLI/runtime surface.
+- What changed: Added explicit bounded operator commands and HTTP endpoints in `control-plane/main.py` for `promote-alert-to-case`, `record-case-observation`, `record-case-lead`, `record-case-recommendation`, `record-case-handoff`, and `record-case-disposition`. The runtime now accepts JSON POSTs for the same bounded actions under `/operator/*`, with strict string/list/datetime validation before delegating into the already-bounded service methods. Added focused CLI and HTTP tests that exercise the full promote-to-casework flow and verify the resulting reviewed case-detail state.
 - Current blocker: none
-- Next exact step: Commit this coherent checkpoint, then decide whether a follow-up is needed to expose bounded operator writes through an explicit runtime/API surface beyond the service layer.
-- Verification gap: Full `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` has not been run yet; verified the related service and CLI modules instead.
-- Files touched: control-plane/aegisops_control_plane/service.py; control-plane/tests/test_service_persistence.py; control-plane/tests/test_cli_inspection.py
-- Rollback concern: The implementation stores triage and handoff semantics inside `CaseRecord.reviewed_context`; if later issues formalize first-class fields for those semantics, this slice may need migration or reshaping.
-- Last focused command: python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence
+- Next exact step: Commit this coherent checkpoint, push `codex/issue-397`, and open a draft PR if one still does not exist.
+- Verification gap: none for the implemented slice; the focused operator-surface tests passed and the full `control-plane/tests` discovery sweep passed.
+- Files touched: control-plane/main.py; control-plane/tests/test_cli_inspection.py
+- Rollback concern: The new write surface intentionally mirrors current service semantics, so any future schema change to case triage or handoff metadata will require corresponding CLI/HTTP payload reshaping.
+- Last focused command: python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/397/issue-journal.md
+++ b/.codex-supervisor/issues/397/issue-journal.md
@@ -5,40 +5,43 @@
 - Branch: codex/issue-397
 - Workspace: .
 - Journal: .codex-supervisor/issues/397/issue-journal.md
-- Current phase: stabilizing
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: dc9e027a779274703198b9af8bdb98872b9ebc2d
+- Current phase: addressing_review
+- Attempt count: 3 (implementation=2, repair=1)
+- Last head SHA: 4268156614001516a59ddc673538e84ccc839983
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-11T22:38:53.361Z
+- Last failure signature: PRRT_kwDOR2iDUc56VJHY|PRRT_kwDOR2iDUc56VJHa|PRRT_kwDOR2iDUc56VJHc|PRRT_kwDOR2iDUc56VJHd|PRRT_kwDOR2iDUc56VJHe|PRRT_kwDOR2iDUc56VJHf
+- Repeated failure signature count: 1
+- Updated at: 2026-04-11T22:57:48.124Z
 
 ## Latest Codex Summary
-Implemented a bounded Phase 19 casework slice in the control-plane service and checkpointed it in `dc9e027` (`Add bounded operator casework actions`).
+Implemented the missing reviewed operator surface for Phase 19 casework on top of the existing service-layer methods. `control-plane/main.py` now exposes bounded CLI commands and matching runtime `POST /operator/*` endpoints for alert promotion, case observations, leads, recommendations, handoff notes, and disposition updates, with strict JSON/string/list/datetime validation before delegating into the control-plane service.
 
-The service now has explicit bounded operator actions for `record_case_observation`, `record_case_lead`, `record_case_recommendation`, `record_case_handoff`, and `record_case_disposition`, instead of relying on raw `persist_record`. `inspect_case_detail` now surfaces linked observations and leads, and the case reviewed context now carries reviewed triage and business-hours handoff metadata. I added a focused reproducer first, then tightened the CLI case-detail coverage so the reviewed surface proves the new artifacts show up.
+I added end-to-end CLI and HTTP tests in `control-plane/tests/test_cli_inspection.py` to prove the full promote-to-casework flow updates the case's reviewed context correctly. Verification passed, the changes are committed as `4268156` (`Expose bounded operator casework actions`), the branch is pushed, and PR [#402](https://github.com/TommyKammy/AegisOps/pull/402) is open.
 
-Verification ran clean on the related slice:
-`python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff`
-`python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_case_detail_with_evidence_provenance_and_cited_advisory_output`
-`python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence`
-
-Summary: Added bounded operator casework actions and exposed their outputs on the reviewed case-detail surface; committed as `dc9e027`.
-State hint: implementing
+Summary: Exposed bounded operator casework actions through the reviewed CLI/runtime surface, added end-to-end CLI/HTTP coverage, pushed `codex/issue-397`, and opened PR #402
+State hint: addressing_review
 Blocked reason: none
-Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_case_detail_with_evidence_provenance_and_cited_advisory_output`; `python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence`
-Next action: Decide whether to expose these bounded casework writes through an explicit runtime/API surface beyond the service layer, then run the full `control-plane/tests` discovery sweep if needed.
-Failure signature: none
+Tests: `python3 -m unittest control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_records_bounded_operator_casework_actions`; `python3 -m unittest control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_long_running_runtime_surface_records_bounded_operator_casework_actions`; `python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence`; `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+Next action: Address PR #402 follow-up review comments on operator auth, request-size handling, atomic case disposition updates, and journal wording, then rerun the focused operator-surface checks before pushing.
+Failure signature: PRRT_kwDOR2iDUc56VJHY|PRRT_kwDOR2iDUc56VJHa|PRRT_kwDOR2iDUc56VJHc|PRRT_kwDOR2iDUc56VJHd|PRRT_kwDOR2iDUc56VJHe|PRRT_kwDOR2iDUc56VJHf
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 6 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/AegisOps/pull/402#discussion_r3068705305
+- Details:
+  - .codex-supervisor/issues/397/issue-journal.md:19 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Clarify awkward phrasing in the summary sentence.** Line 19 reads as a broken compound phrase (“case reviewed context”). url=https://github.com/TommyKammy/AegisOps/pull/402#discussion_r3068705305
+  - .codex-supervisor/issues/397/issue-journal.md:30 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Update stale “Next action” note to match current state.** Line 30 suggests deciding whether to expose bounded writes beyond the service layer... url=https://github.com/TommyKammy/AegisOps/pull/402#discussion_r3068705309
+  - control-plane/aegisops_control_plane/service.py:2184 summary=_⚠️ Potential issue_ | _🟠 Major_ **Wrap multi-record updates in a transaction for atomicity.** This method persists the case record and conditionally persists the alert record ... url=https://github.com/TommyKammy/AegisOps/pull/402#discussion_r3068705311
+  - control-plane/main.py:103 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Differentiate oversized bodies from malformed JSON.** `_read_json_request_body()` raises `ValueError` for size overruns, and every `/operator... url=https://github.com/TommyKammy/AegisOps/pull/402#discussion_r3068705312
+  - control-plane/main.py:620 summary=_⚠️ Potential issue_ | _🔴 Critical_ **Protect `/operator/*` before shipping it.** These handlers are anonymous write APIs right now. url=https://github.com/TommyKammy/AegisOps/pull/402#discussion_r3068705313
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The remaining Phase 19 gap was not in the service layer anymore; it was the reviewed operator surface itself. Operators could inspect alert and case detail, but could not yet promote alerts or record bounded casework actions through the CLI/runtime surface.
 - What changed: Added explicit bounded operator commands and HTTP endpoints in `control-plane/main.py` for `promote-alert-to-case`, `record-case-observation`, `record-case-lead`, `record-case-recommendation`, `record-case-handoff`, and `record-case-disposition`. The runtime now accepts JSON POSTs for the same bounded actions under `/operator/*`, with strict string/list/datetime validation before delegating into the already-bounded service methods. Added focused CLI and HTTP tests that exercise the full promote-to-casework flow and verify the resulting reviewed case-detail state.
-- Current blocker: none
-- Next exact step: Commit this coherent checkpoint, push `codex/issue-397`, and open a draft PR if one still does not exist.
+- Current blocker: CodeRabbit follow-up comments on operator-surface hardening and journal wording.
+- Next exact step: Finish the operator-surface review fixes, rerun the focused CLI/runtime checks, commit the repair on `codex/issue-397`, and push PR #402 for another review pass.
 - Verification gap: none for the implemented slice; the focused operator-surface tests passed and the full `control-plane/tests` discovery sweep passed.
 - Files touched: control-plane/main.py; control-plane/tests/test_cli_inspection.py
 - Rollback concern: The new write surface intentionally mirrors current service semantics, so any future schema change to case triage or handoff metadata will require corresponding CLI/HTTP payload reshaping.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2111,32 +2111,34 @@ class AegisOpsControlPlaneService:
             follow_up_evidence_ids,
             "follow_up_evidence_ids",
         )
-        self._validate_case_evidence_linkage(
-            case=case,
-            evidence_ids=normalized_evidence_ids,
-            field_name="follow_up_evidence_ids",
-        )
-        updated_reviewed_context = _merge_reviewed_context(
-            case.reviewed_context,
-            {
-                "handoff": {
-                    "handoff_at": handoff_at.isoformat(),
-                    "handoff_owner": handoff_owner,
-                    "note": handoff_note,
-                    "follow_up_evidence_ids": normalized_evidence_ids,
-                }
-            },
-        )
-        return self.persist_record(
-            CaseRecord(
-                case_id=case.case_id,
-                alert_id=case.alert_id,
-                finding_id=case.finding_id,
-                evidence_ids=case.evidence_ids,
-                lifecycle_state=case.lifecycle_state,
-                reviewed_context=updated_reviewed_context,
+        with self._store.transaction():
+            case = self._require_case_record(case_id)
+            self._validate_case_evidence_linkage(
+                case=case,
+                evidence_ids=normalized_evidence_ids,
+                field_name="follow_up_evidence_ids",
             )
-        )
+            updated_reviewed_context = _merge_reviewed_context(
+                case.reviewed_context,
+                {
+                    "handoff": {
+                        "handoff_at": handoff_at.isoformat(),
+                        "handoff_owner": handoff_owner,
+                        "note": handoff_note,
+                        "follow_up_evidence_ids": normalized_evidence_ids,
+                    }
+                },
+            )
+            return self.persist_record(
+                CaseRecord(
+                    case_id=case.case_id,
+                    alert_id=case.alert_id,
+                    finding_id=case.finding_id,
+                    evidence_ids=case.evidence_ids,
+                    lifecycle_state=case.lifecycle_state,
+                    reviewed_context=updated_reviewed_context,
+                )
+            )
 
     def record_case_disposition(
         self,
@@ -2146,22 +2148,22 @@ class AegisOpsControlPlaneService:
         rationale: str,
         recorded_at: datetime,
     ) -> CaseRecord:
-        case = self._require_case_record(case_id)
         disposition = self._require_non_empty_string(disposition, "disposition")
         rationale = self._require_non_empty_string(rationale, "rationale")
         recorded_at = self._require_aware_datetime(recorded_at, "recorded_at")
         lifecycle_state = self._case_lifecycle_for_disposition(disposition)
-        updated_reviewed_context = _merge_reviewed_context(
-            case.reviewed_context,
-            {
-                "triage": {
-                    "disposition": disposition,
-                    "closure_rationale": rationale,
-                    "recorded_at": recorded_at.isoformat(),
-                }
-            },
-        )
         with self._store.transaction():
+            case = self._require_case_record(case_id)
+            updated_reviewed_context = _merge_reviewed_context(
+                case.reviewed_context,
+                {
+                    "triage": {
+                        "disposition": disposition,
+                        "closure_rationale": rationale,
+                        "recorded_at": recorded_at.isoformat(),
+                    }
+                },
+            )
             updated_case = self.persist_record(
                 CaseRecord(
                     case_id=case.case_id,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2782,7 +2782,10 @@ class AegisOpsControlPlaneService:
     ) -> str:
         normalized_id = self._normalize_optional_string(requested_id, field_name)
         if normalized_id is None:
-            return self._next_identifier(prefix)
+            generated_id = self._next_identifier(prefix)
+            if self._store.get(record_type, generated_id) is not None:
+                raise ValueError(f"{field_name} {generated_id!r} already exists")
+            return generated_id
         if self._store.get(record_type, normalized_id) is not None:
             raise ValueError(f"{field_name} {normalized_id!r} already exists")
         return normalized_id

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1960,31 +1960,33 @@ class AegisOpsControlPlaneService:
             supporting_evidence_ids,
             "supporting_evidence_ids",
         )
-        self._validate_case_evidence_linkage(
-            case=case,
-            evidence_ids=normalized_evidence_ids,
-            field_name="supporting_evidence_ids",
-        )
-        resolved_observation_id = self._resolve_new_record_identifier(
-            ObservationRecord,
-            observation_id,
-            "observation_id",
-            "observation",
-        )
-        return self.persist_record(
-            ObservationRecord(
-                observation_id=resolved_observation_id,
-                hunt_id=None,
-                hunt_run_id=None,
-                alert_id=case.alert_id,
-                case_id=case.case_id,
-                supporting_evidence_ids=normalized_evidence_ids,
-                author_identity=author_identity,
-                observed_at=observed_at,
-                scope_statement=scope_statement,
-                lifecycle_state=lifecycle_state,
+        with self._store.transaction():
+            case = self._require_case_record(case_id)
+            self._validate_case_evidence_linkage(
+                case=case,
+                evidence_ids=normalized_evidence_ids,
+                field_name="supporting_evidence_ids",
             )
-        )
+            resolved_observation_id = self._resolve_new_record_identifier(
+                ObservationRecord,
+                observation_id,
+                "observation_id",
+                "observation",
+            )
+            return self.persist_record(
+                ObservationRecord(
+                    observation_id=resolved_observation_id,
+                    hunt_id=None,
+                    hunt_run_id=None,
+                    alert_id=case.alert_id,
+                    case_id=case.case_id,
+                    supporting_evidence_ids=normalized_evidence_ids,
+                    author_identity=author_identity,
+                    observed_at=observed_at,
+                    scope_statement=scope_statement,
+                    lifecycle_state=lifecycle_state,
+                )
+            )
 
     def record_case_lead(
         self,
@@ -1996,7 +1998,6 @@ class AegisOpsControlPlaneService:
         lead_id: str | None = None,
         lifecycle_state: str = "triaged",
     ) -> LeadRecord:
-        case = self._require_case_record(case_id)
         triage_owner = self._require_non_empty_string(triage_owner, "triage_owner")
         triage_rationale = self._require_non_empty_string(
             triage_rationale,
@@ -2010,35 +2011,37 @@ class AegisOpsControlPlaneService:
             observation_id,
             "observation_id",
         )
-        if resolved_observation_id is not None:
-            observation = self._store.get(ObservationRecord, resolved_observation_id)
-            if observation is None:
-                raise LookupError(f"Missing observation {resolved_observation_id!r}")
-            if observation.case_id != case.case_id:
-                raise ValueError(
-                    f"Observation {resolved_observation_id!r} is not linked to case "
-                    f"{case.case_id!r}"
-                )
+        with self._store.transaction():
+            case = self._require_case_record(case_id)
+            if resolved_observation_id is not None:
+                observation = self._store.get(ObservationRecord, resolved_observation_id)
+                if observation is None:
+                    raise LookupError(f"Missing observation {resolved_observation_id!r}")
+                if observation.case_id != case.case_id:
+                    raise ValueError(
+                        f"Observation {resolved_observation_id!r} is not linked to case "
+                        f"{case.case_id!r}"
+                    )
 
-        resolved_lead_id = self._resolve_new_record_identifier(
-            LeadRecord,
-            lead_id,
-            "lead_id",
-            "lead",
-        )
-        return self.persist_record(
-            LeadRecord(
-                lead_id=resolved_lead_id,
-                observation_id=resolved_observation_id,
-                finding_id=case.finding_id,
-                hunt_run_id=None,
-                alert_id=case.alert_id,
-                case_id=case.case_id,
-                triage_owner=triage_owner,
-                triage_rationale=triage_rationale,
-                lifecycle_state=lifecycle_state,
+            resolved_lead_id = self._resolve_new_record_identifier(
+                LeadRecord,
+                lead_id,
+                "lead_id",
+                "lead",
             )
-        )
+            return self.persist_record(
+                LeadRecord(
+                    lead_id=resolved_lead_id,
+                    observation_id=resolved_observation_id,
+                    finding_id=case.finding_id,
+                    hunt_run_id=None,
+                    alert_id=case.alert_id,
+                    case_id=case.case_id,
+                    triage_owner=triage_owner,
+                    triage_rationale=triage_rationale,
+                    lifecycle_state=lifecycle_state,
+                )
+            )
 
     def record_case_recommendation(
         self,
@@ -2050,7 +2053,6 @@ class AegisOpsControlPlaneService:
         recommendation_id: str | None = None,
         lifecycle_state: str = "under_review",
     ) -> RecommendationRecord:
-        case = self._require_case_record(case_id)
         review_owner = self._require_non_empty_string(review_owner, "review_owner")
         intended_outcome = self._require_non_empty_string(
             intended_outcome,
@@ -2061,35 +2063,37 @@ class AegisOpsControlPlaneService:
             "lifecycle_state",
         )
         resolved_lead_id = self._normalize_optional_string(lead_id, "lead_id")
-        if resolved_lead_id is not None:
-            lead = self._store.get(LeadRecord, resolved_lead_id)
-            if lead is None:
-                raise LookupError(f"Missing lead {resolved_lead_id!r}")
-            if lead.case_id != case.case_id:
-                raise ValueError(
-                    f"Lead {resolved_lead_id!r} is not linked to case {case.case_id!r}"
-                )
+        with self._store.transaction():
+            case = self._require_case_record(case_id)
+            if resolved_lead_id is not None:
+                lead = self._store.get(LeadRecord, resolved_lead_id)
+                if lead is None:
+                    raise LookupError(f"Missing lead {resolved_lead_id!r}")
+                if lead.case_id != case.case_id:
+                    raise ValueError(
+                        f"Lead {resolved_lead_id!r} is not linked to case {case.case_id!r}"
+                    )
 
-        resolved_recommendation_id = self._resolve_new_record_identifier(
-            RecommendationRecord,
-            recommendation_id,
-            "recommendation_id",
-            "recommendation",
-        )
-        return self.persist_record(
-            RecommendationRecord(
-                recommendation_id=resolved_recommendation_id,
-                lead_id=resolved_lead_id,
-                hunt_run_id=None,
-                alert_id=case.alert_id,
-                case_id=case.case_id,
-                ai_trace_id=None,
-                review_owner=review_owner,
-                intended_outcome=intended_outcome,
-                lifecycle_state=lifecycle_state,
-                reviewed_context=case.reviewed_context,
+            resolved_recommendation_id = self._resolve_new_record_identifier(
+                RecommendationRecord,
+                recommendation_id,
+                "recommendation_id",
+                "recommendation",
             )
-        )
+            return self.persist_record(
+                RecommendationRecord(
+                    recommendation_id=resolved_recommendation_id,
+                    lead_id=resolved_lead_id,
+                    hunt_run_id=None,
+                    alert_id=case.alert_id,
+                    case_id=case.case_id,
+                    ai_trace_id=None,
+                    review_owner=review_owner,
+                    intended_outcome=intended_outcome,
+                    lifecycle_state=lifecycle_state,
+                    reviewed_context=case.reviewed_context,
+                )
+            )
 
     def record_case_handoff(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2155,32 +2155,33 @@ class AegisOpsControlPlaneService:
                 }
             },
         )
-        updated_case = self.persist_record(
-            CaseRecord(
-                case_id=case.case_id,
-                alert_id=case.alert_id,
-                finding_id=case.finding_id,
-                evidence_ids=case.evidence_ids,
-                lifecycle_state=lifecycle_state,
-                reviewed_context=updated_reviewed_context,
-            )
-        )
-        if case.alert_id is not None and lifecycle_state == "closed":
-            alert = self._store.get(AlertRecord, case.alert_id)
-            if alert is not None:
-                self.persist_record(
-                    AlertRecord(
-                        alert_id=alert.alert_id,
-                        finding_id=alert.finding_id,
-                        analytic_signal_id=alert.analytic_signal_id,
-                        case_id=alert.case_id,
-                        lifecycle_state="closed",
-                        reviewed_context=_merge_reviewed_context(
-                            alert.reviewed_context,
-                            {"triage": updated_reviewed_context.get("triage", {})},
-                        ),
-                    )
+        with self._store.transaction():
+            updated_case = self.persist_record(
+                CaseRecord(
+                    case_id=case.case_id,
+                    alert_id=case.alert_id,
+                    finding_id=case.finding_id,
+                    evidence_ids=case.evidence_ids,
+                    lifecycle_state=lifecycle_state,
+                    reviewed_context=updated_reviewed_context,
                 )
+            )
+            if case.alert_id is not None and lifecycle_state == "closed":
+                alert = self._store.get(AlertRecord, case.alert_id)
+                if alert is not None:
+                    self.persist_record(
+                        AlertRecord(
+                            alert_id=alert.alert_id,
+                            finding_id=alert.finding_id,
+                            analytic_signal_id=alert.analytic_signal_id,
+                            case_id=alert.case_id,
+                            lifecycle_state="closed",
+                            reviewed_context=_merge_reviewed_context(
+                                alert.reviewed_context,
+                                {"triage": updated_reviewed_context.get("triage", {})},
+                            ),
+                        )
+                    )
         return updated_case
 
     def inspect_advisory_output(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1965,9 +1965,11 @@ class AegisOpsControlPlaneService:
             evidence_ids=normalized_evidence_ids,
             field_name="supporting_evidence_ids",
         )
-        resolved_observation_id = (
-            self._normalize_optional_string(observation_id, "observation_id")
-            or self._next_identifier("observation")
+        resolved_observation_id = self._resolve_new_record_identifier(
+            ObservationRecord,
+            observation_id,
+            "observation_id",
+            "observation",
         )
         return self.persist_record(
             ObservationRecord(
@@ -2018,9 +2020,11 @@ class AegisOpsControlPlaneService:
                     f"{case.case_id!r}"
                 )
 
-        resolved_lead_id = (
-            self._normalize_optional_string(lead_id, "lead_id")
-            or self._next_identifier("lead")
+        resolved_lead_id = self._resolve_new_record_identifier(
+            LeadRecord,
+            lead_id,
+            "lead_id",
+            "lead",
         )
         return self.persist_record(
             LeadRecord(
@@ -2066,9 +2070,11 @@ class AegisOpsControlPlaneService:
                     f"Lead {resolved_lead_id!r} is not linked to case {case.case_id!r}"
                 )
 
-        resolved_recommendation_id = (
-            self._normalize_optional_string(recommendation_id, "recommendation_id")
-            or self._next_identifier("recommendation")
+        resolved_recommendation_id = self._resolve_new_record_identifier(
+            RecommendationRecord,
+            recommendation_id,
+            "recommendation_id",
+            "recommendation",
         )
         return self.persist_record(
             RecommendationRecord(
@@ -2752,10 +2758,7 @@ class AegisOpsControlPlaneService:
         return value
 
     @staticmethod
-    def _normalize_optional_string(
-        value: object,
-        field_name: str,
-    ) -> str | None:
+    def _normalize_optional_string(value: object, field_name: str) -> str | None:
         if value is None:
             return None
         if not isinstance(value, str):
@@ -2763,6 +2766,20 @@ class AegisOpsControlPlaneService:
         if not value.strip():
             return None
         return value
+
+    def _resolve_new_record_identifier(
+        self,
+        record_type: Type[RecordT],
+        requested_id: object,
+        field_name: str,
+        prefix: str,
+    ) -> str:
+        normalized_id = self._normalize_optional_string(requested_id, field_name)
+        if normalized_id is None:
+            return self._next_identifier(prefix)
+        if self._store.get(record_type, normalized_id) is not None:
+            raise ValueError(f"{field_name} {normalized_id!r} already exists")
+        return normalized_id
 
     def ingest_finding_alert(
         self,
@@ -3948,7 +3965,9 @@ class AegisOpsControlPlaneService:
             "pending_approval",
         }:
             return "pending_action"
-        return "investigating"
+        if disposition == "investigating":
+            return "investigating"
+        raise ValueError(f"Unsupported case disposition {disposition!r}")
 
     @staticmethod
     def _normalize_substrate_detection_record_id(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -197,10 +197,14 @@ class CaseDetailSnapshot:
     advisory_output: dict[str, object]
     reviewed_context: dict[str, object]
     linked_alert_ids: tuple[str, ...]
+    linked_observation_ids: tuple[str, ...]
+    linked_lead_ids: tuple[str, ...]
     linked_evidence_ids: tuple[str, ...]
     linked_recommendation_ids: tuple[str, ...]
     linked_reconciliation_ids: tuple[str, ...]
     linked_alert_records: tuple[dict[str, object], ...]
+    linked_observation_records: tuple[dict[str, object], ...]
+    linked_lead_records: tuple[dict[str, object], ...]
     linked_evidence_records: tuple[dict[str, object], ...]
     linked_recommendation_records: tuple[dict[str, object], ...]
     linked_reconciliation_records: tuple[dict[str, object], ...]
@@ -214,10 +218,14 @@ class CaseDetailSnapshot:
                 "advisory_output": self.advisory_output,
                 "reviewed_context": self.reviewed_context,
                 "linked_alert_ids": self.linked_alert_ids,
+                "linked_observation_ids": self.linked_observation_ids,
+                "linked_lead_ids": self.linked_lead_ids,
                 "linked_evidence_ids": self.linked_evidence_ids,
                 "linked_recommendation_ids": self.linked_recommendation_ids,
                 "linked_reconciliation_ids": self.linked_reconciliation_ids,
                 "linked_alert_records": self.linked_alert_records,
+                "linked_observation_records": self.linked_observation_records,
+                "linked_lead_records": self.linked_lead_records,
                 "linked_evidence_records": self.linked_evidence_records,
                 "linked_recommendation_records": self.linked_recommendation_records,
                 "linked_reconciliation_records": self.linked_reconciliation_records,
@@ -1893,6 +1901,14 @@ class AegisOpsControlPlaneService:
     def inspect_case_detail(self, case_id: str) -> CaseDetailSnapshot:
         case_id = self._require_non_empty_string(case_id, "case_id")
         context_snapshot = self.inspect_assistant_context("case", case_id)
+        observation_records = tuple(
+            _record_to_dict(record)
+            for record in self._observations_for_case(case_id)
+        )
+        lead_records = tuple(
+            _record_to_dict(record)
+            for record in self._leads_for_case(case_id)
+        )
         return CaseDetailSnapshot(
             read_only=True,
             case_id=case_id,
@@ -1900,14 +1916,272 @@ class AegisOpsControlPlaneService:
             advisory_output=dict(context_snapshot.advisory_output),
             reviewed_context=dict(context_snapshot.reviewed_context),
             linked_alert_ids=context_snapshot.linked_alert_ids,
+            linked_observation_ids=tuple(
+                record["observation_id"] for record in observation_records
+            ),
+            linked_lead_ids=tuple(record["lead_id"] for record in lead_records),
             linked_evidence_ids=context_snapshot.linked_evidence_ids,
             linked_recommendation_ids=context_snapshot.linked_recommendation_ids,
             linked_reconciliation_ids=context_snapshot.linked_reconciliation_ids,
             linked_alert_records=context_snapshot.linked_alert_records,
+            linked_observation_records=observation_records,
+            linked_lead_records=lead_records,
             linked_evidence_records=context_snapshot.linked_evidence_records,
             linked_recommendation_records=context_snapshot.linked_recommendation_records,
             linked_reconciliation_records=context_snapshot.linked_reconciliation_records,
         )
+
+    def record_case_observation(
+        self,
+        *,
+        case_id: str,
+        author_identity: str,
+        observed_at: datetime,
+        scope_statement: str,
+        supporting_evidence_ids: tuple[str, ...] = (),
+        observation_id: str | None = None,
+        lifecycle_state: str = "confirmed",
+    ) -> ObservationRecord:
+        case = self._require_case_record(case_id)
+        author_identity = self._require_non_empty_string(
+            author_identity,
+            "author_identity",
+        )
+        observed_at = self._require_aware_datetime(observed_at, "observed_at")
+        scope_statement = self._require_non_empty_string(
+            scope_statement,
+            "scope_statement",
+        )
+        lifecycle_state = self._require_non_empty_string(
+            lifecycle_state,
+            "lifecycle_state",
+        )
+        normalized_evidence_ids = self._normalize_linked_record_ids(
+            supporting_evidence_ids,
+            "supporting_evidence_ids",
+        )
+        self._validate_case_evidence_linkage(
+            case=case,
+            evidence_ids=normalized_evidence_ids,
+            field_name="supporting_evidence_ids",
+        )
+        resolved_observation_id = (
+            self._normalize_optional_string(observation_id, "observation_id")
+            or self._next_identifier("observation")
+        )
+        return self.persist_record(
+            ObservationRecord(
+                observation_id=resolved_observation_id,
+                hunt_id=None,
+                hunt_run_id=None,
+                alert_id=case.alert_id,
+                case_id=case.case_id,
+                supporting_evidence_ids=normalized_evidence_ids,
+                author_identity=author_identity,
+                observed_at=observed_at,
+                scope_statement=scope_statement,
+                lifecycle_state=lifecycle_state,
+            )
+        )
+
+    def record_case_lead(
+        self,
+        *,
+        case_id: str,
+        triage_owner: str,
+        triage_rationale: str,
+        observation_id: str | None = None,
+        lead_id: str | None = None,
+        lifecycle_state: str = "triaged",
+    ) -> LeadRecord:
+        case = self._require_case_record(case_id)
+        triage_owner = self._require_non_empty_string(triage_owner, "triage_owner")
+        triage_rationale = self._require_non_empty_string(
+            triage_rationale,
+            "triage_rationale",
+        )
+        lifecycle_state = self._require_non_empty_string(
+            lifecycle_state,
+            "lifecycle_state",
+        )
+        resolved_observation_id = self._normalize_optional_string(
+            observation_id,
+            "observation_id",
+        )
+        if resolved_observation_id is not None:
+            observation = self._store.get(ObservationRecord, resolved_observation_id)
+            if observation is None:
+                raise LookupError(f"Missing observation {resolved_observation_id!r}")
+            if observation.case_id != case.case_id:
+                raise ValueError(
+                    f"Observation {resolved_observation_id!r} is not linked to case "
+                    f"{case.case_id!r}"
+                )
+
+        resolved_lead_id = (
+            self._normalize_optional_string(lead_id, "lead_id")
+            or self._next_identifier("lead")
+        )
+        return self.persist_record(
+            LeadRecord(
+                lead_id=resolved_lead_id,
+                observation_id=resolved_observation_id,
+                finding_id=case.finding_id,
+                hunt_run_id=None,
+                alert_id=case.alert_id,
+                case_id=case.case_id,
+                triage_owner=triage_owner,
+                triage_rationale=triage_rationale,
+                lifecycle_state=lifecycle_state,
+            )
+        )
+
+    def record_case_recommendation(
+        self,
+        *,
+        case_id: str,
+        review_owner: str,
+        intended_outcome: str,
+        lead_id: str | None = None,
+        recommendation_id: str | None = None,
+        lifecycle_state: str = "under_review",
+    ) -> RecommendationRecord:
+        case = self._require_case_record(case_id)
+        review_owner = self._require_non_empty_string(review_owner, "review_owner")
+        intended_outcome = self._require_non_empty_string(
+            intended_outcome,
+            "intended_outcome",
+        )
+        lifecycle_state = self._require_non_empty_string(
+            lifecycle_state,
+            "lifecycle_state",
+        )
+        resolved_lead_id = self._normalize_optional_string(lead_id, "lead_id")
+        if resolved_lead_id is not None:
+            lead = self._store.get(LeadRecord, resolved_lead_id)
+            if lead is None:
+                raise LookupError(f"Missing lead {resolved_lead_id!r}")
+            if lead.case_id != case.case_id:
+                raise ValueError(
+                    f"Lead {resolved_lead_id!r} is not linked to case {case.case_id!r}"
+                )
+
+        resolved_recommendation_id = (
+            self._normalize_optional_string(recommendation_id, "recommendation_id")
+            or self._next_identifier("recommendation")
+        )
+        return self.persist_record(
+            RecommendationRecord(
+                recommendation_id=resolved_recommendation_id,
+                lead_id=resolved_lead_id,
+                hunt_run_id=None,
+                alert_id=case.alert_id,
+                case_id=case.case_id,
+                ai_trace_id=None,
+                review_owner=review_owner,
+                intended_outcome=intended_outcome,
+                lifecycle_state=lifecycle_state,
+                reviewed_context=case.reviewed_context,
+            )
+        )
+
+    def record_case_handoff(
+        self,
+        *,
+        case_id: str,
+        handoff_at: datetime,
+        handoff_owner: str,
+        handoff_note: str,
+        follow_up_evidence_ids: tuple[str, ...] = (),
+    ) -> CaseRecord:
+        case = self._require_case_record(case_id)
+        handoff_at = self._require_aware_datetime(handoff_at, "handoff_at")
+        handoff_owner = self._require_non_empty_string(
+            handoff_owner,
+            "handoff_owner",
+        )
+        handoff_note = self._require_non_empty_string(handoff_note, "handoff_note")
+        normalized_evidence_ids = self._normalize_linked_record_ids(
+            follow_up_evidence_ids,
+            "follow_up_evidence_ids",
+        )
+        self._validate_case_evidence_linkage(
+            case=case,
+            evidence_ids=normalized_evidence_ids,
+            field_name="follow_up_evidence_ids",
+        )
+        updated_reviewed_context = _merge_reviewed_context(
+            case.reviewed_context,
+            {
+                "handoff": {
+                    "handoff_at": handoff_at.isoformat(),
+                    "handoff_owner": handoff_owner,
+                    "note": handoff_note,
+                    "follow_up_evidence_ids": normalized_evidence_ids,
+                }
+            },
+        )
+        return self.persist_record(
+            CaseRecord(
+                case_id=case.case_id,
+                alert_id=case.alert_id,
+                finding_id=case.finding_id,
+                evidence_ids=case.evidence_ids,
+                lifecycle_state=case.lifecycle_state,
+                reviewed_context=updated_reviewed_context,
+            )
+        )
+
+    def record_case_disposition(
+        self,
+        *,
+        case_id: str,
+        disposition: str,
+        rationale: str,
+        recorded_at: datetime,
+    ) -> CaseRecord:
+        case = self._require_case_record(case_id)
+        disposition = self._require_non_empty_string(disposition, "disposition")
+        rationale = self._require_non_empty_string(rationale, "rationale")
+        recorded_at = self._require_aware_datetime(recorded_at, "recorded_at")
+        lifecycle_state = self._case_lifecycle_for_disposition(disposition)
+        updated_reviewed_context = _merge_reviewed_context(
+            case.reviewed_context,
+            {
+                "triage": {
+                    "disposition": disposition,
+                    "closure_rationale": rationale,
+                    "recorded_at": recorded_at.isoformat(),
+                }
+            },
+        )
+        updated_case = self.persist_record(
+            CaseRecord(
+                case_id=case.case_id,
+                alert_id=case.alert_id,
+                finding_id=case.finding_id,
+                evidence_ids=case.evidence_ids,
+                lifecycle_state=lifecycle_state,
+                reviewed_context=updated_reviewed_context,
+            )
+        )
+        if case.alert_id is not None and lifecycle_state == "closed":
+            alert = self._store.get(AlertRecord, case.alert_id)
+            if alert is not None:
+                self.persist_record(
+                    AlertRecord(
+                        alert_id=alert.alert_id,
+                        finding_id=alert.finding_id,
+                        analytic_signal_id=alert.analytic_signal_id,
+                        case_id=alert.case_id,
+                        lifecycle_state="closed",
+                        reviewed_context=_merge_reviewed_context(
+                            alert.reviewed_context,
+                            {"triage": updated_reviewed_context.get("triage", {})},
+                        ),
+                    )
+                )
+        return updated_case
 
     def inspect_advisory_output(
         self,
@@ -3592,6 +3866,88 @@ class AegisOpsControlPlaneService:
             )
         )
         return f"analytic-signal-{uuid.uuid5(uuid.NAMESPACE_URL, mint_material)}"
+
+    def _require_case_record(self, case_id: str) -> CaseRecord:
+        case_id = self._require_non_empty_string(case_id, "case_id")
+        case = self._store.get(CaseRecord, case_id)
+        if case is None:
+            raise LookupError(f"Missing case {case_id!r}")
+        return case
+
+    def _normalize_linked_record_ids(
+        self,
+        record_ids: tuple[str, ...],
+        field_name: str,
+    ) -> tuple[str, ...]:
+        normalized_ids: tuple[str, ...] = ()
+        for record_id in record_ids:
+            normalized_id = self._require_non_empty_string(record_id, field_name)
+            normalized_ids = self._merge_linked_ids(normalized_ids, normalized_id)
+        return normalized_ids
+
+    def _validate_case_evidence_linkage(
+        self,
+        *,
+        case: CaseRecord,
+        evidence_ids: tuple[str, ...],
+        field_name: str,
+    ) -> None:
+        for evidence_id in evidence_ids:
+            evidence = self._store.get(EvidenceRecord, evidence_id)
+            if evidence is None:
+                raise LookupError(f"Missing evidence {evidence_id!r}")
+            if evidence.case_id not in {None, case.case_id}:
+                raise ValueError(
+                    f"{field_name} contains evidence {evidence_id!r} linked to "
+                    f"different case {evidence.case_id!r}"
+                )
+            if evidence.case_id is None and evidence.alert_id != case.alert_id:
+                raise ValueError(
+                    f"{field_name} contains evidence {evidence_id!r} that is not "
+                    f"linked to case {case.case_id!r} or its source alert"
+                )
+
+    def _observations_for_case(self, case_id: str) -> tuple[ObservationRecord, ...]:
+        return tuple(
+            sorted(
+                (
+                    record
+                    for record in self._store.list(ObservationRecord)
+                    if record.case_id == case_id
+                ),
+                key=lambda record: (record.observed_at, record.observation_id),
+            )
+        )
+
+    def _leads_for_case(self, case_id: str) -> tuple[LeadRecord, ...]:
+        return tuple(
+            sorted(
+                (
+                    record
+                    for record in self._store.list(LeadRecord)
+                    if record.case_id == case_id
+                ),
+                key=lambda record: record.lead_id,
+            )
+        )
+
+    @staticmethod
+    def _case_lifecycle_for_disposition(disposition: str) -> str:
+        if disposition in {
+            "closed_benign",
+            "closed_duplicate",
+            "closed_resolved",
+            "closed_accepted_risk",
+        }:
+            return "closed"
+        if disposition in {
+            "business_hours_handoff",
+            "awaiting_business_hours_review",
+            "pending_external_validation",
+            "pending_approval",
+        }:
+            return "pending_action"
+        return "investigating"
 
     @staticmethod
     def _normalize_substrate_detection_record_id(

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import fields, is_dataclass
+from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
@@ -21,6 +22,85 @@ MAX_WAZUH_INGEST_BODY_BYTES = 1_048_576
 
 def _normalize_alert_id(value: str) -> str:
     return value.strip()
+
+
+def _normalize_case_id(value: str) -> str:
+    return value.strip()
+
+
+def _normalize_optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("optional string fields must be JSON strings when provided")
+    normalized = value.strip()
+    return normalized or None
+
+
+def _require_json_string(payload: Mapping[str, object], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+def _require_json_string_sequence(
+    payload: Mapping[str, object],
+    field_name: str,
+) -> tuple[str, ...]:
+    value = payload.get(field_name, ())
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a JSON array of non-empty strings")
+    normalized_values: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{field_name} must be a JSON array of non-empty strings")
+        normalized_values.append(item.strip())
+    return tuple(normalized_values)
+
+
+def _parse_datetime_arg(value: str, field_name: str) -> datetime:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(f"{field_name} must be a non-empty ISO 8601 datetime")
+    try:
+        parsed = datetime.fromisoformat(normalized_value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be a valid ISO 8601 datetime") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone offset")
+    return parsed
+
+
+def _require_json_datetime(payload: Mapping[str, object], field_name: str) -> datetime:
+    value = payload.get(field_name)
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a non-empty ISO 8601 datetime")
+    return _parse_datetime_arg(value, field_name)
+
+
+def _read_json_request_body(handler: BaseHTTPRequestHandler) -> dict[str, object]:
+    try:
+        content_length = int(handler.headers.get("Content-Length", "0"))
+    except ValueError as exc:
+        raise ValueError("Content-Length must be an integer") from exc
+    if content_length <= 0:
+        raise ValueError("request body is required")
+    if content_length > MAX_WAZUH_INGEST_BODY_BYTES:
+        raise ValueError("request body exceeds the reviewed size limit")
+    try:
+        raw_payload = handler.rfile.read(content_length).decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("request body must be valid UTF-8 JSON") from exc
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"request body must be valid JSON: {exc.msg}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("request body must be a JSON object")
+    return payload
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -74,6 +154,82 @@ def _build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Control-plane case identifier to inspect.",
     )
+    promote_alert_to_case = subparsers.add_parser(
+        "promote-alert-to-case",
+        help="Promote one reviewed alert into durable bounded casework.",
+    )
+    promote_alert_to_case.add_argument(
+        "--alert-id",
+        required=True,
+        help="Control-plane alert identifier to promote.",
+    )
+    promote_alert_to_case.add_argument(
+        "--case-id",
+        help="Optional case identifier to reuse when linking the alert.",
+    )
+    promote_alert_to_case.add_argument(
+        "--case-lifecycle-state",
+        default="open",
+        help="Lifecycle state to apply when the case is first created.",
+    )
+    record_case_observation = subparsers.add_parser(
+        "record-case-observation",
+        help="Record a bounded reviewed case observation.",
+    )
+    record_case_observation.add_argument("--case-id", required=True)
+    record_case_observation.add_argument("--author-identity", required=True)
+    record_case_observation.add_argument("--observed-at", required=True)
+    record_case_observation.add_argument("--scope-statement", required=True)
+    record_case_observation.add_argument(
+        "--supporting-evidence-id",
+        action="append",
+        default=[],
+        help="Supporting evidence identifier to link; may be repeated.",
+    )
+    record_case_lead = subparsers.add_parser(
+        "record-case-lead",
+        help="Record a bounded reviewed triage lead for a case.",
+    )
+    record_case_lead.add_argument("--case-id", required=True)
+    record_case_lead.add_argument("--triage-owner", required=True)
+    record_case_lead.add_argument("--triage-rationale", required=True)
+    record_case_lead.add_argument(
+        "--observation-id",
+        help="Optional observation identifier to anchor the lead.",
+    )
+    record_case_recommendation = subparsers.add_parser(
+        "record-case-recommendation",
+        help="Record a bounded reviewed recommendation for a case.",
+    )
+    record_case_recommendation.add_argument("--case-id", required=True)
+    record_case_recommendation.add_argument("--review-owner", required=True)
+    record_case_recommendation.add_argument("--intended-outcome", required=True)
+    record_case_recommendation.add_argument(
+        "--lead-id",
+        help="Optional lead identifier to anchor the recommendation.",
+    )
+    record_case_handoff = subparsers.add_parser(
+        "record-case-handoff",
+        help="Record a bounded business-hours handoff note for a case.",
+    )
+    record_case_handoff.add_argument("--case-id", required=True)
+    record_case_handoff.add_argument("--handoff-at", required=True)
+    record_case_handoff.add_argument("--handoff-owner", required=True)
+    record_case_handoff.add_argument("--handoff-note", required=True)
+    record_case_handoff.add_argument(
+        "--follow-up-evidence-id",
+        action="append",
+        default=[],
+        help="Follow-up evidence identifier to link; may be repeated.",
+    )
+    record_case_disposition = subparsers.add_parser(
+        "record-case-disposition",
+        help="Record a bounded reviewed case disposition or closure state.",
+    )
+    record_case_disposition.add_argument("--case-id", required=True)
+    record_case_disposition.add_argument("--disposition", required=True)
+    record_case_disposition.add_argument("--rationale", required=True)
+    record_case_disposition.add_argument("--recorded-at", required=True)
     inspect_assistant_context = subparsers.add_parser(
         "inspect-assistant-context",
         help="Render a read-only analyst-assistant context view for one record.",
@@ -234,7 +390,9 @@ def run_control_plane_service(
                 return
 
             if request_path == "/inspect-case-detail":
-                case_id = parse_qs(request_target.query).get("case_id", [""])[0].strip()
+                case_id = _normalize_case_id(
+                    parse_qs(request_target.query).get("case_id", [""])[0]
+                )
                 if not case_id:
                     self._write_json(
                         HTTPStatus.BAD_REQUEST,
@@ -278,6 +436,188 @@ def run_control_plane_service(
         def do_POST(self) -> None:  # noqa: N802
             request_target = urlsplit(self.path)
             request_path = request_target.path
+
+            if request_path == "/operator/promote-alert-to-case":
+                try:
+                    payload = _read_json_request_body(self)
+                    promoted_case = service.promote_alert_to_case(
+                        _normalize_alert_id(_require_json_string(payload, "alert_id")),
+                        case_id=_normalize_optional_string(payload.get("case_id")),
+                        case_lifecycle_state=_require_json_string(
+                            payload,
+                            "case_lifecycle_state",
+                        )
+                        if "case_lifecycle_state" in payload
+                        else "open",
+                    )
+                except (LookupError, ValueError) as exc:
+                    status = (
+                        HTTPStatus.NOT_FOUND
+                        if isinstance(exc, LookupError)
+                        else HTTPStatus.BAD_REQUEST
+                    )
+                    self._write_json(
+                        status,
+                        {
+                            "error": "not_found"
+                            if status == HTTPStatus.NOT_FOUND
+                            else "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, _json_ready(promoted_case))
+                return
+
+            if request_path == "/operator/record-case-observation":
+                try:
+                    payload = _read_json_request_body(self)
+                    observation = service.record_case_observation(
+                        case_id=_normalize_case_id(_require_json_string(payload, "case_id")),
+                        author_identity=_require_json_string(payload, "author_identity"),
+                        observed_at=_require_json_datetime(payload, "observed_at"),
+                        scope_statement=_require_json_string(payload, "scope_statement"),
+                        supporting_evidence_ids=_require_json_string_sequence(
+                            payload,
+                            "supporting_evidence_ids",
+                        ),
+                    )
+                except (LookupError, ValueError) as exc:
+                    status = (
+                        HTTPStatus.NOT_FOUND
+                        if isinstance(exc, LookupError)
+                        else HTTPStatus.BAD_REQUEST
+                    )
+                    self._write_json(
+                        status,
+                        {
+                            "error": "not_found"
+                            if status == HTTPStatus.NOT_FOUND
+                            else "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, _json_ready(observation))
+                return
+
+            if request_path == "/operator/record-case-lead":
+                try:
+                    payload = _read_json_request_body(self)
+                    lead = service.record_case_lead(
+                        case_id=_normalize_case_id(_require_json_string(payload, "case_id")),
+                        triage_owner=_require_json_string(payload, "triage_owner"),
+                        triage_rationale=_require_json_string(payload, "triage_rationale"),
+                        observation_id=_normalize_optional_string(
+                            payload.get("observation_id")
+                        ),
+                    )
+                except (LookupError, ValueError) as exc:
+                    status = (
+                        HTTPStatus.NOT_FOUND
+                        if isinstance(exc, LookupError)
+                        else HTTPStatus.BAD_REQUEST
+                    )
+                    self._write_json(
+                        status,
+                        {
+                            "error": "not_found"
+                            if status == HTTPStatus.NOT_FOUND
+                            else "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, _json_ready(lead))
+                return
+
+            if request_path == "/operator/record-case-recommendation":
+                try:
+                    payload = _read_json_request_body(self)
+                    recommendation = service.record_case_recommendation(
+                        case_id=_normalize_case_id(_require_json_string(payload, "case_id")),
+                        review_owner=_require_json_string(payload, "review_owner"),
+                        intended_outcome=_require_json_string(payload, "intended_outcome"),
+                        lead_id=_normalize_optional_string(payload.get("lead_id")),
+                    )
+                except (LookupError, ValueError) as exc:
+                    status = (
+                        HTTPStatus.NOT_FOUND
+                        if isinstance(exc, LookupError)
+                        else HTTPStatus.BAD_REQUEST
+                    )
+                    self._write_json(
+                        status,
+                        {
+                            "error": "not_found"
+                            if status == HTTPStatus.NOT_FOUND
+                            else "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, _json_ready(recommendation))
+                return
+
+            if request_path == "/operator/record-case-handoff":
+                try:
+                    payload = _read_json_request_body(self)
+                    case_record = service.record_case_handoff(
+                        case_id=_normalize_case_id(_require_json_string(payload, "case_id")),
+                        handoff_at=_require_json_datetime(payload, "handoff_at"),
+                        handoff_owner=_require_json_string(payload, "handoff_owner"),
+                        handoff_note=_require_json_string(payload, "handoff_note"),
+                        follow_up_evidence_ids=_require_json_string_sequence(
+                            payload,
+                            "follow_up_evidence_ids",
+                        ),
+                    )
+                except (LookupError, ValueError) as exc:
+                    status = (
+                        HTTPStatus.NOT_FOUND
+                        if isinstance(exc, LookupError)
+                        else HTTPStatus.BAD_REQUEST
+                    )
+                    self._write_json(
+                        status,
+                        {
+                            "error": "not_found"
+                            if status == HTTPStatus.NOT_FOUND
+                            else "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, _json_ready(case_record))
+                return
+
+            if request_path == "/operator/record-case-disposition":
+                try:
+                    payload = _read_json_request_body(self)
+                    case_record = service.record_case_disposition(
+                        case_id=_normalize_case_id(_require_json_string(payload, "case_id")),
+                        disposition=_require_json_string(payload, "disposition"),
+                        rationale=_require_json_string(payload, "rationale"),
+                        recorded_at=_require_json_datetime(payload, "recorded_at"),
+                    )
+                except (LookupError, ValueError) as exc:
+                    status = (
+                        HTTPStatus.NOT_FOUND
+                        if isinstance(exc, LookupError)
+                        else HTTPStatus.BAD_REQUEST
+                    )
+                    self._write_json(
+                        status,
+                        {
+                            "error": "not_found"
+                            if status == HTTPStatus.NOT_FOUND
+                            else "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, _json_ready(case_record))
+                return
 
             if request_path != "/intake/wazuh":
                 self._write_json(
@@ -480,6 +820,112 @@ def main(
                 parser.error("case_id must be a non-empty string")
             try:
                 payload = service.inspect_case_detail(case_id).to_dict()
+            except (LookupError, ValueError) as exc:
+                parser.error(str(exc))
+        elif command == "promote-alert-to-case":
+            alert_id = _normalize_alert_id(parsed.alert_id)
+            if not alert_id:
+                parser.error("alert_id must be a non-empty string")
+            try:
+                payload = _json_ready(
+                    service.promote_alert_to_case(
+                        alert_id,
+                        case_id=_normalize_optional_string(parsed.case_id),
+                        case_lifecycle_state=parsed.case_lifecycle_state.strip(),
+                    )
+                )
+            except (LookupError, ValueError) as exc:
+                parser.error(str(exc))
+        elif command == "record-case-observation":
+            case_id = _normalize_case_id(parsed.case_id)
+            if not case_id:
+                parser.error("case_id must be a non-empty string")
+            try:
+                payload = _json_ready(
+                    service.record_case_observation(
+                        case_id=case_id,
+                        author_identity=parsed.author_identity.strip(),
+                        observed_at=_parse_datetime_arg(
+                            parsed.observed_at,
+                            "observed_at",
+                        ),
+                        scope_statement=parsed.scope_statement.strip(),
+                        supporting_evidence_ids=tuple(
+                            evidence_id.strip()
+                            for evidence_id in parsed.supporting_evidence_id
+                        ),
+                    )
+                )
+            except (LookupError, ValueError) as exc:
+                parser.error(str(exc))
+        elif command == "record-case-lead":
+            case_id = _normalize_case_id(parsed.case_id)
+            if not case_id:
+                parser.error("case_id must be a non-empty string")
+            try:
+                payload = _json_ready(
+                    service.record_case_lead(
+                        case_id=case_id,
+                        triage_owner=parsed.triage_owner.strip(),
+                        triage_rationale=parsed.triage_rationale.strip(),
+                        observation_id=_normalize_optional_string(parsed.observation_id),
+                    )
+                )
+            except (LookupError, ValueError) as exc:
+                parser.error(str(exc))
+        elif command == "record-case-recommendation":
+            case_id = _normalize_case_id(parsed.case_id)
+            if not case_id:
+                parser.error("case_id must be a non-empty string")
+            try:
+                payload = _json_ready(
+                    service.record_case_recommendation(
+                        case_id=case_id,
+                        review_owner=parsed.review_owner.strip(),
+                        intended_outcome=parsed.intended_outcome.strip(),
+                        lead_id=_normalize_optional_string(parsed.lead_id),
+                    )
+                )
+            except (LookupError, ValueError) as exc:
+                parser.error(str(exc))
+        elif command == "record-case-handoff":
+            case_id = _normalize_case_id(parsed.case_id)
+            if not case_id:
+                parser.error("case_id must be a non-empty string")
+            try:
+                payload = _json_ready(
+                    service.record_case_handoff(
+                        case_id=case_id,
+                        handoff_at=_parse_datetime_arg(
+                            parsed.handoff_at,
+                            "handoff_at",
+                        ),
+                        handoff_owner=parsed.handoff_owner.strip(),
+                        handoff_note=parsed.handoff_note.strip(),
+                        follow_up_evidence_ids=tuple(
+                            evidence_id.strip()
+                            for evidence_id in parsed.follow_up_evidence_id
+                        ),
+                    )
+                )
+            except (LookupError, ValueError) as exc:
+                parser.error(str(exc))
+        elif command == "record-case-disposition":
+            case_id = _normalize_case_id(parsed.case_id)
+            if not case_id:
+                parser.error("case_id must be a non-empty string")
+            try:
+                payload = _json_ready(
+                    service.record_case_disposition(
+                        case_id=case_id,
+                        disposition=parsed.disposition.strip(),
+                        rationale=parsed.rationale.strip(),
+                        recorded_at=_parse_datetime_arg(
+                            parsed.recorded_at,
+                            "recorded_at",
+                        ),
+                    )
+                )
             except (LookupError, ValueError) as exc:
                 parser.error(str(exc))
         elif command == "inspect-advisory-output":

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -7,6 +7,7 @@ from dataclasses import fields, is_dataclass
 from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import ipaddress
 import json
 import sys
 from typing import Mapping, Sequence, TextIO
@@ -18,6 +19,10 @@ from aegisops_control_plane.service import (
 )
 
 MAX_WAZUH_INGEST_BODY_BYTES = 1_048_576
+
+
+class RequestTooLargeError(ValueError):
+    """Raised when a reviewed request body exceeds the allowed size limit."""
 
 
 def _normalize_alert_id(value: str) -> str:
@@ -89,7 +94,7 @@ def _read_json_request_body(handler: BaseHTTPRequestHandler) -> dict[str, object
     if content_length <= 0:
         raise ValueError("request body is required")
     if content_length > MAX_WAZUH_INGEST_BODY_BYTES:
-        raise ValueError("request body exceeds the reviewed size limit")
+        raise RequestTooLargeError("request body exceeds the reviewed size limit")
     try:
         raw_payload = handler.rfile.read(content_length).decode("utf-8")
     except UnicodeDecodeError as exc:
@@ -101,6 +106,24 @@ def _read_json_request_body(handler: BaseHTTPRequestHandler) -> dict[str, object
     if not isinstance(payload, dict):
         raise ValueError("request body must be a JSON object")
     return payload
+
+
+def _peer_addr_is_loopback(peer_addr: str | None) -> bool:
+    if peer_addr is None or peer_addr.strip() == "":
+        return False
+    try:
+        return ipaddress.ip_address(peer_addr.strip()).is_loopback
+    except ValueError:
+        return False
+
+
+def _require_loopback_operator_request(handler: BaseHTTPRequestHandler) -> None:
+    peer_addr = handler.client_address[0] if handler.client_address else None
+    if _peer_addr_is_loopback(peer_addr):
+        return
+    raise PermissionError(
+        "operator write surface only accepts loopback callers until a reviewed operator auth boundary exists"
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -437,6 +460,19 @@ def run_control_plane_service(
             request_target = urlsplit(self.path)
             request_path = request_target.path
 
+            if request_path.startswith("/operator/"):
+                try:
+                    _require_loopback_operator_request(self)
+                except PermissionError as exc:
+                    self._write_json(
+                        HTTPStatus.FORBIDDEN,
+                        {
+                            "error": "forbidden",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+
             if request_path == "/operator/promote-alert-to-case":
                 try:
                     payload = _read_json_request_body(self)
@@ -450,6 +486,15 @@ def run_control_plane_service(
                         if "case_lifecycle_state" in payload
                         else "open",
                     )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
                 except (LookupError, ValueError) as exc:
                     status = (
                         HTTPStatus.NOT_FOUND
@@ -482,6 +527,15 @@ def run_control_plane_service(
                             "supporting_evidence_ids",
                         ),
                     )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
                 except (LookupError, ValueError) as exc:
                     status = (
                         HTTPStatus.NOT_FOUND
@@ -512,6 +566,15 @@ def run_control_plane_service(
                             payload.get("observation_id")
                         ),
                     )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
                 except (LookupError, ValueError) as exc:
                     status = (
                         HTTPStatus.NOT_FOUND
@@ -540,6 +603,15 @@ def run_control_plane_service(
                         intended_outcome=_require_json_string(payload, "intended_outcome"),
                         lead_id=_normalize_optional_string(payload.get("lead_id")),
                     )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
                 except (LookupError, ValueError) as exc:
                     status = (
                         HTTPStatus.NOT_FOUND
@@ -572,6 +644,15 @@ def run_control_plane_service(
                             "follow_up_evidence_ids",
                         ),
                     )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
                 except (LookupError, ValueError) as exc:
                     status = (
                         HTTPStatus.NOT_FOUND
@@ -600,6 +681,15 @@ def run_control_plane_service(
                         rationale=_require_json_string(payload, "rationale"),
                         recorded_at=_require_json_datetime(payload, "recorded_at"),
                     )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
                 except (LookupError, ValueError) as exc:
                     status = (
                         HTTPStatus.NOT_FOUND

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -23,6 +23,7 @@ from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
 from aegisops_control_plane.models import (
     AlertRecord,
     AnalyticSignalRecord,
+    CaseRecord,
     EvidenceRecord,
     RecommendationRecord,
     ReconciliationRecord,
@@ -1596,8 +1597,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 base_url = f"http://127.0.0.1:{servers[0].server_port}"
 
                 def post_json(path: str, payload: dict[str, object]) -> dict[str, object]:
-                    response = request.urlopen(
-                        request.Request(
+                    response = request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                        request.Request(  # noqa: S310 - local in-process test HTTP server
                             f"{base_url}{path}",
                             data=json.dumps(payload).encode("utf-8"),
                             headers={"Content-Type": "application/json"},
@@ -1675,7 +1676,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 self.assertEqual(disposition_payload["lifecycle_state"], "pending_action")
 
                 detail_payload = json.loads(
-                    request.urlopen(
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
                         f"{base_url}/inspect-case-detail?case_id={case_id}",
                         timeout=2,
                     ).read().decode("utf-8")
@@ -1690,6 +1691,137 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     detail_payload["case_record"]["reviewed_context"]["triage"]["disposition"],
                     "business_hours_handoff",
                 )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_long_running_runtime_surface_rejects_oversized_operator_request_body(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1",
+                    servers[0].server_port,
+                    timeout=2,
+                )
+                connection.putrequest("POST", "/operator/promote-alert-to-case")
+                connection.putheader("Content-Type", "application/json")
+                connection.putheader(
+                    "Content-Length",
+                    str(main.MAX_WAZUH_INGEST_BODY_BYTES + 1),
+                )
+                connection.endheaders()
+
+                response = connection.getresponse()
+                self.assertEqual(response.status, 413)
+                response_body = json.loads(response.read().decode("utf-8"))
+                connection.close()
+                self.assertEqual(response_body["error"], "request_too_large")
+                self.assertEqual(store.list(AlertRecord), ())
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_long_running_runtime_surface_forbids_non_loopback_operator_requests(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+        admitted = service.ingest_finding_alert(
+            finding_id="finding-phase19-http-auth-001",
+            analytic_signal_id="signal-phase19-http-auth-001",
+            substrate_detection_record_id="substrate-detection-phase19-http-auth-001",
+            correlation_key="claim:asset-phase19-http-auth-001:github-audit",
+            first_seen_at=datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc),
+            last_seen_at=datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc),
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-http-auth-001"},
+                "identity": {"identity_id": "principal-phase19-http-auth-001"},
+            },
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with (
+            mock.patch.object(main, "ThreadingHTTPServer", RecordingServer),
+            mock.patch.object(
+                main,
+                "_require_loopback_operator_request",
+                side_effect=PermissionError(
+                    "operator write surface only accepts loopback callers until a reviewed operator auth boundary exists"
+                ),
+            ),
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                with self.assertRaises(error.HTTPError) as exc_info:
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                        request.Request(  # noqa: S310 - local in-process test HTTP server
+                            f"http://127.0.0.1:{servers[0].server_port}/operator/promote-alert-to-case",
+                            data=json.dumps({"alert_id": admitted.alert.alert_id}).encode("utf-8"),
+                            headers={"Content-Type": "application/json"},
+                            method="POST",
+                        ),
+                        timeout=2,
+                    )
+
+                self.assertEqual(exc_info.exception.code, 403)
+                response_body = json.loads(exc_info.exception.read().decode("utf-8"))
+                self.assertEqual(response_body["error"], "forbidden")
+                self.assertEqual(store.list(CaseRecord), ())
             finally:
                 if servers:
                     servers[0].shutdown()

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1355,6 +1355,346 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             payload["linked_reconciliation_ids"],
         )
 
+    def test_cli_records_bounded_operator_casework_actions(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        handoff_at = datetime(2026, 4, 7, 17, 45, tzinfo=timezone.utc)
+        admitted = service.ingest_finding_alert(
+            finding_id="finding-phase19-cli-actions-001",
+            analytic_signal_id="signal-phase19-cli-actions-001",
+            substrate_detection_record_id="substrate-detection-phase19-cli-actions-001",
+            correlation_key="claim:asset-phase19-cli-actions-001:github-audit",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-cli-actions-001"},
+                "identity": {"identity_id": "principal-phase19-cli-actions-001"},
+            },
+        )
+        evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-cli-actions-001",
+                source_record_id="substrate-detection-phase19-cli-actions-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+
+        promote_stdout = io.StringIO()
+        main.main(
+            ["promote-alert-to-case", "--alert-id", admitted.alert.alert_id],
+            stdout=promote_stdout,
+            service=service,
+        )
+        promoted_case_payload = json.loads(promote_stdout.getvalue())
+        case_id = promoted_case_payload["case_id"]
+        self.assertEqual(promoted_case_payload["lifecycle_state"], "open")
+
+        observation_stdout = io.StringIO()
+        main.main(
+            [
+                "record-case-observation",
+                "--case-id",
+                case_id,
+                "--author-identity",
+                "analyst-001",
+                "--observed-at",
+                reviewed_at.isoformat(),
+                "--scope-statement",
+                "Observed repository permission change requires tracked review.",
+                "--supporting-evidence-id",
+                evidence.evidence_id,
+            ],
+            stdout=observation_stdout,
+            service=service,
+        )
+        observation_payload = json.loads(observation_stdout.getvalue())
+        self.assertEqual(observation_payload["case_id"], case_id)
+        self.assertEqual(observation_payload["supporting_evidence_ids"], [evidence.evidence_id])
+
+        lead_stdout = io.StringIO()
+        main.main(
+            [
+                "record-case-lead",
+                "--case-id",
+                case_id,
+                "--triage-owner",
+                "analyst-001",
+                "--triage-rationale",
+                "Privilege-impacting change needs durable business-hours follow-up.",
+                "--observation-id",
+                observation_payload["observation_id"],
+            ],
+            stdout=lead_stdout,
+            service=service,
+        )
+        lead_payload = json.loads(lead_stdout.getvalue())
+        self.assertEqual(lead_payload["case_id"], case_id)
+        self.assertEqual(lead_payload["observation_id"], observation_payload["observation_id"])
+
+        recommendation_stdout = io.StringIO()
+        main.main(
+            [
+                "record-case-recommendation",
+                "--case-id",
+                case_id,
+                "--review-owner",
+                "analyst-001",
+                "--intended-outcome",
+                "Review repository owner change evidence before any approval-bound response.",
+                "--lead-id",
+                lead_payload["lead_id"],
+            ],
+            stdout=recommendation_stdout,
+            service=service,
+        )
+        recommendation_payload = json.loads(recommendation_stdout.getvalue())
+        self.assertEqual(recommendation_payload["case_id"], case_id)
+        self.assertEqual(recommendation_payload["lead_id"], lead_payload["lead_id"])
+
+        handoff_stdout = io.StringIO()
+        main.main(
+            [
+                "record-case-handoff",
+                "--case-id",
+                case_id,
+                "--handoff-at",
+                handoff_at.isoformat(),
+                "--handoff-owner",
+                "analyst-001",
+                "--handoff-note",
+                "Recheck repository owner membership against approved change window at next business-hours review.",
+                "--follow-up-evidence-id",
+                evidence.evidence_id,
+            ],
+            stdout=handoff_stdout,
+            service=service,
+        )
+        handoff_payload = json.loads(handoff_stdout.getvalue())
+        self.assertEqual(handoff_payload["case_id"], case_id)
+        self.assertEqual(
+            handoff_payload["reviewed_context"]["handoff"]["follow_up_evidence_ids"],
+            [evidence.evidence_id],
+        )
+
+        disposition_stdout = io.StringIO()
+        main.main(
+            [
+                "record-case-disposition",
+                "--case-id",
+                case_id,
+                "--disposition",
+                "business_hours_handoff",
+                "--rationale",
+                "No same-day response required; preserve next-shift context and keep case open.",
+                "--recorded-at",
+                handoff_at.isoformat(),
+            ],
+            stdout=disposition_stdout,
+            service=service,
+        )
+        disposition_payload = json.loads(disposition_stdout.getvalue())
+        self.assertEqual(disposition_payload["case_id"], case_id)
+        self.assertEqual(disposition_payload["lifecycle_state"], "pending_action")
+        self.assertEqual(
+            disposition_payload["reviewed_context"]["triage"]["disposition"],
+            "business_hours_handoff",
+        )
+
+        detail_stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", case_id],
+            stdout=detail_stdout,
+            service=service,
+        )
+        detail_payload = json.loads(detail_stdout.getvalue())
+        self.assertEqual(detail_payload["linked_observation_ids"], [observation_payload["observation_id"]])
+        self.assertEqual(detail_payload["linked_lead_ids"], [lead_payload["lead_id"]])
+        self.assertIn(
+            recommendation_payload["recommendation_id"],
+            detail_payload["linked_recommendation_ids"],
+        )
+        self.assertEqual(
+            detail_payload["case_record"]["reviewed_context"]["handoff"]["handoff_owner"],
+            "analyst-001",
+        )
+        self.assertEqual(
+            detail_payload["case_record"]["reviewed_context"]["triage"]["disposition"],
+            "business_hours_handoff",
+        )
+
+    def test_long_running_runtime_surface_records_bounded_operator_casework_actions(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        handoff_at = datetime(2026, 4, 7, 17, 45, tzinfo=timezone.utc)
+        admitted = service.ingest_finding_alert(
+            finding_id="finding-phase19-http-actions-001",
+            analytic_signal_id="signal-phase19-http-actions-001",
+            substrate_detection_record_id="substrate-detection-phase19-http-actions-001",
+            correlation_key="claim:asset-phase19-http-actions-001:github-audit",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-http-actions-001"},
+                "identity": {"identity_id": "principal-phase19-http-actions-001"},
+            },
+        )
+        evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-http-actions-001",
+                source_record_id="substrate-detection-phase19-http-actions-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                def post_json(path: str, payload: dict[str, object]) -> dict[str, object]:
+                    response = request.urlopen(
+                        request.Request(
+                            f"{base_url}{path}",
+                            data=json.dumps(payload).encode("utf-8"),
+                            headers={"Content-Type": "application/json"},
+                            method="POST",
+                        ),
+                        timeout=2,
+                    )
+                    return json.loads(response.read().decode("utf-8"))
+
+                promoted_case_payload = post_json(
+                    "/operator/promote-alert-to-case",
+                    {"alert_id": admitted.alert.alert_id},
+                )
+                case_id = promoted_case_payload["case_id"]
+                self.assertEqual(promoted_case_payload["lifecycle_state"], "open")
+
+                observation_payload = post_json(
+                    "/operator/record-case-observation",
+                    {
+                        "case_id": case_id,
+                        "author_identity": "analyst-001",
+                        "observed_at": reviewed_at.isoformat(),
+                        "scope_statement": "Observed repository permission change requires tracked review.",
+                        "supporting_evidence_ids": [evidence.evidence_id],
+                    },
+                )
+                self.assertEqual(observation_payload["case_id"], case_id)
+
+                lead_payload = post_json(
+                    "/operator/record-case-lead",
+                    {
+                        "case_id": case_id,
+                        "triage_owner": "analyst-001",
+                        "triage_rationale": "Privilege-impacting change needs durable business-hours follow-up.",
+                        "observation_id": observation_payload["observation_id"],
+                    },
+                )
+                self.assertEqual(lead_payload["observation_id"], observation_payload["observation_id"])
+
+                recommendation_payload = post_json(
+                    "/operator/record-case-recommendation",
+                    {
+                        "case_id": case_id,
+                        "review_owner": "analyst-001",
+                        "intended_outcome": "Review repository owner change evidence before any approval-bound response.",
+                        "lead_id": lead_payload["lead_id"],
+                    },
+                )
+                self.assertEqual(recommendation_payload["lead_id"], lead_payload["lead_id"])
+
+                handoff_payload = post_json(
+                    "/operator/record-case-handoff",
+                    {
+                        "case_id": case_id,
+                        "handoff_at": handoff_at.isoformat(),
+                        "handoff_owner": "analyst-001",
+                        "handoff_note": "Recheck repository owner membership against approved change window at next business-hours review.",
+                        "follow_up_evidence_ids": [evidence.evidence_id],
+                    },
+                )
+                self.assertEqual(
+                    handoff_payload["reviewed_context"]["handoff"]["follow_up_evidence_ids"],
+                    [evidence.evidence_id],
+                )
+
+                disposition_payload = post_json(
+                    "/operator/record-case-disposition",
+                    {
+                        "case_id": case_id,
+                        "disposition": "business_hours_handoff",
+                        "rationale": "No same-day response required; preserve next-shift context and keep case open.",
+                        "recorded_at": handoff_at.isoformat(),
+                    },
+                )
+                self.assertEqual(disposition_payload["lifecycle_state"], "pending_action")
+
+                detail_payload = json.loads(
+                    request.urlopen(
+                        f"{base_url}/inspect-case-detail?case_id={case_id}",
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+                self.assertEqual(detail_payload["linked_observation_ids"], [observation_payload["observation_id"]])
+                self.assertEqual(detail_payload["linked_lead_ids"], [lead_payload["lead_id"]])
+                self.assertIn(
+                    recommendation_payload["recommendation_id"],
+                    detail_payload["linked_recommendation_ids"],
+                )
+                self.assertEqual(
+                    detail_payload["case_record"]["reviewed_context"]["triage"]["disposition"],
+                    "business_hours_handoff",
+                )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
     def test_cli_renders_recommendation_draft_view_for_a_case(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -133,8 +133,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 host="127.0.0.1",
                 port=0,
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             ),
             store=store,
         )
@@ -223,8 +223,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 host="127.0.0.1",
                 port=0,
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             ),
             store=store,
         )
@@ -354,8 +354,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 host="127.0.0.1",
                 port=0,
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             ),
             store=store,
         )

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1261,10 +1261,23 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             )
         )
         promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=compared_at,
+            scope_statement="Observed permission change remains within reviewed GitHub audit scope.",
+            supporting_evidence_ids=(evidence.evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Preserve durable case context for next business-hours analyst.",
+        )
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-case-detail-cli-001",
-                lead_id=None,
+                lead_id=lead.lead_id,
                 hunt_run_id=None,
                 alert_id=admitted.alert.alert_id,
                 case_id=promoted_case.case_id,
@@ -1274,6 +1287,19 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 lifecycle_state="under_review",
                 reviewed_context=reviewed_context,
             )
+        )
+        service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=compared_at,
+            handoff_owner="analyst-001",
+            handoff_note="Resume owner-membership review during the next business-hours cycle.",
+            follow_up_evidence_ids=(evidence.evidence_id,),
+        )
+        service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Tracked case remains open for the next analyst review window.",
+            recorded_at=compared_at,
         )
 
         stdout = io.StringIO()
@@ -1291,7 +1317,11 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertTrue(payload["read_only"])
         self.assertEqual(payload["case_id"], promoted_case.case_id)
         self.assertEqual(payload["case_record"]["case_id"], promoted_case.case_id)
-        self.assertEqual(payload["reviewed_context"], reviewed_context)
+        self.assertEqual(payload["reviewed_context"]["asset"], reviewed_context["asset"])
+        self.assertEqual(
+            payload["reviewed_context"]["identity"],
+            reviewed_context["identity"],
+        )
         self.assertEqual(
             payload["advisory_output"]["output_kind"],
             "case_summary",
@@ -1305,6 +1335,16 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(
             payload["linked_evidence_records"][0]["derivation_relationship"],
             "admitted_analytic_signal",
+        )
+        self.assertEqual(payload["linked_observation_ids"], [observation.observation_id])
+        self.assertEqual(payload["linked_lead_ids"], [lead.lead_id])
+        self.assertEqual(
+            payload["case_record"]["reviewed_context"]["triage"]["disposition"],
+            "business_hours_handoff",
+        )
+        self.assertEqual(
+            payload["case_record"]["reviewed_context"]["handoff"]["handoff_owner"],
+            "analyst-001",
         )
         self.assertIn(
             recommendation.recommendation_id,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -3990,6 +3990,151 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "Privilege-impacting change needs durable business-hours follow-up.",
         )
 
+    def test_service_rejects_duplicate_casework_identifiers(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = service.ingest_finding_alert(
+            finding_id="finding-phase19-duplicate-ids-001",
+            analytic_signal_id="signal-phase19-duplicate-ids-001",
+            substrate_detection_record_id="substrate-detection-phase19-duplicate-ids-001",
+            correlation_key="claim:asset-phase19-duplicate-ids-001:github-audit",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-duplicate-ids-001"},
+                "identity": {"identity_id": "principal-phase19-duplicate-ids-001"},
+            },
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-duplicate-ids-001",
+                source_record_id="substrate-detection-phase19-duplicate-ids-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            observation_id="observation-phase19-duplicate-ids-001",
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Initial observation for duplicate-id guard coverage.",
+            supporting_evidence_ids=("evidence-phase19-duplicate-ids-001",),
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "observation_id 'observation-phase19-duplicate-ids-001' already exists",
+        ):
+            service.record_case_observation(
+                case_id=promoted_case.case_id,
+                observation_id=observation.observation_id,
+                author_identity="analyst-002",
+                observed_at=reviewed_at,
+                scope_statement="Collision should be rejected before persist_record updates in place.",
+                supporting_evidence_ids=("evidence-phase19-duplicate-ids-001",),
+            )
+
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            lead_id="lead-phase19-duplicate-ids-001",
+            triage_owner="analyst-001",
+            triage_rationale="Create a concrete lead before checking duplicate lead IDs.",
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "lead_id 'lead-phase19-duplicate-ids-001' already exists",
+        ):
+            service.record_case_lead(
+                case_id=promoted_case.case_id,
+                observation_id=observation.observation_id,
+                lead_id=lead.lead_id,
+                triage_owner="analyst-002",
+                triage_rationale="Collision should be rejected before persist_record updates in place.",
+            )
+
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            recommendation_id="recommendation-phase19-duplicate-ids-001",
+            review_owner="analyst-001",
+            intended_outcome="Establish a recommendation before checking duplicate recommendation IDs.",
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "recommendation_id 'recommendation-phase19-duplicate-ids-001' already exists",
+        ):
+            service.record_case_recommendation(
+                case_id=promoted_case.case_id,
+                lead_id=lead.lead_id,
+                recommendation_id=recommendation.recommendation_id,
+                review_owner="analyst-002",
+                intended_outcome="Collision should be rejected before persist_record updates in place.",
+            )
+
+    def test_service_rejects_unknown_case_disposition(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = service.ingest_finding_alert(
+            finding_id="finding-phase19-unsupported-disposition-001",
+            analytic_signal_id="signal-phase19-unsupported-disposition-001",
+            substrate_detection_record_id=(
+                "substrate-detection-phase19-unsupported-disposition-001"
+            ),
+            correlation_key=(
+                "claim:asset-phase19-unsupported-disposition-001:github-audit"
+            ),
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-unsupported-disposition-001"},
+                "identity": {
+                    "identity_id": "principal-phase19-unsupported-disposition-001"
+                },
+            },
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-unsupported-disposition-001",
+                source_record_id=(
+                    "substrate-detection-phase19-unsupported-disposition-001"
+                ),
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unsupported case disposition 'typo_pending_review'",
+        ):
+            service.record_case_disposition(
+                case_id=promoted_case.case_id,
+                disposition="typo_pending_review",
+                rationale="Typos should be rejected instead of changing lifecycle state.",
+                recorded_at=reviewed_at,
+            )
+
     def _assert_service_analyst_queue_prefers_wazuh_source_for_multi_source_linkage(
         self,
         *,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -4135,6 +4135,239 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 recorded_at=reviewed_at,
             )
 
+    def test_service_rejects_raced_observation_identifier_collision(self) -> None:
+        store, _ = make_store()
+        base_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = base_service.ingest_finding_alert(
+            finding_id="finding-phase19-raced-observation-001",
+            analytic_signal_id="signal-phase19-raced-observation-001",
+            substrate_detection_record_id=(
+                "substrate-detection-phase19-raced-observation-001"
+            ),
+            correlation_key="claim:asset-phase19-raced-observation-001:github-audit",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-raced-observation-001"},
+                "identity": {"identity_id": "principal-phase19-raced-observation-001"},
+            },
+        )
+        evidence = base_service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-raced-observation-001",
+                source_record_id="substrate-detection-phase19-raced-observation-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
+        store = _TransactionMutationStore(
+            inner=store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                ObservationRecord(
+                    observation_id="observation-phase19-race-001",
+                    hunt_id=None,
+                    hunt_run_id=None,
+                    alert_id=promoted_case.alert_id,
+                    case_id=promoted_case.case_id,
+                    supporting_evidence_ids=(evidence.evidence_id,),
+                    author_identity="analyst-racer",
+                    observed_at=reviewed_at,
+                    scope_statement="Concurrent writer inserted the requested observation ID.",
+                    lifecycle_state="confirmed",
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "observation_id 'observation-phase19-race-001' already exists",
+        ):
+            service.record_case_observation(
+                case_id=promoted_case.case_id,
+                observation_id="observation-phase19-race-001",
+                author_identity="analyst-001",
+                observed_at=reviewed_at,
+                scope_statement="Caller-supplied observation IDs must reject raced duplicates.",
+                supporting_evidence_ids=(evidence.evidence_id,),
+            )
+
+    def test_service_rejects_raced_lead_identifier_collision(self) -> None:
+        store, _ = make_store()
+        base_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = base_service.ingest_finding_alert(
+            finding_id="finding-phase19-raced-lead-001",
+            analytic_signal_id="signal-phase19-raced-lead-001",
+            substrate_detection_record_id="substrate-detection-phase19-raced-lead-001",
+            correlation_key="claim:asset-phase19-raced-lead-001:github-audit",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-raced-lead-001"},
+                "identity": {"identity_id": "principal-phase19-raced-lead-001"},
+            },
+        )
+        evidence = base_service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-raced-lead-001",
+                source_record_id="substrate-detection-phase19-raced-lead-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
+        observation = base_service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Seed observation for raced lead collision coverage.",
+            supporting_evidence_ids=(evidence.evidence_id,),
+        )
+        store = _TransactionMutationStore(
+            inner=store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                LeadRecord(
+                    lead_id="lead-phase19-race-001",
+                    observation_id=observation.observation_id,
+                    finding_id=promoted_case.finding_id,
+                    hunt_run_id=None,
+                    alert_id=promoted_case.alert_id,
+                    case_id=promoted_case.case_id,
+                    triage_owner="analyst-racer",
+                    triage_rationale="Concurrent writer inserted the requested lead ID.",
+                    lifecycle_state="triaged",
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "lead_id 'lead-phase19-race-001' already exists",
+        ):
+            service.record_case_lead(
+                case_id=promoted_case.case_id,
+                observation_id=observation.observation_id,
+                lead_id="lead-phase19-race-001",
+                triage_owner="analyst-001",
+                triage_rationale="Caller-supplied lead IDs must reject raced duplicates.",
+            )
+
+    def test_service_rejects_raced_recommendation_identifier_collision(self) -> None:
+        store, _ = make_store()
+        base_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = base_service.ingest_finding_alert(
+            finding_id="finding-phase19-raced-recommendation-001",
+            analytic_signal_id="signal-phase19-raced-recommendation-001",
+            substrate_detection_record_id=(
+                "substrate-detection-phase19-raced-recommendation-001"
+            ),
+            correlation_key=(
+                "claim:asset-phase19-raced-recommendation-001:github-audit"
+            ),
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-raced-recommendation-001"},
+                "identity": {
+                    "identity_id": "principal-phase19-raced-recommendation-001"
+                },
+            },
+        )
+        evidence = base_service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-raced-recommendation-001",
+                source_record_id=(
+                    "substrate-detection-phase19-raced-recommendation-001"
+                ),
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
+        observation = base_service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Seed observation for raced recommendation collision coverage.",
+            supporting_evidence_ids=(evidence.evidence_id,),
+        )
+        lead = base_service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Seed lead for raced recommendation collision coverage.",
+        )
+        store = _TransactionMutationStore(
+            inner=store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                RecommendationRecord(
+                    recommendation_id="recommendation-phase19-race-001",
+                    lead_id=lead.lead_id,
+                    hunt_run_id=None,
+                    alert_id=promoted_case.alert_id,
+                    case_id=promoted_case.case_id,
+                    ai_trace_id=None,
+                    review_owner="analyst-racer",
+                    intended_outcome="Concurrent writer inserted the requested recommendation ID.",
+                    lifecycle_state="under_review",
+                    reviewed_context=promoted_case.reviewed_context,
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "recommendation_id 'recommendation-phase19-race-001' already exists",
+        ):
+            service.record_case_recommendation(
+                case_id=promoted_case.case_id,
+                lead_id=lead.lead_id,
+                recommendation_id="recommendation-phase19-race-001",
+                review_owner="analyst-001",
+                intended_outcome=(
+                    "Caller-supplied recommendation IDs must reject raced duplicates."
+                ),
+            )
+
     def test_service_merges_concurrent_reviewed_context_into_case_handoff(self) -> None:
         store, _ = make_store()
         base_service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -10,6 +10,7 @@ import secrets
 import sys
 from typing import Callable, Iterator
 import unittest
+from unittest import mock
 
 
 CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -123,6 +124,38 @@ class _ListCountingStore:
 
     @contextmanager
     def transaction(self) -> Iterator[None]:
+        with self.inner.transaction():
+            yield
+
+
+@dataclass
+class _OutOfBandMutationStore:
+    inner: object
+    mutate_once: Callable[[object], None]
+    _mutated: bool = False
+
+    @property
+    def dsn(self) -> str:
+        return self.inner.dsn
+
+    @property
+    def persistence_mode(self) -> str:
+        return self.inner.persistence_mode
+
+    def save(self, record: object) -> object:
+        return self.inner.save(record)
+
+    def get(self, record_type: object, record_id: str) -> object | None:
+        return self.inner.get(record_type, record_id)
+
+    def list(self, record_type: object) -> tuple[object, ...]:
+        return self.inner.list(record_type)
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        if not self._mutated:
+            self.mutate_once(self.inner)
+            self._mutated = True
         with self.inner.transaction():
             yield
 
@@ -4170,7 +4203,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             )
         )
         promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
-        store = _TransactionMutationStore(
+        store = _OutOfBandMutationStore(
             inner=store,
             mutate_once=lambda transactional_store: transactional_store.save(
                 ObservationRecord(
@@ -4245,7 +4278,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             scope_statement="Seed observation for raced lead collision coverage.",
             supporting_evidence_ids=(evidence.evidence_id,),
         )
-        store = _TransactionMutationStore(
+        store = _OutOfBandMutationStore(
             inner=store,
             mutate_once=lambda transactional_store: transactional_store.save(
                 LeadRecord(
@@ -4332,7 +4365,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             triage_owner="analyst-001",
             triage_rationale="Seed lead for raced recommendation collision coverage.",
         )
-        store = _TransactionMutationStore(
+        store = _OutOfBandMutationStore(
             inner=store,
             mutate_once=lambda transactional_store: transactional_store.save(
                 RecommendationRecord(
@@ -4367,6 +4400,285 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     "Caller-supplied recommendation IDs must reject raced duplicates."
                 ),
             )
+
+    def test_service_rejects_raced_generated_observation_identifier_collision(self) -> None:
+        store, _ = make_store()
+        base_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = base_service.ingest_finding_alert(
+            finding_id="finding-phase19-generated-observation-race-001",
+            analytic_signal_id="signal-phase19-generated-observation-race-001",
+            substrate_detection_record_id=(
+                "substrate-detection-phase19-generated-observation-race-001"
+            ),
+            correlation_key=(
+                "claim:asset-phase19-generated-observation-race-001:github-audit"
+            ),
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-generated-observation-race-001"},
+                "identity": {
+                    "identity_id": "principal-phase19-generated-observation-race-001"
+                },
+            },
+        )
+        evidence = base_service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-generated-observation-race-001",
+                source_record_id=(
+                    "substrate-detection-phase19-generated-observation-race-001"
+                ),
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
+        store = _OutOfBandMutationStore(
+            inner=store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                ObservationRecord(
+                    observation_id="observation-phase19-generated-race-001",
+                    hunt_id=None,
+                    hunt_run_id=None,
+                    alert_id=promoted_case.alert_id,
+                    case_id=promoted_case.case_id,
+                    supporting_evidence_ids=(evidence.evidence_id,),
+                    author_identity="analyst-racer",
+                    observed_at=reviewed_at,
+                    scope_statement="Concurrent writer inserted the minted observation ID.",
+                    lifecycle_state="confirmed",
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        with mock.patch.object(
+            AegisOpsControlPlaneService,
+            "_next_identifier",
+            return_value="observation-phase19-generated-race-001",
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "observation_id 'observation-phase19-generated-race-001' already exists",
+            ):
+                service.record_case_observation(
+                    case_id=promoted_case.case_id,
+                    author_identity="analyst-001",
+                    observed_at=reviewed_at,
+                    scope_statement="Generated observation IDs must reject raced duplicates.",
+                    supporting_evidence_ids=(evidence.evidence_id,),
+                )
+
+        observations = store.list(ObservationRecord)
+        self.assertEqual(len(observations), 1)
+        self.assertEqual(
+            observations[0].observation_id,
+            "observation-phase19-generated-race-001",
+        )
+
+    def test_service_rejects_raced_generated_lead_identifier_collision(self) -> None:
+        store, _ = make_store()
+        base_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = base_service.ingest_finding_alert(
+            finding_id="finding-phase19-generated-lead-race-001",
+            analytic_signal_id="signal-phase19-generated-lead-race-001",
+            substrate_detection_record_id=(
+                "substrate-detection-phase19-generated-lead-race-001"
+            ),
+            correlation_key="claim:asset-phase19-generated-lead-race-001:github-audit",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-generated-lead-race-001"},
+                "identity": {
+                    "identity_id": "principal-phase19-generated-lead-race-001"
+                },
+            },
+        )
+        evidence = base_service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-generated-lead-race-001",
+                source_record_id="substrate-detection-phase19-generated-lead-race-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
+        observation = base_service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Seed observation for generated lead race coverage.",
+            supporting_evidence_ids=(evidence.evidence_id,),
+        )
+        store = _OutOfBandMutationStore(
+            inner=store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                LeadRecord(
+                    lead_id="lead-phase19-generated-race-001",
+                    observation_id=observation.observation_id,
+                    finding_id=promoted_case.finding_id,
+                    hunt_run_id=None,
+                    alert_id=promoted_case.alert_id,
+                    case_id=promoted_case.case_id,
+                    triage_owner="analyst-racer",
+                    triage_rationale="Concurrent writer inserted the minted lead ID.",
+                    lifecycle_state="triaged",
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        with mock.patch.object(
+            AegisOpsControlPlaneService,
+            "_next_identifier",
+            return_value="lead-phase19-generated-race-001",
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "lead_id 'lead-phase19-generated-race-001' already exists",
+            ):
+                service.record_case_lead(
+                    case_id=promoted_case.case_id,
+                    observation_id=observation.observation_id,
+                    triage_owner="analyst-001",
+                    triage_rationale="Generated lead IDs must reject raced duplicates.",
+                )
+
+        leads = store.list(LeadRecord)
+        self.assertEqual(len(leads), 1)
+        self.assertEqual(leads[0].lead_id, "lead-phase19-generated-race-001")
+
+    def test_service_rejects_raced_generated_recommendation_identifier_collision(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        base_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = base_service.ingest_finding_alert(
+            finding_id="finding-phase19-generated-recommendation-race-001",
+            analytic_signal_id="signal-phase19-generated-recommendation-race-001",
+            substrate_detection_record_id=(
+                "substrate-detection-phase19-generated-recommendation-race-001"
+            ),
+            correlation_key=(
+                "claim:asset-phase19-generated-recommendation-race-001:github-audit"
+            ),
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {
+                    "asset_id": "asset-phase19-generated-recommendation-race-001"
+                },
+                "identity": {
+                    "identity_id": "principal-phase19-generated-recommendation-race-001"
+                },
+            },
+        )
+        evidence = base_service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-generated-recommendation-race-001",
+                source_record_id=(
+                    "substrate-detection-phase19-generated-recommendation-race-001"
+                ),
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
+        observation = base_service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Seed observation for generated recommendation race coverage.",
+            supporting_evidence_ids=(evidence.evidence_id,),
+        )
+        lead = base_service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Seed lead for generated recommendation race coverage.",
+        )
+        store = _OutOfBandMutationStore(
+            inner=store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                RecommendationRecord(
+                    recommendation_id="recommendation-phase19-generated-race-001",
+                    lead_id=lead.lead_id,
+                    hunt_run_id=None,
+                    alert_id=promoted_case.alert_id,
+                    case_id=promoted_case.case_id,
+                    ai_trace_id=None,
+                    review_owner="analyst-racer",
+                    intended_outcome=(
+                        "Concurrent writer inserted the minted recommendation ID."
+                    ),
+                    lifecycle_state="under_review",
+                    reviewed_context=promoted_case.reviewed_context,
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        with mock.patch.object(
+            AegisOpsControlPlaneService,
+            "_next_identifier",
+            return_value="recommendation-phase19-generated-race-001",
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "recommendation_id 'recommendation-phase19-generated-race-001' already exists",
+            ):
+                service.record_case_recommendation(
+                    case_id=promoted_case.case_id,
+                    lead_id=lead.lead_id,
+                    review_owner="analyst-001",
+                    intended_outcome=(
+                        "Generated recommendation IDs must reject raced duplicates."
+                    ),
+                )
+
+        recommendations = store.list(RecommendationRecord)
+        self.assertEqual(len(recommendations), 1)
+        self.assertEqual(
+            recommendations[0].recommendation_id,
+            "recommendation-phase19-generated-race-001",
+        )
 
     def test_service_merges_concurrent_reviewed_context_into_case_handoff(self) -> None:
         store, _ = make_store()
@@ -4438,6 +4750,14 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(
             updated_case.reviewed_context["triage"]["disposition"],
             "pending_approval",
+        )
+        self.assertEqual(
+            updated_case.reviewed_context["asset"]["asset_id"],
+            "asset-phase19-handoff-merge-001",
+        )
+        self.assertEqual(
+            updated_case.reviewed_context["identity"]["identity_id"],
+            "principal-phase19-handoff-merge-001",
         )
         self.assertEqual(
             updated_case.reviewed_context["handoff"]["follow_up_evidence_ids"],
@@ -4520,6 +4840,14 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(
             updated_case.reviewed_context["handoff"]["handoff_owner"],
             "analyst-002",
+        )
+        self.assertEqual(
+            updated_case.reviewed_context["asset"]["asset_id"],
+            "asset-phase19-disposition-merge-001",
+        )
+        self.assertEqual(
+            updated_case.reviewed_context["identity"]["identity_id"],
+            "principal-phase19-disposition-merge-001",
         )
         self.assertEqual(
             updated_case.reviewed_context["triage"]["disposition"],

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -27,7 +27,9 @@ from aegisops_control_plane.models import (
     ApprovalDecisionRecord,
     CaseRecord,
     EvidenceRecord,
+    LeadRecord,
     NativeDetectionRecord,
+    ObservationRecord,
     ReconciliationRecord,
     RecommendationRecord,
 )
@@ -3879,6 +3881,113 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(
             queue_view.records[0]["reviewed_context"]["source"]["source_family"],
             "microsoft_365_audit",
+        )
+
+    def test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        handoff_at = datetime(2026, 4, 7, 17, 45, tzinfo=timezone.utc)
+        admitted = service.ingest_finding_alert(
+            finding_id="finding-phase19-casework-001",
+            analytic_signal_id="signal-phase19-casework-001",
+            substrate_detection_record_id="substrate-detection-phase19-casework-001",
+            correlation_key="claim:asset-phase19-casework-001:github-audit",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-casework-001"},
+                "identity": {"identity_id": "principal-phase19-casework-001"},
+            },
+        )
+        evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-casework-001",
+                source_record_id="substrate-detection-phase19-casework-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence.evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        handed_off_case = service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=handoff_at,
+            handoff_owner="analyst-001",
+            handoff_note="Recheck repository owner membership against approved change window at next business-hours review.",
+            follow_up_evidence_ids=(evidence.evidence_id,),
+        )
+        disposed_case = service.record_case_disposition(
+            case_id=handed_off_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="No same-day response required; preserve next-shift context and keep case open.",
+            recorded_at=handoff_at,
+        )
+
+        detail = service.inspect_case_detail(promoted_case.case_id)
+
+        self.assertEqual(observation.case_id, promoted_case.case_id)
+        self.assertEqual(observation.lifecycle_state, "confirmed")
+        self.assertEqual(lead.case_id, promoted_case.case_id)
+        self.assertEqual(lead.lifecycle_state, "triaged")
+        self.assertEqual(recommendation.case_id, promoted_case.case_id)
+        self.assertEqual(recommendation.lifecycle_state, "under_review")
+        self.assertEqual(disposed_case.lifecycle_state, "pending_action")
+        self.assertEqual(
+            detail.case_record["reviewed_context"]["triage"]["disposition"],
+            "business_hours_handoff",
+        )
+        self.assertEqual(
+            detail.case_record["reviewed_context"]["triage"]["closure_rationale"],
+            "No same-day response required; preserve next-shift context and keep case open.",
+        )
+        self.assertEqual(
+            detail.case_record["reviewed_context"]["handoff"]["note"],
+            "Recheck repository owner membership against approved change window at next business-hours review.",
+        )
+        self.assertEqual(
+            detail.case_record["reviewed_context"]["handoff"]["handoff_owner"],
+            "analyst-001",
+        )
+        self.assertEqual(detail.linked_observation_ids, (observation.observation_id,))
+        self.assertEqual(detail.linked_lead_ids, (lead.lead_id,))
+        self.assertIn(recommendation.recommendation_id, detail.linked_recommendation_ids)
+        self.assertEqual(
+            detail.linked_observation_records[0]["supporting_evidence_ids"],
+            (evidence.evidence_id,),
+        )
+        self.assertEqual(
+            detail.linked_lead_records[0]["triage_rationale"],
+            "Privilege-impacting change needs durable business-hours follow-up.",
         )
 
     def _assert_service_analyst_queue_prefers_wazuh_source_for_multi_source_linkage(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -4135,6 +4135,164 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 recorded_at=reviewed_at,
             )
 
+    def test_service_merges_concurrent_reviewed_context_into_case_handoff(self) -> None:
+        store, _ = make_store()
+        base_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = base_service.ingest_finding_alert(
+            finding_id="finding-phase19-handoff-merge-001",
+            analytic_signal_id="signal-phase19-handoff-merge-001",
+            substrate_detection_record_id="substrate-detection-phase19-handoff-merge-001",
+            correlation_key="claim:asset-phase19-handoff-merge-001:github-audit",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-handoff-merge-001"},
+                "identity": {"identity_id": "principal-phase19-handoff-merge-001"},
+            },
+        )
+        evidence = base_service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-handoff-merge-001",
+                source_record_id="substrate-detection-phase19-handoff-merge-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
+        store = _TransactionMutationStore(
+            inner=store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                replace(
+                    transactional_store.get(CaseRecord, promoted_case.case_id),
+                    reviewed_context={
+                        **dict(
+                            transactional_store.get(
+                                CaseRecord,
+                                promoted_case.case_id,
+                            ).reviewed_context
+                        ),
+                        "triage": {
+                            "disposition": "pending_approval",
+                            "closure_rationale": "Concurrent triage update",
+                            "recorded_at": reviewed_at.isoformat(),
+                        },
+                    },
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        updated_case = service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=reviewed_at,
+            handoff_owner="analyst-001",
+            handoff_note="Carry forward the next-step evidence review.",
+            follow_up_evidence_ids=(evidence.evidence_id,),
+        )
+
+        self.assertEqual(
+            updated_case.reviewed_context["triage"]["disposition"],
+            "pending_approval",
+        )
+        self.assertEqual(
+            updated_case.reviewed_context["handoff"]["follow_up_evidence_ids"],
+            (evidence.evidence_id,),
+        )
+
+    def test_service_merges_concurrent_reviewed_context_into_case_disposition(self) -> None:
+        store, _ = make_store()
+        base_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = base_service.ingest_finding_alert(
+            finding_id="finding-phase19-disposition-merge-001",
+            analytic_signal_id="signal-phase19-disposition-merge-001",
+            substrate_detection_record_id=(
+                "substrate-detection-phase19-disposition-merge-001"
+            ),
+            correlation_key="claim:asset-phase19-disposition-merge-001:github-audit",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-disposition-merge-001"},
+                "identity": {
+                    "identity_id": "principal-phase19-disposition-merge-001"
+                },
+            },
+        )
+        base_service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-disposition-merge-001",
+                source_record_id=(
+                    "substrate-detection-phase19-disposition-merge-001"
+                ),
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="collector://wazuh/live",
+                acquired_at=reviewed_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
+        store = _TransactionMutationStore(
+            inner=store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                replace(
+                    transactional_store.get(CaseRecord, promoted_case.case_id),
+                    reviewed_context={
+                        **dict(
+                            transactional_store.get(
+                                CaseRecord,
+                                promoted_case.case_id,
+                            ).reviewed_context
+                        ),
+                        "handoff": {
+                            "handoff_at": reviewed_at.isoformat(),
+                            "handoff_owner": "analyst-002",
+                            "note": "Concurrent handoff note",
+                            "follow_up_evidence_ids": (),
+                        },
+                    },
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        updated_case = service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="pending_approval",
+            rationale="Disposition update should preserve concurrent handoff context.",
+            recorded_at=reviewed_at,
+        )
+
+        self.assertEqual(
+            updated_case.reviewed_context["handoff"]["handoff_owner"],
+            "analyst-002",
+        )
+        self.assertEqual(
+            updated_case.reviewed_context["triage"]["disposition"],
+            "pending_approval",
+        )
+
     def _assert_service_analyst_queue_prefers_wazuh_source_for_multi_source_linkage(
         self,
         *,


### PR DESCRIPTION
## Summary
- expose bounded operator casework commands on the control-plane CLI for alert promotion, observations, leads, recommendations, handoff notes, and disposition
- add matching reviewed runtime POST endpoints under `/operator/*` with bounded JSON validation before delegating into existing service-layer methods
- cover the full operator casework flow through focused CLI and HTTP tests and keep the reviewed case-detail surface as the verification target

## Testing
- `python3 -m unittest control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_records_bounded_operator_casework_actions`
- `python3 -m unittest control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_long_running_runtime_surface_records_bounded_operator_casework_actions`
- `python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`

Closes #397


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator CLI and HTTP write endpoints to promote alerts and record case observations, leads, recommendations, handoffs, and dispositions; inspect-case-detail now surfaces linked observation/lead IDs, recommendations, triage/handoff metadata, and lifecycle transitions.

* **Behavior / Validation**
  * Stronger request/body validation (size, JSON, UTF-8, timezone-aware datetimes, non-empty fields), loopback-only operator access, and rejection of duplicate/invalid identifiers.

* **Tests**
  * Expanded end-to-end CLI and HTTP integration and persistence tests, including concurrency and lifecycle transition coverage.

* **Documentation**
  * Added an issue journal entry documenting changes and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->