### PR TITLE
[codex] Add Phase 19 operator workflow validation

### DIFF
--- a/.codex-supervisor/issues/398/issue-journal.md
+++ b/.codex-supervisor/issues/398/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #398: validation: add end-to-end Phase 19 coverage for the approved operator workflow
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/398
+- Branch: codex/issue-398
+- Workspace: .
+- Journal: .codex-supervisor/issues/398/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: c5dc4906a2b7bf02fa6c2d4384b0f5468516c3d1
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T03:32:36.473Z
+
+## Latest Codex Summary
+- Added a dedicated Phase 19 end-to-end runtime validator that drives the approved Wazuh-backed operator workflow over the reviewed HTTP surface, then wired the Phase 19 verifier, focused shell guard, CI workflow guard, and validation note to require that coverage.
+- The first focused failure was an incorrect queue expectation in the new validator: before case promotion the queue review state is `pending_review`, not `case_required`. I corrected the test to assert the workflow in order by checking pre-promotion queue review first and post-promotion case-required state second.
+- Full repository-local unittest discovery and the updated Phase 19 shell guards now pass.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Phase 19 was missing a dedicated repository-local runtime validator for the approved operator workflow even though the underlying HTTP surface already supported the slice.
+- What changed: Added `control-plane/tests/test_phase19_operator_workflow_validation.py` to exercise queue review, alert detail, case promotion, bounded casework actions, evidence provenance visibility, business-hours handoff/disposition, and cited advisory visibility over the reviewed runtime path. Updated the Phase 19 validation doc, verifier, shell self-test, CI workflow guard, and CI job command to require the new validator.
+- Current blocker: none.
+- Next exact step: Commit the Phase 19 validation checkpoint on `codex/issue-398`; open or update a draft PR if supervisor flow wants the checkpoint published early.
+- Verification gap: none for the requested repository-local Phase 19 validation slice.
+- Files touched: `.github/workflows/ci.yml`; `docs/phase-19-thin-operator-surface-and-daily-analyst-workflow-validation.md`; `scripts/verify-phase-19-thin-operator-surface.sh`; `scripts/test-verify-phase-19-thin-operator-surface.sh`; `scripts/test-verify-ci-phase-19-workflow-coverage.sh`; `control-plane/tests/test_phase19_operator_workflow_validation.py`.
+- Rollback concern: The new validator encodes current reviewed runtime payload shapes for the first Wazuh-backed slice, so later operator-surface broadening will need intentional test updates rather than ad hoc drift.
+- Last focused command: `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Run Phase 19 thin operator surface validation
         run: |
           bash scripts/verify-phase-19-thin-operator-surface.sh
-          python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs
+          python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs control-plane.tests.test_phase19_operator_workflow_validation
 
       - name: Run Phase 19 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-19-workflow-coverage.sh

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -269,6 +269,58 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 self.assertIn(evidence_id, case_detail["advisory_output"]["citations"])
                 self.assertIn(created.alert.alert_id, case_detail["advisory_output"]["citations"])
                 self.assertIn(case_id, case_detail["advisory_output"]["citations"])
+
+                closed_case = post_json(
+                    "/operator/record-case-disposition",
+                    {
+                        "case_id": case_id,
+                        "disposition": "closed_resolved",
+                        "rationale": "Repository owner membership review completed and documented for this alert.",
+                        "recorded_at": "2026-04-08T09:15:00+00:00",
+                    },
+                )
+                self.assertEqual(closed_case["lifecycle_state"], "closed")
+
+                closed_case_detail = get_json(f"/inspect-case-detail?case_id={case_id}")
+                self.assertTrue(closed_case_detail["read_only"])
+                self.assertEqual(closed_case_detail["case_record"]["case_id"], case_id)
+                self.assertEqual(closed_case_detail["case_record"]["lifecycle_state"], "closed")
+                self.assertEqual(
+                    closed_case_detail["case_record"]["reviewed_context"]["triage"]["disposition"],
+                    "closed_resolved",
+                )
+                self.assertEqual(
+                    closed_case_detail["case_record"]["reviewed_context"]["triage"]["closure_rationale"],
+                    "Repository owner membership review completed and documented for this alert.",
+                )
+                self.assertEqual(
+                    closed_case_detail["linked_alert_ids"],
+                    [created.alert.alert_id],
+                )
+                self.assertEqual(
+                    closed_case_detail["linked_observation_ids"],
+                    [observation["observation_id"]],
+                )
+                self.assertEqual(closed_case_detail["linked_lead_ids"], [lead["lead_id"]])
+                self.assertIn(evidence_id, closed_case_detail["linked_evidence_ids"])
+                self.assertIn(
+                    recommendation["recommendation_id"],
+                    closed_case_detail["linked_recommendation_ids"],
+                )
+                self.assertEqual(
+                    closed_case_detail["advisory_output"]["output_kind"],
+                    "case_summary",
+                )
+                self.assertEqual(closed_case_detail["advisory_output"]["status"], "ready")
+                self.assertIn(
+                    evidence_id,
+                    closed_case_detail["advisory_output"]["citations"],
+                )
+                self.assertIn(
+                    created.alert.alert_id,
+                    closed_case_detail["advisory_output"]["citations"],
+                )
+                self.assertIn(case_id, closed_case_detail["advisory_output"]["citations"])
             finally:
                 if servers:
                     servers[0].shutdown()

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import pathlib
+import sys
+import threading
+import unittest
+from urllib import request
+from unittest import mock
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+import main
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
+
+
+FIXTURES_ROOT = pathlib.Path(__file__).resolve().parent / "fixtures" / "wazuh"
+
+
+def _load_wazuh_fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+
+
+class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
+    def test_reviewed_runtime_path_covers_approved_operator_workflow(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106
+            ),
+            store=store,
+        )
+
+        created_alert = _load_wazuh_fixture("github-audit-alert.json")
+        restated_alert = deepcopy(created_alert)
+        restated_alert["id"] = "1731596200.1234568"
+        restated_alert["timestamp"] = "2026-04-05T12:35:00+00:00"
+        deduplicated_alert = deepcopy(restated_alert)
+
+        created = service.ingest_wazuh_alert(
+            raw_alert=created_alert,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
+        )
+        service.ingest_wazuh_alert(
+            raw_alert=restated_alert,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
+        )
+        service.ingest_wazuh_alert(
+            raw_alert=deduplicated_alert,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                def get_json(path: str) -> dict[str, object]:
+                    response = request.urlopen(f"{base_url}{path}", timeout=2)  # noqa: S310
+                    return json.loads(response.read().decode("utf-8"))
+
+                def post_json(path: str, payload: dict[str, object]) -> dict[str, object]:
+                    response = request.urlopen(  # noqa: S310
+                        request.Request(  # noqa: S310
+                            f"{base_url}{path}",
+                            data=json.dumps(payload).encode("utf-8"),
+                            headers={"Content-Type": "application/json"},
+                            method="POST",
+                        ),
+                        timeout=2,
+                    )
+                    return json.loads(response.read().decode("utf-8"))
+
+                queue_payload = get_json("/inspect-analyst-queue")
+                self.assertTrue(queue_payload["read_only"])
+                self.assertEqual(queue_payload["queue_name"], "analyst_review")
+                self.assertEqual(queue_payload["total_records"], 1)
+                self.assertEqual(queue_payload["records"][0]["alert_id"], created.alert.alert_id)
+                self.assertEqual(queue_payload["records"][0]["queue_selection"], "business_hours_triage")
+                self.assertEqual(queue_payload["records"][0]["review_state"], "pending_review")
+                self.assertIsNone(queue_payload["records"][0]["case_id"])
+                self.assertEqual(queue_payload["records"][0]["source_system"], "wazuh")
+                self.assertEqual(
+                    queue_payload["records"][0]["substrate_detection_record_ids"],
+                    ["wazuh:1731595300.1234567", "wazuh:1731596200.1234568"],
+                )
+                self.assertEqual(
+                    queue_payload["records"][0]["accountable_source_identities"],
+                    ["manager:wazuh-manager-github-1"],
+                )
+                self.assertEqual(
+                    queue_payload["records"][0]["reviewed_context"]["source"]["source_family"],
+                    "github_audit",
+                )
+
+                promoted_case = post_json(
+                    "/operator/promote-alert-to-case",
+                    {"alert_id": created.alert.alert_id},
+                )
+                case_id = str(promoted_case["case_id"])
+                self.assertEqual(promoted_case["lifecycle_state"], "open")
+
+                queue_after_promotion = get_json("/inspect-analyst-queue")
+                self.assertEqual(queue_after_promotion["records"][0]["case_id"], case_id)
+                self.assertEqual(
+                    queue_after_promotion["records"][0]["case_lifecycle_state"],
+                    "open",
+                )
+                self.assertEqual(
+                    queue_after_promotion["records"][0]["review_state"],
+                    "case_required",
+                )
+
+                alert_detail = get_json(f"/inspect-alert-detail?alert_id={created.alert.alert_id}")
+                self.assertTrue(alert_detail["read_only"])
+                self.assertEqual(alert_detail["alert"]["case_id"], case_id)
+                self.assertEqual(alert_detail["case_record"]["case_id"], case_id)
+                self.assertEqual(
+                    alert_detail["provenance"],
+                    {
+                        "admission_kind": "live",
+                        "admission_channel": "live_wazuh_webhook",
+                    },
+                )
+                self.assertEqual(
+                    alert_detail["lineage"]["substrate_detection_record_ids"],
+                    ["wazuh:1731595300.1234567", "wazuh:1731596200.1234568"],
+                )
+                self.assertEqual(
+                    alert_detail["lineage"]["accountable_source_identities"],
+                    ["manager:wazuh-manager-github-1"],
+                )
+                self.assertEqual(
+                    alert_detail["reviewed_context"]["source"]["source_family"],
+                    "github_audit",
+                )
+                self.assertGreaterEqual(len(alert_detail["linked_evidence_records"]), 1)
+                live_evidence_records = [
+                    record
+                    for record in alert_detail["linked_evidence_records"]
+                    if record["collector_identity"] == "wazuh-native-detection-adapter"
+                    and record["derivation_relationship"] == "native_detection_record"
+                    and record["source_system"] == "wazuh"
+                ]
+                self.assertTrue(
+                    live_evidence_records,
+                    "expected at least one live Wazuh evidence record in alert detail",
+                )
+                evidence_id = str(live_evidence_records[0]["evidence_id"])
+
+                observation = post_json(
+                    "/operator/record-case-observation",
+                    {
+                        "case_id": case_id,
+                        "author_identity": "analyst-001",
+                        "observed_at": "2026-04-07T09:30:00+00:00",
+                        "scope_statement": "Observed repository permission change requires tracked review.",
+                        "supporting_evidence_ids": [evidence_id],
+                    },
+                )
+                lead = post_json(
+                    "/operator/record-case-lead",
+                    {
+                        "case_id": case_id,
+                        "triage_owner": "analyst-001",
+                        "triage_rationale": "Privilege-impacting change needs durable business-hours follow-up.",
+                        "observation_id": observation["observation_id"],
+                    },
+                )
+                recommendation = post_json(
+                    "/operator/record-case-recommendation",
+                    {
+                        "case_id": case_id,
+                        "review_owner": "analyst-001",
+                        "intended_outcome": "Review repository owner change evidence before any approval-bound response.",
+                        "lead_id": lead["lead_id"],
+                    },
+                )
+                handoff = post_json(
+                    "/operator/record-case-handoff",
+                    {
+                        "case_id": case_id,
+                        "handoff_at": "2026-04-07T17:45:00+00:00",
+                        "handoff_owner": "analyst-001",
+                        "handoff_note": "Recheck repository owner membership against approved change window at next business-hours review.",
+                        "follow_up_evidence_ids": [evidence_id],
+                    },
+                )
+                disposition = post_json(
+                    "/operator/record-case-disposition",
+                    {
+                        "case_id": case_id,
+                        "disposition": "business_hours_handoff",
+                        "rationale": "No same-day response required; preserve next-shift context and keep case open.",
+                        "recorded_at": "2026-04-07T17:45:00+00:00",
+                    },
+                )
+
+                self.assertEqual(observation["supporting_evidence_ids"], [evidence_id])
+                self.assertEqual(lead["observation_id"], observation["observation_id"])
+                self.assertEqual(recommendation["lead_id"], lead["lead_id"])
+                self.assertEqual(
+                    handoff["reviewed_context"]["handoff"]["follow_up_evidence_ids"],
+                    [evidence_id],
+                )
+                self.assertEqual(disposition["lifecycle_state"], "pending_action")
+
+                case_detail = get_json(f"/inspect-case-detail?case_id={case_id}")
+                self.assertTrue(case_detail["read_only"])
+                self.assertEqual(case_detail["case_record"]["case_id"], case_id)
+                self.assertEqual(case_detail["case_record"]["lifecycle_state"], "pending_action")
+                self.assertEqual(case_detail["linked_alert_ids"], [created.alert.alert_id])
+                self.assertEqual(case_detail["linked_observation_ids"], [observation["observation_id"]])
+                self.assertEqual(case_detail["linked_lead_ids"], [lead["lead_id"]])
+                self.assertIn(evidence_id, case_detail["linked_evidence_ids"])
+                self.assertIn(
+                    recommendation["recommendation_id"],
+                    case_detail["linked_recommendation_ids"],
+                )
+                self.assertEqual(
+                    case_detail["reviewed_context"]["handoff"]["note"],
+                    "Recheck repository owner membership against approved change window at next business-hours review.",
+                )
+                self.assertEqual(
+                    case_detail["reviewed_context"]["triage"]["disposition"],
+                    "business_hours_handoff",
+                )
+                self.assertEqual(
+                    case_detail["advisory_output"]["output_kind"],
+                    "case_summary",
+                )
+                self.assertEqual(case_detail["advisory_output"]["status"], "ready")
+                self.assertIn(evidence_id, case_detail["advisory_output"]["citations"])
+                self.assertIn(created.alert.alert_id, case_detail["advisory_output"]["citations"])
+                self.assertIn(case_id, case_detail["advisory_output"]["citations"])
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -21,6 +21,8 @@ from postgres_test_support import make_store
 
 
 FIXTURES_ROOT = pathlib.Path(__file__).resolve().parent / "fixtures" / "wazuh"
+REVIEWED_SHARED_SECRET = "reviewed-shared-secret"  # noqa: S105
+REVIEWED_PROXY_SECRET = "reviewed-proxy-secret"  # noqa: S105
 
 
 def _load_wazuh_fixture(name: str) -> dict[str, object]:
@@ -35,8 +37,8 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 host="127.0.0.1",
                 port=0,
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
             ),
             store=store,
         )
@@ -49,23 +51,23 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
 
         created = service.ingest_wazuh_alert(
             raw_alert=created_alert,
-            authorization_header="Bearer reviewed-shared-secret",
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
             peer_addr="127.0.0.1",
         )
         service.ingest_wazuh_alert(
             raw_alert=restated_alert,
-            authorization_header="Bearer reviewed-shared-secret",
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
             peer_addr="127.0.0.1",
         )
         service.ingest_wazuh_alert(
             raw_alert=deduplicated_alert,
-            authorization_header="Bearer reviewed-shared-secret",
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
             peer_addr="127.0.0.1",
         )
 

--- a/docs/phase-19-thin-operator-surface-and-daily-analyst-workflow-validation.md
+++ b/docs/phase-19-thin-operator-surface-and-daily-analyst-workflow-validation.md
@@ -3,7 +3,7 @@
 - Validation date: 2026-04-11
 - Validation scope: Phase 19 review of the approved thin operator surface for the first Wazuh-backed live slice, the minimum queue review through alert inspection, casework entry, evidence review, and cited advisory review path, confirmation that AegisOps remains the primary daily work surface, and confirmation that deferred surfaces and actions remain visibly out of scope
 - Baseline references: `docs/phase-19-thin-operator-surface-and-daily-analyst-workflow.md`, `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md`, `docs/phase-18-wazuh-lab-topology-validation.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/phase-15-identity-grounded-analyst-assistant-operating-guidance.md`, `docs/architecture.md`
-- Verification commands: `python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs`, `bash scripts/verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-ci-phase-19-workflow-coverage.sh`
+- Verification commands: `python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs control-plane.tests.test_phase19_operator_workflow_validation`, `bash scripts/verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-ci-phase-19-workflow-coverage.sh`
 - Validation status: PASS
 
 ## Required Boundary Artifacts
@@ -17,6 +17,7 @@
 - `docs/phase-15-identity-grounded-analyst-assistant-operating-guidance.md`
 - `docs/architecture.md`
 - `control-plane/tests/test_phase19_operator_surface_docs.py`
+- `control-plane/tests/test_phase19_operator_workflow_validation.py`
 - `scripts/verify-phase-19-thin-operator-surface.sh`
 - `scripts/test-verify-phase-19-thin-operator-surface.sh`
 - `scripts/test-verify-ci-phase-19-workflow-coverage.sh`
@@ -28,6 +29,8 @@ Confirmed the approved Phase 19 thin operator surface is explicitly limited to a
 Confirmed AegisOps as the primary daily work surface for the first live slice by keeping the approved operator reads inside the AegisOps analyst queue, linked alert and case detail, linked reconciliation context, read-only evidence access, and cited advisory review.
 
 Confirmed the approved first daily workflow is queue review through alert inspection, casework entry, evidence review, and cited advisory review.
+
+Confirmed repository-local validation now exercises the reviewed runtime path end to end, including queue review, alert detail, case promotion, bounded casework entry, evidence provenance visibility, business-hours handoff tracking, and cited advisory visibility for the approved Wazuh-backed operator slice.
 
 Confirmed the approved bounded analyst actions are limited to selecting a queue item, inspecting linked records, promoting an alert to a case when review requires tracked casework, entering cited AegisOps-owned casework entries, and requesting cited advisory review from the approved read-only assistant-context path.
 

--- a/docs/phase-19-thin-operator-surface-and-daily-analyst-workflow-validation.md
+++ b/docs/phase-19-thin-operator-surface-and-daily-analyst-workflow-validation.md
@@ -3,7 +3,7 @@
 - Validation date: 2026-04-11
 - Validation scope: Phase 19 review of the approved thin operator surface for the first Wazuh-backed live slice, the minimum queue review through alert inspection, casework entry, evidence review, and cited advisory review path, confirmation that AegisOps remains the primary daily work surface, and confirmation that deferred surfaces and actions remain visibly out of scope
 - Baseline references: `docs/phase-19-thin-operator-surface-and-daily-analyst-workflow.md`, `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md`, `docs/phase-18-wazuh-lab-topology-validation.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/phase-15-identity-grounded-analyst-assistant-operating-guidance.md`, `docs/architecture.md`
-- Verification commands: `python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs control-plane.tests.test_phase19_operator_workflow_validation`, `bash scripts/verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-ci-phase-19-workflow-coverage.sh`
+- Verification commands: `python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs control-plane.tests.test_phase19_operator_workflow_validation`, `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`, `bash scripts/verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-ci-phase-19-workflow-coverage.sh`
 - Validation status: PASS
 
 ## Required Boundary Artifacts

--- a/scripts/test-verify-ci-phase-19-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-19-workflow-coverage.sh
@@ -14,7 +14,7 @@ required_tests=(
 )
 
 required_runtime_commands=(
-  "python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs"
+  "python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs control-plane.tests.test_phase19_operator_workflow_validation"
 )
 
 self_guard_step_name="Run Phase 19 workflow coverage guard"

--- a/scripts/test-verify-phase-19-thin-operator-surface.sh
+++ b/scripts/test-verify-phase-19-thin-operator-surface.sh
@@ -23,6 +23,7 @@ required_artifacts=(
   "docs/phase-15-identity-grounded-analyst-assistant-operating-guidance.md"
   "docs/architecture.md"
   "control-plane/tests/test_phase19_operator_surface_docs.py"
+  "control-plane/tests/test_phase19_operator_workflow_validation.py"
   "scripts/verify-phase-19-thin-operator-surface.sh"
   "scripts/test-verify-phase-19-thin-operator-surface.sh"
   "scripts/test-verify-ci-phase-19-workflow-coverage.sh"
@@ -143,6 +144,16 @@ remove_text_from_file \
   "    def test_phase19_design_doc_defines_operator_surface_workflow_and_deferred_scope(self) -> None:"
 commit_fixture "${missing_test_repo}"
 assert_fails_with "${missing_test_repo}" "Missing required line in ${missing_test_repo}/control-plane/tests/test_phase19_operator_surface_docs.py:     def test_phase19_design_doc_defines_operator_surface_workflow_and_deferred_scope(self) -> None:"
+
+missing_runtime_validation_test_repo="${workdir}/missing-runtime-validation-test"
+create_repo "${missing_runtime_validation_test_repo}"
+write_required_artifacts "${missing_runtime_validation_test_repo}"
+remove_text_from_file \
+  "${missing_runtime_validation_test_repo}" \
+  "control-plane/tests/test_phase19_operator_workflow_validation.py" \
+  "    def test_reviewed_runtime_path_covers_approved_operator_workflow(self) -> None:"
+commit_fixture "${missing_runtime_validation_test_repo}"
+assert_fails_with "${missing_runtime_validation_test_repo}" "Missing required line in ${missing_runtime_validation_test_repo}/control-plane/tests/test_phase19_operator_workflow_validation.py:     def test_reviewed_runtime_path_covers_approved_operator_workflow(self) -> None:"
 
 missing_ci_repo="${workdir}/missing-ci"
 create_repo "${missing_ci_repo}"

--- a/scripts/verify-phase-19-thin-operator-surface.sh
+++ b/scripts/verify-phase-19-thin-operator-surface.sh
@@ -12,6 +12,7 @@ phase16_doc="${repo_root}/docs/phase-16-release-state-and-first-boot-scope.md"
 phase15_guidance_doc="${repo_root}/docs/phase-15-identity-grounded-analyst-assistant-operating-guidance.md"
 architecture_doc="${repo_root}/docs/architecture.md"
 test_doc="${repo_root}/control-plane/tests/test_phase19_operator_surface_docs.py"
+workflow_test_doc="${repo_root}/control-plane/tests/test_phase19_operator_workflow_validation.py"
 workflow_path="${repo_root}/.github/workflows/ci.yml"
 
 require_file() {
@@ -43,6 +44,7 @@ require_file "${phase16_doc}" "Missing Phase 16 first-boot scope doc"
 require_file "${phase15_guidance_doc}" "Missing Phase 15 analyst-assistant operating guidance doc"
 require_file "${architecture_doc}" "Missing architecture overview doc"
 require_file "${test_doc}" "Missing Phase 19 operator surface unittest"
+require_file "${workflow_test_doc}" "Missing Phase 19 operator workflow validation unittest"
 require_file "${workflow_path}" "Missing CI workflow"
 
 design_required_lines=(
@@ -117,6 +119,7 @@ required_artifacts=(
   "docs/phase-15-identity-grounded-analyst-assistant-operating-guidance.md"
   "docs/architecture.md"
   "control-plane/tests/test_phase19_operator_surface_docs.py"
+  "control-plane/tests/test_phase19_operator_workflow_validation.py"
   "scripts/verify-phase-19-thin-operator-surface.sh"
   "scripts/test-verify-phase-19-thin-operator-surface.sh"
   "scripts/test-verify-ci-phase-19-workflow-coverage.sh"
@@ -127,14 +130,16 @@ for artifact in "${required_artifacts[@]}"; do
   require_fixed_line "${validation_doc}" "- \`${artifact}\`"
 done
 
-require_fixed_line "${validation_doc}" '- Verification commands: `python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs`, `bash scripts/verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-ci-phase-19-workflow-coverage.sh`'
+require_fixed_line "${validation_doc}" '- Verification commands: `python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs control-plane.tests.test_phase19_operator_workflow_validation`, `bash scripts/verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-ci-phase-19-workflow-coverage.sh`'
 require_fixed_line "${test_doc}" 'class Phase19OperatorSurfaceDocsTests(unittest.TestCase):'
 require_fixed_line "${test_doc}" '    def test_phase19_design_doc_exists(self) -> None:'
 require_fixed_line "${test_doc}" '    def test_phase19_design_doc_defines_operator_surface_workflow_and_deferred_scope(self) -> None:'
 require_fixed_line "${test_doc}" '    def test_phase19_validation_doc_exists_and_records_alignment_caveat(self) -> None:'
+require_fixed_line "${workflow_test_doc}" 'class Phase19OperatorWorkflowValidationTests(unittest.TestCase):'
+require_fixed_line "${workflow_test_doc}" '    def test_reviewed_runtime_path_covers_approved_operator_workflow(self) -> None:'
 require_fixed_line "${workflow_path}" '      - name: Run Phase 19 thin operator surface validation'
 require_fixed_line "${workflow_path}" '          bash scripts/verify-phase-19-thin-operator-surface.sh'
-require_fixed_line "${workflow_path}" '          python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs'
+require_fixed_line "${workflow_path}" '          python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs control-plane.tests.test_phase19_operator_workflow_validation'
 require_fixed_line "${workflow_path}" '      - name: Run Phase 19 workflow coverage guard'
 require_fixed_line "${workflow_path}" '        run: bash scripts/test-verify-ci-phase-19-workflow-coverage.sh'
 require_fixed_line "${workflow_path}" '          bash scripts/test-verify-phase-19-thin-operator-surface.sh'

--- a/scripts/verify-phase-19-thin-operator-surface.sh
+++ b/scripts/verify-phase-19-thin-operator-surface.sh
@@ -130,7 +130,7 @@ for artifact in "${required_artifacts[@]}"; do
   require_fixed_line "${validation_doc}" "- \`${artifact}\`"
 done
 
-require_fixed_line "${validation_doc}" '- Verification commands: `python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs control-plane.tests.test_phase19_operator_workflow_validation`, `bash scripts/verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-ci-phase-19-workflow-coverage.sh`'
+require_fixed_line "${validation_doc}" '- Verification commands: `python3 -m unittest control-plane.tests.test_phase19_operator_surface_docs control-plane.tests.test_phase19_operator_workflow_validation`, `python3 -m unittest discover -s control-plane/tests -p '\''test_*.py'\''`, `bash scripts/verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-phase-19-thin-operator-surface.sh`, `bash scripts/test-verify-ci-phase-19-workflow-coverage.sh`'
 require_fixed_line "${test_doc}" 'class Phase19OperatorSurfaceDocsTests(unittest.TestCase):'
 require_fixed_line "${test_doc}" '    def test_phase19_design_doc_exists(self) -> None:'
 require_fixed_line "${test_doc}" '    def test_phase19_design_doc_defines_operator_surface_workflow_and_deferred_scope(self) -> None:'


### PR DESCRIPTION
## Summary
- add a dedicated Phase 19 end-to-end validator for the approved operator workflow on the reviewed Wazuh-backed runtime path
- require the new validator in the Phase 19 verification script, shell self-tests, CI workflow guard, and validation documentation
- lock the thin operator baseline around queue review, alert detail, case promotion, bounded casework actions, evidence provenance, reviewed context, handoff notes, disposition, closure, and cited advisory visibility

## Why
Phase 19 needed repository-local validation that would catch drift in the approved operator slice before later phases expand automation breadth or live actions.

## Impact
This gives Phase 20 a stable operator baseline and helps prevent regressions that would force operators back to substrate-native tools or undocumented side channels.

## Verification
- `python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation`
- `bash scripts/verify-phase-19-thin-operator-surface.sh`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end Phase 19 validation test covering the approved operator workflow: queue review, alert detail inspection, case promotion, casework actions, evidence/provenance, handoff tracking, and advisory outputs.

* **Chores**
  * Extended CI to run the new workflow validation alongside existing Phase 19 surface tests.
  * Updated verification scripts and harnesses to require and check the new test.

* **Documentation**
  * Added an issue-journal entry and updated Phase 19 validation docs to reflect the expanded validation commands and artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->