### PR TITLE
[codex] Fail closed on lead-only advisory rendering

### DIFF
--- a/.codex-supervisor/issues/405/issue-journal.md
+++ b/.codex-supervisor/issues/405/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #405: follow-up: fail closed instead of crashing on lead-only advisory rendering
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/405
+- Branch: codex/issue-405
+- Workspace: .
+- Journal: .codex-supervisor/issues/405/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 77491074d5e3a0a72d29af9cbda1c092c8efb34f
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T07:53:06.292Z
+
+## Latest Codex Summary
+- Reproduced the lead-only recommendation crash with a focused persistence test that persists a valid `lead_id` but omits direct `alert_id` and `case_id`, then calls `render_recommendation_draft()`.
+- Fixed `_build_assistant_advisory_output()` so advisory status is computed independently of direct alert/case linkage, which preserves fail-closed `unresolved` output instead of raising `UnboundLocalError`.
+- Verified with `python3 -m unittest control-plane.tests.test_service_persistence` and `python3 -m unittest control-plane.tests.test_cli_inspection`.
+
+## Active Failure Context
+- Resolved: `UnboundLocalError: local variable 'status' referenced before assignment` in `_build_assistant_advisory_output()` for lead-only recommendation rendering.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Lead-only reviewed recommendations bypass direct alert/case linkage, so the advisory builder must set `status` without assuming `linked_alert_ids` or `linked_case_ids` are present.
+- What changed: Added a focused regression test for a valid lead-linked recommendation with no direct alert/case lineage and moved advisory `status` assignment outside the alert/case observation branch.
+- Current blocker: none
+- Next exact step: Commit the bounded fix on `codex/issue-405`.
+- Verification gap: none for the scoped change; focused reproducer, full persistence suite, and CLI inspection suite all pass locally.
+- Files touched: `control-plane/tests/test_service_persistence.py`, `control-plane/aegisops_control_plane/service.py`
+- Rollback concern: Low; the code change only decouples status initialization from alert/case linkage while leaving fail-closed checks and advisory text selection intact.
+- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -785,7 +785,7 @@ def _build_assistant_advisory_output(
             }
         )
 
-        status = "unresolved" if fail_closed else "ready"
+    status = "unresolved" if fail_closed else "ready"
     if status == "ready":
         if output_kind == "recommendation_draft":
             summary_text = _recommendation_draft_review_summary(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -1038,6 +1038,87 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             rejected_ai_trace_draft.recommendation_draft["cited_summary"]["text"],
         )
 
+    def test_service_renders_lead_only_recommendation_draft_as_unresolved(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+
+        admitted = service.ingest_finding_alert(
+            finding_id="finding-lead-only-advisory-001",
+            analytic_signal_id="signal-lead-only-advisory-001",
+            substrate_detection_record_id="substrate-detection-lead-only-advisory-001",
+            correlation_key="claim:lead-only:advisory:001",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-lead-only-advisory-001"},
+            },
+        )
+        evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-lead-only-advisory-001",
+                source_record_id="substrate-detection-lead-only-advisory-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="control-plane-test",
+                acquired_at=first_seen_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=first_seen_at,
+            scope_statement="Lead-only recommendation should fail closed without direct lineage.",
+            supporting_evidence_ids=(evidence.evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Preserve reviewed lead linkage for bounded advisory rendering.",
+        )
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-lead-only-advisory-001",
+                lead_id=lead.lead_id,
+                hunt_run_id=None,
+                alert_id=None,
+                case_id=None,
+                ai_trace_id=None,
+                review_owner="analyst-001",
+                intended_outcome="Review the lead linkage before any broader response.",
+                lifecycle_state="under_review",
+                reviewed_context={
+                    "asset": {"asset_id": "asset-lead-only-advisory-001"},
+                },
+            )
+        )
+
+        draft = service.render_recommendation_draft(
+            "recommendation",
+            recommendation.recommendation_id,
+        )
+
+        self.assertEqual(draft.linked_alert_ids, ())
+        self.assertEqual(draft.linked_case_ids, ())
+        self.assertEqual(draft.linked_evidence_ids, ())
+        self.assertEqual(draft.recommendation_draft["status"], "unresolved")
+        self.assertIn(
+            "missing_evidence_citation",
+            draft.recommendation_draft["uncertainty_flags"],
+        )
+        self.assertIn(
+            "remains unresolved",
+            draft.recommendation_draft["cited_summary"]["text"],
+        )
+
     def test_service_includes_evidence_derived_recommendations_in_ai_trace_context(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- stop reviewed advisory rendering from depending on direct alert/case linkage before assigning advisory status
- preserve fail-closed cited advisory semantics for lead-only recommendations by returning structured `status="unresolved"` output instead of raising
- add a regression covering `render_recommendation_draft()` for a reviewed recommendation linked through a lead with no direct alert or case linkage

## Root cause
The cited advisory rendering path initialized advisory `status` inside the direct alert/case linkage branch. A reviewed recommendation with valid lead linkage but no direct linked alert or linked case reached the advisory builder with enough context to render, but without those direct linkage collections. That path then referenced `status` before assignment and raised `UnboundLocalError` instead of failing closed.

## Validation
- `python3 -m unittest control-plane.tests.test_service_persistence`
- `python3 -m unittest control-plane.tests.test_cli_inspection`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed advisory status rendering in scenarios where certain evidence linkages are not present.

* **Tests**
  * Added test coverage for lead-only recommendation rendering.

* **Chores**
  * Added supervisor issue journal documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->