### PR TITLE
[codex] Expose advisory review runtime routes

### DIFF
--- a/.codex-supervisor/issues/404/issue-journal.md
+++ b/.codex-supervisor/issues/404/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #404: follow-up: expose cited advisory review routes on the Phase 19 runtime surface
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/404
+- Branch: codex/issue-404
+- Workspace: .
+- Journal: .codex-supervisor/issues/404/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: c1fc55eeaa7647aa5855a316ed4f942f4597c08d
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T08:20:26.406Z
+
+## Latest Codex Summary
+- Added the three cited advisory review GET routes to the long-running runtime surface and aligned their `400`/`404` handling with the existing reviewed inspection routes.
+- Added a focused HTTP reproducer in `control-plane/tests/test_cli_inspection.py` and extended the Phase 19 workflow validation to exercise the advisory review reads over runtime HTTP.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The CLI advisory inspection commands already worked, but `run_control_plane_service()` never routed `/inspect-assistant-context`, `/inspect-advisory-output`, or `/render-recommendation-draft`, so runtime callers fell through to generic route-level `404 not_found`.
+- What changed: Added reviewed GET handlers for the three advisory routes in `control-plane/main.py`, preserving read-only behavior and mapping missing `family`/`record_id` to `400`, `ValueError` to `400`, and `LookupError` to `404`. Added a focused runtime regression test in `control-plane/tests/test_cli_inspection.py` and extended `control-plane/tests/test_phase19_operator_workflow_validation.py` to exercise the advisory review reads.
+- Current blocker: none.
+- Next exact step: Commit the runtime route and test changes on `codex/issue-404`, then hand back with the focused verification results.
+- Verification gap: Did not run the entire repository test suite; focused verification covered `control-plane.tests.test_cli_inspection` and `control-plane.tests.test_phase19_operator_workflow_validation`.
+- Files touched: `control-plane/main.py`, `control-plane/tests/test_cli_inspection.py`, `control-plane/tests/test_phase19_operator_workflow_validation.py`.
+- Rollback concern: Low; changes are limited to read-only GET routing and test coverage, with no operator write-path or auth-boundary expansion.
+- Last focused command: `python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_phase19_operator_workflow_validation`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -33,6 +33,14 @@ def _normalize_case_id(value: str) -> str:
     return value.strip()
 
 
+def _normalize_record_family(value: str) -> str:
+    return value.strip()
+
+
+def _normalize_record_id(value: str) -> str:
+    return value.strip()
+
+
 def _normalize_optional_string(value: object) -> str | None:
     if value is None:
         return None
@@ -427,6 +435,72 @@ def run_control_plane_service(
                     return
                 try:
                     payload = service.inspect_case_detail(case_id).to_dict()
+                except ValueError as exc:
+                    self._write_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {
+                            "error": "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                except LookupError as exc:
+                    self._write_json(
+                        HTTPStatus.NOT_FOUND,
+                        {
+                            "error": "not_found",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, payload)
+                return
+
+            if request_path in {
+                "/inspect-assistant-context",
+                "/inspect-advisory-output",
+                "/render-recommendation-draft",
+            }:
+                family = _normalize_record_family(
+                    parse_qs(request_target.query).get("family", [""])[0]
+                )
+                if not family:
+                    self._write_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {
+                            "error": "invalid_request",
+                            "message": "family query parameter is required",
+                        },
+                    )
+                    return
+                record_id = _normalize_record_id(
+                    parse_qs(request_target.query).get("record_id", [""])[0]
+                )
+                if not record_id:
+                    self._write_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {
+                            "error": "invalid_request",
+                            "message": "record_id query parameter is required",
+                        },
+                    )
+                    return
+                try:
+                    if request_path == "/inspect-assistant-context":
+                        payload = service.inspect_assistant_context(
+                            family,
+                            record_id,
+                        ).to_dict()
+                    elif request_path == "/inspect-advisory-output":
+                        payload = service.inspect_advisory_output(
+                            family,
+                            record_id,
+                        ).to_dict()
+                    else:
+                        payload = service.render_recommendation_draft(
+                            family,
+                            record_id,
+                        ).to_dict()
                 except ValueError as exc:
                     self._write_json(
                         HTTPStatus.BAD_REQUEST,

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1703,8 +1703,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 host="127.0.0.1",
                 port=0,
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             ),
             store=store,
         )
@@ -1780,7 +1780,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 base_url = f"http://127.0.0.1:{servers[0].server_port}"
 
                 assistant_context = json.loads(
-                    request.urlopen(
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
                         (
                             f"{base_url}/inspect-assistant-context"
                             f"?family=case&record_id={promoted_case.case_id}"
@@ -1789,7 +1789,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     ).read().decode("utf-8")
                 )
                 advisory_output = json.loads(
-                    request.urlopen(
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
                         (
                             f"{base_url}/inspect-advisory-output"
                             f"?family=case&record_id={promoted_case.case_id}"
@@ -1798,7 +1798,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     ).read().decode("utf-8")
                 )
                 recommendation_draft = json.loads(
-                    request.urlopen(
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
                         (
                             f"{base_url}/render-recommendation-draft"
                             f"?family=case&record_id={promoted_case.case_id}"
@@ -1841,7 +1841,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 )
 
                 with self.assertRaises(error.HTTPError) as invalid_family_exc:
-                    request.urlopen(
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
                         (
                             f"{base_url}/inspect-advisory-output"
                             "?family=not-a-family"
@@ -1861,7 +1861,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 )
 
                 with self.assertRaises(error.HTTPError) as missing_record_exc:
-                    request.urlopen(
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
                         (
                             f"{base_url}/render-recommendation-draft"
                             "?family=case"

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1696,6 +1696,194 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     servers[0].shutdown()
                 thread.join(timeout=2)
 
+    def test_long_running_runtime_surface_exposes_cited_advisory_review_routes(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+        compared_at = datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc)
+        reviewed_context = {
+            "asset": {
+                "asset_id": "asset-phase19-http-advisory-001",
+                "criticality": "high",
+            },
+            "identity": {
+                "identity_id": "principal-phase19-http-advisory-001",
+            },
+        }
+        admitted = service.ingest_finding_alert(
+            finding_id="finding-phase19-http-advisory-001",
+            analytic_signal_id="signal-phase19-http-advisory-001",
+            substrate_detection_record_id="substrate-detection-phase19-http-advisory-001",
+            correlation_key="claim:asset-phase19-http-advisory-001:github-audit",
+            first_seen_at=compared_at,
+            last_seen_at=compared_at,
+            reviewed_context=reviewed_context,
+        )
+        evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-http-advisory-001",
+                source_record_id="substrate-detection-phase19-http-advisory-001",
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="control-plane-test",
+                acquired_at=compared_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase19-http-advisory-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=admitted.alert.alert_id,
+                case_id=promoted_case.case_id,
+                ai_trace_id=None,
+                review_owner="reviewer-001",
+                intended_outcome="review the cited evidence before escalation",
+                lifecycle_state="under_review",
+                reviewed_context=reviewed_context,
+            )
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                assistant_context = json.loads(
+                    request.urlopen(
+                        (
+                            f"{base_url}/inspect-assistant-context"
+                            f"?family=case&record_id={promoted_case.case_id}"
+                        ),
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+                advisory_output = json.loads(
+                    request.urlopen(
+                        (
+                            f"{base_url}/inspect-advisory-output"
+                            f"?family=case&record_id={promoted_case.case_id}"
+                        ),
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+                recommendation_draft = json.loads(
+                    request.urlopen(
+                        (
+                            f"{base_url}/render-recommendation-draft"
+                            f"?family=case&record_id={promoted_case.case_id}"
+                        ),
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+
+                self.assertTrue(assistant_context["read_only"])
+                self.assertEqual(assistant_context["record_family"], "case")
+                self.assertEqual(assistant_context["record_id"], promoted_case.case_id)
+                self.assertEqual(
+                    assistant_context["advisory_output"]["output_kind"],
+                    "case_summary",
+                )
+                self.assertEqual(assistant_context["reviewed_context"], reviewed_context)
+                self.assertEqual(assistant_context["linked_evidence_ids"], [evidence.evidence_id])
+
+                self.assertTrue(advisory_output["read_only"])
+                self.assertEqual(advisory_output["record_family"], "case")
+                self.assertEqual(advisory_output["record_id"], promoted_case.case_id)
+                self.assertEqual(advisory_output["output_kind"], "case_summary")
+                self.assertEqual(advisory_output["status"], "ready")
+                self.assertIn(evidence.evidence_id, advisory_output["citations"])
+
+                self.assertTrue(recommendation_draft["read_only"])
+                self.assertEqual(recommendation_draft["record_family"], "case")
+                self.assertEqual(recommendation_draft["record_id"], promoted_case.case_id)
+                self.assertEqual(
+                    recommendation_draft["recommendation_draft"]["source_output_kind"],
+                    "case_summary",
+                )
+                self.assertEqual(
+                    recommendation_draft["recommendation_draft"]["status"],
+                    "ready",
+                )
+                self.assertIn(
+                    recommendation.recommendation_id,
+                    recommendation_draft["linked_recommendation_ids"],
+                )
+
+                with self.assertRaises(error.HTTPError) as invalid_family_exc:
+                    request.urlopen(
+                        (
+                            f"{base_url}/inspect-advisory-output"
+                            "?family=not-a-family"
+                            f"&record_id={promoted_case.case_id}"
+                        ),
+                        timeout=2,
+                    )
+
+                self.assertEqual(invalid_family_exc.exception.code, 400)
+                invalid_family_payload = json.loads(
+                    invalid_family_exc.exception.read().decode("utf-8")
+                )
+                self.assertEqual(invalid_family_payload["error"], "invalid_request")
+                self.assertIn(
+                    "Unsupported control-plane record family",
+                    invalid_family_payload["message"],
+                )
+
+                with self.assertRaises(error.HTTPError) as missing_record_exc:
+                    request.urlopen(
+                        (
+                            f"{base_url}/render-recommendation-draft"
+                            "?family=case"
+                            "&record_id=case-missing-phase19-http-advisory-001"
+                        ),
+                        timeout=2,
+                    )
+
+                self.assertEqual(missing_record_exc.exception.code, 404)
+                missing_record_payload = json.loads(
+                    missing_record_exc.exception.read().decode("utf-8")
+                )
+                self.assertEqual(missing_record_payload["error"], "not_found")
+                self.assertIn(
+                    "Missing case record",
+                    missing_record_payload["message"],
+                )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
     def test_long_running_runtime_surface_rejects_oversized_operator_request_body(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -272,6 +272,52 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 self.assertIn(created.alert.alert_id, case_detail["advisory_output"]["citations"])
                 self.assertIn(case_id, case_detail["advisory_output"]["citations"])
 
+                assistant_context = get_json(
+                    f"/inspect-assistant-context?family=case&record_id={case_id}"
+                )
+                self.assertTrue(assistant_context["read_only"])
+                self.assertEqual(assistant_context["record_family"], "case")
+                self.assertEqual(assistant_context["record_id"], case_id)
+                self.assertEqual(
+                    assistant_context["advisory_output"]["output_kind"],
+                    "case_summary",
+                )
+                self.assertIn(evidence_id, assistant_context["linked_evidence_ids"])
+                self.assertIn(
+                    recommendation["recommendation_id"],
+                    assistant_context["linked_recommendation_ids"],
+                )
+
+                advisory_output = get_json(
+                    f"/inspect-advisory-output?family=case&record_id={case_id}"
+                )
+                self.assertTrue(advisory_output["read_only"])
+                self.assertEqual(advisory_output["record_family"], "case")
+                self.assertEqual(advisory_output["record_id"], case_id)
+                self.assertEqual(advisory_output["output_kind"], "case_summary")
+                self.assertEqual(advisory_output["status"], "ready")
+                self.assertIn(evidence_id, advisory_output["citations"])
+                self.assertIn(created.alert.alert_id, advisory_output["citations"])
+
+                recommendation_draft = get_json(
+                    f"/render-recommendation-draft?family=case&record_id={case_id}"
+                )
+                self.assertTrue(recommendation_draft["read_only"])
+                self.assertEqual(recommendation_draft["record_family"], "case")
+                self.assertEqual(recommendation_draft["record_id"], case_id)
+                self.assertEqual(
+                    recommendation_draft["recommendation_draft"]["source_output_kind"],
+                    "case_summary",
+                )
+                self.assertEqual(
+                    recommendation_draft["recommendation_draft"]["status"],
+                    "ready",
+                )
+                self.assertIn(
+                    recommendation["recommendation_id"],
+                    recommendation_draft["linked_recommendation_ids"],
+                )
+
                 closed_case = post_json(
                     "/operator/record-case-disposition",
                     {


### PR DESCRIPTION
## Summary
Expose the cited advisory review reads on the Phase 19 runtime surface so runtime callers can fetch reviewed assistant context, advisory output, and recommendation drafts over HTTP.

## What changed
- add read-only `GET /inspect-assistant-context`, `GET /inspect-advisory-output`, and `GET /render-recommendation-draft` runtime routes
- reuse the existing inspection route validation and error mapping style so invalid inputs return structured `400 invalid_request` and missing records return `404 not_found`
- add focused runtime regression coverage for success, invalid-family, and missing-record cases
- extend the Phase 19 workflow validation to exercise the advisory review reads over HTTP instead of relying on CLI-only behavior

## Root cause
The CLI inspection commands already supported these advisory review reads, but the long-running Phase 19 runtime surface did not route them, so HTTP callers fell through to the generic route-level `404 not_found` response.

## Validation
- `python3 -m unittest control-plane.tests.test_cli_inspection`
- `python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three new GET endpoints to retrieve advisory review contexts, advisory outputs, and recommendation drafts.

* **Bug Fixes**
  * Standardized HTTP responses: 400 for invalid/missing parameters and 404 for missing records.

* **Tests**
  * Added integration and workflow tests exercising the new endpoints and validating read-only views and error cases.

* **Documentation**
  * New supervisor issue journal documenting the change, phase state, and test coverage updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->