### PR TITLE
[codex] Constrain Phase 19 operator cases to live GitHub audit slice

### DIFF
--- a/.codex-supervisor/issues/408/issue-journal.md
+++ b/.codex-supervisor/issues/408/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #408: implementation: constrain the Phase 19 operator workflow to the approved Wazuh-backed GitHub audit slice
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/408
+- Branch: codex/issue-408
+- Workspace: .
+- Journal: .codex-supervisor/issues/408/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 4f8e280ffb144da4ba71ae19fe19bc24e6148282
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T10:08:44.608Z
+
+## Latest Codex Summary
+- Reproduced the gap with focused Phase 19 service tests: replay-only GitHub audit cases and broader-family Wazuh-backed cases still allowed `inspect_case_detail` and bounded casework writes.
+- Added a fail-closed Phase 19 eligibility gate in the service layer so case detail and bounded write actions only admit cases linked to live `live_wazuh_webhook` provenance, Wazuh-backed reconciliation, and `github_audit` source family.
+- Updated service and CLI tests to seed approved in-scope casework from the reviewed live Wazuh GitHub audit fixture, and added focused negative coverage for rejected replay-only and broader-family cases.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Phase 19 case detail and bounded casework paths were only checking that a case existed, so replay-only or broader-family cases could enter the operator surface even though live intake was already narrowed to the reviewed Wazuh GitHub audit slice.
+- What changed: Added `_require_phase19_operator_case` and slice eligibility helpers in `control-plane/aegisops_control_plane/service.py`; gated `inspect_case_detail`, `record_case_observation`, `record_case_lead`, `record_case_recommendation`, `record_case_handoff`, and `record_case_disposition`; added focused rejection tests in `control-plane/tests/test_service_persistence.py`; updated CLI/runtime casework tests in `control-plane/tests/test_cli_inspection.py` to use the approved live Wazuh GitHub audit path.
+- Current blocker: none
+- Next exact step: Commit the service/test changes on `codex/issue-408`.
+- Verification gap: none after local full-suite discovery
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_service_persistence.py`, `control-plane/tests/test_cli_inspection.py`
+- Rollback concern: Reverting the eligibility gate would silently reopen replay-only and broader-family cases to the Phase 19 operator workflow.
+- Last focused command: `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3919,9 +3919,21 @@ class AegisOpsControlPlaneService:
         alert = self._store.get(AlertRecord, alert_id)
         if alert is None:
             return False
+        if alert.case_id != case.case_id:
+            return False
 
         reconciliation = self._latest_detection_reconciliation_for_alert(alert.alert_id)
         if reconciliation is None or not self._reconciliation_is_wazuh_origin(reconciliation):
+            return False
+        if not self._linked_id_exists(
+            reconciliation.subject_linkage.get("alert_ids"),
+            alert.alert_id,
+        ):
+            return False
+        if not self._linked_id_exists(
+            reconciliation.subject_linkage.get("case_ids"),
+            case.case_id,
+        ):
             return False
 
         admission_provenance = (

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1899,7 +1899,8 @@ class AegisOpsControlPlaneService:
         )
 
     def inspect_case_detail(self, case_id: str) -> CaseDetailSnapshot:
-        case_id = self._require_non_empty_string(case_id, "case_id")
+        case = self._require_phase19_operator_case(case_id)
+        case_id = case.case_id
         context_snapshot = self.inspect_assistant_context("case", case_id)
         observation_records = tuple(
             _record_to_dict(record)
@@ -1961,7 +1962,7 @@ class AegisOpsControlPlaneService:
             "supporting_evidence_ids",
         )
         with self._store.transaction():
-            case = self._require_case_record(case_id)
+            case = self._require_phase19_operator_case(case_id)
             self._validate_case_evidence_linkage(
                 case=case,
                 evidence_ids=normalized_evidence_ids,
@@ -2012,7 +2013,7 @@ class AegisOpsControlPlaneService:
             "observation_id",
         )
         with self._store.transaction():
-            case = self._require_case_record(case_id)
+            case = self._require_phase19_operator_case(case_id)
             if resolved_observation_id is not None:
                 observation = self._store.get(ObservationRecord, resolved_observation_id)
                 if observation is None:
@@ -2064,7 +2065,7 @@ class AegisOpsControlPlaneService:
         )
         resolved_lead_id = self._normalize_optional_string(lead_id, "lead_id")
         with self._store.transaction():
-            case = self._require_case_record(case_id)
+            case = self._require_phase19_operator_case(case_id)
             if resolved_lead_id is not None:
                 lead = self._store.get(LeadRecord, resolved_lead_id)
                 if lead is None:
@@ -2116,7 +2117,7 @@ class AegisOpsControlPlaneService:
             "follow_up_evidence_ids",
         )
         with self._store.transaction():
-            case = self._require_case_record(case_id)
+            case = self._require_phase19_operator_case(case_id)
             self._validate_case_evidence_linkage(
                 case=case,
                 evidence_ids=normalized_evidence_ids,
@@ -2157,7 +2158,7 @@ class AegisOpsControlPlaneService:
         recorded_at = self._require_aware_datetime(recorded_at, "recorded_at")
         lifecycle_state = self._case_lifecycle_for_disposition(disposition)
         with self._store.transaction():
-            case = self._require_case_record(case_id)
+            case = self._require_phase19_operator_case(case_id)
             updated_reviewed_context = _merge_reviewed_context(
                 case.reviewed_context,
                 {
@@ -3900,6 +3901,70 @@ class AegisOpsControlPlaneService:
         if case is None:
             raise LookupError(f"Missing case {case_id!r}")
         return case
+
+    def _require_phase19_operator_case(self, case_id: str) -> CaseRecord:
+        case = self._require_case_record(case_id)
+        if not self._case_is_in_phase19_operator_slice(case):
+            raise ValueError(
+                f"Case {case.case_id!r} is outside the approved Phase 19 "
+                "Wazuh-backed GitHub audit live slice"
+            )
+        return case
+
+    def _case_is_in_phase19_operator_slice(self, case: CaseRecord) -> bool:
+        alert_id = self._normalize_optional_string(case.alert_id, "case.alert_id")
+        if alert_id is None:
+            return False
+
+        alert = self._store.get(AlertRecord, alert_id)
+        if alert is None:
+            return False
+
+        reconciliation = self._latest_detection_reconciliation_for_alert(alert.alert_id)
+        if reconciliation is None or not self._reconciliation_is_wazuh_origin(reconciliation):
+            return False
+
+        admission_provenance = (
+            _normalize_admission_provenance(
+                reconciliation.subject_linkage.get("admission_provenance")
+            )
+            or _normalize_admission_provenance(case.reviewed_context.get("provenance"))
+            or _normalize_admission_provenance(alert.reviewed_context.get("provenance"))
+        )
+        if admission_provenance != {
+            "admission_kind": "live",
+            "admission_channel": "live_wazuh_webhook",
+        }:
+            return False
+
+        return (
+            self._phase19_operator_source_family(case.reviewed_context)
+            or self._phase19_operator_source_family(alert.reviewed_context)
+            or self._phase19_operator_source_family(
+                reconciliation.subject_linkage.get("reviewed_source_profile")
+            )
+        ) == "github_audit"
+
+    @staticmethod
+    def _phase19_operator_source_family(context: object) -> str | None:
+        if not isinstance(context, Mapping):
+            return None
+
+        source_context = context.get("source")
+        if isinstance(source_context, Mapping):
+            source_family = source_context.get("source_family")
+            if isinstance(source_family, str):
+                normalized_source_family = source_family.strip()
+                if normalized_source_family:
+                    return normalized_source_family
+
+        source_family = context.get("source_family")
+        if isinstance(source_family, str):
+            normalized_source_family = source_family.strip()
+            if normalized_source_family:
+                return normalized_source_family
+
+        return None
 
     def _normalize_linked_record_ids(
         self,

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -40,6 +40,36 @@ def _load_wazuh_fixture(name: str) -> dict[str, object]:
 
 
 class ControlPlaneCliInspectionTests(unittest.TestCase):
+    def _build_phase19_in_scope_case(
+        self,
+        *,
+        store: object | None = None,
+        host: str | None = None,
+        port: int | None = None,
+    ) -> tuple[object, AegisOpsControlPlaneService, CaseRecord, str, datetime]:
+        if store is None:
+            store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1" if host is None else host,
+                port=0 if port is None else port,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        return store, service, promoted_case, promoted_case.evidence_ids[0], reviewed_at
+
     def test_runtime_command_uses_runtime_service_builder_when_not_injected(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -1224,50 +1254,15 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
     def test_cli_renders_case_detail_with_evidence_provenance_and_cited_advisory_output(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        _, service, promoted_case, evidence_id, compared_at = (
+            self._build_phase19_in_scope_case()
         )
-        compared_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {
-                "asset_id": "asset-repo-case-detail-cli-001",
-                "criticality": "high",
-            },
-            "identity": {
-                "identity_id": "principal-case-detail-cli-001",
-            },
-        }
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-case-detail-cli-001",
-            analytic_signal_id="signal-case-detail-cli-001",
-            substrate_detection_record_id="substrate-detection-case-detail-cli-001",
-            correlation_key="claim:asset-repo-case-detail-cli-001:case-detail-cli",
-            first_seen_at=compared_at,
-            last_seen_at=compared_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-case-detail-cli-001",
-                source_record_id="substrate-detection-case-detail-cli-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=compared_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         observation = service.record_case_observation(
             case_id=promoted_case.case_id,
             author_identity="analyst-001",
             observed_at=compared_at,
             scope_statement="Observed permission change remains within reviewed GitHub audit scope.",
-            supporting_evidence_ids=(evidence.evidence_id,),
+            supporting_evidence_ids=(evidence_id,),
         )
         lead = service.record_case_lead(
             case_id=promoted_case.case_id,
@@ -1280,13 +1275,13 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 recommendation_id="recommendation-case-detail-cli-001",
                 lead_id=lead.lead_id,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-001",
                 intended_outcome="review the cited evidence before any approval",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
         service.record_case_handoff(
@@ -1294,7 +1289,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             handoff_at=compared_at,
             handoff_owner="analyst-001",
             handoff_note="Resume owner-membership review during the next business-hours cycle.",
-            follow_up_evidence_ids=(evidence.evidence_id,),
+            follow_up_evidence_ids=(evidence_id,),
         )
         service.record_case_disposition(
             case_id=promoted_case.case_id,
@@ -1318,24 +1313,27 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertTrue(payload["read_only"])
         self.assertEqual(payload["case_id"], promoted_case.case_id)
         self.assertEqual(payload["case_record"]["case_id"], promoted_case.case_id)
-        self.assertEqual(payload["reviewed_context"]["asset"], reviewed_context["asset"])
+        self.assertEqual(
+            payload["reviewed_context"]["asset"],
+            promoted_case.reviewed_context["asset"],
+        )
         self.assertEqual(
             payload["reviewed_context"]["identity"],
-            reviewed_context["identity"],
+            promoted_case.reviewed_context["identity"],
         )
         self.assertEqual(
             payload["advisory_output"]["output_kind"],
             "case_summary",
         )
         self.assertEqual(payload["advisory_output"]["status"], "ready")
-        self.assertEqual(payload["linked_evidence_ids"], [evidence.evidence_id])
+        self.assertEqual(payload["linked_evidence_ids"], [evidence_id])
         self.assertEqual(
             payload["linked_evidence_records"][0]["collector_identity"],
-            "collector://wazuh/live",
+            "wazuh-native-detection-adapter",
         )
         self.assertEqual(
             payload["linked_evidence_records"][0]["derivation_relationship"],
-            "admitted_analytic_signal",
+            "native_detection_record",
         )
         self.assertEqual(payload["linked_observation_ids"], [observation.observation_id])
         self.assertEqual(payload["linked_lead_ids"], [lead.lead_id])
@@ -1352,47 +1350,30 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             payload["linked_recommendation_ids"],
         )
         self.assertIn(
-            admitted.reconciliation.reconciliation_id,
+            (
+                "reviewed_context.provenance.rule_id="
+                f"{promoted_case.reviewed_context['provenance']['rule_id']}"
+            ),
+            payload["advisory_output"]["citations"],
+        )
+        self.assertIn(
+            promoted_case.case_id,
+            payload["linked_reconciliation_records"][0]["subject_linkage"]["case_ids"],
+        )
+        self.assertIn(
+            payload["linked_reconciliation_records"][0]["reconciliation_id"],
             payload["linked_reconciliation_ids"],
         )
 
     def test_cli_records_bounded_operator_casework_actions(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
         handoff_at = datetime(2026, 4, 7, 17, 45, tzinfo=timezone.utc)
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-phase19-cli-actions-001",
-            analytic_signal_id="signal-phase19-cli-actions-001",
-            substrate_detection_record_id="substrate-detection-phase19-cli-actions-001",
-            correlation_key="claim:asset-phase19-cli-actions-001:github-audit",
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-cli-actions-001"},
-                "identity": {"identity_id": "principal-phase19-cli-actions-001"},
-            },
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-cli-actions-001",
-                source_record_id="substrate-detection-phase19-cli-actions-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
 
         promote_stdout = io.StringIO()
         main.main(
-            ["promote-alert-to-case", "--alert-id", admitted.alert.alert_id],
+            ["promote-alert-to-case", "--alert-id", promoted_case.alert_id],
             stdout=promote_stdout,
             service=service,
         )
@@ -1413,14 +1394,14 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 "--scope-statement",
                 "Observed repository permission change requires tracked review.",
                 "--supporting-evidence-id",
-                evidence.evidence_id,
+                evidence_id,
             ],
             stdout=observation_stdout,
             service=service,
         )
         observation_payload = json.loads(observation_stdout.getvalue())
         self.assertEqual(observation_payload["case_id"], case_id)
-        self.assertEqual(observation_payload["supporting_evidence_ids"], [evidence.evidence_id])
+        self.assertEqual(observation_payload["supporting_evidence_ids"], [evidence_id])
 
         lead_stdout = io.StringIO()
         main.main(
@@ -1475,7 +1456,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 "--handoff-note",
                 "Recheck repository owner membership against approved change window at next business-hours review.",
                 "--follow-up-evidence-id",
-                evidence.evidence_id,
+                evidence_id,
             ],
             stdout=handoff_stdout,
             service=service,
@@ -1484,7 +1465,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(handoff_payload["case_id"], case_id)
         self.assertEqual(
             handoff_payload["reviewed_context"]["handoff"]["follow_up_evidence_ids"],
-            [evidence.evidence_id],
+            [evidence_id],
         )
 
         disposition_stdout = io.StringIO()
@@ -1534,44 +1515,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
 
     def test_long_running_runtime_surface_records_bounded_operator_casework_actions(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(
-                host="127.0.0.1",
-                port=0,
-                postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
-            ),
-            store=store,
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case(host="127.0.0.1", port=0)
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
         handoff_at = datetime(2026, 4, 7, 17, 45, tzinfo=timezone.utc)
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-phase19-http-actions-001",
-            analytic_signal_id="signal-phase19-http-actions-001",
-            substrate_detection_record_id="substrate-detection-phase19-http-actions-001",
-            correlation_key="claim:asset-phase19-http-actions-001:github-audit",
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-http-actions-001"},
-                "identity": {"identity_id": "principal-phase19-http-actions-001"},
-            },
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-http-actions-001",
-                source_record_id="substrate-detection-phase19-http-actions-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
 
         servers: list[main.ThreadingHTTPServer] = []
 
@@ -1610,7 +1557,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
 
                 promoted_case_payload = post_json(
                     "/operator/promote-alert-to-case",
-                    {"alert_id": admitted.alert.alert_id},
+                    {"alert_id": promoted_case.alert_id},
                 )
                 case_id = promoted_case_payload["case_id"]
                 self.assertEqual(promoted_case_payload["lifecycle_state"], "open")
@@ -1622,7 +1569,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                         "author_identity": "analyst-001",
                         "observed_at": reviewed_at.isoformat(),
                         "scope_statement": "Observed repository permission change requires tracked review.",
-                        "supporting_evidence_ids": [evidence.evidence_id],
+                        "supporting_evidence_ids": [evidence_id],
                     },
                 )
                 self.assertEqual(observation_payload["case_id"], case_id)
@@ -1656,12 +1603,12 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                         "handoff_at": handoff_at.isoformat(),
                         "handoff_owner": "analyst-001",
                         "handoff_note": "Recheck repository owner membership against approved change window at next business-hours review.",
-                        "follow_up_evidence_ids": [evidence.evidence_id],
+                        "follow_up_evidence_ids": [evidence_id],
                     },
                 )
                 self.assertEqual(
                     handoff_payload["reviewed_context"]["handoff"]["follow_up_evidence_ids"],
-                    [evidence.evidence_id],
+                    [evidence_id],
                 )
 
                 disposition_payload = post_json(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -54,17 +54,17 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 host="127.0.0.1" if host is None else host,
                 port=0 if port is None else port,
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             ),
             store=store,
         )
         reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
         admitted = service.ingest_wazuh_alert(
             raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
-            authorization_header="Bearer reviewed-shared-secret",
+            authorization_header="Bearer reviewed-shared-secret",  # noqa: S106 - test fixture secret
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             peer_addr="127.0.0.1",
         )
         promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -4323,7 +4323,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_rejects_raced_observation_identifier_collision(self) -> None:
         store, _ = make_store()
-        store, base_service, promoted_case, evidence_id, reviewed_at = (
+        store, _base_service, promoted_case, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case(store=store)
         )
         store = _OutOfBandMutationStore(
@@ -4462,7 +4462,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_rejects_raced_generated_observation_identifier_collision(self) -> None:
         store, _ = make_store()
-        store, base_service, promoted_case, evidence_id, reviewed_at = (
+        store, _base_service, promoted_case, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case(store=store)
         )
         store = _OutOfBandMutationStore(
@@ -4635,7 +4635,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_merges_concurrent_reviewed_context_into_case_handoff(self) -> None:
         store, _ = make_store()
-        store, base_service, promoted_case, evidence_id, reviewed_at = (
+        store, _base_service, promoted_case, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case(store=store)
         )
         store = _TransactionMutationStore(
@@ -4691,7 +4691,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_merges_concurrent_reviewed_context_into_case_disposition(self) -> None:
         store, _ = make_store()
-        store, base_service, promoted_case, _, reviewed_at = (
+        store, _base_service, promoted_case, _, reviewed_at = (
             self._build_phase19_in_scope_case(store=store)
         )
         store = _TransactionMutationStore(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -161,6 +161,64 @@ class _OutOfBandMutationStore:
 
 
 class ControlPlaneServicePersistenceTests(unittest.TestCase):
+    def _build_phase19_in_scope_case(
+        self,
+        *,
+        store: object | None = None,
+    ) -> tuple[object, AegisOpsControlPlaneService, CaseRecord, str, datetime]:
+        if store is None:
+            store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        return store, service, promoted_case, promoted_case.evidence_ids[0], reviewed_at
+
+    def _build_phase19_out_of_scope_case(
+        self,
+        *,
+        fixture_name: str,
+    ) -> tuple[AegisOpsControlPlaneService, CaseRecord, str, datetime]:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        adapter = WazuhAlertAdapter()
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(_load_wazuh_fixture(fixture_name)),
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id=f"evidence-{fixture_name}",
+                source_record_id=admitted.alert.finding_id,
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="wazuh",
+                collector_identity="collector://wazuh/replay",
+                acquired_at=reviewed_at,
+                derivation_relationship="native_detection_record",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        return service, promoted_case, admitted.alert.alert_id, reviewed_at
+
     def test_service_admits_wazuh_fixture_through_substrate_adapter_boundary(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -1039,44 +1097,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
     def test_service_renders_lead_only_recommendation_draft_as_unresolved(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        _, service, promoted_case, evidence_id, first_seen_at = (
+            self._build_phase19_in_scope_case()
         )
-        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-lead-only-advisory-001",
-            analytic_signal_id="signal-lead-only-advisory-001",
-            substrate_detection_record_id="substrate-detection-lead-only-advisory-001",
-            correlation_key="claim:lead-only:advisory:001",
-            first_seen_at=first_seen_at,
-            last_seen_at=first_seen_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-lead-only-advisory-001"},
-            },
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-lead-only-advisory-001",
-                source_record_id="substrate-detection-lead-only-advisory-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=first_seen_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         observation = service.record_case_observation(
             case_id=promoted_case.case_id,
             author_identity="analyst-001",
             observed_at=first_seen_at,
             scope_statement="Lead-only recommendation should fail closed without direct lineage.",
-            supporting_evidence_ids=(evidence.evidence_id,),
+            supporting_evidence_ids=(evidence_id,),
         )
         lead = service.record_case_lead(
             case_id=promoted_case.case_id,
@@ -1095,9 +1124,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 review_owner="analyst-001",
                 intended_outcome="Review the lead linkage before any broader response.",
                 lifecycle_state="under_review",
-                reviewed_context={
-                    "asset": {"asset_id": "asset-lead-only-advisory-001"},
-                },
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
 
@@ -4000,46 +4027,17 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_records_bounded_casework_actions_for_triage_disposition_and_handoff(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
         handoff_at = datetime(2026, 4, 7, 17, 45, tzinfo=timezone.utc)
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-phase19-casework-001",
-            analytic_signal_id="signal-phase19-casework-001",
-            substrate_detection_record_id="substrate-detection-phase19-casework-001",
-            correlation_key="claim:asset-phase19-casework-001:github-audit",
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-casework-001"},
-                "identity": {"identity_id": "principal-phase19-casework-001"},
-            },
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-casework-001",
-                source_record_id="substrate-detection-phase19-casework-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
 
         observation = service.record_case_observation(
             case_id=promoted_case.case_id,
             author_identity="analyst-001",
             observed_at=reviewed_at,
             scope_statement="Observed repository permission change requires tracked review.",
-            supporting_evidence_ids=(evidence.evidence_id,),
+            supporting_evidence_ids=(evidence_id,),
         )
         lead = service.record_case_lead(
             case_id=promoted_case.case_id,
@@ -4058,7 +4056,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             handoff_at=handoff_at,
             handoff_owner="analyst-001",
             handoff_note="Recheck repository owner membership against approved change window at next business-hours review.",
-            follow_up_evidence_ids=(evidence.evidence_id,),
+            follow_up_evidence_ids=(evidence_id,),
         )
         disposed_case = service.record_case_disposition(
             case_id=handed_off_case.case_id,
@@ -4097,53 +4095,112 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertIn(recommendation.recommendation_id, detail.linked_recommendation_ids)
         self.assertEqual(
             detail.linked_observation_records[0]["supporting_evidence_ids"],
-            (evidence.evidence_id,),
+            (evidence_id,),
         )
         self.assertEqual(
             detail.linked_lead_records[0]["triage_rationale"],
             "Privilege-impacting change needs durable business-hours follow-up.",
         )
 
-    def test_service_rejects_duplicate_casework_identifiers(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+    def test_service_rejects_replay_only_case_from_phase19_operator_surface(self) -> None:
+        service, promoted_case, _, reviewed_at = self._build_phase19_out_of_scope_case(
+            fixture_name="github-audit-alert.json"
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-phase19-duplicate-ids-001",
-            analytic_signal_id="signal-phase19-duplicate-ids-001",
-            substrate_detection_record_id="substrate-detection-phase19-duplicate-ids-001",
-            correlation_key="claim:asset-phase19-duplicate-ids-001:github-audit",
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-duplicate-ids-001"},
-                "identity": {"identity_id": "principal-phase19-duplicate-ids-001"},
-            },
-        )
-        service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-duplicate-ids-001",
-                source_record_id="substrate-detection-phase19-duplicate-ids-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.inspect_case_detail(promoted_case.case_id)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.record_case_observation(
+                case_id=promoted_case.case_id,
+                author_identity="analyst-001",
+                observed_at=reviewed_at,
+                scope_statement="Replay-only casework must fail closed.",
             )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.record_case_lead(
+                case_id=promoted_case.case_id,
+                triage_owner="analyst-001",
+                triage_rationale="Replay-only casework must fail closed.",
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.record_case_recommendation(
+                case_id=promoted_case.case_id,
+                review_owner="analyst-001",
+                intended_outcome="Replay-only casework must fail closed.",
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.record_case_handoff(
+                case_id=promoted_case.case_id,
+                handoff_at=reviewed_at,
+                handoff_owner="analyst-001",
+                handoff_note="Replay-only casework must fail closed.",
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.record_case_disposition(
+                case_id=promoted_case.case_id,
+                disposition="business_hours_handoff",
+                rationale="Replay-only casework must fail closed.",
+                recorded_at=reviewed_at,
+            )
+
+    def test_service_rejects_non_github_audit_case_from_phase19_operator_surface(
+        self,
+    ) -> None:
+        service, promoted_case, _, reviewed_at = self._build_phase19_out_of_scope_case(
+            fixture_name="microsoft-365-audit-alert.json"
         )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.inspect_case_detail(promoted_case.case_id)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.record_case_observation(
+                case_id=promoted_case.case_id,
+                author_identity="analyst-001",
+                observed_at=reviewed_at,
+                scope_statement="Broader source-family casework must fail closed.",
+            )
+
+    def test_service_rejects_duplicate_casework_identifiers(self) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
         observation = service.record_case_observation(
             case_id=promoted_case.case_id,
             observation_id="observation-phase19-duplicate-ids-001",
             author_identity="analyst-001",
             observed_at=reviewed_at,
             scope_statement="Initial observation for duplicate-id guard coverage.",
-            supporting_evidence_ids=("evidence-phase19-duplicate-ids-001",),
+            supporting_evidence_ids=(evidence_id,),
         )
         with self.assertRaisesRegex(
             ValueError,
@@ -4155,7 +4212,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 author_identity="analyst-002",
                 observed_at=reviewed_at,
                 scope_statement="Collision should be rejected before persist_record updates in place.",
-                supporting_evidence_ids=("evidence-phase19-duplicate-ids-001",),
+                supporting_evidence_ids=(evidence_id,),
             )
 
         lead = service.record_case_lead(
@@ -4197,46 +4254,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             )
 
     def test_service_rejects_unknown_case_disposition(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
-        )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-phase19-unsupported-disposition-001",
-            analytic_signal_id="signal-phase19-unsupported-disposition-001",
-            substrate_detection_record_id=(
-                "substrate-detection-phase19-unsupported-disposition-001"
-            ),
-            correlation_key=(
-                "claim:asset-phase19-unsupported-disposition-001:github-audit"
-            ),
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-unsupported-disposition-001"},
-                "identity": {
-                    "identity_id": "principal-phase19-unsupported-disposition-001"
-                },
-            },
-        )
-        service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-unsupported-disposition-001",
-                source_record_id=(
-                    "substrate-detection-phase19-unsupported-disposition-001"
-                ),
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        _, service, promoted_case, _, reviewed_at = self._build_phase19_in_scope_case()
 
         with self.assertRaisesRegex(
             ValueError,
@@ -4251,39 +4269,9 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_rejects_raced_observation_identifier_collision(self) -> None:
         store, _ = make_store()
-        base_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        store, base_service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = base_service.ingest_finding_alert(
-            finding_id="finding-phase19-raced-observation-001",
-            analytic_signal_id="signal-phase19-raced-observation-001",
-            substrate_detection_record_id=(
-                "substrate-detection-phase19-raced-observation-001"
-            ),
-            correlation_key="claim:asset-phase19-raced-observation-001:github-audit",
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-raced-observation-001"},
-                "identity": {"identity_id": "principal-phase19-raced-observation-001"},
-            },
-        )
-        evidence = base_service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-raced-observation-001",
-                source_record_id="substrate-detection-phase19-raced-observation-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
         store = _OutOfBandMutationStore(
             inner=store,
             mutate_once=lambda transactional_store: transactional_store.save(
@@ -4293,7 +4281,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     hunt_run_id=None,
                     alert_id=promoted_case.alert_id,
                     case_id=promoted_case.case_id,
-                    supporting_evidence_ids=(evidence.evidence_id,),
+                    supporting_evidence_ids=(evidence_id,),
                     author_identity="analyst-racer",
                     observed_at=reviewed_at,
                     scope_statement="Concurrent writer inserted the requested observation ID.",
@@ -4316,48 +4304,20 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 author_identity="analyst-001",
                 observed_at=reviewed_at,
                 scope_statement="Caller-supplied observation IDs must reject raced duplicates.",
-                supporting_evidence_ids=(evidence.evidence_id,),
+                supporting_evidence_ids=(evidence_id,),
             )
 
     def test_service_rejects_raced_lead_identifier_collision(self) -> None:
         store, _ = make_store()
-        base_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        store, base_service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = base_service.ingest_finding_alert(
-            finding_id="finding-phase19-raced-lead-001",
-            analytic_signal_id="signal-phase19-raced-lead-001",
-            substrate_detection_record_id="substrate-detection-phase19-raced-lead-001",
-            correlation_key="claim:asset-phase19-raced-lead-001:github-audit",
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-raced-lead-001"},
-                "identity": {"identity_id": "principal-phase19-raced-lead-001"},
-            },
-        )
-        evidence = base_service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-raced-lead-001",
-                source_record_id="substrate-detection-phase19-raced-lead-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
         observation = base_service.record_case_observation(
             case_id=promoted_case.case_id,
             author_identity="analyst-001",
             observed_at=reviewed_at,
             scope_statement="Seed observation for raced lead collision coverage.",
-            supporting_evidence_ids=(evidence.evidence_id,),
+            supporting_evidence_ids=(evidence_id,),
         )
         store = _OutOfBandMutationStore(
             inner=store,
@@ -4394,51 +4354,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_rejects_raced_recommendation_identifier_collision(self) -> None:
         store, _ = make_store()
-        base_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        store, base_service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = base_service.ingest_finding_alert(
-            finding_id="finding-phase19-raced-recommendation-001",
-            analytic_signal_id="signal-phase19-raced-recommendation-001",
-            substrate_detection_record_id=(
-                "substrate-detection-phase19-raced-recommendation-001"
-            ),
-            correlation_key=(
-                "claim:asset-phase19-raced-recommendation-001:github-audit"
-            ),
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-raced-recommendation-001"},
-                "identity": {
-                    "identity_id": "principal-phase19-raced-recommendation-001"
-                },
-            },
-        )
-        evidence = base_service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-raced-recommendation-001",
-                source_record_id=(
-                    "substrate-detection-phase19-raced-recommendation-001"
-                ),
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
         observation = base_service.record_case_observation(
             case_id=promoted_case.case_id,
             author_identity="analyst-001",
             observed_at=reviewed_at,
             scope_statement="Seed observation for raced recommendation collision coverage.",
-            supporting_evidence_ids=(evidence.evidence_id,),
+            supporting_evidence_ids=(evidence_id,),
         )
         lead = base_service.record_case_lead(
             case_id=promoted_case.case_id,
@@ -4484,45 +4408,9 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_rejects_raced_generated_observation_identifier_collision(self) -> None:
         store, _ = make_store()
-        base_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        store, base_service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = base_service.ingest_finding_alert(
-            finding_id="finding-phase19-generated-observation-race-001",
-            analytic_signal_id="signal-phase19-generated-observation-race-001",
-            substrate_detection_record_id=(
-                "substrate-detection-phase19-generated-observation-race-001"
-            ),
-            correlation_key=(
-                "claim:asset-phase19-generated-observation-race-001:github-audit"
-            ),
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-generated-observation-race-001"},
-                "identity": {
-                    "identity_id": "principal-phase19-generated-observation-race-001"
-                },
-            },
-        )
-        evidence = base_service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-generated-observation-race-001",
-                source_record_id=(
-                    "substrate-detection-phase19-generated-observation-race-001"
-                ),
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
         store = _OutOfBandMutationStore(
             inner=store,
             mutate_once=lambda transactional_store: transactional_store.save(
@@ -4532,7 +4420,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     hunt_run_id=None,
                     alert_id=promoted_case.alert_id,
                     case_id=promoted_case.case_id,
-                    supporting_evidence_ids=(evidence.evidence_id,),
+                    supporting_evidence_ids=(evidence_id,),
                     author_identity="analyst-racer",
                     observed_at=reviewed_at,
                     scope_statement="Concurrent writer inserted the minted observation ID.",
@@ -4559,7 +4447,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     author_identity="analyst-001",
                     observed_at=reviewed_at,
                     scope_statement="Generated observation IDs must reject raced duplicates.",
-                    supporting_evidence_ids=(evidence.evidence_id,),
+                    supporting_evidence_ids=(evidence_id,),
                 )
 
         observations = store.list(ObservationRecord)
@@ -4571,47 +4459,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_rejects_raced_generated_lead_identifier_collision(self) -> None:
         store, _ = make_store()
-        base_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        store, base_service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = base_service.ingest_finding_alert(
-            finding_id="finding-phase19-generated-lead-race-001",
-            analytic_signal_id="signal-phase19-generated-lead-race-001",
-            substrate_detection_record_id=(
-                "substrate-detection-phase19-generated-lead-race-001"
-            ),
-            correlation_key="claim:asset-phase19-generated-lead-race-001:github-audit",
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-generated-lead-race-001"},
-                "identity": {
-                    "identity_id": "principal-phase19-generated-lead-race-001"
-                },
-            },
-        )
-        evidence = base_service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-generated-lead-race-001",
-                source_record_id="substrate-detection-phase19-generated-lead-race-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
         observation = base_service.record_case_observation(
             case_id=promoted_case.case_id,
             author_identity="analyst-001",
             observed_at=reviewed_at,
             scope_statement="Seed observation for generated lead race coverage.",
-            supporting_evidence_ids=(evidence.evidence_id,),
+            supporting_evidence_ids=(evidence_id,),
         )
         store = _OutOfBandMutationStore(
             inner=store,
@@ -4658,53 +4514,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self,
     ) -> None:
         store, _ = make_store()
-        base_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        store, base_service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = base_service.ingest_finding_alert(
-            finding_id="finding-phase19-generated-recommendation-race-001",
-            analytic_signal_id="signal-phase19-generated-recommendation-race-001",
-            substrate_detection_record_id=(
-                "substrate-detection-phase19-generated-recommendation-race-001"
-            ),
-            correlation_key=(
-                "claim:asset-phase19-generated-recommendation-race-001:github-audit"
-            ),
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {
-                    "asset_id": "asset-phase19-generated-recommendation-race-001"
-                },
-                "identity": {
-                    "identity_id": "principal-phase19-generated-recommendation-race-001"
-                },
-            },
-        )
-        evidence = base_service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-generated-recommendation-race-001",
-                source_record_id=(
-                    "substrate-detection-phase19-generated-recommendation-race-001"
-                ),
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
         observation = base_service.record_case_observation(
             case_id=promoted_case.case_id,
             author_identity="analyst-001",
             observed_at=reviewed_at,
             scope_statement="Seed observation for generated recommendation race coverage.",
-            supporting_evidence_ids=(evidence.evidence_id,),
+            supporting_evidence_ids=(evidence_id,),
         )
         lead = base_service.record_case_lead(
             case_id=promoted_case.case_id,
@@ -4763,37 +4581,9 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_merges_concurrent_reviewed_context_into_case_handoff(self) -> None:
         store, _ = make_store()
-        base_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        store, base_service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = base_service.ingest_finding_alert(
-            finding_id="finding-phase19-handoff-merge-001",
-            analytic_signal_id="signal-phase19-handoff-merge-001",
-            substrate_detection_record_id="substrate-detection-phase19-handoff-merge-001",
-            correlation_key="claim:asset-phase19-handoff-merge-001:github-audit",
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-handoff-merge-001"},
-                "identity": {"identity_id": "principal-phase19-handoff-merge-001"},
-            },
-        )
-        evidence = base_service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-handoff-merge-001",
-                source_record_id="substrate-detection-phase19-handoff-merge-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
         store = _TransactionMutationStore(
             inner=store,
             mutate_once=lambda transactional_store: transactional_store.save(
@@ -4825,7 +4615,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             handoff_at=reviewed_at,
             handoff_owner="analyst-001",
             handoff_note="Carry forward the next-step evidence review.",
-            follow_up_evidence_ids=(evidence.evidence_id,),
+            follow_up_evidence_ids=(evidence_id,),
         )
 
         self.assertEqual(
@@ -4833,57 +4623,23 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "pending_approval",
         )
         self.assertEqual(
-            updated_case.reviewed_context["asset"]["asset_id"],
-            "asset-phase19-handoff-merge-001",
+            updated_case.reviewed_context["asset"]["repository"]["repository_full_name"],
+            "TommyKammy/AegisOps",
         )
         self.assertEqual(
-            updated_case.reviewed_context["identity"]["identity_id"],
-            "principal-phase19-handoff-merge-001",
+            updated_case.reviewed_context["identity"]["actor"]["identity_id"],
+            "octocat",
         )
         self.assertEqual(
             updated_case.reviewed_context["handoff"]["follow_up_evidence_ids"],
-            (evidence.evidence_id,),
+            (evidence_id,),
         )
 
     def test_service_merges_concurrent_reviewed_context_into_case_disposition(self) -> None:
         store, _ = make_store()
-        base_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        store, base_service, promoted_case, _, reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
         )
-        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
-        admitted = base_service.ingest_finding_alert(
-            finding_id="finding-phase19-disposition-merge-001",
-            analytic_signal_id="signal-phase19-disposition-merge-001",
-            substrate_detection_record_id=(
-                "substrate-detection-phase19-disposition-merge-001"
-            ),
-            correlation_key="claim:asset-phase19-disposition-merge-001:github-audit",
-            first_seen_at=reviewed_at,
-            last_seen_at=reviewed_at,
-            reviewed_context={
-                "asset": {"asset_id": "asset-phase19-disposition-merge-001"},
-                "identity": {
-                    "identity_id": "principal-phase19-disposition-merge-001"
-                },
-            },
-        )
-        base_service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-disposition-merge-001",
-                source_record_id=(
-                    "substrate-detection-phase19-disposition-merge-001"
-                ),
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="collector://wazuh/live",
-                acquired_at=reviewed_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = base_service.promote_alert_to_case(admitted.alert.alert_id)
         store = _TransactionMutationStore(
             inner=store,
             mutate_once=lambda transactional_store: transactional_store.save(
@@ -4923,12 +4679,12 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "analyst-002",
         )
         self.assertEqual(
-            updated_case.reviewed_context["asset"]["asset_id"],
-            "asset-phase19-disposition-merge-001",
+            updated_case.reviewed_context["asset"]["repository"]["repository_full_name"],
+            "TommyKammy/AegisOps",
         )
         self.assertEqual(
-            updated_case.reviewed_context["identity"]["identity_id"],
-            "principal-phase19-disposition-merge-001",
+            updated_case.reviewed_context["identity"]["actor"]["identity_id"],
+            "octocat",
         )
         self.assertEqual(
             updated_case.reviewed_context["triage"]["disposition"],

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -168,20 +168,22 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     ) -> tuple[object, AegisOpsControlPlaneService, CaseRecord, str, datetime]:
         if store is None:
             store, _ = make_store()
+        shared_secret = secrets.token_urlsafe(24)
+        reverse_proxy_secret = secrets.token_urlsafe(24)
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret=shared_secret,
+                wazuh_ingest_reverse_proxy_secret=reverse_proxy_secret,
             ),
             store=store,
         )
         reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
         admitted = service.ingest_wazuh_alert(
             raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
-            authorization_header="Bearer reviewed-shared-secret",
+            authorization_header=f"Bearer {shared_secret}",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header=reverse_proxy_secret,
             peer_addr="127.0.0.1",
         )
         promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
@@ -4189,6 +4191,58 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 observed_at=reviewed_at,
                 scope_statement="Broader source-family casework must fail closed.",
             )
+
+    def test_service_rejects_case_without_reciprocal_alert_linkage_from_phase19_operator_surface(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+        spoofed_case = service.persist_record(
+            CaseRecord(
+                case_id="case-phase19-spoofed-alert-linkage",
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                evidence_ids=promoted_case.evidence_ids,
+                lifecycle_state=promoted_case.lifecycle_state,
+                reviewed_context=dict(promoted_case.reviewed_context),
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.inspect_case_detail(spoofed_case.case_id)
+
+    def test_service_rejects_case_without_reciprocal_reconciliation_linkage_from_phase19_operator_surface(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+        alert = service.get_record(AlertRecord, promoted_case.alert_id)
+        self.assertIsNotNone(alert)
+
+        spoofed_case_id = "case-phase19-spoofed-reconciliation-linkage"
+        service.persist_record(
+            replace(
+                alert,
+                case_id=spoofed_case_id,
+            )
+        )
+        spoofed_case = service.persist_record(
+            CaseRecord(
+                case_id=spoofed_case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                evidence_ids=promoted_case.evidence_ids,
+                lifecycle_state=promoted_case.lifecycle_state,
+                reviewed_context=dict(promoted_case.reviewed_context),
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.inspect_case_detail(spoofed_case.case_id)
 
     def test_service_rejects_duplicate_casework_identifiers(self) -> None:
         _, service, promoted_case, evidence_id, reviewed_at = (


### PR DESCRIPTION
## Summary
- restrict the Phase 19 operator workflow to cases linked to the approved live Wazuh-backed `github_audit` slice
- fail closed for `inspect-case-detail` and bounded Phase 19 casework writes when a case is replay-only, synthetic, or otherwise outside that approved slice
- update focused tests to cover both the approved path and representative rejected out-of-scope cases

## Why
Phase 19 operator case detail and bounded casework actions were only validating case existence. That allowed replay-only or broader-family cases to enter the operator runtime path even though live intake had already been narrowed to the reviewed Wazuh GitHub audit slice.

## Validation
- `python3 -m unittest control-plane.tests.test_service_persistence`
- `python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tightened validation so case inspection and operator actions are limited to an approved Phase 19 live Wazuh GitHub-audit slice.

* **Tests**
  * Added helpers to build in-scope/out-of-scope Phase 19 cases and refactored tests to use them.
  * Added negative tests asserting rejection of replay-only, non-GitHub-audit, and cases lacking reciprocal linkages.
  * Updated CLI/operator test expectations to match Phase 19 provenance and evidence metadata.

* **Documentation**
  * Added a supervisor journal entry recording the Phase 19 slice changes and next steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->