### PR TITLE
[codex] Gate case assistant context to Phase 19 slice

### DIFF
--- a/.codex-supervisor/issues/410/issue-journal.md
+++ b/.codex-supervisor/issues/410/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #410: implementation: gate case-scoped assistant-context inspection to the approved Phase 19 operator slice
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/410
+- Branch: codex/issue-410
+- Workspace: .
+- Journal: .codex-supervisor/issues/410/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: ab0c92a606fca85e9e9e6e12b652328d1a165edb
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T11:13:35.942Z
+
+## Latest Codex Summary
+- Added a fail-closed Phase 19 eligibility check at `inspect_assistant_context("case", ...)` so case-scoped assistant context now requires the approved Wazuh-backed GitHub audit live slice.
+- Added focused in-scope and replay-only rejection coverage, then updated older case-scoped assistant/advisory/draft tests to use the reviewed Phase 19 in-scope fixture path instead of synthetic cases.
+- Verified with focused `unittest` targets and a full `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` run.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `inspect_assistant_context("case", ...)` was bypassing the existing Phase 19 case-slice gate, so replay-only and other out-of-scope cases could still read case-scoped assistant context.
+- What changed: Gated case-family assistant-context inspection through `_require_phase19_operator_case`, added focused service tests for accepted in-scope and rejected replay-only cases, and migrated existing case-scoped assistant/advisory/draft tests to the Phase 19 in-scope Wazuh GitHub audit fixture path.
+- Current blocker: none
+- Next exact step: Commit the verified checkpoint on `codex/issue-410`.
+- Verification gap: none after full `control-plane/tests` discovery run.
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_service_persistence.py`, `control-plane/tests/test_cli_inspection.py`, `.codex-supervisor/issues/410/issue-journal.md`
+- Rollback concern: Low; behavior change is intentionally limited to `record_family == "case"` for assistant-context-derived case surfaces.
+- Last focused command: `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1519,6 +1519,8 @@ class AegisOpsControlPlaneService:
                 f"Unsupported control-plane record family {record_family!r}; "
                 f"expected one of: {known_families}"
             )
+        if record_family == "case":
+            self._require_phase19_operator_case(record_id)
 
         record = self._store.get(record_type, record_id)
         if record is None:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1519,14 +1519,13 @@ class AegisOpsControlPlaneService:
                 f"Unsupported control-plane record family {record_family!r}; "
                 f"expected one of: {known_families}"
             )
-        if record_family == "case":
-            self._require_phase19_operator_case(record_id)
-
         record = self._store.get(record_type, record_id)
         if record is None:
             raise LookupError(
                 f"Missing {record_family} record {record_id!r} for assistant context"
             )
+        if record_family == "case":
+            self._require_phase19_operator_case_record(record)
 
         linked_alert_ids = self._assistant_ids_from_value(
             getattr(record, "alert_id", None)
@@ -3906,6 +3905,9 @@ class AegisOpsControlPlaneService:
 
     def _require_phase19_operator_case(self, case_id: str) -> CaseRecord:
         case = self._require_case_record(case_id)
+        return self._require_phase19_operator_case_record(case)
+
+    def _require_phase19_operator_case_record(self, case: CaseRecord) -> CaseRecord:
         if not self._case_is_in_phase19_operator_slice(case):
             raise ValueError(
                 f"Case {case.case_id!r} is outside the approved Phase 19 "

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1562,7 +1562,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 thread.join(timeout=2)
 
     def test_long_running_runtime_surface_exposes_cited_advisory_review_routes(self) -> None:
-        store, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case(
+        _, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case(
             host="127.0.0.1",
             port=0,
         )

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1075,58 +1075,19 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
 
     def test_cli_renders_analyst_assistant_context_view_for_a_case(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
-        )
-        compared_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {
-                "asset_id": "asset-repo-001",
-                "criticality": "high",
-                "ownership": "platform-security",
-            },
-            "identity": {
-                "identity_id": "principal-001",
-                "owner": "identity-operations",
-            },
-        }
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-assistant-cli-001",
-            analytic_signal_id="signal-assistant-cli-001",
-            substrate_detection_record_id="substrate-detection-assistant-cli-001",
-            correlation_key="claim:asset-repo-001:assistant-cli-review",
-            first_seen_at=compared_at,
-            last_seen_at=compared_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-assistant-cli-001",
-                source_record_id="substrate-detection-assistant-cli-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=compared_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        _, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case()
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-assistant-cli-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-001",
                 intended_outcome="follow reviewed evidence",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
 
@@ -1150,74 +1111,34 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(payload["record"]["case_id"], promoted_case.case_id)
         self.assertEqual(payload["advisory_output"]["output_kind"], "case_summary")
         self.assertEqual(payload["advisory_output"]["status"], "ready")
-        self.assertIn(evidence.evidence_id, payload["advisory_output"]["citations"])
-        self.assertEqual(payload["reviewed_context"], reviewed_context)
-        self.assertEqual(payload["linked_evidence_ids"], [evidence.evidence_id])
+        self.assertIn(evidence_id, payload["advisory_output"]["citations"])
+        self.assertEqual(payload["reviewed_context"], promoted_case.reviewed_context)
+        self.assertEqual(payload["linked_evidence_ids"], [evidence_id])
         self.assertEqual(
             payload["linked_evidence_records"][0]["evidence_id"],
-            evidence.evidence_id,
+            evidence_id,
         )
-        self.assertIn(admitted.alert.alert_id, payload["linked_alert_ids"])
+        self.assertIn(promoted_case.alert_id, payload["linked_alert_ids"])
         self.assertIn(
             recommendation.recommendation_id,
             payload["linked_recommendation_ids"],
         )
-        self.assertIn(
-            admitted.reconciliation.reconciliation_id,
-            payload["linked_reconciliation_ids"],
-        )
+        self.assertTrue(payload["linked_reconciliation_ids"])
 
     def test_cli_renders_cited_advisory_output_view_for_a_case(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
-        )
-        compared_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {
-                "asset_id": "asset-repo-advisory-cli-001",
-                "criticality": "high",
-            },
-            "identity": {
-                "identity_id": "principal-advisory-cli-001",
-            },
-        }
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-advisory-cli-001",
-            analytic_signal_id="signal-advisory-cli-001",
-            substrate_detection_record_id="substrate-detection-advisory-cli-001",
-            correlation_key="claim:asset-repo-advisory-cli-001:assistant-advisory-cli",
-            first_seen_at=compared_at,
-            last_seen_at=compared_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-advisory-cli-001",
-                source_record_id="substrate-detection-advisory-cli-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=compared_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        _, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case()
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-advisory-cli-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-001",
                 intended_outcome="review the cited evidence before any approval",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
 
@@ -1240,16 +1161,13 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(payload["record_id"], promoted_case.case_id)
         self.assertEqual(payload["output_kind"], "case_summary")
         self.assertEqual(payload["status"], "ready")
-        self.assertEqual(payload["reviewed_context"], reviewed_context)
-        self.assertIn(evidence.evidence_id, payload["citations"])
+        self.assertEqual(payload["reviewed_context"], promoted_case.reviewed_context)
+        self.assertIn(evidence_id, payload["citations"])
         self.assertIn("advisory_only", payload["uncertainty_flags"])
-        self.assertEqual(payload["linked_evidence_ids"], [evidence.evidence_id])
-        self.assertIn(admitted.alert.alert_id, payload["linked_alert_ids"])
+        self.assertEqual(payload["linked_evidence_ids"], [evidence_id])
+        self.assertIn(promoted_case.alert_id, payload["linked_alert_ids"])
         self.assertIn(recommendation.recommendation_id, payload["linked_recommendation_ids"])
-        self.assertIn(
-            admitted.reconciliation.reconciliation_id,
-            payload["linked_reconciliation_ids"],
-        )
+        self.assertTrue(payload["linked_reconciliation_ids"])
 
     def test_cli_renders_case_detail_with_evidence_provenance_and_cited_advisory_output(
         self,
@@ -1644,62 +1562,22 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 thread.join(timeout=2)
 
     def test_long_running_runtime_surface_exposes_cited_advisory_review_routes(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(
-                host="127.0.0.1",
-                port=0,
-                postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
-            ),
-            store=store,
+        store, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case(
+            host="127.0.0.1",
+            port=0,
         )
-        compared_at = datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {
-                "asset_id": "asset-phase19-http-advisory-001",
-                "criticality": "high",
-            },
-            "identity": {
-                "identity_id": "principal-phase19-http-advisory-001",
-            },
-        }
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-phase19-http-advisory-001",
-            analytic_signal_id="signal-phase19-http-advisory-001",
-            substrate_detection_record_id="substrate-detection-phase19-http-advisory-001",
-            correlation_key="claim:asset-phase19-http-advisory-001:github-audit",
-            first_seen_at=compared_at,
-            last_seen_at=compared_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-phase19-http-advisory-001",
-                source_record_id="substrate-detection-phase19-http-advisory-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=compared_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-phase19-http-advisory-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-001",
                 intended_outcome="review the cited evidence before escalation",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
 
@@ -1761,15 +1639,15 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     assistant_context["advisory_output"]["output_kind"],
                     "case_summary",
                 )
-                self.assertEqual(assistant_context["reviewed_context"], reviewed_context)
-                self.assertEqual(assistant_context["linked_evidence_ids"], [evidence.evidence_id])
+                self.assertEqual(assistant_context["reviewed_context"], promoted_case.reviewed_context)
+                self.assertEqual(assistant_context["linked_evidence_ids"], [evidence_id])
 
                 self.assertTrue(advisory_output["read_only"])
                 self.assertEqual(advisory_output["record_family"], "case")
                 self.assertEqual(advisory_output["record_id"], promoted_case.case_id)
                 self.assertEqual(advisory_output["output_kind"], "case_summary")
                 self.assertEqual(advisory_output["status"], "ready")
-                self.assertIn(evidence.evidence_id, advisory_output["citations"])
+                self.assertIn(evidence_id, advisory_output["citations"])
 
                 self.assertTrue(recommendation_draft["read_only"])
                 self.assertEqual(recommendation_draft["record_family"], "case")
@@ -1823,7 +1701,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 )
                 self.assertEqual(missing_record_payload["error"], "not_found")
                 self.assertIn(
-                    "Missing case record",
+                    "Missing case",
                     missing_record_payload["message"],
                 )
             finally:
@@ -1963,56 +1841,19 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 thread.join(timeout=2)
 
     def test_cli_renders_recommendation_draft_view_for_a_case(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
-        )
-        compared_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {
-                "asset_id": "asset-repo-draft-cli-001",
-                "criticality": "high",
-            },
-            "identity": {
-                "identity_id": "principal-draft-cli-001",
-            },
-        }
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-draft-cli-001",
-            analytic_signal_id="signal-draft-cli-001",
-            substrate_detection_record_id="substrate-detection-draft-cli-001",
-            correlation_key="claim:asset-repo-draft-cli-001:assistant-draft-cli",
-            first_seen_at=compared_at,
-            last_seen_at=compared_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-draft-cli-001",
-                source_record_id="substrate-detection-draft-cli-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=compared_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        _, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case()
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-draft-cli-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-001",
                 intended_outcome="review the cited evidence before escalation",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
 
@@ -2033,7 +1874,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertTrue(payload["read_only"])
         self.assertEqual(payload["record_family"], "case")
         self.assertEqual(payload["record_id"], promoted_case.case_id)
-        self.assertEqual(payload["reviewed_context"], reviewed_context)
+        self.assertEqual(payload["reviewed_context"], promoted_case.reviewed_context)
         self.assertEqual(
             payload["recommendation_draft"]["source_output_kind"],
             "case_summary",
@@ -2041,20 +1882,17 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(payload["recommendation_draft"]["status"], "ready")
         self.assertTrue(payload["recommendation_draft"]["candidate_recommendations"])
         self.assertIn(
-            evidence.evidence_id,
+            evidence_id,
             payload["recommendation_draft"]["citations"],
         )
         self.assertIn(
             "advisory_only",
             payload["recommendation_draft"]["uncertainty_flags"],
         )
-        self.assertEqual(payload["linked_evidence_ids"], [evidence.evidence_id])
-        self.assertIn(admitted.alert.alert_id, payload["linked_alert_ids"])
+        self.assertEqual(payload["linked_evidence_ids"], [evidence_id])
+        self.assertIn(promoted_case.alert_id, payload["linked_alert_ids"])
         self.assertIn(recommendation.recommendation_id, payload["linked_recommendation_ids"])
-        self.assertIn(
-            admitted.reconciliation.reconciliation_id,
-            payload["linked_reconciliation_ids"],
-        )
+        self.assertTrue(payload["linked_reconciliation_ids"])
 
     def test_cli_renders_recommendation_draft_with_source_review_outcome(self) -> None:
         store, _ = make_store()

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -393,63 +393,21 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
     def test_service_exposes_analyst_assistant_context_with_linked_evidence(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        _, service, promoted_case, evidence_id, first_seen_at = (
+            self._build_phase19_in_scope_case()
         )
-        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {
-                "asset_id": "asset-repo-001",
-                "ownership": "platform-security",
-                "criticality": "high",
-            },
-            "identity": {
-                "identity_id": "principal-001",
-                "owner": "identity-operations",
-            },
-            "privilege": {
-                "privilege_scope": "repository_admin",
-                "delegated_authority": "reviewed",
-            },
-        }
-
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-assistant-001",
-            analytic_signal_id="signal-assistant-001",
-            substrate_detection_record_id="substrate-detection-assistant-001",
-            correlation_key="claim:asset-repo-001:assistant-review",
-            first_seen_at=first_seen_at,
-            last_seen_at=first_seen_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-assistant-001",
-                source_record_id="substrate-detection-assistant-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=first_seen_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-assistant-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-001",
                 intended_outcome="follow reviewed evidence",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
         colliding_recommendation = service.persist_record(
@@ -457,20 +415,20 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 recommendation_id=promoted_case.case_id,
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-002",
                 intended_outcome="keep reviewed evidence visible",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
         colliding_reconciliation = service.persist_record(
             ReconciliationRecord(
                 reconciliation_id=promoted_case.case_id,
                 subject_linkage={
-                    "alert_ids": (admitted.alert.alert_id,),
+                    "alert_ids": (promoted_case.alert_id,),
                 },
                 alert_id=None,
                 finding_id=None,
@@ -493,17 +451,17 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(snapshot.record_family, "case")
         self.assertEqual(snapshot.record_id, promoted_case.case_id)
         self.assertEqual(snapshot.record["case_id"], promoted_case.case_id)
-        self.assertEqual(snapshot.reviewed_context, reviewed_context)
-        self.assertEqual(snapshot.linked_evidence_ids, (evidence.evidence_id,))
+        self.assertEqual(snapshot.reviewed_context, promoted_case.reviewed_context)
+        self.assertEqual(snapshot.linked_evidence_ids, (evidence_id,))
         self.assertEqual(
             snapshot.linked_evidence_records[0]["evidence_id"],
-            evidence.evidence_id,
+            evidence_id,
         )
         self.assertEqual(
             snapshot.linked_evidence_records[0]["alert_id"],
-            admitted.alert.alert_id,
+            promoted_case.alert_id,
         )
-        self.assertIn(admitted.alert.alert_id, snapshot.linked_alert_ids)
+        self.assertIn(promoted_case.alert_id, snapshot.linked_alert_ids)
         self.assertIn(
             recommendation.recommendation_id,
             snapshot.linked_recommendation_ids,
@@ -512,10 +470,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             colliding_recommendation.recommendation_id,
             snapshot.linked_recommendation_ids,
         )
-        self.assertIn(
-            admitted.reconciliation.reconciliation_id,
-            snapshot.linked_reconciliation_ids,
-        )
+        self.assertTrue(snapshot.linked_reconciliation_ids)
         self.assertIn(
             colliding_reconciliation.reconciliation_id,
             snapshot.linked_reconciliation_ids,
@@ -670,51 +625,19 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_projects_assistant_context_into_advisory_and_draft_views(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
-        )
-        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {"asset_id": "asset-projection-001"},
-            "identity": {"identity_id": "principal-projection-001"},
-        }
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-projection-001",
-            analytic_signal_id="signal-projection-001",
-            substrate_detection_record_id="substrate-detection-projection-001",
-            correlation_key="claim:asset-projection-001:assistant-projection",
-            first_seen_at=first_seen_at,
-            last_seen_at=first_seen_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-projection-001",
-                source_record_id="substrate-detection-projection-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=first_seen_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        _, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case()
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-projection-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-001",
                 intended_outcome="review the cited evidence before escalation",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
 
@@ -729,19 +652,16 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(advisory_snapshot.record_id, promoted_case.case_id)
         self.assertEqual(advisory_snapshot.output_kind, "case_summary")
         self.assertEqual(advisory_snapshot.status, "ready")
-        self.assertEqual(advisory_snapshot.reviewed_context, reviewed_context)
-        self.assertIn(evidence.evidence_id, advisory_snapshot.citations)
+        self.assertEqual(advisory_snapshot.reviewed_context, promoted_case.reviewed_context)
+        self.assertIn(evidence_id, advisory_snapshot.citations)
         self.assertIn("advisory_only", advisory_snapshot.uncertainty_flags)
-        self.assertIn(admitted.alert.alert_id, advisory_snapshot.linked_alert_ids)
-        self.assertEqual(advisory_snapshot.linked_evidence_ids, (evidence.evidence_id,))
+        self.assertIn(promoted_case.alert_id, advisory_snapshot.linked_alert_ids)
+        self.assertEqual(advisory_snapshot.linked_evidence_ids, (evidence_id,))
         self.assertIn(
             recommendation.recommendation_id,
             advisory_snapshot.linked_recommendation_ids,
         )
-        self.assertIn(
-            admitted.reconciliation.reconciliation_id,
-            advisory_snapshot.linked_reconciliation_ids,
-        )
+        self.assertTrue(advisory_snapshot.linked_reconciliation_ids)
 
         self.assertTrue(recommendation_draft.read_only)
         self.assertEqual(
@@ -756,17 +676,20 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             recommendation_draft.recommendation_draft["candidate_recommendations"]
         )
         self.assertIn(
-            evidence.evidence_id,
+            evidence_id,
             recommendation_draft.recommendation_draft["citations"],
         )
         self.assertIn(
             "advisory_only",
             recommendation_draft.recommendation_draft["uncertainty_flags"],
         )
-        self.assertEqual(recommendation_draft.reviewed_context, reviewed_context)
+        self.assertEqual(
+            recommendation_draft.reviewed_context,
+            promoted_case.reviewed_context,
+        )
         self.assertEqual(
             recommendation_draft.linked_evidence_ids,
-            (evidence.evidence_id,),
+            (evidence_id,),
         )
         self.assertIn(
             recommendation.recommendation_id,
@@ -2346,35 +2269,14 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_preserves_declared_missing_evidence_ids_in_assistant_context(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
-        )
-        compared_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        _, service, case, evidence_id, _ = self._build_phase19_in_scope_case()
         case = service.persist_record(
-            CaseRecord(
-                case_id="case-assistant-missing-evidence-001",
-                alert_id=None,
-                finding_id="finding-assistant-missing-evidence-001",
+            replace(
+                case,
                 evidence_ids=(
                     "evidence-assistant-missing-001",
-                    "evidence-assistant-present-001",
+                    evidence_id,
                 ),
-                lifecycle_state="open",
-            )
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-assistant-present-001",
-                source_record_id="substrate-detection-assistant-missing-001",
-                alert_id=None,
-                case_id=case.case_id,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=compared_at,
-                derivation_relationship="observed_artifact",
-                lifecycle_state="collected",
             )
         )
 
@@ -2384,13 +2286,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             snapshot.linked_evidence_ids,
             (
                 "evidence-assistant-missing-001",
-                evidence.evidence_id,
+                evidence_id,
             ),
         )
         self.assertEqual(len(snapshot.linked_evidence_records), 1)
         self.assertEqual(
             snapshot.linked_evidence_records[0]["evidence_id"],
-            evidence.evidence_id,
+            evidence_id,
         )
 
     def test_service_merges_reviewed_context_for_existing_alert_updates(self) -> None:
@@ -4104,10 +4006,30 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "Privilege-impacting change needs durable business-hours follow-up.",
         )
 
+    def test_service_allows_in_scope_case_assistant_context_on_phase19_operator_surface(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case()
+
+        snapshot = service.inspect_assistant_context("case", promoted_case.case_id)
+
+        self.assertTrue(snapshot.read_only)
+        self.assertEqual(snapshot.record_family, "case")
+        self.assertEqual(snapshot.record_id, promoted_case.case_id)
+        self.assertEqual(snapshot.record["case_id"], promoted_case.case_id)
+        self.assertEqual(snapshot.advisory_output["output_kind"], "case_summary")
+        self.assertIn(evidence_id, snapshot.linked_evidence_ids)
+
     def test_service_rejects_replay_only_case_from_phase19_operator_surface(self) -> None:
         service, promoted_case, _, reviewed_at = self._build_phase19_out_of_scope_case(
             fixture_name="github-audit-alert.json"
         )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.inspect_assistant_context("case", promoted_case.case_id)
 
         with self.assertRaisesRegex(
             ValueError,


### PR DESCRIPTION
## What changed
- gate `inspect_assistant_context("case", ...)` through the existing Phase 19 operator-case eligibility check
- fail closed for replay-only, synthetic, and other out-of-scope cases
- keep non-case assistant-context inspection behavior unchanged
- update case-scoped assistant/advisory/draft tests to use the approved in-scope Wazuh GitHub audit fixture path
- add focused service coverage for accepted in-scope and rejected out-of-scope case inspection

## Why
Case-scoped assistant-context inspection was still reachable outside the approved Phase 19 operator slice. This narrows that read path to the reviewed live Wazuh-backed GitHub audit surface and preserves fail-closed behavior for out-of-scope cases.

## Impact
- approved in-scope Phase 19 cases still render assistant-context snapshots
- replay-only and synthetic cases now reject case-scoped assistant-context inspection
- no broader assistant authority or operator-surface expansion

## Verification
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_rejects_replay_only_case_from_phase19_operator_surface`
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_allows_in_scope_case_assistant_context_on_phase19_operator_surface control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_rejects_replay_only_case_from_phase19_operator_surface`
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_exposes_analyst_assistant_context_with_linked_evidence control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_projects_assistant_context_into_advisory_and_draft_views control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_preserves_declared_missing_evidence_ids_in_assistant_context`
- `python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_analyst_assistant_context_view_for_a_case control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_cited_advisory_output_view_for_a_case control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_recommendation_draft_view_for_a_case control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_long_running_runtime_surface_exposes_cited_advisory_review_routes`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added eligibility validation for case-context inspection on the operator surface.

* **Tests**
  * Expanded and tightened tests for in-scope vs out-of-scope case handling.
  * Consolidated inspection tests to use a shared Phase 19 in-scope fixture for consistency.

* **Documentation**
  * Added a supervisor issue journal entry recording the current snapshot, test updates, and verification notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->