### PR TITLE
[codex] Fail closed advisory-output and recommendation-draft reads

### DIFF
--- a/.codex-supervisor/issues/411/issue-journal.md
+++ b/.codex-supervisor/issues/411/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #411: implementation: fail closed advisory-output and recommendation-draft reads for out-of-scope Phase 19 cases
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/411
+- Branch: codex/issue-411
+- Workspace: .
+- Journal: .codex-supervisor/issues/411/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 531c23244e1b4e69ceda7cb8931f65f3d15cc401
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T11:47:34.960Z
+
+## Latest Codex Summary
+- Added a Phase 19 case-scope guard to `inspect_advisory_output(...)` and `render_recommendation_draft(...)` so advisory reads fail closed when the requested record is a case or links to a case outside the approved Wazuh-backed GitHub audit live slice.
+- Added focused service, CLI, and HTTP tests covering rejected replay-linked `recommendation`/`ai_trace` advisory reads while keeping accepted in-scope case reads green.
+- Rebased older recommendation-draft and advisory-draft attachment tests onto the existing in-scope Phase 19 fixture so lifecycle and attachment coverage stays on the approved slice.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The fail-open path was not the direct `family=case` read, but advisory reads for `recommendation` and `ai_trace` records that inherited scope from replay-only cases because only `inspect_assistant_context(..., family=\"case\")` enforced the Phase 19 slice gate.
+- What changed: Added `_require_phase19_case_scoped_advisory_read(...)` and invoked it from `inspect_advisory_output(...)` and `render_recommendation_draft(...)`; added focused rejection tests for replay-linked review records on service/CLI/HTTP paths; updated older advisory-draft lifecycle tests to use the approved in-scope Phase 19 fixture.
+- Current blocker: none
+- Next exact step: Commit the local changes on `codex/issue-411`; PR creation can follow from this checkpoint if needed.
+- Verification gap: none from local suite; full `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` passed.
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_service_persistence.py`, `control-plane/tests/test_cli_inspection.py`, `.codex-supervisor/issues/411/issue-journal.md`
+- Rollback concern: The new guard intentionally narrows advisory reads for review records linked to out-of-scope cases; older non-Phase-19 advisory-draft tests were updated to keep approved-slice behavior explicit.
+- Last focused command: `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2204,6 +2204,7 @@ class AegisOpsControlPlaneService:
         record_id: str,
     ) -> AdvisoryInspectionSnapshot:
         context_snapshot = self.inspect_assistant_context(record_family, record_id)
+        self._require_phase19_case_scoped_advisory_read(context_snapshot)
         return _advisory_inspection_snapshot_from_context(context_snapshot)
 
     def render_recommendation_draft(
@@ -2212,6 +2213,7 @@ class AegisOpsControlPlaneService:
         record_id: str,
     ) -> RecommendationDraftSnapshot:
         context_snapshot = self.inspect_assistant_context(record_family, record_id)
+        self._require_phase19_case_scoped_advisory_read(context_snapshot)
         return _recommendation_draft_snapshot_from_context(context_snapshot)
 
     def attach_assistant_advisory_draft(
@@ -3906,6 +3908,17 @@ class AegisOpsControlPlaneService:
     def _require_phase19_operator_case(self, case_id: str) -> CaseRecord:
         case = self._require_case_record(case_id)
         return self._require_phase19_operator_case_record(case)
+
+    def _require_phase19_case_scoped_advisory_read(
+        self,
+        context_snapshot: AnalystAssistantContextSnapshot,
+    ) -> None:
+        if context_snapshot.record_family == "case":
+            self._require_phase19_operator_case(context_snapshot.record_id)
+            return
+
+        for case_id in context_snapshot.linked_case_ids:
+            self._require_phase19_operator_case(case_id)
 
     def _require_phase19_operator_case_record(self, case: CaseRecord) -> CaseRecord:
         if not self._case_is_in_phase19_operator_slice(case):

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3916,6 +3916,11 @@ class AegisOpsControlPlaneService:
         if context_snapshot.record_family == "case":
             self._require_phase19_operator_case(context_snapshot.record_id)
             return
+        if not context_snapshot.linked_case_ids:
+            raise ValueError(
+                f"{context_snapshot.record_family} {context_snapshot.record_id!r} "
+                "is outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+            )
 
         for case_id in context_snapshot.linked_case_ids:
             self._require_phase19_operator_case(case_id)

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -137,6 +137,57 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
         return service, recommendation, ai_trace
 
+    def _build_case_scoped_advisory_records_without_case_lineage(
+        self,
+        *,
+        host: str | None = None,
+        port: int | None = None,
+    ) -> tuple[AegisOpsControlPlaneService, RecommendationRecord, AITraceRecord]:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case(
+            host=host,
+            port=port,
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Case-scoped advisory reads must fail closed without case lineage.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Preserve reviewed lead linkage for bounded advisory rendering.",
+        )
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-cli-lead-only-advisory-001",
+                lead_id=lead.lead_id,
+                hunt_run_id=None,
+                alert_id=None,
+                case_id=None,
+                ai_trace_id=None,
+                review_owner="analyst-001",
+                intended_outcome="Review the lead linkage before any broader response.",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+        ai_trace = service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-cli-lead-only-advisory-001",
+                subject_linkage={"recommendation_ids": (recommendation.recommendation_id,)},
+                model_identity="gpt-5.4",
+                prompt_version="prompt-v1",
+                generated_at=reviewed_at,
+                material_input_refs=(),
+                reviewer_identity="analyst-001",
+                lifecycle_state="under_review",
+            )
+        )
+        return service, recommendation, ai_trace
+
     def test_runtime_command_uses_runtime_service_builder_when_not_injected(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -1855,6 +1906,86 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     servers[0].shutdown()
                 thread.join(timeout=2)
 
+    def test_long_running_runtime_surface_rejects_case_scoped_advisory_reads_without_linked_case(
+        self,
+    ) -> None:
+        service, recommendation, ai_trace = (
+            self._build_case_scoped_advisory_records_without_case_lineage(
+                host="127.0.0.1",
+                port=0,
+            )
+        )
+        expected_message = (
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                for path, record_family, record_id in (
+                    (
+                        "/inspect-advisory-output",
+                        "recommendation",
+                        recommendation.recommendation_id,
+                    ),
+                    (
+                        "/inspect-advisory-output",
+                        "ai_trace",
+                        ai_trace.ai_trace_id,
+                    ),
+                    (
+                        "/render-recommendation-draft",
+                        "recommendation",
+                        recommendation.recommendation_id,
+                    ),
+                    (
+                        "/render-recommendation-draft",
+                        "ai_trace",
+                        ai_trace.ai_trace_id,
+                    ),
+                ):
+                    with self.subTest(
+                        path=path,
+                        record_family=record_family,
+                    ):
+                        with self.assertRaises(error.HTTPError) as exc_info:
+                            request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                                (
+                                    f"{base_url}{path}"
+                                    f"?family={record_family}&record_id={record_id}"
+                                ),
+                                timeout=2,
+                            )
+
+                        self.assertEqual(exc_info.exception.code, 400)
+                        payload = json.loads(
+                            exc_info.exception.read().decode("utf-8")
+                        )
+                        self.assertEqual(payload["error"], "invalid_request")
+                        self.assertIn(expected_message, payload["message"])
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
     def test_long_running_runtime_surface_rejects_oversized_operator_request_body(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -2045,6 +2176,58 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
     ) -> None:
         service, recommendation, ai_trace = self._build_out_of_scope_case_advisory_review_records(
             fixture_name="github-audit-alert.json"
+        )
+        expected_message = (
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+        )
+
+        for command, record_family, record_id in (
+            (
+                "inspect-advisory-output",
+                "recommendation",
+                recommendation.recommendation_id,
+            ),
+            (
+                "inspect-advisory-output",
+                "ai_trace",
+                ai_trace.ai_trace_id,
+            ),
+            (
+                "render-recommendation-draft",
+                "recommendation",
+                recommendation.recommendation_id,
+            ),
+            (
+                "render-recommendation-draft",
+                "ai_trace",
+                ai_trace.ai_trace_id,
+            ),
+        ):
+            stderr = io.StringIO()
+            with self.subTest(
+                command=command,
+                record_family=record_family,
+            ), contextlib.redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as exc_info:
+                    main.main(
+                        [
+                            command,
+                            "--family",
+                            record_family,
+                            "--record-id",
+                            record_id,
+                        ],
+                        service=service,
+                    )
+
+            self.assertEqual(exc_info.exception.code, 2)
+            self.assertIn(expected_message, stderr.getvalue())
+
+    def test_cli_rejects_case_scoped_advisory_reads_without_linked_case_as_usage_errors(
+        self,
+    ) -> None:
+        service, recommendation, ai_trace = (
+            self._build_case_scoped_advisory_records_without_case_lineage()
         )
         expected_message = (
             "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -21,6 +21,7 @@ import main
 from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
 from aegisops_control_plane.models import (
+    AITraceRecord,
     AlertRecord,
     AnalyticSignalRecord,
     CaseRecord,
@@ -69,6 +70,72 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
         promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         return store, service, promoted_case, promoted_case.evidence_ids[0], reviewed_at
+
+    def _build_phase19_out_of_scope_case(
+        self,
+        *,
+        fixture_name: str,
+        host: str | None = None,
+        port: int | None = None,
+    ) -> tuple[AegisOpsControlPlaneService, CaseRecord]:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1" if host is None else host,
+                port=0 if port is None else port,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+            ),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(_load_wazuh_fixture(fixture_name)),
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        return service, promoted_case
+
+    def _build_out_of_scope_case_advisory_review_records(
+        self,
+        *,
+        fixture_name: str,
+        host: str | None = None,
+        port: int | None = None,
+    ) -> tuple[AegisOpsControlPlaneService, RecommendationRecord, AITraceRecord]:
+        service, promoted_case = self._build_phase19_out_of_scope_case(
+            fixture_name=fixture_name,
+            host=host,
+            port=port,
+        )
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase19-cli-replay-linked-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                ai_trace_id="ai-trace-phase19-cli-replay-linked-001",
+                review_owner="reviewer-001",
+                intended_outcome="Replay-linked advisory reads must fail closed.",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+        ai_trace = service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-phase19-cli-replay-linked-001",
+                subject_linkage={"recommendation_ids": (recommendation.recommendation_id,)},
+                model_identity="gpt-5.4",
+                prompt_version="prompt-v1",
+                generated_at=datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc),
+                material_input_refs=(),
+                reviewer_identity="reviewer-001",
+                lifecycle_state="under_review",
+            )
+        )
+        return service, recommendation, ai_trace
 
     def test_runtime_command_uses_runtime_service_builder_when_not_injected(self) -> None:
         store, _ = make_store()
@@ -1709,6 +1776,85 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     servers[0].shutdown()
                 thread.join(timeout=2)
 
+    def test_long_running_runtime_surface_rejects_case_scoped_out_of_scope_advisory_reads(
+        self,
+    ) -> None:
+        service, recommendation, ai_trace = self._build_out_of_scope_case_advisory_review_records(
+            fixture_name="github-audit-alert.json",
+            host="127.0.0.1",
+            port=0,
+        )
+        expected_message = (
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                for path, record_family, record_id in (
+                    (
+                        "/inspect-advisory-output",
+                        "recommendation",
+                        recommendation.recommendation_id,
+                    ),
+                    (
+                        "/inspect-advisory-output",
+                        "ai_trace",
+                        ai_trace.ai_trace_id,
+                    ),
+                    (
+                        "/render-recommendation-draft",
+                        "recommendation",
+                        recommendation.recommendation_id,
+                    ),
+                    (
+                        "/render-recommendation-draft",
+                        "ai_trace",
+                        ai_trace.ai_trace_id,
+                    ),
+                ):
+                    with self.subTest(
+                        path=path,
+                        record_family=record_family,
+                    ):
+                        with self.assertRaises(error.HTTPError) as exc_info:
+                            request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                                (
+                                    f"{base_url}{path}"
+                                    f"?family={record_family}&record_id={record_id}"
+                                ),
+                                timeout=2,
+                            )
+
+                        self.assertEqual(exc_info.exception.code, 400)
+                        payload = json.loads(
+                            exc_info.exception.read().decode("utf-8")
+                        )
+                        self.assertEqual(payload["error"], "invalid_request")
+                        self.assertIn(expected_message, payload["message"])
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
     def test_long_running_runtime_surface_rejects_oversized_operator_request_body(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -1894,59 +2040,72 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertIn(recommendation.recommendation_id, payload["linked_recommendation_ids"])
         self.assertTrue(payload["linked_reconciliation_ids"])
 
-    def test_cli_renders_recommendation_draft_with_source_review_outcome(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+    def test_cli_rejects_case_scoped_out_of_scope_advisory_reads_as_usage_errors(
+        self,
+    ) -> None:
+        service, recommendation, ai_trace = self._build_out_of_scope_case_advisory_review_records(
+            fixture_name="github-audit-alert.json"
         )
-        compared_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {
-                "asset_id": "asset-repo-draft-cli-outcome-001",
-                "criticality": "high",
-            },
-            "identity": {
-                "identity_id": "principal-repo-draft-cli-outcome-001",
-                "criticality": "elevated",
-            },
-        }
+        expected_message = (
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+        )
 
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-draft-cli-outcome-001",
-            analytic_signal_id="signal-draft-cli-outcome-001",
-            substrate_detection_record_id="substrate-detection-draft-cli-outcome-001",
-            correlation_key="claim:asset-repo-draft-cli-outcome-001:assistant-draft-cli",
-            first_seen_at=compared_at,
-            last_seen_at=compared_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-draft-cli-outcome-001",
-                source_record_id="substrate-detection-draft-cli-outcome-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=compared_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        for command, record_family, record_id in (
+            (
+                "inspect-advisory-output",
+                "recommendation",
+                recommendation.recommendation_id,
+            ),
+            (
+                "inspect-advisory-output",
+                "ai_trace",
+                ai_trace.ai_trace_id,
+            ),
+            (
+                "render-recommendation-draft",
+                "recommendation",
+                recommendation.recommendation_id,
+            ),
+            (
+                "render-recommendation-draft",
+                "ai_trace",
+                ai_trace.ai_trace_id,
+            ),
+        ):
+            stderr = io.StringIO()
+            with self.subTest(
+                command=command,
+                record_family=record_family,
+            ), contextlib.redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as exc_info:
+                    main.main(
+                        [
+                            command,
+                            "--family",
+                            record_family,
+                            "--record-id",
+                            record_id,
+                        ],
+                        service=service,
+                    )
+
+            self.assertEqual(exc_info.exception.code, 2)
+            self.assertIn(expected_message, stderr.getvalue())
+
+    def test_cli_renders_recommendation_draft_with_source_review_outcome(self) -> None:
+        _, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case()
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-draft-cli-outcome-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-001",
                 intended_outcome="review the cited evidence before escalation",
                 lifecycle_state="accepted",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
 
@@ -1983,7 +2142,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             payload["recommendation_draft"]["cited_summary"]["text"],
         )
         self.assertIn(
-            evidence.evidence_id,
+            evidence_id,
             payload["recommendation_draft"]["citations"],
         )
 

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -697,52 +697,21 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
     def test_service_materializes_assistant_advisory_drafts_on_review_records(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        _, service, promoted_case, evidence_id, first_seen_at = (
+            self._build_phase19_in_scope_case()
         )
-        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {"asset_id": "asset-advisory-review-001"},
-            "identity": {"identity_id": "principal-advisory-review-001"},
-        }
-
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-advisory-review-001",
-            analytic_signal_id="signal-advisory-review-001",
-            substrate_detection_record_id="substrate-detection-advisory-review-001",
-            correlation_key="claim:assistant:advisory-review:001",
-            first_seen_at=first_seen_at,
-            last_seen_at=first_seen_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-advisory-review-001",
-                source_record_id="substrate-detection-advisory-review-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=first_seen_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-advisory-review-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id="ai-trace-advisory-review-001",
                 review_owner="reviewer-001",
                 intended_outcome="review the cited evidence before escalation",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
         ai_trace = service.persist_record(
@@ -752,7 +721,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 model_identity="gpt-5.4",
                 prompt_version="prompt-v1",
                 generated_at=first_seen_at,
-                material_input_refs=(evidence.evidence_id,),
+                material_input_refs=(evidence_id,),
                 reviewer_identity="reviewer-001",
                 lifecycle_state="under_review",
             )
@@ -788,7 +757,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "ready",
         )
         self.assertIn(
-            evidence.evidence_id,
+            evidence_id,
             attached_recommendation.assistant_advisory_draft["citations"],
         )
 
@@ -846,23 +815,19 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_preserves_prior_assistant_advisory_draft_revisions_on_repeat_attachment(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
-        )
-        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        _, service, promoted_case, _, first_seen_at = self._build_phase19_in_scope_case()
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-advisory-history-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id="alert-advisory-history-001",
-                case_id="case-advisory-history-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
                 ai_trace_id=None,
                 review_owner="reviewer-001",
                 intended_outcome="review the draft history",
                 lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
 
@@ -901,52 +866,21 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
     def test_service_renders_recommendation_draft_with_current_review_outcome(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=store,
+        _, service, promoted_case, evidence_id, first_seen_at = (
+            self._build_phase19_in_scope_case()
         )
-        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        reviewed_context = {
-            "asset": {"asset_id": "asset-advisory-render-001"},
-            "identity": {"identity_id": "principal-advisory-render-001"},
-        }
-
-        admitted = service.ingest_finding_alert(
-            finding_id="finding-advisory-render-001",
-            analytic_signal_id="signal-advisory-render-001",
-            substrate_detection_record_id="substrate-detection-advisory-render-001",
-            correlation_key="claim:assistant:advisory-render:001",
-            first_seen_at=first_seen_at,
-            last_seen_at=first_seen_at,
-            reviewed_context=reviewed_context,
-        )
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id="evidence-advisory-render-001",
-                source_record_id="substrate-detection-advisory-render-001",
-                alert_id=admitted.alert.alert_id,
-                case_id=None,
-                source_system="reviewed-source",
-                collector_identity="control-plane-test",
-                acquired_at=first_seen_at,
-                derivation_relationship="admitted_analytic_signal",
-                lifecycle_state="collected",
-            )
-        )
-        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         recommendation = service.persist_record(
             RecommendationRecord(
                 recommendation_id="recommendation-advisory-render-001",
                 lead_id=None,
                 hunt_run_id=None,
-                alert_id=admitted.alert.alert_id,
+                alert_id=promoted_case.alert_id,
                 case_id=promoted_case.case_id,
                 ai_trace_id="ai-trace-advisory-render-001",
                 review_owner="reviewer-001",
                 intended_outcome="review the cited evidence before escalation",
                 lifecycle_state="under_review",
-                reviewed_context=reviewed_context,
+                reviewed_context=promoted_case.reviewed_context,
             )
         )
         ai_trace = service.persist_record(
@@ -956,7 +890,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 model_identity="gpt-5.4",
                 prompt_version="prompt-v1",
                 generated_at=first_seen_at,
-                material_input_refs=(evidence.evidence_id,),
+                material_input_refs=(evidence_id,),
                 reviewer_identity="reviewer-001",
                 lifecycle_state="under_review",
             )
@@ -4089,6 +4023,56 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 rationale="Replay-only casework must fail closed.",
                 recorded_at=reviewed_at,
             )
+
+    def test_service_rejects_case_scoped_advisory_reads_linked_to_replay_only_case(
+        self,
+    ) -> None:
+        service, promoted_case, _, reviewed_at = self._build_phase19_out_of_scope_case(
+            fixture_name="github-audit-alert.json"
+        )
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase19-replay-linked-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                ai_trace_id="ai-trace-phase19-replay-linked-001",
+                review_owner="reviewer-001",
+                intended_outcome="Replay-linked advisory reads must fail closed.",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+        ai_trace = service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-phase19-replay-linked-001",
+                subject_linkage={"recommendation_ids": (recommendation.recommendation_id,)},
+                model_identity="gpt-5.4",
+                prompt_version="prompt-v1",
+                generated_at=reviewed_at,
+                material_input_refs=(),
+                reviewer_identity="reviewer-001",
+                lifecycle_state="under_review",
+            )
+        )
+
+        for record_family, record_id in (
+            ("recommendation", recommendation.recommendation_id),
+            ("ai_trace", ai_trace.ai_trace_id),
+        ):
+            with self.subTest(record_family=record_family):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                ):
+                    service.inspect_advisory_output(record_family, record_id)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                ):
+                    service.render_recommendation_draft(record_family, record_id)
 
     def test_service_rejects_non_github_audit_case_from_phase19_operator_surface(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -221,6 +221,53 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         return service, promoted_case, admitted.alert.alert_id, reviewed_at
 
+    def _build_case_scoped_advisory_records_without_case_lineage(
+        self,
+    ) -> tuple[AegisOpsControlPlaneService, RecommendationRecord, AITraceRecord]:
+        _, service, promoted_case, evidence_id, first_seen_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=first_seen_at,
+            scope_statement="Case-scoped advisory reads must fail closed without case lineage.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Preserve reviewed lead linkage for bounded advisory rendering.",
+        )
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-lead-only-advisory-001",
+                lead_id=lead.lead_id,
+                hunt_run_id=None,
+                alert_id=None,
+                case_id=None,
+                ai_trace_id=None,
+                review_owner="analyst-001",
+                intended_outcome="Review the lead linkage before any broader response.",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+        ai_trace = service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-lead-only-advisory-001",
+                subject_linkage={"recommendation_ids": (recommendation.recommendation_id,)},
+                model_identity="gpt-5.4",
+                prompt_version="prompt-v1",
+                generated_at=first_seen_at,
+                material_input_refs=(),
+                reviewer_identity="analyst-001",
+                lifecycle_state="under_review",
+            )
+        )
+        return service, recommendation, ai_trace
+
     def test_service_admits_wazuh_fixture_through_substrate_adapter_boundary(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -955,55 +1002,29 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             rejected_ai_trace_draft.recommendation_draft["cited_summary"]["text"],
         )
 
-    def test_service_renders_lead_only_recommendation_draft_as_unresolved(self) -> None:
-        _, service, promoted_case, evidence_id, first_seen_at = (
-            self._build_phase19_in_scope_case()
-        )
-        observation = service.record_case_observation(
-            case_id=promoted_case.case_id,
-            author_identity="analyst-001",
-            observed_at=first_seen_at,
-            scope_statement="Lead-only recommendation should fail closed without direct lineage.",
-            supporting_evidence_ids=(evidence_id,),
-        )
-        lead = service.record_case_lead(
-            case_id=promoted_case.case_id,
-            observation_id=observation.observation_id,
-            triage_owner="analyst-001",
-            triage_rationale="Preserve reviewed lead linkage for bounded advisory rendering.",
-        )
-        recommendation = service.persist_record(
-            RecommendationRecord(
-                recommendation_id="recommendation-lead-only-advisory-001",
-                lead_id=lead.lead_id,
-                hunt_run_id=None,
-                alert_id=None,
-                case_id=None,
-                ai_trace_id=None,
-                review_owner="analyst-001",
-                intended_outcome="Review the lead linkage before any broader response.",
-                lifecycle_state="under_review",
-                reviewed_context=promoted_case.reviewed_context,
-            )
+    def test_service_rejects_case_scoped_advisory_reads_without_linked_case(
+        self,
+    ) -> None:
+        service, recommendation, ai_trace = (
+            self._build_case_scoped_advisory_records_without_case_lineage()
         )
 
-        draft = service.render_recommendation_draft(
-            "recommendation",
-            recommendation.recommendation_id,
-        )
+        for record_family, record_id in (
+            ("recommendation", recommendation.recommendation_id),
+            ("ai_trace", ai_trace.ai_trace_id),
+        ):
+            with self.subTest(record_family=record_family):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                ):
+                    service.inspect_advisory_output(record_family, record_id)
 
-        self.assertEqual(draft.linked_alert_ids, ())
-        self.assertEqual(draft.linked_case_ids, ())
-        self.assertEqual(draft.linked_evidence_ids, ())
-        self.assertEqual(draft.recommendation_draft["status"], "unresolved")
-        self.assertIn(
-            "missing_evidence_citation",
-            draft.recommendation_draft["uncertainty_flags"],
-        )
-        self.assertIn(
-            "remains unresolved",
-            draft.recommendation_draft["cited_summary"]["text"],
-        )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                ):
+                    service.render_recommendation_draft(record_family, record_id)
 
     def test_service_includes_evidence_derived_recommendations_in_ai_trace_context(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -4079,6 +4079,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
         for record_family, record_id in (
+            ("case", promoted_case.case_id),
             ("recommendation", recommendation.recommendation_id),
             ("ai_trace", ai_trace.ai_trace_id),
         ):


### PR DESCRIPTION
## Summary
- fail closed `inspect_advisory_output(...)` and `render_recommendation_draft(...)` for cases and linked records outside the approved Phase 19 Wazuh-backed GitHub audit live slice
- keep the approved in-scope cited advisory review path available for accepted Phase 19 cases
- add focused service, CLI, and HTTP tests covering both accepted in-scope reads and rejected out-of-scope advisory requests

## Root Cause
Advisory reads were guarded when directly scoped to `family=case`, but `recommendation` and `ai_trace` reads could still inherit scope from replay-only cases and remain visible through the advisory review surfaces.

## Validation
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Advisory inspection and recommendation-draft rendering now enforce Phase 19 case-scope validation, rejecting out-of-scope advisory reads (recommendation and AI trace) with a clear usage/invalid_request error.

* **Tests**
  * Added unit, HTTP, and CLI tests to cover rejected out-of-scope advisory reads and preserved in-scope behavior.

* **Documentation**
  * Added a supervisor journal entry documenting the change, verification notes, and test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->