### PR TITLE
[codex] Add fail-closed coverage for out-of-scope Phase 19 case reads

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3935,6 +3935,10 @@ class AegisOpsControlPlaneService:
                 error_message=error_message,
             )
         elif context_snapshot.record_family == "ai_trace":
+            if self._phase19_context_declares_out_of_scope_provenance(
+                context_snapshot.record.get("subject_linkage")
+            ):
+                raise ValueError(error_message)
             if not context_snapshot.linked_recommendation_records:
                 raise ValueError(error_message)
             for recommendation in context_snapshot.linked_recommendation_records:
@@ -4057,13 +4061,17 @@ class AegisOpsControlPlaneService:
 
     def _phase19_context_declares_out_of_scope_provenance(self, context: object) -> bool:
         if not isinstance(context, Mapping):
-            return False
+            return True
 
-        source_family = self._phase19_operator_source_family(context)
+        source_family = self._phase19_operator_source_family(
+            context
+        ) or self._phase19_operator_source_family(context.get("reviewed_source_profile"))
         if source_family is not None and source_family != "github_audit":
             return True
 
-        admission_provenance = _normalize_admission_provenance(context.get("provenance"))
+        admission_provenance = _normalize_admission_provenance(
+            context.get("provenance")
+        ) or _normalize_admission_provenance(context.get("admission_provenance"))
         return (
             admission_provenance is not None
             and admission_provenance

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1863,7 +1863,7 @@ class AegisOpsControlPlaneService:
             for recommendation in linked_recommendation_records
         )
 
-        return AnalystAssistantContextSnapshot(
+        snapshot = AnalystAssistantContextSnapshot(
             read_only=True,
             record_family=record_family,
             record_id=record_id,
@@ -1898,6 +1898,7 @@ class AegisOpsControlPlaneService:
                 for reconciliation in linked_reconciliation_records
             ),
         )
+        return snapshot
 
     def inspect_case_detail(self, case_id: str) -> CaseDetailSnapshot:
         case = self._require_phase19_operator_case(case_id)
@@ -3913,17 +3914,71 @@ class AegisOpsControlPlaneService:
         self,
         context_snapshot: AnalystAssistantContextSnapshot,
     ) -> None:
+        error_message = self._phase19_case_scoped_read_error(
+            context_snapshot.record_family,
+            context_snapshot.record_id,
+        )
         if context_snapshot.record_family == "case":
             self._require_phase19_operator_case(context_snapshot.record_id)
             return
         if not context_snapshot.linked_case_ids:
-            raise ValueError(
-                f"{context_snapshot.record_family} {context_snapshot.record_id!r} "
-                "is outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
-            )
+            raise ValueError(error_message)
 
+        approved_cases: dict[str, CaseRecord] = {}
         for case_id in context_snapshot.linked_case_ids:
-            self._require_phase19_operator_case(case_id)
+            approved_cases[case_id] = self._require_phase19_operator_case(case_id)
+
+        if context_snapshot.record_family == "recommendation":
+            self._require_phase19_case_scoped_recommendation_payload(
+                context_snapshot.record,
+                approved_cases=approved_cases,
+                error_message=error_message,
+            )
+        elif context_snapshot.record_family == "ai_trace":
+            if not context_snapshot.linked_recommendation_records:
+                raise ValueError(error_message)
+            for recommendation in context_snapshot.linked_recommendation_records:
+                self._require_phase19_case_scoped_recommendation_payload(
+                    recommendation,
+                    approved_cases=approved_cases,
+                    error_message=error_message,
+                )
+
+    @staticmethod
+    def _phase19_case_scoped_read_error(record_family: str, record_id: str) -> str:
+        return (
+            f"{record_family} {record_id!r} is outside the approved Phase 19 "
+            "Wazuh-backed GitHub audit live slice"
+        )
+
+    def _require_phase19_case_scoped_recommendation_payload(
+        self,
+        payload: Mapping[str, object],
+        *,
+        approved_cases: Mapping[str, CaseRecord],
+        error_message: str,
+    ) -> None:
+        case_id = self._normalize_optional_string(payload.get("case_id"), "case_id")
+        if case_id is None:
+            raise ValueError(error_message)
+        approved_case = approved_cases.get(case_id)
+        if approved_case is None:
+            raise ValueError(error_message)
+
+        alert_id = self._normalize_optional_string(payload.get("alert_id"), "alert_id")
+        if alert_id is not None and approved_case.alert_id != alert_id:
+            raise ValueError(error_message)
+
+        lead_id = self._normalize_optional_string(payload.get("lead_id"), "lead_id")
+        if lead_id is not None:
+            lead = self._store.get(LeadRecord, lead_id)
+            if lead is None or lead.case_id != case_id:
+                raise ValueError(error_message)
+
+        if self._phase19_context_declares_out_of_scope_provenance(
+            payload.get("reviewed_context")
+        ):
+            raise ValueError(error_message)
 
     def _require_phase19_operator_case_record(self, case: CaseRecord) -> CaseRecord:
         if not self._case_is_in_phase19_operator_slice(case):
@@ -3999,6 +4054,24 @@ class AegisOpsControlPlaneService:
                 return normalized_source_family
 
         return None
+
+    def _phase19_context_declares_out_of_scope_provenance(self, context: object) -> bool:
+        if not isinstance(context, Mapping):
+            return False
+
+        source_family = self._phase19_operator_source_family(context)
+        if source_family is not None and source_family != "github_audit":
+            return True
+
+        admission_provenance = _normalize_admission_provenance(context.get("provenance"))
+        return (
+            admission_provenance is not None
+            and admission_provenance
+            != {
+                "admission_kind": "live",
+                "admission_channel": "live_wazuh_webhook",
+            }
+        )
 
     def _normalize_linked_record_ids(
         self,

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -6,7 +6,7 @@ import pathlib
 import sys
 import threading
 import unittest
-from urllib import request
+from urllib import error, request
 from unittest import mock
 
 
@@ -15,7 +15,9 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
 import main
+from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
 from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.models import AITraceRecord, CaseRecord, RecommendationRecord
 from aegisops_control_plane.service import AegisOpsControlPlaneService
 from postgres_test_support import make_store
 
@@ -369,6 +371,235 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     closed_case_detail["advisory_output"]["citations"],
                 )
                 self.assertIn(case_id, closed_case_detail["advisory_output"]["citations"])
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_reviewed_runtime_path_fails_closed_for_out_of_scope_case_reads(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        in_scope_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        in_scope_recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase19-workflow-live-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=in_scope_case.alert_id,
+                case_id=in_scope_case.case_id,
+                ai_trace_id="ai-trace-phase19-workflow-live-001",
+                review_owner="reviewer-001",
+                intended_outcome="Review cited evidence before any escalation-bound follow-up.",
+                lifecycle_state="under_review",
+            )
+        )
+        in_scope_ai_trace = service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-phase19-workflow-live-001",
+                subject_linkage={
+                    "recommendation_ids": (in_scope_recommendation.recommendation_id,)
+                },
+                model_identity="gpt-5.4",
+                prompt_version="prompt-v1",
+                generated_at=admitted.reconciliation.compared_at,
+                material_input_refs=in_scope_case.evidence_ids,
+                reviewer_identity="reviewer-001",
+                lifecycle_state="accepted_for_reference",
+            )
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                def get_json(path: str) -> dict[str, object]:
+                    response = request.urlopen(f"{base_url}{path}", timeout=2)  # noqa: S310
+                    return json.loads(response.read().decode("utf-8"))
+
+                def get_error_payload(path: str) -> dict[str, object]:
+                    with self.assertRaises(error.HTTPError) as exc_info:
+                        request.urlopen(f"{base_url}{path}", timeout=2)  # noqa: S310
+                    self.assertEqual(exc_info.exception.code, 400)
+                    return json.loads(exc_info.exception.read().decode("utf-8"))
+
+                for path, record_family, record_id in (
+                    (
+                        "/inspect-advisory-output",
+                        "recommendation",
+                        in_scope_recommendation.recommendation_id,
+                    ),
+                    (
+                        "/inspect-advisory-output",
+                        "ai_trace",
+                        in_scope_ai_trace.ai_trace_id,
+                    ),
+                    (
+                        "/render-recommendation-draft",
+                        "recommendation",
+                        in_scope_recommendation.recommendation_id,
+                    ),
+                    (
+                        "/render-recommendation-draft",
+                        "ai_trace",
+                        in_scope_ai_trace.ai_trace_id,
+                    ),
+                ):
+                    with self.subTest(path=path, record_family=record_family):
+                        payload = get_json(
+                            f"{path}?family={record_family}&record_id={record_id}"
+                        )
+                        self.assertTrue(payload["read_only"])
+                        self.assertEqual(payload["record_family"], record_family)
+                        self.assertEqual(payload["record_id"], record_id)
+                        self.assertIn(in_scope_case.case_id, payload["linked_case_ids"])
+
+                adapter = WazuhAlertAdapter()
+                replay_admitted = service.ingest_native_detection_record(
+                    adapter,
+                    adapter.build_native_detection_record(
+                        _load_wazuh_fixture("github-audit-alert.json")
+                    ),
+                )
+                replay_case = service.promote_alert_to_case(replay_admitted.alert.alert_id)
+
+                spoofed_case = service.persist_record(
+                    CaseRecord(
+                        case_id="case-phase19-workflow-spoofed-001",
+                        alert_id=in_scope_case.alert_id,
+                        finding_id=in_scope_case.finding_id,
+                        evidence_ids=in_scope_case.evidence_ids,
+                        lifecycle_state=in_scope_case.lifecycle_state,
+                        reviewed_context=dict(in_scope_case.reviewed_context),
+                    )
+                )
+
+                synthetic_recommendation = service.persist_record(
+                    RecommendationRecord(
+                        recommendation_id="recommendation-phase19-workflow-synthetic-001",
+                        lead_id=None,
+                        hunt_run_id=None,
+                        alert_id=in_scope_case.alert_id,
+                        case_id=in_scope_case.case_id,
+                        ai_trace_id="ai-trace-phase19-workflow-synthetic-001",
+                        review_owner="reviewer-001",
+                        intended_outcome="Synthetic advisory reads must fail closed.",
+                        lifecycle_state="under_review",
+                        reviewed_context={
+                            "source": {
+                                "source_family": "synthetic_review_fixture",
+                                "admission_kind": "replay",
+                            }
+                        },
+                    )
+                )
+                synthetic_ai_trace = service.persist_record(
+                    AITraceRecord(
+                        ai_trace_id="ai-trace-phase19-workflow-synthetic-001",
+                        subject_linkage={
+                            "recommendation_ids": (
+                                synthetic_recommendation.recommendation_id,
+                            )
+                        },
+                        model_identity="gpt-5.4",
+                        prompt_version="prompt-v1",
+                        generated_at=admitted.reconciliation.compared_at,
+                        material_input_refs=("fixture://synthetic-phase19-review",),
+                        reviewer_identity="reviewer-001",
+                        lifecycle_state="under_review",
+                    )
+                )
+
+                for path in (
+                    f"/inspect-case-detail?case_id={replay_case.case_id}",
+                    (
+                        "/inspect-assistant-context"
+                        f"?family=case&record_id={replay_case.case_id}"
+                    ),
+                    f"/inspect-advisory-output?family=case&record_id={replay_case.case_id}",
+                    (
+                        "/render-recommendation-draft"
+                        f"?family=case&record_id={replay_case.case_id}"
+                    ),
+                    f"/inspect-case-detail?case_id={spoofed_case.case_id}",
+                    (
+                        "/inspect-assistant-context"
+                        f"?family=case&record_id={spoofed_case.case_id}"
+                    ),
+                ):
+                    with self.subTest(path=path):
+                        payload = get_error_payload(path)
+                        self.assertEqual(payload["error"], "invalid_request")
+                        self.assertIn(
+                            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                            payload["message"],
+                        )
+
+                for path, record_family, record_id in (
+                    (
+                        "/inspect-advisory-output",
+                        "recommendation",
+                        synthetic_recommendation.recommendation_id,
+                    ),
+                    (
+                        "/inspect-advisory-output",
+                        "ai_trace",
+                        synthetic_ai_trace.ai_trace_id,
+                    ),
+                    (
+                        "/render-recommendation-draft",
+                        "recommendation",
+                        synthetic_recommendation.recommendation_id,
+                    ),
+                    (
+                        "/render-recommendation-draft",
+                        "ai_trace",
+                        synthetic_ai_trace.ai_trace_id,
+                    ),
+                ):
+                    with self.subTest(path=path, record_family=record_family):
+                        payload = get_error_payload(
+                            f"{path}?family={record_family}&record_id={record_id}"
+                        )
+                        self.assertEqual(payload["error"], "invalid_request")
+                        self.assertIn(
+                            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                            payload["message"],
+                        )
             finally:
                 if servers:
                     servers[0].shutdown()

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -560,6 +560,11 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                         "/inspect-assistant-context"
                         f"?family=case&record_id={spoofed_case.case_id}"
                     ),
+                    f"/inspect-advisory-output?family=case&record_id={spoofed_case.case_id}",
+                    (
+                        "/render-recommendation-draft"
+                        f"?family=case&record_id={spoofed_case.case_id}"
+                    ),
                 ):
                     with self.subTest(path=path):
                         payload = get_error_payload(path)

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -4096,6 +4096,59 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 ):
                     service.render_recommendation_draft(record_family, record_id)
 
+    def test_service_rejects_synthetic_case_scoped_reads_spoofing_in_scope_case_lineage(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, reviewed_at = self._build_phase19_in_scope_case()
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase19-synthetic-linked-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                ai_trace_id="ai-trace-phase19-synthetic-linked-001",
+                review_owner="reviewer-001",
+                intended_outcome="Synthetic case-scoped advisory reads must fail closed.",
+                lifecycle_state="under_review",
+                reviewed_context={
+                    "source": {
+                        "source_family": "synthetic_review_fixture",
+                        "admission_kind": "replay",
+                    }
+                },
+            )
+        )
+        ai_trace = service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-phase19-synthetic-linked-001",
+                subject_linkage={"recommendation_ids": (recommendation.recommendation_id,)},
+                model_identity="gpt-5.4",
+                prompt_version="prompt-v1",
+                generated_at=reviewed_at,
+                material_input_refs=("fixture://synthetic-phase19-review",),
+                reviewer_identity="reviewer-001",
+                lifecycle_state="under_review",
+            )
+        )
+
+        for record_family, record_id in (
+            ("recommendation", recommendation.recommendation_id),
+            ("ai_trace", ai_trace.ai_trace_id),
+        ):
+            with self.subTest(record_family=record_family):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                ):
+                    service.inspect_advisory_output(record_family, record_id)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                ):
+                    service.render_recommendation_draft(record_family, record_id)
+
     def test_service_rejects_non_github_audit_case_from_phase19_operator_surface(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -4149,6 +4149,67 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 ):
                     service.render_recommendation_draft(record_family, record_id)
 
+    def test_service_rejects_ai_trace_subject_linkage_declaring_out_of_scope_provenance(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, reviewed_at = self._build_phase19_in_scope_case()
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase19-trace-provenance-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                ai_trace_id="ai-trace-phase19-trace-provenance-001",
+                review_owner="reviewer-001",
+                intended_outcome="AI trace lineage must validate its own provenance.",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+        ai_trace = service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-phase19-trace-provenance-001",
+                subject_linkage={
+                    "recommendation_ids": (recommendation.recommendation_id,),
+                    "reviewed_source_profile": {
+                        "source_family": "synthetic_review_fixture",
+                    },
+                    "admission_provenance": {
+                        "admission_kind": "replay",
+                        "admission_channel": "fixture_replay",
+                    },
+                },
+                model_identity="gpt-5.4",
+                prompt_version="prompt-v1",
+                generated_at=reviewed_at,
+                material_input_refs=("fixture://synthetic-phase19-review",),
+                reviewer_identity="reviewer-001",
+                lifecycle_state="under_review",
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.inspect_advisory_output("ai_trace", ai_trace.ai_trace_id)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.render_recommendation_draft("ai_trace", ai_trace.ai_trace_id)
+
+    def test_service_treats_non_mapping_provenance_context_as_out_of_scope(self) -> None:
+        _, service, _, _, _ = self._build_phase19_in_scope_case()
+
+        self.assertTrue(
+            service._phase19_context_declares_out_of_scope_provenance(
+                "synthetic_review_fixture"
+            )
+        )
+
     def test_service_rejects_non_github_audit_case_from_phase19_operator_surface(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- fail closed Phase 19 case-scoped advisory reads when recommendation or AI trace payloads do not stay inside the approved live GitHub-audit case slice
- add focused persistence and runtime coverage for replay-only, synthetic, and linkage-spoofed case read attempts across case detail, assistant-context, advisory-output, and recommendation-draft paths
- preserve approved in-scope advisory reads so accepted Phase 19 records still render through the intended operator surface

## Root cause
Phase 19 case-scoped advisory validation was checking linked case IDs, but recommendation and AI trace payload provenance could still spoof an approved case lineage and re-enter the allowed read surface.

## Validation
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_rejects_synthetic_case_scoped_reads_spoofing_in_scope_case_lineage control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_exposes_citation_ready_context_for_recommendation_and_ai_trace control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_uses_ai_trace_subject_linkage_and_material_inputs_for_citation_context`
- `python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_recommendation_draft_view_for_a_case control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_rejects_case_scoped_out_of_scope_advisory_reads_as_usage_errors control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_long_running_runtime_surface_rejects_case_scoped_out_of_scope_advisory_reads control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_long_running_runtime_surface_rejects_case_scoped_advisory_reads_without_linked_case`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for case-scoped advisory reads, rejecting unauthorized access attempts.
  * Added payload validation to prevent out-of-scope data access and synthetic record injection.
  * Improved error handling with centralized messaging for invalid read requests.

* **Tests**
  * Added comprehensive test coverage for Phase 19 workflow validation and access control enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->