### PR TITLE
implementation: expose the reviewed operator path from cited recommendation review to approval-bound action request (#418)

### DIFF
--- a/.codex-supervisor/issues/418/issue-journal.md
+++ b/.codex-supervisor/issues/418/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #418: implementation: expose the reviewed operator path from cited recommendation review to approval-bound action request
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/418
+- Branch: codex/issue-418
+- Workspace: .
+- Journal: .codex-supervisor/issues/418/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 9565fc5d9b238de92d3b6197914b0630a60d1bb4
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T21:43:28.376Z
+
+## Latest Codex Summary
+- Added an operator-facing reviewed action-request path that materializes a bounded `notify_identity_owner` `ActionRequestRecord` from cited recommendation/advisory context, persists exact requested payload binding in AegisOps-owned records, and exposes the path through CLI and HTTP operator surfaces.
+- Added focused service tests for successful request creation plus fail-closed rejection on malformed input and out-of-scope advisory context, and extended CLI/runtime workflow coverage for the new operator path.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The missing implementation gap was the absence of any service/runtime path that could turn a reviewed recommendation/advisory context into an approval-bound `ActionRequestRecord` while preserving exact payload binding inside AegisOps-owned records.
+- What changed: Added `create_reviewed_action_request_from_advisory` in the control-plane service; extended `ActionRequestRecord` with `requester_identity` and persisted `requested_payload`; exposed the path via `create-reviewed-action-request` CLI and `/operator/create-reviewed-action-request` HTTP POST; added focused service, CLI, and runtime workflow tests.
+- Current blocker: none
+- Next exact step: Commit the checkpoint, then decide whether to open a draft PR or continue by wiring any downstream approval-surface follow-up that issue #418 still requires.
+- Verification gap: Full `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` was not run in this turn; targeted touched-module coverage passed.
+- Files touched: control-plane/aegisops_control_plane/models.py; control-plane/aegisops_control_plane/adapters/postgres.py; control-plane/aegisops_control_plane/service.py; control-plane/main.py; control-plane/tests/test_service_persistence.py; control-plane/tests/test_cli_inspection.py; control-plane/tests/test_phase19_operator_workflow_validation.py; .codex-supervisor/issues/418/issue-journal.md
+- Rollback concern: `ActionRequestRecord` now persists `requester_identity` and `requested_payload`; any older callers constructing the dataclass still work through defaults, but downstream code that assumes payload hash is the only request binding should be rechecked if broader action-request features are added later.
+- Last focused command: `python3 -m unittest control-plane.tests.test_postgres_store control-plane.tests.test_cli_inspection control-plane.tests.test_phase19_operator_workflow_validation control-plane.tests.test_phase20_low_risk_action_validation`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -231,7 +231,9 @@ _TABLES_BY_RECORD_TYPE: dict[Type[ControlPlaneRecord], TableConfig] = {
     ActionRequestRecord: TableConfig(
         ActionRequestRecord,
         "action_request_records",
-        json_fields=frozenset({"target_scope", "policy_basis", "policy_evaluation"}),
+        json_fields=frozenset(
+            {"target_scope", "requested_payload", "policy_basis", "policy_evaluation"}
+        ),
     ),
     ActionExecutionRecord: TableConfig(
         ActionExecutionRecord,

--- a/control-plane/aegisops_control_plane/models.py
+++ b/control-plane/aegisops_control_plane/models.py
@@ -222,11 +222,18 @@ class ActionRequestRecord(ControlPlaneRecord):
     requested_at: datetime
     expires_at: datetime | None
     lifecycle_state: str
+    requester_identity: str | None = None
+    requested_payload: Mapping[str, object] = field(default_factory=dict)
     policy_basis: Mapping[str, object] = field(default_factory=dict)
     policy_evaluation: Mapping[str, object] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "target_scope", _freeze_mapping(self.target_scope))
+        object.__setattr__(
+            self,
+            "requested_payload",
+            _freeze_mapping(self.requested_payload),
+        )
         object.__setattr__(self, "policy_basis", _freeze_mapping(self.policy_basis))
         object.__setattr__(
             self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1273,6 +1273,8 @@ class AegisOpsControlPlaneService:
             requested_at=action_request.requested_at,
             expires_at=action_request.expires_at,
             lifecycle_state=action_request.lifecycle_state,
+            requester_identity=action_request.requester_identity,
+            requested_payload=action_request.requested_payload,
             policy_basis=normalized_policy_basis,
             policy_evaluation=policy_evaluation,
         )
@@ -2216,6 +2218,138 @@ class AegisOpsControlPlaneService:
         context_snapshot = self.inspect_assistant_context(record_family, record_id)
         self._require_phase19_case_scoped_advisory_read(context_snapshot)
         return _recommendation_draft_snapshot_from_context(context_snapshot)
+
+    def create_reviewed_action_request_from_advisory(
+        self,
+        *,
+        record_family: str,
+        record_id: str,
+        requester_identity: str,
+        recipient_identity: str,
+        message_intent: str,
+        escalation_reason: str,
+        expires_at: datetime,
+        action_request_id: str | None = None,
+    ) -> ActionRequestRecord:
+        requester_identity = self._require_non_empty_string(
+            requester_identity,
+            "requester_identity",
+        )
+        recipient_identity = self._require_non_empty_string(
+            recipient_identity,
+            "recipient_identity",
+        )
+        message_intent = self._require_non_empty_string(
+            message_intent,
+            "message_intent",
+        )
+        escalation_reason = self._require_non_empty_string(
+            escalation_reason,
+            "escalation_reason",
+        )
+        expires_at = self._require_aware_datetime(expires_at, "expires_at")
+
+        context_snapshot = self.inspect_assistant_context(record_family, record_id)
+        self._require_phase19_case_scoped_advisory_read(context_snapshot)
+        recommendation_draft = self.render_recommendation_draft(record_family, record_id)
+        if recommendation_draft.recommendation_draft.get("status") != "ready":
+            raise ValueError(
+                "reviewed advisory context is not ready for approval-bound action requests"
+            )
+
+        recommendation_id = self._require_single_recommendation_binding(
+            record_family=record_family,
+            record_id=record_id,
+            linked_recommendation_ids=recommendation_draft.linked_recommendation_ids,
+        )
+        case_id = self._require_single_linked_case_id(recommendation_draft.linked_case_ids)
+        case = self._require_phase19_operator_case(case_id)
+        if expires_at <= datetime.now(timezone.utc):
+            raise ValueError("expires_at must be in the future")
+
+        requested_payload = {
+            "action_type": "notify_identity_owner",
+            "recipient_identity": recipient_identity,
+            "message_intent": message_intent,
+            "escalation_reason": escalation_reason,
+            "source_record_family": record_family,
+            "source_record_id": record_id,
+            "recommendation_id": recommendation_id,
+            "case_id": case.case_id,
+            "alert_id": case.alert_id,
+            "finding_id": case.finding_id,
+            "linked_evidence_ids": recommendation_draft.linked_evidence_ids,
+        }
+        target_scope = {
+            "record_family": record_family,
+            "record_id": record_id,
+            "case_id": case.case_id,
+            "alert_id": case.alert_id,
+            "finding_id": case.finding_id,
+            "recipient_identity": recipient_identity,
+        }
+        payload_hash = _approved_payload_binding_hash(
+            target_scope=target_scope,
+            approved_payload=requested_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        requested_at = datetime.now(timezone.utc)
+        if expires_at <= requested_at:
+            raise ValueError("expires_at must be after requested_at")
+
+        normalized_action_request_id = self._resolve_new_record_identifier(
+            ActionRequestRecord,
+            action_request_id,
+            "action_request_id",
+            "action-request",
+        )
+        idempotency_material = json.dumps(
+            {
+                "payload_hash": payload_hash,
+                "record_family": record_family,
+                "record_id": record_id,
+                "expires_at": expires_at.isoformat(),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        idempotency_key = (
+            "notify-identity-owner:"
+            + hashlib.sha256(idempotency_material.encode("utf-8")).hexdigest()
+        )
+        return self.persist_record(
+            ActionRequestRecord(
+                action_request_id=normalized_action_request_id,
+                approval_decision_id=None,
+                case_id=case.case_id,
+                alert_id=case.alert_id,
+                finding_id=case.finding_id,
+                idempotency_key=idempotency_key,
+                target_scope=target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=expires_at,
+                lifecycle_state="pending_approval",
+                requester_identity=requester_identity,
+                requested_payload=requested_payload,
+                policy_basis={
+                    "severity": "low",
+                    "target_scope": "single_identity",
+                    "action_reversibility": "reversible",
+                    "asset_criticality": "standard",
+                    "identity_criticality": "standard",
+                    "blast_radius": "single_target",
+                    "execution_constraint": "routine_allowed",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
 
     def attach_assistant_advisory_draft(
         self,
@@ -3909,6 +4043,30 @@ class AegisOpsControlPlaneService:
     def _require_phase19_operator_case(self, case_id: str) -> CaseRecord:
         case = self._require_case_record(case_id)
         return self._require_phase19_operator_case_record(case)
+
+    @staticmethod
+    def _require_single_linked_case_id(linked_case_ids: tuple[str, ...]) -> str:
+        if len(linked_case_ids) != 1:
+            raise ValueError(
+                "reviewed advisory context must bind exactly one case before creating an action request"
+            )
+        return linked_case_ids[0]
+
+    @staticmethod
+    def _require_single_recommendation_binding(
+        *,
+        record_family: str,
+        record_id: str,
+        linked_recommendation_ids: tuple[str, ...],
+    ) -> str:
+        recommendation_ids = linked_recommendation_ids
+        if record_family == "recommendation":
+            recommendation_ids = (record_id,)
+        if len(recommendation_ids) != 1:
+            raise ValueError(
+                "reviewed advisory context must bind exactly one recommendation before creating an action request"
+            )
+        return recommendation_ids[0]
 
     def _require_phase19_case_scoped_advisory_read(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2249,107 +2249,117 @@ class AegisOpsControlPlaneService:
         )
         expires_at = self._require_aware_datetime(expires_at, "expires_at")
 
-        context_snapshot = self.inspect_assistant_context(record_family, record_id)
-        self._require_phase19_case_scoped_advisory_read(context_snapshot)
-        recommendation_draft = self.render_recommendation_draft(record_family, record_id)
-        if recommendation_draft.recommendation_draft.get("status") != "ready":
-            raise ValueError(
-                "reviewed advisory context is not ready for approval-bound action requests"
+        with self._store.transaction():
+            context_snapshot = self.inspect_assistant_context(record_family, record_id)
+            self._require_phase19_case_scoped_advisory_read(context_snapshot)
+            recommendation_draft = self.render_recommendation_draft(
+                record_family,
+                record_id,
             )
+            if recommendation_draft.recommendation_draft.get("status") != "ready":
+                raise ValueError(
+                    "reviewed advisory context is not ready for approval-bound action requests"
+                )
 
-        recommendation_id = self._require_single_recommendation_binding(
-            record_family=record_family,
-            record_id=record_id,
-            linked_recommendation_ids=recommendation_draft.linked_recommendation_ids,
-        )
-        case_id = self._require_single_linked_case_id(recommendation_draft.linked_case_ids)
-        case = self._require_phase19_operator_case(case_id)
-        if expires_at <= datetime.now(timezone.utc):
-            raise ValueError("expires_at must be in the future")
+            recommendation_id = self._require_single_recommendation_binding(
+                record_family=record_family,
+                record_id=record_id,
+                linked_recommendation_ids=recommendation_draft.linked_recommendation_ids,
+            )
+            case_id = self._require_single_linked_case_id(
+                recommendation_draft.linked_case_ids
+            )
+            case = self._require_phase19_operator_case(case_id)
+            if expires_at <= datetime.now(timezone.utc):
+                raise ValueError("expires_at must be in the future")
 
-        requested_payload = {
-            "action_type": "notify_identity_owner",
-            "recipient_identity": recipient_identity,
-            "message_intent": message_intent,
-            "escalation_reason": escalation_reason,
-            "source_record_family": record_family,
-            "source_record_id": record_id,
-            "recommendation_id": recommendation_id,
-            "case_id": case.case_id,
-            "alert_id": case.alert_id,
-            "finding_id": case.finding_id,
-            "linked_evidence_ids": recommendation_draft.linked_evidence_ids,
-        }
-        target_scope = {
-            "record_family": record_family,
-            "record_id": record_id,
-            "case_id": case.case_id,
-            "alert_id": case.alert_id,
-            "finding_id": case.finding_id,
-            "recipient_identity": recipient_identity,
-        }
-        payload_hash = _approved_payload_binding_hash(
-            target_scope=target_scope,
-            approved_payload=requested_payload,
-            execution_surface_type="automation_substrate",
-            execution_surface_id="shuffle",
-        )
-        requested_at = datetime.now(timezone.utc)
-        if expires_at <= requested_at:
-            raise ValueError("expires_at must be after requested_at")
-
-        normalized_action_request_id = self._resolve_new_record_identifier(
-            ActionRequestRecord,
-            action_request_id,
-            "action_request_id",
-            "action-request",
-        )
-        idempotency_material = json.dumps(
-            {
-                "payload_hash": payload_hash,
+            requested_payload = {
+                "action_type": "notify_identity_owner",
+                "recipient_identity": recipient_identity,
+                "message_intent": message_intent,
+                "escalation_reason": escalation_reason,
+                "source_record_family": record_family,
+                "source_record_id": record_id,
+                "recommendation_id": recommendation_id,
+                "case_id": case.case_id,
+                "alert_id": case.alert_id,
+                "finding_id": case.finding_id,
+                "linked_evidence_ids": recommendation_draft.linked_evidence_ids,
+            }
+            target_scope = {
                 "record_family": record_family,
                 "record_id": record_id,
-                "expires_at": expires_at.isoformat(),
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-        idempotency_key = (
-            "notify-identity-owner:"
-            + hashlib.sha256(idempotency_material.encode("utf-8")).hexdigest()
-        )
-        return self.persist_record(
-            ActionRequestRecord(
-                action_request_id=normalized_action_request_id,
-                approval_decision_id=None,
-                case_id=case.case_id,
-                alert_id=case.alert_id,
-                finding_id=case.finding_id,
-                idempotency_key=idempotency_key,
+                "case_id": case.case_id,
+                "alert_id": case.alert_id,
+                "finding_id": case.finding_id,
+                "recipient_identity": recipient_identity,
+            }
+            payload_hash = _approved_payload_binding_hash(
                 target_scope=target_scope,
-                payload_hash=payload_hash,
-                requested_at=requested_at,
-                expires_at=expires_at,
-                lifecycle_state="pending_approval",
-                requester_identity=requester_identity,
-                requested_payload=requested_payload,
-                policy_basis={
-                    "severity": "low",
-                    "target_scope": "single_identity",
-                    "action_reversibility": "reversible",
-                    "asset_criticality": "standard",
-                    "identity_criticality": "standard",
-                    "blast_radius": "single_target",
-                    "execution_constraint": "routine_allowed",
-                },
-                policy_evaluation={
-                    "approval_requirement": "human_required",
-                    "routing_target": "approval",
-                    "execution_surface_type": "automation_substrate",
-                    "execution_surface_id": "shuffle",
-                },
+                approved_payload=requested_payload,
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
             )
-        )
+            requested_at = datetime.now(timezone.utc)
+            if expires_at <= requested_at:
+                raise ValueError("expires_at must be after requested_at")
+
+            idempotency_material = json.dumps(
+                {
+                    "payload_hash": payload_hash,
+                    "record_family": record_family,
+                    "record_id": record_id,
+                    "expires_at": expires_at.isoformat(),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            idempotency_key = (
+                "notify-identity-owner:"
+                + hashlib.sha256(idempotency_material.encode("utf-8")).hexdigest()
+            )
+            for existing in self._store.list(ActionRequestRecord):
+                if existing.idempotency_key == idempotency_key:
+                    return existing
+
+            normalized_action_request_id = self._resolve_new_record_identifier(
+                ActionRequestRecord,
+                action_request_id,
+                "action_request_id",
+                "action-request",
+            )
+            return self.persist_record(
+                ActionRequestRecord(
+                    action_request_id=normalized_action_request_id,
+                    approval_decision_id=None,
+                    case_id=case.case_id,
+                    alert_id=case.alert_id,
+                    finding_id=case.finding_id,
+                    idempotency_key=idempotency_key,
+                    target_scope=target_scope,
+                    payload_hash=payload_hash,
+                    requested_at=requested_at,
+                    expires_at=expires_at,
+                    lifecycle_state="pending_approval",
+                    requester_identity=requester_identity,
+                    requested_payload=requested_payload,
+                    policy_basis={
+                        "severity": "low",
+                        "target_scope": "single_identity",
+                        "action_reversibility": "reversible",
+                        "asset_criticality": "standard",
+                        "identity_criticality": "standard",
+                        "blast_radius": "single_target",
+                        "execution_constraint": "routine_allowed",
+                    },
+                    policy_evaluation={
+                        "approval_requirement": "human_required",
+                        "routing_target": "approval",
+                        "execution_surface_type": "automation_substrate",
+                        "execution_surface_id": "shuffle",
+                    },
+                )
+            )
 
     def attach_assistant_advisory_draft(
         self,

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -261,6 +261,21 @@ def _build_parser() -> argparse.ArgumentParser:
     record_case_disposition.add_argument("--disposition", required=True)
     record_case_disposition.add_argument("--rationale", required=True)
     record_case_disposition.add_argument("--recorded-at", required=True)
+    create_reviewed_action_request = subparsers.add_parser(
+        "create-reviewed-action-request",
+        help="Create an approval-bound reviewed action request from cited advisory context.",
+    )
+    create_reviewed_action_request.add_argument("--family", required=True)
+    create_reviewed_action_request.add_argument("--record-id", required=True)
+    create_reviewed_action_request.add_argument("--requester-identity", required=True)
+    create_reviewed_action_request.add_argument("--recipient-identity", required=True)
+    create_reviewed_action_request.add_argument("--message-intent", required=True)
+    create_reviewed_action_request.add_argument("--escalation-reason", required=True)
+    create_reviewed_action_request.add_argument("--expires-at", required=True)
+    create_reviewed_action_request.add_argument(
+        "--action-request-id",
+        help="Optional action request identifier to use instead of an auto-generated value.",
+    )
     inspect_assistant_context = subparsers.add_parser(
         "inspect-assistant-context",
         help="Render a read-only analyst-assistant context view for one record.",
@@ -783,6 +798,58 @@ def run_control_plane_service(
                 self._write_json(HTTPStatus.OK, _json_ready(case_record))
                 return
 
+            if request_path == "/operator/create-reviewed-action-request":
+                try:
+                    payload = _read_json_request_body(self)
+                    action_request = service.create_reviewed_action_request_from_advisory(
+                        record_family=_require_json_string(payload, "family"),
+                        record_id=_require_json_string(payload, "record_id"),
+                        requester_identity=_require_json_string(
+                            payload,
+                            "requester_identity",
+                        ),
+                        recipient_identity=_require_json_string(
+                            payload,
+                            "recipient_identity",
+                        ),
+                        message_intent=_require_json_string(payload, "message_intent"),
+                        escalation_reason=_require_json_string(
+                            payload,
+                            "escalation_reason",
+                        ),
+                        expires_at=_require_json_datetime(payload, "expires_at"),
+                        action_request_id=_normalize_optional_string(
+                            payload.get("action_request_id")
+                        ),
+                    )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                except (LookupError, ValueError) as exc:
+                    status = (
+                        HTTPStatus.NOT_FOUND
+                        if isinstance(exc, LookupError)
+                        else HTTPStatus.BAD_REQUEST
+                    )
+                    self._write_json(
+                        status,
+                        {
+                            "error": "not_found"
+                            if status == HTTPStatus.NOT_FOUND
+                            else "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, _json_ready(action_request))
+                return
+
             if request_path != "/intake/wazuh":
                 self._write_json(
                     HTTPStatus.NOT_FOUND,
@@ -1087,6 +1154,27 @@ def main(
                         recorded_at=_parse_datetime_arg(
                             parsed.recorded_at,
                             "recorded_at",
+                        ),
+                    )
+                )
+            except (LookupError, ValueError) as exc:
+                parser.error(str(exc))
+        elif command == "create-reviewed-action-request":
+            try:
+                payload = _json_ready(
+                    service.create_reviewed_action_request_from_advisory(
+                        record_family=parsed.family.strip(),
+                        record_id=parsed.record_id.strip(),
+                        requester_identity=parsed.requester_identity.strip(),
+                        recipient_identity=parsed.recipient_identity.strip(),
+                        message_intent=parsed.message_intent.strip(),
+                        escalation_reason=parsed.escalation_reason.strip(),
+                        expires_at=_parse_datetime_arg(
+                            parsed.expires_at,
+                            "expires_at",
+                        ),
+                        action_request_id=_normalize_optional_string(
+                            parsed.action_request_id
                         ),
                     )
                 )

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import http.client
 import io
 import json
@@ -2170,6 +2170,72 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertIn(promoted_case.alert_id, payload["linked_alert_ids"])
         self.assertIn(recommendation.recommendation_id, payload["linked_recommendation_ids"])
         self.assertTrue(payload["linked_reconciliation_ids"])
+
+    def test_cli_creates_reviewed_action_request_from_recommendation_context(self) -> None:
+        _, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-cli-action-request-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                ai_trace_id=None,
+                review_owner="reviewer-001",
+                intended_outcome="review the cited evidence before escalation",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            [
+                "create-reviewed-action-request",
+                "--family",
+                "recommendation",
+                "--record-id",
+                recommendation.recommendation_id,
+                "--requester-identity",
+                "analyst-001",
+                "--recipient-identity",
+                "repo-owner-001",
+                "--message-intent",
+                "Notify the accountable repository owner about the reviewed permission change.",
+                "--escalation-reason",
+                "Reviewed GitHub audit evidence requires bounded owner notification.",
+                "--expires-at",
+                (datetime.now(timezone.utc) + timedelta(hours=4)).isoformat(),
+                "--action-request-id",
+                "action-request-cli-reviewed-001",
+            ],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["action_request_id"], "action-request-cli-reviewed-001")
+        self.assertEqual(payload["case_id"], promoted_case.case_id)
+        self.assertEqual(payload["alert_id"], promoted_case.alert_id)
+        self.assertEqual(payload["requester_identity"], "analyst-001")
+        self.assertEqual(payload["lifecycle_state"], "pending_approval")
+        self.assertEqual(
+            payload["policy_evaluation"],
+            {
+                "approval_requirement": "human_required",
+                "routing_target": "approval",
+                "execution_surface_type": "automation_substrate",
+                "execution_surface_id": "shuffle",
+            },
+        )
+        self.assertEqual(
+            payload["requested_payload"]["action_type"],
+            "notify_identity_owner",
+        )
+        self.assertEqual(
+            payload["requested_payload"]["recommendation_id"],
+            recommendation.recommendation_id,
+        )
 
     def test_cli_rejects_case_scoped_out_of_scope_advisory_reads_as_usage_errors(
         self,

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import datetime, timedelta, timezone
 import json
 import pathlib
 import sys
@@ -318,6 +319,42 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 self.assertIn(
                     recommendation["recommendation_id"],
                     recommendation_draft["linked_recommendation_ids"],
+                )
+
+                action_request = post_json(
+                    "/operator/create-reviewed-action-request",
+                    {
+                        "family": "recommendation",
+                        "record_id": recommendation["recommendation_id"],
+                        "requester_identity": "analyst-001",
+                        "recipient_identity": "repo-owner-001",
+                        "message_intent": "Notify the accountable repository owner about the reviewed permission change.",
+                        "escalation_reason": "Reviewed GitHub audit evidence requires bounded owner notification.",
+                        "expires_at": (
+                            datetime.now(timezone.utc) + timedelta(hours=4)
+                        ).isoformat(),
+                    },
+                )
+                self.assertEqual(action_request["case_id"], case_id)
+                self.assertEqual(action_request["alert_id"], created.alert.alert_id)
+                self.assertEqual(action_request["requester_identity"], "analyst-001")
+                self.assertEqual(action_request["lifecycle_state"], "pending_approval")
+                self.assertEqual(
+                    action_request["policy_evaluation"],
+                    {
+                        "approval_requirement": "human_required",
+                        "routing_target": "approval",
+                        "execution_surface_type": "automation_substrate",
+                        "execution_surface_id": "shuffle",
+                    },
+                )
+                self.assertEqual(
+                    action_request["requested_payload"]["action_type"],
+                    "notify_identity_owner",
+                )
+                self.assertEqual(
+                    action_request["requested_payload"]["recommendation_id"],
+                    recommendation["recommendation_id"],
                 )
 
                 closed_case = post_json(

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -149,8 +149,27 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
             "add column if not exists requested_payload jsonb not null default '{}'::jsonb;",
             migration_sql,
         )
+        self.assertIn(
+            (
+                "update aegisops_control.action_request_records\n"
+                "set requested_payload = '{}'::jsonb\n"
+                "where requested_payload is null;"
+            ),
+            migration_sql,
+        )
+        self.assertIn(
+            (
+                "alter table if exists aegisops_control.action_request_records\n"
+                "  alter column requested_payload drop default;"
+            ),
+            migration_sql,
+        )
         self.assertIn("requester_identity text", schema_sql)
         self.assertIn(
+            "requested_payload jsonb not null",
+            schema_sql,
+        )
+        self.assertNotIn(
             "requested_payload jsonb not null default '{}'::jsonb",
             schema_sql,
         )

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -116,6 +116,45 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
             migration_sql,
         )
 
+    def test_phase20_action_request_binding_forward_migration_asset_exists(self) -> None:
+        migration_path = (
+            CONTROL_PLANE_ROOT.parent
+            / "postgres"
+            / "control-plane"
+            / "migrations"
+            / "0004_phase_20_action_request_binding_columns.sql"
+        )
+
+        self.assertTrue(
+            migration_path.exists(),
+            f"Missing Phase 20 forward migration asset: {migration_path}",
+        )
+
+        migration_sql = migration_path.read_text(encoding="utf-8").lower()
+        schema_sql = (
+            CONTROL_PLANE_ROOT.parent / "postgres" / "control-plane" / "schema.sql"
+        ).read_text(encoding="utf-8").lower()
+
+        self.assertIn("begin;", migration_sql)
+        self.assertIn("commit;", migration_sql)
+        self.assertIn(
+            "alter table if exists aegisops_control.action_request_records",
+            migration_sql,
+        )
+        self.assertIn(
+            "add column if not exists requester_identity text;",
+            migration_sql,
+        )
+        self.assertIn(
+            "add column if not exists requested_payload jsonb not null default '{}'::jsonb;",
+            migration_sql,
+        )
+        self.assertIn("requester_identity text", schema_sql)
+        self.assertIn(
+            "requested_payload jsonb not null default '{}'::jsonb",
+            schema_sql,
+        )
+
     def test_store_round_trips_reviewed_record_families_by_aegisops_ids(self) -> None:
         store, _ = make_store()
         timestamp = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
@@ -233,6 +272,8 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
                 finding_id="finding-001",
                 idempotency_key="idempotency-001",
                 target_scope={"asset_id": "asset-001"},
+                requester_identity="analyst-001",
+                requested_payload={"action_type": "notify_identity_owner"},
                 policy_basis={
                     "severity": "high",
                     "target_scope": "single_asset",

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -7338,7 +7338,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_rejects_reviewed_action_request_creation_when_malformed_or_out_of_scope(
         self,
     ) -> None:
-        _, service, promoted_case, evidence_id, reviewed_at = (
+        _, service, promoted_case, _, _ = (
             self._build_phase19_in_scope_case()
         )
         recommendation = service.record_case_recommendation(
@@ -7393,6 +7393,120 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
                 expires_at=future_expiry,
             )
+
+    def test_service_reuses_reviewed_action_request_for_matching_idempotency_key(
+        self,
+    ) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=service.record_case_lead(
+                case_id=promoted_case.case_id,
+                triage_owner="analyst-001",
+                triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+                observation_id=observation.observation_id,
+            ).lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+
+        first_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        second_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+
+        self.assertEqual(second_request, first_request)
+        self.assertEqual(store.list(ActionRequestRecord), (first_request,))
+
+    def test_service_rechecks_reviewed_action_request_context_inside_transaction(
+        self,
+    ) -> None:
+        inner_store, _ = make_store()
+        (
+            _,
+            base_service,
+            promoted_case,
+            evidence_id,
+            reviewed_at,
+        ) = self._build_phase19_in_scope_case(store=inner_store)
+        observation = base_service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = base_service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = base_service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        store = _TransactionMutationStore(
+            inner=inner_store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                replace(
+                    transactional_store.get(
+                        RecommendationRecord,
+                        recommendation.recommendation_id,
+                    ),
+                    intended_outcome=(
+                        "Execute an organization-wide response immediately without waiting "
+                        "for approval."
+                    ),
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "reviewed advisory context is not ready for approval-bound action requests",
+        ):
+            service.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id=recommendation.recommendation_id,
+                requester_identity="analyst-001",
+                recipient_identity="repo-owner-001",
+                message_intent="Notify the accountable repository owner about the reviewed permission change.",
+                escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            )
+
+        self.assertEqual(inner_store.list(ActionRequestRecord), ())
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -7240,6 +7240,160 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         self.assertEqual(store.list(ActionExecutionRecord), ())
 
+    def test_service_creates_approval_bound_action_request_from_reviewed_recommendation(
+        self,
+    ) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+
+        self.assertIsNone(action_request.approval_decision_id)
+        self.assertEqual(action_request.case_id, promoted_case.case_id)
+        self.assertEqual(action_request.alert_id, promoted_case.alert_id)
+        self.assertEqual(action_request.finding_id, promoted_case.finding_id)
+        self.assertEqual(action_request.requester_identity, "analyst-001")
+        self.assertEqual(
+            action_request.target_scope,
+            {
+                "record_family": "recommendation",
+                "record_id": recommendation.recommendation_id,
+                "case_id": promoted_case.case_id,
+                "alert_id": promoted_case.alert_id,
+                "finding_id": promoted_case.finding_id,
+                "recipient_identity": "repo-owner-001",
+            },
+        )
+        self.assertEqual(
+            action_request.requested_payload,
+            {
+                "action_type": "notify_identity_owner",
+                "recipient_identity": "repo-owner-001",
+                "message_intent": "Notify the accountable repository owner about the reviewed permission change.",
+                "escalation_reason": "Reviewed GitHub audit evidence requires bounded owner notification.",
+                "source_record_family": "recommendation",
+                "source_record_id": recommendation.recommendation_id,
+                "recommendation_id": recommendation.recommendation_id,
+                "case_id": promoted_case.case_id,
+                "alert_id": promoted_case.alert_id,
+                "finding_id": promoted_case.finding_id,
+                "linked_evidence_ids": (evidence_id,),
+            },
+        )
+        self.assertEqual(
+            action_request.payload_hash,
+            _approved_binding_hash(
+                target_scope=dict(action_request.target_scope),
+                approved_payload=dict(action_request.requested_payload),
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+            ),
+        )
+        self.assertEqual(action_request.expires_at, expires_at)
+        self.assertEqual(action_request.lifecycle_state, "pending_approval")
+        self.assertEqual(
+            action_request.policy_evaluation,
+            {
+                "approval_requirement": "human_required",
+                "routing_target": "approval",
+                "execution_surface_type": "automation_substrate",
+                "execution_surface_id": "shuffle",
+            },
+        )
+        self.assertEqual(
+            service.get_record(ActionRequestRecord, action_request.action_request_id),
+            action_request,
+        )
+        self.assertEqual(store.list(ActionExecutionRecord), ())
+
+    def test_service_rejects_reviewed_action_request_creation_when_malformed_or_out_of_scope(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        future_expiry = datetime.now(timezone.utc) + timedelta(hours=4)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "recipient_identity must be a non-empty string",
+        ):
+            service.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id=recommendation.recommendation_id,
+                requester_identity="analyst-001",
+                recipient_identity="",
+                message_intent="Notify the accountable repository owner about the reviewed permission change.",
+                escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+                expires_at=future_expiry,
+            )
+
+        replay_service, replay_case, _, _ = self._build_phase19_out_of_scope_case(
+            fixture_name="github-audit-alert.json"
+        )
+        replay_recommendation = replay_service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase20-out-of-scope-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=replay_case.alert_id,
+                case_id=replay_case.case_id,
+                ai_trace_id=None,
+                review_owner="analyst-001",
+                intended_outcome="Synthetic advisory reads must fail closed.",
+                lifecycle_state="under_review",
+                reviewed_context=replay_case.reviewed_context,
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            replay_service.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id=replay_recommendation.recommendation_id,
+                requester_identity="analyst-001",
+                recipient_identity="repo-owner-001",
+                message_intent="Notify the accountable repository owner about the reviewed permission change.",
+                escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+                expires_at=future_expiry,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/postgres/control-plane/migrations/0004_phase_20_action_request_binding_columns.sql
+++ b/postgres/control-plane/migrations/0004_phase_20_action_request_binding_columns.sql
@@ -1,0 +1,10 @@
+-- Phase 20 forward migration for approval-bound action request payload grounding.
+begin;
+
+alter table if exists aegisops_control.action_request_records
+  add column if not exists requester_identity text;
+
+alter table if exists aegisops_control.action_request_records
+  add column if not exists requested_payload jsonb not null default '{}'::jsonb;
+
+commit;

--- a/postgres/control-plane/migrations/0004_phase_20_action_request_binding_columns.sql
+++ b/postgres/control-plane/migrations/0004_phase_20_action_request_binding_columns.sql
@@ -7,4 +7,11 @@ alter table if exists aegisops_control.action_request_records
 alter table if exists aegisops_control.action_request_records
   add column if not exists requested_payload jsonb not null default '{}'::jsonb;
 
+update aegisops_control.action_request_records
+set requested_payload = '{}'::jsonb
+where requested_payload is null;
+
+alter table if exists aegisops_control.action_request_records
+  alter column requested_payload drop default;
+
 commit;

--- a/postgres/control-plane/schema.sql
+++ b/postgres/control-plane/schema.sql
@@ -142,6 +142,8 @@ create table if not exists aegisops_control.action_request_records (
   finding_id text,
   idempotency_key text not null,
   target_scope jsonb not null,
+  requester_identity text,
+  requested_payload jsonb not null default '{}'::jsonb,
   policy_basis jsonb not null default '{}'::jsonb,
   policy_evaluation jsonb not null default '{}'::jsonb,
   payload_hash text not null,

--- a/postgres/control-plane/schema.sql
+++ b/postgres/control-plane/schema.sql
@@ -143,7 +143,7 @@ create table if not exists aegisops_control.action_request_records (
   idempotency_key text not null,
   target_scope jsonb not null,
   requester_identity text,
-  requested_payload jsonb not null default '{}'::jsonb,
+  requested_payload jsonb not null,
   policy_basis jsonb not null default '{}'::jsonb,
   policy_evaluation jsonb not null default '{}'::jsonb,
   payload_hash text not null,


### PR DESCRIPTION
Closes #418
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the reviewed operator path for issue `#418` on `codex/issue-418` and committed it as `a5b5d12` (`Add reviewed action request operator path`).

The control plane now materializes an approval-bound `ActionRequestRecord` from cited recommendation/advisory context via `create_reviewed_action_request_from_advisory`, persists `requester_identity` plus the exact `requested_payload` in AegisOps-owned records, computes the shuffle-bound payload hash from that stored payload and target scope, and exposes the path through both the CLI (`create-reviewed-action-request`) and HTTP operator surface (`POST /operator/create-reviewed-action-request`). The path fails closed on malformed input and out-of-scope advisory context, and I added focused service, CLI, and runtime workflow coverage around that behavior.

Verification I ran:
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_creates_approval_bound_action_request_from_reviewed_recommendation control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_rejects_reviewed_action_request_creation_when_malformed_or_out_of_scope control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_creates_reviewed_action_request_from_recommendation_context control-plane.tests.test_phase19_operator_workflow_validation.Phase19OperatorWorkflowValidationTests.test_reviewed_runtime_path_covers_approved_operator_workflow`
- `pyth...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI command and HTTP operator endpoint to create reviewed action requests from recommendations (includes requester identity, expiry, and optional action-request ID)
  * Action requests now persist requester identity and a requested payload; creation is idempotent and validates advisory context

* **Tests**
  * New service and persistence tests for creation success, validation failures, out-of-scope rejection, idempotency, and transactional checks
  * Expanded CLI and runtime operator workflow test coverage

* **Chores**
  * Database migration and schema updated to add requester identity and requested payload fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->