### PR TITLE
[codex] Connect Phase 20 notify action to Shuffle delegation path

### DIFF
--- a/.codex-supervisor/issues/419/issue-journal.md
+++ b/.codex-supervisor/issues/419/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #419: implementation: connect the approved first live low-risk action to the reviewed Shuffle delegation path
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/419
+- Branch: codex/issue-419
+- Workspace: .
+- Journal: .codex-supervisor/issues/419/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 332b912c837e21745fa7c08f3d062923cf597295
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T22:19:57.264Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The reviewed action-request path already mints the bounded `notify_identity_owner` payload, but the live Shuffle adapter was still generic and would delegate any approved Shuffle-routed payload, which widened the Phase 20 surface beyond the approved first action.
+- What changed: Added a focused reproducer in `control-plane/tests/test_service_persistence.py` proving an approved-but-unsupported Shuffle action (`open_ticket`) was accepted; then tightened `control-plane/aegisops_control_plane/adapters/shuffle.py` to fail closed unless the delegated payload is the reviewed Phase 20 `notify_identity_owner` shape with non-empty `recipient_identity`, `message_intent`, and `escalation_reason`. Updated existing successful Shuffle-path tests to use the reviewed payload shape instead of minimal scaffolding payloads.
+- Current blocker: none
+- Next exact step: Commit the narrowed Shuffle adapter gate and focused regression test on `codex/issue-419`.
+- Verification gap: none for repository-local coverage; full `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` passed after the fix.
+- Files touched: `control-plane/aegisops_control_plane/adapters/shuffle.py`, `control-plane/tests/test_service_persistence.py`
+- Rollback concern: Reverting the adapter gate would reopen the live Shuffle path to arbitrary approved Shuffle payloads instead of the reviewed first-action boundary.
+- Last focused command: `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/adapters/shuffle.py
+++ b/control-plane/aegisops_control_plane/adapters/shuffle.py
@@ -37,8 +37,8 @@ class ShuffleActionAdapter:
         del approval_decision_id
         del payload_hash
         del idempotency_key
-        del approved_payload
         del delegated_at
+        self._require_reviewed_phase20_notify_payload(approved_payload)
         return ShuffleDelegationReceipt(
             execution_surface_type=self.execution_surface_type,
             execution_surface_id=self.execution_surface_id,
@@ -46,3 +46,24 @@ class ShuffleActionAdapter:
             adapter="shuffle",
             base_url=self.base_url,
         )
+
+    @staticmethod
+    def _require_reviewed_phase20_notify_payload(
+        approved_payload: Mapping[str, object],
+    ) -> None:
+        action_type = approved_payload.get("action_type")
+        if action_type != "notify_identity_owner":
+            raise ValueError(
+                "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+            )
+
+        for field_name in (
+            "recipient_identity",
+            "message_intent",
+            "escalation_reason",
+        ):
+            value = approved_payload.get(field_name)
+            if not isinstance(value, str) or value.strip() == "":
+                raise ValueError(
+                    "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+                )

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -66,6 +66,38 @@ def _approved_binding_hash(
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _phase20_notify_identity_owner_payload(
+    *,
+    recipient_identity: str,
+    case_id: str,
+    alert_id: str,
+    finding_id: str,
+    source_record_family: str = "recommendation",
+    source_record_id: str = "recommendation-001",
+    recommendation_id: str = "recommendation-001",
+    linked_evidence_ids: tuple[str, ...] = ("evidence-001",),
+    message_intent: str = (
+        "Notify the accountable owner about the reviewed low-risk escalation."
+    ),
+    escalation_reason: str = (
+        "Reviewed evidence requires a bounded single-recipient owner notification."
+    ),
+) -> dict[str, object]:
+    return {
+        "action_type": "notify_identity_owner",
+        "recipient_identity": recipient_identity,
+        "message_intent": message_intent,
+        "escalation_reason": escalation_reason,
+        "source_record_family": source_record_family,
+        "source_record_id": source_record_id,
+        "recommendation_id": recommendation_id,
+        "case_id": case_id,
+        "alert_id": alert_id,
+        "finding_id": finding_id,
+        "linked_evidence_ids": linked_evidence_ids,
+    }
+
+
 @dataclass
 class _TransactionMutationStore:
     inner: object
@@ -1627,10 +1659,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             )
         )
         approval_target_scope = {"asset_id": "asset-repo-approval-001"}
-        approved_payload = {
-            "action_type": "notify_identity_owner",
-            "asset_id": "asset-repo-approval-001",
-        }
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id=promoted_case.case_id,
+            alert_id=admitted.alert.alert_id,
+            finding_id=admitted.alert.finding_id,
+            source_record_id=recommendation.recommendation_id,
+            recommendation_id=recommendation.recommendation_id,
+            linked_evidence_ids=(evidence.evidence_id,),
+        )
         payload_hash = _approved_binding_hash(
             target_scope=approval_target_scope,
             approved_payload=approved_payload,
@@ -1797,10 +1834,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             )
         )
         approval_target_scope = {"asset_id": "asset-repo-reconciliation-001"}
-        approved_payload = {
-            "action_type": "notify_identity_owner",
-            "asset_id": "asset-repo-reconciliation-001",
-        }
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id=promoted_case.case_id,
+            alert_id=admitted.alert.alert_id,
+            finding_id=admitted.alert.finding_id,
+            source_record_id=recommendation.recommendation_id,
+            recommendation_id=recommendation.recommendation_id,
+            linked_evidence_ids=("evidence-assistant-reconciliation-001",),
+        )
         payload_hash = _approved_binding_hash(
             target_scope=approval_target_scope,
             approved_payload=approved_payload,
@@ -6050,10 +6092,12 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
         compared_at = datetime(2026, 4, 5, 12, 12, tzinfo=timezone.utc)
         approved_target_scope = {"asset_id": "workstation-001"}
-        approved_payload = {
-            "action_type": "notify_identity_owner",
-            "asset_id": "workstation-001",
-        }
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
         payload_hash = _approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
@@ -6256,10 +6300,12 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
         compared_at = datetime(2026, 4, 5, 12, 12, tzinfo=timezone.utc)
         approved_target_scope = {"asset_id": "workstation-001"}
-        approved_payload = {
-            "action_type": "notify_identity_owner",
-            "asset_id": "workstation-001",
-        }
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
         payload_hash = _approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
@@ -6446,10 +6492,12 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
         expires_at = datetime(2026, 4, 5, 13, 0, tzinfo=timezone.utc)
         approved_target_scope = {"asset_id": "workstation-001"}
-        approved_payload = {
-            "action_type": "notify_identity_owner",
-            "asset_id": "workstation-001",
-        }
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
         payload_hash = _approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
@@ -6524,10 +6572,12 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(execution.payload_hash, payload_hash)
         self.assertEqual(
             execution.approved_payload,
-            {
-                "action_type": "notify_identity_owner",
-                "asset_id": "workstation-001",
-            },
+            _phase20_notify_identity_owner_payload(
+                recipient_identity="repo-owner-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+            ),
         )
         self.assertEqual(
             execution.provenance,
@@ -6554,10 +6604,12 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
         delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
         approved_target_scope = {"asset_id": "workstation-001"}
-        approved_payload = {
-            "action_type": "notify_identity_owner",
-            "asset_id": "workstation-001",
-        }
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
         payload_hash = _approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
@@ -6941,6 +6993,74 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 delegated_at=datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc),
                 delegation_issuer="control-plane-service",
             )
+
+    def test_service_rejects_shuffle_delegation_for_non_phase20_live_action(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "workstation-unsupported-001"}
+        approved_payload = {
+            "action_type": "open_ticket",
+            "asset_id": "workstation-unsupported-001",
+            "ticket_queue": "soc-owner-followup",
+        }
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-routine-unsupported-action-001",
+                action_request_id="action-request-routine-unsupported-action-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-routine-unsupported-action-001",
+                approval_decision_id="approval-routine-unsupported-action-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-routine-unsupported-action-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "shuffle",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "approved action is outside the reviewed Phase 20 Shuffle delegation scope",
+        ):
+            service.delegate_approved_action_to_shuffle(
+                action_request_id="action-request-routine-unsupported-action-001",
+                approved_payload=approved_payload,
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+            )
+
+        self.assertEqual(store.list(ActionExecutionRecord), ())
 
     def test_service_delegates_approved_high_risk_action_through_isolated_executor(
         self,


### PR DESCRIPTION
## Summary
- reject approved Shuffle delegations unless the payload is the reviewed Phase 20 `notify_identity_owner` action with the required recipient and message fields
- add a focused regression test proving approved-but-unsupported Shuffle actions fail closed instead of opening the live delegation surface
- align existing Shuffle success-path tests to the reviewed Phase 20 payload shape used by the approved action-request path

## Root cause
The live Shuffle adapter accepted any approved Shuffle-routed payload that satisfied the binding hash checks. That preserved payload integrity but did not enforce the narrower Phase 20 rule that only the first reviewed live low-risk action may be delegated on this path.

## Validation
- `python3 -m unittest control-plane.tests.test_service_persistence`
- `python3 -m unittest control-plane.tests.test_phase20_low_risk_action_validation control-plane.tests.test_phase20_low_risk_action_docs`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation in action delegation to enforce strict payload schema requirements and reject operations outside the approved scope.

* **Tests**
  * Added test coverage for payload validation, including verification that invalid action types are properly rejected and required fields are enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->