### PR TITLE
implementation: persist authoritative downstream action execution and reconciliation for the first live action (#420)

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3677,6 +3677,11 @@ class AegisOpsControlPlaneService:
             last_seen_at = latest_execution["observed_at"]
             observed_execution_surface_id = latest_execution["execution_surface_id"]
             observed_idempotency_key = latest_execution["idempotency_key"]
+            expected_execution_run_id = (
+                None
+                if authoritative_execution is None
+                else authoritative_execution.execution_run_id
+            )
             if last_seen_at < stale_after and compared_at >= stale_after:
                 ingest_disposition = "stale"
                 lifecycle_state = "stale"
@@ -3695,6 +3700,16 @@ class AegisOpsControlPlaneService:
                 lifecycle_state = "mismatched"
                 mismatch_summary = (
                     "execution surface/idempotency mismatch between approved request and observed execution"
+                )
+            elif (
+                expected_execution_run_id is not None
+                and execution_run_id != expected_execution_run_id
+            ):
+                ingest_disposition = "mismatch"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "execution run identity mismatch between authoritative action execution "
+                    "and observed downstream execution"
                 )
             else:
                 ingest_disposition = "matched"

--- a/control-plane/tests/test_phase20_low_risk_action_validation.py
+++ b/control-plane/tests/test_phase20_low_risk_action_validation.py
@@ -28,6 +28,7 @@ class Phase20LowRiskActionValidationTests(unittest.TestCase):
             "def test_service_rejects_shuffle_delegation_when_target_scope_drifts(",
             "def test_service_reconciles_shuffle_run_back_into_authoritative_action_execution(",
             "def test_service_reconciliation_mismatch_does_not_mutate_authoritative_execution(",
+            "def test_service_reconciliation_fail_closes_when_downstream_run_identity_drifts(",
             '"action_type": "notify_identity_owner"',
             '"execution_surface_id": "shuffle"',
             "approved payload binding does not match",

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -6380,6 +6380,99 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(stored_execution.lifecycle_state, "queued")
         self.assertEqual(stored_execution.execution_run_id, execution.execution_run_id)
 
+    def test_service_reconciliation_fail_closes_when_downstream_run_identity_drifts(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        compared_at = datetime(2026, 4, 5, 12, 12, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "workstation-001"}
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-routine-reconcile-run-drift-001",
+                action_request_id="action-request-routine-reconcile-run-drift-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-routine-reconcile-run-drift-001",
+                approval_decision_id="approval-routine-reconcile-run-drift-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-routine-reconcile-run-drift-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "shuffle",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-routine-reconcile-run-drift-001",
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-004",),
+        )
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id="action-request-routine-reconcile-run-drift-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": "shuffle-run-unexpected-001",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": execution.idempotency_key,
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=datetime(2026, 4, 5, 12, 30, tzinfo=timezone.utc),
+        )
+
+        stored_execution = service.get_record(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertIsNotNone(stored_execution)
+        self.assertEqual(reconciliation.ingest_disposition, "mismatch")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertIn("run identity mismatch", reconciliation.mismatch_summary)
+        self.assertEqual(stored_execution.lifecycle_state, "queued")
+        self.assertEqual(stored_execution.execution_run_id, execution.execution_run_id)
+
     def test_service_evaluates_action_policy_into_approval_and_isolated_executor(
         self,
     ) -> None:


### PR DESCRIPTION
Closes #420
This PR was opened by codex-supervisor.
Latest Codex summary:

Tightened Phase 20 action reconciliation so an observed downstream execution only counts as `matched` when it also preserves the authoritative `execution_run_id`. Before the fix, a Shuffle observation with the right surface and idempotency but the wrong run id was incorrectly accepted and could advance reconciliation as if it were the approved run.

I added a focused failing test for that run-identity drift case in [test_service_persistence.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-420/control-plane/tests/test_service_persistence.py), updated [service.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-420/control-plane/aegisops_control_plane/service.py) to mark it as `mismatch`/`mismatched` without mutating the stored `ActionExecutionRecord`, and extended the Phase 20 validation guard in [test_phase20_low_risk_action_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-420/control-plane/tests/test_phase20_low_risk_action_validation.py). Checkpoint commit: `7865dd4` (`Fail closed on action execution run drift`).

Summary: Fail-closed reconciliation now rejects downstream Shuffle run-id drift against the authoritative action execution record, with focused coverage added and full control-plane tests passing.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_reconciliation_fail_closes_when_downstream_run_identity_drifts control-plane.tests.test_serv...