### PR TITLE
validation: add end-to-end Phase 20 coverage for approval-bound first live action execution (#421)

### DIFF
--- a/control-plane/tests/test_phase20_low_risk_action_validation.py
+++ b/control-plane/tests/test_phase20_low_risk_action_validation.py
@@ -21,6 +21,8 @@ class Phase20LowRiskActionValidationTests(unittest.TestCase):
         text = service_test_doc.read_text(encoding="utf-8")
 
         for term in (
+            "def test_service_executes_phase20_first_live_action_end_to_end_from_reviewed_recommendation(",
+            "def test_service_phase20_first_live_action_fail_closes_on_downstream_execution_surface_mismatch(",
             "def test_service_delegates_approved_low_risk_action_through_shuffle_adapter(",
             "def test_service_rechecks_shuffle_approval_inside_transaction(",
             "def test_service_rejects_shuffle_delegation_when_payload_binding_drifts(",
@@ -33,6 +35,9 @@ class Phase20LowRiskActionValidationTests(unittest.TestCase):
             '"execution_surface_id": "shuffle"',
             "approved payload binding does not match",
             "approved expiry window does not match action request expiry",
+            "create_reviewed_action_request_from_advisory(",
+            "delegate_approved_action_to_shuffle(",
+            "reconcile_action_execution(",
         ):
             self.assertIn(term, text)
 

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -7548,6 +7548,233 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
         self.assertEqual(store.list(ActionExecutionRecord), ())
 
+    def test_service_executes_phase20_first_live_action_end_to_end_from_reviewed_recommendation(
+        self,
+    ) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        decided_at = action_request.requested_at + timedelta(minutes=5)
+        delegated_at = action_request.requested_at + timedelta(minutes=10)
+        observed_at = action_request.requested_at + timedelta(minutes=15)
+        compared_at = action_request.requested_at + timedelta(minutes=16)
+        stale_after = action_request.requested_at + timedelta(hours=1)
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase20-e2e-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=decided_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "observed_at": observed_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=stale_after,
+        )
+
+        stored_execution = service.get_record(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertEqual(
+            approved_request.requested_payload["action_type"],
+            "notify_identity_owner",
+        )
+        self.assertIsNotNone(stored_execution)
+        self.assertEqual(stored_execution.lifecycle_state, "succeeded")
+        self.assertEqual(stored_execution.approval_decision_id, "approval-phase20-e2e-001")
+        self.assertEqual(stored_execution.execution_surface_type, "automation_substrate")
+        self.assertEqual(stored_execution.execution_surface_id, "shuffle")
+        self.assertEqual(reconciliation.ingest_disposition, "matched")
+        self.assertEqual(reconciliation.lifecycle_state, "matched")
+        self.assertEqual(reconciliation.execution_run_id, execution.execution_run_id)
+        self.assertEqual(
+            reconciliation.subject_linkage["action_request_ids"],
+            (approved_request.action_request_id,),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["approval_decision_ids"],
+            ("approval-phase20-e2e-001",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["action_execution_ids"],
+            (execution.action_execution_id,),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["delegation_ids"],
+            (execution.delegation_id,),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["evidence_ids"],
+            (evidence_id,),
+        )
+
+    def test_service_phase20_first_live_action_fail_closes_on_downstream_execution_surface_mismatch(
+        self,
+    ) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        decided_at = action_request.requested_at + timedelta(minutes=5)
+        delegated_at = action_request.requested_at + timedelta(minutes=10)
+        observed_at = action_request.requested_at + timedelta(minutes=15)
+        compared_at = action_request.requested_at + timedelta(minutes=16)
+        stale_after = action_request.requested_at + timedelta(hours=1)
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase20-mismatch-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=decided_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "n8n",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "observed_at": observed_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=stale_after,
+        )
+
+        stored_execution = service.get_record(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertIsNotNone(stored_execution)
+        self.assertEqual(stored_execution.lifecycle_state, "queued")
+        self.assertEqual(stored_execution.execution_surface_id, "shuffle")
+        self.assertEqual(reconciliation.ingest_disposition, "mismatch")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertEqual(
+            reconciliation.mismatch_summary,
+            "execution surface/idempotency mismatch between approved request and observed execution",
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["approval_decision_ids"],
+            ("approval-phase20-mismatch-001",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["action_execution_ids"],
+            (execution.action_execution_id,),
+        )
+
     def test_service_rejects_reviewed_action_request_creation_when_malformed_or_out_of_scope(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -7551,7 +7551,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_executes_phase20_first_live_action_end_to_end_from_reviewed_recommendation(
         self,
     ) -> None:
-        store, service, promoted_case, evidence_id, reviewed_at = (
+        _store, service, promoted_case, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()
         )
         observation = service.record_case_observation(
@@ -7672,7 +7672,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_phase20_first_live_action_fail_closes_on_downstream_execution_surface_mismatch(
         self,
     ) -> None:
-        store, service, promoted_case, evidence_id, reviewed_at = (
+        _store, service, promoted_case, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()
         )
         observation = service.record_case_observation(


### PR DESCRIPTION
Closes #421
This PR was opened by codex-supervisor.
Latest Codex summary:

Tightened Phase 20 validation so it now requires a real end-to-end first live action path, not just scattered boundary tests. Added two focused service tests in [control-plane/tests/test_service_persistence.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-421/control-plane/tests/test_service_persistence.py) and updated [control-plane/tests/test_phase20_low_risk_action_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-421/control-plane/tests/test_phase20_low_risk_action_validation.py) to gate on them. The new coverage verifies reviewed recommendation -> approval-bound action request -> approved Shuffle delegation -> authoritative reconciliation, plus fail-closed behavior when downstream observation reports the wrong execution surface.

Focused verification passed, and I cut checkpoint commit `62406aa` with the repository changes. I also updated the supervisor journal in the local `.codex-supervisor` area with the reproduced failures, commands run, and next step.

Summary: Added focused Phase 20 end-to-end validation coverage for the approved first live action path and a fail-closed downstream mismatch case; committed as `62406aa`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase20_low_risk_action_validation`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_executes_phase20_first_live_action_end_to_end_from_reviewed_recommendation control-plane...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for Phase 20 first live action workflows, including end-to-end scenarios that validate action request processing, approval persistence, delegation, and execution reconciliation with comprehensive state lifecycle validation for both successful and failure paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->