### PR TITLE
follow-up: fail closed case-scoped advisory reads outside the approved Phase 19 operator slice (#427)

### DIFF
--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1906,6 +1906,65 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     servers[0].shutdown()
                 thread.join(timeout=2)
 
+    def test_long_running_runtime_surface_rejects_case_family_out_of_scope_advisory_reads(
+        self,
+    ) -> None:
+        service, promoted_case = self._build_phase19_out_of_scope_case(
+            fixture_name="github-audit-alert.json",
+            host="127.0.0.1",
+            port=0,
+        )
+        expected_message = (
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                for path in (
+                    "/inspect-assistant-context",
+                    "/inspect-advisory-output",
+                    "/render-recommendation-draft",
+                ):
+                    with self.subTest(path=path):
+                        with self.assertRaises(error.HTTPError) as exc_info:
+                            request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                                (
+                                    f"{base_url}{path}"
+                                    f"?family=case&record_id={promoted_case.case_id}"
+                                ),
+                                timeout=2,
+                            )
+
+                        self.assertEqual(exc_info.exception.code, 400)
+                        payload = json.loads(
+                            exc_info.exception.read().decode("utf-8")
+                        )
+                        self.assertEqual(payload["error"], "invalid_request")
+                        self.assertIn(expected_message, payload["message"])
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
     def test_long_running_runtime_surface_rejects_case_scoped_advisory_reads_without_linked_case(
         self,
     ) -> None:
@@ -2282,6 +2341,38 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                             record_family,
                             "--record-id",
                             record_id,
+                        ],
+                        service=service,
+                    )
+
+            self.assertEqual(exc_info.exception.code, 2)
+            self.assertIn(expected_message, stderr.getvalue())
+
+    def test_cli_rejects_case_family_out_of_scope_advisory_reads_as_usage_errors(
+        self,
+    ) -> None:
+        service, promoted_case = self._build_phase19_out_of_scope_case(
+            fixture_name="github-audit-alert.json"
+        )
+        expected_message = (
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+        )
+
+        for command in (
+            "inspect-assistant-context",
+            "inspect-advisory-output",
+            "render-recommendation-draft",
+        ):
+            stderr = io.StringIO()
+            with self.subTest(command=command), contextlib.redirect_stderr(stderr):
+                with self.assertRaises(SystemExit) as exc_info:
+                    main.main(
+                        [
+                            command,
+                            "--family",
+                            "case",
+                            "--record-id",
+                            promoted_case.case_id,
                         ],
                         service=service,
                     )

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -253,6 +253,47 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         return service, promoted_case, admitted.alert.alert_id, reviewed_at
 
+    def _build_phase19_synthetic_out_of_scope_case(
+        self,
+    ) -> tuple[AegisOpsControlPlaneService, CaseRecord, datetime]:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = service.ingest_finding_alert(
+            finding_id="finding-phase19-synthetic-case-001",
+            analytic_signal_id="signal-phase19-synthetic-case-001",
+            substrate_detection_record_id="synthetic-phase19-case-record-001",
+            correlation_key="claim:asset-phase19-synthetic-case-001:synthetic",
+            first_seen_at=reviewed_at,
+            last_seen_at=reviewed_at,
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase19-synthetic-case-001"},
+                "identity": {"identity_id": "principal-phase19-synthetic-case-001"},
+                "source": {
+                    "source_family": "synthetic_review_fixture",
+                    "admission_kind": "synthetic",
+                },
+            },
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase19-synthetic-case-001",
+                source_record_id=admitted.alert.finding_id,
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="synthetic",
+                collector_identity="collector://synthetic/fixture",
+                acquired_at=reviewed_at,
+                derivation_relationship="finding_alert",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        return service, promoted_case, reviewed_at
+
     def _build_case_scoped_advisory_records_without_case_lineage(
         self,
     ) -> tuple[AegisOpsControlPlaneService, RecommendationRecord, AITraceRecord]:
@@ -4190,6 +4231,29 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
                 ):
                     service.render_recommendation_draft(record_family, record_id)
+
+    def test_service_rejects_synthetic_case_scoped_advisory_reads_from_ingested_finding_case(
+        self,
+    ) -> None:
+        service, promoted_case, _ = self._build_phase19_synthetic_out_of_scope_case()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.inspect_assistant_context("case", promoted_case.case_id)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.inspect_advisory_output("case", promoted_case.case_id)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+        ):
+            service.render_recommendation_draft("case", promoted_case.case_id)
 
     def test_service_rejects_ai_trace_subject_linkage_declaring_out_of_scope_provenance(
         self,


### PR DESCRIPTION
Closes #427
This PR was opened by codex-supervisor.
Latest Codex summary:

Added focused regression coverage for the Phase 19 case-scoped advisory gate without changing runtime logic. The service already failed closed for out-of-scope `case` reads; the gap was explicit proof for `family=case` on the exposed advisory-read surfaces and a synthetic out-of-scope case reproduction built through `ingest_finding_alert(...)`.

Committed as `b75d968` with `Add Phase 19 case advisory gate regressions`. The new tests cover service-level rejection of synthetic case reads for `inspect_assistant_context`, `inspect_advisory_output`, and `render_recommendation_draft`, plus CLI and HTTP rejection of out-of-scope replay `family=case` reads on the same three paths. I also updated the issue journal working notes for the supervisor.

Summary: Added focused test coverage proving Phase 19 case-scoped advisory reads fail closed for out-of-scope cases across service, CLI, and HTTP; committed as `b75d968`.
State hint: stabilizing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_rejects_synthetic_case_scoped_advisory_reads_from_ingested_finding_case control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_long_running_runtime_surface_rejects_case_family_out_of_scope_advisory_reads control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_rejects_case_family_out_of_scope_advisory_reads_as_usage_errors`; `python3 -m unittest control-plane.tes...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests to ensure inspection endpoints properly reject requests for out-of-scope cases with appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->