### PR TITLE
implementation: fail closed Phase 20 reconciliation when downstream evidence lacks approved binding identifiers (#429)

### DIFF
--- a/.codex-supervisor/issues/429/issue-journal.md
+++ b/.codex-supervisor/issues/429/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #429: implementation: fail closed Phase 20 reconciliation when downstream evidence lacks approved binding identifiers
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/429
+- Branch: codex/issue-429
+- Workspace: .
+- Journal: .codex-supervisor/issues/429/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 61ae17fe301f00c9f227504c357f07983f443c29
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-13T00:28:46.122Z
+
+## Latest Codex Summary
+- Reproduced the Phase 20 fail-open path with a focused service test showing `reconcile_action_execution(...)` accepted reviewed Shuffle evidence that omitted `approval_decision_id`, `delegation_id`, and `payload_hash`.
+- Tightened reviewed Shuffle reconciliation normalization to require those binding identifiers, compare them against the authoritative `ActionExecutionRecord`, and preserve the reviewed binding in Shuffle delegation provenance.
+- Verified the focused Phase 20 persistence and validation tests plus a generic non-Phase-20 reconciliation guard.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Phase 20 reconciliation was fail-open because `_normalize_observed_executions(...)` only required execution-surface/idempotency fields, allowing reviewed Shuffle evidence with missing approved-binding identifiers to normalize into `matched`.
+- What changed: Added a reproducing service test for missing binding identifiers; updated the reviewed Shuffle adapter receipt/provenance to preserve `approval_decision_id`, `delegation_id`, and `payload_hash`; required those fields for observed Shuffle executions during reconciliation and fail-closed on missing or mismatched binding data; updated the Phase 20 validation sentinel to require the new test.
+- Current blocker: none
+- Next exact step: Stage the focused implementation/test changes, create a checkpoint commit on `codex/issue-429`, and hand back the verified state.
+- Verification gap: Focused Phase 20 and adjacent generic tests passed via `python3 -m unittest`; broader repository suites were not run this turn.
+- Files touched: control-plane/aegisops_control_plane/adapters/shuffle.py; control-plane/aegisops_control_plane/service.py; control-plane/tests/test_service_persistence.py; control-plane/tests/test_phase20_low_risk_action_validation.py
+- Rollback concern: Low to moderate; the reconciliation contract is intentionally stricter for reviewed Shuffle evidence and would surface any caller still omitting binding identifiers.
+- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_delegates_approved_low_risk_action_through_shuffle_adapter control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_reconcile_action_execution_supports_generic_execution_surfaces`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/adapters/shuffle.py
+++ b/control-plane/aegisops_control_plane/adapters/shuffle.py
@@ -10,6 +10,9 @@ class ShuffleDelegationReceipt:
     execution_surface_type: str
     execution_surface_id: str
     execution_run_id: str
+    approval_decision_id: str
+    delegation_id: str
+    payload_hash: str
     adapter: str
     base_url: str
 
@@ -34,8 +37,6 @@ class ShuffleActionAdapter:
         delegated_at: datetime,
     ) -> ShuffleDelegationReceipt:
         del action_request_id
-        del approval_decision_id
-        del payload_hash
         del idempotency_key
         del delegated_at
         self._require_reviewed_phase20_notify_payload(approved_payload)
@@ -43,6 +44,9 @@ class ShuffleActionAdapter:
             execution_surface_type=self.execution_surface_type,
             execution_surface_id=self.execution_surface_id,
             execution_run_id=f"shuffle-run-{delegation_id}",
+            approval_decision_id=approval_decision_id,
+            delegation_id=delegation_id,
+            payload_hash=payload_hash,
             adapter="shuffle",
             base_url=self.base_url,
         )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1141,6 +1141,11 @@ class AegisOpsControlPlaneService:
                 "delegation_issuer": delegation_issuer,
                 "evidence_ids": evidence_ids,
                 "adapter": receipt.adapter,
+                "downstream_binding": {
+                    "approval_decision_id": receipt.approval_decision_id,
+                    "delegation_id": receipt.delegation_id,
+                    "payload_hash": receipt.payload_hash,
+                },
             }
             if receipt.base_url.strip() and receipt.base_url != "<set-me>":
                 provenance["adapter_base_url"] = receipt.base_url
@@ -3611,7 +3616,14 @@ class AegisOpsControlPlaneService:
                 f"(state={action_request.lifecycle_state!r})"
             )
 
-        normalized_executions = self._normalize_observed_executions(observed_executions)
+        require_binding_identifiers = (
+            execution_surface_type == "automation_substrate"
+            and execution_surface_id == "shuffle"
+        )
+        normalized_executions = self._normalize_observed_executions(
+            observed_executions,
+            require_binding_identifiers=require_binding_identifiers,
+        )
         linked_execution_run_ids = tuple(
             execution["execution_run_id"] for execution in normalized_executions
         )
@@ -3677,6 +3689,9 @@ class AegisOpsControlPlaneService:
             last_seen_at = latest_execution["observed_at"]
             observed_execution_surface_id = latest_execution["execution_surface_id"]
             observed_idempotency_key = latest_execution["idempotency_key"]
+            observed_approval_decision_id = latest_execution.get("approval_decision_id")
+            observed_delegation_id = latest_execution.get("delegation_id")
+            observed_payload_hash = latest_execution.get("payload_hash")
             expected_execution_run_id = (
                 None
                 if authoritative_execution is None
@@ -3709,6 +3724,23 @@ class AegisOpsControlPlaneService:
                 lifecycle_state = "mismatched"
                 mismatch_summary = (
                     "execution run identity mismatch between authoritative action execution "
+                    "and observed downstream execution"
+                )
+            elif (
+                authoritative_execution is not None
+                and authoritative_execution.execution_surface_type == "automation_substrate"
+                and authoritative_execution.execution_surface_id == "shuffle"
+                and (
+                    observed_approval_decision_id
+                    != authoritative_execution.approval_decision_id
+                    or observed_delegation_id != authoritative_execution.delegation_id
+                    or observed_payload_hash != authoritative_execution.payload_hash
+                )
+            ):
+                ingest_disposition = "mismatch"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "approved binding mismatch between authoritative action execution "
                     "and observed downstream execution"
                 )
             else:
@@ -4351,9 +4383,11 @@ class AegisOpsControlPlaneService:
             return substrate_detection_record_id
         return f"{namespaced_prefix}{substrate_detection_record_id}"
 
-    @staticmethod
     def _normalize_observed_executions(
+        self,
         observed_executions: tuple[Mapping[str, object], ...],
+        *,
+        require_binding_identifiers: bool = False,
     ) -> tuple[dict[str, object], ...]:
         normalized: list[dict[str, object]] = []
         for execution in observed_executions:
@@ -4361,6 +4395,9 @@ class AegisOpsControlPlaneService:
             execution_surface_id = execution.get("execution_surface_id")
             idempotency_key = execution.get("idempotency_key")
             observed_at = execution.get("observed_at")
+            approval_decision_id = execution.get("approval_decision_id")
+            delegation_id = execution.get("delegation_id")
+            payload_hash = execution.get("payload_hash")
             if not isinstance(execution_run_id, str):
                 raise ValueError("observed execution must include string execution_run_id")
             if not isinstance(execution_surface_id, str):
@@ -4375,12 +4412,24 @@ class AegisOpsControlPlaneService:
                 observed_at,
                 "observed_at",
             )
+            if require_binding_identifiers:
+                if not isinstance(approval_decision_id, str):
+                    raise ValueError(
+                        "observed execution must include string approval_decision_id"
+                    )
+                if not isinstance(delegation_id, str):
+                    raise ValueError("observed execution must include string delegation_id")
+                if not isinstance(payload_hash, str):
+                    raise ValueError("observed execution must include string payload_hash")
             normalized.append(
                 {
                     "execution_run_id": execution_run_id,
                     "execution_surface_id": execution_surface_id,
                     "idempotency_key": idempotency_key,
                     "observed_at": observed_at,
+                    "approval_decision_id": approval_decision_id,
+                    "delegation_id": delegation_id,
+                    "payload_hash": payload_hash,
                     "status": execution.get("status"),
                 }
             )

--- a/control-plane/tests/test_phase20_low_risk_action_validation.py
+++ b/control-plane/tests/test_phase20_low_risk_action_validation.py
@@ -31,6 +31,7 @@ class Phase20LowRiskActionValidationTests(unittest.TestCase):
             "def test_service_reconciles_shuffle_run_back_into_authoritative_action_execution(",
             "def test_service_reconciliation_mismatch_does_not_mutate_authoritative_execution(",
             "def test_service_reconciliation_fail_closes_when_downstream_run_identity_drifts(",
+            "def test_service_phase20_reconciliation_rejects_downstream_evidence_missing_binding_identifiers(",
             '"action_type": "notify_identity_owner"',
             '"execution_surface_id": "shuffle"',
             "approved payload binding does not match",

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -6218,6 +6218,9 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     "execution_run_id": execution.execution_run_id,
                     "execution_surface_id": "shuffle",
                     "idempotency_key": "idempotency-routine-reconcile-001",
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
                     "observed_at": compared_at,
                     "status": "success",
                 },
@@ -6426,6 +6429,9 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     "execution_run_id": execution.execution_run_id,
                     "execution_surface_id": "n8n",
                     "idempotency_key": execution.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
                     "observed_at": compared_at,
                     "status": "failed",
                 },
@@ -6518,6 +6524,9 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     "execution_run_id": "shuffle-run-unexpected-001",
                     "execution_surface_id": "shuffle",
                     "idempotency_key": execution.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
                     "observed_at": compared_at,
                     "status": "success",
                 },
@@ -6742,6 +6751,11 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 "delegation_issuer": "control-plane-service",
                 "evidence_ids": ("evidence-001",),
                 "adapter": "shuffle",
+                "downstream_binding": {
+                    "approval_decision_id": "approval-routine-001",
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": payload_hash,
+                },
             },
         )
         self.assertEqual(execution.lifecycle_state, "queued")
@@ -7688,6 +7702,9 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     "execution_run_id": execution.execution_run_id,
                     "execution_surface_id": "shuffle",
                     "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
                     "observed_at": observed_at,
                     "status": "success",
                 },
@@ -7809,6 +7826,9 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                     "execution_run_id": execution.execution_run_id,
                     "execution_surface_id": "n8n",
                     "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
                     "observed_at": observed_at,
                     "status": "success",
                 },
@@ -7838,6 +7858,95 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             reconciliation.subject_linkage["action_execution_ids"],
             (execution.action_execution_id,),
         )
+
+    def test_service_phase20_reconciliation_rejects_downstream_evidence_missing_binding_identifiers(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        decided_at = action_request.requested_at + timedelta(minutes=5)
+        delegated_at = action_request.requested_at + timedelta(minutes=10)
+        observed_at = action_request.requested_at + timedelta(minutes=15)
+        compared_at = action_request.requested_at + timedelta(minutes=16)
+        stale_after = action_request.requested_at + timedelta(hours=1)
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase20-missing-binding-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=decided_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "observed execution must include string approval_decision_id",
+        ):
+            service.reconcile_action_execution(
+                action_request_id=approved_request.action_request_id,
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                observed_executions=(
+                    {
+                        "execution_run_id": execution.execution_run_id,
+                        "execution_surface_id": "shuffle",
+                        "idempotency_key": approved_request.idempotency_key,
+                        "observed_at": observed_at,
+                        "status": "success",
+                    },
+                ),
+                compared_at=compared_at,
+                stale_after=stale_after,
+            )
 
     def test_service_rejects_reviewed_action_request_creation_when_malformed_or_out_of_scope(
         self,


### PR DESCRIPTION
Closes #429
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Phase 20 fail-closed binding check and committed it as `45e955a` on `codex/issue-429`.

The main change is in [service.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-429/control-plane/aegisops_control_plane/service.py:3585): reviewed Shuffle reconciliation now requires observed downstream evidence to include `approval_decision_id`, `delegation_id`, and `payload_hash`, and it compares those values against the authoritative `ActionExecutionRecord` before allowing a `matched` reconciliation. Missing binding fields now raise a validation error; mismatched binding fields reconcile as an explicit mismatch. I also updated the reviewed Shuffle adapter in [shuffle.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-429/control-plane/aegisops_control_plane/adapters/shuffle.py:8) so the delegation receipt preserves the approved binding, and the service now stores that under `provenance["downstream_binding"]`.

Coverage was tightened in [test_service_persistence.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-429/control-plane/tests/test_service_persistence.py:6212) with a focused reproducer for missing binding identifiers plus updates to the Phase 20 success and mismatch cases so the reviewed Shuffle path still passes when the full approved binding is present. The Phase 20 sentinel in [test_phase20_low_risk_action_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-429/control-plane/tests/test_phase20_low_risk_action_validation.py:24) now requires that new tes...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced delegation receipt tracking with approval decision and delegation identifiers.
  * Added binding identifier preservation in action delegation provenance.

* **Bug Fixes**
  * Improved validation behavior to enforce required approval binding identifiers in downstream reconciliation evidence (fail-closed approach).

* **Tests**
  * Added validation test for missing binding identifiers in action execution reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->