### PR TITLE
implementation: keep requester identity inside the Phase 20 action-request deduplication boundary (#430)

### DIFF
--- a/.codex-supervisor/issues/430/issue-journal.md
+++ b/.codex-supervisor/issues/430/issue-journal.md
@@ -1,0 +1,37 @@
+# Issue #430: implementation: keep requester identity inside the Phase 20 action-request deduplication boundary
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/430
+- Branch: codex/issue-430
+- Workspace: .
+- Journal: .codex-supervisor/issues/430/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 859bc268e8f7a18fcce2d85ae5cbdb7fd65daa8f
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-13T00:41:02.529Z
+
+## Latest Codex Summary
+- Reproduced Phase 20 reviewed action-request deduplication reusing the same record across different `requester_identity` values.
+- Added a focused persistence test for the `analyst-001` then `analyst-002` scenario and fixed the dedup boundary by including `requester_identity` in the reviewed action-request idempotency material.
+- Focused Phase 20 request creation, approval/delegation, reconciliation, and validation tests passed after the change.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Reviewed Phase 20 action-request reuse was keyed too broadly because `requester_identity` was excluded from the idempotency material used for deduplication.
+- What changed: Added a focused service persistence test covering `analyst-001` then `analyst-002`; updated `create_reviewed_action_request_from_advisory` so the idempotency key now includes `requester_identity`.
+- Current blocker: none
+- Next exact step: Commit the focused fix and journal update on `codex/issue-430`.
+- Verification gap: Full suite not run; verification is limited to focused Phase 20 request creation, delegation, reconciliation, and validation tests.
+- Files touched: `control-plane/aegisops_control_plane/service.py`; `control-plane/tests/test_service_persistence.py`; `.codex-supervisor/issues/430/issue-journal.md`
+- Rollback concern: Low. The change only narrows reviewed action-request reuse by requester identity; same-requester duplicate reuse remains covered by the existing test.
+- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_delegates_approved_low_risk_action_through_shuffle_adapter control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_rejects_shuffle_delegation_when_payload_binding_drifts control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_reconciles_shuffle_run_back_into_authoritative_action_execution control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_reconciliation_fail_closes_when_downstream_run_identity_drifts`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Reproducer command: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_keeps_requester_identity_inside_reviewed_action_request_deduplication control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_reuses_reviewed_action_request_for_matching_idempotency_key`
+- Reproduced failure before fix: second call from `analyst-002` returned the first action request ID.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2314,6 +2314,7 @@ class AegisOpsControlPlaneService:
                     "payload_hash": payload_hash,
                     "record_family": record_family,
                     "record_id": record_id,
+                    "requester_identity": requester_identity,
                     "expires_at": expires_at.isoformat(),
                 },
                 sort_keys=True,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -8104,7 +8104,17 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(first_request.requester_identity, "analyst-001")
         self.assertEqual(second_request.requester_identity, "analyst-002")
         self.assertNotEqual(second_request.idempotency_key, first_request.idempotency_key)
-        self.assertEqual(store.list(ActionRequestRecord), (first_request, second_request))
+        persisted_by_requester = {
+            record.requester_identity: record
+            for record in store.list(ActionRequestRecord)
+        }
+        self.assertEqual(
+            persisted_by_requester,
+            {
+                "analyst-001": first_request,
+                "analyst-002": second_request,
+            },
+        )
 
     def test_service_rechecks_reviewed_action_request_context_inside_transaction(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -8055,6 +8055,57 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(second_request, first_request)
         self.assertEqual(store.list(ActionRequestRecord), (first_request,))
 
+    def test_service_keeps_requester_identity_inside_reviewed_action_request_deduplication(
+        self,
+    ) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=service.record_case_lead(
+                case_id=promoted_case.case_id,
+                triage_owner="analyst-001",
+                triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+                observation_id=observation.observation_id,
+            ).lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+
+        first_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        second_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-002",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+
+        self.assertNotEqual(second_request.action_request_id, first_request.action_request_id)
+        self.assertEqual(first_request.requester_identity, "analyst-001")
+        self.assertEqual(second_request.requester_identity, "analyst-002")
+        self.assertNotEqual(second_request.idempotency_key, first_request.idempotency_key)
+        self.assertEqual(store.list(ActionRequestRecord), (first_request, second_request))
+
     def test_service_rechecks_reviewed_action_request_context_inside_transaction(
         self,
     ) -> None:


### PR DESCRIPTION
Closes #430
This PR was opened by codex-supervisor.
Latest Codex summary:

Tightened the Phase 20 reviewed action-request dedup boundary so it no longer reuses a prior request across different `requester_identity` values. The service now includes `requester_identity` in the idempotency material, and I added a focused persistence test that reproduces the `analyst-001` then `analyst-002` collision and proves the second request gets its own record while same-requester duplicates still reuse the existing one.

Focused verification passed with `python3 -m unittest` for the new reproducer, the existing same-requester reuse case, the end-to-end Phase 20 reviewed flow, transaction recheck coverage, the Phase 20 validation doc test, and selected Shuffle delegation/reconciliation tests. I committed the checkpoint as `e9a73d2` on `codex/issue-430`.

Summary: Reproduced and fixed Phase 20 action-request dedup to keep requester identity inside the reuse boundary; committed as `e9a73d2`.
State hint: stabilizing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_keeps_requester_identity_inside_reviewed_action_request_deduplication control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_reuses_reviewed_action_request_for_matching_idempotency_key`; `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_reuses_reviewed_action_request_for_matching_idempotency_key control-plane.t...