### PR TITLE
implementation: add startup/shutdown, backup/restore, and restore-drill hardening for the control-plane record chain (#436)

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -502,6 +502,10 @@ class PostgresControlPlaneStore:
     ) -> Iterator[None]:
         active_connection = self._active_connection.get()
         if active_connection is not None:
+            if isolation_level is not None:
+                raise ValueError(
+                    "Cannot set isolation_level inside an active transaction"
+                )
             yield
             return
 

--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -60,6 +60,9 @@ class ConnectionProtocol(Protocol):
 
 
 ConnectionFactory = Callable[[str], ConnectionProtocol]
+_ALLOWED_TRANSACTION_ISOLATION_LEVELS = frozenset(
+    {"READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"}
+)
 
 
 @dataclass(frozen=True)
@@ -492,13 +495,31 @@ class PostgresControlPlaneStore:
             connection.close()
 
     @contextmanager
-    def transaction(self) -> Iterator[None]:
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> Iterator[None]:
         active_connection = self._active_connection.get()
         if active_connection is not None:
             yield
             return
 
         with self._connection() as connection:
+            if isolation_level is not None:
+                normalized_isolation_level = isolation_level.strip().upper()
+                if normalized_isolation_level not in _ALLOWED_TRANSACTION_ISOLATION_LEVELS:
+                    raise ValueError(
+                        "Unsupported transaction isolation level "
+                        f"{isolation_level!r}"
+                    )
+                cursor = connection.cursor()
+                try:
+                    cursor.execute(
+                        f"SET TRANSACTION ISOLATION LEVEL {normalized_isolation_level}"
+                    )
+                finally:
+                    cursor.close()
             token = self._active_connection.set(connection)
             try:
                 yield

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -357,6 +357,62 @@ class RecommendationDraftSnapshot:
         )
 
 
+@dataclass(frozen=True)
+class StartupStatusSnapshot:
+    read_only: bool
+    startup_ready: bool
+    required_bindings: tuple[str, ...]
+    missing_bindings: tuple[str, ...]
+    validated_surfaces: tuple[str, ...]
+    blocking_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(asdict(self))
+
+
+@dataclass(frozen=True)
+class ShutdownStatusSnapshot:
+    read_only: bool
+    shutdown_ready: bool
+    blocking_reasons: tuple[str, ...]
+    open_case_ids: tuple[str, ...]
+    active_action_request_ids: tuple[str, ...]
+    active_action_execution_ids: tuple[str, ...]
+    unresolved_reconciliation_ids: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(asdict(self))
+
+
+@dataclass(frozen=True)
+class RestoreDrillSnapshot:
+    read_only: bool
+    drill_passed: bool
+    verified_case_ids: tuple[str, ...]
+    verified_approval_decision_ids: tuple[str, ...]
+    verified_action_execution_ids: tuple[str, ...]
+    verified_reconciliation_ids: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(asdict(self))
+
+
+@dataclass(frozen=True)
+class RestoreSummarySnapshot:
+    read_only: bool
+    restored_record_counts: dict[str, int]
+    restore_drill: RestoreDrillSnapshot
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(
+            {
+                "read_only": self.read_only,
+                "restored_record_counts": self.restored_record_counts,
+                "restore_drill": self.restore_drill.to_dict(),
+            }
+        )
+
+
 RECORD_TYPES_BY_FAMILY: dict[str, Type[ControlPlaneRecord]] = {
     record_type.record_family: record_type
     for record_type in (
@@ -375,6 +431,37 @@ RECORD_TYPES_BY_FAMILY: dict[str, Type[ControlPlaneRecord]] = {
         AITraceRecord,
         ReconciliationRecord,
     )
+}
+
+AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES: tuple[Type[ControlPlaneRecord], ...] = (
+    AnalyticSignalRecord,
+    AlertRecord,
+    EvidenceRecord,
+    CaseRecord,
+    ApprovalDecisionRecord,
+    ActionRequestRecord,
+    ActionExecutionRecord,
+    ReconciliationRecord,
+)
+AUTHORITATIVE_RECORD_CHAIN_FAMILIES: tuple[str, ...] = tuple(
+    record_type.record_family for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES
+)
+AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION = (
+    "phase21.authoritative-record-chain.v1"
+)
+_BACKUP_DATETIME_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
+    "analytic_signal": ("first_seen_at", "last_seen_at"),
+    "evidence": ("acquired_at",),
+    "approval_decision": ("decided_at", "approved_expires_at"),
+    "action_request": ("requested_at", "expires_at"),
+    "action_execution": ("delegated_at", "expires_at"),
+    "reconciliation": ("first_seen_at", "last_seen_at", "compared_at"),
+}
+_BACKUP_TUPLE_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
+    "analytic_signal": ("alert_ids", "case_ids"),
+    "case": ("evidence_ids",),
+    "approval_decision": ("approver_identities",),
+    "reconciliation": ("linked_execution_run_ids",),
 }
 
 _ACTION_POLICY_ALLOWED_VALUES: dict[str, tuple[str, ...]] = {
@@ -432,6 +519,53 @@ def _record_to_dict(record: ControlPlaneRecord) -> dict[str, object]:
         field.name: getattr(record, field.name)
         for field in fields(record)
     }
+
+
+def _parse_backup_datetime(value: object, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty ISO 8601 datetime")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be a valid ISO 8601 datetime") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone offset")
+    return parsed
+
+
+def _record_from_backup_payload(
+    record_type: Type[RecordT],
+    payload: Mapping[str, object],
+) -> RecordT:
+    if not isinstance(payload, Mapping):
+        raise ValueError(
+            f"{record_type.record_family} backup entries must be JSON objects"
+        )
+    family = record_type.record_family
+    datetime_fields = set(_BACKUP_DATETIME_FIELDS_BY_FAMILY.get(family, ()))
+    tuple_fields = set(_BACKUP_TUPLE_FIELDS_BY_FAMILY.get(family, ()))
+    kwargs: dict[str, object] = {}
+    for field_info in fields(record_type):
+        if field_info.name not in payload:
+            raise ValueError(
+                f"{family} backup entry is missing required field {field_info.name!r}"
+            )
+        value = payload[field_info.name]
+        if field_info.name in datetime_fields:
+            value = _parse_backup_datetime(value, field_info.name)
+        elif field_info.name in tuple_fields:
+            if value is None:
+                value = ()
+            elif isinstance(value, list):
+                value = tuple(value)
+            elif not isinstance(value, tuple):
+                raise ValueError(
+                    f"{family}.{field_info.name} must be a JSON array in restore payload"
+                )
+        kwargs[field_info.name] = value
+    return record_type(**kwargs)
 
 
 def _approved_payload_binding_hash(
@@ -1474,6 +1608,234 @@ class AegisOpsControlPlaneService:
             by_lifecycle_state=by_lifecycle_state,
             by_ingest_disposition=by_ingest_disposition,
             records=tuple(_record_to_dict(record) for record in records),
+        )
+
+    def describe_startup_status(self) -> StartupStatusSnapshot:
+        required_bindings = (
+            "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN",
+            "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET",
+            "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET",
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET",
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT",
+            "AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN",
+            "AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN",
+        )
+        binding_values = {
+            "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": self._config.postgres_dsn,
+            "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET": (
+                self._config.wazuh_ingest_shared_secret
+            ),
+            "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET": (
+                self._config.wazuh_ingest_reverse_proxy_secret
+            ),
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET": (
+                self._config.protected_surface_reverse_proxy_secret
+            ),
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT": (
+                self._config.protected_surface_proxy_service_account
+            ),
+            "AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN": (
+                self._config.admin_bootstrap_token
+            ),
+            "AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN": self._config.break_glass_token,
+        }
+        missing_bindings = tuple(
+            binding_name
+            for binding_name in required_bindings
+            if not str(binding_values[binding_name]).strip()
+            or binding_values[binding_name] == "<set-me>"
+        )
+        validated_surfaces: list[str] = []
+        blocking_reasons: list[str] = []
+        try:
+            self.validate_wazuh_ingest_runtime()
+        except ValueError as exc:
+            blocking_reasons.append(str(exc))
+        else:
+            validated_surfaces.append("wazuh_ingest")
+        try:
+            self.validate_protected_surface_runtime()
+        except ValueError as exc:
+            blocking_reasons.append(str(exc))
+        else:
+            validated_surfaces.append("protected_surface")
+
+        return StartupStatusSnapshot(
+            read_only=True,
+            startup_ready=not missing_bindings and not blocking_reasons,
+            required_bindings=required_bindings,
+            missing_bindings=missing_bindings,
+            validated_surfaces=tuple(validated_surfaces),
+            blocking_reasons=tuple(blocking_reasons),
+        )
+
+    def describe_shutdown_status(self) -> ShutdownStatusSnapshot:
+        open_case_ids = tuple(
+            record.case_id
+            for record in self._store.list(CaseRecord)
+            if record.lifecycle_state
+            in {
+                "open",
+                "investigating",
+                "pending_action",
+                "contained_pending_validation",
+                "reopened",
+            }
+        )
+        active_action_request_ids = tuple(
+            record.action_request_id
+            for record in self._store.list(ActionRequestRecord)
+            if record.lifecycle_state
+            in {"pending_approval", "approved", "executing", "unresolved"}
+        )
+        active_action_execution_ids = tuple(
+            record.action_execution_id
+            for record in self._store.list(ActionExecutionRecord)
+            if record.lifecycle_state in {"queued", "running"}
+        )
+        unresolved_reconciliation_ids = tuple(
+            record.reconciliation_id
+            for record in self._store.list(ReconciliationRecord)
+            if record.lifecycle_state in {"pending", "mismatched", "stale"}
+        )
+        blocking_reasons: list[str] = []
+        if open_case_ids:
+            blocking_reasons.append(
+                "controlled shutdown requires resolving or explicitly handing off open casework"
+            )
+        if active_action_request_ids:
+            blocking_reasons.append(
+                "controlled shutdown requires approval-bound action requests to leave an inactive state"
+            )
+        if active_action_execution_ids:
+            blocking_reasons.append(
+                "controlled shutdown requires queued or running executions to reach a terminal state"
+            )
+        if unresolved_reconciliation_ids:
+            blocking_reasons.append(
+                "controlled shutdown requires pending reconciliation mismatches to be reviewed first"
+            )
+        return ShutdownStatusSnapshot(
+            read_only=True,
+            shutdown_ready=not blocking_reasons,
+            blocking_reasons=tuple(blocking_reasons),
+            open_case_ids=open_case_ids,
+            active_action_request_ids=active_action_request_ids,
+            active_action_execution_ids=active_action_execution_ids,
+            unresolved_reconciliation_ids=unresolved_reconciliation_ids,
+        )
+
+    def export_authoritative_record_chain_backup(self) -> dict[str, object]:
+        record_families: dict[str, list[dict[str, object]]] = {}
+        record_counts: dict[str, int] = {}
+        for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
+            family = record_type.record_family
+            records = [
+                _json_ready(_record_to_dict(record))
+                for record in self._store.list(record_type)
+            ]
+            record_families[family] = records
+            record_counts[family] = len(records)
+        return {
+            "backup_schema_version": AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "persistence_mode": self._store.persistence_mode,
+            "record_families": record_families,
+            "record_counts": record_counts,
+        }
+
+    def restore_authoritative_record_chain_backup(
+        self,
+        backup_payload: Mapping[str, object],
+    ) -> RestoreSummarySnapshot:
+        if not isinstance(backup_payload, Mapping):
+            raise ValueError("restore payload must be a JSON object")
+        backup_schema_version = backup_payload.get("backup_schema_version")
+        if backup_schema_version != AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION:
+            raise ValueError(
+                "restore payload must declare the reviewed authoritative record-chain schema version"
+            )
+        record_families_payload = backup_payload.get("record_families")
+        if not isinstance(record_families_payload, Mapping):
+            raise ValueError("restore payload must contain record_families")
+        record_counts_payload = backup_payload.get("record_counts")
+        if not isinstance(record_counts_payload, Mapping):
+            raise ValueError("restore payload must contain record_counts")
+
+        parsed_records: dict[str, tuple[ControlPlaneRecord, ...]] = {}
+        restored_record_counts: dict[str, int] = {}
+        for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
+            family = record_type.record_family
+            raw_records = record_families_payload.get(family)
+            if not isinstance(raw_records, list):
+                raise ValueError(
+                    f"restore payload must contain a JSON array for record family {family!r}"
+                )
+            expected_count = record_counts_payload.get(family)
+            if expected_count != len(raw_records):
+                raise ValueError(
+                    f"restore payload record count mismatch for {family!r}: "
+                    f"expected {expected_count!r}, found {len(raw_records)}"
+                )
+            parsed = tuple(
+                _record_from_backup_payload(record_type, raw_record)
+                for raw_record in raw_records
+            )
+            parsed_records[family] = parsed
+            restored_record_counts[family] = len(parsed)
+
+        self._validate_authoritative_record_chain_restore(parsed_records)
+        with self._store.transaction():
+            self._require_empty_authoritative_restore_target()
+            for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
+                for record in parsed_records[record_type.record_family]:
+                    self.persist_record(record)
+            restore_drill = self.run_authoritative_restore_drill()
+        return RestoreSummarySnapshot(
+            read_only=True,
+            restored_record_counts=restored_record_counts,
+            restore_drill=restore_drill,
+        )
+
+    def run_authoritative_restore_drill(self) -> RestoreDrillSnapshot:
+        self._validate_authoritative_record_chain_restore(
+            {
+                record_type.record_family: self._store.list(record_type)
+                for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES
+            }
+        )
+        verified_case_ids = tuple(
+            record.case_id for record in self._store.list(CaseRecord)
+        )
+        verified_approval_decision_ids = tuple(
+            record.approval_decision_id
+            for record in self._store.list(ApprovalDecisionRecord)
+        )
+        verified_action_execution_ids = tuple(
+            record.action_execution_id
+            for record in self._store.list(ActionExecutionRecord)
+        )
+        verified_reconciliation_ids = tuple(
+            record.reconciliation_id
+            for record in self._store.list(ReconciliationRecord)
+            if record.execution_run_id is not None
+        )
+
+        for case_id in verified_case_ids:
+            self.inspect_case_detail(case_id)
+        for approval_decision_id in verified_approval_decision_ids:
+            self.inspect_assistant_context("approval_decision", approval_decision_id)
+        for action_execution_id in verified_action_execution_ids:
+            self.inspect_assistant_context("action_execution", action_execution_id)
+        self.inspect_reconciliation_status()
+
+        return RestoreDrillSnapshot(
+            read_only=True,
+            drill_passed=True,
+            verified_case_ids=verified_case_ids,
+            verified_approval_decision_ids=verified_approval_decision_ids,
+            verified_action_execution_ids=verified_action_execution_ids,
+            verified_reconciliation_ids=verified_reconciliation_ids,
         )
 
     def inspect_analyst_queue(self) -> AnalystQueueSnapshot:
@@ -4243,6 +4605,194 @@ class AegisOpsControlPlaneService:
             )
         )
         return f"analytic-signal-{uuid.uuid5(uuid.NAMESPACE_URL, mint_material)}"
+
+    def _require_empty_authoritative_restore_target(self) -> None:
+        populated_families = [
+            record_type.record_family
+            for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES
+            if self._store.list(record_type)
+        ]
+        if populated_families:
+            raise ValueError(
+                "authoritative restore target must be empty before restore; found existing "
+                f"records for {', '.join(populated_families)}"
+            )
+
+    def _validate_authoritative_record_chain_restore(
+        self,
+        records_by_family: Mapping[str, tuple[ControlPlaneRecord, ...]],
+    ) -> None:
+        analytic_signals = {
+            record.analytic_signal_id: record
+            for record in records_by_family.get("analytic_signal", ())
+            if isinstance(record, AnalyticSignalRecord)
+        }
+        alerts = {
+            record.alert_id: record
+            for record in records_by_family.get("alert", ())
+            if isinstance(record, AlertRecord)
+        }
+        evidence_records = {
+            record.evidence_id: record
+            for record in records_by_family.get("evidence", ())
+            if isinstance(record, EvidenceRecord)
+        }
+        cases = {
+            record.case_id: record
+            for record in records_by_family.get("case", ())
+            if isinstance(record, CaseRecord)
+        }
+        approval_decisions = {
+            record.approval_decision_id: record
+            for record in records_by_family.get("approval_decision", ())
+            if isinstance(record, ApprovalDecisionRecord)
+        }
+        action_requests = {
+            record.action_request_id: record
+            for record in records_by_family.get("action_request", ())
+            if isinstance(record, ActionRequestRecord)
+        }
+        action_executions = {
+            record.action_execution_id: record
+            for record in records_by_family.get("action_execution", ())
+            if isinstance(record, ActionExecutionRecord)
+        }
+        action_executions_by_run_id = {
+            record.execution_run_id: record for record in action_executions.values()
+        }
+        reconciliations = tuple(
+            record
+            for record in records_by_family.get("reconciliation", ())
+            if isinstance(record, ReconciliationRecord)
+        )
+
+        for alert in alerts.values():
+            if alert.analytic_signal_id and alert.analytic_signal_id not in analytic_signals:
+                raise ValueError(
+                    f"missing analytic_signal record {alert.analytic_signal_id!r} required by alert "
+                    f"{alert.alert_id!r}"
+                )
+            if alert.case_id and alert.case_id not in cases:
+                raise ValueError(
+                    f"missing case record {alert.case_id!r} required by alert {alert.alert_id!r}"
+                )
+
+        for evidence in evidence_records.values():
+            if evidence.alert_id and evidence.alert_id not in alerts:
+                raise ValueError(
+                    f"missing alert record {evidence.alert_id!r} required by evidence "
+                    f"{evidence.evidence_id!r}"
+                )
+            if evidence.case_id and evidence.case_id not in cases:
+                raise ValueError(
+                    f"missing case record {evidence.case_id!r} required by evidence "
+                    f"{evidence.evidence_id!r}"
+                )
+
+        for case in cases.values():
+            if case.alert_id and case.alert_id not in alerts:
+                raise ValueError(
+                    f"missing alert record {case.alert_id!r} required by case {case.case_id!r}"
+                )
+            for evidence_id in case.evidence_ids:
+                if evidence_id not in evidence_records:
+                    raise ValueError(
+                        f"missing evidence record {evidence_id!r} required by case {case.case_id!r}"
+                    )
+
+        for approval_decision in approval_decisions.values():
+            if approval_decision.action_request_id not in action_requests:
+                raise ValueError(
+                    f"missing action_request record {approval_decision.action_request_id!r} required by "
+                    f"approval decision {approval_decision.approval_decision_id!r}"
+                )
+
+        for action_request in action_requests.values():
+            if action_request.case_id and action_request.case_id not in cases:
+                raise ValueError(
+                    f"missing case record {action_request.case_id!r} required by action request "
+                    f"{action_request.action_request_id!r}"
+                )
+            if action_request.alert_id and action_request.alert_id not in alerts:
+                raise ValueError(
+                    f"missing alert record {action_request.alert_id!r} required by action request "
+                    f"{action_request.action_request_id!r}"
+                )
+            if (
+                action_request.approval_decision_id
+                and action_request.approval_decision_id not in approval_decisions
+            ):
+                raise ValueError(
+                    f"missing approval_decision record {action_request.approval_decision_id!r} "
+                    f"required by action request {action_request.action_request_id!r}"
+                )
+
+        for action_execution in action_executions.values():
+            action_request = action_requests.get(action_execution.action_request_id)
+            if action_request is None:
+                raise ValueError(
+                    f"missing action_request record {action_execution.action_request_id!r} required by "
+                    f"action execution {action_execution.action_execution_id!r}"
+                )
+            if action_execution.approval_decision_id not in approval_decisions:
+                raise ValueError(
+                    f"missing approval_decision record {action_execution.approval_decision_id!r} "
+                    f"required by action execution {action_execution.action_execution_id!r}"
+                )
+            if (
+                action_request.approval_decision_id is not None
+                and action_request.approval_decision_id
+                != action_execution.approval_decision_id
+            ):
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match action "
+                    f"request approval binding"
+                )
+
+        for reconciliation in reconciliations:
+            if reconciliation.alert_id and reconciliation.alert_id not in alerts:
+                raise ValueError(
+                    f"missing alert record {reconciliation.alert_id!r} required by reconciliation "
+                    f"{reconciliation.reconciliation_id!r}"
+                )
+            if (
+                reconciliation.analytic_signal_id
+                and reconciliation.analytic_signal_id not in analytic_signals
+            ):
+                raise ValueError(
+                    f"missing analytic_signal record {reconciliation.analytic_signal_id!r} required by "
+                    f"reconciliation {reconciliation.reconciliation_id!r}"
+                )
+            if (
+                reconciliation.execution_run_id
+                and reconciliation.execution_run_id not in action_executions_by_run_id
+            ):
+                raise ValueError(
+                    f"missing action execution run {reconciliation.execution_run_id!r} required by "
+                    f"reconciliation {reconciliation.reconciliation_id!r}"
+                )
+            for field_name, known_ids in (
+                ("alert_ids", alerts),
+                ("case_ids", cases),
+                ("evidence_ids", evidence_records),
+                ("approval_decision_ids", approval_decisions),
+                ("action_request_ids", action_requests),
+                ("action_execution_ids", action_executions),
+            ):
+                for linked_id in self._assistant_ids_from_mapping(
+                    reconciliation.subject_linkage,
+                    field_name,
+                ):
+                    if linked_id not in known_ids:
+                        singular_name = (
+                            field_name[:-4]
+                            if field_name.endswith("_ids")
+                            else field_name
+                        )
+                        raise ValueError(
+                            f"missing {singular_name} record {linked_id!r} required by reconciliation "
+                            f"{reconciliation.reconciliation_id!r}"
+                        )
 
     def _require_case_record(self, case_id: str) -> CaseRecord:
         case_id = self._require_non_empty_string(case_id, "case_id")

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -593,6 +593,10 @@ def _record_from_backup_payload(
                 raise ValueError(
                     f"{family}.{field_info.name} must be a JSON array in restore payload"
                 )
+            if any(not isinstance(item, str) or not item.strip() for item in value):
+                raise ValueError(
+                    f"{family}.{field_info.name} must contain only non-empty strings"
+                )
         elif field_info.name in mapping_fields:
             if not isinstance(value, Mapping):
                 raise ValueError(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1839,7 +1839,7 @@ class AegisOpsControlPlaneService:
             parsed_records,
             restored_record_counts=restored_record_counts,
         )
-        with self._store.transaction():
+        with self._store.transaction(isolation_level="SERIALIZABLE"):
             self._require_empty_authoritative_restore_target()
             for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
                 for record in parsed_records[record_type.record_family]:
@@ -4962,8 +4962,36 @@ class AegisOpsControlPlaneService:
                     f"action execution {action_execution.action_execution_id!r} does not match approval "
                     "decision payload binding"
                 )
+            if approval_decision.approved_expires_at != action_request.expires_at:
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match approval "
+                    "decision expiry binding"
+                )
+            if action_execution.expires_at != action_request.expires_at:
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match action "
+                    "request expiry binding"
+                )
+            if (
+                approval_decision.approved_expires_at is not None
+                and action_execution.delegated_at > approval_decision.approved_expires_at
+            ):
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} exceeds approval "
+                    "expiry binding"
+                )
 
         for reconciliation in reconciliations:
+            subject_action_execution_ids = self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "action_execution_ids",
+            )
+            subject_execution_run_ids = {
+                action_executions[action_execution_id].execution_run_id
+                for action_execution_id in subject_action_execution_ids
+                if action_execution_id in action_executions
+                and action_executions[action_execution_id].execution_run_id is not None
+            }
             if reconciliation.alert_id and reconciliation.alert_id not in alerts:
                 raise ValueError(
                     f"missing alert record {reconciliation.alert_id!r} required by reconciliation "
@@ -4985,11 +5013,28 @@ class AegisOpsControlPlaneService:
                     f"missing action execution run {reconciliation.execution_run_id!r} required by "
                     f"reconciliation {reconciliation.reconciliation_id!r}"
                 )
+            if (
+                reconciliation.execution_run_id is not None
+                and subject_execution_run_ids
+                and reconciliation.execution_run_id not in subject_execution_run_ids
+            ):
+                raise ValueError(
+                    f"reconciliation {reconciliation.reconciliation_id!r} does not match its action "
+                    "execution run binding"
+                )
             for linked_execution_run_id in reconciliation.linked_execution_run_ids:
                 if linked_execution_run_id not in action_executions_by_run_id:
                     raise ValueError(
                         f"missing action execution run {linked_execution_run_id!r} required by "
                         f"reconciliation {reconciliation.reconciliation_id!r}"
+                    )
+                if (
+                    subject_execution_run_ids
+                    and linked_execution_run_id not in subject_execution_run_ids
+                ):
+                    raise ValueError(
+                        f"reconciliation {reconciliation.reconciliation_id!r} does not match its linked "
+                        "action execution runs"
                     )
             for field_name, known_ids in (
                 ("analytic_signal_ids", analytic_signals),

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -449,6 +449,16 @@ AUTHORITATIVE_RECORD_CHAIN_FAMILIES: tuple[str, ...] = tuple(
 AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION = (
     "phase21.authoritative-record-chain.v1"
 )
+_AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY: dict[str, str] = {
+    "analytic_signal": "analytic_signal_id",
+    "alert": "alert_id",
+    "evidence": "evidence_id",
+    "case": "case_id",
+    "approval_decision": "approval_decision_id",
+    "action_request": "action_request_id",
+    "action_execution": "action_execution_id",
+    "reconciliation": "reconciliation_id",
+}
 _BACKUP_DATETIME_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
     "analytic_signal": ("first_seen_at", "last_seen_at"),
     "evidence": ("acquired_at",),
@@ -615,6 +625,12 @@ def _dedupe_strings(values: object) -> tuple[str, ...]:
         if isinstance(value, str) and value not in deduped:
             deduped.append(value)
     return tuple(deduped)
+
+
+def _find_duplicate_strings(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        sorted(value for value, count in Counter(values).items() if count > 1)
+    )
 
 
 def _collect_reviewed_context_scalar_paths(
@@ -1737,14 +1753,15 @@ class AegisOpsControlPlaneService:
     def export_authoritative_record_chain_backup(self) -> dict[str, object]:
         record_families: dict[str, list[dict[str, object]]] = {}
         record_counts: dict[str, int] = {}
-        for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
-            family = record_type.record_family
-            records = [
-                _json_ready(_record_to_dict(record))
-                for record in self._store.list(record_type)
-            ]
-            record_families[family] = records
-            record_counts[family] = len(records)
+        with self._store.transaction():
+            for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
+                family = record_type.record_family
+                records = [
+                    _json_ready(_record_to_dict(record))
+                    for record in self._store.list(record_type)
+                ]
+                record_families[family] = records
+                record_counts[family] = len(records)
         return {
             "backup_schema_version": AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION,
             "created_at": datetime.now(timezone.utc).isoformat(),
@@ -1793,7 +1810,10 @@ class AegisOpsControlPlaneService:
             parsed_records[family] = parsed
             restored_record_counts[family] = len(parsed)
 
-        self._validate_authoritative_record_chain_restore(parsed_records)
+        self._validate_authoritative_record_chain_restore(
+            parsed_records,
+            restored_record_counts=restored_record_counts,
+        )
         with self._store.transaction():
             self._require_empty_authoritative_restore_target()
             for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
@@ -4633,50 +4653,116 @@ class AegisOpsControlPlaneService:
     def _validate_authoritative_record_chain_restore(
         self,
         records_by_family: Mapping[str, tuple[ControlPlaneRecord, ...]],
+        *,
+        restored_record_counts: Mapping[str, int] | None = None,
     ) -> None:
-        analytic_signals = {
-            record.analytic_signal_id: record
+        def duplicate_restore_count_suffix(family: str) -> str:
+            if restored_record_counts is None:
+                return ""
+            return (
+                "; restored_record_counts"
+                f"[{family!r}]={restored_record_counts.get(family)!r}"
+            )
+
+        analytic_signal_records = tuple(
+            record
             for record in records_by_family.get("analytic_signal", ())
             if isinstance(record, AnalyticSignalRecord)
-        }
-        alerts = {
-            record.alert_id: record
+        )
+        alert_records = tuple(
+            record
             for record in records_by_family.get("alert", ())
             if isinstance(record, AlertRecord)
-        }
-        evidence_records = {
-            record.evidence_id: record
+        )
+        evidence_record_family = tuple(
+            record
             for record in records_by_family.get("evidence", ())
             if isinstance(record, EvidenceRecord)
-        }
-        cases = {
-            record.case_id: record
+        )
+        case_records = tuple(
+            record
             for record in records_by_family.get("case", ())
             if isinstance(record, CaseRecord)
-        }
-        approval_decisions = {
-            record.approval_decision_id: record
+        )
+        approval_decision_records = tuple(
+            record
             for record in records_by_family.get("approval_decision", ())
             if isinstance(record, ApprovalDecisionRecord)
-        }
-        action_requests = {
-            record.action_request_id: record
+        )
+        action_request_records = tuple(
+            record
             for record in records_by_family.get("action_request", ())
             if isinstance(record, ActionRequestRecord)
-        }
-        action_executions = {
-            record.action_execution_id: record
+        )
+        action_execution_records = tuple(
+            record
             for record in records_by_family.get("action_execution", ())
             if isinstance(record, ActionExecutionRecord)
-        }
-        action_executions_by_run_id = {
-            record.execution_run_id: record for record in action_executions.values()
-        }
+        )
         reconciliations = tuple(
             record
             for record in records_by_family.get("reconciliation", ())
             if isinstance(record, ReconciliationRecord)
         )
+        for family, records in (
+            ("analytic_signal", analytic_signal_records),
+            ("alert", alert_records),
+            ("evidence", evidence_record_family),
+            ("case", case_records),
+            ("approval_decision", approval_decision_records),
+            ("action_request", action_request_records),
+            ("action_execution", action_execution_records),
+            ("reconciliation", reconciliations),
+        ):
+            duplicates = _find_duplicate_strings(
+                tuple(
+                    getattr(record, _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY[family])
+                    for record in records
+                )
+            )
+            if duplicates:
+                raise ValueError(
+                    "restore payload contains duplicate "
+                    f"{family} identifiers {duplicates!r}"
+                    f"{duplicate_restore_count_suffix(family)}"
+                )
+        duplicate_execution_run_ids = _find_duplicate_strings(
+            tuple(
+                record.execution_run_id
+                for record in action_execution_records
+                if record.execution_run_id is not None
+            )
+        )
+        if duplicate_execution_run_ids:
+            raise ValueError(
+                "restore payload contains duplicate action_execution "
+                f"execution_run_id values {duplicate_execution_run_ids!r}"
+                f"{duplicate_restore_count_suffix('action_execution')}"
+            )
+
+        analytic_signals = {
+            record.analytic_signal_id: record for record in analytic_signal_records
+        }
+        alerts = {record.alert_id: record for record in alert_records}
+        evidence_records = {
+            record.evidence_id: record for record in evidence_record_family
+        }
+        cases = {record.case_id: record for record in case_records}
+        approval_decisions = {
+            record.approval_decision_id: record
+            for record in approval_decision_records
+        }
+        action_requests = {
+            record.action_request_id: record for record in action_request_records
+        }
+        action_executions = {
+            record.action_execution_id: record for record in action_execution_records
+        }
+        action_executions_by_run_id = {
+            record.execution_run_id: record
+            for record in action_execution_records
+            if record.execution_run_id is not None
+        }
 
         for alert in alerts.values():
             if alert.analytic_signal_id and alert.analytic_signal_id not in analytic_signals:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1611,12 +1611,21 @@ class AegisOpsControlPlaneService:
         )
 
     def describe_startup_status(self) -> StartupStatusSnapshot:
+        protected_surface_proxy_bindings_required = bool(
+            self._config.protected_surface_trusted_proxy_cidrs
+        )
         required_bindings = (
             "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN",
             "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET",
             "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET",
-            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET",
-            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT",
+            *(
+                (
+                    "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET",
+                    "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT",
+                )
+                if protected_surface_proxy_bindings_required
+                else ()
+            ),
             "AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN",
             "AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN",
         )
@@ -1827,6 +1836,8 @@ class AegisOpsControlPlaneService:
             self.inspect_assistant_context("approval_decision", approval_decision_id)
         for action_execution_id in verified_action_execution_ids:
             self.inspect_assistant_context("action_execution", action_execution_id)
+        for reconciliation_id in verified_reconciliation_ids:
+            self.inspect_assistant_context("reconciliation", reconciliation_id)
         self.inspect_reconciliation_status()
 
         return RestoreDrillSnapshot(
@@ -4607,9 +4618,10 @@ class AegisOpsControlPlaneService:
         return f"analytic-signal-{uuid.uuid5(uuid.NAMESPACE_URL, mint_material)}"
 
     def _require_empty_authoritative_restore_target(self) -> None:
+        all_record_types = tuple(dict.fromkeys(RECORD_TYPES_BY_FAMILY.values()))
         populated_families = [
             record_type.record_family
-            for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES
+            for record_type in all_record_types
             if self._store.list(record_type)
         ]
         if populated_families:
@@ -4676,6 +4688,20 @@ class AegisOpsControlPlaneService:
                 raise ValueError(
                     f"missing case record {alert.case_id!r} required by alert {alert.alert_id!r}"
                 )
+
+        for analytic_signal in analytic_signals.values():
+            for alert_id in analytic_signal.alert_ids:
+                if alert_id not in alerts:
+                    raise ValueError(
+                        f"missing alert record {alert_id!r} required by analytic signal "
+                        f"{analytic_signal.analytic_signal_id!r}"
+                    )
+            for case_id in analytic_signal.case_ids:
+                if case_id not in cases:
+                    raise ValueError(
+                        f"missing case record {case_id!r} required by analytic signal "
+                        f"{analytic_signal.analytic_signal_id!r}"
+                    )
 
         for evidence in evidence_records.values():
             if evidence.alert_id and evidence.alert_id not in alerts:
@@ -4771,7 +4797,14 @@ class AegisOpsControlPlaneService:
                     f"missing action execution run {reconciliation.execution_run_id!r} required by "
                     f"reconciliation {reconciliation.reconciliation_id!r}"
                 )
+            for linked_execution_run_id in reconciliation.linked_execution_run_ids:
+                if linked_execution_run_id not in action_executions_by_run_id:
+                    raise ValueError(
+                        f"missing action execution run {linked_execution_run_id!r} required by "
+                        f"reconciliation {reconciliation.reconciliation_id!r}"
+                    )
             for field_name, known_ids in (
+                ("analytic_signal_ids", analytic_signals),
                 ("alert_ids", alerts),
                 ("case_ids", cases),
                 ("evidence_ids", evidence_records),

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -55,7 +55,11 @@ class ControlPlaneStore(Protocol):
     def list(self, record_type: Type[RecordT]) -> tuple[RecordT, ...]:
         ...
 
-    def transaction(self) -> AbstractContextManager[None]:
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> AbstractContextManager[None]:
         ...
 
 
@@ -473,6 +477,20 @@ _BACKUP_TUPLE_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
     "approval_decision": ("approver_identities",),
     "reconciliation": ("linked_execution_run_ids",),
 }
+_BACKUP_MAPPING_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
+    "analytic_signal": ("reviewed_context",),
+    "alert": ("reviewed_context",),
+    "case": ("reviewed_context",),
+    "approval_decision": ("target_snapshot",),
+    "action_request": (
+        "target_scope",
+        "requested_payload",
+        "policy_basis",
+        "policy_evaluation",
+    ),
+    "action_execution": ("target_scope", "approved_payload", "provenance"),
+    "reconciliation": ("subject_linkage",),
+}
 
 _ACTION_POLICY_ALLOWED_VALUES: dict[str, tuple[str, ...]] = {
     "severity": ("low", "medium", "high", "critical"),
@@ -556,6 +574,7 @@ def _record_from_backup_payload(
     family = record_type.record_family
     datetime_fields = set(_BACKUP_DATETIME_FIELDS_BY_FAMILY.get(family, ()))
     tuple_fields = set(_BACKUP_TUPLE_FIELDS_BY_FAMILY.get(family, ()))
+    mapping_fields = set(_BACKUP_MAPPING_FIELDS_BY_FAMILY.get(family, ()))
     kwargs: dict[str, object] = {}
     for field_info in fields(record_type):
         if field_info.name not in payload:
@@ -574,6 +593,12 @@ def _record_from_backup_payload(
                 raise ValueError(
                     f"{family}.{field_info.name} must be a JSON array in restore payload"
                 )
+        elif field_info.name in mapping_fields:
+            if not isinstance(value, Mapping):
+                raise ValueError(
+                    f"{family}.{field_info.name} must be a JSON object in restore payload"
+                )
+            value = {str(key): item for key, item in value.items()}
         kwargs[field_info.name] = value
     return record_type(**kwargs)
 
@@ -1753,7 +1778,7 @@ class AegisOpsControlPlaneService:
     def export_authoritative_record_chain_backup(self) -> dict[str, object]:
         record_families: dict[str, list[dict[str, object]]] = {}
         record_counts: dict[str, int] = {}
-        with self._store.transaction():
+        with self._store.transaction(isolation_level="REPEATABLE READ"):
             for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
                 family = record_type.record_family
                 records = [
@@ -1847,7 +1872,6 @@ class AegisOpsControlPlaneService:
         verified_reconciliation_ids = tuple(
             record.reconciliation_id
             for record in self._store.list(ReconciliationRecord)
-            if record.execution_run_id is not None
         )
 
         for case_id in verified_case_ids:
@@ -4813,10 +4837,21 @@ class AegisOpsControlPlaneService:
                     )
 
         for approval_decision in approval_decisions.values():
-            if approval_decision.action_request_id not in action_requests:
+            action_request = action_requests.get(approval_decision.action_request_id)
+            if action_request is None:
                 raise ValueError(
                     f"missing action_request record {approval_decision.action_request_id!r} required by "
                     f"approval decision {approval_decision.approval_decision_id!r}"
+                )
+            if approval_decision.target_snapshot != action_request.target_scope:
+                raise ValueError(
+                    f"approval decision {approval_decision.approval_decision_id!r} does not match "
+                    "action request target binding"
+                )
+            if approval_decision.payload_hash != action_request.payload_hash:
+                raise ValueError(
+                    f"approval decision {approval_decision.approval_decision_id!r} does not match "
+                    "action request payload binding"
                 )
 
         for action_request in action_requests.values():
@@ -4838,6 +4873,24 @@ class AegisOpsControlPlaneService:
                     f"missing approval_decision record {action_request.approval_decision_id!r} "
                     f"required by action request {action_request.action_request_id!r}"
                 )
+            approval_decision = approval_decisions.get(action_request.approval_decision_id)
+            if approval_decision is None:
+                continue
+            if approval_decision.action_request_id != action_request.action_request_id:
+                raise ValueError(
+                    f"action request {action_request.action_request_id!r} does not match approval "
+                    "decision binding"
+                )
+            if approval_decision.target_snapshot != action_request.target_scope:
+                raise ValueError(
+                    f"action request {action_request.action_request_id!r} does not match approval "
+                    "decision target binding"
+                )
+            if approval_decision.payload_hash != action_request.payload_hash:
+                raise ValueError(
+                    f"action request {action_request.action_request_id!r} does not match approval "
+                    "decision payload binding"
+                )
 
         for action_execution in action_executions.values():
             action_request = action_requests.get(action_execution.action_request_id)
@@ -4851,14 +4904,63 @@ class AegisOpsControlPlaneService:
                     f"missing approval_decision record {action_execution.approval_decision_id!r} "
                     f"required by action execution {action_execution.action_execution_id!r}"
                 )
-            if (
-                action_request.approval_decision_id is not None
-                and action_request.approval_decision_id
-                != action_execution.approval_decision_id
-            ):
+            approval_decision = approval_decisions[action_execution.approval_decision_id]
+            if action_request.approval_decision_id != action_execution.approval_decision_id:
                 raise ValueError(
                     f"action execution {action_execution.action_execution_id!r} does not match action "
                     f"request approval binding"
+                )
+            if approval_decision.action_request_id != action_request.action_request_id:
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match approval "
+                    "decision binding"
+                )
+            if action_execution.idempotency_key != action_request.idempotency_key:
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match action "
+                    "request idempotency binding"
+                )
+            if action_execution.target_scope != action_request.target_scope:
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match action "
+                    "request target binding"
+                )
+            if action_execution.approved_payload != action_request.requested_payload:
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match action "
+                    "request approved payload binding"
+                )
+            if action_execution.payload_hash != action_request.payload_hash:
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match action "
+                    "request payload binding"
+                )
+            policy_evaluation = action_request.policy_evaluation
+            if (
+                policy_evaluation.get("execution_surface_type")
+                != action_execution.execution_surface_type
+            ):
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match action "
+                    "request execution surface binding"
+                )
+            if (
+                policy_evaluation.get("execution_surface_id")
+                != action_execution.execution_surface_id
+            ):
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match action "
+                    "request execution surface binding"
+                )
+            if approval_decision.target_snapshot != action_request.target_scope:
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match approval "
+                    "decision target binding"
+                )
+            if approval_decision.payload_hash != action_request.payload_hash:
+                raise ValueError(
+                    f"action execution {action_execution.action_execution_id!r} does not match approval "
+                    "decision payload binding"
                 )
 
         for reconciliation in reconciliations:

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -1479,7 +1479,7 @@ def main(
                 payload = service.restore_authoritative_record_chain_backup(
                     _read_json_file(parsed.input)
                 ).to_dict()
-            except ValueError as exc:
+            except (LookupError, ValueError) as exc:
                 parser.error(str(exc))
         elif command == "run-authoritative-restore-drill":
             try:

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -116,6 +116,22 @@ def _read_json_request_body(handler: BaseHTTPRequestHandler) -> dict[str, object
     return payload
 
 
+def _read_json_file(path: str) -> dict[str, object]:
+    normalized_path = path.strip()
+    if not normalized_path:
+        raise ValueError("input path must be a non-empty string")
+    try:
+        with open(normalized_path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except OSError as exc:
+        raise ValueError(f"input path must point to a readable JSON file: {normalized_path!r}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"input path must contain valid JSON: {exc.msg}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("input path must contain a JSON object")
+    return payload
+
+
 def _peer_addr_is_loopback(peer_addr: str | None) -> bool:
     if peer_addr is None or peer_addr.strip() == "":
         return False
@@ -162,6 +178,31 @@ def _build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser(
         "inspect-reconciliation-status",
         help="Render a read-only reconciliation status summary.",
+    )
+    subparsers.add_parser(
+        "startup-status",
+        help="Render the reviewed production-like startup readiness summary.",
+    )
+    subparsers.add_parser(
+        "shutdown-status",
+        help="Render the reviewed controlled shutdown readiness summary.",
+    )
+    subparsers.add_parser(
+        "backup-authoritative-record-chain",
+        help="Render the reviewed authoritative backup payload for the control-plane record chain.",
+    )
+    restore_backup = subparsers.add_parser(
+        "restore-authoritative-record-chain",
+        help="Restore the reviewed authoritative backup payload into an empty control-plane store.",
+    )
+    restore_backup.add_argument(
+        "--input",
+        required=True,
+        help="Path to the reviewed authoritative backup JSON payload.",
+    )
+    subparsers.add_parser(
+        "run-authoritative-restore-drill",
+        help="Reread the restored authoritative record chain through reviewed service inspections.",
     )
     subparsers.add_parser(
         "inspect-analyst-queue",
@@ -1424,6 +1465,24 @@ def main(
                 parser.error(str(exc))
         elif command == "inspect-reconciliation-status":
             payload = service.inspect_reconciliation_status().to_dict()
+        elif command == "startup-status":
+            payload = service.describe_startup_status().to_dict()
+        elif command == "shutdown-status":
+            payload = service.describe_shutdown_status().to_dict()
+        elif command == "backup-authoritative-record-chain":
+            payload = service.export_authoritative_record_chain_backup()
+        elif command == "restore-authoritative-record-chain":
+            try:
+                payload = service.restore_authoritative_record_chain_backup(
+                    _read_json_file(parsed.input)
+                ).to_dict()
+            except ValueError as exc:
+                parser.error(str(exc))
+        elif command == "run-authoritative-restore-drill":
+            try:
+                payload = service.run_authoritative_restore_drill().to_dict()
+            except (LookupError, ValueError) as exc:
+                parser.error(str(exc))
         elif command == "inspect-analyst-queue":
             payload = service.inspect_analyst_queue().to_dict()
         elif command == "inspect-alert-detail":

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -1470,7 +1470,10 @@ def main(
         elif command == "shutdown-status":
             payload = service.describe_shutdown_status().to_dict()
         elif command == "backup-authoritative-record-chain":
-            payload = service.export_authoritative_record_chain_backup()
+            try:
+                payload = service.export_authoritative_record_chain_backup()
+            except ValueError as exc:
+                parser.error(str(exc))
         elif command == "restore-authoritative-record-chain":
             try:
                 payload = service.restore_authoritative_record_chain_backup(

--- a/control-plane/postgres_test_support.py
+++ b/control-plane/postgres_test_support.py
@@ -68,6 +68,11 @@ class FakePostgresCursor:
         normalized = " ".join(query.strip().split())
         self.backend.statements.append((normalized, params))
 
+        if normalized.upper().startswith("SET TRANSACTION ISOLATION LEVEL "):
+            self.description = None
+            self._rows = []
+            return
+
         insert_match = _INSERT_RE.fullmatch(normalized)
         if insert_match is not None:
             self._execute_insert(insert_match.group("table"), insert_match.group("columns"), params)

--- a/control-plane/postgres_test_support.py
+++ b/control-plane/postgres_test_support.py
@@ -38,12 +38,14 @@ class FakePostgresConnection:
         self.backend = backend
         self.dsn = dsn
         self.tables = copy.deepcopy(backend.tables)
+        self.dirty = False
 
     def cursor(self) -> "FakePostgresCursor":
-        return FakePostgresCursor(self.backend, self.tables)
+        return FakePostgresCursor(self.backend, self.tables, self)
 
     def commit(self) -> None:
-        self.backend.tables = copy.deepcopy(self.tables)
+        if self.dirty:
+            self.backend.tables = copy.deepcopy(self.tables)
 
     def rollback(self) -> None:
         self.tables = copy.deepcopy(self.backend.tables)
@@ -58,9 +60,11 @@ class FakePostgresCursor:
         self,
         backend: FakePostgresBackend,
         tables: dict[str, dict[str, dict[str, object]]],
+        connection: FakePostgresConnection,
     ) -> None:
         self.backend = backend
         self.tables = tables
+        self.connection = connection
         self.description: tuple[tuple[str], ...] | None = None
         self._rows: list[dict[str, object]] = []
 
@@ -109,6 +113,7 @@ class FakePostgresCursor:
         identifier_value = row[identifier_field]
         table_rows = self.tables.setdefault(table, {})
         table_rows[str(identifier_value)] = row
+        self.connection.dirty = True
         self.description = None
         self._rows = []
 

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import http.client
 import io
@@ -24,6 +25,7 @@ from aegisops_control_plane.models import (
     AITraceRecord,
     AlertRecord,
     AnalyticSignalRecord,
+    ApprovalDecisionRecord,
     CaseRecord,
     EvidenceRecord,
     RecommendationRecord,
@@ -280,6 +282,128 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         build_runtime_service.assert_called_once_with()
         run_control_plane_service.assert_called_once_with(service, stderr=mock.ANY)
+
+    def test_startup_and_shutdown_status_commands_render_reviewed_contracts(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
+                protected_surface_reverse_proxy_secret="reviewed-surface-secret",
+                protected_surface_trusted_proxy_cidrs=("10.10.0.5/32",),
+                protected_surface_proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",
+                break_glass_token="reviewed-break-glass-token",
+            ),
+            store=store,
+        )
+        service.persist_record(
+            CaseRecord(
+                case_id="case-shutdown-001",
+                alert_id="alert-shutdown-001",
+                finding_id="finding-shutdown-001",
+                evidence_ids=("evidence-shutdown-001",),
+                lifecycle_state="open",
+            )
+        )
+        startup_stdout = io.StringIO()
+        shutdown_stdout = io.StringIO()
+
+        main.main(["startup-status"], stdout=startup_stdout, service=service)
+        main.main(["shutdown-status"], stdout=shutdown_stdout, service=service)
+
+        startup_payload = json.loads(startup_stdout.getvalue())
+        shutdown_payload = json.loads(shutdown_stdout.getvalue())
+        self.assertTrue(startup_payload["startup_ready"])
+        self.assertEqual(
+            startup_payload["validated_surfaces"],
+            ["wazuh_ingest", "protected_surface"],
+        )
+        self.assertFalse(shutdown_payload["shutdown_ready"])
+        self.assertEqual(shutdown_payload["open_case_ids"], ["case-shutdown-001"])
+
+    def test_backup_and_restore_drill_commands_render_recovery_payloads(self) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-restore-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=action_request.requested_at + timedelta(minutes=10),
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "observed_at": action_request.requested_at + timedelta(minutes=15),
+                    "status": "success",
+                },
+            ),
+            compared_at=action_request.requested_at + timedelta(minutes=16),
+            stale_after=action_request.requested_at + timedelta(hours=1),
+        )
+        backup_stdout = io.StringIO()
+        drill_stdout = io.StringIO()
+
+        main.main(["backup-authoritative-record-chain"], stdout=backup_stdout, service=service)
+        main.main(["run-authoritative-restore-drill"], stdout=drill_stdout, service=service)
+
+        backup_payload = json.loads(backup_stdout.getvalue())
+        drill_payload = json.loads(drill_stdout.getvalue())
+        self.assertEqual(
+            backup_payload["backup_schema_version"],
+            "phase21.authoritative-record-chain.v1",
+        )
+        self.assertEqual(backup_payload["record_counts"]["action_execution"], 1)
+        self.assertTrue(drill_payload["drill_passed"])
+        self.assertIn(
+            approval_decision.approval_decision_id,
+            drill_payload["verified_approval_decision_ids"],
+        )
 
     def test_long_running_runtime_surface_starts_http_server(self) -> None:
         store, _ = make_store()

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -451,6 +451,30 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(exc.exception.code, 2)
         self.assertIn("backup invariants failed closed", stderr.getvalue())
 
+    def test_restore_authoritative_record_chain_reports_usage_error_on_lookup_failure(
+        self,
+    ) -> None:
+        service = mock.Mock()
+        service.restore_authoritative_record_chain_backup.side_effect = LookupError(
+            "restore drill failed closed"
+        )
+        stderr = io.StringIO()
+
+        with mock.patch.object(main, "_read_json_file", return_value={}):
+            with mock.patch.object(sys, "stderr", stderr):
+                with self.assertRaises(SystemExit) as exc:
+                    main.main(
+                        [
+                            "restore-authoritative-record-chain",
+                            "--input",
+                            "authoritative-backup.json",
+                        ],
+                        service=service,
+                    )
+
+        self.assertEqual(exc.exception.code, 2)
+        self.assertIn("restore drill failed closed", stderr.getvalue())
+
     def test_long_running_runtime_surface_starts_http_server(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -288,14 +288,14 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
                 wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
-                protected_surface_reverse_proxy_secret="reviewed-surface-secret",
+                protected_surface_reverse_proxy_secret="reviewed-surface-secret",  # noqa: S106 - test fixture secret
                 protected_surface_trusted_proxy_cidrs=("10.10.0.5/32",),
                 protected_surface_proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
-                admin_bootstrap_token="reviewed-admin-bootstrap-token",
-                break_glass_token="reviewed-break-glass-token",
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
             ),
             store=store,
         )
@@ -323,6 +323,36 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
         self.assertFalse(shutdown_payload["shutdown_ready"])
         self.assertEqual(shutdown_payload["open_case_ids"], ["case-shutdown-001"])
+
+    def test_startup_status_allows_loopback_protected_surface_without_proxy_bindings(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
+            store=store,
+        )
+        startup_stdout = io.StringIO()
+
+        main.main(["startup-status"], stdout=startup_stdout, service=service)
+
+        startup_payload = json.loads(startup_stdout.getvalue())
+        self.assertTrue(startup_payload["startup_ready"])
+        self.assertNotIn(
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET",
+            startup_payload["required_bindings"],
+        )
+        self.assertEqual(
+            startup_payload["validated_surfaces"],
+            ["wazuh_ingest", "protected_surface"],
+        )
 
     def test_backup_and_restore_drill_commands_render_recovery_payloads(self) -> None:
         _store, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
@@ -404,6 +434,22 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             approval_decision.approval_decision_id,
             drill_payload["verified_approval_decision_ids"],
         )
+
+    def test_backup_authoritative_record_chain_reports_usage_error_on_invalid_backup(
+        self,
+    ) -> None:
+        service = mock.Mock()
+        service.export_authoritative_record_chain_backup.side_effect = ValueError(
+            "backup invariants failed closed"
+        )
+        stderr = io.StringIO()
+
+        with mock.patch.object(sys, "stderr", stderr):
+            with self.assertRaises(SystemExit) as exc:
+                main.main(["backup-authoritative-record-chain"], service=service)
+
+        self.assertEqual(exc.exception.code, 2)
+        self.assertIn("backup invariants failed closed", stderr.getvalue())
 
     def test_long_running_runtime_surface_starts_http_server(self) -> None:
         store, _ = make_store()

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -839,6 +839,17 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
         self.assertIsNone(store.get(AlertRecord, "alert-001"))
         self.assertEqual(store.list(AlertRecord), ())
 
+    def test_store_rejects_nested_isolation_level_requests(self) -> None:
+        store, _ = make_store()
+
+        with store.transaction():
+            with self.assertRaisesRegex(
+                ValueError,
+                "Cannot set isolation_level inside an active transaction",
+            ):
+                with store.transaction(isolation_level="SERIALIZABLE"):
+                    pass
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -191,7 +191,6 @@ class _OutOfBandMutationStore:
         with self.inner.transaction():
             yield
 
-
 class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def _build_phase19_in_scope_case(
         self,
@@ -7897,6 +7896,170 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             restored_approval_context.linked_reconciliation_ids,
         )
 
+    def test_service_phase21_backup_uses_single_transaction_snapshot(self) -> None:
+        base_store, _ = make_store()
+        _store, service, promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case(store=base_store)
+        )
+        seed_alert = service.get_record(AlertRecord, promoted_case.alert_id)
+        if seed_alert is None:
+            self.fail("expected seeded alert record before snapshot export")
+
+        snapshot_store = _TransactionMutationStore(
+            inner=base_store,
+            mutate_once=lambda inner_store: inner_store.save(
+                replace(
+                    seed_alert,
+                    alert_id="alert-phase21-backup-concurrent-001",
+                )
+            ),
+        )
+        snapshot_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=snapshot_store,
+        )
+
+        backup = snapshot_service.export_authoritative_record_chain_backup()
+
+        self.assertEqual(backup["record_counts"]["alert"], 2)
+        self.assertEqual(len(backup["record_families"]["alert"]), 2)
+        self.assertCountEqual(
+            [record["alert_id"] for record in backup["record_families"]["alert"]],
+            (
+                "alert-phase21-backup-concurrent-001",
+                promoted_case.alert_id,
+            ),
+        )
+        self.assertEqual(len(base_store.list(AlertRecord)), 2)
+
+    def test_service_phase21_restore_fails_closed_on_duplicate_alert_identifiers(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["alert"].append(
+            dict(backup["record_families"]["alert"][0])
+        )
+        backup["record_counts"]["alert"] = len(backup["record_families"]["alert"])
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"duplicate alert identifiers .*restored_record_counts\['alert'\]=2",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self.assertEqual(restored_store.list(AlertRecord), ())
+
+    def test_service_phase21_restore_fails_closed_on_duplicate_execution_run_ids(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-duplicate-run-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-phase21-duplicate-run-001",
+                action_request_id=approved_request.action_request_id,
+                approval_decision_id=approval_decision.approval_decision_id,
+                delegation_id="delegation-phase21-duplicate-run-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-phase21-duplicate-run-001",
+                idempotency_key=approved_request.idempotency_key,
+                target_scope=dict(approved_request.target_scope),
+                approved_payload=dict(approved_request.requested_payload),
+                payload_hash=approved_request.payload_hash,
+                delegated_at=reviewed_at + timedelta(minutes=1),
+                expires_at=approved_request.expires_at,
+                provenance={"evidence_ids": (evidence_id,)},
+                lifecycle_state="queued",
+            )
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        duplicate_execution = dict(backup["record_families"]["action_execution"][0])
+        duplicate_execution["action_execution_id"] = (
+            "action-execution-phase21-duplicate-run-002"
+        )
+        duplicate_execution["delegation_id"] = "delegation-phase21-duplicate-run-002"
+        duplicate_execution["delegated_at"] = (
+            reviewed_at + timedelta(minutes=2)
+        ).isoformat()
+        backup["record_families"]["action_execution"].append(duplicate_execution)
+        backup["record_counts"]["action_execution"] = len(
+            backup["record_families"]["action_execution"]
+        )
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            (
+                r"duplicate action_execution execution_run_id values "
+                r".*restored_record_counts\['action_execution'\]=2"
+            ),
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self.assertEqual(restored_store.list(ActionExecutionRecord), ())
+
     def test_service_phase21_restore_fails_closed_when_approval_record_is_missing(
         self,
     ) -> None:
@@ -7979,11 +8142,19 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         ):
             restored_service.restore_authoritative_record_chain_backup(backup)
 
+        for record_type in (
+            AnalyticSignalRecord,
+            AlertRecord,
+            EvidenceRecord,
+            CaseRecord,
+            ApprovalDecisionRecord,
+            ActionRequestRecord,
+            ActionExecutionRecord,
+            ReconciliationRecord,
+        ):
+            self.assertEqual(restored_store.list(record_type), ())
         self.assertIsNone(
-            restored_service.get_record(
-                ActionExecutionRecord,
-                execution.action_execution_id,
-            )
+            restored_service.get_record(ActionExecutionRecord, execution.action_execution_id)
         )
 
     def test_service_phase21_restore_fails_closed_when_target_contains_recommendation(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -37,6 +37,7 @@ from aegisops_control_plane.models import (
 from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
 from aegisops_control_plane.service import (
     AegisOpsControlPlaneService,
+    AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES,
     NativeDetectionRecordAdapter,
 )
 from postgres_test_support import make_store
@@ -122,8 +123,12 @@ class _TransactionMutationStore:
         return self.inner.list(record_type)
 
     @contextmanager
-    def transaction(self) -> Iterator[None]:
-        with self.inner.transaction():
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> Iterator[None]:
+        with self.inner.transaction(isolation_level=isolation_level):
             if not self._mutated:
                 self.mutate_once(self.inner)
                 self._mutated = True
@@ -155,8 +160,12 @@ class _ListCountingStore:
         return self.inner.list(record_type)
 
     @contextmanager
-    def transaction(self) -> Iterator[None]:
-        with self.inner.transaction():
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> Iterator[None]:
+        with self.inner.transaction(isolation_level=isolation_level):
             yield
 
 
@@ -184,14 +193,23 @@ class _OutOfBandMutationStore:
         return self.inner.list(record_type)
 
     @contextmanager
-    def transaction(self) -> Iterator[None]:
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> Iterator[None]:
         if not self._mutated:
             self.mutate_once(self.inner)
             self._mutated = True
-        with self.inner.transaction():
+        with self.inner.transaction(isolation_level=isolation_level):
             yield
 
+
 class ControlPlaneServicePersistenceTests(unittest.TestCase):
+    def _assert_authoritative_store_empty(self, store: object) -> None:
+        for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
+            self.assertEqual(store.list(record_type), ())
+
     def _build_phase19_in_scope_case(
         self,
         *,
@@ -7871,6 +7889,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             reconciliation.reconciliation_id,
             restore_drill.verified_reconciliation_ids,
         )
+        self.assertCountEqual(
+            restore_drill.verified_reconciliation_ids,
+            tuple(
+                record.reconciliation_id
+                for record in service._store.list(ReconciliationRecord)
+            ),
+        )
         self.assertIn(
             mock.call("reconciliation", reconciliation.reconciliation_id),
             inspect_assistant_context.call_args_list,
@@ -7897,7 +7922,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
 
     def test_service_phase21_backup_uses_single_transaction_snapshot(self) -> None:
-        base_store, _ = make_store()
+        base_store, backend = make_store()
         _store, service, promoted_case, _evidence_id, _reviewed_at = (
             self._build_phase19_in_scope_case(store=base_store)
         )
@@ -7919,8 +7944,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             store=snapshot_store,
         )
 
+        statement_count_before_backup = len(backend.statements)
         backup = snapshot_service.export_authoritative_record_chain_backup()
 
+        self.assertEqual(
+            backend.statements[statement_count_before_backup][0],
+            "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+        )
         self.assertEqual(backup["record_counts"]["alert"], 2)
         self.assertEqual(len(backup["record_families"]["alert"]), 2)
         self.assertCountEqual(
@@ -7955,7 +7985,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             r"duplicate alert identifiers .*restored_record_counts\['alert'\]=2",
         ):
             restored_service.restore_authoritative_record_chain_backup(backup)
-        self.assertEqual(restored_store.list(AlertRecord), ())
+        self._assert_authoritative_store_empty(restored_store)
 
     def test_service_phase21_restore_fails_closed_on_duplicate_execution_run_ids(
         self,
@@ -8058,7 +8088,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             ),
         ):
             restored_service.restore_authoritative_record_chain_backup(backup)
-        self.assertEqual(restored_store.list(ActionExecutionRecord), ())
+        self._assert_authoritative_store_empty(restored_store)
 
     def test_service_phase21_restore_fails_closed_when_approval_record_is_missing(
         self,
@@ -8142,17 +8172,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         ):
             restored_service.restore_authoritative_record_chain_backup(backup)
 
-        for record_type in (
-            AnalyticSignalRecord,
-            AlertRecord,
-            EvidenceRecord,
-            CaseRecord,
-            ApprovalDecisionRecord,
-            ActionRequestRecord,
-            ActionExecutionRecord,
-            ReconciliationRecord,
-        ):
-            self.assertEqual(restored_store.list(record_type), ())
+        self._assert_authoritative_store_empty(restored_store)
         self.assertIsNone(
             restored_service.get_record(ActionExecutionRecord, execution.action_execution_id)
         )
@@ -8214,6 +8234,165 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "missing alert record 'alert-phase21-missing-analytic-signal-link-001' required by analytic signal",
         ):
             restored_service.restore_authoritative_record_chain_backup(backup)
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_service_phase21_restore_rejects_non_mapping_payload_fields(self) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["alert"][0]["reviewed_context"] = ["not-a-mapping"]
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "alert.reviewed_context must be a JSON object in restore payload",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_service_phase21_restore_rejects_approval_target_binding_mismatch(self) -> None:
+        _store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-binding-mismatch-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["approval_decision"][0]["target_snapshot"] = {
+            "record_family": "recommendation",
+            "record_id": recommendation.recommendation_id,
+            "case_id": promoted_case.case_id,
+            "alert_id": promoted_case.alert_id,
+            "finding_id": promoted_case.finding_id,
+            "recipient_identity": "repo-owner-999",
+        }
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "approval decision 'approval-phase21-binding-mismatch-001' does not match action request target binding",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_service_phase21_restore_rejects_action_execution_surface_binding_mismatch(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-execution-binding-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-phase21-execution-binding-001",
+                action_request_id=approved_request.action_request_id,
+                approval_decision_id=approval_decision.approval_decision_id,
+                delegation_id="delegation-phase21-execution-binding-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-phase21-execution-binding-001",
+                idempotency_key=approved_request.idempotency_key,
+                target_scope=dict(approved_request.target_scope),
+                approved_payload=dict(approved_request.requested_payload),
+                payload_hash=approved_request.payload_hash,
+                delegated_at=reviewed_at + timedelta(minutes=1),
+                expires_at=approved_request.expires_at,
+                provenance={"evidence_ids": (evidence_id,)},
+                lifecycle_state="queued",
+            )
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["action_execution"][0]["execution_surface_id"] = (
+            "isolated-executor"
+        )
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "action execution 'action-execution-phase21-execution-binding-001' does not match action request execution surface binding",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self._assert_authoritative_store_empty(restored_store)
 
     def test_service_phase20_first_live_action_fail_closes_on_downstream_execution_surface_mismatch(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -136,6 +136,42 @@ class _TransactionMutationStore:
 
 
 @dataclass
+class _ConcurrentListMutationStore:
+    inner: object
+    mutate_once: Callable[[], None]
+    _mutated: bool = False
+
+    @property
+    def dsn(self) -> str:
+        return self.inner.dsn
+
+    @property
+    def persistence_mode(self) -> str:
+        return self.inner.persistence_mode
+
+    def save(self, record: object) -> object:
+        return self.inner.save(record)
+
+    def get(self, record_type: object, record_id: str) -> object | None:
+        return self.inner.get(record_type, record_id)
+
+    def list(self, record_type: object) -> tuple[object, ...]:
+        if not self._mutated:
+            self.mutate_once()
+            self._mutated = True
+        return self.inner.list(record_type)
+
+    @contextmanager
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> Iterator[None]:
+        with self.inner.transaction(isolation_level=isolation_level):
+            yield
+
+
+@dataclass
 class _ListCountingStore:
     inner: object
     reconciliation_list_calls: int = 0
@@ -7855,11 +7891,12 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         backup = service.export_authoritative_record_chain_backup()
 
-        restored_store, _ = make_store()
+        restored_store, restored_backend = make_store()
         restored_service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=restored_store,
         )
+        statement_count_before_restore = len(restored_backend.statements)
         with mock.patch.object(
             restored_service,
             "inspect_assistant_context",
@@ -7869,6 +7906,11 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 backup
             )
             restore_drill = restored_service.run_authoritative_restore_drill()
+
+        self.assertEqual(
+            restored_backend.statements[statement_count_before_restore][0],
+            "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+        )
 
         self.assertEqual(
             backup["backup_schema_version"],
@@ -7923,6 +7965,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
     def test_service_phase21_backup_uses_single_transaction_snapshot(self) -> None:
         base_store, backend = make_store()
+        concurrent_store, _ = make_store(backend)
         _store, service, promoted_case, _evidence_id, _reviewed_at = (
             self._build_phase19_in_scope_case(store=base_store)
         )
@@ -7930,9 +7973,9 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         if seed_alert is None:
             self.fail("expected seeded alert record before snapshot export")
 
-        snapshot_store = _TransactionMutationStore(
+        snapshot_store = _ConcurrentListMutationStore(
             inner=base_store,
-            mutate_once=lambda inner_store: inner_store.save(
+            mutate_once=lambda: concurrent_store.save(
                 replace(
                     seed_alert,
                     alert_id="alert-phase21-backup-concurrent-001",
@@ -7951,16 +7994,20 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             backend.statements[statement_count_before_backup][0],
             "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ",
         )
-        self.assertEqual(backup["record_counts"]["alert"], 2)
-        self.assertEqual(len(backup["record_families"]["alert"]), 2)
+        self.assertEqual(backup["record_counts"]["alert"], 1)
+        self.assertEqual(len(backup["record_families"]["alert"]), 1)
         self.assertCountEqual(
             [record["alert_id"] for record in backup["record_families"]["alert"]],
-            (
-                "alert-phase21-backup-concurrent-001",
-                promoted_case.alert_id,
-            ),
+            (promoted_case.alert_id,),
         )
         self.assertEqual(len(base_store.list(AlertRecord)), 2)
+        self.assertEqual(
+            concurrent_store.get(AlertRecord, "alert-phase21-backup-concurrent-001"),
+            replace(
+                seed_alert,
+                alert_id="alert-phase21-backup-concurrent-001",
+            ),
+        )
 
     def test_service_phase21_restore_fails_closed_on_duplicate_alert_identifiers(
         self,
@@ -8390,6 +8437,297 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError,
             "action execution 'action-execution-phase21-execution-binding-001' does not match action request execution surface binding",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_service_phase21_restore_rejects_action_execution_expiry_binding_mismatch(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-expiry-binding-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-phase21-expiry-binding-001",
+                action_request_id=approved_request.action_request_id,
+                approval_decision_id=approval_decision.approval_decision_id,
+                delegation_id="delegation-phase21-expiry-binding-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-phase21-expiry-binding-001",
+                idempotency_key=approved_request.idempotency_key,
+                target_scope=dict(approved_request.target_scope),
+                approved_payload=dict(approved_request.requested_payload),
+                payload_hash=approved_request.payload_hash,
+                delegated_at=reviewed_at + timedelta(minutes=1),
+                expires_at=approved_request.expires_at,
+                provenance={"evidence_ids": (evidence_id,)},
+                lifecycle_state="queued",
+            )
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["action_execution"][0]["expires_at"] = (
+            approved_request.expires_at + timedelta(minutes=5)
+        ).isoformat()
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "action execution 'action-execution-phase21-expiry-binding-001' does not match action request expiry binding",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_service_phase21_restore_rejects_action_execution_delegation_after_approval_expiry(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-expiry-window-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-phase21-expiry-window-001",
+                action_request_id=approved_request.action_request_id,
+                approval_decision_id=approval_decision.approval_decision_id,
+                delegation_id="delegation-phase21-expiry-window-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-phase21-expiry-window-001",
+                idempotency_key=approved_request.idempotency_key,
+                target_scope=dict(approved_request.target_scope),
+                approved_payload=dict(approved_request.requested_payload),
+                payload_hash=approved_request.payload_hash,
+                delegated_at=reviewed_at + timedelta(minutes=1),
+                expires_at=approved_request.expires_at,
+                provenance={"evidence_ids": (evidence_id,)},
+                lifecycle_state="queued",
+            )
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["action_execution"][0]["delegated_at"] = (
+            approved_request.expires_at + timedelta(minutes=1)
+        ).isoformat()
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "action execution 'action-execution-phase21-expiry-window-001' exceeds approval expiry binding",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_service_phase21_restore_rejects_reconciliation_run_binding_mismatch(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        primary_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        primary_decided_at = primary_request.requested_at + timedelta(minutes=1)
+        primary_delegated_at = primary_request.requested_at + timedelta(minutes=2)
+        primary_observed_at = primary_request.requested_at + timedelta(minutes=3)
+        primary_compared_at = primary_request.requested_at + timedelta(minutes=4)
+        primary_stale_after = primary_request.requested_at + timedelta(hours=1)
+        primary_approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-reconciliation-primary-001",
+                action_request_id=primary_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(primary_request.target_scope),
+                payload_hash=primary_request.payload_hash,
+                decided_at=primary_decided_at,
+                lifecycle_state="approved",
+                approved_expires_at=primary_request.expires_at,
+            )
+        )
+        approved_primary_request = service.persist_record(
+            replace(
+                primary_request,
+                approval_decision_id=primary_approval.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        primary_execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_primary_request.action_request_id,
+            approved_payload=dict(approved_primary_request.requested_payload),
+            delegated_at=primary_delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        primary_reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_primary_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": primary_execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_primary_request.idempotency_key,
+                    "approval_decision_id": primary_execution.approval_decision_id,
+                    "delegation_id": primary_execution.delegation_id,
+                    "payload_hash": primary_execution.payload_hash,
+                    "observed_at": primary_observed_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=primary_compared_at,
+            stale_after=primary_stale_after,
+        )
+
+        secondary_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-002",
+            message_intent="Notify the backup repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at + timedelta(hours=1),
+        )
+        secondary_decided_at = secondary_request.requested_at + timedelta(minutes=1)
+        secondary_delegated_at = secondary_request.requested_at + timedelta(minutes=2)
+        secondary_approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-reconciliation-secondary-001",
+                action_request_id=secondary_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(secondary_request.target_scope),
+                payload_hash=secondary_request.payload_hash,
+                decided_at=secondary_decided_at,
+                lifecycle_state="approved",
+                approved_expires_at=secondary_request.expires_at,
+            )
+        )
+        approved_secondary_request = service.persist_record(
+            replace(
+                secondary_request,
+                approval_decision_id=secondary_approval.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        secondary_execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_secondary_request.action_request_id,
+            approved_payload=dict(approved_secondary_request.requested_payload),
+            delegated_at=secondary_delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+
+        backup = service.export_authoritative_record_chain_backup()
+        for record in backup["record_families"]["reconciliation"]:
+            if (
+                record["reconciliation_id"]
+                == primary_reconciliation.reconciliation_id
+            ):
+                record["execution_run_id"] = secondary_execution.execution_run_id
+                record["linked_execution_run_ids"] = [
+                    secondary_execution.execution_run_id
+                ]
+                break
+        else:
+            self.fail("expected primary reconciliation in authoritative backup")
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            f"reconciliation '{primary_reconciliation.reconciliation_id}' does not match its action execution run binding",
         ):
             restored_service.restore_authoritative_record_chain_backup(backup)
         self._assert_authoritative_store_empty(restored_store)

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -7843,8 +7843,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=restored_store,
         )
-        restore_summary = restored_service.restore_authoritative_record_chain_backup(backup)
-        restore_drill = restored_service.run_authoritative_restore_drill()
+        with mock.patch.object(
+            restored_service,
+            "inspect_assistant_context",
+            wraps=restored_service.inspect_assistant_context,
+        ) as inspect_assistant_context:
+            restore_summary = restored_service.restore_authoritative_record_chain_backup(
+                backup
+            )
+            restore_drill = restored_service.run_authoritative_restore_drill()
 
         self.assertEqual(
             backup["backup_schema_version"],
@@ -7864,6 +7871,10 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertIn(
             reconciliation.reconciliation_id,
             restore_drill.verified_reconciliation_ids,
+        )
+        self.assertIn(
+            mock.call("reconciliation", reconciliation.reconciliation_id),
+            inspect_assistant_context.call_args_list,
         )
 
         restored_case_detail = restored_service.inspect_case_detail(promoted_case.case_id)
@@ -7907,10 +7918,22 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
             expires_at=expires_at,
         )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-missing-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
         approved_request = service.persist_record(
             replace(
                 action_request,
-                approval_decision_id="approval-phase21-missing-001",
+                approval_decision_id=approval_decision.approval_decision_id,
                 lifecycle_state="approved",
             )
         )
@@ -7934,8 +7957,15 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             )
         )
         backup = service.export_authoritative_record_chain_backup()
-        backup["record_families"]["approval_decision"] = []
-        backup["record_counts"]["approval_decision"] = 0
+        self.assertEqual(len(backup["record_families"]["approval_decision"]), 1)
+        backup["record_families"]["approval_decision"] = [
+            record
+            for record in backup["record_families"]["approval_decision"]
+            if record["approval_decision_id"] != approval_decision.approval_decision_id
+        ]
+        backup["record_counts"]["approval_decision"] = len(
+            backup["record_families"]["approval_decision"]
+        )
 
         restored_store, _ = make_store()
         restored_service = AegisOpsControlPlaneService(
@@ -7955,6 +7985,64 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 execution.action_execution_id,
             )
         )
+
+    def test_service_phase21_restore_fails_closed_when_target_contains_recommendation(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+        restored_service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-existing-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id="alert-existing-001",
+                case_id="case-existing-001",
+                ai_trace_id=None,
+                review_owner="analyst-001",
+                intended_outcome="Pre-existing recommendation should block restore.",
+                lifecycle_state="under_review",
+                reviewed_context={"reviewed_at": reviewed_at.isoformat()},
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "authoritative restore target must be empty before restore; found existing records for recommendation",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+
+    def test_service_phase21_restore_fails_closed_when_analytic_signal_links_missing_alert(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        self.assertEqual(len(backup["record_families"]["analytic_signal"]), 1)
+        backup["record_families"]["analytic_signal"][0]["alert_ids"] = [
+            "alert-phase21-missing-analytic-signal-link-001"
+        ]
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "missing alert record 'alert-phase21-missing-analytic-signal-link-001' required by analytic signal",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
 
     def test_service_phase20_first_live_action_fail_closes_on_downstream_execution_surface_mismatch(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -7750,6 +7750,212 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             (evidence_id,),
         )
 
+    def test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        decided_at = action_request.requested_at + timedelta(minutes=5)
+        delegated_at = action_request.requested_at + timedelta(minutes=10)
+        observed_at = action_request.requested_at + timedelta(minutes=15)
+        compared_at = action_request.requested_at + timedelta(minutes=16)
+        stale_after = action_request.requested_at + timedelta(hours=1)
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-restore-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=decided_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "observed_at": observed_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=stale_after,
+        )
+
+        backup = service.export_authoritative_record_chain_backup()
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+        restore_summary = restored_service.restore_authoritative_record_chain_backup(backup)
+        restore_drill = restored_service.run_authoritative_restore_drill()
+
+        self.assertEqual(
+            backup["backup_schema_version"],
+            "phase21.authoritative-record-chain.v1",
+        )
+        self.assertEqual(backup["record_counts"]["action_execution"], 1)
+        self.assertEqual(restore_summary.restored_record_counts["reconciliation"], 2)
+        self.assertEqual(
+            restore_drill.verified_action_execution_ids,
+            (execution.action_execution_id,),
+        )
+        self.assertEqual(
+            restore_drill.verified_approval_decision_ids,
+            (approval_decision.approval_decision_id,),
+        )
+        self.assertIn(promoted_case.case_id, restore_drill.verified_case_ids)
+        self.assertIn(
+            reconciliation.reconciliation_id,
+            restore_drill.verified_reconciliation_ids,
+        )
+
+        restored_case_detail = restored_service.inspect_case_detail(promoted_case.case_id)
+        self.assertEqual(
+            restored_case_detail.case_record["case_id"],
+            promoted_case.case_id,
+        )
+        self.assertEqual(restored_case_detail.linked_evidence_ids, (evidence_id,))
+
+        restored_approval_context = restored_service.inspect_assistant_context(
+            "approval_decision",
+            approval_decision.approval_decision_id,
+        )
+        self.assertEqual(
+            restored_approval_context.linked_case_ids,
+            (promoted_case.case_id,),
+        )
+        self.assertIn(
+            reconciliation.reconciliation_id,
+            restored_approval_context.linked_reconciliation_ids,
+        )
+
+    def test_service_phase21_restore_fails_closed_when_approval_record_is_missing(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id="approval-phase21-missing-001",
+                lifecycle_state="approved",
+            )
+        )
+        execution = service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-phase21-missing-001",
+                action_request_id=approved_request.action_request_id,
+                approval_decision_id="approval-phase21-missing-001",
+                delegation_id="delegation-phase21-missing-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-phase21-missing-001",
+                idempotency_key=approved_request.idempotency_key,
+                target_scope=dict(approved_request.target_scope),
+                approved_payload=dict(approved_request.requested_payload),
+                payload_hash=approved_request.payload_hash,
+                delegated_at=reviewed_at + timedelta(minutes=1),
+                expires_at=approved_request.expires_at,
+                provenance={"evidence_ids": (evidence_id,)},
+                lifecycle_state="queued",
+            )
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["approval_decision"] = []
+        backup["record_counts"]["approval_decision"] = 0
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "missing approval_decision record 'approval-phase21-missing-001' required by action request",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+
+        self.assertIsNone(
+            restored_service.get_record(
+                ActionExecutionRecord,
+                execution.action_execution_id,
+            )
+        )
+
     def test_service_phase20_first_live_action_fail_closes_on_downstream_execution_surface_mismatch(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -156,10 +156,11 @@ class _ConcurrentListMutationStore:
         return self.inner.get(record_type, record_id)
 
     def list(self, record_type: object) -> tuple[object, ...]:
+        records = self.inner.list(record_type)
         if not self._mutated:
             self.mutate_once()
             self._mutated = True
-        return self.inner.list(record_type)
+        return records
 
     @contextmanager
     def transaction(
@@ -7905,7 +7906,6 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             restore_summary = restored_service.restore_authoritative_record_chain_backup(
                 backup
             )
-            restore_drill = restored_service.run_authoritative_restore_drill()
 
         self.assertEqual(
             restored_backend.statements[statement_count_before_restore][0],
@@ -7918,21 +7918,25 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
         self.assertEqual(backup["record_counts"]["action_execution"], 1)
         self.assertEqual(restore_summary.restored_record_counts["reconciliation"], 2)
+        self.assertTrue(restore_summary.restore_drill.drill_passed)
         self.assertEqual(
-            restore_drill.verified_action_execution_ids,
+            restore_summary.restore_drill.verified_action_execution_ids,
             (execution.action_execution_id,),
         )
         self.assertEqual(
-            restore_drill.verified_approval_decision_ids,
+            restore_summary.restore_drill.verified_approval_decision_ids,
             (approval_decision.approval_decision_id,),
         )
-        self.assertIn(promoted_case.case_id, restore_drill.verified_case_ids)
+        self.assertIn(
+            promoted_case.case_id,
+            restore_summary.restore_drill.verified_case_ids,
+        )
         self.assertIn(
             reconciliation.reconciliation_id,
-            restore_drill.verified_reconciliation_ids,
+            restore_summary.restore_drill.verified_reconciliation_ids,
         )
         self.assertCountEqual(
-            restore_drill.verified_reconciliation_ids,
+            restore_summary.restore_drill.verified_reconciliation_ids,
             tuple(
                 record.reconciliation_id
                 for record in service._store.list(ReconciliationRecord)
@@ -7962,6 +7966,39 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             reconciliation.reconciliation_id,
             restored_approval_context.linked_reconciliation_ids,
         )
+
+    def test_service_phase21_restore_drill_can_run_standalone_after_restore(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        restore_summary = restored_service.restore_authoritative_record_chain_backup(
+            backup
+        )
+        restore_drill = restored_service.run_authoritative_restore_drill()
+
+        self.assertTrue(restore_drill.drill_passed)
+        self.assertEqual(
+            restore_drill.verified_case_ids,
+            restore_summary.restore_drill.verified_case_ids,
+        )
+        self.assertEqual(
+            restore_drill.verified_reconciliation_ids,
+            restore_summary.restore_drill.verified_reconciliation_ids,
+        )
+        self.assertEqual(restore_drill.verified_case_ids, (promoted_case.case_id,))
+
+        restored_case_detail = restored_service.inspect_case_detail(promoted_case.case_id)
+        self.assertEqual(restored_case_detail.linked_evidence_ids, (evidence_id,))
 
     def test_service_phase21_backup_uses_single_transaction_snapshot(self) -> None:
         base_store, backend = make_store()
@@ -8008,6 +8045,31 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
                 alert_id="alert-phase21-backup-concurrent-001",
             ),
         )
+
+    def test_service_phase21_restore_rejects_non_string_tuple_elements(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["case"][0]["evidence_ids"] = [
+            backup["record_families"]["case"][0]["evidence_ids"][0],
+            {"invalid": "evidence-id"},
+        ]
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "case.evidence_ids must contain only non-empty strings",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self._assert_authoritative_store_empty(restored_store)
 
     def test_service_phase21_restore_fails_closed_on_duplicate_alert_identifiers(
         self,
@@ -8598,7 +8660,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_phase21_restore_rejects_reconciliation_run_binding_mismatch(
         self,
     ) -> None:
-        _store, service, promoted_case, evidence_id, reviewed_at = (
+        _store, service, promoted_case, evidence_id, _reviewed_at = (
             self._build_phase19_in_scope_case()
         )
         recommendation = service.record_case_recommendation(


### PR DESCRIPTION
Closes #436
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Phase 21 recovery slice in the control-plane service and committed it as `526de07` (`Add control-plane recovery chain backup and restore drill`).

The change adds reviewed startup/shutdown status surfaces, authoritative record-chain backup/export, fail-closed restore into an empty target, and a restore drill that rereads restored case, approval, execution, and reconciliation lineage through existing inspection APIs instead of treating raw bytes as sufficient. I also exposed the new startup/shutdown and recovery flows through `control-plane/main.py`, and added focused persistence and CLI tests for successful restore plus missing-approval fail-closed behavior. The issue journal was updated in the workspace with the reproduction, commands, and next-step notes.

Summary: Added startup/shutdown status, authoritative backup/restore, and restore-drill hardening for the control-plane record chain; committed locally as `526de07`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_postgres_store control-plane.tests.test_runtime_skeleton control-plane.tests.test_cli_inspection control-plane.tests.test_phase21_runtime_auth_validation`
Failure signature: none
Next action: push `codex/issue-436` and open/update a draft PR, then extend docs/runbook validation around the new recovery commands if required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup/shutdown diagnostics report required bindings, blockers, and readiness snapshots.
  * Export/import of authoritative record-chain backups with schema/version, timestamps, per-family records, transactional restore, strict validation, and a post-restore verification drill.
  * CLI commands for startup-status, shutdown-status, backup, restore (from file), and restore-drill.
  * Optional transaction isolation control to produce repeatable-read export snapshots.

* **Tests**
  * End-to-end, CLI, snapshot-isolation export, and multiple fail-closed validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->