### PR TITLE
implementation: add structured logs, metrics, health diagnostics, and a production-like operator readiness surface (#437)

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -684,6 +684,10 @@ class PostgresControlPlaneStore:
         )
 
     def inspect_readiness_aggregates(self) -> ReadinessDiagnosticsAggregates:
+        if self._active_connection.get() is None:
+            with self.transaction(isolation_level="REPEATABLE READ"):
+                return self.inspect_readiness_aggregates()
+
         alert_lifecycle_counts = self._count_grouped_by_field(
             AlertRecord,
             "lifecycle_state",

--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -29,6 +29,28 @@ from ..models import (
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
 
 
+@dataclass(frozen=True)
+class ReadinessDiagnosticsAggregates:
+    alert_total: int
+    alert_lifecycle_counts: dict[str, int]
+    case_total: int
+    open_case_ids: tuple[str, ...]
+    action_request_total: int
+    action_request_lifecycle_counts: dict[str, int]
+    active_action_request_ids: tuple[str, ...]
+    action_execution_total: int
+    action_execution_lifecycle_counts: dict[str, int]
+    active_action_execution_ids: tuple[str, ...]
+    reconciliation_total: int
+    reconciliation_lifecycle_counts: dict[str, int]
+    reconciliation_ingest_disposition_counts: dict[str, int]
+    unresolved_reconciliation_ids: tuple[str, ...]
+    latest_reconciliation: ReconciliationRecord | None
+    phase20_requested_action_requests: int
+    phase20_approved_action_requests: int
+    phase20_reconciled_executions: int
+
+
 class CursorProtocol(Protocol):
     description: object | None
 
@@ -660,3 +682,206 @@ class PostgresControlPlaneStore:
             self._row_to_record(record_type, _row_to_mapping(cursor, row))
             for row in rows
         )
+
+    def inspect_readiness_aggregates(self) -> ReadinessDiagnosticsAggregates:
+        alert_lifecycle_counts = self._count_grouped_by_field(
+            AlertRecord,
+            "lifecycle_state",
+        )
+        case_lifecycle_counts = self._count_grouped_by_field(
+            CaseRecord,
+            "lifecycle_state",
+        )
+        action_request_lifecycle_counts = self._count_grouped_by_field(
+            ActionRequestRecord,
+            "lifecycle_state",
+        )
+        action_execution_lifecycle_counts = self._count_grouped_by_field(
+            ActionExecutionRecord,
+            "lifecycle_state",
+        )
+        reconciliation_lifecycle_counts = self._count_grouped_by_field(
+            ReconciliationRecord,
+            "lifecycle_state",
+        )
+        reconciliation_ingest_disposition_counts = self._count_grouped_by_field(
+            ReconciliationRecord,
+            "ingest_disposition",
+        )
+        return ReadinessDiagnosticsAggregates(
+            alert_total=sum(alert_lifecycle_counts.values()),
+            alert_lifecycle_counts=alert_lifecycle_counts,
+            case_total=sum(case_lifecycle_counts.values()),
+            open_case_ids=self._list_identifier_values_by_lifecycle_states(
+                CaseRecord,
+                (
+                    "open",
+                    "investigating",
+                    "pending_action",
+                    "contained_pending_validation",
+                    "reopened",
+                ),
+            ),
+            action_request_total=sum(action_request_lifecycle_counts.values()),
+            action_request_lifecycle_counts=action_request_lifecycle_counts,
+            active_action_request_ids=self._list_identifier_values_by_lifecycle_states(
+                ActionRequestRecord,
+                ("pending_approval", "approved", "executing", "unresolved"),
+            ),
+            action_execution_total=sum(action_execution_lifecycle_counts.values()),
+            action_execution_lifecycle_counts=action_execution_lifecycle_counts,
+            active_action_execution_ids=self._list_identifier_values_by_lifecycle_states(
+                ActionExecutionRecord,
+                ("queued", "running"),
+            ),
+            reconciliation_total=sum(reconciliation_lifecycle_counts.values()),
+            reconciliation_lifecycle_counts=reconciliation_lifecycle_counts,
+            reconciliation_ingest_disposition_counts=reconciliation_ingest_disposition_counts,
+            unresolved_reconciliation_ids=self._list_identifier_values_by_lifecycle_states(
+                ReconciliationRecord,
+                ("pending", "mismatched", "stale"),
+            ),
+            latest_reconciliation=self._latest_reconciliation(),
+            phase20_requested_action_requests=self._count_action_requests_by_action_type(
+                "notify_identity_owner"
+            ),
+            phase20_approved_action_requests=self._count_action_requests_by_action_type(
+                "notify_identity_owner",
+                lifecycle_state="approved",
+            ),
+            phase20_reconciled_executions=self._count_distinct_matched_execution_runs_for_action_type(
+                "notify_identity_owner"
+            ),
+        )
+
+    def _count_grouped_by_field(
+        self,
+        record_type: Type[ControlPlaneRecord],
+        field_name: str,
+    ) -> dict[str, int]:
+        table = self._table_config(record_type)
+        query = (
+            f"select {field_name} as group_value, count(*) as record_count "
+            f"from aegisops_control.{table.table_name} "
+            f"group by {field_name} order by {field_name}"
+        )
+
+        with self._borrow_connection() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(query)
+                rows = cursor.fetchall()
+            finally:
+                cursor.close()
+
+        counts: dict[str, int] = {}
+        for row in rows:
+            mapping = _row_to_mapping(cursor, row)
+            group_value = mapping.get("group_value")
+            if group_value is None:
+                continue
+            counts[str(group_value)] = int(mapping["record_count"])
+        return counts
+
+    def _list_identifier_values_by_lifecycle_states(
+        self,
+        record_type: Type[ControlPlaneRecord],
+        lifecycle_states: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        if not lifecycle_states:
+            return ()
+
+        table = self._table_config(record_type)
+        placeholders = ", ".join("%s" for _ in lifecycle_states)
+        query = (
+            f"select {table.identifier_field} "
+            f"from aegisops_control.{table.table_name} "
+            f"where lifecycle_state in ({placeholders}) "
+            f"order by {table.identifier_field}"
+        )
+
+        with self._borrow_connection() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(query, lifecycle_states)
+                rows = cursor.fetchall()
+            finally:
+                cursor.close()
+
+        return tuple(str(_row_to_mapping(cursor, row)[table.identifier_field]) for row in rows)
+
+    def _latest_reconciliation(self) -> ReconciliationRecord | None:
+        table = self._table_config(ReconciliationRecord)
+        query = (
+            f"select {', '.join(table.record_fields)} "
+            f"from aegisops_control.{table.table_name} "
+            "order by compared_at desc, reconciliation_id desc limit 1"
+        )
+
+        with self._borrow_connection() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(query)
+                row = cursor.fetchone()
+            finally:
+                cursor.close()
+
+        if row is None:
+            return None
+        return self._row_to_record(ReconciliationRecord, _row_to_mapping(cursor, row))
+
+    def _count_action_requests_by_action_type(
+        self,
+        action_type: str,
+        *,
+        lifecycle_state: str | None = None,
+    ) -> int:
+        query = (
+            "select count(*) as record_count "
+            "from aegisops_control.action_request_records "
+            "where requested_payload ->> 'action_type' = %s"
+        )
+        params: tuple[object, ...] = (action_type,)
+        if lifecycle_state is not None:
+            query += " and lifecycle_state = %s"
+            params += (lifecycle_state,)
+
+        with self._borrow_connection() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(query, params)
+                row = cursor.fetchone()
+            finally:
+                cursor.close()
+
+        if row is None:
+            return 0
+        return int(_row_to_mapping(cursor, row)["record_count"])
+
+    def _count_distinct_matched_execution_runs_for_action_type(
+        self,
+        action_type: str,
+    ) -> int:
+        query = (
+            "select count(distinct reconciliation.execution_run_id) as record_count "
+            "from aegisops_control.reconciliation_records as reconciliation "
+            "join aegisops_control.action_execution_records as execution "
+            "on execution.execution_run_id = reconciliation.execution_run_id "
+            "join aegisops_control.action_request_records as action_request "
+            "on action_request.action_request_id = execution.action_request_id "
+            "where action_request.requested_payload ->> 'action_type' = %s "
+            "and reconciliation.lifecycle_state = 'matched' "
+            "and reconciliation.execution_run_id is not null"
+        )
+
+        with self._borrow_connection() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(query, (action_type,))
+                row = cursor.fetchone()
+            finally:
+                cursor.close()
+
+        if row is None:
+            return 0
+        return int(_row_to_mapping(cursor, row)["record_count"])

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -15,7 +15,10 @@ from typing import Mapping, Protocol, Type, TypeVar
 
 from .adapters.executor import IsolatedExecutorAdapter
 from .adapters.n8n import N8NReconciliationAdapter
-from .adapters.postgres import PostgresControlPlaneStore
+from .adapters.postgres import (
+    PostgresControlPlaneStore,
+    ReadinessDiagnosticsAggregates,
+)
 from .adapters.shuffle import ShuffleActionAdapter
 from .adapters.wazuh import WazuhAlertAdapter
 from .config import RuntimeConfig
@@ -61,6 +64,9 @@ class ControlPlaneStore(Protocol):
         *,
         isolation_level: str | None = None,
     ) -> AbstractContextManager[None]:
+        ...
+
+    def inspect_readiness_aggregates(self) -> ReadinessDiagnosticsAggregates:
         ...
 
 
@@ -631,6 +637,41 @@ def _redacted_reconciliation_payload(
         redacted_subject_linkage.pop("latest_native_payload", None)
         payload["subject_linkage"] = redacted_subject_linkage
     return payload
+
+
+def _build_shutdown_status_snapshot(
+    *,
+    open_case_ids: tuple[str, ...],
+    active_action_request_ids: tuple[str, ...],
+    active_action_execution_ids: tuple[str, ...],
+    unresolved_reconciliation_ids: tuple[str, ...],
+) -> ShutdownStatusSnapshot:
+    blocking_reasons: list[str] = []
+    if open_case_ids:
+        blocking_reasons.append(
+            "controlled shutdown requires resolving or explicitly handing off open casework"
+        )
+    if active_action_request_ids:
+        blocking_reasons.append(
+            "controlled shutdown requires approval-bound action requests to leave an inactive state"
+        )
+    if active_action_execution_ids:
+        blocking_reasons.append(
+            "controlled shutdown requires queued or running executions to reach a terminal state"
+        )
+    if unresolved_reconciliation_ids:
+        blocking_reasons.append(
+            "controlled shutdown requires pending reconciliation mismatches to be reviewed first"
+        )
+    return ShutdownStatusSnapshot(
+        read_only=True,
+        shutdown_ready=not blocking_reasons,
+        blocking_reasons=tuple(blocking_reasons),
+        open_case_ids=open_case_ids,
+        active_action_request_ids=active_action_request_ids,
+        active_action_execution_ids=active_action_execution_ids,
+        unresolved_reconciliation_ids=unresolved_reconciliation_ids,
+    )
 
 
 def _parse_backup_datetime(value: object, field_name: str) -> datetime | None:
@@ -1891,184 +1932,99 @@ class AegisOpsControlPlaneService:
         )
 
     def describe_shutdown_status(self) -> ShutdownStatusSnapshot:
-        open_case_ids = tuple(
-            record.case_id
-            for record in self._store.list(CaseRecord)
-            if record.lifecycle_state
-            in {
-                "open",
-                "investigating",
-                "pending_action",
-                "contained_pending_validation",
-                "reopened",
-            }
-        )
-        active_action_request_ids = tuple(
-            record.action_request_id
-            for record in self._store.list(ActionRequestRecord)
-            if record.lifecycle_state
-            in {"pending_approval", "approved", "executing", "unresolved"}
-        )
-        active_action_execution_ids = tuple(
-            record.action_execution_id
-            for record in self._store.list(ActionExecutionRecord)
-            if record.lifecycle_state in {"queued", "running"}
-        )
-        unresolved_reconciliation_ids = tuple(
-            record.reconciliation_id
-            for record in self._store.list(ReconciliationRecord)
-            if record.lifecycle_state in {"pending", "mismatched", "stale"}
-        )
-        blocking_reasons: list[str] = []
-        if open_case_ids:
-            blocking_reasons.append(
-                "controlled shutdown requires resolving or explicitly handing off open casework"
-            )
-        if active_action_request_ids:
-            blocking_reasons.append(
-                "controlled shutdown requires approval-bound action requests to leave an inactive state"
-            )
-        if active_action_execution_ids:
-            blocking_reasons.append(
-                "controlled shutdown requires queued or running executions to reach a terminal state"
-            )
-        if unresolved_reconciliation_ids:
-            blocking_reasons.append(
-                "controlled shutdown requires pending reconciliation mismatches to be reviewed first"
-            )
-        return ShutdownStatusSnapshot(
-            read_only=True,
-            shutdown_ready=not blocking_reasons,
-            blocking_reasons=tuple(blocking_reasons),
-            open_case_ids=open_case_ids,
-            active_action_request_ids=active_action_request_ids,
-            active_action_execution_ids=active_action_execution_ids,
-            unresolved_reconciliation_ids=unresolved_reconciliation_ids,
+        readiness_aggregates = self._inspect_readiness_aggregates()
+        return _build_shutdown_status_snapshot(
+            open_case_ids=readiness_aggregates.open_case_ids,
+            active_action_request_ids=readiness_aggregates.active_action_request_ids,
+            active_action_execution_ids=readiness_aggregates.active_action_execution_ids,
+            unresolved_reconciliation_ids=readiness_aggregates.unresolved_reconciliation_ids,
         )
 
     def inspect_readiness_diagnostics(self) -> ReadinessDiagnosticsSnapshot:
         with self._store.transaction(isolation_level="REPEATABLE READ"):
             startup = self.describe_startup_status()
-            shutdown = self.describe_shutdown_status()
-            alerts = self._store.list(AlertRecord)
-            cases = self._store.list(CaseRecord)
-            action_requests = self._store.list(ActionRequestRecord)
-            action_executions = self._store.list(ActionExecutionRecord)
-            reconciliations = self._store.list(ReconciliationRecord)
+            readiness_aggregates = self._inspect_readiness_aggregates()
 
-        latest_reconciliation = max(
-            reconciliations,
-            key=lambda record: (record.compared_at, record.reconciliation_id),
-            default=None,
+        shutdown = _build_shutdown_status_snapshot(
+            open_case_ids=readiness_aggregates.open_case_ids,
+            active_action_request_ids=readiness_aggregates.active_action_request_ids,
+            active_action_execution_ids=readiness_aggregates.active_action_execution_ids,
+            unresolved_reconciliation_ids=readiness_aggregates.unresolved_reconciliation_ids,
         )
-        reconciliation_states = Counter(
-            record.lifecycle_state for record in reconciliations
-        )
-        action_request_states = Counter(
-            record.lifecycle_state for record in action_requests
-        )
-        action_execution_states = Counter(
-            record.lifecycle_state for record in action_executions
-        )
-        alert_states = Counter(record.lifecycle_state for record in alerts)
-        open_case_states = {
-            "open",
-            "investigating",
-            "pending_action",
-            "contained_pending_validation",
-            "reopened",
-        }
-        phase20_action_requests = tuple(
-            record
-            for record in action_requests
-            if record.requested_payload.get("action_type") == "notify_identity_owner"
-        )
-        phase20_request_ids = {
-            record.action_request_id for record in phase20_action_requests
-        }
-        phase20_executions = tuple(
-            record
-            for record in action_executions
-            if record.action_request_id in phase20_request_ids
-        )
-        phase20_execution_run_ids = {
-            record.execution_run_id
-            for record in phase20_executions
-            if record.execution_run_id is not None
-        }
-        phase20_reconciliations = tuple(
-            record
-            for record in reconciliations
-            if record.execution_run_id in phase20_execution_run_ids
-        )
-        phase20_matched_execution_run_ids = {
-            record.execution_run_id
-            for record in phase20_reconciliations
-            if (
-                record.lifecycle_state == "matched"
-                and record.execution_run_id is not None
-            )
-        }
 
         if not startup.startup_ready:
             status = "failing_closed"
-        elif reconciliation_states.get("stale", 0):
+        elif readiness_aggregates.reconciliation_lifecycle_counts.get("stale", 0):
             status = "stale"
-        elif reconciliation_states.get("mismatched", 0):
+        elif readiness_aggregates.reconciliation_lifecycle_counts.get("mismatched", 0):
             status = "degraded"
         else:
             status = "ready"
 
         metrics = {
             "alerts": {
-                "total": len(alerts),
-                "by_lifecycle_state": dict(sorted(alert_states.items())),
-            },
-            "cases": {
-                "total": len(cases),
-                "open": sum(
-                    1 for record in cases if record.lifecycle_state in open_case_states
+                "total": readiness_aggregates.alert_total,
+                "by_lifecycle_state": dict(
+                    sorted(readiness_aggregates.alert_lifecycle_counts.items())
                 ),
             },
+            "cases": {
+                "total": readiness_aggregates.case_total,
+                "open": len(readiness_aggregates.open_case_ids),
+            },
             "action_requests": {
-                "total": len(action_requests),
-                "pending_approval": action_request_states.get("pending_approval", 0),
-                "approved": action_request_states.get("approved", 0),
-                "executing": action_request_states.get("executing", 0),
-                "unresolved": action_request_states.get("unresolved", 0),
+                "total": readiness_aggregates.action_request_total,
+                "pending_approval": readiness_aggregates.action_request_lifecycle_counts.get(
+                    "pending_approval", 0
+                ),
+                "approved": readiness_aggregates.action_request_lifecycle_counts.get(
+                    "approved", 0
+                ),
+                "executing": readiness_aggregates.action_request_lifecycle_counts.get(
+                    "executing", 0
+                ),
+                "unresolved": readiness_aggregates.action_request_lifecycle_counts.get(
+                    "unresolved", 0
+                ),
             },
             "action_executions": {
-                "total": len(action_executions),
-                "queued": action_execution_states.get("queued", 0),
-                "running": action_execution_states.get("running", 0),
+                "total": readiness_aggregates.action_execution_total,
+                "queued": readiness_aggregates.action_execution_lifecycle_counts.get(
+                    "queued", 0
+                ),
+                "running": readiness_aggregates.action_execution_lifecycle_counts.get(
+                    "running", 0
+                ),
                 "terminal": sum(
                     count
-                    for state, count in action_execution_states.items()
+                    for state, count in readiness_aggregates.action_execution_lifecycle_counts.items()
                     if state not in {"queued", "running"}
                 ),
             },
             "reconciliations": {
-                "total": len(reconciliations),
-                "matched": reconciliation_states.get("matched", 0),
-                "pending": reconciliation_states.get("pending", 0),
-                "mismatched": reconciliation_states.get("mismatched", 0),
-                "stale": reconciliation_states.get("stale", 0),
+                "total": readiness_aggregates.reconciliation_total,
+                "matched": readiness_aggregates.reconciliation_lifecycle_counts.get(
+                    "matched", 0
+                ),
+                "pending": readiness_aggregates.reconciliation_lifecycle_counts.get(
+                    "pending", 0
+                ),
+                "mismatched": readiness_aggregates.reconciliation_lifecycle_counts.get(
+                    "mismatched", 0
+                ),
+                "stale": readiness_aggregates.reconciliation_lifecycle_counts.get(
+                    "stale", 0
+                ),
                 "by_ingest_disposition": dict(
                     sorted(
-                        Counter(
-                            record.ingest_disposition for record in reconciliations
-                        ).items()
+                        readiness_aggregates.reconciliation_ingest_disposition_counts.items()
                     )
                 ),
             },
             "phase20_notify_identity_owner": {
-                "requested_action_requests": len(phase20_action_requests),
-                "approved_action_requests": sum(
-                    1
-                    for record in phase20_action_requests
-                    if record.lifecycle_state == "approved"
-                ),
-                "reconciled_executions": len(phase20_matched_execution_run_ids),
+                "requested_action_requests": readiness_aggregates.phase20_requested_action_requests,
+                "approved_action_requests": readiness_aggregates.phase20_approved_action_requests,
+                "reconciled_executions": readiness_aggregates.phase20_reconciled_executions,
             },
         }
 
@@ -2080,9 +2036,111 @@ class AegisOpsControlPlaneService:
             shutdown=shutdown.to_dict(),
             metrics=metrics,
             latest_reconciliation=(
-                _redacted_reconciliation_payload(latest_reconciliation)
-                if latest_reconciliation is not None
+                _redacted_reconciliation_payload(
+                    readiness_aggregates.latest_reconciliation
+                )
+                if readiness_aggregates.latest_reconciliation is not None
                 else None
+            ),
+        )
+
+    def _inspect_readiness_aggregates(self) -> ReadinessDiagnosticsAggregates:
+        aggregate_reader = getattr(self._store, "inspect_readiness_aggregates", None)
+        if callable(aggregate_reader):
+            return aggregate_reader()
+
+        alerts = self._store.list(AlertRecord)
+        cases = self._store.list(CaseRecord)
+        action_requests = self._store.list(ActionRequestRecord)
+        action_executions = self._store.list(ActionExecutionRecord)
+        reconciliations = self._store.list(ReconciliationRecord)
+
+        latest_reconciliation = max(
+            reconciliations,
+            key=lambda record: (record.compared_at, record.reconciliation_id),
+            default=None,
+        )
+        phase20_action_requests = tuple(
+            record
+            for record in action_requests
+            if record.requested_payload.get("action_type") == "notify_identity_owner"
+        )
+        phase20_request_ids = {
+            record.action_request_id for record in phase20_action_requests
+        }
+        phase20_execution_run_ids = {
+            record.execution_run_id
+            for record in action_executions
+            if (
+                record.action_request_id in phase20_request_ids
+                and record.execution_run_id is not None
+            )
+        }
+        return ReadinessDiagnosticsAggregates(
+            alert_total=len(alerts),
+            alert_lifecycle_counts=dict(
+                Counter(record.lifecycle_state for record in alerts)
+            ),
+            case_total=len(cases),
+            open_case_ids=tuple(
+                record.case_id
+                for record in cases
+                if record.lifecycle_state
+                in {
+                    "open",
+                    "investigating",
+                    "pending_action",
+                    "contained_pending_validation",
+                    "reopened",
+                }
+            ),
+            action_request_total=len(action_requests),
+            action_request_lifecycle_counts=dict(
+                Counter(record.lifecycle_state for record in action_requests)
+            ),
+            active_action_request_ids=tuple(
+                record.action_request_id
+                for record in action_requests
+                if record.lifecycle_state
+                in {"pending_approval", "approved", "executing", "unresolved"}
+            ),
+            action_execution_total=len(action_executions),
+            action_execution_lifecycle_counts=dict(
+                Counter(record.lifecycle_state for record in action_executions)
+            ),
+            active_action_execution_ids=tuple(
+                record.action_execution_id
+                for record in action_executions
+                if record.lifecycle_state in {"queued", "running"}
+            ),
+            reconciliation_total=len(reconciliations),
+            reconciliation_lifecycle_counts=dict(
+                Counter(record.lifecycle_state for record in reconciliations)
+            ),
+            reconciliation_ingest_disposition_counts=dict(
+                Counter(record.ingest_disposition for record in reconciliations)
+            ),
+            unresolved_reconciliation_ids=tuple(
+                record.reconciliation_id
+                for record in reconciliations
+                if record.lifecycle_state in {"pending", "mismatched", "stale"}
+            ),
+            latest_reconciliation=latest_reconciliation,
+            phase20_requested_action_requests=len(phase20_action_requests),
+            phase20_approved_action_requests=sum(
+                1
+                for record in phase20_action_requests
+                if record.lifecycle_state == "approved"
+            ),
+            phase20_reconciled_executions=len(
+                {
+                    record.execution_run_id
+                    for record in reconciliations
+                    if (
+                        record.lifecycle_state == "matched"
+                        and record.execution_run_id in phase20_execution_run_ids
+                    )
+                }
             ),
         )
 

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -8,6 +8,7 @@ import hashlib
 import hmac
 import ipaddress
 import json
+import logging
 import re
 import uuid
 from typing import Mapping, Protocol, Type, TypeVar
@@ -413,6 +414,30 @@ class RestoreSummarySnapshot:
                 "read_only": self.read_only,
                 "restored_record_counts": self.restored_record_counts,
                 "restore_drill": self.restore_drill.to_dict(),
+            }
+        )
+
+
+@dataclass(frozen=True)
+class ReadinessDiagnosticsSnapshot:
+    read_only: bool
+    booted: bool
+    status: str
+    startup: dict[str, object]
+    shutdown: dict[str, object]
+    metrics: dict[str, object]
+    latest_reconciliation: dict[str, object] | None
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(
+            {
+                "read_only": self.read_only,
+                "booted": self.booted,
+                "status": self.status,
+                "startup": self.startup,
+                "shutdown": self.shutdown,
+                "metrics": self.metrics,
+                "latest_reconciliation": self.latest_reconciliation,
             }
         )
 
@@ -1126,6 +1151,7 @@ class AegisOpsControlPlaneService:
         self._isolated_executor = IsolatedExecutorAdapter(
             config.isolated_executor_base_url
         )
+        self._logger = logging.getLogger("aegisops.control_plane")
 
     def describe_runtime(self) -> RuntimeSnapshot:
         return RuntimeSnapshot(
@@ -1150,6 +1176,20 @@ class AegisOpsControlPlaneService:
 
     def persist_record(self, record: RecordT) -> RecordT:
         return self._store.save(record)
+
+    def _emit_structured_event(
+        self,
+        level: int,
+        event: str,
+        **fields: object,
+    ) -> None:
+        payload = {
+            "event": event,
+            "service_name": "aegisops-control-plane",
+            "occurred_at": datetime.now(timezone.utc).isoformat(),
+            **_json_ready(fields),
+        }
+        self._logger.log(level, json.dumps(payload, sort_keys=True, separators=(",", ":")))
 
     def get_record(self, record_type: Type[RecordT], record_id: str) -> RecordT | None:
         return self._store.get(record_type, record_id)
@@ -1316,11 +1356,23 @@ class AegisOpsControlPlaneService:
         self.validate_wazuh_ingest_runtime()
 
         if not self._is_trusted_wazuh_ingest_peer(peer_addr):
+            self._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="untrusted_peer",
+                peer_addr=peer_addr,
+            )
             raise PermissionError(
                 "live Wazuh ingest rejects requests that bypass the reviewed reverse proxy peer boundary"
             )
 
         if (forwarded_proto or "").strip().lower() != "https":
+            self._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="forwarded_proto_not_https",
+                peer_addr=peer_addr,
+            )
             raise PermissionError(
                 "live Wazuh ingest requires the reviewed reverse proxy HTTPS boundary"
             )
@@ -1328,12 +1380,24 @@ class AegisOpsControlPlaneService:
             (reverse_proxy_secret_header or "").strip(),
             self._config.wazuh_ingest_reverse_proxy_secret,
         ):
+            self._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="reverse_proxy_secret_mismatch",
+                peer_addr=peer_addr,
+            )
             raise PermissionError(
                 "live Wazuh ingest requires the reviewed reverse proxy boundary credential"
             )
 
         scheme, separator, supplied_secret = (authorization_header or "").partition(" ")
         if separator == "" or scheme != "Bearer" or supplied_secret.strip() == "":
+            self._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="missing_bearer_secret",
+                peer_addr=peer_addr,
+            )
             raise PermissionError(
                 "live Wazuh ingest requires Authorization: Bearer <shared secret>"
             )
@@ -1341,6 +1405,12 @@ class AegisOpsControlPlaneService:
             supplied_secret.strip(),
             self._config.wazuh_ingest_shared_secret,
         ):
+            self._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="bearer_secret_mismatch",
+                peer_addr=peer_addr,
+            )
             raise PermissionError(
                 "live Wazuh ingest bearer credential did not match the reviewed shared secret"
             )
@@ -1356,6 +1426,13 @@ class AegisOpsControlPlaneService:
             "data.source_family",
         )
         if source_family != "github_audit":
+            self._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="unsupported_source_family",
+                peer_addr=peer_addr,
+                source_family=source_family,
+            )
             raise ValueError(
                 "live Wazuh ingest only admits the reviewed github_audit first live source family"
             )
@@ -1366,7 +1443,18 @@ class AegisOpsControlPlaneService:
             admission_kind="live",
             admission_channel="live_wazuh_webhook",
         )
-        return self.ingest_native_detection_record(adapter, native_record)
+        ingest_result = self.ingest_native_detection_record(adapter, native_record)
+        self._emit_structured_event(
+            logging.INFO,
+            "wazuh_ingest_admitted",
+            peer_addr=peer_addr,
+            source_family=source_family,
+            disposition=ingest_result.disposition,
+            alert_id=ingest_result.alert.alert_id,
+            finding_id=ingest_result.alert.finding_id,
+            reconciliation_id=ingest_result.reconciliation.reconciliation_id,
+        )
+        return ingest_result
 
     def _wazuh_ingest_listener_is_loopback(self) -> bool:
         host = self._config.host.strip()
@@ -1482,7 +1570,7 @@ class AegisOpsControlPlaneService:
             if receipt.base_url.strip() and receipt.base_url != "<set-me>":
                 provenance["adapter_base_url"] = receipt.base_url
 
-            return self.persist_record(
+            execution = self.persist_record(
                 ActionExecutionRecord(
                     action_execution_id=self._next_identifier("action-execution"),
                     action_request_id=action_request.action_request_id,
@@ -1501,6 +1589,18 @@ class AegisOpsControlPlaneService:
                     lifecycle_state="queued",
                 )
             )
+            self._emit_structured_event(
+                logging.INFO,
+                "action_execution_delegated",
+                action_execution_id=execution.action_execution_id,
+                action_request_id=execution.action_request_id,
+                approval_decision_id=execution.approval_decision_id,
+                execution_surface_type=execution.execution_surface_type,
+                execution_surface_id=execution.execution_surface_id,
+                execution_run_id=execution.execution_run_id,
+                lifecycle_state=execution.lifecycle_state,
+            )
+            return execution
 
     def delegate_approved_action_to_isolated_executor(
         self,
@@ -1777,6 +1877,139 @@ class AegisOpsControlPlaneService:
             active_action_request_ids=active_action_request_ids,
             active_action_execution_ids=active_action_execution_ids,
             unresolved_reconciliation_ids=unresolved_reconciliation_ids,
+        )
+
+    def inspect_readiness_diagnostics(self) -> ReadinessDiagnosticsSnapshot:
+        startup = self.describe_startup_status()
+        shutdown = self.describe_shutdown_status()
+        alerts = self._store.list(AlertRecord)
+        cases = self._store.list(CaseRecord)
+        action_requests = self._store.list(ActionRequestRecord)
+        action_executions = self._store.list(ActionExecutionRecord)
+        reconciliations = self._store.list(ReconciliationRecord)
+
+        latest_reconciliation = max(
+            reconciliations,
+            key=lambda record: record.compared_at,
+            default=None,
+        )
+        reconciliation_states = Counter(
+            record.lifecycle_state for record in reconciliations
+        )
+        action_request_states = Counter(
+            record.lifecycle_state for record in action_requests
+        )
+        action_execution_states = Counter(
+            record.lifecycle_state for record in action_executions
+        )
+        alert_states = Counter(record.lifecycle_state for record in alerts)
+        open_case_states = {
+            "open",
+            "investigating",
+            "pending_action",
+            "contained_pending_validation",
+            "reopened",
+        }
+        phase20_action_requests = tuple(
+            record
+            for record in action_requests
+            if record.requested_payload.get("action_type") == "notify_identity_owner"
+        )
+        phase20_request_ids = {
+            record.action_request_id for record in phase20_action_requests
+        }
+        phase20_executions = tuple(
+            record
+            for record in action_executions
+            if record.action_request_id in phase20_request_ids
+        )
+        phase20_execution_ids = {
+            record.execution_run_id for record in phase20_executions
+        }
+        phase20_reconciliations = tuple(
+            record
+            for record in reconciliations
+            if record.execution_run_id in phase20_execution_ids
+        )
+
+        if not startup.startup_ready:
+            status = "failing_closed"
+        elif reconciliation_states.get("stale", 0):
+            status = "stale"
+        elif reconciliation_states.get("mismatched", 0):
+            status = "degraded"
+        else:
+            status = "ready"
+
+        metrics = {
+            "alerts": {
+                "total": len(alerts),
+                "by_lifecycle_state": dict(sorted(alert_states.items())),
+            },
+            "cases": {
+                "total": len(cases),
+                "open": sum(
+                    1 for record in cases if record.lifecycle_state in open_case_states
+                ),
+            },
+            "action_requests": {
+                "total": len(action_requests),
+                "pending_approval": action_request_states.get("pending_approval", 0),
+                "approved": action_request_states.get("approved", 0),
+                "executing": action_request_states.get("executing", 0),
+                "unresolved": action_request_states.get("unresolved", 0),
+            },
+            "action_executions": {
+                "total": len(action_executions),
+                "queued": action_execution_states.get("queued", 0),
+                "running": action_execution_states.get("running", 0),
+                "terminal": sum(
+                    count
+                    for state, count in action_execution_states.items()
+                    if state not in {"queued", "running"}
+                ),
+            },
+            "reconciliations": {
+                "total": len(reconciliations),
+                "matched": reconciliation_states.get("matched", 0),
+                "pending": reconciliation_states.get("pending", 0),
+                "mismatched": reconciliation_states.get("mismatched", 0),
+                "stale": reconciliation_states.get("stale", 0),
+                "by_ingest_disposition": dict(
+                    sorted(
+                        Counter(
+                            record.ingest_disposition for record in reconciliations
+                        ).items()
+                    )
+                ),
+            },
+            "phase20_notify_identity_owner": {
+                "requested_action_requests": len(phase20_action_requests),
+                "approved_action_requests": sum(
+                    1
+                    for record in phase20_action_requests
+                    if record.lifecycle_state == "approved"
+                ),
+                "reconciled_executions": sum(
+                    1
+                    for record in phase20_reconciliations
+                    if record.lifecycle_state == "matched"
+                ),
+            },
+        }
+
+        return ReadinessDiagnosticsSnapshot(
+            read_only=True,
+            booted=True,
+            status=status,
+            startup=startup.to_dict(),
+            shutdown=shutdown.to_dict(),
+            metrics=metrics,
+            latest_reconciliation=(
+                _record_to_dict(latest_reconciliation)
+                if latest_reconciliation is not None
+                else None
+            ),
         )
 
     def export_authoritative_record_chain_backup(self) -> dict[str, object]:
@@ -2900,6 +3133,14 @@ class AegisOpsControlPlaneService:
             )
             for existing in self._store.list(ActionRequestRecord):
                 if existing.idempotency_key == idempotency_key:
+                    self._emit_structured_event(
+                        logging.INFO,
+                        "action_request_reused",
+                        action_request_id=existing.action_request_id,
+                        action_type=existing.requested_payload.get("action_type"),
+                        lifecycle_state=existing.lifecycle_state,
+                        case_id=existing.case_id,
+                    )
                     return existing
 
             normalized_action_request_id = self._resolve_new_record_identifier(
@@ -2908,7 +3149,7 @@ class AegisOpsControlPlaneService:
                 "action_request_id",
                 "action-request",
             )
-            return self.persist_record(
+            created_request = self.persist_record(
                 ActionRequestRecord(
                     action_request_id=normalized_action_request_id,
                     approval_decision_id=None,
@@ -2940,6 +3181,20 @@ class AegisOpsControlPlaneService:
                     },
                 )
             )
+            self._emit_structured_event(
+                logging.INFO,
+                "action_request_created",
+                action_request_id=created_request.action_request_id,
+                action_type=created_request.requested_payload.get("action_type"),
+                requester_identity=created_request.requester_identity,
+                case_id=created_request.case_id,
+                alert_id=created_request.alert_id,
+                lifecycle_state=created_request.lifecycle_state,
+                expires_at=created_request.expires_at.isoformat()
+                if created_request.expires_at is not None
+                else None,
+            )
+            return created_request
 
     def attach_assistant_advisory_draft(
         self,
@@ -4355,7 +4610,7 @@ class AegisOpsControlPlaneService:
                     )
                 )
 
-        return self.persist_record(
+        reconciliation = self.persist_record(
             ReconciliationRecord(
                 reconciliation_id=self._next_identifier("reconciliation"),
                 subject_linkage=subject_linkage,
@@ -4378,6 +4633,18 @@ class AegisOpsControlPlaneService:
                 lifecycle_state=lifecycle_state,
             )
         )
+        self._emit_structured_event(
+            logging.INFO,
+            "action_execution_reconciled",
+            reconciliation_id=reconciliation.reconciliation_id,
+            action_request_id=action_request.action_request_id,
+            execution_surface_type=execution_surface_type,
+            execution_surface_id=execution_surface_id,
+            ingest_disposition=reconciliation.ingest_disposition,
+            lifecycle_state=reconciliation.lifecycle_state,
+            execution_run_id=reconciliation.execution_run_id,
+        )
+        return reconciliation
 
     def _build_action_execution_reconciliation_key(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1250,6 +1250,22 @@ class AegisOpsControlPlaneService:
         }
         self._logger.log(level, json.dumps(payload, sort_keys=True, separators=(",", ":")))
 
+    def _emit_action_execution_delegated_event(
+        self,
+        execution: ActionExecutionRecord,
+    ) -> None:
+        self._emit_structured_event(
+            logging.INFO,
+            "action_execution_delegated",
+            action_execution_id=execution.action_execution_id,
+            action_request_id=execution.action_request_id,
+            approval_decision_id=execution.approval_decision_id,
+            execution_surface_type=execution.execution_surface_type,
+            execution_surface_id=execution.execution_surface_id,
+            execution_run_id=execution.execution_run_id,
+            lifecycle_state=execution.lifecycle_state,
+        )
+
     def get_record(self, record_type: Type[RecordT], record_id: str) -> RecordT | None:
         return self._store.get(record_type, record_id)
 
@@ -1648,17 +1664,7 @@ class AegisOpsControlPlaneService:
                     lifecycle_state="queued",
                 )
             )
-        self._emit_structured_event(
-            logging.INFO,
-            "action_execution_delegated",
-            action_execution_id=execution.action_execution_id,
-            action_request_id=execution.action_request_id,
-            approval_decision_id=execution.approval_decision_id,
-            execution_surface_type=execution.execution_surface_type,
-            execution_surface_id=execution.execution_surface_id,
-            execution_run_id=execution.execution_run_id,
-            lifecycle_state=execution.lifecycle_state,
-        )
+        self._emit_action_execution_delegated_event(execution)
         return execution
 
     def delegate_approved_action_to_isolated_executor(
@@ -1724,7 +1730,7 @@ class AegisOpsControlPlaneService:
             if receipt.base_url.strip() and receipt.base_url != "<set-me>":
                 provenance["adapter_base_url"] = receipt.base_url
 
-            return self.persist_record(
+            execution = self.persist_record(
                 ActionExecutionRecord(
                     action_execution_id=self._next_identifier("action-execution"),
                     action_request_id=action_request.action_request_id,
@@ -1743,6 +1749,8 @@ class AegisOpsControlPlaneService:
                     lifecycle_state="queued",
                 )
             )
+        self._emit_action_execution_delegated_event(execution)
+        return execution
 
     def evaluate_action_policy(self, action_request_id: str) -> ActionRequestRecord:
         action_request_id = self._require_non_empty_string(
@@ -1950,7 +1958,7 @@ class AegisOpsControlPlaneService:
 
         latest_reconciliation = max(
             reconciliations,
-            key=lambda record: record.compared_at,
+            key=lambda record: (record.compared_at, record.reconciliation_id),
             default=None,
         )
         reconciliation_states = Counter(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -621,6 +621,18 @@ def _record_to_dict(record: ControlPlaneRecord) -> dict[str, object]:
     }
 
 
+def _redacted_reconciliation_payload(
+    reconciliation: ReconciliationRecord,
+) -> dict[str, object]:
+    payload = _record_to_dict(reconciliation)
+    subject_linkage_payload = payload.get("subject_linkage")
+    if isinstance(subject_linkage_payload, Mapping):
+        redacted_subject_linkage = dict(subject_linkage_payload)
+        redacted_subject_linkage.pop("latest_native_payload", None)
+        payload["subject_linkage"] = redacted_subject_linkage
+    return payload
+
+
 def _parse_backup_datetime(value: object, field_name: str) -> datetime | None:
     if value is None:
         return None
@@ -1636,18 +1648,18 @@ class AegisOpsControlPlaneService:
                     lifecycle_state="queued",
                 )
             )
-            self._emit_structured_event(
-                logging.INFO,
-                "action_execution_delegated",
-                action_execution_id=execution.action_execution_id,
-                action_request_id=execution.action_request_id,
-                approval_decision_id=execution.approval_decision_id,
-                execution_surface_type=execution.execution_surface_type,
-                execution_surface_id=execution.execution_surface_id,
-                execution_run_id=execution.execution_run_id,
-                lifecycle_state=execution.lifecycle_state,
-            )
-            return execution
+        self._emit_structured_event(
+            logging.INFO,
+            "action_execution_delegated",
+            action_execution_id=execution.action_execution_id,
+            action_request_id=execution.action_request_id,
+            approval_decision_id=execution.approval_decision_id,
+            execution_surface_type=execution.execution_surface_type,
+            execution_surface_id=execution.execution_surface_id,
+            execution_run_id=execution.execution_run_id,
+            lifecycle_state=execution.lifecycle_state,
+        )
+        return execution
 
     def delegate_approved_action_to_isolated_executor(
         self,
@@ -1971,14 +1983,24 @@ class AegisOpsControlPlaneService:
             for record in action_executions
             if record.action_request_id in phase20_request_ids
         )
-        phase20_execution_ids = {
-            record.execution_run_id for record in phase20_executions
+        phase20_execution_run_ids = {
+            record.execution_run_id
+            for record in phase20_executions
+            if record.execution_run_id is not None
         }
         phase20_reconciliations = tuple(
             record
             for record in reconciliations
-            if record.execution_run_id in phase20_execution_ids
+            if record.execution_run_id in phase20_execution_run_ids
         )
+        phase20_matched_execution_run_ids = {
+            record.execution_run_id
+            for record in phase20_reconciliations
+            if (
+                record.lifecycle_state == "matched"
+                and record.execution_run_id is not None
+            )
+        }
 
         if not startup.startup_ready:
             status = "failing_closed"
@@ -2038,11 +2060,7 @@ class AegisOpsControlPlaneService:
                     for record in phase20_action_requests
                     if record.lifecycle_state == "approved"
                 ),
-                "reconciled_executions": sum(
-                    1
-                    for record in phase20_reconciliations
-                    if record.lifecycle_state == "matched"
-                ),
+                "reconciled_executions": len(phase20_matched_execution_run_ids),
             },
         }
 
@@ -2054,7 +2072,7 @@ class AegisOpsControlPlaneService:
             shutdown=shutdown.to_dict(),
             metrics=metrics,
             latest_reconciliation=(
-                _record_to_dict(latest_reconciliation)
+                _redacted_reconciliation_payload(latest_reconciliation)
                 if latest_reconciliation is not None
                 else None
             ),
@@ -2315,12 +2333,9 @@ class AegisOpsControlPlaneService:
                 else (source_systems[0] if source_systems else "wazuh")
             )
         )
-        latest_reconciliation_payload = _record_to_dict(reconciliation)
-        subject_linkage_payload = latest_reconciliation_payload.get("subject_linkage")
-        if isinstance(subject_linkage_payload, Mapping):
-            redacted_subject_linkage = dict(subject_linkage_payload)
-            redacted_subject_linkage.pop("latest_native_payload", None)
-            latest_reconciliation_payload["subject_linkage"] = redacted_subject_linkage
+        latest_reconciliation_payload = _redacted_reconciliation_payload(
+            reconciliation
+        )
         lineage = {
             "finding_id": alert.finding_id,
             "analytic_signal_id": alert.analytic_signal_id,
@@ -3229,20 +3244,20 @@ class AegisOpsControlPlaneService:
                     },
                 )
             )
-            self._emit_structured_event(
-                logging.INFO,
-                "action_request_created",
-                action_request_id=created_request.action_request_id,
-                action_type=created_request.requested_payload.get("action_type"),
-                requester_identity=created_request.requester_identity,
-                case_id=created_request.case_id,
-                alert_id=created_request.alert_id,
-                lifecycle_state=created_request.lifecycle_state,
-                expires_at=created_request.expires_at.isoformat()
-                if created_request.expires_at is not None
-                else None,
-            )
-            return created_request
+        self._emit_structured_event(
+            logging.INFO,
+            "action_request_created",
+            action_request_id=created_request.action_request_id,
+            action_type=created_request.requested_payload.get("action_type"),
+            requester_identity=created_request.requester_identity,
+            case_id=created_request.case_id,
+            alert_id=created_request.alert_id,
+            lifecycle_state=created_request.lifecycle_state,
+            expires_at=created_request.expires_at.isoformat()
+            if created_request.expires_at is not None
+            else None,
+        )
+        return created_request
 
     def attach_assistant_advisory_draft(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -567,6 +567,53 @@ def _json_ready(value: object) -> object:
     return value
 
 
+def _classify_network_identifier(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return "missing"
+    try:
+        peer_ip = ipaddress.ip_address(value.strip())
+    except ValueError:
+        return "invalid"
+    if peer_ip.is_loopback:
+        return "loopback"
+    if peer_ip.is_private:
+        return "private"
+    if peer_ip.is_global:
+        return "public"
+    return "special"
+
+
+def _count_identity_values(value: object) -> int:
+    if isinstance(value, (tuple, list)):
+        return sum(
+            1 for item in value if isinstance(item, str) and item.strip()
+        )
+    if isinstance(value, str) and value.strip():
+        return 1
+    return 0
+
+
+def _sanitize_structured_event_fields(
+    fields: Mapping[str, object],
+) -> dict[str, object]:
+    sanitized: dict[str, object] = {}
+    for key, value in fields.items():
+        normalized_key = str(key)
+        if normalized_key == "peer_addr":
+            sanitized["peer_addr_class"] = _classify_network_identifier(value)
+            continue
+        if normalized_key.endswith("_identity"):
+            sanitized[f"{normalized_key}_present"] = (
+                _count_identity_values(value) > 0
+            )
+            continue
+        if normalized_key.endswith("_identities"):
+            sanitized[f"{normalized_key}_count"] = _count_identity_values(value)
+            continue
+        sanitized[normalized_key] = _json_ready(value)
+    return sanitized
+
+
 def _record_to_dict(record: ControlPlaneRecord) -> dict[str, object]:
     return {
         field.name: getattr(record, field.name)
@@ -1187,7 +1234,7 @@ class AegisOpsControlPlaneService:
             "event": event,
             "service_name": "aegisops-control-plane",
             "occurred_at": datetime.now(timezone.utc).isoformat(),
-            **_json_ready(fields),
+            **_sanitize_structured_event_fields(fields),
         }
         self._logger.log(level, json.dumps(payload, sort_keys=True, separators=(",", ":")))
 
@@ -1880,13 +1927,14 @@ class AegisOpsControlPlaneService:
         )
 
     def inspect_readiness_diagnostics(self) -> ReadinessDiagnosticsSnapshot:
-        startup = self.describe_startup_status()
-        shutdown = self.describe_shutdown_status()
-        alerts = self._store.list(AlertRecord)
-        cases = self._store.list(CaseRecord)
-        action_requests = self._store.list(ActionRequestRecord)
-        action_executions = self._store.list(ActionExecutionRecord)
-        reconciliations = self._store.list(ReconciliationRecord)
+        with self._store.transaction(isolation_level="REPEATABLE READ"):
+            startup = self.describe_startup_status()
+            shutdown = self.describe_shutdown_status()
+            alerts = self._store.list(AlertRecord)
+            cases = self._store.list(CaseRecord)
+            action_requests = self._store.list(ActionRequestRecord)
+            action_executions = self._store.list(ActionExecutionRecord)
+            reconciliations = self._store.list(ReconciliationRecord)
 
         latest_reconciliation = max(
             reconciliations,

--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -449,6 +449,20 @@ def run_control_plane_service(
                 self._write_json(HTTPStatus.OK, service.describe_runtime().to_dict())
                 return
 
+            if request_path == "/diagnostics/readiness":
+                try:
+                    self._require_authenticated_surface_access(
+                        allowed_roles=("analyst", "approver", "platform_admin"),
+                    )
+                except PermissionError as exc:
+                    self._write_forbidden(str(exc))
+                    return
+                self._write_json(
+                    HTTPStatus.OK,
+                    service.inspect_readiness_diagnostics().to_dict(),
+                )
+                return
+
             if request_path == "/admin/bootstrap-status":
                 try:
                     self._require_authenticated_surface_access(

--- a/control-plane/postgres_test_support.py
+++ b/control-plane/postgres_test_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import re
 
 from aegisops_control_plane.adapters.postgres import PostgresControlPlaneStore
@@ -20,6 +21,42 @@ _SELECT_ONE_RE = re.compile(
 _SELECT_ALL_RE = re.compile(
     r"select (?P<columns>.+) from aegisops_control\.(?P<table>\w+) "
     r"order by (?P<identifier>\w+)",
+    re.IGNORECASE,
+)
+_SELECT_GROUP_COUNT_RE = re.compile(
+    r"select (?P<field>\w+) as group_value, count\(\*\) as record_count "
+    r"from aegisops_control\.(?P<table>\w+) "
+    r"group by (?P=field) order by (?P=field)",
+    re.IGNORECASE,
+)
+_SELECT_IDS_BY_STATES_RE = re.compile(
+    r"select (?P<identifier>\w+) from aegisops_control\.(?P<table>\w+) "
+    r"where lifecycle_state in \((?P<placeholders>.+)\) "
+    r"order by (?P=identifier)",
+    re.IGNORECASE,
+)
+_SELECT_LATEST_RECONCILIATION_RE = re.compile(
+    r"select (?P<columns>.+) from aegisops_control\.reconciliation_records "
+    r"order by compared_at desc, reconciliation_id desc limit 1",
+    re.IGNORECASE,
+)
+_COUNT_ACTION_REQUESTS_BY_TYPE_RE = re.compile(
+    r"select count\(\*\) as record_count "
+    r"from aegisops_control\.action_request_records "
+    r"where requested_payload ->> 'action_type' = %s"
+    r"(?: and lifecycle_state = %s)?",
+    re.IGNORECASE,
+)
+_COUNT_MATCHED_EXECUTION_RUNS_BY_TYPE_RE = re.compile(
+    r"select count\(distinct reconciliation\.execution_run_id\) as record_count "
+    r"from aegisops_control\.reconciliation_records as reconciliation "
+    r"join aegisops_control\.action_execution_records as execution "
+    r"on execution\.execution_run_id = reconciliation\.execution_run_id "
+    r"join aegisops_control\.action_request_records as action_request "
+    r"on action_request\.action_request_id = execution\.action_request_id "
+    r"where action_request\.requested_payload ->> 'action_type' = %s "
+    r"and reconciliation\.lifecycle_state = 'matched' "
+    r"and reconciliation\.execution_run_id is not null",
     re.IGNORECASE,
 )
 
@@ -99,6 +136,46 @@ class FakePostgresCursor:
             )
             return
 
+        select_group_count_match = _SELECT_GROUP_COUNT_RE.fullmatch(normalized)
+        if select_group_count_match is not None:
+            self._execute_select_group_count(
+                select_group_count_match.group("table"),
+                select_group_count_match.group("field"),
+            )
+            return
+
+        select_ids_by_states_match = _SELECT_IDS_BY_STATES_RE.fullmatch(normalized)
+        if select_ids_by_states_match is not None:
+            self._execute_select_ids_by_states(
+                select_ids_by_states_match.group("table"),
+                select_ids_by_states_match.group("identifier"),
+                params,
+            )
+            return
+
+        select_latest_reconciliation_match = _SELECT_LATEST_RECONCILIATION_RE.fullmatch(
+            normalized
+        )
+        if select_latest_reconciliation_match is not None:
+            self._execute_select_latest_reconciliation(
+                select_latest_reconciliation_match.group("columns")
+            )
+            return
+
+        count_action_requests_match = _COUNT_ACTION_REQUESTS_BY_TYPE_RE.fullmatch(
+            normalized
+        )
+        if count_action_requests_match is not None:
+            self._execute_count_action_requests_by_type(params)
+            return
+
+        count_matched_execution_runs_match = (
+            _COUNT_MATCHED_EXECUTION_RUNS_BY_TYPE_RE.fullmatch(normalized)
+        )
+        if count_matched_execution_runs_match is not None:
+            self._execute_count_matched_execution_runs_by_type(params)
+            return
+
         raise AssertionError(f"Unsupported fake PostgreSQL query: {normalized}")
 
     def _execute_insert(
@@ -141,6 +218,93 @@ class FakePostgresCursor:
             self._project_row(rows[record_id], column_names)
             for record_id in sorted(rows)
         ]
+
+    def _execute_select_group_count(self, table: str, field_name: str) -> None:
+        grouped_counts: dict[object, int] = {}
+        for row in self.tables.get(table, {}).values():
+            grouped_counts[row[field_name]] = grouped_counts.get(row[field_name], 0) + 1
+        self.description = (("group_value",), ("record_count",))
+        self._rows = [
+            {"group_value": group_value, "record_count": grouped_counts[group_value]}
+            for group_value in sorted(grouped_counts, key=lambda value: str(value))
+        ]
+
+    def _execute_select_ids_by_states(
+        self,
+        table: str,
+        identifier_field: str,
+        params: tuple[object, ...] | None,
+    ) -> None:
+        lifecycle_states = {str(value) for value in (params or ())}
+        rows = self.tables.get(table, {})
+        self.description = ((identifier_field,),)
+        self._rows = [
+            {identifier_field: rows[record_id][identifier_field]}
+            for record_id in sorted(rows)
+            if str(rows[record_id]["lifecycle_state"]) in lifecycle_states
+        ]
+
+    def _execute_select_latest_reconciliation(self, columns: str) -> None:
+        column_names = [column.strip() for column in columns.split(",")]
+        rows = list(self.tables.get("reconciliation_records", {}).values())
+        rows.sort(
+            key=lambda row: (row["compared_at"], row["reconciliation_id"]),
+            reverse=True,
+        )
+        self.description = tuple((name,) for name in column_names)
+        if not rows:
+            self._rows = []
+            return
+        self._rows = [self._project_row(rows[0], column_names)]
+
+    def _execute_count_action_requests_by_type(
+        self,
+        params: tuple[object, ...] | None,
+    ) -> None:
+        action_type = str((params or ("",))[0])
+        lifecycle_state = str(params[1]) if params and len(params) > 1 else None
+        count = 0
+        for row in self.tables.get("action_request_records", {}).values():
+            payload = row.get("requested_payload") or {}
+            if isinstance(payload, str):
+                payload = json.loads(payload)
+            if payload.get("action_type") != action_type:
+                continue
+            if lifecycle_state is not None and row.get("lifecycle_state") != lifecycle_state:
+                continue
+            count += 1
+        self.description = (("record_count",),)
+        self._rows = [{"record_count": count}]
+
+    def _execute_count_matched_execution_runs_by_type(
+        self,
+        params: tuple[object, ...] | None,
+    ) -> None:
+        action_type = str((params or ("",))[0])
+        request_ids = {
+            row["action_request_id"]
+            for row in self.tables.get("action_request_records", {}).values()
+            if (
+                json.loads(row["requested_payload"])
+                if isinstance(row.get("requested_payload"), str)
+                else (row.get("requested_payload") or {})
+            ).get("action_type")
+            == action_type
+        }
+        execution_run_ids = {
+            row["execution_run_id"]
+            for row in self.tables.get("action_execution_records", {}).values()
+            if row.get("action_request_id") in request_ids
+            and row.get("execution_run_id") is not None
+        }
+        matched_execution_run_ids = {
+            row["execution_run_id"]
+            for row in self.tables.get("reconciliation_records", {}).values()
+            if row.get("lifecycle_state") == "matched"
+            and row.get("execution_run_id") in execution_run_ids
+        }
+        self.description = (("record_count",),)
+        self._rows = [{"record_count": len(matched_execution_run_ids)}]
 
     @staticmethod
     def _project_row(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -361,7 +361,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             review_owner="analyst-001",
             intended_outcome="Review repository owner change evidence before any approval-bound response.",
         )
-        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        base_now = datetime.now(timezone.utc)
+        expires_at = base_now + timedelta(hours=4)
         action_request = service.create_reviewed_action_request_from_advisory(
             record_family="recommendation",
             record_id=recommendation.recommendation_id,
@@ -378,7 +379,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 approver_identities=("approver-001",),
                 target_snapshot=dict(action_request.target_scope),
                 payload_hash=action_request.payload_hash,
-                decided_at=reviewed_at + timedelta(minutes=5),
+                decided_at=base_now + timedelta(minutes=5),
                 lifecycle_state="approved",
                 approved_expires_at=action_request.expires_at,
             )
@@ -588,6 +589,272 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 if servers:
                     servers[0].shutdown()
                 thread.join(timeout=2)
+
+    def test_long_running_runtime_surface_exposes_operator_readiness_diagnostics_http_view(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header="Bearer reviewed-shared-secret",  # noqa: S106 - test fixture secret
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        evidence_id = promoted_case.evidence_ids[0]
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        base_now = datetime.now(timezone.utc)
+        expires_at = base_now + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-http-readiness-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=base_now + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=base_now + timedelta(minutes=10),
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "observed_at": base_now + timedelta(minutes=15),
+                    "status": "success",
+                },
+            ),
+            compared_at=base_now + timedelta(minutes=16),
+            stale_after=base_now + timedelta(hours=1),
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
+            service,
+            principal=REVIEWED_ANALYST_PRINCIPAL,
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+                diagnostics_payload = json.loads(
+                    request.urlopen(
+                        f"{base_url}/diagnostics/readiness",
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+
+                self.assertTrue(diagnostics_payload["read_only"])
+                self.assertEqual(diagnostics_payload["status"], "ready")
+                self.assertTrue(diagnostics_payload["booted"])
+                self.assertTrue(diagnostics_payload["startup"]["startup_ready"])
+                self.assertFalse(diagnostics_payload["shutdown"]["shutdown_ready"])
+                self.assertEqual(
+                    diagnostics_payload["metrics"]["action_requests"]["approved"],
+                    1,
+                )
+                self.assertEqual(
+                    diagnostics_payload["metrics"]["action_executions"]["terminal"],
+                    1,
+                )
+                self.assertEqual(
+                    diagnostics_payload["metrics"]["reconciliations"]["matched"],
+                    2,
+                )
+                self.assertEqual(
+                    diagnostics_payload["metrics"]["phase20_notify_identity_owner"]["approved_action_requests"],
+                    1,
+                )
+                self.assertEqual(
+                    diagnostics_payload["metrics"]["phase20_notify_identity_owner"]["reconciled_executions"],
+                    1,
+                )
+                self.assertEqual(
+                    diagnostics_payload["latest_reconciliation"]["reconciliation_id"],
+                    reconciliation.reconciliation_id,
+                )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_service_emits_structured_observability_logs_for_live_path_and_fail_closed_rejection(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        base_now = datetime.now(timezone.utc)
+        expires_at = base_now + timedelta(hours=4)
+
+        with self.assertLogs("aegisops.control_plane", level="INFO") as log_output:
+            service.ingest_wazuh_alert(
+                raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+                authorization_header="Bearer reviewed-shared-secret",
+                forwarded_proto="https",
+                reverse_proxy_secret_header="reviewed-proxy-secret",
+                peer_addr="127.0.0.1",
+            )
+            action_request = service.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id=recommendation.recommendation_id,
+                requester_identity="analyst-001",
+                recipient_identity="repo-owner-001",
+                message_intent="Notify the accountable repository owner about the reviewed permission change.",
+                escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+                expires_at=expires_at,
+            )
+            approval_decision = service.persist_record(
+                ApprovalDecisionRecord(
+                    approval_decision_id="approval-observability-log-001",
+                    action_request_id=action_request.action_request_id,
+                    approver_identities=("approver-001",),
+                    target_snapshot=dict(action_request.target_scope),
+                    payload_hash=action_request.payload_hash,
+                    decided_at=base_now + timedelta(minutes=5),
+                    lifecycle_state="approved",
+                    approved_expires_at=action_request.expires_at,
+                )
+            )
+            approved_request = service.persist_record(
+                replace(
+                    action_request,
+                    approval_decision_id=approval_decision.approval_decision_id,
+                    lifecycle_state="approved",
+                )
+            )
+            execution = service.delegate_approved_action_to_shuffle(
+                action_request_id=approved_request.action_request_id,
+                approved_payload=dict(approved_request.requested_payload),
+                delegated_at=base_now + timedelta(minutes=10),
+                delegation_issuer="control-plane-service",
+                evidence_ids=(evidence_id,),
+            )
+            service.reconcile_action_execution(
+                action_request_id=approved_request.action_request_id,
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                observed_executions=(
+                    {
+                        "execution_run_id": execution.execution_run_id,
+                        "execution_surface_id": "shuffle",
+                        "idempotency_key": approved_request.idempotency_key,
+                        "approval_decision_id": execution.approval_decision_id,
+                        "delegation_id": execution.delegation_id,
+                        "payload_hash": execution.payload_hash,
+                        "observed_at": base_now + timedelta(minutes=15),
+                        "status": "success",
+                    },
+                ),
+                compared_at=base_now + timedelta(minutes=16),
+                stale_after=base_now + timedelta(hours=1),
+            )
+
+        structured_events = [
+            json.loads(entry.split(":", 2)[2]) for entry in log_output.output
+        ]
+        self.assertEqual(
+            [event["event"] for event in structured_events],
+            [
+                "wazuh_ingest_admitted",
+                "action_request_created",
+                "action_execution_delegated",
+                "action_execution_reconciled",
+            ],
+        )
+        self.assertEqual(structured_events[0]["disposition"], "deduplicated")
+        self.assertEqual(
+            structured_events[1]["action_type"],
+            "notify_identity_owner",
+        )
+        self.assertEqual(structured_events[2]["execution_surface_id"], "shuffle")
+        self.assertEqual(structured_events[3]["lifecycle_state"], "matched")
+
+        with self.assertLogs("aegisops.control_plane", level="WARNING") as rejected_logs:
+            with self.assertRaisesRegex(
+                PermissionError,
+                "reviewed reverse proxy boundary credential",
+            ):
+                service.ingest_wazuh_alert(
+                    raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+                    authorization_header="Bearer reviewed-shared-secret",
+                    forwarded_proto="https",
+                    reverse_proxy_secret_header="invalid-secret",
+                    peer_addr="127.0.0.1",
+                )
+
+        rejection_event = json.loads(rejected_logs.output[0].split(":", 2)[2])
+        self.assertEqual(rejection_event["event"], "wazuh_ingest_rejected")
+        self.assertEqual(rejection_event["reason"], "reverse_proxy_secret_mismatch")
 
     def test_long_running_runtime_surface_exposes_analyst_queue_alert_detail_and_case_detail_http_views(
         self,

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -704,7 +704,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
 
                 base_url = f"http://127.0.0.1:{servers[0].server_port}"
                 diagnostics_payload = json.loads(
-                    request.urlopen(
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
                         f"{base_url}/diagnostics/readiness",
                         timeout=2,
                     ).read().decode("utf-8")
@@ -747,7 +747,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
     def test_service_emits_structured_observability_logs_for_live_path_and_fail_closed_rejection(
         self,
     ) -> None:
-        _store, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        _store, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case()
         recommendation = service.record_case_recommendation(
             case_id=promoted_case.case_id,
             review_owner="analyst-001",
@@ -759,9 +759,9 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         with self.assertLogs("aegisops.control_plane", level="INFO") as log_output:
             service.ingest_wazuh_alert(
                 raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
-                authorization_header="Bearer reviewed-shared-secret",
+                authorization_header="Bearer reviewed-shared-secret",  # noqa: S106 - test fixture secret
                 forwarded_proto="https",
-                reverse_proxy_secret_header="reviewed-proxy-secret",
+                reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
                 peer_addr="127.0.0.1",
             )
             action_request = service.create_reviewed_action_request_from_advisory(
@@ -832,10 +832,14 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             ],
         )
         self.assertEqual(structured_events[0]["disposition"], "deduplicated")
+        self.assertEqual(structured_events[0]["peer_addr_class"], "loopback")
+        self.assertNotIn("peer_addr", structured_events[0])
         self.assertEqual(
             structured_events[1]["action_type"],
             "notify_identity_owner",
         )
+        self.assertTrue(structured_events[1]["requester_identity_present"])
+        self.assertNotIn("requester_identity", structured_events[1])
         self.assertEqual(structured_events[2]["execution_surface_id"], "shuffle")
         self.assertEqual(structured_events[3]["lifecycle_state"], "matched")
 
@@ -846,15 +850,17 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             ):
                 service.ingest_wazuh_alert(
                     raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
-                    authorization_header="Bearer reviewed-shared-secret",
+                    authorization_header="Bearer reviewed-shared-secret",  # noqa: S106 - test fixture secret
                     forwarded_proto="https",
-                    reverse_proxy_secret_header="invalid-secret",
+                    reverse_proxy_secret_header="invalid-secret",  # noqa: S106 - intentional negative test fixture
                     peer_addr="127.0.0.1",
                 )
 
         rejection_event = json.loads(rejected_logs.output[0].split(":", 2)[2])
         self.assertEqual(rejection_event["event"], "wazuh_ingest_rejected")
         self.assertEqual(rejection_event["reason"], "reverse_proxy_secret_mismatch")
+        self.assertEqual(rejection_event["peer_addr_class"], "loopback")
+        self.assertNotIn("peer_addr", rejection_event)
 
     def test_long_running_runtime_surface_exposes_analyst_queue_alert_detail_and_case_detail_http_views(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -8046,6 +8046,64 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             ),
         )
 
+    def test_service_phase21_readiness_uses_single_transaction_snapshot(self) -> None:
+        base_store, backend = make_store()
+        concurrent_store, _ = make_store(backend)
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case(store=base_store)
+        )
+        seed_reconciliation = max(
+            service._store.list(ReconciliationRecord),
+            key=lambda record: record.compared_at,
+            default=None,
+        )
+        if seed_reconciliation is None:
+            self.fail("expected seeded reconciliation record before readiness snapshot")
+
+        concurrent_reconciliation = replace(
+            seed_reconciliation,
+            reconciliation_id="reconciliation-phase21-readiness-concurrent-001",
+            compared_at=seed_reconciliation.compared_at + timedelta(minutes=30),
+            lifecycle_state="stale",
+        )
+        snapshot_store = _ConcurrentListMutationStore(
+            inner=base_store,
+            mutate_once=lambda: concurrent_store.save(concurrent_reconciliation),
+        )
+        snapshot_service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
+            store=snapshot_store,
+        )
+
+        statement_count_before_snapshot = len(backend.statements)
+        readiness = snapshot_service.inspect_readiness_diagnostics()
+
+        self.assertEqual(
+            backend.statements[statement_count_before_snapshot][0],
+            "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+        )
+        self.assertEqual(readiness.status, "ready")
+        self.assertEqual(readiness.metrics["reconciliations"]["stale"], 0)
+        self.assertEqual(
+            readiness.latest_reconciliation["reconciliation_id"],
+            seed_reconciliation.reconciliation_id,
+        )
+        self.assertEqual(len(base_store.list(ReconciliationRecord)), 2)
+        self.assertEqual(
+            concurrent_store.get(
+                ReconciliationRecord,
+                "reconciliation-phase21-readiness-concurrent-001",
+            ),
+            concurrent_reconciliation,
+        )
+
     def test_service_phase21_restore_rejects_non_string_tuple_elements(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -123,6 +123,9 @@ class _TransactionMutationStore:
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
 
+    def inspect_readiness_aggregates(self) -> object:
+        return self.inner.inspect_readiness_aggregates()
+
     @contextmanager
     def transaction(
         self,
@@ -163,6 +166,13 @@ class _ConcurrentListMutationStore:
             self._mutated = True
         return records
 
+    def inspect_readiness_aggregates(self) -> object:
+        aggregates = self.inner.inspect_readiness_aggregates()
+        if not self._mutated:
+            self.mutate_once()
+            self._mutated = True
+        return aggregates
+
     @contextmanager
     def transaction(
         self,
@@ -195,6 +205,9 @@ class _CommitFailingStore:
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
 
+    def inspect_readiness_aggregates(self) -> object:
+        return self.inner.inspect_readiness_aggregates()
+
     @contextmanager
     def transaction(
         self,
@@ -209,6 +222,7 @@ class _CommitFailingStore:
 @dataclass
 class _ListCountingStore:
     inner: object
+    list_calls: int = 0
     reconciliation_list_calls: int = 0
 
     @property
@@ -226,9 +240,13 @@ class _ListCountingStore:
         return self.inner.get(record_type, record_id)
 
     def list(self, record_type: object) -> tuple[object, ...]:
+        self.list_calls += 1
         if record_type is ReconciliationRecord:
             self.reconciliation_list_calls += 1
         return self.inner.list(record_type)
+
+    def inspect_readiness_aggregates(self) -> object:
+        return self.inner.inspect_readiness_aggregates()
 
     @contextmanager
     def transaction(
@@ -262,6 +280,9 @@ class _OutOfBandMutationStore:
 
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
+
+    def inspect_readiness_aggregates(self) -> object:
+        return self.inner.inspect_readiness_aggregates()
 
     @contextmanager
     def transaction(
@@ -8338,6 +8359,30 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             ),
             concurrent_reconciliation,
         )
+
+    def test_service_phase21_readiness_avoids_full_table_list_reads(self) -> None:
+        inner_store, _ = make_store()
+        store = _ListCountingStore(inner=inner_store)
+        _store, _service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
+            store=store,
+        )
+
+        store.list_calls = 0
+        readiness = service.inspect_readiness_diagnostics()
+
+        self.assertEqual(readiness.status, "ready")
+        self.assertEqual(store.list_calls, 0)
 
     def test_service_phase21_readiness_counts_distinct_execution_runs_and_redacts_payload(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -173,6 +173,39 @@ class _ConcurrentListMutationStore:
 
 
 @dataclass
+class _CommitFailingStore:
+    inner: object
+    message: str = "synthetic commit failure"
+
+    @property
+    def dsn(self) -> str:
+        return self.inner.dsn
+
+    @property
+    def persistence_mode(self) -> str:
+        return self.inner.persistence_mode
+
+    def save(self, record: object) -> object:
+        return self.inner.save(record)
+
+    def get(self, record_type: object, record_id: str) -> object | None:
+        return self.inner.get(record_type, record_id)
+
+    def list(self, record_type: object) -> tuple[object, ...]:
+        return self.inner.list(record_type)
+
+    @contextmanager
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> Iterator[None]:
+        with self.inner.transaction(isolation_level=isolation_level):
+            yield
+            raise RuntimeError(self.message)
+
+
+@dataclass
 class _ListCountingStore:
     inner: object
     reconciliation_list_calls: int = 0
@@ -6820,6 +6853,90 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             execution,
         )
 
+    def test_service_does_not_emit_action_execution_delegated_log_before_commit(
+        self,
+    ) -> None:
+        base_store, _ = make_store()
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        expires_at = datetime(2026, 4, 5, 13, 0, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "workstation-001"}
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        seed_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=base_store,
+        )
+        seed_service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-routine-commit-failure-001",
+                action_request_id="action-request-routine-commit-failure-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        seed_service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-routine-commit-failure-001",
+                approval_decision_id="approval-routine-commit-failure-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-routine-commit-failure-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=expires_at,
+                lifecycle_state="approved",
+                policy_basis={
+                    "severity": "low",
+                    "target_scope": "single_asset",
+                    "action_reversibility": "reversible",
+                    "asset_criticality": "standard",
+                    "identity_criticality": "standard",
+                    "blast_radius": "single_target",
+                    "execution_constraint": "routine_allowed",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "shuffle",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+                requested_payload=approved_payload,
+            )
+        )
+        failing_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=_CommitFailingStore(base_store),
+        )
+
+        with mock.patch.object(failing_service, "_emit_structured_event") as emit_event:
+            with self.assertRaisesRegex(RuntimeError, "synthetic commit failure"):
+                failing_service.delegate_approved_action_to_shuffle(
+                    action_request_id="action-request-routine-commit-failure-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        emit_event.assert_not_called()
+        self.assertEqual(base_store.list(ActionExecutionRecord), ())
+
     def test_service_rechecks_shuffle_approval_inside_transaction(self) -> None:
         inner_store, _ = make_store()
         seed_service = AegisOpsControlPlaneService(
@@ -7680,6 +7797,38 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
         self.assertEqual(store.list(ActionExecutionRecord), ())
 
+    def test_service_does_not_emit_action_request_created_log_before_commit(
+        self,
+    ) -> None:
+        base_store, service, promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Prepare a reviewed owner notification request.",
+        )
+        failing_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=_CommitFailingStore(base_store),
+        )
+        baseline_requests = base_store.list(ActionRequestRecord)
+
+        with mock.patch.object(failing_service, "_emit_structured_event") as emit_event:
+            with self.assertRaisesRegex(RuntimeError, "synthetic commit failure"):
+                failing_service.create_reviewed_action_request_from_advisory(
+                    record_family="recommendation",
+                    record_id=recommendation.recommendation_id,
+                    requester_identity="analyst-001",
+                    recipient_identity="repo-owner-001",
+                    message_intent="Notify the repository owner about the reviewed change.",
+                    escalation_reason="Reviewed low-risk action remains approval-bound.",
+                    expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+                )
+
+        emit_event.assert_not_called()
+        self.assertEqual(base_store.list(ActionRequestRecord), baseline_requests)
+
     def test_service_executes_phase20_first_live_action_end_to_end_from_reviewed_recommendation(
         self,
     ) -> None:
@@ -8103,6 +8252,180 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             ),
             concurrent_reconciliation,
         )
+
+    def test_service_phase21_readiness_counts_distinct_execution_runs_and_redacts_payload(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        target_scope = {"asset_id": "asset-phase21-readiness-001"}
+        latest_seed_reconciliation = max(
+            service._store.list(ReconciliationRecord),
+            key=lambda record: record.compared_at,
+        )
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id=promoted_case.case_id,
+            alert_id=promoted_case.alert_id,
+            finding_id=promoted_case.finding_id,
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        requested_at = latest_seed_reconciliation.compared_at + timedelta(minutes=10)
+        delegated_at = requested_at + timedelta(minutes=5)
+        expires_at = requested_at + timedelta(hours=1)
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-readiness-001",
+                action_request_id="action-request-phase21-readiness-001",
+                approver_identities=("approver-001",),
+                target_snapshot=target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-phase21-readiness-001",
+                approval_decision_id="approval-phase21-readiness-001",
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                idempotency_key="idempotency-phase21-readiness-001",
+                target_scope=target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=expires_at,
+                lifecycle_state="approved",
+                requester_identity="analyst-001",
+                requested_payload=approved_payload,
+                policy_basis={
+                    "severity": "low",
+                    "target_scope": "single_identity",
+                    "action_reversibility": "reversible",
+                    "asset_criticality": "standard",
+                    "identity_criticality": "standard",
+                    "blast_radius": "single_target",
+                    "execution_constraint": "routine_allowed",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-phase21-readiness-001",
+                action_request_id="action-request-phase21-readiness-001",
+                approval_decision_id="approval-phase21-readiness-001",
+                delegation_id="delegation-phase21-readiness-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-phase21-readiness-001",
+                idempotency_key="idempotency-phase21-readiness-001",
+                target_scope=target_scope,
+                approved_payload=approved_payload,
+                payload_hash=payload_hash,
+                delegated_at=delegated_at,
+                expires_at=expires_at,
+                provenance={"adapter": "shuffle"},
+                lifecycle_state="queued",
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase21-readiness-distinct-001",
+                subject_linkage={
+                    "action_request_ids": ("action-request-phase21-readiness-001",),
+                    "latest_native_payload": {"secret": "keep-in-store"},
+                },
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id="execution-run-phase21-readiness-001",
+                linked_execution_run_ids=(),
+                correlation_key="reconciliation:phase21-readiness:distinct-001",
+                first_seen_at=requested_at,
+                last_seen_at=delegated_at,
+                ingest_disposition="matched",
+                mismatch_summary="phase20 execution matched",
+                compared_at=delegated_at + timedelta(minutes=1),
+                lifecycle_state="matched",
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase21-readiness-distinct-002",
+                subject_linkage={
+                    "action_request_ids": ("action-request-phase21-readiness-001",),
+                    "latest_native_payload": {"secret": "keep-in-store"},
+                },
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id="execution-run-phase21-readiness-001",
+                linked_execution_run_ids=(),
+                correlation_key="reconciliation:phase21-readiness:distinct-002",
+                first_seen_at=requested_at,
+                last_seen_at=delegated_at,
+                ingest_disposition="matched",
+                mismatch_summary="duplicate reconciliation for same execution run",
+                compared_at=delegated_at + timedelta(minutes=2),
+                lifecycle_state="matched",
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase21-readiness-distinct-none-001",
+                subject_linkage={
+                    "action_request_ids": ("action-request-phase21-readiness-001",),
+                    "latest_native_payload": {"secret": "keep-in-store"},
+                },
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id=None,
+                linked_execution_run_ids=(),
+                correlation_key="reconciliation:phase21-readiness:distinct-none-001",
+                first_seen_at=requested_at,
+                last_seen_at=delegated_at,
+                ingest_disposition="matched",
+                mismatch_summary="null execution run should stay out of phase20 metric",
+                compared_at=delegated_at + timedelta(minutes=3),
+                lifecycle_state="matched",
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+
+        self.assertEqual(
+            readiness.metrics["phase20_notify_identity_owner"]["reconciled_executions"],
+            1,
+        )
+        self.assertEqual(
+            readiness.latest_reconciliation["reconciliation_id"],
+            "reconciliation-phase21-readiness-distinct-none-001",
+        )
+        self.assertNotIn(
+            "latest_native_payload",
+            readiness.latest_reconciliation["subject_linkage"],
+        )
+        stored_latest = service.get_record(
+            ReconciliationRecord,
+            "reconciliation-phase21-readiness-distinct-none-001",
+        )
+        self.assertIsNotNone(stored_latest)
+        self.assertIn("latest_native_payload", stored_latest.subject_linkage)
 
     def test_service_phase21_restore_rejects_non_string_tuple_elements(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 import hashlib
 import json
+import logging
 import pathlib
 import secrets
 import sys
@@ -7506,6 +7507,91 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             execution,
         )
 
+    def test_service_emits_action_execution_delegated_log_for_isolated_executor(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        expires_at = datetime(2026, 4, 5, 13, 0, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "critical-host-003"}
+        approved_payload = {
+            "action_type": "disable_identity",
+            "asset_id": "critical-host-003",
+        }
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="executor",
+            execution_surface_id="isolated-executor",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-executor-log-001",
+                action_request_id="action-request-executor-log-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-executor-log-001",
+                approval_decision_id="approval-executor-log-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-executor-log-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=expires_at,
+                lifecycle_state="approved",
+                policy_basis={
+                    "severity": "critical",
+                    "target_scope": "single_asset",
+                    "action_reversibility": "irreversible",
+                    "asset_criticality": "critical",
+                    "identity_criticality": "high",
+                    "blast_radius": "organization",
+                    "execution_constraint": "requires_isolated_executor",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "executor",
+                    "execution_surface_id": "isolated-executor",
+                },
+            )
+        )
+
+        with mock.patch.object(service, "_emit_structured_event") as emit_event:
+            execution = service.delegate_approved_action_to_isolated_executor(
+                action_request_id="action-request-executor-log-001",
+                approved_payload=approved_payload,
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+            )
+
+        emit_event.assert_called_once_with(
+            logging.INFO,
+            "action_execution_delegated",
+            action_execution_id=execution.action_execution_id,
+            action_request_id=execution.action_request_id,
+            approval_decision_id=execution.approval_decision_id,
+            execution_surface_type=execution.execution_surface_type,
+            execution_surface_id=execution.execution_surface_id,
+            execution_run_id=execution.execution_run_id,
+            lifecycle_state=execution.lifecycle_state,
+        )
+
     def test_service_rejects_isolated_executor_delegation_for_cross_linked_approval(
         self,
     ) -> None:
@@ -8426,6 +8512,43 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
         self.assertIsNotNone(stored_latest)
         self.assertIn("latest_native_payload", stored_latest.subject_linkage)
+
+    def test_service_phase21_readiness_prefers_higher_reconciliation_id_when_compared_at_ties(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("agent-origin-alert.json")
+            ),
+        )
+        reconciliation = service.get_record(
+            ReconciliationRecord,
+            admitted.reconciliation.reconciliation_id,
+        )
+        self.assertIsNotNone(reconciliation)
+
+        preferred_reconciliation = replace(
+            reconciliation,
+            reconciliation_id=f"{reconciliation.reconciliation_id}-z",
+            correlation_key=f"{reconciliation.correlation_key}:z",
+        )
+        service.persist_record(preferred_reconciliation)
+
+        readiness = service.inspect_readiness_diagnostics()
+
+        self.assertIsNotNone(readiness.latest_reconciliation)
+        self.assertEqual(
+            readiness.latest_reconciliation["reconciliation_id"],
+            preferred_reconciliation.reconciliation_id,
+        )
 
     def test_service_phase21_restore_rejects_non_string_tuple_elements(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -214,9 +214,43 @@ class _CommitFailingStore:
         *,
         isolation_level: str | None = None,
     ) -> Iterator[None]:
-        with self.inner.transaction(isolation_level=isolation_level):
-            yield
-            raise RuntimeError(self.message)
+        connection_factory = self.inner.connection_factory
+        if connection_factory is None:
+            raise AssertionError(
+                "_CommitFailingStore requires an explicit connection factory"
+            )
+
+        def commit_failing_connection_factory(dsn: str) -> "_CommitFailingConnection":
+            return _CommitFailingConnection(
+                inner=connection_factory(dsn),
+                message=self.message,
+            )
+
+        with mock.patch.object(
+            self.inner,
+            "connection_factory",
+            commit_failing_connection_factory,
+        ):
+            with self.inner.transaction(isolation_level=isolation_level):
+                yield
+
+
+@dataclass
+class _CommitFailingConnection:
+    inner: object
+    message: str
+
+    def cursor(self) -> object:
+        return self.inner.cursor()
+
+    def commit(self) -> None:
+        raise RuntimeError(self.message)
+
+    def rollback(self) -> object:
+        return self.inner.rollback()
+
+    def close(self) -> object:
+        return self.inner.close()
 
 
 @dataclass
@@ -8356,6 +8390,68 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             concurrent_store.get(
                 ReconciliationRecord,
                 "reconciliation-phase21-readiness-concurrent-001",
+            ),
+            concurrent_reconciliation,
+        )
+
+    def test_store_phase21_readiness_aggregates_use_single_transaction_snapshot(self) -> None:
+        base_store, backend = make_store()
+        concurrent_store, _ = make_store(backend)
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case(store=base_store)
+        )
+        seed_reconciliation = max(
+            service._store.list(ReconciliationRecord),
+            key=lambda record: record.compared_at,
+            default=None,
+        )
+        if seed_reconciliation is None:
+            self.fail("expected seeded reconciliation record before readiness aggregate snapshot")
+
+        concurrent_reconciliation = replace(
+            seed_reconciliation,
+            reconciliation_id="reconciliation-phase21-aggregate-concurrent-001",
+            compared_at=seed_reconciliation.compared_at + timedelta(minutes=30),
+            lifecycle_state="stale",
+        )
+        original_count_grouped_by_field = base_store._count_grouped_by_field
+        mutation_applied = False
+
+        def count_grouped_by_field(
+            record_type: object,
+            field_name: str,
+        ) -> dict[str, int]:
+            nonlocal mutation_applied
+            counts = original_count_grouped_by_field(record_type, field_name)
+            if not mutation_applied:
+                mutation_applied = True
+                concurrent_store.save(concurrent_reconciliation)
+            return counts
+
+        statement_count_before_snapshot = len(backend.statements)
+        with mock.patch.object(
+            base_store,
+            "_count_grouped_by_field",
+            side_effect=count_grouped_by_field,
+        ):
+            aggregates = base_store.inspect_readiness_aggregates()
+
+        self.assertEqual(
+            backend.statements[statement_count_before_snapshot][0],
+            "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+        )
+        self.assertEqual(aggregates.reconciliation_lifecycle_counts.get("stale", 0), 0)
+        self.assertEqual(
+            aggregates.latest_reconciliation.reconciliation_id
+            if aggregates.latest_reconciliation is not None
+            else None,
+            seed_reconciliation.reconciliation_id,
+        )
+        self.assertEqual(len(base_store.list(ReconciliationRecord)), 2)
+        self.assertEqual(
+            concurrent_store.get(
+                ReconciliationRecord,
+                "reconciliation-phase21-aggregate-concurrent-001",
             ),
             concurrent_reconciliation,
         )


### PR DESCRIPTION
Closes #437
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a focused runtime slice on `codex/issue-437` and committed it as `c0fa68d` (`Add runtime readiness diagnostics and structured logs`).

The change adds a protected operator-facing readiness surface at `GET /diagnostics/readiness`, backed by a typed service snapshot that reports startup state, shutdown blockers, readiness status, latest reconciliation context, and scoped metrics for alerts, cases, action requests, executions, reconciliations, and the Phase 20 `notify_identity_owner` path. It also adds structured JSON service logs for admitted and rejected Wazuh ingest, action-request creation or reuse, delegation, and reconciliation transitions. The main coverage landed in [service.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-437/control-plane/aegisops_control_plane/service.py), [main.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-437/control-plane/main.py), and [test_cli_inspection.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-437/control-plane/tests/test_cli_inspection.py).

Verification run:
`python3 -m unittest control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_long_running_runtime_surface_exposes_operator_readiness_diagnostics_http_view control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_service_emits_structured_observability_logs_for_live_path_and_fail_closed_rejection`
`python3 -m unittest control-plane.tests.test_cli_inspection control-plane.tests.test_runtime_skeleton`
`python3 -m unittest control...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Readiness diagnostics HTTP view exposing health/status flags, boot/shutdown readiness, aggregated lifecycle metrics, and a redacted latest reconciliation payload.
  * Structured JSON observability: emits normalized events for ingest (admitted/rejected with reason) and lifecycle actions (delegation/reconciliation/creation/reuse).

* **Bug Fixes**
  * Ensure lifecycle events are emitted only after successful persistence; readiness inspection returns redacted sensitive payloads.

* **Tests**
  * Added tests for readiness view, snapshot isolation, structured logs, commit-failure ordering, and delegation/reconciliation metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->