### PR TITLE
implementation: onboard the first reviewed identity-rich second live source on the existing control-plane contracts (#439)

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -5522,8 +5522,9 @@ class AegisOpsControlPlaneService:
                 error_message=error_message,
             )
         elif context_snapshot.record_family == "ai_trace":
-            if self._phase19_context_declares_out_of_scope_provenance(
-                context_snapshot.record.get("subject_linkage")
+            subject_linkage = context_snapshot.record.get("subject_linkage")
+            if self._phase19_context_explicitly_declares_provenance(subject_linkage) and (
+                self._phase19_context_declares_out_of_scope_provenance(subject_linkage)
             ):
                 raise ValueError(error_message)
             if not context_snapshot.linked_recommendation_records:
@@ -5566,8 +5567,9 @@ class AegisOpsControlPlaneService:
             if lead is None or lead.case_id != case_id:
                 raise ValueError(error_message)
 
-        if self._phase19_context_declares_out_of_scope_provenance(
-            payload.get("reviewed_context")
+        reviewed_context = payload.get("reviewed_context")
+        if self._phase19_context_explicitly_declares_provenance(reviewed_context) and (
+            self._phase19_context_declares_out_of_scope_provenance(reviewed_context)
         ):
             raise ValueError(error_message)
 
@@ -5667,6 +5669,16 @@ class AegisOpsControlPlaneService:
                 "admission_channel": "live_wazuh_webhook",
             }
         )
+
+    @staticmethod
+    def _phase19_context_explicitly_declares_provenance(context: object) -> bool:
+        if not isinstance(context, Mapping):
+            return context is not None
+        if "source_family" in context or "source" in context:
+            return True
+        if "reviewed_source_profile" in context:
+            return True
+        return "provenance" in context or "admission_provenance" in context
 
     def _normalize_linked_record_ids(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -44,6 +44,8 @@ from .models import (
 
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
+REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES = frozenset({"github_audit", "entra_id"})
+REVIEWED_PHASE19_LIVE_SLICE_LABEL = "Wazuh-backed GitHub audit and Entra ID live slice"
 
 
 class ControlPlaneStore(Protocol):
@@ -1541,7 +1543,7 @@ class AegisOpsControlPlaneService:
             ).get("source_family"),
             "data.source_family",
         )
-        if source_family != "github_audit":
+        if source_family not in REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES:
             self._emit_structured_event(
                 logging.WARNING,
                 "wazuh_ingest_rejected",
@@ -1550,7 +1552,7 @@ class AegisOpsControlPlaneService:
                 source_family=source_family,
             )
             raise ValueError(
-                "live Wazuh ingest only admits the reviewed github_audit first live source family"
+                "live Wazuh ingest only admits the reviewed github_audit and entra_id live source families"
             )
 
         adapter = WazuhAlertAdapter()
@@ -5537,7 +5539,7 @@ class AegisOpsControlPlaneService:
     def _phase19_case_scoped_read_error(record_family: str, record_id: str) -> str:
         return (
             f"{record_family} {record_id!r} is outside the approved Phase 19 "
-            "Wazuh-backed GitHub audit live slice"
+            f"{REVIEWED_PHASE19_LIVE_SLICE_LABEL}"
         )
 
     def _require_phase19_case_scoped_recommendation_payload(
@@ -5573,7 +5575,7 @@ class AegisOpsControlPlaneService:
         if not self._case_is_in_phase19_operator_slice(case):
             raise ValueError(
                 f"Case {case.case_id!r} is outside the approved Phase 19 "
-                "Wazuh-backed GitHub audit live slice"
+                f"{REVIEWED_PHASE19_LIVE_SLICE_LABEL}"
             )
         return case
 
@@ -5621,7 +5623,7 @@ class AegisOpsControlPlaneService:
             or self._phase19_operator_source_family(
                 reconciliation.subject_linkage.get("reviewed_source_profile")
             )
-        ) == "github_audit"
+        ) in REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES
 
     @staticmethod
     def _phase19_operator_source_family(context: object) -> str | None:
@@ -5651,7 +5653,10 @@ class AegisOpsControlPlaneService:
         source_family = self._phase19_operator_source_family(
             context
         ) or self._phase19_operator_source_family(context.get("reviewed_source_profile"))
-        if source_family is not None and source_family != "github_audit":
+        if (
+            source_family is not None
+            and source_family not in REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES
+        ):
             return True
 
         admission_provenance = _normalize_admission_provenance(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -5653,10 +5653,7 @@ class AegisOpsControlPlaneService:
         source_family = self._phase19_operator_source_family(
             context
         ) or self._phase19_operator_source_family(context.get("reviewed_source_profile"))
-        if (
-            source_family is not None
-            and source_family not in REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES
-        ):
+        if source_family not in REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES:
             return True
 
         admission_provenance = _normalize_admission_provenance(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -2366,7 +2366,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             port=0,
         )
         expected_message = (
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice"
         )
         servers: list[main.ThreadingHTTPServer] = []
 
@@ -2448,7 +2448,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             port=0,
         )
         expected_message = (
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice"
         )
         servers: list[main.ThreadingHTTPServer] = []
 
@@ -2511,7 +2511,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             )
         )
         expected_message = (
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice"
         )
         servers: list[main.ThreadingHTTPServer] = []
 
@@ -2845,7 +2845,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             fixture_name="github-audit-alert.json"
         )
         expected_message = (
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice"
         )
 
         for command, record_family, record_id in (
@@ -2897,7 +2897,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             fixture_name="github-audit-alert.json"
         )
         expected_message = (
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice"
         )
 
         for command in (
@@ -2929,7 +2929,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             self._build_case_scoped_advisory_records_without_case_lineage()
         )
         expected_message = (
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice"
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice"
         )
 
         for command, record_family, record_id in (

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -438,6 +438,81 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     servers[0].shutdown()
                 thread.join(timeout=2)
 
+    def test_reviewed_runtime_path_exposes_live_entra_id_case_through_existing_operator_surface(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("entra-id-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
+            service
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                queue_payload = json.loads(
+                    request.urlopen(  # noqa: S310
+                        f"{base_url}/inspect-analyst-queue",
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+                case_payload = json.loads(
+                    request.urlopen(  # noqa: S310
+                        f"{base_url}/inspect-case-detail?case_id={promoted_case.case_id}",
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+
+                self.assertEqual(queue_payload["total_records"], 1)
+                self.assertEqual(
+                    queue_payload["records"][0]["reviewed_context"]["source"]["source_family"],
+                    "entra_id",
+                )
+                self.assertEqual(case_payload["case_id"], promoted_case.case_id)
+                self.assertEqual(
+                    case_payload["reviewed_context"]["source"]["source_family"],
+                    "entra_id",
+                )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
     def test_reviewed_runtime_path_fails_closed_for_out_of_scope_case_reads(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -634,7 +709,7 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                         payload = get_error_payload(path)
                         self.assertEqual(payload["error"], "invalid_request")
                         self.assertIn(
-                            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
                             payload["message"],
                         )
 
@@ -666,7 +741,7 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                         )
                         self.assertEqual(payload["error"], "invalid_request")
                         self.assertIn(
-                            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
                             payload["message"],
                         )
             finally:

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -1232,13 +1232,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             with self.subTest(record_family=record_family):
                 with self.assertRaisesRegex(
                     ValueError,
-                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
                 ):
                     service.inspect_advisory_output(record_family, record_id)
 
                 with self.assertRaisesRegex(
                     ValueError,
-                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
                 ):
                     service.render_recommendation_draft(record_family, record_id)
 
@@ -3288,6 +3288,45 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             (promoted_case.case_id, promoted_case.case_id),
         )
 
+    def test_service_exposes_live_wazuh_entra_id_ingest_through_phase19_operator_surface(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+            ),
+            store=store,
+        )
+
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("entra-id-alert.json"),
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+
+        queue_view = service.inspect_analyst_queue()
+        self.assertEqual(queue_view.total_records, 1)
+        self.assertEqual(queue_view.records[0]["alert_id"], admitted.alert.alert_id)
+        self.assertEqual(queue_view.records[0]["case_id"], promoted_case.case_id)
+        self.assertEqual(
+            queue_view.records[0]["reviewed_context"]["source"]["source_family"],
+            "entra_id",
+        )
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+        self.assertEqual(case_detail.case_id, promoted_case.case_id)
+        self.assertEqual(
+            case_detail.reviewed_context["source"]["source_family"],
+            "entra_id",
+        )
+        self.assertEqual(case_detail.linked_alert_ids, (admitted.alert.alert_id,))
+
     def test_service_admits_microsoft_365_audit_fixture_through_wazuh_source_profile(
         self,
     ) -> None:
@@ -4208,19 +4247,19 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.inspect_assistant_context("case", promoted_case.case_id)
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.inspect_case_detail(promoted_case.case_id)
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.record_case_observation(
                 case_id=promoted_case.case_id,
@@ -4231,7 +4270,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.record_case_lead(
                 case_id=promoted_case.case_id,
@@ -4241,7 +4280,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.record_case_recommendation(
                 case_id=promoted_case.case_id,
@@ -4251,7 +4290,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.record_case_handoff(
                 case_id=promoted_case.case_id,
@@ -4262,7 +4301,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.record_case_disposition(
                 case_id=promoted_case.case_id,
@@ -4312,13 +4351,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             with self.subTest(record_family=record_family):
                 with self.assertRaisesRegex(
                     ValueError,
-                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
                 ):
                     service.inspect_advisory_output(record_family, record_id)
 
                 with self.assertRaisesRegex(
                     ValueError,
-                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
                 ):
                     service.render_recommendation_draft(record_family, record_id)
 
@@ -4365,13 +4404,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             with self.subTest(record_family=record_family):
                 with self.assertRaisesRegex(
                     ValueError,
-                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
                 ):
                     service.inspect_advisory_output(record_family, record_id)
 
                 with self.assertRaisesRegex(
                     ValueError,
-                    "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+                    "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
                 ):
                     service.render_recommendation_draft(record_family, record_id)
 
@@ -4382,19 +4421,19 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.inspect_assistant_context("case", promoted_case.case_id)
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.inspect_advisory_output("case", promoted_case.case_id)
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.render_recommendation_draft("case", promoted_case.case_id)
 
@@ -4440,13 +4479,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.inspect_advisory_output("ai_trace", ai_trace.ai_trace_id)
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.render_recommendation_draft("ai_trace", ai_trace.ai_trace_id)
 
@@ -4468,13 +4507,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.inspect_case_detail(promoted_case.case_id)
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.record_case_observation(
                 case_id=promoted_case.case_id,
@@ -4500,7 +4539,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.inspect_case_detail(spoofed_case.case_id)
 
@@ -4531,7 +4570,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             service.inspect_case_detail(spoofed_case.case_id)
 
@@ -9684,7 +9723,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "outside the approved Phase 19 Wazuh-backed GitHub audit live slice",
+            "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
         ):
             replay_service.create_reviewed_action_request_from_advisory(
                 record_family="recommendation",

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -3049,8 +3049,8 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         live_service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             ),
             store=live_store,
         )
@@ -3065,7 +3065,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             raw_alert=payload,
             authorization_header="Bearer reviewed-shared-secret",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             peer_addr="127.0.0.1",
         )
 
@@ -3113,8 +3113,8 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             ),
             store=store,
         )
@@ -3124,7 +3124,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             raw_alert=payload,
             authorization_header="Bearer reviewed-shared-secret",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             peer_addr="127.0.0.1",
         )
         promoted_case = service.promote_alert_to_case(created.alert.alert_id)
@@ -3136,14 +3136,14 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             raw_alert=restated_payload,
             authorization_header="Bearer reviewed-shared-secret",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             peer_addr="127.0.0.1",
         )
         deduplicated = service.ingest_wazuh_alert(
             raw_alert=restated_payload,
             authorization_header="Bearer reviewed-shared-secret",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             peer_addr="127.0.0.1",
         )
 
@@ -3295,8 +3295,8 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             ),
             store=store,
         )
@@ -3305,7 +3305,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             raw_alert=_load_wazuh_fixture("entra-id-alert.json"),
             authorization_header="Bearer reviewed-shared-secret",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             peer_addr="127.0.0.1",
         )
         promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
@@ -4495,6 +4495,20 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertTrue(
             service._phase19_context_declares_out_of_scope_provenance(
                 "synthetic_review_fixture"
+            )
+        )
+
+    def test_service_treats_missing_source_family_as_out_of_scope(self) -> None:
+        _, service, _, _, _ = self._build_phase19_in_scope_case()
+
+        self.assertTrue(
+            service._phase19_context_declares_out_of_scope_provenance(
+                {
+                    "provenance": {
+                        "admission_kind": "live",
+                        "admission_channel": "live_wazuh_webhook",
+                    }
+                }
             )
         )
 


### PR DESCRIPTION
Closes #439
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the narrow Entra live-source onboarding slice on top of the existing control-plane contracts.

The runtime now admits `entra_id` through the reviewed live Wazuh webhook path using the same contract as `github_audit`, and the Phase 19 operator-surface scope checks were widened to the same approved live-source set so live Entra alerts/cases show up through the existing queue and case-detail workflow without reopening broader source breadth. I added one focused persistence reproducer for live Entra onboarding and one runtime HTTP operator-surface test, and updated the out-of-scope assertions to keep Microsoft 365, replay-only, and synthetic paths fail-closed. Checkpoint commit: `de1913d` (`Admit live Entra ID operator workflow`).

Verification ran with focused `unittest` coverage across adapter, persistence, runtime/operator surface, CLI out-of-scope enforcement, and Phase 21 validation:
`python3 -m unittest control-plane.tests.test_wazuh_adapter.WazuhAlertAdapterTests.test_adapter_builds_reviewed_source_profile_for_entra_id_fixture control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_admits_entra_id_fixture_through_wazuh_source_profile control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_exposes_live_wazuh_entra_id_ingest_through_phase19_operator_surface control-plane.tests.test_phase19_operator_workflow_validation.Phase19OperatorWorkflowValidationTests.test_reviewed_runtime_path_ex...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase 19 live Wazuh alert ingestion now accepts Entra ID alongside GitHub audit sources.
  * Phase 19 approval/scope label updated to reference both GitHub audit and Entra ID live slices.

* **Behavior Changes**
  * Operator scope and provenance gating updated so cases and provenance are evaluated against the expanded approved live sources.

* **Tests**
  * Added tests for Entra ID ingest and operator inspection exposure; updated assertions and messages to match the expanded scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->