### PR TITLE
validation: add end-to-end Phase 21 coverage for auth, restore, observability, and second-source onboarding (#440)

### DIFF
--- a/.codex-supervisor/issues/440/issue-journal.md
+++ b/.codex-supervisor/issues/440/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #440: validation: add end-to-end Phase 21 coverage for auth, restore, observability, and second-source onboarding
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/440
+- Branch: codex/issue-440
+- Workspace: .
+- Journal: .codex-supervisor/issues/440/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 085bb1e7de8de976fda2c7e6cd7132022cece821
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-13T21:04:23.539Z
+
+## Latest Codex Summary
+- Added `control-plane/tests/test_phase21_end_to_end_validation.py` to cover Phase 21 auth fail-closed behavior, restore/readiness continuity, narrow Entra ID second-source onboarding, and preservation of the completed Phase 20 `notify_identity_owner` live path.
+- Updated the Phase 21 validation doc, verifier scripts, and CI workflow so the new focused runtime proof is treated as a required validation artifact.
+- Focused verification passed for the new Phase 21 suite, the Phase 21 verifier scripts, the Phase 20 workflow guard, and the relevant existing runtime/operator-surface/persistence/source-onboarding suites.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The repo already had most Phase 21 behavior, but it lacked one explicit end-to-end validation slice that packaged auth fail-closed, restore, observability, second-source onboarding, and preserved Phase 20 flow into a required artifact.
+- What changed: Added `control-plane/tests/test_phase21_end_to_end_validation.py`; updated `docs/phase-21-production-like-hardening-boundary-and-sequence-validation.md`; updated `control-plane/tests/test_phase21_production_like_hardening_boundary_docs.py`, `control-plane/tests/test_phase21_production_like_hardening_boundary_validation.py`, `scripts/verify-phase-21-production-like-hardening-boundary.sh`, `scripts/test-verify-phase-21-production-like-hardening-boundary.sh`, `scripts/test-verify-ci-phase-21-workflow-coverage.sh`, and `.github/workflows/ci.yml` to require the new artifact.
+- Current blocker: none
+- Next exact step: Commit the focused validation changes on `codex/issue-440` and hand back with the passing verification set.
+- Verification gap: No known local gap in the targeted Phase 21/Phase 20/runtime coverage that was requested for this turn.
+- Files touched: `.github/workflows/ci.yml`, `control-plane/tests/test_phase21_end_to_end_validation.py`, `control-plane/tests/test_phase21_production_like_hardening_boundary_docs.py`, `control-plane/tests/test_phase21_production_like_hardening_boundary_validation.py`, `docs/phase-21-production-like-hardening-boundary-and-sequence-validation.md`, `scripts/test-verify-ci-phase-21-workflow-coverage.sh`, `scripts/test-verify-phase-21-production-like-hardening-boundary.sh`, `scripts/verify-phase-21-production-like-hardening-boundary.sh`
+- Rollback concern: Low; changes are limited to validation/tests/docs/workflow wiring and do not modify control-plane runtime behavior.
+- Last focused command: `python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation control-plane.tests.test_cli_inspection control-plane.tests.test_service_persistence control-plane.tests.test_phase20_low_risk_action_validation control-plane.tests.test_wazuh_adapter`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Run Phase 21 production-like hardening boundary validation
         run: |
           bash scripts/verify-phase-21-production-like-hardening-boundary.sh
-          python3 -m unittest control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation
+          python3 -m unittest control-plane.tests.test_phase21_end_to_end_validation control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation
 
       - name: Run Phase 21 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-21-workflow-coverage.sh

--- a/control-plane/tests/test_phase21_end_to_end_validation.py
+++ b/control-plane/tests/test_phase21_end_to_end_validation.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+import pathlib
+import sys
+import threading
+import unittest
+from urllib import error, request
+from unittest import mock
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+import main
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.models import ApprovalDecisionRecord, ReconciliationRecord
+from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
+
+
+FIXTURES_ROOT = pathlib.Path(__file__).resolve().parent / "fixtures" / "wazuh"
+REVIEWED_SHARED_SECRET = "reviewed-shared-secret"  # noqa: S105
+REVIEWED_WAZUH_PROXY_SECRET = "reviewed-wazuh-proxy-secret"  # noqa: S105
+REVIEWED_SURFACE_PROXY_SECRET = "reviewed-surface-proxy-secret"  # noqa: S105
+REVIEWED_PROXY_SERVICE_ACCOUNT = "svc-aegisops-proxy-control-plane"  # noqa: S105
+REVIEWED_ADMIN_BOOTSTRAP_TOKEN = "reviewed-admin-bootstrap-token"  # noqa: S105
+REVIEWED_BREAK_GLASS_TOKEN = "reviewed-break-glass-token"  # noqa: S105
+
+
+def _load_wazuh_fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+
+
+class Phase21EndToEndValidationTests(unittest.TestCase):
+    def _build_service(
+        self,
+        *,
+        store: object | None = None,
+        host: str = "127.0.0.1",
+    ) -> tuple[object, AegisOpsControlPlaneService]:
+        if store is None:
+            store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host=host,
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_WAZUH_PROXY_SECRET,
+                wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
+                protected_surface_reverse_proxy_secret=REVIEWED_SURFACE_PROXY_SECRET,
+                protected_surface_trusted_proxy_cidrs=("10.10.0.5/32",),
+                protected_surface_proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+                admin_bootstrap_token=REVIEWED_ADMIN_BOOTSTRAP_TOKEN,
+                break_glass_token=REVIEWED_BREAK_GLASS_TOKEN,
+            ),
+            store=store,
+        )
+        return store, service
+
+    def _build_phase19_in_scope_case(
+        self,
+        *,
+        service: AegisOpsControlPlaneService | None = None,
+    ) -> tuple[AegisOpsControlPlaneService, object, str, datetime]:
+        if service is None:
+            _, service = self._build_service()
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_WAZUH_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        return service, promoted_case, promoted_case.evidence_ids[0], reviewed_at
+
+    def _complete_phase20_live_path(
+        self,
+        service: AegisOpsControlPlaneService,
+        *,
+        case_id: str,
+        alert_id: str,
+        finding_id: str,
+        evidence_id: str,
+        reviewed_at: datetime,
+    ) -> tuple[object, object, object, object]:
+        observation = service.record_case_observation(
+            case_id=case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-e2e-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=action_request.requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=action_request.requested_at + timedelta(minutes=10),
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "observed_at": action_request.requested_at + timedelta(minutes=15),
+                    "status": "success",
+                },
+            ),
+            compared_at=action_request.requested_at + timedelta(minutes=16),
+            stale_after=action_request.requested_at + timedelta(hours=1),
+        )
+        return approved_request, approval_decision, execution, reconciliation
+
+    @contextmanager
+    def _run_http_service(self, service: AegisOpsControlPlaneService) -> object:
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                yield f"http://127.0.0.1:{servers[0].server_port}"
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                    servers[0].server_close()
+                thread.join(timeout=2)
+
+    def test_phase21_end_to_end_auth_boundaries_fail_closed_and_emit_observability(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        invalid_surface_service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="0.0.0.0",
+                port=8080,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_WAZUH_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_TRUSTED_PROXY_CIDRS must be set",
+        ):
+            invalid_surface_service.validate_protected_surface_runtime()
+
+        _, service = self._build_service()
+        with self._run_http_service(service) as base_url, self.assertLogs(
+            "aegisops.control_plane",
+            level="INFO",
+        ) as log_output:
+            intake_request = request.Request(  # noqa: S310 - local in-process test HTTP server
+                f"{base_url}/intake/wazuh",
+                data=json.dumps(_load_wazuh_fixture("github-audit-alert.json")).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Forwarded-Proto": "https",
+                    "X-AegisOps-Proxy-Secret": REVIEWED_WAZUH_PROXY_SECRET,
+                },
+                method="POST",
+            )
+
+            with self.assertRaises(error.HTTPError) as intake_error:
+                request.urlopen(intake_request, timeout=2)  # noqa: S310
+            self.assertEqual(intake_error.exception.code, 403)
+            intake_payload = json.loads(intake_error.exception.read().decode("utf-8"))
+            self.assertEqual(
+                intake_payload["message"],
+                "live Wazuh ingest requires Authorization: Bearer <shared secret>",
+            )
+
+            with self.assertRaises(error.HTTPError) as diagnostics_error:
+                request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                    f"{base_url}/diagnostics/readiness",
+                    timeout=2,
+                )
+            self.assertEqual(diagnostics_error.exception.code, 403)
+            diagnostics_payload = json.loads(
+                diagnostics_error.exception.read().decode("utf-8")
+            )
+            self.assertIn("protected control-plane surface role is not authorized", diagnostics_payload["message"])
+
+        joined_logs = "\n".join(log_output.output)
+        self.assertIn('"event":"wazuh_ingest_rejected"', joined_logs)
+        self.assertIn('"reason":"missing_bearer_secret"', joined_logs)
+
+    def test_phase21_end_to_end_restore_and_readiness_preserve_phase20_live_path(
+        self,
+    ) -> None:
+        _, service = self._build_service()
+        service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case(
+            service=service
+        )
+        approved_request, approval_decision, execution, reconciliation = (
+            self._complete_phase20_live_path(
+                service,
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                evidence_id=evidence_id,
+                reviewed_at=reviewed_at,
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        self.assertEqual(readiness.status, "ready")
+        self.assertEqual(
+            readiness.metrics["phase20_notify_identity_owner"]["approved_action_requests"],
+            1,
+        )
+        self.assertEqual(
+            readiness.metrics["phase20_notify_identity_owner"]["reconciled_executions"],
+            1,
+        )
+        self.assertEqual(
+            readiness.latest_reconciliation["reconciliation_id"],
+            reconciliation.reconciliation_id,
+        )
+
+        backup = service.export_authoritative_record_chain_backup()
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        restore_summary = restored_service.restore_authoritative_record_chain_backup(backup)
+        restored_readiness = restored_service.inspect_readiness_diagnostics()
+        restored_case_detail = restored_service.inspect_case_detail(promoted_case.case_id)
+        restored_reconciliation = restored_service.get_record(
+            ReconciliationRecord,
+            reconciliation.reconciliation_id,
+        )
+
+        self.assertTrue(restore_summary.restore_drill.drill_passed)
+        self.assertEqual(
+            restore_summary.restore_drill.verified_action_execution_ids,
+            (execution.action_execution_id,),
+        )
+        self.assertEqual(
+            restore_summary.restore_drill.verified_approval_decision_ids,
+            (approval_decision.approval_decision_id,),
+        )
+        self.assertEqual(
+            restored_readiness.metrics["phase20_notify_identity_owner"]["approved_action_requests"],
+            1,
+        )
+        self.assertEqual(
+            restored_readiness.metrics["phase20_notify_identity_owner"]["reconciled_executions"],
+            1,
+        )
+        self.assertEqual(restored_case_detail.case_id, promoted_case.case_id)
+        self.assertEqual(restored_case_detail.linked_evidence_ids, (evidence_id,))
+        self.assertIsNotNone(restored_reconciliation)
+        self.assertEqual(
+            restored_reconciliation.execution_run_id,
+            execution.execution_run_id,
+        )
+        restored_approval_context = restored_service.inspect_assistant_context(
+            "approval_decision",
+            approval_decision.approval_decision_id,
+        )
+        self.assertEqual(restored_approval_context.linked_case_ids, (promoted_case.case_id,))
+        self.assertIn(
+            reconciliation.reconciliation_id,
+            restored_approval_context.linked_reconciliation_ids,
+        )
+
+    def test_phase21_end_to_end_second_source_onboarding_stays_narrow(
+        self,
+    ) -> None:
+        _, service = self._build_service()
+
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("entra-id-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_WAZUH_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        reviewed_at = datetime(2026, 4, 8, 9, 30, tzinfo=timezone.utc)
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed Entra ID directory privilege context requires reviewed follow-up.",
+            supporting_evidence_ids=(promoted_case.evidence_ids[0],),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Preserve the reviewed Phase 19 casework contract for the approved second source.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review the Entra ID directory privilege change before any approval-bound action.",
+            lead_id=lead.lead_id,
+        )
+
+        queue_view = service.inspect_analyst_queue()
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+        advisory_context = service.inspect_assistant_context(
+            "recommendation",
+            recommendation.recommendation_id,
+        )
+
+        self.assertEqual(queue_view.total_records, 1)
+        self.assertEqual(queue_view.records[0]["alert_id"], admitted.alert.alert_id)
+        self.assertEqual(
+            queue_view.records[0]["reviewed_context"]["source"]["source_family"],
+            "entra_id",
+        )
+        self.assertEqual(case_detail.case_id, promoted_case.case_id)
+        self.assertEqual(
+            case_detail.reviewed_context["source"]["source_family"],
+            "entra_id",
+        )
+        self.assertEqual(advisory_context.linked_case_ids, (promoted_case.case_id,))
+        self.assertEqual(
+            advisory_context.linked_evidence_ids,
+            (promoted_case.evidence_ids[0],),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "live Wazuh ingest only admits the reviewed github_audit and entra_id live source families",
+        ):
+            service.ingest_wazuh_alert(
+                raw_alert=_load_wazuh_fixture("microsoft-365-audit-alert.json"),
+                authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+                forwarded_proto="https",
+                reverse_proxy_secret_header=REVIEWED_WAZUH_PROXY_SECRET,
+                peer_addr="127.0.0.1",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase21_end_to_end_validation.py
+++ b/control-plane/tests/test_phase21_end_to_end_validation.py
@@ -292,10 +292,7 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
 
         backup = service.export_authoritative_record_chain_backup()
         restored_store, _ = make_store()
-        restored_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
-            store=restored_store,
-        )
+        _, restored_service = self._build_service(store=restored_store)
 
         restore_summary = restored_service.restore_authoritative_record_chain_backup(backup)
         restored_readiness = restored_service.inspect_readiness_diagnostics()
@@ -321,6 +318,11 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
         self.assertEqual(
             restored_readiness.metrics["phase20_notify_identity_owner"]["reconciled_executions"],
             1,
+        )
+        self.assertEqual(restored_readiness.status, "ready")
+        self.assertEqual(
+            restored_readiness.startup["validated_surfaces"],
+            readiness.startup["validated_surfaces"],
         )
         self.assertEqual(restored_case_detail.case_id, promoted_case.case_id)
         self.assertEqual(restored_case_detail.linked_evidence_ids, (evidence_id,))
@@ -396,6 +398,7 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
             advisory_context.linked_evidence_ids,
             (promoted_case.evidence_ids[0],),
         )
+        baseline_readiness = service.inspect_readiness_diagnostics()
 
         with self.assertRaisesRegex(
             ValueError,
@@ -408,6 +411,19 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
                 reverse_proxy_secret_header=REVIEWED_WAZUH_PROXY_SECRET,
                 peer_addr="127.0.0.1",
             )
+
+        post_rejection_queue = service.inspect_analyst_queue()
+        self.assertEqual(post_rejection_queue.total_records, queue_view.total_records)
+        self.assertEqual(post_rejection_queue.records, queue_view.records)
+        post_rejection_readiness = service.inspect_readiness_diagnostics()
+        self.assertEqual(
+            post_rejection_readiness.metrics["alerts"],
+            baseline_readiness.metrics["alerts"],
+        )
+        self.assertEqual(
+            post_rejection_readiness.metrics["cases"],
+            baseline_readiness.metrics["cases"],
+        )
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_phase21_end_to_end_validation.py
+++ b/control-plane/tests/test_phase21_end_to_end_validation.py
@@ -264,7 +264,7 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
         service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case(
             service=service
         )
-        approved_request, approval_decision, execution, reconciliation = (
+        _approved_request, approval_decision, execution, reconciliation = (
             self._complete_phase20_live_path(
                 service,
                 case_id=promoted_case.case_id,

--- a/control-plane/tests/test_phase21_production_like_hardening_boundary_docs.py
+++ b/control-plane/tests/test_phase21_production_like_hardening_boundary_docs.py
@@ -68,6 +68,8 @@ class Phase21ProductionLikeHardeningBoundaryDocsTests(unittest.TestCase):
             "production-like hardening around the completed Phase 20 live path",
             "auth and secrets -> admin bootstrap and break-glass controls -> restore proof -> observability proof -> topology growth gate review -> Entra ID second-source onboarding",
             "GitHub audit -> Entra ID -> Microsoft 365 audit",
+            "control-plane/tests/test_phase21_end_to_end_validation.py",
+            "Phase 21 end-to-end validation test keeps auth fail-closed behavior, restore readability, readiness diagnostics, second-source onboarding, and the completed Phase 20 live path under one focused runtime proof.",
             "Phase 16-21 Epic Roadmap.md",
             "Validation cannot pass until the requested `Phase 16-21 Epic Roadmap.md` comparison is completed from a reviewed local artifact.",
         ):

--- a/control-plane/tests/test_phase21_production_like_hardening_boundary_validation.py
+++ b/control-plane/tests/test_phase21_production_like_hardening_boundary_validation.py
@@ -32,6 +32,14 @@ class Phase21ProductionLikeHardeningBoundaryValidationTests(unittest.TestCase):
         design_text = design_doc.read_text(encoding="utf-8")
         validation_text = validation_doc.read_text(encoding="utf-8")
         roadmap_doc = REPO_ROOT / "docs" / "Phase 16-21 Epic Roadmap.md"
+        end_to_end_test = (
+            REPO_ROOT / "control-plane" / "tests" / "test_phase21_end_to_end_validation.py"
+        )
+
+        self.assertTrue(
+            end_to_end_test.exists(),
+            f"expected Phase 21 end-to-end validation tests at {end_to_end_test}",
+        )
 
         for term in (
             "docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md",
@@ -51,6 +59,11 @@ class Phase21ProductionLikeHardeningBoundaryValidationTests(unittest.TestCase):
         ):
             self.assertIn(term, design_text)
             self.assertIn(term, validation_text)
+
+        self.assertIn(
+            "control-plane/tests/test_phase21_end_to_end_validation.py",
+            validation_text,
+        )
 
         validation_terms = [
             "Entra ID is the first reviewed second live source to onboard",
@@ -76,6 +89,12 @@ class Phase21ProductionLikeHardeningBoundaryValidationTests(unittest.TestCase):
             )
 
         for term in validation_terms:
+            self.assertIn(term, validation_text)
+
+        for term in (
+            "python3 -m unittest control-plane.tests.test_phase21_end_to_end_validation control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation",
+            "Phase 21 end-to-end validation test keeps auth fail-closed behavior, restore readability, readiness diagnostics, second-source onboarding, and the completed Phase 20 live path under one focused runtime proof.",
+        ):
             self.assertIn(term, validation_text)
 
 

--- a/docs/phase-21-production-like-hardening-boundary-and-sequence-validation.md
+++ b/docs/phase-21-production-like-hardening-boundary-and-sequence-validation.md
@@ -3,7 +3,7 @@
 - Validation date: 2026-04-13
 - Validation scope: Phase 21 review of the production-like hardening boundary around the completed Phase 20 live path, including auth and secrets, service-account ownership, reverse-proxy protections, admin bootstrap, break-glass access, restore, observability, one-node-to-multi-node growth conditions, and one reviewed second-source onboarding target without widening broader source, UI, or action scope
 - Baseline references: `docs/phase-21-production-like-hardening-boundary-and-sequence.md`, `docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md`, `docs/auth-baseline.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/runbook.md`, `docs/automation-substrate-contract.md`, `docs/response-action-safety-model.md`, `docs/source-onboarding-contract.md`, `docs/phase-14-identity-rich-source-family-design.md`, `docs/phase-18-wazuh-lab-topology-and-live-ingest-contract.md`, `docs/wazuh-alert-ingest-contract.md`, `docs/control-plane-state-model.md`, `docs/phase-19-thin-operator-surface-and-daily-analyst-workflow.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `docs/architecture.md`
-- Verification commands: `python3 -m unittest control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation`, `bash scripts/verify-phase-21-production-like-hardening-boundary.sh`, `bash scripts/test-verify-phase-21-production-like-hardening-boundary.sh`, `bash scripts/test-verify-ci-phase-21-workflow-coverage.sh`
+- Verification commands: `python3 -m unittest control-plane.tests.test_phase21_end_to_end_validation control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation`, `bash scripts/verify-phase-21-production-like-hardening-boundary.sh`, `bash scripts/test-verify-phase-21-production-like-hardening-boundary.sh`, `bash scripts/test-verify-ci-phase-21-workflow-coverage.sh`
 - Validation status: FAIL
 
 ## Required Boundary Artifacts
@@ -24,6 +24,7 @@
 - `docs/phase-19-thin-operator-surface-and-daily-analyst-workflow.md`
 - `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`
 - `docs/architecture.md`
+- `control-plane/tests/test_phase21_end_to_end_validation.py`
 - `control-plane/tests/test_phase21_production_like_hardening_boundary_docs.py`
 - `control-plane/tests/test_phase21_production_like_hardening_boundary_validation.py`
 - `scripts/verify-phase-21-production-like-hardening-boundary.sh`
@@ -48,6 +49,8 @@ Confirmed topology growth remains conditional only and cannot proceed unless aut
 Confirmed the reviewed second-source onboarding boundary reuses the existing payload-admission, dedupe, restatement, evidence-preservation, case-linkage, and thin-operator-surface contracts rather than introducing a parallel second-source model.
 
 Confirmed explicit non-expansion rules keep broad multi-source breadth, broad UI expansion, direct vendor-local actioning, and production-scale topology claims out of scope for Phase 21.
+
+Phase 21 end-to-end validation test keeps auth fail-closed behavior, restore readability, readiness diagnostics, second-source onboarding, and the completed Phase 20 live path under one focused runtime proof.
 
 The issue requested review against `Phase 16-21 Epic Roadmap.md`, but that roadmap file was not present in the local worktree and could not be located via repository search during this validation snapshot.
 

--- a/scripts/test-verify-ci-phase-21-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-21-workflow-coverage.sh
@@ -14,7 +14,7 @@ required_tests=(
 )
 
 required_runtime_commands=(
-  "python3 -m unittest control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation"
+  "python3 -m unittest control-plane.tests.test_phase21_end_to_end_validation control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation"
 )
 
 self_guard_step_name="Run Phase 21 workflow coverage guard"

--- a/scripts/test-verify-phase-21-production-like-hardening-boundary.sh
+++ b/scripts/test-verify-phase-21-production-like-hardening-boundary.sh
@@ -32,6 +32,7 @@ required_artifacts=(
   "docs/architecture.md"
   "control-plane/tests/test_phase21_production_like_hardening_boundary_docs.py"
   "control-plane/tests/test_phase21_production_like_hardening_boundary_validation.py"
+  "control-plane/tests/test_phase21_end_to_end_validation.py"
   "scripts/verify-phase-21-production-like-hardening-boundary.sh"
   "scripts/test-verify-phase-21-production-like-hardening-boundary.sh"
   "scripts/test-verify-ci-phase-21-workflow-coverage.sh"

--- a/scripts/verify-phase-21-production-like-hardening-boundary.sh
+++ b/scripts/verify-phase-21-production-like-hardening-boundary.sh
@@ -21,6 +21,7 @@ phase17_doc="${repo_root}/docs/phase-17-runtime-config-contract-and-boot-command
 architecture_doc="${repo_root}/docs/architecture.md"
 docs_test="${repo_root}/control-plane/tests/test_phase21_production_like_hardening_boundary_docs.py"
 validation_test="${repo_root}/control-plane/tests/test_phase21_production_like_hardening_boundary_validation.py"
+end_to_end_test="${repo_root}/control-plane/tests/test_phase21_end_to_end_validation.py"
 workflow_path="${repo_root}/.github/workflows/ci.yml"
 roadmap_filename="Phase 16-21 Epic Roadmap.md"
 roadmap_relative_path="docs/${roadmap_filename}"
@@ -74,6 +75,7 @@ require_file "${phase17_doc}" "Missing Phase 17 runtime config contract doc"
 require_file "${architecture_doc}" "Missing architecture overview doc"
 require_file "${docs_test}" "Missing Phase 21 docs unittest"
 require_file "${validation_test}" "Missing Phase 21 validation unittest"
+require_file "${end_to_end_test}" "Missing Phase 21 end-to-end validation unittest"
 require_file "${workflow_path}" "Missing CI workflow"
 
 design_required_lines=(
@@ -171,6 +173,7 @@ required_artifacts=(
   "docs/architecture.md"
   "control-plane/tests/test_phase21_production_like_hardening_boundary_docs.py"
   "control-plane/tests/test_phase21_production_like_hardening_boundary_validation.py"
+  "control-plane/tests/test_phase21_end_to_end_validation.py"
   "scripts/verify-phase-21-production-like-hardening-boundary.sh"
   "scripts/test-verify-phase-21-production-like-hardening-boundary.sh"
   "scripts/test-verify-ci-phase-21-workflow-coverage.sh"
@@ -186,15 +189,19 @@ for artifact in "${required_artifacts[@]}"; do
   require_fixed_line "${validation_doc}" "- \`${artifact}\`"
 done
 
-require_fixed_line "${validation_doc}" '- Verification commands: `python3 -m unittest control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation`, `bash scripts/verify-phase-21-production-like-hardening-boundary.sh`, `bash scripts/test-verify-phase-21-production-like-hardening-boundary.sh`, `bash scripts/test-verify-ci-phase-21-workflow-coverage.sh`'
+require_fixed_line "${validation_doc}" '- Verification commands: `python3 -m unittest control-plane.tests.test_phase21_end_to_end_validation control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation`, `bash scripts/verify-phase-21-production-like-hardening-boundary.sh`, `bash scripts/test-verify-phase-21-production-like-hardening-boundary.sh`, `bash scripts/test-verify-ci-phase-21-workflow-coverage.sh`'
 require_fixed_line "${docs_test}" 'class Phase21ProductionLikeHardeningBoundaryDocsTests(unittest.TestCase):'
 require_fixed_line "${docs_test}" '    def test_phase21_design_doc_exists(self) -> None:'
 require_fixed_line "${docs_test}" '    def test_phase21_design_doc_defines_boundary_sequence_and_non_expansion_rules(self) -> None:'
 require_fixed_line "${validation_test}" 'class Phase21ProductionLikeHardeningBoundaryValidationTests(unittest.TestCase):'
 require_fixed_line "${validation_test}" '    def test_phase21_validation_artifacts_cross_reference_governing_contracts(self) -> None:'
+require_fixed_line "${end_to_end_test}" 'class Phase21EndToEndValidationTests(unittest.TestCase):'
+require_fixed_line "${end_to_end_test}" '    def test_phase21_end_to_end_auth_boundaries_fail_closed_and_emit_observability('
+require_fixed_line "${end_to_end_test}" '    def test_phase21_end_to_end_restore_and_readiness_preserve_phase20_live_path('
+require_fixed_line "${end_to_end_test}" '    def test_phase21_end_to_end_second_source_onboarding_stays_narrow('
 require_fixed_line "${workflow_path}" '      - name: Run Phase 21 production-like hardening boundary validation'
 require_fixed_line "${workflow_path}" '          bash scripts/verify-phase-21-production-like-hardening-boundary.sh'
-require_fixed_line "${workflow_path}" '          python3 -m unittest control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation'
+require_fixed_line "${workflow_path}" '          python3 -m unittest control-plane.tests.test_phase21_end_to_end_validation control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation'
 require_fixed_line "${workflow_path}" '      - name: Run Phase 21 workflow coverage guard'
 require_fixed_line "${workflow_path}" '        run: bash scripts/test-verify-ci-phase-21-workflow-coverage.sh'
 require_fixed_line "${workflow_path}" '          bash scripts/test-verify-phase-21-production-like-hardening-boundary.sh'


### PR DESCRIPTION
Closes #440
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused Phase 21 runtime proof in `control-plane/tests/test_phase21_end_to_end_validation.py`. It covers auth fail-closed behavior and structured rejection logs, backup/restore plus restore-drill readability, readiness diagnostics and Phase 20 metric continuity, and the narrow Entra ID second-source onboarding path while still rejecting broader Microsoft 365 live admission. I also wired that test into the Phase 21 validation doc, verifier scripts, and CI workflow so it is now a required artifact rather than incidental coverage.

Checkpoint commit is `03082bc` (`Add Phase 21 end-to-end validation coverage`). The targeted verification set passed, including the new Phase 21 suite, Phase 21 verifier scripts, the Phase 20 workflow guard, and the relevant existing runtime/operator-surface/persistence/source-onboarding suites.

Summary: Added required Phase 21 end-to-end validation coverage and CI/verifier wiring; committed as `03082bc`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase21_end_to_end_validation control-plane.tests.test_phase21_production_like_hardening_boundary_docs control-plane.tests.test_phase21_production_like_hardening_boundary_validation`; `bash scripts/verify-phase-21-production-like-hardening-boundary.sh`; `bash scripts/test-verify-phase-21-production-like-hardening-boundary.sh`; `bash scripts/test-verify-ci-phase-21-workflow-coverage.sh`; `python3 -m unittest control-plane.tests.test_phase21_r...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end Phase 21 validation suite with three scenarios: auth boundaries fail-closed and observability, backup/restore preserving Phase 20 readiness/linkage, and narrow second-source onboarding.

* **Documentation**
  * Updated Phase 21 validation guidance and verification commands to include the new end-to-end validation.

* **Chores**
  * CI and verification tooling updated to require and execute the new end-to-end validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->