### PR TITLE
follow-up: make Phase 21 restore drill fail closed when runtime bindings are still missing after restore (#448)

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, contextmanager
 from collections import Counter
 from dataclasses import asdict, dataclass, fields, replace
 from datetime import datetime, timezone
@@ -11,7 +11,7 @@ import json
 import logging
 import re
 import uuid
-from typing import Mapping, Protocol, Type, TypeVar
+from typing import Iterator, Mapping, Protocol, Type, TypeVar
 
 from .adapters.executor import IsolatedExecutorAdapter
 from .adapters.n8n import N8NReconciliationAdapter
@@ -2232,7 +2232,23 @@ class AegisOpsControlPlaneService:
             restore_drill=restore_drill,
         )
 
+    @contextmanager
+    def _restore_drill_snapshot_transaction(self) -> Iterator[None]:
+        try:
+            with self._store.transaction(isolation_level="REPEATABLE READ"):
+                yield
+                return
+        except ValueError as exc:
+            if str(exc) != "Cannot set isolation_level inside an active transaction":
+                raise
+        with self._store.transaction():
+            yield
+
     def run_authoritative_restore_drill(self) -> RestoreDrillSnapshot:
+        with self._restore_drill_snapshot_transaction():
+            return self._run_authoritative_restore_drill_snapshot()
+
+    def _run_authoritative_restore_drill_snapshot(self) -> RestoreDrillSnapshot:
         self._validate_authoritative_record_chain_restore(
             {
                 record_type.record_family: self._store.list(record_type)

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -450,6 +450,20 @@ class ReadinessDiagnosticsSnapshot:
         )
 
 
+def _derive_readiness_status(
+    *,
+    startup_ready: bool,
+    reconciliation_lifecycle_counts: Mapping[str, int],
+) -> str:
+    if not startup_ready:
+        return "failing_closed"
+    if reconciliation_lifecycle_counts.get("stale", 0):
+        return "stale"
+    if reconciliation_lifecycle_counts.get("mismatched", 0):
+        return "degraded"
+    return "ready"
+
+
 RECORD_TYPES_BY_FAMILY: dict[str, Type[ControlPlaneRecord]] = {
     record_type.record_family: record_type
     for record_type in (
@@ -1954,14 +1968,10 @@ class AegisOpsControlPlaneService:
             unresolved_reconciliation_ids=readiness_aggregates.unresolved_reconciliation_ids,
         )
 
-        if not startup.startup_ready:
-            status = "failing_closed"
-        elif readiness_aggregates.reconciliation_lifecycle_counts.get("stale", 0):
-            status = "stale"
-        elif readiness_aggregates.reconciliation_lifecycle_counts.get("mismatched", 0):
-            status = "degraded"
-        else:
-            status = "ready"
+        status = _derive_readiness_status(
+            startup_ready=startup.startup_ready,
+            reconciliation_lifecycle_counts=readiness_aggregates.reconciliation_lifecycle_counts,
+        )
 
         metrics = {
             "alerts": {
@@ -2254,10 +2264,16 @@ class AegisOpsControlPlaneService:
         for reconciliation_id in verified_reconciliation_ids:
             self.inspect_assistant_context("reconciliation", reconciliation_id)
         self.inspect_reconciliation_status()
+        startup = self.describe_startup_status()
+        readiness_aggregates = self._inspect_readiness_aggregates()
+        readiness_status = _derive_readiness_status(
+            startup_ready=startup.startup_ready,
+            reconciliation_lifecycle_counts=readiness_aggregates.reconciliation_lifecycle_counts,
+        )
 
         return RestoreDrillSnapshot(
             read_only=True,
-            drill_passed=True,
+            drill_passed=readiness_status == "ready",
             verified_case_ids=verified_case_ids,
             verified_approval_decision_ids=verified_approval_decision_ids,
             verified_action_execution_ids=verified_action_execution_ids,

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -89,6 +89,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 postgres_dsn="postgresql://control-plane.local/aegisops",
                 wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
                 wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
             ),
             store=store,
         )

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -8385,6 +8385,65 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             readiness.startup["missing_bindings"],
         )
 
+    def test_service_phase21_restore_drill_uses_single_transaction_snapshot(
+        self,
+    ) -> None:
+        base_store, backend = make_store()
+        concurrent_store, _ = make_store(backend)
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case(store=base_store)
+        )
+        seed_reconciliation = max(
+            service._store.list(ReconciliationRecord),
+            key=lambda record: record.compared_at,
+            default=None,
+        )
+        if seed_reconciliation is None:
+            self.fail("expected seeded reconciliation record before restore drill")
+
+        concurrent_reconciliation = replace(
+            seed_reconciliation,
+            reconciliation_id="reconciliation-phase21-restore-drill-concurrent-001",
+            compared_at=seed_reconciliation.compared_at + timedelta(minutes=30),
+            lifecycle_state="stale",
+        )
+        snapshot_store = _ConcurrentListMutationStore(
+            inner=base_store,
+            mutate_once=lambda: concurrent_store.save(concurrent_reconciliation),
+        )
+        snapshot_service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
+            store=snapshot_store,
+        )
+
+        statement_count_before_snapshot = len(backend.statements)
+        restore_drill = snapshot_service.run_authoritative_restore_drill()
+
+        self.assertEqual(
+            backend.statements[statement_count_before_snapshot][0],
+            "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+        )
+        self.assertTrue(restore_drill.drill_passed)
+        self.assertEqual(
+            restore_drill.verified_reconciliation_ids,
+            (seed_reconciliation.reconciliation_id,),
+        )
+        self.assertEqual(len(base_store.list(ReconciliationRecord)), 2)
+        self.assertEqual(
+            concurrent_store.get(
+                ReconciliationRecord,
+                "reconciliation-phase21-restore-drill-concurrent-001",
+            ),
+            concurrent_reconciliation,
+        )
+
     def test_service_phase21_backup_uses_single_transaction_snapshot(self) -> None:
         base_store, backend = make_store()
         concurrent_store, _ = make_store(backend)

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -8237,7 +8237,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         restored_store, restored_backend = make_store()
         restored_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
             store=restored_store,
         )
         statement_count_before_restore = len(restored_backend.statements)
@@ -8320,7 +8326,13 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         restored_store, _ = make_store()
         restored_service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
             store=restored_store,
         )
 
@@ -8342,6 +8354,36 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         restored_case_detail = restored_service.inspect_case_detail(promoted_case.case_id)
         self.assertEqual(restored_case_detail.linked_evidence_ids, (evidence_id,))
+
+    def test_service_phase21_restore_drill_fails_closed_when_runtime_bindings_missing_after_restore(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        restore_summary = restored_service.restore_authoritative_record_chain_backup(
+            backup
+        )
+        readiness = restored_service.inspect_readiness_diagnostics()
+
+        self.assertFalse(restore_summary.restore_drill.drill_passed)
+        self.assertEqual(readiness.status, "failing_closed")
+        self.assertIn(
+            "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET",
+            readiness.startup["missing_bindings"],
+        )
+        self.assertIn(
+            "AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN",
+            readiness.startup["missing_bindings"],
+        )
 
     def test_service_phase21_backup_uses_single_transaction_snapshot(self) -> None:
         base_store, backend = make_store()


### PR DESCRIPTION
Closes #448
This PR was opened by codex-supervisor.
Latest Codex summary:

Tightened the Phase 21 restore drill so it no longer treats record-chain readability alone as success. `run_authoritative_restore_drill()` now derives pass/fail from the same startup/readiness contract used elsewhere, which makes a restored `postgres_dsn`-only runtime fail closed instead of returning `drill_passed=True`. I also added the focused negative reproducer in [test_service_persistence.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-448/control-plane/tests/test_service_persistence.py) and updated the existing positive restore/CLI tests to provide the reviewed runtime bindings they now require. The implementation is committed as `47eb1a8` (`Fail restore drill closed on missing runtime bindings`).

Verification run:
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_phase21_restore_drill_fails_closed_when_runtime_bindings_missing_after_restore`
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_phase21_restore_drill_can_run_standalone_after_restore`
- `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServicePersistenceTests.test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain`
- `python3 -m unittest control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_backup_and_restore_drill_commands_render_recovery_payloads`
- `python3 -m unittest control-plane.tests.test_phase2...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restore drills now only pass when the system is truly ready; improved readiness classification and diagnostics.
  * Restore execution now enforces single-transaction snapshot semantics (with a safe fallback), reducing race conditions during restore.

* **Tests**
  * Expanded coverage for restore operations with missing runtime bindings and for single-transaction snapshot behavior under concurrent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->