### PR TITLE
[codex] Fix phase 21 startup break-glass readiness

### DIFF
--- a/.codex-supervisor/issues/449/issue-journal.md
+++ b/.codex-supervisor/issues/449/issue-journal.md
@@ -18,6 +18,7 @@
 - Fixed `describe_startup_status()` so break-glass is no longer treated as a mandatory startup binding while keeping admin bootstrap and other reviewed required bindings intact.
 - Extended runtime-auth coverage to prove the break-glass contract still fails closed when disabled by default and when a wrong token is supplied.
 - Verified the fix with focused runtime-auth, CLI inspection, end-to-end, and Phase 21 boundary validation suites.
+- Published commit `8b3f5c4` to `origin/codex/issue-449` and opened draft PR `#451`.
 
 ## Active Failure Context
 - None recorded.
@@ -27,11 +28,11 @@
 - Hypothesis: `describe_startup_status()` was incorrectly including `AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN` in `required_bindings`, which forced readiness to fail closed even though the reviewed design keeps break-glass disabled by default until explicitly configured.
 - What changed: Removed break-glass from the mandatory startup binding tuple in `control-plane/aegisops_control_plane/service.py`; added a focused service test proving startup/readiness stay healthy with PostgreSQL, Wazuh ingest, and admin bootstrap configured but break-glass unset; added direct tests proving break-glass still rejects use when disabled and when a wrong token is supplied.
 - Current blocker: none
-- Next exact step: Commit the focused fix on `codex/issue-449`; PR does not exist yet.
+- Next exact step: Monitor draft PR `#451` and address any review or CI feedback.
 - Verification gap: Did not run the full repository test suite; focused Phase 21 runtime-auth, CLI, end-to-end, and boundary validation coverage passed.
 - Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_phase21_runtime_auth_validation.py`, `.codex-supervisor/issues/449/issue-journal.md`
 - Rollback concern: Low; change is limited to startup/readiness semantics and does not alter break-glass activation enforcement.
-- Last focused command: `python3 -m unittest control-plane.tests.test_phase21_production_like_hardening_boundary_validation`
+- Last focused command: `gh pr create --draft --title "[codex] Fix phase 21 startup break-glass readiness" --body-file "$tmpfile" --base main --head codex/issue-449`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Reproducing test failure before fix: `python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_startup_and_readiness_do_not_require_break_glass_when_unset` -> `AssertionError: False is not true`

--- a/.codex-supervisor/issues/449/issue-journal.md
+++ b/.codex-supervisor/issues/449/issue-journal.md
@@ -1,0 +1,37 @@
+# Issue #449: follow-up: stop treating break-glass as a mandatory Phase 21 startup binding when the reviewed design keeps it disabled by default
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/449
+- Branch: codex/issue-449
+- Workspace: .
+- Journal: .codex-supervisor/issues/449/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 0509c6a7c559721d4ce87966ca764770b985212d
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-13T22:34:43.246Z
+
+## Latest Codex Summary
+- Reproduced the Phase 21 startup/readiness defect with a focused runtime-auth service test showing `startup_ready=False` when break-glass is intentionally unset.
+- Fixed `describe_startup_status()` so break-glass is no longer treated as a mandatory startup binding while keeping admin bootstrap and other reviewed required bindings intact.
+- Extended runtime-auth coverage to prove the break-glass contract still fails closed when disabled by default and when a wrong token is supplied.
+- Verified the fix with focused runtime-auth, CLI inspection, end-to-end, and Phase 21 boundary validation suites.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `describe_startup_status()` was incorrectly including `AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN` in `required_bindings`, which forced readiness to fail closed even though the reviewed design keeps break-glass disabled by default until explicitly configured.
+- What changed: Removed break-glass from the mandatory startup binding tuple in `control-plane/aegisops_control_plane/service.py`; added a focused service test proving startup/readiness stay healthy with PostgreSQL, Wazuh ingest, and admin bootstrap configured but break-glass unset; added direct tests proving break-glass still rejects use when disabled and when a wrong token is supplied.
+- Current blocker: none
+- Next exact step: Commit the focused fix on `codex/issue-449`; PR does not exist yet.
+- Verification gap: Did not run the full repository test suite; focused Phase 21 runtime-auth, CLI, end-to-end, and boundary validation coverage passed.
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_phase21_runtime_auth_validation.py`, `.codex-supervisor/issues/449/issue-journal.md`
+- Rollback concern: Low; change is limited to startup/readiness semantics and does not alter break-glass activation enforcement.
+- Last focused command: `python3 -m unittest control-plane.tests.test_phase21_production_like_hardening_boundary_validation`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Reproducing test failure before fix: `python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_startup_and_readiness_do_not_require_break_glass_when_unset` -> `AssertionError: False is not true`

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1896,7 +1896,6 @@ class AegisOpsControlPlaneService:
                 else ()
             ),
             "AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN",
-            "AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN",
         )
         binding_values = {
             "AEGISOPS_CONTROL_PLANE_POSTGRES_DSN": self._config.postgres_dsn,

--- a/control-plane/tests/test_phase21_runtime_auth_validation.py
+++ b/control-plane/tests/test_phase21_runtime_auth_validation.py
@@ -58,6 +58,33 @@ def _build_service(*, host: str = "127.0.0.1") -> AegisOpsControlPlaneService:
 
 
 class Phase21RuntimeAuthValidationTests(unittest.TestCase):
+    def test_startup_and_readiness_do_not_require_break_glass_when_unset(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_WAZUH_PROXY_SECRET,
+                admin_bootstrap_token=REVIEWED_ADMIN_BOOTSTRAP_TOKEN,
+            ),
+            store=store,
+        )
+
+        startup = service.describe_startup_status()
+        readiness = service.inspect_readiness_diagnostics()
+
+        self.assertTrue(startup.startup_ready)
+        self.assertNotIn(
+            "AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN",
+            startup.required_bindings,
+        )
+        self.assertNotIn(
+            "AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN",
+            startup.missing_bindings,
+        )
+        self.assertEqual(readiness.status, "ready")
+
     def test_protected_surface_runtime_fails_closed_without_trusted_proxy_bindings(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -202,6 +229,34 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
                     servers[0].shutdown()
                     servers[0].server_close()
                 thread.join(timeout=2)
+
+    def test_break_glass_contract_is_disabled_until_token_is_bound(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_WAZUH_PROXY_SECRET,
+                admin_bootstrap_token=REVIEWED_ADMIN_BOOTSTRAP_TOKEN,
+            ),
+            store=store,
+        )
+
+        with self.assertRaisesRegex(
+            PermissionError,
+            "break-glass contract is disabled until AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN is bound",
+        ):
+            service.require_break_glass_token("reviewed-break-glass-token")
+
+    def test_break_glass_contract_rejects_wrong_token(self) -> None:
+        service = _build_service()
+
+        with self.assertRaisesRegex(
+            PermissionError,
+            "break-glass token did not match the reviewed secret",
+        ):
+            service.require_break_glass_token("wrong-token")
 
     def test_break_glass_contract_rejects_expiry_outside_reviewed_window(self) -> None:
         service = _build_service()


### PR DESCRIPTION
## Summary
Fix Phase 21 startup/readiness semantics so break-glass stays disabled by default instead of being treated as a mandatory startup binding.

## What changed
- removed `AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN` from the required startup binding set used by `describe_startup_status()`
- added a focused service-level test proving startup/readiness stay healthy when PostgreSQL, Wazuh ingest, and admin bootstrap bindings are present but break-glass is intentionally unset
- added direct break-glass contract tests proving the recovery path still fails closed when the token is unbound or wrong

## Why
The reviewed Phase 21 boundary says break-glass is a controlled recovery exception that is disabled by default. Startup readiness was incorrectly failing closed solely because the break-glass token was unset, which widened break-glass into a mandatory normal-runtime dependency.

## Validation
- `python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation`
- `python3 -m unittest control-plane.tests.test_cli_inspection`
- `python3 -m unittest control-plane.tests.test_phase21_end_to_end_validation`
- `python3 -m unittest control-plane.tests.test_phase21_production_like_hardening_boundary_validation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed break-glass token from mandatory startup requirements. The service now starts up successfully without the break-glass token bound, while maintaining fail-closed behavior when break-glass functionality is invoked.

* **Tests**
  * Added comprehensive validation tests confirming service startup succeeds without break-glass configuration and verifying proper error handling for break-glass operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->