### PR TITLE
cleanup: remove duplicated low-level validators and normalize shared helper placement in service.py (#454)

### DIFF
--- a/.codex-supervisor/issues/454/issue-journal.md
+++ b/.codex-supervisor/issues/454/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #454: cleanup: remove duplicated low-level validators and normalize shared helper placement in service.py
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/454
+- Branch: codex/issue-454
+- Workspace: .
+- Journal: .codex-supervisor/issues/454/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 4803547f05ff7aa16a89c81d6855229b82abaf6e
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-13T23:44:14.636Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `control-plane/aegisops_control_plane/service.py` still contains duplicated low-level helper definitions and near-duplicate loopback/trusted-peer helpers that can be consolidated without changing runtime auth semantics.
+- What changed: Added a focused source-layout regression test for `_require_non_empty_string`, removed the duplicate `_require_non_empty_string` definition, renamed the listener loopback helper to `_listener_is_loopback`, and centralized trusted-peer CIDR evaluation in `_is_trusted_peer_for_proxy_cidrs(...)`.
+- Current blocker: none
+- Next exact step: Review diff and continue with supervisor-directed follow-up if any new cleanup or review feedback appears.
+- Verification gap: none for the requested local suites; no PR/CI checks were available in this turn.
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_service_persistence.py`
+- Rollback concern: Low; the shared trusted-peer helper is used by both protected-surface and Wazuh-ingest auth paths, so any rollback should preserve the current per-surface CIDR selection.
+- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection control-plane.tests.test_phase21_runtime_auth_validation`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/454/issue-journal.md
+++ b/.codex-supervisor/issues/454/issue-journal.md
@@ -5,29 +5,43 @@
 - Branch: codex/issue-454
 - Workspace: .
 - Journal: .codex-supervisor/issues/454/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 4803547f05ff7aa16a89c81d6855229b82abaf6e
+- Current phase: addressing_review
+- Attempt count: 4 (implementation=1, repair=3)
+- Last head SHA: 98b53cf13283b8ddc008da585d0357407c782f77
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-13T23:44:14.636Z
+- Last failure signature: PRRT_kwDOR2iDUc56rYGh|PRRT_kwDOR2iDUc56rdC5
+- Repeated failure signature count: 1
+- Updated at: 2026-04-14T00:09:40.3NZ
 
 ## Latest Codex Summary
-- None yet.
+Checked PR #464 review-thread state with `gh pr view` plus the `gh-address-comments` thread fetcher and confirmed the service normalization comment is already resolved on head `98b53cf`; the remaining actionable work was the stale journal snapshot plus missing Ruff suppressions on the trusted-proxy Wazuh ingest tests in [test_cli_inspection.py](control-plane/tests/test_cli_inspection.py:1411).
+
+I added `# noqa` suppressions for intentional `S104` and `S106` fixtures across the three contiguous trusted-proxy Wazuh ingest tests, re-ran the requested unittest suites successfully, and refreshed this journal against the latest verification pass. Local lint verification was limited because `ruff` is not installed in this workspace.
+
+Summary: Added Ruff suppressions for the intentional non-loopback/secret proxy-ingest test fixtures, re-ran the requested unittest suites, and refreshed the issue journal against the current PR review state.
+State hint: addressing_review
+Blocked reason: none
+Tests: `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection control-plane.tests.test_phase21_runtime_auth_validation`
+Next action: Commit and push the Ruff-suppression/journal refresh so PR #464 can re-evaluate the remaining review threads.
+Failure signature: PRRT_kwDOR2iDUc56rYGh|PRRT_kwDOR2iDUc56rdC5
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 2 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/AegisOps/pull/464#discussion_r3076426214
+- Details:
+  - .codex-supervisor/issues/454/issue-journal.md:15 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Sync snapshot metadata with the latest PR state.** `Current phase`, `Last head SHA`, and timestamp appear stale versus this PR context (e.g.,... url=https://github.com/TommyKammy/AegisOps/pull/464#discussion_r3076426214
+  - control-plane/tests/test_cli_inspection.py:1467 summary=_⚠️ Potential issue_ | _🟠 Major_ **Add Ruff security suppressions to keep this test consistent and CI-clean.** This new test introduces S104/S106 violations (bind-all-interface... url=https://github.com/TommyKammy/AegisOps/pull/464#discussion_r3076453666
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `control-plane/aegisops_control_plane/service.py` still contains duplicated low-level helper definitions and near-duplicate loopback/trusted-peer helpers that can be consolidated without changing runtime auth semantics.
-- What changed: Added a focused source-layout regression test for `_require_non_empty_string`, removed the duplicate `_require_non_empty_string` definition, renamed the listener loopback helper to `_listener_is_loopback`, and centralized trusted-peer CIDR evaluation in `_is_trusted_peer_for_proxy_cidrs(...)`.
+- Hypothesis: Publishing the new test-fixture suppression patch and this journal refresh should address both remaining automated review threads on PR #464.
+- What changed: Added inline `# noqa: S104` / `# noqa: S106` suppressions to the three contiguous trusted-proxy Wazuh ingest tests in `control-plane/tests/test_cli_inspection.py` and refreshed the journal after re-checking the live PR thread state.
 - Current blocker: none
-- Next exact step: Review diff and continue with supervisor-directed follow-up if any new cleanup or review feedback appears.
-- Verification gap: none for the requested local suites; no PR/CI checks were available in this turn.
-- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_service_persistence.py`
-- Rollback concern: Low; the shared trusted-peer helper is used by both protected-surface and Wazuh-ingest auth paths, so any rollback should preserve the current per-surface CIDR selection.
+- Next exact step: Commit and push `codex/issue-454`, then re-check the unresolved review-thread state on PR #464.
+- Verification gap: No local Ruff binary is available in this workspace, so lint confirmation is by targeted file inspection plus the existing review finding; the requested unittest suites passed after the edit.
+- Files touched: `control-plane/tests/test_cli_inspection.py`, `.codex-supervisor/issues/454/issue-journal.md`
+- Rollback concern: Low; the code change is comment-only in tests and does not alter runtime behavior.
 - Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_cli_inspection control-plane.tests.test_phase21_runtime_auth_validation`
 ### Scratchpad
-- Keep this section short. The supervisor may compact older notes automatically.
+- `gh pr view 464` and `fetch_comments.py --repo TommyKammy/AegisOps --pr 464` showed PR head `98b53cf13283b8ddc008da585d0357407c782f77`, one resolved service thread, and two unresolved threads for the journal snapshot plus CLI-inspection fixture suppressions.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1614,10 +1614,13 @@ class AegisOpsControlPlaneService:
         peer_addr: str | None,
         trusted_proxy_cidrs: tuple[str, ...],
     ) -> bool:
-        if peer_addr is None or peer_addr.strip() == "":
+        if peer_addr is None:
+            return False
+        normalized_peer_addr = peer_addr.strip()
+        if normalized_peer_addr == "":
             return False
         try:
-            peer_ip = ipaddress.ip_address(peer_addr)
+            peer_ip = ipaddress.ip_address(normalized_peer_addr)
         except ValueError:
             return False
         if self._listener_is_loopback():

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1341,7 +1341,7 @@ class AegisOpsControlPlaneService:
                     f"only valid IP networks, got: {cidr!r}"
                 ) from exc
         if (
-            not self._wazuh_ingest_listener_is_loopback()
+            not self._listener_is_loopback()
             and not self._config.wazuh_ingest_trusted_proxy_cidrs
         ):
             raise ValueError(
@@ -1364,7 +1364,7 @@ class AegisOpsControlPlaneService:
                     f"only valid IP networks, got: {cidr!r}"
                 ) from exc
         if (
-            not self._wazuh_ingest_listener_is_loopback()
+            not self._listener_is_loopback()
             and not self._config.protected_surface_trusted_proxy_cidrs
         ):
             raise ValueError(
@@ -1588,7 +1588,7 @@ class AegisOpsControlPlaneService:
         )
         return ingest_result
 
-    def _wazuh_ingest_listener_is_loopback(self) -> bool:
+    def _listener_is_loopback(self) -> bool:
         host = self._config.host.strip()
         if host.lower() == "localhost":
             return True
@@ -1598,29 +1598,31 @@ class AegisOpsControlPlaneService:
             return False
 
     def _is_trusted_wazuh_ingest_peer(self, peer_addr: str | None) -> bool:
-        if peer_addr is None or peer_addr.strip() == "":
-            return False
-        try:
-            peer_ip = ipaddress.ip_address(peer_addr)
-        except ValueError:
-            return False
-        if self._wazuh_ingest_listener_is_loopback():
-            return peer_ip.is_loopback
-        for cidr in self._config.wazuh_ingest_trusted_proxy_cidrs:
-            if peer_ip in ipaddress.ip_network(cidr, strict=False):
-                return True
-        return False
+        return self._is_trusted_peer_for_proxy_cidrs(
+            peer_addr,
+            self._config.wazuh_ingest_trusted_proxy_cidrs,
+        )
 
     def _is_trusted_protected_surface_peer(self, peer_addr: str | None) -> bool:
+        return self._is_trusted_peer_for_proxy_cidrs(
+            peer_addr,
+            self._config.protected_surface_trusted_proxy_cidrs,
+        )
+
+    def _is_trusted_peer_for_proxy_cidrs(
+        self,
+        peer_addr: str | None,
+        trusted_proxy_cidrs: tuple[str, ...],
+    ) -> bool:
         if peer_addr is None or peer_addr.strip() == "":
             return False
         try:
             peer_ip = ipaddress.ip_address(peer_addr)
         except ValueError:
             return False
-        if self._wazuh_ingest_listener_is_loopback():
+        if self._listener_is_loopback():
             return peer_ip.is_loopback
-        for cidr in self._config.protected_surface_trusted_proxy_cidrs:
+        for cidr in trusted_proxy_cidrs:
             if peer_ip in ipaddress.ip_network(cidr, strict=False):
                 return True
         return False
@@ -6026,12 +6028,6 @@ class AegisOpsControlPlaneService:
         if alert.lifecycle_state == "escalated_to_case":
             return "tracked_case"
         return "next_business_hours_review"
-
-    @staticmethod
-    def _require_non_empty_string(value: object, field_name: str) -> str:
-        if not isinstance(value, str) or value.strip() == "":
-            raise ValueError(f"{field_name} must be a non-empty string")
-        return value
 
     @staticmethod
     def _require_mapping(value: object, field_name: str) -> dict[str, object]:

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1410,10 +1410,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
-                host="0.0.0.0",
+                host="0.0.0.0",  # noqa: S104 - intentional non-loopback test coverage
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
                 wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
             ),
             store=store,
@@ -1427,7 +1427,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
                 authorization_header="Bearer reviewed-shared-secret",
                 forwarded_proto="https",
-                reverse_proxy_secret_header="reviewed-proxy-secret",
+                reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
                 peer_addr="10.10.0.6",
             )
 
@@ -1435,10 +1435,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
-                host="0.0.0.0",
+                host="0.0.0.0",  # noqa: S104 - intentional non-loopback test coverage
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
                 wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
             ),
             store=store,
@@ -1448,7 +1448,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
             authorization_header="Bearer reviewed-shared-secret",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             peer_addr="10.10.0.5",
         )
 
@@ -1460,10 +1460,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
-                host="0.0.0.0",
+                host="0.0.0.0",  # noqa: S104 - intentional non-loopback test coverage
                 postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
                 wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
             ),
             store=store,
@@ -1473,7 +1473,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
             authorization_header="Bearer reviewed-shared-secret",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
             peer_addr=" 10.10.0.5 ",
         )
 

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1456,6 +1456,31 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(len(store.list(AlertRecord)), 1)
         self.assertEqual(len(store.list(AnalyticSignalRecord)), 1)
 
+    def test_service_admits_trusted_proxy_peer_with_surrounding_whitespace(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="0.0.0.0",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
+                wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
+            ),
+            store=store,
+        )
+
+        ingest_result = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr=" 10.10.0.5 ",
+        )
+
+        self.assertEqual(ingest_result.disposition, "created")
+        self.assertEqual(len(store.list(AlertRecord)), 1)
+        self.assertEqual(len(store.list(AnalyticSignalRecord)), 1)
+
     def test_long_running_runtime_surface_rejects_oversized_wazuh_ingest_body(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 import hashlib
+import inspect
 import json
 import logging
 import pathlib
@@ -329,6 +330,12 @@ class _OutOfBandMutationStore:
             self._mutated = True
         with self.inner.transaction(isolation_level=isolation_level):
             yield
+
+
+class ControlPlaneServiceHelperLayoutTests(unittest.TestCase):
+    def test_service_defines_require_non_empty_string_once(self) -> None:
+        source = inspect.getsource(AegisOpsControlPlaneService)
+        self.assertEqual(source.count("def _require_non_empty_string("), 1)
 
 
 class ControlPlaneServicePersistenceTests(unittest.TestCase):


### PR DESCRIPTION
Closes #454
This PR was opened by codex-supervisor.
Latest Codex summary:

Cleaned up `control-plane/aegisops_control_plane/service.py` in a narrow pass. I removed the duplicate `_require_non_empty_string` definition, renamed the listener loopback helper to the shared `_listener_is_loopback`, and collapsed the duplicated trusted-peer CIDR logic behind `_is_trusted_peer_for_proxy_cidrs(...)` so both protected-surface and Wazuh-ingest paths keep the same fail-closed behavior with less repetition.

I also added a focused regression test in [test_service_persistence.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-454/control-plane/tests/test_service_persistence.py:335) that inspects the class source and asserts `_require_non_empty_string` is defined only once. That test failed before the cleanup and passes now. The work is committed on `codex/issue-454` as `7958fd8` (`Clean up duplicated service validators`).

Summary: Removed the duplicated low-level validator, normalized shared loopback/trusted-peer helper placement in `service.py`, added a focused reproducer test, and verified the requested suites.
State hint: stabilizing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence.ControlPlaneServiceHelperLayoutTests.test_service_defines_require_non_empty_string_once`; `python3 -m unittest control-plane.tests.test_service_persistence`; `python3 -m unittest control-plane.tests.test_cli_inspection`; `python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation`
Failure signature: none
Next action: O...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated trusted-peer validation to reduce duplication and improve consistency.

* **Bug Fixes**
  * Accept trusted proxy addresses even when they include surrounding whitespace.

* **Tests**
  * Added tests to guard helper-definition uniqueness and trusted-proxy acceptance.

* **Chores**
  * Added an internal supervisor journal documenting issue/PR metadata, review notes, and verification status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->