### PR TITLE
implementation: extract reviewed action-request, delegation, and reconciliation flows into a dedicated execution coordinator (#456)

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -737,7 +737,7 @@ class PostgresControlPlaneStore:
             action_execution_lifecycle_counts=action_execution_lifecycle_counts,
             active_action_execution_ids=self._list_identifier_values_by_lifecycle_states(
                 ActionExecutionRecord,
-                ("queued", "running"),
+                ("dispatching", "queued", "running"),
             ),
             reconciliation_total=sum(reconciliation_lifecycle_counts.values()),
             reconciliation_lifecycle_counts=reconciliation_lifecycle_counts,

--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -174,6 +174,7 @@ _LIFECYCLE_STATES_BY_FAMILY: dict[str, frozenset[str]] = {
     ),
     "action_execution": frozenset(
         {
+            "dispatching",
             "queued",
             "running",
             "succeeded",

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -514,59 +514,58 @@ class ExecutionCoordinator:
                     "matched approved action request to reviewed execution run"
                 )
 
-        if (
-            authoritative_execution is not None
-            and latest_execution is not None
-            and ingest_disposition == "matched"
-        ):
-            reconciled_lifecycle_state = self._action_execution_lifecycle_from_status(
-                latest_execution.get("status"),
-                authoritative_execution.lifecycle_state,
-            )
-            if reconciled_lifecycle_state != authoritative_execution.lifecycle_state:
-                authoritative_execution = self._service.persist_record(
-                    ActionExecutionRecord(
-                        action_execution_id=authoritative_execution.action_execution_id,
-                        action_request_id=authoritative_execution.action_request_id,
-                        approval_decision_id=authoritative_execution.approval_decision_id,
-                        delegation_id=authoritative_execution.delegation_id,
-                        execution_surface_type=authoritative_execution.execution_surface_type,
-                        execution_surface_id=authoritative_execution.execution_surface_id,
-                        execution_run_id=authoritative_execution.execution_run_id,
-                        idempotency_key=authoritative_execution.idempotency_key,
-                        target_scope=authoritative_execution.target_scope,
-                        approved_payload=authoritative_execution.approved_payload,
-                        payload_hash=authoritative_execution.payload_hash,
-                        delegated_at=authoritative_execution.delegated_at,
-                        expires_at=authoritative_execution.expires_at,
-                        provenance=authoritative_execution.provenance,
-                        lifecycle_state=reconciled_lifecycle_state,
-                    )
+        with self._service._store.transaction():
+            if authoritative_execution is not None:
+                stored_execution = self._service._store.get(
+                    ActionExecutionRecord,
+                    authoritative_execution.action_execution_id,
                 )
+                if stored_execution is None:
+                    raise LookupError(
+                        "missing authoritative action execution during reconciliation"
+                    )
+                authoritative_execution = stored_execution
 
-        reconciliation = self._service.persist_record(
-            ReconciliationRecord(
-                reconciliation_id=self._service._next_identifier("reconciliation"),
-                subject_linkage=subject_linkage,
-                alert_id=action_request.alert_id,
-                finding_id=action_request.finding_id,
-                analytic_signal_id=None,
-                execution_run_id=execution_run_id,
-                linked_execution_run_ids=linked_execution_run_ids,
-                correlation_key=self._build_action_execution_reconciliation_key(
-                    action_request=action_request,
-                    execution_surface_type=execution_surface_type,
-                    execution_surface_id=execution_surface_id,
-                    authoritative_execution=authoritative_execution,
-                ),
-                first_seen_at=action_request.requested_at,
-                last_seen_at=last_seen_at,
-                ingest_disposition=ingest_disposition,
-                mismatch_summary=mismatch_summary,
-                compared_at=compared_at,
-                lifecycle_state=lifecycle_state,
+            if (
+                authoritative_execution is not None
+                and latest_execution is not None
+                and ingest_disposition == "matched"
+            ):
+                reconciled_lifecycle_state = self._action_execution_lifecycle_from_status(
+                    latest_execution.get("status"),
+                    authoritative_execution.lifecycle_state,
+                )
+                if reconciled_lifecycle_state != authoritative_execution.lifecycle_state:
+                    authoritative_execution = self._service.persist_record(
+                        replace(
+                            authoritative_execution,
+                            lifecycle_state=reconciled_lifecycle_state,
+                        )
+                    )
+
+            reconciliation = self._service.persist_record(
+                ReconciliationRecord(
+                    reconciliation_id=self._service._next_identifier("reconciliation"),
+                    subject_linkage=subject_linkage,
+                    alert_id=action_request.alert_id,
+                    finding_id=action_request.finding_id,
+                    analytic_signal_id=None,
+                    execution_run_id=execution_run_id,
+                    linked_execution_run_ids=linked_execution_run_ids,
+                    correlation_key=self._build_action_execution_reconciliation_key(
+                        action_request=action_request,
+                        execution_surface_type=execution_surface_type,
+                        execution_surface_id=execution_surface_id,
+                        authoritative_execution=authoritative_execution,
+                    ),
+                    first_seen_at=action_request.requested_at,
+                    last_seen_at=last_seen_at,
+                    ingest_disposition=ingest_disposition,
+                    mismatch_summary=mismatch_summary,
+                    compared_at=compared_at,
+                    lifecycle_state=lifecycle_state,
+                )
             )
-        )
         self._service._emit_structured_event(
             logging.INFO,
             "action_execution_reconciled",
@@ -875,16 +874,39 @@ class ExecutionCoordinator:
             return current_lifecycle_state
 
         normalized_status = status.strip().lower()
-        if normalized_status in {"queued", "pending"}:
-            return "queued"
-        if normalized_status in {"running", "in_progress"}:
-            return "running"
-        if normalized_status in {"success", "succeeded", "completed"}:
-            return "succeeded"
-        if normalized_status in {"failed", "error"}:
-            return "failed"
-        if normalized_status in {"canceled", "cancelled"}:
-            return "canceled"
+        observed_state = {
+            "queued": "queued",
+            "pending": "queued",
+            "running": "running",
+            "in_progress": "running",
+            "success": "succeeded",
+            "succeeded": "succeeded",
+            "completed": "succeeded",
+            "failed": "failed",
+            "error": "failed",
+            "canceled": "canceled",
+            "cancelled": "canceled",
+        }.get(normalized_status)
+        if observed_state is None:
+            return current_lifecycle_state
+
+        normalized_current_lifecycle_state = current_lifecycle_state.strip().lower()
+        if normalized_current_lifecycle_state in {"succeeded", "failed", "canceled"}:
+            return current_lifecycle_state
+
+        lifecycle_rank = {
+            "dispatching": 0,
+            "queued": 1,
+            "running": 2,
+            "succeeded": 3,
+            "failed": 3,
+            "canceled": 3,
+        }
+        if lifecycle_rank[observed_state] >= lifecycle_rank.get(
+            normalized_current_lifecycle_state,
+            -1,
+        ):
+            return observed_state
         return current_lifecycle_state
 
     def _build_action_execution_reconciliation_key(

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -789,17 +789,38 @@ class ExecutionCoordinator:
         execution_surface_id: str,
     ) -> dict[str, object]:
         provenance = dict(execution.provenance)
-        provenance["adapter"] = getattr(receipt, "adapter")
+        provenance["adapter"] = self._require_receipt_string_attribute(
+            receipt,
+            "adapter",
+        )
         base_url = getattr(receipt, "base_url", "")
         if isinstance(base_url, str) and base_url.strip() and base_url != "<set-me>":
             provenance["adapter_base_url"] = base_url
         if execution_surface_id == "shuffle":
             provenance["downstream_binding"] = {
-                "approval_decision_id": getattr(receipt, "approval_decision_id"),
-                "delegation_id": getattr(receipt, "delegation_id"),
-                "payload_hash": getattr(receipt, "payload_hash"),
+                "approval_decision_id": self._require_receipt_string_attribute(
+                    receipt,
+                    "approval_decision_id",
+                ),
+                "delegation_id": self._require_receipt_string_attribute(
+                    receipt,
+                    "delegation_id",
+                ),
+                "payload_hash": self._require_receipt_string_attribute(
+                    receipt,
+                    "payload_hash",
+                ),
             }
         return provenance
+
+    @staticmethod
+    def _require_receipt_string_attribute(receipt: object, field_name: str) -> str:
+        value = getattr(receipt, field_name, None)
+        if not isinstance(value, str) or value.strip() == "":
+            raise ValueError(
+                f"adapter receipt missing required '{field_name}' attribute"
+            )
+        return value
 
     def _mark_dispatch_failure(
         self,

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -112,7 +112,9 @@ def _approved_payload_binding_hash(
 
 def _json_ready(value: object) -> object:
     if isinstance(value, datetime):
-        return value.isoformat()
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("datetime values used for binding must be timezone-aware")
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
     if isinstance(value, Mapping):
         return {str(key): _json_ready(item) for key, item in value.items()}
     if isinstance(value, tuple):
@@ -217,13 +219,15 @@ class ExecutionCoordinator:
                 raise ValueError("expires_at must be after requested_at")
 
             idempotency_material = json.dumps(
-                {
-                    "payload_hash": payload_hash,
-                    "record_family": record_family,
-                    "record_id": record_id,
-                    "requester_identity": requester_identity,
-                    "expires_at": expires_at.isoformat(),
-                },
+                _json_ready(
+                    {
+                        "payload_hash": payload_hash,
+                        "record_family": record_family,
+                        "record_id": record_id,
+                        "requester_identity": requester_identity,
+                        "expires_at": expires_at,
+                    }
+                ),
                 sort_keys=True,
                 separators=(",", ":"),
             )
@@ -672,6 +676,7 @@ class ExecutionCoordinator:
                 )
             )
         receipt = None
+        execution_run_id: str
         try:
             receipt = adapter.dispatch_approved_action(
                 delegation_id=delegation_id,
@@ -689,6 +694,10 @@ class ExecutionCoordinator:
                 delegation_id=delegation_id,
                 execution_surface_type=execution_surface_type,
                 execution_surface_id=execution_surface_id,
+            )
+            execution_run_id = self._require_receipt_string_attribute(
+                receipt,
+                "execution_run_id",
             )
         except Exception as exc:
             self._mark_dispatch_failure(
@@ -711,7 +720,7 @@ class ExecutionCoordinator:
                 execution = self._service.persist_record(
                     replace(
                         stored_execution,
-                        execution_run_id=receipt.execution_run_id,
+                        execution_run_id=execution_run_id,
                         provenance=self._finalized_execution_provenance(
                             execution=stored_execution,
                             receipt=receipt,

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -699,27 +699,35 @@ class ExecutionCoordinator:
             )
             raise
 
-        with self._service._store.transaction():
-            stored_execution = self._service._store.get(
-                ActionExecutionRecord,
-                predispatch_execution.action_execution_id,
-            )
-            if stored_execution is None:
-                raise LookupError(
-                    "missing pre-dispatch action execution record during delegation finalization"
+        try:
+            with self._service._store.transaction():
+                stored_execution = self._service._store.get(
+                    ActionExecutionRecord,
+                    predispatch_execution.action_execution_id,
                 )
-            execution = self._service.persist_record(
-                replace(
-                    stored_execution,
-                    execution_run_id=receipt.execution_run_id,
-                    provenance=self._finalized_execution_provenance(
-                        execution=stored_execution,
-                        receipt=receipt,
-                        execution_surface_id=execution_surface_id,
-                    ),
-                    lifecycle_state="queued",
+                if stored_execution is None:
+                    raise LookupError(
+                        "missing pre-dispatch action execution record during delegation finalization"
+                    )
+                execution = self._service.persist_record(
+                    replace(
+                        stored_execution,
+                        execution_run_id=receipt.execution_run_id,
+                        provenance=self._finalized_execution_provenance(
+                            execution=stored_execution,
+                            receipt=receipt,
+                            execution_surface_id=execution_surface_id,
+                        ),
+                        lifecycle_state="queued",
+                    )
                 )
+        except Exception as exc:
+            self._mark_dispatch_failure(
+                execution=predispatch_execution,
+                error=exc,
+                receipt=receipt,
             )
+            raise
         self._service._emit_action_execution_delegated_event(execution)
         return execution
 

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -1,0 +1,913 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import logging
+from typing import Mapping, Protocol
+
+from .models import (
+    ActionExecutionRecord,
+    ActionRequestRecord,
+    ApprovalDecisionRecord,
+    ReconciliationRecord,
+)
+
+
+class ExecutionCoordinatorServiceDependencies(Protocol):
+    _store: object
+    _shuffle: object
+    _isolated_executor: object
+
+    def inspect_assistant_context(self, record_family: str, record_id: str) -> object:
+        ...
+
+    def render_recommendation_draft(self, record_family: str, record_id: str) -> object:
+        ...
+
+    def persist_record(self, record: object) -> object:
+        ...
+
+    def _emit_structured_event(
+        self,
+        level: int,
+        event: str,
+        **fields: object,
+    ) -> None:
+        ...
+
+    def _emit_action_execution_delegated_event(
+        self,
+        execution: ActionExecutionRecord,
+    ) -> None:
+        ...
+
+    def _require_phase19_case_scoped_advisory_read(self, context_snapshot: object) -> None:
+        ...
+
+    def _require_single_recommendation_binding(
+        self,
+        *,
+        record_family: str,
+        record_id: str,
+        linked_recommendation_ids: tuple[str, ...],
+    ) -> str:
+        ...
+
+    def _require_single_linked_case_id(self, linked_case_ids: tuple[str, ...]) -> str:
+        ...
+
+    def _require_phase19_operator_case(self, case_id: str) -> object:
+        ...
+
+    def _resolve_new_record_identifier(
+        self,
+        record_type: type,
+        requested_identifier: str | None,
+        field_name: str,
+        prefix: str,
+    ) -> str:
+        ...
+
+    def _require_aware_datetime(self, value: datetime, field_name: str) -> datetime:
+        ...
+
+    def _require_non_empty_string(self, value: object, field_name: str) -> str:
+        ...
+
+    def _require_mapping(self, value: object, field_name: str) -> dict[str, object]:
+        ...
+
+    def _next_identifier(self, prefix: str) -> str:
+        ...
+
+    def _merge_linked_ids(
+        self,
+        existing_values: object,
+        incoming_value: str | None,
+    ) -> tuple[str, ...]:
+        ...
+
+
+def _approved_payload_binding_hash(
+    *,
+    target_scope: Mapping[str, object],
+    approved_payload: Mapping[str, object],
+    execution_surface_type: str,
+    execution_surface_id: str,
+) -> str:
+    binding = _json_ready(
+        {
+            "approved_payload": approved_payload,
+            "execution_surface_id": execution_surface_id,
+            "execution_surface_type": execution_surface_type,
+            "target_scope": target_scope,
+        }
+    )
+    return hashlib.sha256(
+        json.dumps(binding, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _json_ready(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    return value
+
+
+class ExecutionCoordinator:
+    """Owns approved action request, delegation, and reconciliation flows."""
+
+    def __init__(self, service: ExecutionCoordinatorServiceDependencies) -> None:
+        self._service = service
+
+    def create_reviewed_action_request_from_advisory(
+        self,
+        *,
+        record_family: str,
+        record_id: str,
+        requester_identity: str,
+        recipient_identity: str,
+        message_intent: str,
+        escalation_reason: str,
+        expires_at: datetime,
+        action_request_id: str | None = None,
+    ) -> ActionRequestRecord:
+        requester_identity = self._service._require_non_empty_string(
+            requester_identity,
+            "requester_identity",
+        )
+        recipient_identity = self._service._require_non_empty_string(
+            recipient_identity,
+            "recipient_identity",
+        )
+        message_intent = self._service._require_non_empty_string(
+            message_intent,
+            "message_intent",
+        )
+        escalation_reason = self._service._require_non_empty_string(
+            escalation_reason,
+            "escalation_reason",
+        )
+        expires_at = self._service._require_aware_datetime(expires_at, "expires_at")
+
+        with self._service._store.transaction():
+            context_snapshot = self._service.inspect_assistant_context(
+                record_family,
+                record_id,
+            )
+            self._service._require_phase19_case_scoped_advisory_read(context_snapshot)
+            recommendation_draft = self._service.render_recommendation_draft(
+                record_family,
+                record_id,
+            )
+            if recommendation_draft.recommendation_draft.get("status") != "ready":
+                raise ValueError(
+                    "reviewed advisory context is not ready for approval-bound action requests"
+                )
+
+            recommendation_id = self._service._require_single_recommendation_binding(
+                record_family=record_family,
+                record_id=record_id,
+                linked_recommendation_ids=recommendation_draft.linked_recommendation_ids,
+            )
+            case_id = self._service._require_single_linked_case_id(
+                recommendation_draft.linked_case_ids
+            )
+            case = self._service._require_phase19_operator_case(case_id)
+            if expires_at <= datetime.now(timezone.utc):
+                raise ValueError("expires_at must be in the future")
+
+            requested_payload = {
+                "action_type": "notify_identity_owner",
+                "recipient_identity": recipient_identity,
+                "message_intent": message_intent,
+                "escalation_reason": escalation_reason,
+                "source_record_family": record_family,
+                "source_record_id": record_id,
+                "recommendation_id": recommendation_id,
+                "case_id": case.case_id,
+                "alert_id": case.alert_id,
+                "finding_id": case.finding_id,
+                "linked_evidence_ids": recommendation_draft.linked_evidence_ids,
+            }
+            target_scope = {
+                "record_family": record_family,
+                "record_id": record_id,
+                "case_id": case.case_id,
+                "alert_id": case.alert_id,
+                "finding_id": case.finding_id,
+                "recipient_identity": recipient_identity,
+            }
+            payload_hash = _approved_payload_binding_hash(
+                target_scope=target_scope,
+                approved_payload=requested_payload,
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+            )
+            requested_at = datetime.now(timezone.utc)
+            if expires_at <= requested_at:
+                raise ValueError("expires_at must be after requested_at")
+
+            idempotency_material = json.dumps(
+                {
+                    "payload_hash": payload_hash,
+                    "record_family": record_family,
+                    "record_id": record_id,
+                    "requester_identity": requester_identity,
+                    "expires_at": expires_at.isoformat(),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            idempotency_key = (
+                "notify-identity-owner:"
+                + hashlib.sha256(idempotency_material.encode("utf-8")).hexdigest()
+            )
+            for existing in self._service._store.list(ActionRequestRecord):
+                if existing.idempotency_key == idempotency_key:
+                    self._service._emit_structured_event(
+                        logging.INFO,
+                        "action_request_reused",
+                        action_request_id=existing.action_request_id,
+                        action_type=existing.requested_payload.get("action_type"),
+                        lifecycle_state=existing.lifecycle_state,
+                        case_id=existing.case_id,
+                    )
+                    return existing
+
+            normalized_action_request_id = self._service._resolve_new_record_identifier(
+                ActionRequestRecord,
+                action_request_id,
+                "action_request_id",
+                "action-request",
+            )
+            created_request = self._service.persist_record(
+                ActionRequestRecord(
+                    action_request_id=normalized_action_request_id,
+                    approval_decision_id=None,
+                    case_id=case.case_id,
+                    alert_id=case.alert_id,
+                    finding_id=case.finding_id,
+                    idempotency_key=idempotency_key,
+                    target_scope=target_scope,
+                    payload_hash=payload_hash,
+                    requested_at=requested_at,
+                    expires_at=expires_at,
+                    lifecycle_state="pending_approval",
+                    requester_identity=requester_identity,
+                    requested_payload=requested_payload,
+                    policy_basis={
+                        "severity": "low",
+                        "target_scope": "single_identity",
+                        "action_reversibility": "reversible",
+                        "asset_criticality": "standard",
+                        "identity_criticality": "standard",
+                        "blast_radius": "single_target",
+                        "execution_constraint": "routine_allowed",
+                    },
+                    policy_evaluation={
+                        "approval_requirement": "human_required",
+                        "routing_target": "approval",
+                        "execution_surface_type": "automation_substrate",
+                        "execution_surface_id": "shuffle",
+                    },
+                )
+            )
+        self._service._emit_structured_event(
+            logging.INFO,
+            "action_request_created",
+            action_request_id=created_request.action_request_id,
+            action_type=created_request.requested_payload.get("action_type"),
+            requester_identity=created_request.requester_identity,
+            case_id=created_request.case_id,
+            alert_id=created_request.alert_id,
+            lifecycle_state=created_request.lifecycle_state,
+            expires_at=created_request.expires_at.isoformat()
+            if created_request.expires_at is not None
+            else None,
+        )
+        return created_request
+
+    def delegate_approved_action_to_shuffle(
+        self,
+        *,
+        action_request_id: str,
+        approved_payload: Mapping[str, object],
+        delegated_at: datetime,
+        delegation_issuer: str,
+        evidence_ids: tuple[str, ...] = (),
+    ) -> ActionExecutionRecord:
+        return self._delegate_approved_action(
+            action_request_id=action_request_id,
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer=delegation_issuer,
+            evidence_ids=evidence_ids,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            invalid_execution_surface_type_message=(
+                "approved action request is not delegated through the automation "
+                "substrate path"
+            ),
+            invalid_execution_surface_id_message=(
+                "approved action request is not routed to the reviewed shuffle adapter"
+            ),
+            delegation_label="shuffle",
+        )
+
+    def delegate_approved_action_to_isolated_executor(
+        self,
+        *,
+        action_request_id: str,
+        approved_payload: Mapping[str, object],
+        delegated_at: datetime,
+        delegation_issuer: str,
+        evidence_ids: tuple[str, ...] = (),
+    ) -> ActionExecutionRecord:
+        return self._delegate_approved_action(
+            action_request_id=action_request_id,
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer=delegation_issuer,
+            evidence_ids=evidence_ids,
+            execution_surface_type="executor",
+            execution_surface_id="isolated-executor",
+            invalid_execution_surface_type_message=(
+                "approved action request is not delegated through the isolated "
+                "executor path"
+            ),
+            invalid_execution_surface_id_message=(
+                "approved action request is not routed to the reviewed isolated executor"
+            ),
+            delegation_label="isolated executor",
+        )
+
+    def reconcile_action_execution(
+        self,
+        *,
+        action_request_id: str,
+        execution_surface_type: str,
+        execution_surface_id: str,
+        observed_executions: tuple[Mapping[str, object], ...],
+        compared_at: datetime,
+        stale_after: datetime,
+    ) -> ReconciliationRecord:
+        compared_at = self._service._require_aware_datetime(compared_at, "compared_at")
+        stale_after = self._service._require_aware_datetime(stale_after, "stale_after")
+        execution_surface_type = self._service._require_non_empty_string(
+            execution_surface_type,
+            "execution_surface_type",
+        )
+        execution_surface_id = self._service._require_non_empty_string(
+            execution_surface_id,
+            "execution_surface_id",
+        )
+        action_request = self._service._store.get(ActionRequestRecord, action_request_id)
+        if action_request is None:
+            raise LookupError(f"Missing action request {action_request_id!r}")
+        if action_request.lifecycle_state != "approved":
+            raise ValueError(
+                f"Action request {action_request_id!r} is not approved "
+                f"(state={action_request.lifecycle_state!r})"
+            )
+
+        require_binding_identifiers = (
+            execution_surface_type == "automation_substrate"
+            and execution_surface_id == "shuffle"
+        )
+        normalized_executions = self._normalize_observed_executions(
+            observed_executions,
+            require_binding_identifiers=require_binding_identifiers,
+        )
+        linked_execution_run_ids = tuple(
+            execution["execution_run_id"] for execution in normalized_executions
+        )
+        unique_execution_run_ids = tuple(dict.fromkeys(linked_execution_run_ids))
+        latest_execution = normalized_executions[-1] if normalized_executions else None
+        authoritative_execution = self._find_authoritative_action_execution(
+            action_request_id=action_request.action_request_id,
+            execution_surface_type=execution_surface_type,
+            execution_surface_id=execution_surface_id,
+            execution_run_id=(
+                None if latest_execution is None else latest_execution["execution_run_id"]
+            ),
+            idempotency_key=(
+                action_request.idempotency_key
+                if latest_execution is None
+                else latest_execution["idempotency_key"]
+            ),
+        )
+
+        subject_linkage: dict[str, object] = {
+            "action_request_ids": (action_request.action_request_id,),
+            "execution_surface_types": (execution_surface_type,),
+            "execution_surface_ids": (execution_surface_id,),
+        }
+        if action_request.approval_decision_id is not None:
+            subject_linkage["approval_decision_ids"] = (
+                action_request.approval_decision_id,
+            )
+        if action_request.alert_id is not None:
+            subject_linkage["alert_ids"] = (action_request.alert_id,)
+        if action_request.case_id is not None:
+            subject_linkage["case_ids"] = (action_request.case_id,)
+        if action_request.finding_id is not None:
+            subject_linkage["finding_ids"] = (action_request.finding_id,)
+        if authoritative_execution is not None:
+            subject_linkage["action_execution_ids"] = (
+                authoritative_execution.action_execution_id,
+            )
+            subject_linkage["delegation_ids"] = (
+                authoritative_execution.delegation_id,
+            )
+            evidence_ids = self._service._merge_linked_ids(
+                authoritative_execution.provenance.get("evidence_ids"),
+                None,
+            )
+            if evidence_ids:
+                subject_linkage["evidence_ids"] = evidence_ids
+
+        ingest_disposition: str
+        lifecycle_state: str
+        mismatch_summary: str
+        execution_run_id: str | None = None
+        last_seen_at = action_request.requested_at
+
+        if latest_execution is None:
+            ingest_disposition = "missing"
+            lifecycle_state = "pending"
+            mismatch_summary = (
+                "missing downstream execution for approved action request correlation"
+            )
+        else:
+            execution_run_id = latest_execution["execution_run_id"]
+            last_seen_at = latest_execution["observed_at"]
+            observed_execution_surface_id = latest_execution["execution_surface_id"]
+            observed_idempotency_key = latest_execution["idempotency_key"]
+            observed_approval_decision_id = latest_execution.get("approval_decision_id")
+            observed_delegation_id = latest_execution.get("delegation_id")
+            observed_payload_hash = latest_execution.get("payload_hash")
+            expected_execution_run_id = (
+                None
+                if authoritative_execution is None
+                else authoritative_execution.execution_run_id
+            )
+            if last_seen_at < stale_after and compared_at >= stale_after:
+                ingest_disposition = "stale"
+                lifecycle_state = "stale"
+                mismatch_summary = "stale downstream execution observation requires refresh"
+            elif len(unique_execution_run_ids) > 1:
+                ingest_disposition = "duplicate"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "duplicate downstream executions observed for one approved request"
+                )
+            elif (
+                observed_execution_surface_id != execution_surface_id
+                or observed_idempotency_key != action_request.idempotency_key
+            ):
+                ingest_disposition = "mismatch"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "execution surface/idempotency mismatch between approved request and observed execution"
+                )
+            elif (
+                expected_execution_run_id is not None
+                and execution_run_id != expected_execution_run_id
+            ):
+                ingest_disposition = "mismatch"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "execution run identity mismatch between authoritative action execution "
+                    "and observed downstream execution"
+                )
+            elif (
+                authoritative_execution is not None
+                and authoritative_execution.execution_surface_type == "automation_substrate"
+                and authoritative_execution.execution_surface_id == "shuffle"
+                and (
+                    observed_approval_decision_id
+                    != authoritative_execution.approval_decision_id
+                    or observed_delegation_id != authoritative_execution.delegation_id
+                    or observed_payload_hash != authoritative_execution.payload_hash
+                )
+            ):
+                ingest_disposition = "mismatch"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "approved binding mismatch between authoritative action execution "
+                    "and observed downstream execution"
+                )
+            else:
+                ingest_disposition = "matched"
+                lifecycle_state = "matched"
+                mismatch_summary = (
+                    "matched approved action request to reviewed execution run"
+                )
+
+        if (
+            authoritative_execution is not None
+            and latest_execution is not None
+            and ingest_disposition == "matched"
+        ):
+            reconciled_lifecycle_state = self._action_execution_lifecycle_from_status(
+                latest_execution.get("status"),
+                authoritative_execution.lifecycle_state,
+            )
+            if reconciled_lifecycle_state != authoritative_execution.lifecycle_state:
+                authoritative_execution = self._service.persist_record(
+                    ActionExecutionRecord(
+                        action_execution_id=authoritative_execution.action_execution_id,
+                        action_request_id=authoritative_execution.action_request_id,
+                        approval_decision_id=authoritative_execution.approval_decision_id,
+                        delegation_id=authoritative_execution.delegation_id,
+                        execution_surface_type=authoritative_execution.execution_surface_type,
+                        execution_surface_id=authoritative_execution.execution_surface_id,
+                        execution_run_id=authoritative_execution.execution_run_id,
+                        idempotency_key=authoritative_execution.idempotency_key,
+                        target_scope=authoritative_execution.target_scope,
+                        approved_payload=authoritative_execution.approved_payload,
+                        payload_hash=authoritative_execution.payload_hash,
+                        delegated_at=authoritative_execution.delegated_at,
+                        expires_at=authoritative_execution.expires_at,
+                        provenance=authoritative_execution.provenance,
+                        lifecycle_state=reconciled_lifecycle_state,
+                    )
+                )
+
+        reconciliation = self._service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id=self._service._next_identifier("reconciliation"),
+                subject_linkage=subject_linkage,
+                alert_id=action_request.alert_id,
+                finding_id=action_request.finding_id,
+                analytic_signal_id=None,
+                execution_run_id=execution_run_id,
+                linked_execution_run_ids=linked_execution_run_ids,
+                correlation_key=self._build_action_execution_reconciliation_key(
+                    action_request=action_request,
+                    execution_surface_type=execution_surface_type,
+                    execution_surface_id=execution_surface_id,
+                    authoritative_execution=authoritative_execution,
+                ),
+                first_seen_at=action_request.requested_at,
+                last_seen_at=last_seen_at,
+                ingest_disposition=ingest_disposition,
+                mismatch_summary=mismatch_summary,
+                compared_at=compared_at,
+                lifecycle_state=lifecycle_state,
+            )
+        )
+        self._service._emit_structured_event(
+            logging.INFO,
+            "action_execution_reconciled",
+            reconciliation_id=reconciliation.reconciliation_id,
+            action_request_id=action_request.action_request_id,
+            execution_surface_type=execution_surface_type,
+            execution_surface_id=execution_surface_id,
+            ingest_disposition=reconciliation.ingest_disposition,
+            lifecycle_state=reconciliation.lifecycle_state,
+            execution_run_id=reconciliation.execution_run_id,
+        )
+        return reconciliation
+
+    def _delegate_approved_action(
+        self,
+        *,
+        action_request_id: str,
+        approved_payload: Mapping[str, object],
+        delegated_at: datetime,
+        delegation_issuer: str,
+        evidence_ids: tuple[str, ...],
+        execution_surface_type: str,
+        execution_surface_id: str,
+        invalid_execution_surface_type_message: str,
+        invalid_execution_surface_id_message: str,
+        delegation_label: str,
+    ) -> ActionExecutionRecord:
+        delegated_at = self._service._require_aware_datetime(delegated_at, "delegated_at")
+        action_request_id = self._service._require_non_empty_string(
+            action_request_id,
+            "action_request_id",
+        )
+        delegation_issuer = self._service._require_non_empty_string(
+            delegation_issuer,
+            "delegation_issuer",
+        )
+        normalized_payload = self._service._require_mapping(
+            approved_payload,
+            "approved_payload",
+        )
+        with self._service._store.transaction():
+            action_request, approval_decision = self._load_approved_delegation_context(
+                action_request_id=action_request_id,
+                approved_payload=normalized_payload,
+                delegated_at=delegated_at,
+                execution_surface_type=execution_surface_type,
+                execution_surface_id=execution_surface_id,
+                invalid_execution_surface_type_message=(
+                    invalid_execution_surface_type_message
+                ),
+                invalid_execution_surface_id_message=(
+                    invalid_execution_surface_id_message
+                ),
+                delegation_label=delegation_label,
+            )
+            approval_decision_id = approval_decision.approval_decision_id
+            for existing in self._service._store.list(ActionExecutionRecord):
+                if (
+                    existing.action_request_id == action_request.action_request_id
+                    and existing.execution_surface_type == execution_surface_type
+                    and existing.execution_surface_id == execution_surface_id
+                    and existing.idempotency_key == action_request.idempotency_key
+                ):
+                    return existing
+
+            delegation_id = self._service._next_identifier("delegation")
+            adapter = (
+                self._service._shuffle
+                if execution_surface_id == "shuffle"
+                else self._service._isolated_executor
+            )
+            receipt = adapter.dispatch_approved_action(
+                delegation_id=delegation_id,
+                action_request_id=action_request.action_request_id,
+                approval_decision_id=approval_decision_id,
+                payload_hash=action_request.payload_hash,
+                idempotency_key=action_request.idempotency_key,
+                approved_payload=normalized_payload,
+                delegated_at=delegated_at,
+            )
+            provenance: dict[str, object] = {
+                "delegation_issuer": delegation_issuer,
+                "evidence_ids": evidence_ids,
+                "adapter": receipt.adapter,
+            }
+            if execution_surface_id == "shuffle":
+                provenance["downstream_binding"] = {
+                    "approval_decision_id": receipt.approval_decision_id,
+                    "delegation_id": receipt.delegation_id,
+                    "payload_hash": receipt.payload_hash,
+                }
+            if receipt.base_url.strip() and receipt.base_url != "<set-me>":
+                provenance["adapter_base_url"] = receipt.base_url
+
+            execution = self._service.persist_record(
+                ActionExecutionRecord(
+                    action_execution_id=self._service._next_identifier("action-execution"),
+                    action_request_id=action_request.action_request_id,
+                    approval_decision_id=approval_decision_id,
+                    delegation_id=delegation_id,
+                    execution_surface_type=receipt.execution_surface_type,
+                    execution_surface_id=receipt.execution_surface_id,
+                    execution_run_id=receipt.execution_run_id,
+                    idempotency_key=action_request.idempotency_key,
+                    target_scope=action_request.target_scope,
+                    approved_payload=normalized_payload,
+                    payload_hash=action_request.payload_hash,
+                    delegated_at=delegated_at,
+                    expires_at=action_request.expires_at,
+                    provenance=provenance,
+                    lifecycle_state="queued",
+                )
+            )
+        self._service._emit_action_execution_delegated_event(execution)
+        return execution
+
+    @staticmethod
+    def _action_execution_lifecycle_from_status(
+        status: object,
+        current_lifecycle_state: str,
+    ) -> str:
+        if not isinstance(status, str):
+            return current_lifecycle_state
+
+        normalized_status = status.strip().lower()
+        if normalized_status in {"queued", "pending"}:
+            return "queued"
+        if normalized_status in {"running", "in_progress"}:
+            return "running"
+        if normalized_status in {"success", "succeeded", "completed"}:
+            return "succeeded"
+        if normalized_status in {"failed", "error"}:
+            return "failed"
+        if normalized_status in {"canceled", "cancelled"}:
+            return "canceled"
+        return current_lifecycle_state
+
+    def _build_action_execution_reconciliation_key(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        execution_surface_type: str,
+        execution_surface_id: str,
+        authoritative_execution: ActionExecutionRecord | None,
+    ) -> str:
+        components = [action_request.action_request_id]
+        if action_request.approval_decision_id is not None:
+            components.append(action_request.approval_decision_id)
+        if authoritative_execution is not None:
+            components.append(authoritative_execution.delegation_id)
+        components.extend(
+            (
+                execution_surface_type,
+                execution_surface_id,
+                action_request.idempotency_key,
+            )
+        )
+        return ":".join(components)
+
+    def _find_authoritative_action_execution(
+        self,
+        *,
+        action_request_id: str,
+        execution_surface_type: str,
+        execution_surface_id: str,
+        execution_run_id: str | None,
+        idempotency_key: str,
+    ) -> ActionExecutionRecord | None:
+        matches = [
+            execution
+            for execution in self._service._store.list(ActionExecutionRecord)
+            if (
+                execution.action_request_id == action_request_id
+                and execution.execution_surface_type == execution_surface_type
+                and execution.execution_surface_id == execution_surface_id
+                and execution.idempotency_key == idempotency_key
+            )
+        ]
+        if execution_run_id is not None:
+            for execution in matches:
+                if execution.execution_run_id == execution_run_id:
+                    return execution
+        return matches[0] if matches else None
+
+    def _normalize_observed_executions(
+        self,
+        observed_executions: tuple[Mapping[str, object], ...],
+        *,
+        require_binding_identifiers: bool = False,
+    ) -> tuple[dict[str, object], ...]:
+        normalized: list[dict[str, object]] = []
+        for execution in observed_executions:
+            execution_run_id = execution.get("execution_run_id")
+            execution_surface_id = execution.get("execution_surface_id")
+            idempotency_key = execution.get("idempotency_key")
+            observed_at = execution.get("observed_at")
+            approval_decision_id = execution.get("approval_decision_id")
+            delegation_id = execution.get("delegation_id")
+            payload_hash = execution.get("payload_hash")
+            if not isinstance(execution_run_id, str):
+                raise ValueError("observed execution must include string execution_run_id")
+            if not isinstance(execution_surface_id, str):
+                raise ValueError(
+                    "observed execution must include string execution_surface_id"
+                )
+            if not isinstance(idempotency_key, str):
+                raise ValueError("observed execution must include string idempotency_key")
+            if not isinstance(observed_at, datetime):
+                raise ValueError("observed execution must include datetime observed_at")
+            observed_at = self._service._require_aware_datetime(observed_at, "observed_at")
+            if require_binding_identifiers:
+                if not isinstance(approval_decision_id, str):
+                    raise ValueError(
+                        "observed execution must include string approval_decision_id"
+                    )
+                if not isinstance(delegation_id, str):
+                    raise ValueError("observed execution must include string delegation_id")
+                if not isinstance(payload_hash, str):
+                    raise ValueError("observed execution must include string payload_hash")
+            normalized.append(
+                {
+                    "execution_run_id": execution_run_id,
+                    "execution_surface_id": execution_surface_id,
+                    "idempotency_key": idempotency_key,
+                    "observed_at": observed_at,
+                    "approval_decision_id": approval_decision_id,
+                    "delegation_id": delegation_id,
+                    "payload_hash": payload_hash,
+                    "status": execution.get("status"),
+                }
+            )
+
+        normalized.sort(key=lambda execution: execution["observed_at"])
+        return tuple(normalized)
+
+    def _load_approved_delegation_context(
+        self,
+        *,
+        action_request_id: str,
+        approved_payload: Mapping[str, object],
+        delegated_at: datetime,
+        execution_surface_type: str,
+        execution_surface_id: str,
+        invalid_execution_surface_type_message: str,
+        invalid_execution_surface_id_message: str,
+        delegation_label: str,
+    ) -> tuple[ActionRequestRecord, ApprovalDecisionRecord]:
+        action_request = self._service._store.get(ActionRequestRecord, action_request_id)
+        if action_request is None:
+            raise LookupError(f"Missing action request {action_request_id!r}")
+        if action_request.lifecycle_state != "approved":
+            raise ValueError(
+                f"Action request {action_request_id!r} is not approved "
+                f"(state={action_request.lifecycle_state!r})"
+            )
+        approval_decision_id = self._service._require_non_empty_string(
+            action_request.approval_decision_id,
+            "action_request.approval_decision_id",
+        )
+        approval_decision = self._service._store.get(
+            ApprovalDecisionRecord,
+            approval_decision_id,
+        )
+        if approval_decision is None:
+            raise LookupError(
+                f"Missing approval decision {approval_decision_id!r} for action request "
+                f"{action_request_id!r}"
+            )
+        if approval_decision.lifecycle_state != "approved":
+            raise ValueError(
+                f"Approval decision {approval_decision_id!r} is not approved "
+                f"(state={approval_decision.lifecycle_state!r})"
+            )
+        if approval_decision.payload_hash != action_request.payload_hash:
+            raise ValueError(
+                "approval decision payload_hash does not match action request payload_hash"
+            )
+        policy_evaluation = action_request.policy_evaluation
+        if policy_evaluation.get("execution_surface_type") != execution_surface_type:
+            raise ValueError(invalid_execution_surface_type_message)
+        if policy_evaluation.get("execution_surface_id") != execution_surface_id:
+            raise ValueError(invalid_execution_surface_id_message)
+        self._require_exact_approved_payload_binding(
+            action_request=action_request,
+            approval_decision=approval_decision,
+            approved_payload=approved_payload,
+            execution_surface_type=execution_surface_type,
+            execution_surface_id=execution_surface_id,
+        )
+        self._require_exact_approved_expiry_binding(
+            action_request=action_request,
+            approval_decision=approval_decision,
+            delegated_at=delegated_at,
+            delegation_label=delegation_label,
+        )
+        return action_request, approval_decision
+
+    def _require_exact_approved_expiry_binding(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord,
+        delegated_at: datetime,
+        delegation_label: str,
+    ) -> None:
+        if approval_decision.approved_expires_at != action_request.expires_at:
+            raise ValueError("approved expiry window does not match action request expiry")
+        if (
+            approval_decision.approved_expires_at is not None
+            and delegated_at > approval_decision.approved_expires_at
+        ):
+            raise ValueError(
+                f"Action request {action_request.action_request_id!r} expired before {delegation_label} delegation"
+            )
+
+    def _require_exact_approved_payload_binding(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord,
+        approved_payload: Mapping[str, object],
+        execution_surface_type: str,
+        execution_surface_id: str,
+    ) -> None:
+        if approval_decision.action_request_id != action_request.action_request_id:
+            raise ValueError(
+                "approved payload binding does not match approved action request and approval decision"
+            )
+        if approval_decision.target_snapshot != action_request.target_scope:
+            raise ValueError(
+                "approved payload binding does not match approved action request and approval decision"
+            )
+
+        payload_hash = _approved_payload_binding_hash(
+            target_scope=action_request.target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type=execution_surface_type,
+            execution_surface_id=execution_surface_id,
+        )
+        if (
+            payload_hash != action_request.payload_hash
+            or payload_hash != approval_decision.payload_hash
+        ):
+            raise ValueError(
+                "approved payload binding does not match approved action request and approval decision"
+            )

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timezone
 import hashlib
 import json
@@ -274,6 +275,7 @@ class ExecutionCoordinator:
                     },
                     policy_evaluation={
                         "approval_requirement": "human_required",
+                        "approval_requirement_override": "human_required",
                         "routing_target": "approval",
                         "execution_surface_type": "automation_substrate",
                         "execution_surface_id": "shuffle",
@@ -605,6 +607,15 @@ class ExecutionCoordinator:
             approved_payload,
             "approved_payload",
         )
+        adapter = (
+            self._service._shuffle
+            if execution_surface_id == "shuffle"
+            else self._service._isolated_executor
+        )
+        predispatch_execution: ActionExecutionRecord
+        action_request: ActionRequestRecord
+        approval_decision: ApprovalDecisionRecord
+        approval_decision_id: str
         with self._service._store.transaction():
             action_request, approval_decision = self._load_approved_delegation_context(
                 action_request_id=action_request_id,
@@ -628,14 +639,41 @@ class ExecutionCoordinator:
                     and existing.execution_surface_id == execution_surface_id
                     and existing.idempotency_key == action_request.idempotency_key
                 ):
+                    if existing.lifecycle_state == "dispatching":
+                        raise RuntimeError(
+                            "approved action delegation is already dispatching"
+                        )
                     return existing
+            if execution_surface_id == "shuffle":
+                self._require_reviewed_phase20_shuffle_payload(normalized_payload)
 
             delegation_id = self._service._next_identifier("delegation")
-            adapter = (
-                self._service._shuffle
-                if execution_surface_id == "shuffle"
-                else self._service._isolated_executor
+            predispatch_execution = self._service.persist_record(
+                ActionExecutionRecord(
+                    action_execution_id=self._service._next_identifier("action-execution"),
+                    action_request_id=action_request.action_request_id,
+                    approval_decision_id=approval_decision_id,
+                    delegation_id=delegation_id,
+                    execution_surface_type=execution_surface_type,
+                    execution_surface_id=execution_surface_id,
+                    execution_run_id=self._pending_dispatch_execution_run_id(
+                        delegation_id
+                    ),
+                    idempotency_key=action_request.idempotency_key,
+                    target_scope=action_request.target_scope,
+                    approved_payload=normalized_payload,
+                    payload_hash=action_request.payload_hash,
+                    delegated_at=delegated_at,
+                    expires_at=action_request.expires_at,
+                    provenance={
+                        "delegation_issuer": delegation_issuer,
+                        "evidence_ids": evidence_ids,
+                    },
+                    lifecycle_state="dispatching",
+                )
             )
+        receipt = None
+        try:
             receipt = adapter.dispatch_approved_action(
                 delegation_id=delegation_id,
                 action_request_id=action_request.action_request_id,
@@ -645,41 +683,159 @@ class ExecutionCoordinator:
                 approved_payload=normalized_payload,
                 delegated_at=delegated_at,
             )
-            provenance: dict[str, object] = {
-                "delegation_issuer": delegation_issuer,
-                "evidence_ids": evidence_ids,
-                "adapter": receipt.adapter,
-            }
-            if execution_surface_id == "shuffle":
-                provenance["downstream_binding"] = {
-                    "approval_decision_id": receipt.approval_decision_id,
-                    "delegation_id": receipt.delegation_id,
-                    "payload_hash": receipt.payload_hash,
-                }
-            if receipt.base_url.strip() and receipt.base_url != "<set-me>":
-                provenance["adapter_base_url"] = receipt.base_url
+            self._require_exact_adapter_receipt_binding(
+                receipt=receipt,
+                action_request=action_request,
+                approval_decision_id=approval_decision_id,
+                delegation_id=delegation_id,
+                execution_surface_type=execution_surface_type,
+                execution_surface_id=execution_surface_id,
+            )
+        except Exception as exc:
+            self._mark_dispatch_failure(
+                execution=predispatch_execution,
+                error=exc,
+                receipt=receipt,
+            )
+            raise
 
+        with self._service._store.transaction():
+            stored_execution = self._service._store.get(
+                ActionExecutionRecord,
+                predispatch_execution.action_execution_id,
+            )
+            if stored_execution is None:
+                raise LookupError(
+                    "missing pre-dispatch action execution record during delegation finalization"
+                )
             execution = self._service.persist_record(
-                ActionExecutionRecord(
-                    action_execution_id=self._service._next_identifier("action-execution"),
-                    action_request_id=action_request.action_request_id,
-                    approval_decision_id=approval_decision_id,
-                    delegation_id=delegation_id,
-                    execution_surface_type=receipt.execution_surface_type,
-                    execution_surface_id=receipt.execution_surface_id,
+                replace(
+                    stored_execution,
                     execution_run_id=receipt.execution_run_id,
-                    idempotency_key=action_request.idempotency_key,
-                    target_scope=action_request.target_scope,
-                    approved_payload=normalized_payload,
-                    payload_hash=action_request.payload_hash,
-                    delegated_at=delegated_at,
-                    expires_at=action_request.expires_at,
-                    provenance=provenance,
+                    provenance=self._finalized_execution_provenance(
+                        execution=stored_execution,
+                        receipt=receipt,
+                        execution_surface_id=execution_surface_id,
+                    ),
                     lifecycle_state="queued",
                 )
             )
         self._service._emit_action_execution_delegated_event(execution)
         return execution
+
+    @staticmethod
+    def _pending_dispatch_execution_run_id(delegation_id: str) -> str:
+        return f"pending-dispatch-{delegation_id}"
+
+    def _require_reviewed_phase20_shuffle_payload(
+        self,
+        approved_payload: Mapping[str, object],
+    ) -> None:
+        action_type = approved_payload.get("action_type")
+        if action_type != "notify_identity_owner":
+            raise ValueError(
+                "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+            )
+
+        for field_name in (
+            "recipient_identity",
+            "message_intent",
+            "escalation_reason",
+        ):
+            value = approved_payload.get(field_name)
+            if not isinstance(value, str) or value.strip() == "":
+                raise ValueError(
+                    "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+                )
+
+    def _require_exact_adapter_receipt_binding(
+        self,
+        *,
+        receipt: object,
+        action_request: ActionRequestRecord,
+        approval_decision_id: str,
+        delegation_id: str,
+        execution_surface_type: str,
+        execution_surface_id: str,
+    ) -> None:
+        if getattr(receipt, "execution_surface_type", None) != execution_surface_type:
+            raise ValueError("adapter receipt does not match approved execution surface")
+        if getattr(receipt, "execution_surface_id", None) != execution_surface_id:
+            raise ValueError("adapter receipt does not match approved execution surface")
+        if execution_surface_id == "shuffle" and any(
+            (
+                getattr(receipt, "approval_decision_id", None) != approval_decision_id,
+                getattr(receipt, "delegation_id", None) != delegation_id,
+                getattr(receipt, "payload_hash", None) != action_request.payload_hash,
+            )
+        ):
+            raise ValueError(
+                "shuffle receipt does not match approved delegation binding"
+            )
+
+    def _finalized_execution_provenance(
+        self,
+        *,
+        execution: ActionExecutionRecord,
+        receipt: object,
+        execution_surface_id: str,
+    ) -> dict[str, object]:
+        provenance = dict(execution.provenance)
+        provenance["adapter"] = getattr(receipt, "adapter")
+        base_url = getattr(receipt, "base_url", "")
+        if isinstance(base_url, str) and base_url.strip() and base_url != "<set-me>":
+            provenance["adapter_base_url"] = base_url
+        if execution_surface_id == "shuffle":
+            provenance["downstream_binding"] = {
+                "approval_decision_id": getattr(receipt, "approval_decision_id"),
+                "delegation_id": getattr(receipt, "delegation_id"),
+                "payload_hash": getattr(receipt, "payload_hash"),
+            }
+        return provenance
+
+    def _mark_dispatch_failure(
+        self,
+        *,
+        execution: ActionExecutionRecord,
+        error: Exception,
+        receipt: object | None,
+    ) -> None:
+        failure_provenance = dict(execution.provenance)
+        dispatch_failure = {
+            "error": str(error),
+            "error_type": type(error).__name__,
+        }
+        if receipt is not None:
+            adapter = getattr(receipt, "adapter", None)
+            if isinstance(adapter, str) and adapter.strip():
+                failure_provenance["adapter"] = adapter
+            base_url = getattr(receipt, "base_url", None)
+            if isinstance(base_url, str) and base_url.strip() and base_url != "<set-me>":
+                failure_provenance["adapter_base_url"] = base_url
+            observed_surface_type = getattr(receipt, "execution_surface_type", None)
+            observed_surface_id = getattr(receipt, "execution_surface_id", None)
+            if isinstance(observed_surface_type, str) and observed_surface_type.strip():
+                dispatch_failure["observed_execution_surface_type"] = (
+                    observed_surface_type
+                )
+            if isinstance(observed_surface_id, str) and observed_surface_id.strip():
+                dispatch_failure["observed_execution_surface_id"] = observed_surface_id
+
+        failure_provenance["dispatch_failure"] = dispatch_failure
+        with self._service._store.transaction():
+            current_execution = self._service._store.get(
+                ActionExecutionRecord,
+                execution.action_execution_id,
+            )
+            if current_execution is None or current_execution.lifecycle_state != "dispatching":
+                return
+            self._service.persist_record(
+                replace(
+                    current_execution,
+                    provenance=failure_provenance,
+                    lifecycle_state="failed",
+                )
+            )
 
     @staticmethod
     def _action_execution_lifecycle_from_status(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1312,7 +1312,12 @@ class AegisOpsControlPlaneService:
         normalized_policy_basis = self._normalize_action_policy_basis(
             action_request.policy_basis
         )
-        policy_evaluation = self._determine_action_policy(normalized_policy_basis)
+        policy_evaluation = self._apply_action_policy_evaluation_overrides(
+            computed_policy_evaluation=self._determine_action_policy(
+                normalized_policy_basis
+            ),
+            persisted_policy_evaluation=action_request.policy_evaluation,
+        )
         evaluated = ActionRequestRecord(
             action_request_id=action_request.action_request_id,
             approval_decision_id=action_request.approval_decision_id,
@@ -3665,6 +3670,34 @@ class AegisOpsControlPlaneService:
             "execution_surface_type": execution_surface_type,
             "execution_surface_id": execution_surface_id,
         }
+
+    def _apply_action_policy_evaluation_overrides(
+        self,
+        *,
+        computed_policy_evaluation: Mapping[str, str],
+        persisted_policy_evaluation: Mapping[str, object],
+    ) -> dict[str, str]:
+        merged = dict(computed_policy_evaluation)
+        approval_requirement_override = persisted_policy_evaluation.get(
+            "approval_requirement_override"
+        )
+        if approval_requirement_override is None:
+            return merged
+
+        normalized_override = self._require_non_empty_string(
+            approval_requirement_override,
+            "policy_evaluation.approval_requirement_override",
+        )
+        if normalized_override != "human_required":
+            raise ValueError(
+                "policy_evaluation.approval_requirement_override must be "
+                "'human_required'"
+            )
+
+        merged["approval_requirement"] = "human_required"
+        merged["routing_target"] = "approval"
+        merged["approval_requirement_override"] = normalized_override
+        return merged
 
     @staticmethod
     def _merge_linked_ids(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -673,7 +673,7 @@ def _build_shutdown_status_snapshot(
         )
     if active_action_execution_ids:
         blocking_reasons.append(
-            "controlled shutdown requires queued or running executions to reach a terminal state"
+            "controlled shutdown requires dispatching, queued, or running executions to reach a terminal state"
         )
     if unresolved_reconciliation_ids:
         blocking_reasons.append(
@@ -1618,7 +1618,7 @@ class AegisOpsControlPlaneService:
             active_action_execution_ids=tuple(
                 record.action_execution_id
                 for record in action_executions
-                if record.lifecycle_state in {"queued", "running"}
+                if record.lifecycle_state in {"dispatching", "queued", "running"}
             ),
             reconciliation_total=len(reconciliations),
             reconciliation_lifecycle_counts=dict(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4,7 +4,6 @@ from contextlib import AbstractContextManager, contextmanager
 from collections import Counter
 from dataclasses import asdict, dataclass, fields, replace
 from datetime import datetime, timezone
-import hashlib
 import hmac
 import ipaddress
 import json
@@ -21,6 +20,7 @@ from .adapters.postgres import (
 from .adapters.shuffle import ShuffleActionAdapter
 from .adapters.wazuh import WazuhAlertAdapter
 from .config import RuntimeConfig
+from .execution_coordinator import ExecutionCoordinator
 from .models import (
     AITraceRecord,
     ActionExecutionRecord,
@@ -747,26 +747,6 @@ def _record_from_backup_payload(
         kwargs[field_info.name] = value
     return record_type(**kwargs)
 
-
-def _approved_payload_binding_hash(
-    *,
-    target_scope: Mapping[str, object],
-    approved_payload: Mapping[str, object],
-    execution_surface_type: str,
-    execution_surface_id: str,
-) -> str:
-    binding = _json_ready(
-        {
-            "approved_payload": approved_payload,
-            "execution_surface_id": execution_surface_id,
-            "execution_surface_type": execution_surface_type,
-            "target_scope": target_scope,
-        }
-    )
-    encoded = json.dumps(binding, separators=(",", ":"), sort_keys=True).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
-
-
 def _merge_reviewed_context(
     existing_context: Mapping[str, object] | None,
     incoming_context: Mapping[str, object] | None,
@@ -914,6 +894,7 @@ class AegisOpsControlPlaneService:
                 _recommendation_draft_snapshot_from_context
             ),
         )
+        self._execution_coordinator = ExecutionCoordinator(self)
 
     def describe_runtime(self) -> RuntimeSnapshot:
         return RuntimeSnapshot(
@@ -1294,86 +1275,13 @@ class AegisOpsControlPlaneService:
         delegation_issuer: str,
         evidence_ids: tuple[str, ...] = (),
     ) -> ActionExecutionRecord:
-        delegated_at = self._require_aware_datetime(delegated_at, "delegated_at")
-        action_request_id = self._require_non_empty_string(
-            action_request_id,
-            "action_request_id",
+        return self._execution_coordinator.delegate_approved_action_to_shuffle(
+            action_request_id=action_request_id,
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer=delegation_issuer,
+            evidence_ids=evidence_ids,
         )
-        delegation_issuer = self._require_non_empty_string(
-            delegation_issuer,
-            "delegation_issuer",
-        )
-        normalized_payload = self._require_mapping(approved_payload, "approved_payload")
-        with self._store.transaction():
-            action_request, approval_decision = self._load_approved_delegation_context(
-                action_request_id=action_request_id,
-                approved_payload=normalized_payload,
-                delegated_at=delegated_at,
-                execution_surface_type="automation_substrate",
-                execution_surface_id="shuffle",
-                invalid_execution_surface_type_message=(
-                    "approved action request is not delegated through the automation "
-                    "substrate path"
-                ),
-                invalid_execution_surface_id_message=(
-                    "approved action request is not routed to the reviewed shuffle adapter"
-                ),
-                delegation_label="shuffle",
-            )
-            approval_decision_id = approval_decision.approval_decision_id
-            for existing in self._store.list(ActionExecutionRecord):
-                if (
-                    existing.action_request_id == action_request.action_request_id
-                    and existing.execution_surface_type == "automation_substrate"
-                    and existing.execution_surface_id == "shuffle"
-                    and existing.idempotency_key == action_request.idempotency_key
-                ):
-                    return existing
-
-            delegation_id = self._next_identifier("delegation")
-            receipt = self._shuffle.dispatch_approved_action(
-                delegation_id=delegation_id,
-                action_request_id=action_request.action_request_id,
-                approval_decision_id=approval_decision_id,
-                payload_hash=action_request.payload_hash,
-                idempotency_key=action_request.idempotency_key,
-                approved_payload=normalized_payload,
-                delegated_at=delegated_at,
-            )
-            provenance: dict[str, object] = {
-                "delegation_issuer": delegation_issuer,
-                "evidence_ids": evidence_ids,
-                "adapter": receipt.adapter,
-                "downstream_binding": {
-                    "approval_decision_id": receipt.approval_decision_id,
-                    "delegation_id": receipt.delegation_id,
-                    "payload_hash": receipt.payload_hash,
-                },
-            }
-            if receipt.base_url.strip() and receipt.base_url != "<set-me>":
-                provenance["adapter_base_url"] = receipt.base_url
-
-            execution = self.persist_record(
-                ActionExecutionRecord(
-                    action_execution_id=self._next_identifier("action-execution"),
-                    action_request_id=action_request.action_request_id,
-                    approval_decision_id=approval_decision_id,
-                    delegation_id=delegation_id,
-                    execution_surface_type=receipt.execution_surface_type,
-                    execution_surface_id=receipt.execution_surface_id,
-                    execution_run_id=receipt.execution_run_id,
-                    idempotency_key=action_request.idempotency_key,
-                    target_scope=action_request.target_scope,
-                    approved_payload=normalized_payload,
-                    payload_hash=action_request.payload_hash,
-                    delegated_at=delegated_at,
-                    expires_at=action_request.expires_at,
-                    provenance=provenance,
-                    lifecycle_state="queued",
-                )
-            )
-        self._emit_action_execution_delegated_event(execution)
-        return execution
 
     def delegate_approved_action_to_isolated_executor(
         self,
@@ -1384,81 +1292,13 @@ class AegisOpsControlPlaneService:
         delegation_issuer: str,
         evidence_ids: tuple[str, ...] = (),
     ) -> ActionExecutionRecord:
-        delegated_at = self._require_aware_datetime(delegated_at, "delegated_at")
-        action_request_id = self._require_non_empty_string(
-            action_request_id,
-            "action_request_id",
+        return self._execution_coordinator.delegate_approved_action_to_isolated_executor(
+            action_request_id=action_request_id,
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer=delegation_issuer,
+            evidence_ids=evidence_ids,
         )
-        delegation_issuer = self._require_non_empty_string(
-            delegation_issuer,
-            "delegation_issuer",
-        )
-        normalized_payload = self._require_mapping(approved_payload, "approved_payload")
-        with self._store.transaction():
-            action_request, approval_decision = self._load_approved_delegation_context(
-                action_request_id=action_request_id,
-                approved_payload=normalized_payload,
-                delegated_at=delegated_at,
-                execution_surface_type="executor",
-                execution_surface_id="isolated-executor",
-                invalid_execution_surface_type_message=(
-                    "approved action request is not delegated through the isolated "
-                    "executor path"
-                ),
-                invalid_execution_surface_id_message=(
-                    "approved action request is not routed to the reviewed isolated executor"
-                ),
-                delegation_label="isolated executor",
-            )
-            approval_decision_id = approval_decision.approval_decision_id
-            for existing in self._store.list(ActionExecutionRecord):
-                if (
-                    existing.action_request_id == action_request.action_request_id
-                    and existing.execution_surface_type == "executor"
-                    and existing.execution_surface_id == "isolated-executor"
-                    and existing.idempotency_key == action_request.idempotency_key
-                ):
-                    return existing
-
-            delegation_id = self._next_identifier("delegation")
-            receipt = self._isolated_executor.dispatch_approved_action(
-                delegation_id=delegation_id,
-                action_request_id=action_request.action_request_id,
-                approval_decision_id=approval_decision_id,
-                payload_hash=action_request.payload_hash,
-                idempotency_key=action_request.idempotency_key,
-                approved_payload=normalized_payload,
-                delegated_at=delegated_at,
-            )
-            provenance: dict[str, object] = {
-                "delegation_issuer": delegation_issuer,
-                "evidence_ids": evidence_ids,
-                "adapter": receipt.adapter,
-            }
-            if receipt.base_url.strip() and receipt.base_url != "<set-me>":
-                provenance["adapter_base_url"] = receipt.base_url
-
-            execution = self.persist_record(
-                ActionExecutionRecord(
-                    action_execution_id=self._next_identifier("action-execution"),
-                    action_request_id=action_request.action_request_id,
-                    approval_decision_id=approval_decision_id,
-                    delegation_id=delegation_id,
-                    execution_surface_type=receipt.execution_surface_type,
-                    execution_surface_id=receipt.execution_surface_id,
-                    execution_run_id=receipt.execution_run_id,
-                    idempotency_key=action_request.idempotency_key,
-                    target_scope=action_request.target_scope,
-                    approved_payload=normalized_payload,
-                    payload_hash=action_request.payload_hash,
-                    delegated_at=delegated_at,
-                    expires_at=action_request.expires_at,
-                    provenance=provenance,
-                    lifecycle_state="queued",
-                )
-            )
-        self._emit_action_execution_delegated_event(execution)
-        return execution
 
     def evaluate_action_policy(self, action_request_id: str) -> ActionRequestRecord:
         action_request_id = self._require_non_empty_string(
@@ -2473,158 +2313,16 @@ class AegisOpsControlPlaneService:
         expires_at: datetime,
         action_request_id: str | None = None,
     ) -> ActionRequestRecord:
-        requester_identity = self._require_non_empty_string(
-            requester_identity,
-            "requester_identity",
+        return self._execution_coordinator.create_reviewed_action_request_from_advisory(
+            record_family=record_family,
+            record_id=record_id,
+            requester_identity=requester_identity,
+            recipient_identity=recipient_identity,
+            message_intent=message_intent,
+            escalation_reason=escalation_reason,
+            expires_at=expires_at,
+            action_request_id=action_request_id,
         )
-        recipient_identity = self._require_non_empty_string(
-            recipient_identity,
-            "recipient_identity",
-        )
-        message_intent = self._require_non_empty_string(
-            message_intent,
-            "message_intent",
-        )
-        escalation_reason = self._require_non_empty_string(
-            escalation_reason,
-            "escalation_reason",
-        )
-        expires_at = self._require_aware_datetime(expires_at, "expires_at")
-
-        with self._store.transaction():
-            context_snapshot = self.inspect_assistant_context(record_family, record_id)
-            self._require_phase19_case_scoped_advisory_read(context_snapshot)
-            recommendation_draft = self.render_recommendation_draft(
-                record_family,
-                record_id,
-            )
-            if recommendation_draft.recommendation_draft.get("status") != "ready":
-                raise ValueError(
-                    "reviewed advisory context is not ready for approval-bound action requests"
-                )
-
-            recommendation_id = self._require_single_recommendation_binding(
-                record_family=record_family,
-                record_id=record_id,
-                linked_recommendation_ids=recommendation_draft.linked_recommendation_ids,
-            )
-            case_id = self._require_single_linked_case_id(
-                recommendation_draft.linked_case_ids
-            )
-            case = self._require_phase19_operator_case(case_id)
-            if expires_at <= datetime.now(timezone.utc):
-                raise ValueError("expires_at must be in the future")
-
-            requested_payload = {
-                "action_type": "notify_identity_owner",
-                "recipient_identity": recipient_identity,
-                "message_intent": message_intent,
-                "escalation_reason": escalation_reason,
-                "source_record_family": record_family,
-                "source_record_id": record_id,
-                "recommendation_id": recommendation_id,
-                "case_id": case.case_id,
-                "alert_id": case.alert_id,
-                "finding_id": case.finding_id,
-                "linked_evidence_ids": recommendation_draft.linked_evidence_ids,
-            }
-            target_scope = {
-                "record_family": record_family,
-                "record_id": record_id,
-                "case_id": case.case_id,
-                "alert_id": case.alert_id,
-                "finding_id": case.finding_id,
-                "recipient_identity": recipient_identity,
-            }
-            payload_hash = _approved_payload_binding_hash(
-                target_scope=target_scope,
-                approved_payload=requested_payload,
-                execution_surface_type="automation_substrate",
-                execution_surface_id="shuffle",
-            )
-            requested_at = datetime.now(timezone.utc)
-            if expires_at <= requested_at:
-                raise ValueError("expires_at must be after requested_at")
-
-            idempotency_material = json.dumps(
-                {
-                    "payload_hash": payload_hash,
-                    "record_family": record_family,
-                    "record_id": record_id,
-                    "requester_identity": requester_identity,
-                    "expires_at": expires_at.isoformat(),
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            idempotency_key = (
-                "notify-identity-owner:"
-                + hashlib.sha256(idempotency_material.encode("utf-8")).hexdigest()
-            )
-            for existing in self._store.list(ActionRequestRecord):
-                if existing.idempotency_key == idempotency_key:
-                    self._emit_structured_event(
-                        logging.INFO,
-                        "action_request_reused",
-                        action_request_id=existing.action_request_id,
-                        action_type=existing.requested_payload.get("action_type"),
-                        lifecycle_state=existing.lifecycle_state,
-                        case_id=existing.case_id,
-                    )
-                    return existing
-
-            normalized_action_request_id = self._resolve_new_record_identifier(
-                ActionRequestRecord,
-                action_request_id,
-                "action_request_id",
-                "action-request",
-            )
-            created_request = self.persist_record(
-                ActionRequestRecord(
-                    action_request_id=normalized_action_request_id,
-                    approval_decision_id=None,
-                    case_id=case.case_id,
-                    alert_id=case.alert_id,
-                    finding_id=case.finding_id,
-                    idempotency_key=idempotency_key,
-                    target_scope=target_scope,
-                    payload_hash=payload_hash,
-                    requested_at=requested_at,
-                    expires_at=expires_at,
-                    lifecycle_state="pending_approval",
-                    requester_identity=requester_identity,
-                    requested_payload=requested_payload,
-                    policy_basis={
-                        "severity": "low",
-                        "target_scope": "single_identity",
-                        "action_reversibility": "reversible",
-                        "asset_criticality": "standard",
-                        "identity_criticality": "standard",
-                        "blast_radius": "single_target",
-                        "execution_constraint": "routine_allowed",
-                    },
-                    policy_evaluation={
-                        "approval_requirement": "human_required",
-                        "routing_target": "approval",
-                        "execution_surface_type": "automation_substrate",
-                        "execution_surface_id": "shuffle",
-                    },
-                )
-            )
-        self._emit_structured_event(
-            logging.INFO,
-            "action_request_created",
-            action_request_id=created_request.action_request_id,
-            action_type=created_request.requested_payload.get("action_type"),
-            requester_identity=created_request.requester_identity,
-            case_id=created_request.case_id,
-            alert_id=created_request.alert_id,
-            lifecycle_state=created_request.lifecycle_state,
-            expires_at=created_request.expires_at.isoformat()
-            if created_request.expires_at is not None
-            else None,
-        )
-        return created_request
 
     def attach_assistant_advisory_draft(
         self,
@@ -3857,246 +3555,14 @@ class AegisOpsControlPlaneService:
         compared_at: datetime,
         stale_after: datetime,
     ) -> ReconciliationRecord:
-        compared_at = self._require_aware_datetime(compared_at, "compared_at")
-        stale_after = self._require_aware_datetime(stale_after, "stale_after")
-        execution_surface_type = self._require_non_empty_string(
-            execution_surface_type,
-            "execution_surface_type",
-        )
-        execution_surface_id = self._require_non_empty_string(
-            execution_surface_id,
-            "execution_surface_id",
-        )
-        action_request = self._store.get(ActionRequestRecord, action_request_id)
-        if action_request is None:
-            raise LookupError(f"Missing action request {action_request_id!r}")
-        if action_request.lifecycle_state != "approved":
-            raise ValueError(
-                f"Action request {action_request_id!r} is not approved "
-                f"(state={action_request.lifecycle_state!r})"
-            )
-
-        require_binding_identifiers = (
-            execution_surface_type == "automation_substrate"
-            and execution_surface_id == "shuffle"
-        )
-        normalized_executions = self._normalize_observed_executions(
-            observed_executions,
-            require_binding_identifiers=require_binding_identifiers,
-        )
-        linked_execution_run_ids = tuple(
-            execution["execution_run_id"] for execution in normalized_executions
-        )
-        unique_execution_run_ids = tuple(dict.fromkeys(linked_execution_run_ids))
-        latest_execution = normalized_executions[-1] if normalized_executions else None
-        authoritative_execution = self._find_authoritative_action_execution(
-            action_request_id=action_request.action_request_id,
+        return self._execution_coordinator.reconcile_action_execution(
+            action_request_id=action_request_id,
             execution_surface_type=execution_surface_type,
             execution_surface_id=execution_surface_id,
-            execution_run_id=(
-                None if latest_execution is None else latest_execution["execution_run_id"]
-            ),
-            idempotency_key=(
-                action_request.idempotency_key
-                if latest_execution is None
-                else latest_execution["idempotency_key"]
-            ),
+            observed_executions=observed_executions,
+            compared_at=compared_at,
+            stale_after=stale_after,
         )
-
-        subject_linkage: dict[str, object] = {
-            "action_request_ids": (action_request.action_request_id,),
-            "execution_surface_types": (execution_surface_type,),
-            "execution_surface_ids": (execution_surface_id,),
-        }
-        if action_request.approval_decision_id is not None:
-            subject_linkage["approval_decision_ids"] = (
-                action_request.approval_decision_id,
-            )
-        if action_request.alert_id is not None:
-            subject_linkage["alert_ids"] = (action_request.alert_id,)
-        if action_request.case_id is not None:
-            subject_linkage["case_ids"] = (action_request.case_id,)
-        if action_request.finding_id is not None:
-            subject_linkage["finding_ids"] = (action_request.finding_id,)
-        if authoritative_execution is not None:
-            subject_linkage["action_execution_ids"] = (
-                authoritative_execution.action_execution_id,
-            )
-            subject_linkage["delegation_ids"] = (
-                authoritative_execution.delegation_id,
-            )
-            evidence_ids = self._merge_linked_ids(
-                authoritative_execution.provenance.get("evidence_ids"),
-                None,
-            )
-            if evidence_ids:
-                subject_linkage["evidence_ids"] = evidence_ids
-
-        ingest_disposition: str
-        lifecycle_state: str
-        mismatch_summary: str
-        execution_run_id: str | None = None
-        last_seen_at = action_request.requested_at
-
-        if latest_execution is None:
-            ingest_disposition = "missing"
-            lifecycle_state = "pending"
-            mismatch_summary = (
-                "missing downstream execution for approved action request correlation"
-            )
-        else:
-            execution_run_id = latest_execution["execution_run_id"]
-            last_seen_at = latest_execution["observed_at"]
-            observed_execution_surface_id = latest_execution["execution_surface_id"]
-            observed_idempotency_key = latest_execution["idempotency_key"]
-            observed_approval_decision_id = latest_execution.get("approval_decision_id")
-            observed_delegation_id = latest_execution.get("delegation_id")
-            observed_payload_hash = latest_execution.get("payload_hash")
-            expected_execution_run_id = (
-                None
-                if authoritative_execution is None
-                else authoritative_execution.execution_run_id
-            )
-            if last_seen_at < stale_after and compared_at >= stale_after:
-                ingest_disposition = "stale"
-                lifecycle_state = "stale"
-                mismatch_summary = "stale downstream execution observation requires refresh"
-            elif len(unique_execution_run_ids) > 1:
-                ingest_disposition = "duplicate"
-                lifecycle_state = "mismatched"
-                mismatch_summary = (
-                    "duplicate downstream executions observed for one approved request"
-                )
-            elif (
-                observed_execution_surface_id != execution_surface_id
-                or observed_idempotency_key != action_request.idempotency_key
-            ):
-                ingest_disposition = "mismatch"
-                lifecycle_state = "mismatched"
-                mismatch_summary = (
-                    "execution surface/idempotency mismatch between approved request and observed execution"
-                )
-            elif (
-                expected_execution_run_id is not None
-                and execution_run_id != expected_execution_run_id
-            ):
-                ingest_disposition = "mismatch"
-                lifecycle_state = "mismatched"
-                mismatch_summary = (
-                    "execution run identity mismatch between authoritative action execution "
-                    "and observed downstream execution"
-                )
-            elif (
-                authoritative_execution is not None
-                and authoritative_execution.execution_surface_type == "automation_substrate"
-                and authoritative_execution.execution_surface_id == "shuffle"
-                and (
-                    observed_approval_decision_id
-                    != authoritative_execution.approval_decision_id
-                    or observed_delegation_id != authoritative_execution.delegation_id
-                    or observed_payload_hash != authoritative_execution.payload_hash
-                )
-            ):
-                ingest_disposition = "mismatch"
-                lifecycle_state = "mismatched"
-                mismatch_summary = (
-                    "approved binding mismatch between authoritative action execution "
-                    "and observed downstream execution"
-                )
-            else:
-                ingest_disposition = "matched"
-                lifecycle_state = "matched"
-                mismatch_summary = (
-                    "matched approved action request to reviewed execution run"
-                )
-
-        if (
-            authoritative_execution is not None
-            and latest_execution is not None
-            and ingest_disposition == "matched"
-        ):
-            reconciled_lifecycle_state = self._action_execution_lifecycle_from_status(
-                latest_execution.get("status"),
-                authoritative_execution.lifecycle_state,
-            )
-            if reconciled_lifecycle_state != authoritative_execution.lifecycle_state:
-                authoritative_execution = self.persist_record(
-                    ActionExecutionRecord(
-                        action_execution_id=authoritative_execution.action_execution_id,
-                        action_request_id=authoritative_execution.action_request_id,
-                        approval_decision_id=authoritative_execution.approval_decision_id,
-                        delegation_id=authoritative_execution.delegation_id,
-                        execution_surface_type=authoritative_execution.execution_surface_type,
-                        execution_surface_id=authoritative_execution.execution_surface_id,
-                        execution_run_id=authoritative_execution.execution_run_id,
-                        idempotency_key=authoritative_execution.idempotency_key,
-                        target_scope=authoritative_execution.target_scope,
-                        approved_payload=authoritative_execution.approved_payload,
-                        payload_hash=authoritative_execution.payload_hash,
-                        delegated_at=authoritative_execution.delegated_at,
-                        expires_at=authoritative_execution.expires_at,
-                        provenance=authoritative_execution.provenance,
-                        lifecycle_state=reconciled_lifecycle_state,
-                    )
-                )
-
-        reconciliation = self.persist_record(
-            ReconciliationRecord(
-                reconciliation_id=self._next_identifier("reconciliation"),
-                subject_linkage=subject_linkage,
-                alert_id=action_request.alert_id,
-                finding_id=action_request.finding_id,
-                analytic_signal_id=None,
-                execution_run_id=execution_run_id,
-                linked_execution_run_ids=linked_execution_run_ids,
-                correlation_key=self._build_action_execution_reconciliation_key(
-                    action_request=action_request,
-                    execution_surface_type=execution_surface_type,
-                    execution_surface_id=execution_surface_id,
-                    authoritative_execution=authoritative_execution,
-                ),
-                first_seen_at=action_request.requested_at,
-                last_seen_at=last_seen_at,
-                ingest_disposition=ingest_disposition,
-                mismatch_summary=mismatch_summary,
-                compared_at=compared_at,
-                lifecycle_state=lifecycle_state,
-            )
-        )
-        self._emit_structured_event(
-            logging.INFO,
-            "action_execution_reconciled",
-            reconciliation_id=reconciliation.reconciliation_id,
-            action_request_id=action_request.action_request_id,
-            execution_surface_type=execution_surface_type,
-            execution_surface_id=execution_surface_id,
-            ingest_disposition=reconciliation.ingest_disposition,
-            lifecycle_state=reconciliation.lifecycle_state,
-            execution_run_id=reconciliation.execution_run_id,
-        )
-        return reconciliation
-
-    def _build_action_execution_reconciliation_key(
-        self,
-        *,
-        action_request: ActionRequestRecord,
-        execution_surface_type: str,
-        execution_surface_id: str,
-        authoritative_execution: ActionExecutionRecord | None,
-    ) -> str:
-        components = [action_request.action_request_id]
-        if action_request.approval_decision_id is not None:
-            components.append(action_request.approval_decision_id)
-        if authoritative_execution is not None:
-            components.append(authoritative_execution.delegation_id)
-        components.extend(
-            (
-                execution_surface_type,
-                execution_surface_id,
-                action_request.idempotency_key,
-            )
-        )
-        return ":".join(components)
 
     def _normalize_action_policy_basis(
         self,
@@ -5066,218 +4532,9 @@ class AegisOpsControlPlaneService:
             return substrate_detection_record_id
         return f"{namespaced_prefix}{substrate_detection_record_id}"
 
-    def _normalize_observed_executions(
-        self,
-        observed_executions: tuple[Mapping[str, object], ...],
-        *,
-        require_binding_identifiers: bool = False,
-    ) -> tuple[dict[str, object], ...]:
-        normalized: list[dict[str, object]] = []
-        for execution in observed_executions:
-            execution_run_id = execution.get("execution_run_id")
-            execution_surface_id = execution.get("execution_surface_id")
-            idempotency_key = execution.get("idempotency_key")
-            observed_at = execution.get("observed_at")
-            approval_decision_id = execution.get("approval_decision_id")
-            delegation_id = execution.get("delegation_id")
-            payload_hash = execution.get("payload_hash")
-            if not isinstance(execution_run_id, str):
-                raise ValueError("observed execution must include string execution_run_id")
-            if not isinstance(execution_surface_id, str):
-                raise ValueError(
-                    "observed execution must include string execution_surface_id"
-                )
-            if not isinstance(idempotency_key, str):
-                raise ValueError("observed execution must include string idempotency_key")
-            if not isinstance(observed_at, datetime):
-                raise ValueError("observed execution must include datetime observed_at")
-            observed_at = AegisOpsControlPlaneService._require_aware_datetime(
-                observed_at,
-                "observed_at",
-            )
-            if require_binding_identifiers:
-                if not isinstance(approval_decision_id, str):
-                    raise ValueError(
-                        "observed execution must include string approval_decision_id"
-                    )
-                if not isinstance(delegation_id, str):
-                    raise ValueError("observed execution must include string delegation_id")
-                if not isinstance(payload_hash, str):
-                    raise ValueError("observed execution must include string payload_hash")
-            normalized.append(
-                {
-                    "execution_run_id": execution_run_id,
-                    "execution_surface_id": execution_surface_id,
-                    "idempotency_key": idempotency_key,
-                    "observed_at": observed_at,
-                    "approval_decision_id": approval_decision_id,
-                    "delegation_id": delegation_id,
-                    "payload_hash": payload_hash,
-                    "status": execution.get("status"),
-                }
-            )
-
-        normalized.sort(key=lambda execution: execution["observed_at"])
-        return tuple(normalized)
-
-    def _find_authoritative_action_execution(
-        self,
-        *,
-        action_request_id: str,
-        execution_surface_type: str,
-        execution_surface_id: str,
-        execution_run_id: str | None,
-        idempotency_key: str,
-    ) -> ActionExecutionRecord | None:
-        matches = [
-            execution
-            for execution in self._store.list(ActionExecutionRecord)
-            if (
-                execution.action_request_id == action_request_id
-                and execution.execution_surface_type == execution_surface_type
-                and execution.execution_surface_id == execution_surface_id
-                and execution.idempotency_key == idempotency_key
-            )
-        ]
-        if execution_run_id is not None:
-            for execution in matches:
-                if execution.execution_run_id == execution_run_id:
-                    return execution
-        return matches[0] if matches else None
-
-    @staticmethod
-    def _action_execution_lifecycle_from_status(
-        status: object,
-        current_lifecycle_state: str,
-    ) -> str:
-        if not isinstance(status, str):
-            return current_lifecycle_state
-
-        normalized_status = status.strip().lower()
-        if normalized_status in {"queued", "pending"}:
-            return "queued"
-        if normalized_status in {"running", "in_progress"}:
-            return "running"
-        if normalized_status in {"success", "succeeded", "completed"}:
-            return "succeeded"
-        if normalized_status in {"failed", "error"}:
-            return "failed"
-        if normalized_status in {"canceled", "cancelled"}:
-            return "canceled"
-        return current_lifecycle_state
-
     @staticmethod
     def _next_identifier(prefix: str) -> str:
         return f"{prefix}-{uuid.uuid4()}"
-
-    @staticmethod
-    def _require_exact_approved_payload_binding(
-        *,
-        action_request: ActionRequestRecord,
-        approval_decision: ApprovalDecisionRecord,
-        approved_payload: Mapping[str, object],
-        execution_surface_type: str,
-        execution_surface_id: str,
-    ) -> None:
-        if approval_decision.action_request_id != action_request.action_request_id:
-            raise ValueError(
-                "approved payload binding does not match approved action request and approval decision"
-            )
-        if approval_decision.target_snapshot != action_request.target_scope:
-            raise ValueError(
-                "approved payload binding does not match approved action request and approval decision"
-            )
-
-        payload_hash = _approved_payload_binding_hash(
-            target_scope=action_request.target_scope,
-            approved_payload=approved_payload,
-            execution_surface_type=execution_surface_type,
-            execution_surface_id=execution_surface_id,
-        )
-        if (
-            payload_hash != action_request.payload_hash
-            or payload_hash != approval_decision.payload_hash
-        ):
-            raise ValueError(
-                "approved payload binding does not match approved action request and approval decision"
-            )
-
-    @staticmethod
-    def _require_exact_approved_expiry_binding(
-        *,
-        action_request: ActionRequestRecord,
-        approval_decision: ApprovalDecisionRecord,
-        delegated_at: datetime,
-        delegation_label: str,
-    ) -> None:
-        if approval_decision.approved_expires_at != action_request.expires_at:
-            raise ValueError("approved expiry window does not match action request expiry")
-        if (
-            approval_decision.approved_expires_at is not None
-            and delegated_at > approval_decision.approved_expires_at
-        ):
-            raise ValueError(
-                f"Action request {action_request.action_request_id!r} expired before {delegation_label} delegation"
-            )
-
-    def _load_approved_delegation_context(
-        self,
-        *,
-        action_request_id: str,
-        approved_payload: Mapping[str, object],
-        delegated_at: datetime,
-        execution_surface_type: str,
-        execution_surface_id: str,
-        invalid_execution_surface_type_message: str,
-        invalid_execution_surface_id_message: str,
-        delegation_label: str,
-    ) -> tuple[ActionRequestRecord, ApprovalDecisionRecord]:
-        action_request = self._store.get(ActionRequestRecord, action_request_id)
-        if action_request is None:
-            raise LookupError(f"Missing action request {action_request_id!r}")
-        if action_request.lifecycle_state != "approved":
-            raise ValueError(
-                f"Action request {action_request_id!r} is not approved "
-                f"(state={action_request.lifecycle_state!r})"
-            )
-        approval_decision_id = self._require_non_empty_string(
-            action_request.approval_decision_id,
-            "action_request.approval_decision_id",
-        )
-        approval_decision = self._store.get(ApprovalDecisionRecord, approval_decision_id)
-        if approval_decision is None:
-            raise LookupError(
-                f"Missing approval decision {approval_decision_id!r} for action request "
-                f"{action_request_id!r}"
-            )
-        if approval_decision.lifecycle_state != "approved":
-            raise ValueError(
-                f"Approval decision {approval_decision_id!r} is not approved "
-                f"(state={approval_decision.lifecycle_state!r})"
-            )
-        if approval_decision.payload_hash != action_request.payload_hash:
-            raise ValueError(
-                "approval decision payload_hash does not match action request payload_hash"
-            )
-        policy_evaluation = action_request.policy_evaluation
-        if policy_evaluation.get("execution_surface_type") != execution_surface_type:
-            raise ValueError(invalid_execution_surface_type_message)
-        if policy_evaluation.get("execution_surface_id") != execution_surface_id:
-            raise ValueError(invalid_execution_surface_id_message)
-        self._require_exact_approved_payload_binding(
-            action_request=action_request,
-            approval_decision=approval_decision,
-            approved_payload=approved_payload,
-            execution_surface_type=execution_surface_type,
-            execution_surface_id=execution_surface_id,
-        )
-        self._require_exact_approved_expiry_binding(
-            action_request=action_request,
-            approval_decision=approval_decision,
-            delegated_at=delegated_at,
-            delegation_label=delegation_label,
-        )
-        return action_request, approval_decision
 
     @staticmethod
     def _alert_review_state(alert: AlertRecord) -> str:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1496,6 +1496,9 @@ class AegisOpsControlPlaneService:
             },
             "action_executions": {
                 "total": readiness_aggregates.action_execution_total,
+                "dispatching": readiness_aggregates.action_execution_lifecycle_counts.get(
+                    "dispatching", 0
+                ),
                 "queued": readiness_aggregates.action_execution_lifecycle_counts.get(
                     "queued", 0
                 ),
@@ -1505,7 +1508,7 @@ class AegisOpsControlPlaneService:
                 "terminal": sum(
                     count
                     for state, count in readiness_aggregates.action_execution_lifecycle_counts.items()
-                    if state not in {"queued", "running"}
+                    if state not in {"dispatching", "queued", "running"}
                 ),
             },
             "reconciliations": {

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -2851,6 +2851,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             payload["policy_evaluation"],
             {
                 "approval_requirement": "human_required",
+                "approval_requirement_override": "human_required",
                 "routing_target": "approval",
                 "execution_surface_type": "automation_substrate",
                 "execution_surface_id": "shuffle",

--- a/control-plane/tests/test_execution_coordinator_boundary.py
+++ b/control-plane/tests/test_execution_coordinator_boundary.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
+
+
+class ExecutionCoordinatorBoundaryTests(unittest.TestCase):
+    def _build_service(self) -> AegisOpsControlPlaneService:
+        store, _ = make_store()
+        return AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+            ),
+            store=store,
+        )
+
+    def test_service_initializes_dedicated_execution_coordinator(self) -> None:
+        service = self._build_service()
+
+        self.assertTrue(
+            hasattr(service, "_execution_coordinator"),
+            "expected AegisOpsControlPlaneService to compose a dedicated execution coordinator",
+        )
+
+    def test_service_delegates_reviewed_action_request_creation_to_execution_coordinator(
+        self,
+    ) -> None:
+        service = self._build_service()
+        expected = object()
+        coordinator = mock.Mock()
+        coordinator.create_reviewed_action_request_from_advisory.return_value = expected
+        service._execution_coordinator = coordinator
+
+        result = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id="recommendation-001",
+            requester_identity="analyst-001",
+            recipient_identity="owner-001",
+            message_intent="notify",
+            escalation_reason="bounded reason",
+            expires_at=datetime(2026, 4, 15, 0, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertIs(result, expected)
+        coordinator.create_reviewed_action_request_from_advisory.assert_called_once_with(
+            record_family="recommendation",
+            record_id="recommendation-001",
+            requester_identity="analyst-001",
+            recipient_identity="owner-001",
+            message_intent="notify",
+            escalation_reason="bounded reason",
+            expires_at=datetime(2026, 4, 15, 0, 0, tzinfo=timezone.utc),
+            action_request_id=None,
+        )
+
+    def test_service_delegates_shuffle_and_isolated_executor_flows_to_execution_coordinator(
+        self,
+    ) -> None:
+        service = self._build_service()
+        shuffle_result = object()
+        isolated_result = object()
+        coordinator = mock.Mock()
+        coordinator.delegate_approved_action_to_shuffle.return_value = shuffle_result
+        coordinator.delegate_approved_action_to_isolated_executor.return_value = (
+            isolated_result
+        )
+        service._execution_coordinator = coordinator
+        delegated_at = datetime(2026, 4, 15, 1, 0, tzinfo=timezone.utc)
+
+        shuffle = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-001",
+            approved_payload={"action": "notify"},
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-001",),
+        )
+        isolated = service.delegate_approved_action_to_isolated_executor(
+            action_request_id="action-request-002",
+            approved_payload={"action": "notify"},
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-002",),
+        )
+
+        self.assertIs(shuffle, shuffle_result)
+        self.assertIs(isolated, isolated_result)
+        coordinator.delegate_approved_action_to_shuffle.assert_called_once_with(
+            action_request_id="action-request-001",
+            approved_payload={"action": "notify"},
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-001",),
+        )
+        coordinator.delegate_approved_action_to_isolated_executor.assert_called_once_with(
+            action_request_id="action-request-002",
+            approved_payload={"action": "notify"},
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-002",),
+        )
+
+    def test_service_delegates_reconciliation_flow_to_execution_coordinator(self) -> None:
+        service = self._build_service()
+        expected = object()
+        coordinator = mock.Mock()
+        coordinator.reconcile_action_execution.return_value = expected
+        service._execution_coordinator = coordinator
+        compared_at = datetime(2026, 4, 15, 2, 0, tzinfo=timezone.utc)
+        stale_after = datetime(2026, 4, 15, 3, 0, tzinfo=timezone.utc)
+        observed_executions = (
+            {
+                "execution_run_id": "shuffle-run-001",
+                "execution_surface_id": "shuffle",
+                "idempotency_key": "idem-001",
+                "approval_decision_id": "approval-001",
+                "delegation_id": "delegation-001",
+                "payload_hash": "payload-001",
+                "observed_at": compared_at,
+            },
+        )
+
+        result = service.reconcile_action_execution(
+            action_request_id="action-request-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=observed_executions,
+            compared_at=compared_at,
+            stale_after=stale_after,
+        )
+
+        self.assertIs(result, expected)
+        coordinator.reconcile_action_execution.assert_called_once_with(
+            action_request_id="action-request-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=observed_executions,
+            compared_at=compared_at,
+            stale_after=stale_after,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -368,6 +368,7 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     action_request["policy_evaluation"],
                     {
                         "approval_requirement": "human_required",
+                        "approval_requirement_override": "human_required",
                         "routing_target": "approval",
                         "execution_surface_type": "automation_substrate",
                         "execution_surface_id": "shuffle",

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -41,6 +41,7 @@ from aegisops_control_plane.models import (
     RecommendationRecord,
 )
 from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
+from aegisops_control_plane.execution_coordinator import _approved_payload_binding_hash
 from aegisops_control_plane.service import (
     AegisOpsControlPlaneService,
     AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES,
@@ -7698,6 +7699,100 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "adapter receipt missing required 'adapter' attribute",
         )
 
+    def test_service_fail_closes_when_shuffle_receipt_omits_execution_run_id(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "workstation-001"}
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-routine-missing-run-id-001",
+                action_request_id="action-request-routine-missing-run-id-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-routine-missing-run-id-001",
+                approval_decision_id="approval-routine-missing-run-id-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-routine-missing-run-id-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        original_dispatch = type(service._shuffle).dispatch_approved_action
+
+        def dispatch_without_execution_run_id(adapter: object, **kwargs: object) -> object:
+            receipt = original_dispatch(adapter, **kwargs)
+            return replace(receipt, execution_run_id="")
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_without_execution_run_id,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "adapter receipt missing required 'execution_run_id' attribute",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id="action-request-routine-missing-run-id-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertTrue(
+            executions[0].execution_run_id.startswith("pending-dispatch-delegation-")
+        )
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error_type"],
+            "ValueError",
+        )
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error"],
+            "adapter receipt missing required 'execution_run_id' attribute",
+        )
+
     def test_service_fail_closes_when_isolated_executor_receipt_surface_drifts(
         self,
     ) -> None:
@@ -7799,6 +7894,107 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(
             executions[0].provenance["dispatch_failure"]["error_type"],
             "ValueError",
+        )
+
+    def test_service_fail_closes_when_isolated_executor_receipt_omits_execution_run_id(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "critical-host-001"}
+        approved_payload = {
+            "action_type": "disable_identity",
+            "asset_id": "critical-host-001",
+        }
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="executor",
+            execution_surface_id="isolated-executor",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-executor-missing-run-id-001",
+                action_request_id="action-request-executor-missing-run-id-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-executor-missing-run-id-001",
+                approval_decision_id="approval-executor-missing-run-id-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-executor-missing-run-id-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_basis={
+                    "severity": "critical",
+                    "target_scope": "single_asset",
+                    "action_reversibility": "irreversible",
+                    "asset_criticality": "critical",
+                    "identity_criticality": "high",
+                    "blast_radius": "organization",
+                    "execution_constraint": "requires_isolated_executor",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "executor",
+                    "execution_surface_id": "isolated-executor",
+                },
+            )
+        )
+        original_dispatch = type(service._isolated_executor).dispatch_approved_action
+
+        def dispatch_without_execution_run_id(adapter: object, **kwargs: object) -> object:
+            receipt = original_dispatch(adapter, **kwargs)
+            return replace(receipt, execution_run_id="")
+
+        with mock.patch.object(
+            type(service._isolated_executor),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_without_execution_run_id,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "adapter receipt missing required 'execution_run_id' attribute",
+            ):
+                service.delegate_approved_action_to_isolated_executor(
+                    action_request_id="action-request-executor-missing-run-id-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertTrue(
+            executions[0].execution_run_id.startswith("pending-dispatch-delegation-")
+        )
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error_type"],
+            "ValueError",
+        )
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error"],
+            "adapter receipt missing required 'execution_run_id' attribute",
         )
 
     def test_service_rejects_shuffle_delegation_when_payload_binding_drifts(
@@ -10439,7 +10635,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_reconciliation_rolls_back_execution_state_when_reconciliation_write_fails(
         self,
     ) -> None:
-        base_store, seed_service, promoted_case, evidence_id, reviewed_at = (
+        base_store, seed_service, promoted_case, evidence_id, _reviewed_at = (
             self._build_phase19_in_scope_case()
         )
         recommendation = seed_service.record_case_recommendation(
@@ -10543,7 +10739,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
     def test_service_reconciliation_does_not_downgrade_authoritative_execution_lifecycle(
         self,
     ) -> None:
-        _store, service, promoted_case, evidence_id, reviewed_at = (
+        _store, service, promoted_case, evidence_id, _reviewed_at = (
             self._build_phase19_in_scope_case()
         )
         recommendation = service.record_case_recommendation(
@@ -10825,6 +11021,92 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
 
         self.assertEqual(second_request, first_request)
         self.assertEqual(store.list(ActionRequestRecord), (first_request,))
+
+    def test_service_reuses_reviewed_action_request_for_equivalent_expiry_instants(
+        self,
+    ) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=service.record_case_lead(
+                case_id=promoted_case.case_id,
+                triage_owner="analyst-001",
+                triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+                observation_id=observation.observation_id,
+            ).lead_id,
+        )
+        expires_at_utc = datetime.now(timezone.utc) + timedelta(hours=4)
+        expires_at_plus_two = expires_at_utc.astimezone(
+            timezone(timedelta(hours=2))
+        )
+
+        first_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at_utc,
+        )
+        second_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at_plus_two,
+        )
+
+        self.assertEqual(second_request, first_request)
+        self.assertEqual(store.list(ActionRequestRecord), (first_request,))
+
+    def test_approved_payload_binding_hash_normalizes_equivalent_datetime_offsets(
+        self,
+    ) -> None:
+        scheduled_for_utc = datetime.now(timezone.utc) + timedelta(hours=4)
+        scheduled_for_plus_two = scheduled_for_utc.astimezone(
+            timezone(timedelta(hours=2))
+        )
+
+        binding_hash_utc = _approved_payload_binding_hash(
+            target_scope={
+                "asset_id": "critical-host-001",
+                "scheduled_for": scheduled_for_utc,
+            },
+            approved_payload={
+                "action_type": "disable_identity",
+                "scheduled_for": scheduled_for_utc,
+            },
+            execution_surface_type="executor",
+            execution_surface_id="isolated-executor",
+        )
+        binding_hash_plus_two = _approved_payload_binding_hash(
+            target_scope={
+                "asset_id": "critical-host-001",
+                "scheduled_for": scheduled_for_plus_two,
+            },
+            approved_payload={
+                "action_type": "disable_identity",
+                "scheduled_for": scheduled_for_plus_two,
+            },
+            execution_surface_type="executor",
+            execution_surface_id="isolated-executor",
+        )
+
+        self.assertEqual(binding_hash_plus_two, binding_hash_utc)
 
     def test_service_keeps_requester_identity_inside_reviewed_action_request_deduplication(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -7454,6 +7454,113 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "ValueError",
         )
 
+    def test_service_fail_closes_when_shuffle_finalization_fails_after_dispatch(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        expires_at = datetime(2026, 4, 5, 13, 0, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "workstation-001"}
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-routine-finalization-failure-001",
+                action_request_id="action-request-routine-finalization-failure-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-routine-finalization-failure-001",
+                approval_decision_id="approval-routine-finalization-failure-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-routine-finalization-failure-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=expires_at,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_basis={
+                    "severity": "low",
+                    "target_scope": "single_asset",
+                    "action_reversibility": "reversible",
+                    "asset_criticality": "standard",
+                    "identity_criticality": "standard",
+                    "blast_radius": "single_target",
+                    "execution_constraint": "routine_allowed",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "shuffle",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        original_persist_record = service.persist_record
+
+        def persist_record_with_finalization_failure(record: object) -> object:
+            if (
+                isinstance(record, ActionExecutionRecord)
+                and record.lifecycle_state == "queued"
+            ):
+                raise RuntimeError("synthetic finalization failure")
+            return original_persist_record(record)
+
+        with mock.patch.object(
+            service,
+            "persist_record",
+            side_effect=persist_record_with_finalization_failure,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "synthetic finalization failure"):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id="action-request-routine-finalization-failure-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertEqual(executions[0].execution_surface_type, "automation_substrate")
+        self.assertEqual(executions[0].execution_surface_id, "shuffle")
+        self.assertTrue(
+            executions[0].execution_run_id.startswith("pending-dispatch-delegation-")
+        )
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error_type"],
+            "RuntimeError",
+        )
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error"],
+            "synthetic finalization failure",
+        )
+
     def test_service_fail_closes_when_isolated_executor_receipt_surface_drifts(
         self,
     ) -> None:
@@ -9243,6 +9350,58 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         )
         self.assertIsNotNone(stored_latest)
         self.assertIn("latest_native_payload", stored_latest.subject_linkage)
+
+    def test_service_phase21_readiness_treats_dispatching_executions_as_active(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
+            store=store,
+        )
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        execution = service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-phase21-dispatching-001",
+                action_request_id="action-request-phase21-dispatching-001",
+                approval_decision_id="approval-phase21-dispatching-001",
+                delegation_id="delegation-phase21-dispatching-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="pending-dispatch-delegation-phase21-dispatching-001",
+                idempotency_key="idempotency-phase21-dispatching-001",
+                target_scope={"asset_id": "asset-phase21-dispatching-001"},
+                approved_payload={
+                    "action_type": "notify_identity_owner",
+                    "recipient_identity": "repo-owner-001",
+                },
+                payload_hash="payload-hash-phase21-dispatching-001",
+                delegated_at=delegated_at,
+                expires_at=delegated_at + timedelta(hours=1),
+                provenance={"delegation_issuer": "control-plane-service"},
+                lifecycle_state="dispatching",
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        aggregates = store.inspect_readiness_aggregates()
+
+        self.assertFalse(readiness.shutdown["shutdown_ready"])
+        self.assertEqual(
+            readiness.shutdown["active_action_execution_ids"],
+            [execution.action_execution_id],
+        )
+        self.assertEqual(
+            aggregates.active_action_execution_ids,
+            (execution.action_execution_id,),
+        )
 
     def test_service_phase21_readiness_prefers_higher_reconciliation_id_when_compared_at_ties(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -6927,6 +6927,70 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             },
         )
 
+    def test_service_evaluate_action_policy_preserves_reviewed_human_gate_override(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-policy-reviewed-routine",
+                approval_decision_id=None,
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-policy-reviewed-routine",
+                target_scope={"recipient_identity": "repo-owner-001"},
+                payload_hash="payload-hash-policy-reviewed-routine",
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="pending_approval",
+                requester_identity="analyst-001",
+                requested_payload=approved_payload,
+                policy_basis={
+                    "severity": "low",
+                    "target_scope": "single_identity",
+                    "action_reversibility": "reversible",
+                    "asset_criticality": "standard",
+                    "identity_criticality": "standard",
+                    "blast_radius": "single_target",
+                    "execution_constraint": "routine_allowed",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "approval_requirement_override": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        evaluated = service.evaluate_action_policy(
+            "action-request-policy-reviewed-routine"
+        )
+
+        self.assertEqual(
+            evaluated.policy_evaluation,
+            {
+                "approval_requirement": "human_required",
+                "approval_requirement_override": "human_required",
+                "routing_target": "approval",
+                "execution_surface_type": "automation_substrate",
+                "execution_surface_id": "shuffle",
+            },
+        )
+
     def test_service_delegates_approved_low_risk_action_through_shuffle_adapter(
         self,
     ) -> None:
@@ -7131,6 +7195,96 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         emit_event.assert_not_called()
         self.assertEqual(base_store.list(ActionExecutionRecord), ())
 
+    def test_service_dispatches_shuffle_approved_action_outside_store_transaction(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        expires_at = datetime(2026, 4, 5, 13, 0, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "workstation-001"}
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-routine-no-open-tx-001",
+                action_request_id="action-request-routine-no-open-tx-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-routine-no-open-tx-001",
+                approval_decision_id="approval-routine-no-open-tx-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-routine-no-open-tx-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=expires_at,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_basis={
+                    "severity": "low",
+                    "target_scope": "single_asset",
+                    "action_reversibility": "reversible",
+                    "asset_criticality": "standard",
+                    "identity_criticality": "standard",
+                    "blast_radius": "single_target",
+                    "execution_constraint": "routine_allowed",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        original_dispatch = type(service._shuffle).dispatch_approved_action
+
+        def dispatch_without_transaction(adapter: object, **kwargs: object) -> object:
+            self.assertIsNone(store._active_connection.get())
+            return original_dispatch(adapter, **kwargs)
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_without_transaction,
+        ):
+            execution = service.delegate_approved_action_to_shuffle(
+                action_request_id="action-request-routine-no-open-tx-001",
+                approved_payload=approved_payload,
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+            )
+
+        self.assertEqual(execution.lifecycle_state, "queued")
+        self.assertTrue(execution.execution_run_id.startswith("shuffle-run-"))
+
     def test_service_rechecks_shuffle_approval_inside_transaction(self) -> None:
         inner_store, _ = make_store()
         seed_service = AegisOpsControlPlaneService(
@@ -7206,6 +7360,202 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             )
 
         self.assertEqual(inner_store.list(ActionExecutionRecord), ())
+
+    def test_service_fail_closes_when_shuffle_receipt_binding_drifts_after_dispatch(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "workstation-001"}
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-routine-receipt-drift-001",
+                action_request_id="action-request-routine-receipt-drift-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-routine-receipt-drift-001",
+                approval_decision_id="approval-routine-receipt-drift-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-routine-receipt-drift-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        original_dispatch = type(service._shuffle).dispatch_approved_action
+
+        def dispatch_with_binding_drift(adapter: object, **kwargs: object) -> object:
+            receipt = original_dispatch(adapter, **kwargs)
+            return replace(receipt, payload_hash="payload-hash-drifted")
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_with_binding_drift,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "shuffle receipt does not match approved delegation binding",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id="action-request-routine-receipt-drift-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertEqual(executions[0].execution_surface_type, "automation_substrate")
+        self.assertEqual(executions[0].execution_surface_id, "shuffle")
+        self.assertTrue(
+            executions[0].execution_run_id.startswith("pending-dispatch-delegation-")
+        )
+        self.assertNotIn("downstream_binding", executions[0].provenance)
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error_type"],
+            "ValueError",
+        )
+
+    def test_service_fail_closes_when_isolated_executor_receipt_surface_drifts(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "critical-host-001"}
+        approved_payload = {
+            "action_type": "disable_identity",
+            "asset_id": "critical-host-001",
+        }
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="executor",
+            execution_surface_id="isolated-executor",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-executor-receipt-drift-001",
+                action_request_id="action-request-executor-receipt-drift-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-executor-receipt-drift-001",
+                approval_decision_id="approval-executor-receipt-drift-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-executor-receipt-drift-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_basis={
+                    "severity": "critical",
+                    "target_scope": "single_asset",
+                    "action_reversibility": "irreversible",
+                    "asset_criticality": "critical",
+                    "identity_criticality": "high",
+                    "blast_radius": "organization",
+                    "execution_constraint": "requires_isolated_executor",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "executor",
+                    "execution_surface_id": "isolated-executor",
+                },
+            )
+        )
+        original_dispatch = type(service._isolated_executor).dispatch_approved_action
+
+        def dispatch_with_surface_drift(adapter: object, **kwargs: object) -> object:
+            receipt = original_dispatch(adapter, **kwargs)
+            return replace(
+                receipt,
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+            )
+
+        with mock.patch.object(
+            type(service._isolated_executor),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_with_surface_drift,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "adapter receipt does not match approved execution surface",
+            ):
+                service.delegate_approved_action_to_isolated_executor(
+                    action_request_id="action-request-executor-receipt-drift-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertEqual(executions[0].execution_surface_type, "executor")
+        self.assertEqual(executions[0].execution_surface_id, "isolated-executor")
+        self.assertTrue(
+            executions[0].execution_run_id.startswith("pending-dispatch-delegation-")
+        )
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error_type"],
+            "ValueError",
+        )
 
     def test_service_rejects_shuffle_delegation_when_payload_binding_drifts(
         self,
@@ -8065,6 +8415,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             action_request.policy_evaluation,
             {
                 "approval_requirement": "human_required",
+                "approval_requirement_override": "human_required",
                 "routing_target": "approval",
                 "execution_surface_type": "automation_substrate",
                 "execution_surface_id": "shuffle",

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -9,6 +9,7 @@ import json
 import logging
 import pathlib
 import secrets
+from types import SimpleNamespace
 import sys
 from typing import Callable, Iterator
 import unittest
@@ -7561,6 +7562,104 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "synthetic finalization failure",
         )
 
+    def test_service_fail_closes_when_shuffle_receipt_omits_adapter(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 5, 12, 5, tzinfo=timezone.utc)
+        approved_target_scope = {"asset_id": "workstation-001"}
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="repo-owner-001",
+            case_id="case-001",
+            alert_id="alert-001",
+            finding_id="finding-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-routine-missing-adapter-001",
+                action_request_id="action-request-routine-missing-adapter-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-routine-missing-adapter-001",
+                approval_decision_id="approval-routine-missing-adapter-001",
+                case_id="case-001",
+                alert_id="alert-001",
+                finding_id="finding-001",
+                idempotency_key="idempotency-routine-missing-adapter-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        original_dispatch = type(service._shuffle).dispatch_approved_action
+
+        def dispatch_without_adapter(adapter: object, **kwargs: object) -> object:
+            receipt = original_dispatch(adapter, **kwargs)
+            return SimpleNamespace(
+                execution_surface_type=receipt.execution_surface_type,
+                execution_surface_id=receipt.execution_surface_id,
+                execution_run_id=receipt.execution_run_id,
+                approval_decision_id=receipt.approval_decision_id,
+                delegation_id=receipt.delegation_id,
+                payload_hash=receipt.payload_hash,
+                base_url=receipt.base_url,
+            )
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_without_adapter,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "adapter receipt missing required 'adapter' attribute",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id="action-request-routine-missing-adapter-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertNotIn("adapter", executions[0].provenance)
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error_type"],
+            "ValueError",
+        )
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error"],
+            "adapter receipt missing required 'adapter' attribute",
+        )
+
     def test_service_fail_closes_when_isolated_executor_receipt_surface_drifts(
         self,
     ) -> None:
@@ -9402,6 +9501,8 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             aggregates.active_action_execution_ids,
             (execution.action_execution_id,),
         )
+        self.assertEqual(readiness.metrics["action_executions"]["dispatching"], 1)
+        self.assertEqual(readiness.metrics["action_executions"]["terminal"], 0)
 
     def test_service_phase21_readiness_prefers_higher_reconciliation_id_when_compared_at_ties(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -241,6 +241,44 @@ class _CommitFailingStore:
 
 
 @dataclass
+class _RecordTypeSaveFailingStore:
+    inner: object
+    record_type: type[object]
+    message: str = "synthetic save failure"
+
+    @property
+    def dsn(self) -> str:
+        return self.inner.dsn
+
+    @property
+    def persistence_mode(self) -> str:
+        return self.inner.persistence_mode
+
+    def save(self, record: object) -> object:
+        if isinstance(record, self.record_type):
+            raise RuntimeError(self.message)
+        return self.inner.save(record)
+
+    def get(self, record_type: object, record_id: str) -> object | None:
+        return self.inner.get(record_type, record_id)
+
+    def list(self, record_type: object) -> tuple[object, ...]:
+        return self.inner.list(record_type)
+
+    def inspect_readiness_aggregates(self) -> object:
+        return self.inner.inspect_readiness_aggregates()
+
+    @contextmanager
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> Iterator[None]:
+        with self.inner.transaction(isolation_level=isolation_level):
+            yield
+
+
+@dataclass
 class _CommitFailingConnection:
     inner: object
     message: str
@@ -10396,6 +10434,200 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         self.assertEqual(
             reconciliation.subject_linkage["action_execution_ids"],
             (execution.action_execution_id,),
+        )
+
+    def test_service_reconciliation_rolls_back_execution_state_when_reconciliation_write_fails(
+        self,
+    ) -> None:
+        base_store, seed_service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = seed_service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = seed_service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        decided_at = action_request.requested_at + timedelta(minutes=5)
+        delegated_at = action_request.requested_at + timedelta(minutes=10)
+        observed_at = action_request.requested_at + timedelta(minutes=15)
+        compared_at = action_request.requested_at + timedelta(minutes=16)
+        stale_after = action_request.requested_at + timedelta(hours=1)
+        approval_decision = seed_service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase20-reconciliation-atomic-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=decided_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = seed_service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        execution = seed_service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        existing_reconciliation_ids = {
+            record.reconciliation_id for record in base_store.list(ReconciliationRecord)
+        }
+        failing_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=_RecordTypeSaveFailingStore(
+                inner=base_store,
+                record_type=ReconciliationRecord,
+                message="synthetic reconciliation save failure",
+            ),
+        )
+
+        with mock.patch.object(failing_service, "_emit_structured_event") as emit_event:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "synthetic reconciliation save failure",
+            ):
+                failing_service.reconcile_action_execution(
+                    action_request_id=approved_request.action_request_id,
+                    execution_surface_type="automation_substrate",
+                    execution_surface_id="shuffle",
+                    observed_executions=(
+                        {
+                            "execution_run_id": execution.execution_run_id,
+                            "execution_surface_id": "shuffle",
+                            "idempotency_key": approved_request.idempotency_key,
+                            "approval_decision_id": execution.approval_decision_id,
+                            "delegation_id": execution.delegation_id,
+                            "payload_hash": execution.payload_hash,
+                            "observed_at": observed_at,
+                            "status": "success",
+                        },
+                    ),
+                    compared_at=compared_at,
+                    stale_after=stale_after,
+                )
+
+        emit_event.assert_not_called()
+        stored_execution = base_store.get(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertIsNotNone(stored_execution)
+        self.assertEqual(stored_execution.lifecycle_state, "queued")
+        self.assertEqual(
+            {
+                record.reconciliation_id
+                for record in base_store.list(ReconciliationRecord)
+            },
+            existing_reconciliation_ids,
+        )
+
+    def test_service_reconciliation_does_not_downgrade_authoritative_execution_lifecycle(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        decided_at = action_request.requested_at + timedelta(minutes=5)
+        delegated_at = action_request.requested_at + timedelta(minutes=10)
+        observed_at = action_request.requested_at + timedelta(minutes=15)
+        compared_at = action_request.requested_at + timedelta(minutes=16)
+        stale_after = action_request.requested_at + timedelta(hours=1)
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase20-reconciliation-monotonic-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=decided_at,
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        service.persist_record(replace(execution, lifecycle_state="running"))
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "observed_at": observed_at,
+                    "status": "queued",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=stale_after,
+        )
+
+        stored_execution = service.get_record(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertIsNotNone(stored_execution)
+        self.assertEqual(stored_execution.lifecycle_state, "running")
+        self.assertEqual(reconciliation.ingest_disposition, "matched")
+        self.assertEqual(reconciliation.lifecycle_state, "matched")
+        self.assertEqual(
+            service._execution_coordinator._action_execution_lifecycle_from_status(
+                "running",
+                "succeeded",
+            ),
+            "succeeded",
         )
 
     def test_service_phase20_reconciliation_rejects_downstream_evidence_missing_binding_identifiers(


### PR DESCRIPTION
Closes #456
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the reviewed execution flow into a dedicated coordinator and left `AegisOpsControlPlaneService` as the public facade. The new [`execution_coordinator.py`](/Users/jp.infra/Dev/AegisOps-worktrees/issue-456/control-plane/aegisops_control_plane/execution_coordinator.py) now owns reviewed action-request creation, shuffle and isolated-executor delegation, exact approved binding and expiry validation, and reconciliation. The facade methods in [`service.py`](/Users/jp.infra/Dev/AegisOps-worktrees/issue-456/control-plane/aegisops_control_plane/service.py) now delegate to that collaborator, and the duplicate helper logic was removed from the monolithic service.

I added a focused structural reproducer in [`test_execution_coordinator_boundary.py`](/Users/jp.infra/Dev/AegisOps-worktrees/issue-456/control-plane/tests/test_execution_coordinator_boundary.py) first, then verified the existing persistence and Phase 20/21 behavior stayed intact. The implementation is checkpointed in commit `bf7aa01` (`Extract reviewed execution coordinator`). The issue journal’s Codex Working Notes section was updated locally.

Summary: Extracted reviewed action/delegation/reconciliation logic into `ExecutionCoordinator`, added a focused coordinator-boundary test, preserved existing Phase 20/21 behavior, and committed the change as `bf7aa01`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_execution_coordinator_boundary`; `python3 -m unittest cont...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end orchestration for reviewed/approved actions: deterministic request binding, idempotent request reuse, adapter delegation, and reconciliation with structured events.
  * Policy evaluations now include an explicit approval override ("human_required").
  * Execution lifecycle adds a "dispatching" state.

* **Bug Fixes**
  * Improved dispatch error handling and provenance; reconciliation rollback preserves lifecycle consistency.

* **Refactor**
  * Core workflows moved into a dedicated coordinator for clearer separation.

* **Tests**
  * Expanded coverage for delegation, reconciliation, failure modes, readiness, and policy-override preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->