### PR TITLE
implementation: isolate the current Phase 19 live-slice policy checks behind reusable reviewed-slice policy logic (#458)

### DIFF
--- a/.codex-supervisor/issues/458/issue-journal.md
+++ b/.codex-supervisor/issues/458/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #458: implementation: isolate the current Phase 19 live-slice policy checks behind reusable reviewed-slice policy logic
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/458
+- Branch: codex/issue-458
+- Workspace: .
+- Journal: .codex-supervisor/issues/458/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: c2ef907ddb11cefc74e5aafb194a41927f7a5caa
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T03:26:33.521Z
+
+## Latest Codex Summary
+- Extracted the Phase 19 reviewed live-slice checks into `control-plane/aegisops_control_plane/reviewed_slice_policy.py`, rewired assistant/advisory and action-request paths through generic reviewed-slice wrappers, and added a focused delegation test to pin the extraction boundary while preserving existing fail-closed behavior.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The Phase 19 operator/advisory gating can move behind a dedicated reviewed-slice policy object without changing current live Wazuh-backed scope decisions or fail-closed behavior.
+- What changed: Added `reviewed_slice_policy.py`; service now owns a reusable `ReviewedSlicePolicy` and delegates reviewed operator-case and case-scoped advisory checks through generic reviewed-slice wrappers; assistant context and execution coordinator call the generic reviewed-slice hooks; added a narrow service test that asserts the reusable policy object is the enforcement boundary; preserved the existing `Phase 19 ... live slice` error text after the first focused run exposed that compatibility requirement.
+- Current blocker: none.
+- Next exact step: Commit the verified extraction on `codex/issue-458`; if requested later, open a draft PR from this checkpoint.
+- Verification gap: No additional manual verification run beyond the covered automated fail-closed workflow cases.
+- Files touched: `control-plane/aegisops_control_plane/reviewed_slice_policy.py`, `control-plane/aegisops_control_plane/service.py`, `control-plane/aegisops_control_plane/assistant_context.py`, `control-plane/aegisops_control_plane/execution_coordinator.py`, `control-plane/tests/test_service_persistence.py`.
+- Rollback concern: Low; the main risk is accidental drift in error wording or reviewed-slice gating if future changes bypass the new policy wrappers.
+- Last focused command: `python3 -m unittest control-plane.tests.test_service_persistence control-plane.tests.test_phase19_operator_workflow_validation`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -425,7 +425,7 @@ class AssistantContextAssembler:
                 f"Missing {record_family} record {record_id!r} for assistant context"
             )
         if record_family == "case":
-            self._service._require_phase19_operator_case_record(record)
+            self._service._require_reviewed_operator_case_record(record)
 
         linked_alert_ids = self._service._assistant_ids_from_value(
             getattr(record, "alert_id", None)
@@ -807,10 +807,10 @@ class AssistantContextAssembler:
 
     def inspect_advisory_output(self, record_family: str, record_id: str) -> Any:
         context_snapshot = self.inspect_assistant_context(record_family, record_id)
-        self._service._require_phase19_case_scoped_advisory_read(context_snapshot)
+        self._service._require_reviewed_case_scoped_advisory_read(context_snapshot)
         return self._advisory_snapshot_from_context(context_snapshot)
 
     def render_recommendation_draft(self, record_family: str, record_id: str) -> Any:
         context_snapshot = self.inspect_assistant_context(record_family, record_id)
-        self._service._require_phase19_case_scoped_advisory_read(context_snapshot)
+        self._service._require_reviewed_case_scoped_advisory_read(context_snapshot)
         return self._recommendation_draft_snapshot_from_context(context_snapshot)

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -43,7 +43,10 @@ class ExecutionCoordinatorServiceDependencies(Protocol):
     ) -> None:
         ...
 
-    def _require_phase19_case_scoped_advisory_read(self, context_snapshot: object) -> None:
+    def _require_reviewed_case_scoped_advisory_read(
+        self,
+        context_snapshot: object,
+    ) -> None:
         ...
 
     def _require_single_recommendation_binding(
@@ -58,7 +61,7 @@ class ExecutionCoordinatorServiceDependencies(Protocol):
     def _require_single_linked_case_id(self, linked_case_ids: tuple[str, ...]) -> str:
         ...
 
-    def _require_phase19_operator_case(self, case_id: str) -> object:
+    def _require_reviewed_operator_case(self, case_id: str) -> object:
         ...
 
     def _resolve_new_record_identifier(
@@ -165,7 +168,7 @@ class ExecutionCoordinator:
                 record_family,
                 record_id,
             )
-            self._service._require_phase19_case_scoped_advisory_read(context_snapshot)
+            self._service._require_reviewed_case_scoped_advisory_read(context_snapshot)
             recommendation_draft = self._service.render_recommendation_draft(
                 record_family,
                 record_id,
@@ -183,7 +186,7 @@ class ExecutionCoordinator:
             case_id = self._service._require_single_linked_case_id(
                 recommendation_draft.linked_case_ids
             )
-            case = self._service._require_phase19_operator_case(case_id)
+            case = self._service._require_reviewed_operator_case(case_id)
             if expires_at <= datetime.now(timezone.utc):
                 raise ValueError("expires_at must be in the future")
 

--- a/control-plane/aegisops_control_plane/reviewed_slice_policy.py
+++ b/control-plane/aegisops_control_plane/reviewed_slice_policy.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from typing import Callable, Mapping, Protocol
+
+from .models import AlertRecord, CaseRecord, LeadRecord, ReconciliationRecord
+
+
+REVIEWED_LIVE_SOURCE_FAMILIES = frozenset({"github_audit", "entra_id"})
+REVIEWED_LIVE_SLICE_LABEL = "Phase 19 Wazuh-backed GitHub audit and Entra ID live slice"
+
+
+class ReviewedSlicePolicyServiceDependencies(Protocol):
+    _store: object
+
+    def _require_case_record(self, case_id: str) -> CaseRecord:
+        ...
+
+    def _normalize_optional_string(
+        self,
+        value: object,
+        field_name: str,
+    ) -> str | None:
+        ...
+
+    def _latest_detection_reconciliation_for_alert(
+        self,
+        alert_id: str,
+    ) -> ReconciliationRecord | None:
+        ...
+
+    def _reconciliation_is_wazuh_origin(
+        self,
+        reconciliation: ReconciliationRecord,
+    ) -> bool:
+        ...
+
+    def _linked_id_exists(self, values: object, expected_id: str) -> bool:
+        ...
+
+
+class ReviewedSlicePolicy:
+    """Encapsulates the approved reviewed live-slice access rules."""
+
+    def __init__(
+        self,
+        service: ReviewedSlicePolicyServiceDependencies,
+        *,
+        normalize_admission_provenance: Callable[
+            [object], dict[str, str] | None
+        ],
+    ) -> None:
+        self._service = service
+        self._normalize_admission_provenance = normalize_admission_provenance
+
+    def require_operator_case(self, case_id: str) -> CaseRecord:
+        case = self._service._require_case_record(case_id)
+        return self.require_operator_case_record(case)
+
+    def require_case_scoped_advisory_read(self, context_snapshot: object) -> None:
+        record_family = str(getattr(context_snapshot, "record_family"))
+        record_id = str(getattr(context_snapshot, "record_id"))
+        error_message = self.case_scoped_read_error(record_family, record_id)
+
+        if record_family == "case":
+            self.require_operator_case(record_id)
+            return
+
+        linked_case_ids = tuple(getattr(context_snapshot, "linked_case_ids"))
+        if not linked_case_ids:
+            raise ValueError(error_message)
+
+        approved_cases = {
+            case_id: self.require_operator_case(case_id) for case_id in linked_case_ids
+        }
+
+        if record_family == "recommendation":
+            self.require_case_scoped_recommendation_payload(
+                getattr(context_snapshot, "record"),
+                approved_cases=approved_cases,
+                error_message=error_message,
+            )
+        elif record_family == "ai_trace":
+            subject_linkage = getattr(context_snapshot, "record").get("subject_linkage")
+            if self.context_explicitly_declares_provenance(
+                subject_linkage
+            ) and self.context_declares_out_of_scope_provenance(subject_linkage):
+                raise ValueError(error_message)
+
+            linked_recommendation_records = tuple(
+                getattr(context_snapshot, "linked_recommendation_records")
+            )
+            if not linked_recommendation_records:
+                raise ValueError(error_message)
+            for recommendation in linked_recommendation_records:
+                self.require_case_scoped_recommendation_payload(
+                    recommendation,
+                    approved_cases=approved_cases,
+                    error_message=error_message,
+                )
+
+    @staticmethod
+    def case_scoped_read_error(record_family: str, record_id: str) -> str:
+        return (
+            f"{record_family} {record_id!r} is outside the approved "
+            f"{REVIEWED_LIVE_SLICE_LABEL}"
+        )
+
+    def require_case_scoped_recommendation_payload(
+        self,
+        payload: Mapping[str, object],
+        *,
+        approved_cases: Mapping[str, CaseRecord],
+        error_message: str,
+    ) -> None:
+        case_id = self._service._normalize_optional_string(payload.get("case_id"), "case_id")
+        if case_id is None:
+            raise ValueError(error_message)
+        approved_case = approved_cases.get(case_id)
+        if approved_case is None:
+            raise ValueError(error_message)
+
+        alert_id = self._service._normalize_optional_string(payload.get("alert_id"), "alert_id")
+        if alert_id is not None and approved_case.alert_id != alert_id:
+            raise ValueError(error_message)
+
+        lead_id = self._service._normalize_optional_string(payload.get("lead_id"), "lead_id")
+        if lead_id is not None:
+            lead = self._service._store.get(LeadRecord, lead_id)
+            if lead is None or lead.case_id != case_id:
+                raise ValueError(error_message)
+
+        reviewed_context = payload.get("reviewed_context")
+        if self.context_explicitly_declares_provenance(
+            reviewed_context
+        ) and self.context_declares_out_of_scope_provenance(reviewed_context):
+            raise ValueError(error_message)
+
+    def require_operator_case_record(self, case: CaseRecord) -> CaseRecord:
+        if not self.case_is_in_operator_slice(case):
+            raise ValueError(
+                f"Case {case.case_id!r} is outside the approved "
+                f"{REVIEWED_LIVE_SLICE_LABEL}"
+            )
+        return case
+
+    def case_is_in_operator_slice(self, case: CaseRecord) -> bool:
+        alert_id = self._service._normalize_optional_string(case.alert_id, "case.alert_id")
+        if alert_id is None:
+            return False
+
+        alert = self._service._store.get(AlertRecord, alert_id)
+        if alert is None:
+            return False
+        if alert.case_id != case.case_id:
+            return False
+
+        reconciliation = self._service._latest_detection_reconciliation_for_alert(
+            alert.alert_id
+        )
+        if reconciliation is None or not self._service._reconciliation_is_wazuh_origin(
+            reconciliation
+        ):
+            return False
+        if not self._service._linked_id_exists(
+            reconciliation.subject_linkage.get("alert_ids"),
+            alert.alert_id,
+        ):
+            return False
+        if not self._service._linked_id_exists(
+            reconciliation.subject_linkage.get("case_ids"),
+            case.case_id,
+        ):
+            return False
+
+        admission_provenance = (
+            self._normalize_admission_provenance(
+                reconciliation.subject_linkage.get("admission_provenance")
+            )
+            or self._normalize_admission_provenance(case.reviewed_context.get("provenance"))
+            or self._normalize_admission_provenance(alert.reviewed_context.get("provenance"))
+        )
+        if admission_provenance != {
+            "admission_kind": "live",
+            "admission_channel": "live_wazuh_webhook",
+        }:
+            return False
+
+        return (
+            self.source_family(case.reviewed_context)
+            or self.source_family(alert.reviewed_context)
+            or self.source_family(reconciliation.subject_linkage.get("reviewed_source_profile"))
+        ) in REVIEWED_LIVE_SOURCE_FAMILIES
+
+    @staticmethod
+    def source_family(context: object) -> str | None:
+        if not isinstance(context, Mapping):
+            return None
+
+        source_context = context.get("source")
+        if isinstance(source_context, Mapping):
+            source_family = source_context.get("source_family")
+            if isinstance(source_family, str):
+                normalized_source_family = source_family.strip()
+                if normalized_source_family:
+                    return normalized_source_family
+
+        source_family = context.get("source_family")
+        if isinstance(source_family, str):
+            normalized_source_family = source_family.strip()
+            if normalized_source_family:
+                return normalized_source_family
+
+        return None
+
+    def context_declares_out_of_scope_provenance(self, context: object) -> bool:
+        if not isinstance(context, Mapping):
+            return True
+
+        source_family = self.source_family(context) or self.source_family(
+            context.get("reviewed_source_profile")
+        )
+        if source_family not in REVIEWED_LIVE_SOURCE_FAMILIES:
+            return True
+
+        admission_provenance = self._normalize_admission_provenance(
+            context.get("provenance")
+        ) or self._normalize_admission_provenance(context.get("admission_provenance"))
+        return (
+            admission_provenance is not None
+            and admission_provenance
+            != {
+                "admission_kind": "live",
+                "admission_channel": "live_wazuh_webhook",
+            }
+        )
+
+    @staticmethod
+    def context_explicitly_declares_provenance(context: object) -> bool:
+        if not isinstance(context, Mapping):
+            return context is not None
+        if "source_family" in context or "source" in context:
+            return True
+        if "reviewed_source_profile" in context:
+            return True
+        return "provenance" in context or "admission_provenance" in context

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -42,11 +42,14 @@ from .models import (
 )
 from .operations import RestoreReadinessService, RuntimeBoundaryService
 from .assistant_context import AssistantContextAssembler
+from .reviewed_slice_policy import (
+    REVIEWED_LIVE_SLICE_LABEL,
+    REVIEWED_LIVE_SOURCE_FAMILIES,
+    ReviewedSlicePolicy,
+)
 
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
-REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES = frozenset({"github_audit", "entra_id"})
-REVIEWED_PHASE19_LIVE_SLICE_LABEL = "Wazuh-backed GitHub audit and Entra ID live slice"
 
 
 class ControlPlaneStore(Protocol):
@@ -884,6 +887,10 @@ class AegisOpsControlPlaneService:
             config.isolated_executor_base_url
         )
         self._logger = logging.getLogger("aegisops.control_plane")
+        self._reviewed_slice_policy = ReviewedSlicePolicy(
+            self,
+            normalize_admission_provenance=_normalize_admission_provenance,
+        )
         self._assistant_context_assembler = AssistantContextAssembler(
             self,
             record_types_by_family=RECORD_TYPES_BY_FAMILY,
@@ -1094,7 +1101,7 @@ class AegisOpsControlPlaneService:
             ).get("source_family"),
             "data.source_family",
         )
-        if source_family not in REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES:
+        if source_family not in REVIEWED_LIVE_SOURCE_FAMILIES:
             self._emit_structured_event(
                 logging.WARNING,
                 "wazuh_ingest_rejected",
@@ -1490,7 +1497,7 @@ class AegisOpsControlPlaneService:
         )
 
     def inspect_case_detail(self, case_id: str) -> CaseDetailSnapshot:
-        case = self._require_phase19_operator_case(case_id)
+        case = self._require_reviewed_operator_case(case_id)
         case_id = case.case_id
         context_snapshot = self.inspect_assistant_context("case", case_id)
         observation_records = tuple(
@@ -1553,7 +1560,7 @@ class AegisOpsControlPlaneService:
             "supporting_evidence_ids",
         )
         with self._store.transaction():
-            case = self._require_phase19_operator_case(case_id)
+            case = self._require_reviewed_operator_case(case_id)
             self._validate_case_evidence_linkage(
                 case=case,
                 evidence_ids=normalized_evidence_ids,
@@ -1604,7 +1611,7 @@ class AegisOpsControlPlaneService:
             "observation_id",
         )
         with self._store.transaction():
-            case = self._require_phase19_operator_case(case_id)
+            case = self._require_reviewed_operator_case(case_id)
             if resolved_observation_id is not None:
                 observation = self._store.get(ObservationRecord, resolved_observation_id)
                 if observation is None:
@@ -1656,7 +1663,7 @@ class AegisOpsControlPlaneService:
         )
         resolved_lead_id = self._normalize_optional_string(lead_id, "lead_id")
         with self._store.transaction():
-            case = self._require_phase19_operator_case(case_id)
+            case = self._require_reviewed_operator_case(case_id)
             if resolved_lead_id is not None:
                 lead = self._store.get(LeadRecord, resolved_lead_id)
                 if lead is None:
@@ -1708,7 +1715,7 @@ class AegisOpsControlPlaneService:
             "follow_up_evidence_ids",
         )
         with self._store.transaction():
-            case = self._require_phase19_operator_case(case_id)
+            case = self._require_reviewed_operator_case(case_id)
             self._validate_case_evidence_linkage(
                 case=case,
                 evidence_ids=normalized_evidence_ids,
@@ -1749,7 +1756,7 @@ class AegisOpsControlPlaneService:
         recorded_at = self._require_aware_datetime(recorded_at, "recorded_at")
         lifecycle_state = self._case_lifecycle_for_disposition(disposition)
         with self._store.transaction():
-            case = self._require_phase19_operator_case(case_id)
+            case = self._require_reviewed_operator_case(case_id)
             updated_reviewed_context = _merge_reviewed_context(
                 case.reviewed_context,
                 {
@@ -3384,9 +3391,8 @@ class AegisOpsControlPlaneService:
             raise LookupError(f"Missing case {case_id!r}")
         return case
 
-    def _require_phase19_operator_case(self, case_id: str) -> CaseRecord:
-        case = self._require_case_record(case_id)
-        return self._require_phase19_operator_case_record(case)
+    def _require_reviewed_operator_case(self, case_id: str) -> CaseRecord:
+        return self._reviewed_slice_policy.require_operator_case(case_id)
 
     @staticmethod
     def _require_single_linked_case_id(linked_case_ids: tuple[str, ...]) -> str:
@@ -3412,188 +3418,47 @@ class AegisOpsControlPlaneService:
             )
         return recommendation_ids[0]
 
-    def _require_phase19_case_scoped_advisory_read(
+    def _require_reviewed_case_scoped_advisory_read(
         self,
         context_snapshot: AnalystAssistantContextSnapshot,
     ) -> None:
-        error_message = self._phase19_case_scoped_read_error(
-            context_snapshot.record_family,
-            context_snapshot.record_id,
-        )
-        if context_snapshot.record_family == "case":
-            self._require_phase19_operator_case(context_snapshot.record_id)
-            return
-        if not context_snapshot.linked_case_ids:
-            raise ValueError(error_message)
-
-        approved_cases: dict[str, CaseRecord] = {}
-        for case_id in context_snapshot.linked_case_ids:
-            approved_cases[case_id] = self._require_phase19_operator_case(case_id)
-
-        if context_snapshot.record_family == "recommendation":
-            self._require_phase19_case_scoped_recommendation_payload(
-                context_snapshot.record,
-                approved_cases=approved_cases,
-                error_message=error_message,
-            )
-        elif context_snapshot.record_family == "ai_trace":
-            subject_linkage = context_snapshot.record.get("subject_linkage")
-            if self._phase19_context_explicitly_declares_provenance(subject_linkage) and (
-                self._phase19_context_declares_out_of_scope_provenance(subject_linkage)
-            ):
-                raise ValueError(error_message)
-            if not context_snapshot.linked_recommendation_records:
-                raise ValueError(error_message)
-            for recommendation in context_snapshot.linked_recommendation_records:
-                self._require_phase19_case_scoped_recommendation_payload(
-                    recommendation,
-                    approved_cases=approved_cases,
-                    error_message=error_message,
-                )
+        self._reviewed_slice_policy.require_case_scoped_advisory_read(context_snapshot)
 
     @staticmethod
-    def _phase19_case_scoped_read_error(record_family: str, record_id: str) -> str:
-        return (
-            f"{record_family} {record_id!r} is outside the approved Phase 19 "
-            f"{REVIEWED_PHASE19_LIVE_SLICE_LABEL}"
-        )
+    def _reviewed_case_scoped_read_error(record_family: str, record_id: str) -> str:
+        return ReviewedSlicePolicy.case_scoped_read_error(record_family, record_id)
 
-    def _require_phase19_case_scoped_recommendation_payload(
+    def _require_reviewed_case_scoped_recommendation_payload(
         self,
         payload: Mapping[str, object],
         *,
         approved_cases: Mapping[str, CaseRecord],
         error_message: str,
     ) -> None:
-        case_id = self._normalize_optional_string(payload.get("case_id"), "case_id")
-        if case_id is None:
-            raise ValueError(error_message)
-        approved_case = approved_cases.get(case_id)
-        if approved_case is None:
-            raise ValueError(error_message)
-
-        alert_id = self._normalize_optional_string(payload.get("alert_id"), "alert_id")
-        if alert_id is not None and approved_case.alert_id != alert_id:
-            raise ValueError(error_message)
-
-        lead_id = self._normalize_optional_string(payload.get("lead_id"), "lead_id")
-        if lead_id is not None:
-            lead = self._store.get(LeadRecord, lead_id)
-            if lead is None or lead.case_id != case_id:
-                raise ValueError(error_message)
-
-        reviewed_context = payload.get("reviewed_context")
-        if self._phase19_context_explicitly_declares_provenance(reviewed_context) and (
-            self._phase19_context_declares_out_of_scope_provenance(reviewed_context)
-        ):
-            raise ValueError(error_message)
-
-    def _require_phase19_operator_case_record(self, case: CaseRecord) -> CaseRecord:
-        if not self._case_is_in_phase19_operator_slice(case):
-            raise ValueError(
-                f"Case {case.case_id!r} is outside the approved Phase 19 "
-                f"{REVIEWED_PHASE19_LIVE_SLICE_LABEL}"
-            )
-        return case
-
-    def _case_is_in_phase19_operator_slice(self, case: CaseRecord) -> bool:
-        alert_id = self._normalize_optional_string(case.alert_id, "case.alert_id")
-        if alert_id is None:
-            return False
-
-        alert = self._store.get(AlertRecord, alert_id)
-        if alert is None:
-            return False
-        if alert.case_id != case.case_id:
-            return False
-
-        reconciliation = self._latest_detection_reconciliation_for_alert(alert.alert_id)
-        if reconciliation is None or not self._reconciliation_is_wazuh_origin(reconciliation):
-            return False
-        if not self._linked_id_exists(
-            reconciliation.subject_linkage.get("alert_ids"),
-            alert.alert_id,
-        ):
-            return False
-        if not self._linked_id_exists(
-            reconciliation.subject_linkage.get("case_ids"),
-            case.case_id,
-        ):
-            return False
-
-        admission_provenance = (
-            _normalize_admission_provenance(
-                reconciliation.subject_linkage.get("admission_provenance")
-            )
-            or _normalize_admission_provenance(case.reviewed_context.get("provenance"))
-            or _normalize_admission_provenance(alert.reviewed_context.get("provenance"))
+        self._reviewed_slice_policy.require_case_scoped_recommendation_payload(
+            payload,
+            approved_cases=approved_cases,
+            error_message=error_message,
         )
-        if admission_provenance != {
-            "admission_kind": "live",
-            "admission_channel": "live_wazuh_webhook",
-        }:
-            return False
-
-        return (
-            self._phase19_operator_source_family(case.reviewed_context)
-            or self._phase19_operator_source_family(alert.reviewed_context)
-            or self._phase19_operator_source_family(
-                reconciliation.subject_linkage.get("reviewed_source_profile")
-            )
-        ) in REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES
 
     @staticmethod
-    def _phase19_operator_source_family(context: object) -> str | None:
-        if not isinstance(context, Mapping):
-            return None
+    def _reviewed_operator_source_family(context: object) -> str | None:
+        return ReviewedSlicePolicy.source_family(context)
 
-        source_context = context.get("source")
-        if isinstance(source_context, Mapping):
-            source_family = source_context.get("source_family")
-            if isinstance(source_family, str):
-                normalized_source_family = source_family.strip()
-                if normalized_source_family:
-                    return normalized_source_family
+    @staticmethod
+    def _reviewed_context_explicitly_declares_provenance(context: object) -> bool:
+        return ReviewedSlicePolicy.context_explicitly_declares_provenance(context)
 
-        source_family = context.get("source_family")
-        if isinstance(source_family, str):
-            normalized_source_family = source_family.strip()
-            if normalized_source_family:
-                return normalized_source_family
+    def _require_reviewed_operator_case_record(self, case: CaseRecord) -> CaseRecord:
+        return self._reviewed_slice_policy.require_operator_case_record(case)
 
-        return None
+    def _case_is_in_reviewed_operator_slice(self, case: CaseRecord) -> bool:
+        return self._reviewed_slice_policy.case_is_in_operator_slice(case)
 
-    def _phase19_context_declares_out_of_scope_provenance(self, context: object) -> bool:
-        if not isinstance(context, Mapping):
-            return True
-
-        source_family = self._phase19_operator_source_family(
+    def _reviewed_context_declares_out_of_scope_provenance(self, context: object) -> bool:
+        return self._reviewed_slice_policy.context_declares_out_of_scope_provenance(
             context
-        ) or self._phase19_operator_source_family(context.get("reviewed_source_profile"))
-        if source_family not in REVIEWED_LIVE_WAZUH_SOURCE_FAMILIES:
-            return True
-
-        admission_provenance = _normalize_admission_provenance(
-            context.get("provenance")
-        ) or _normalize_admission_provenance(context.get("admission_provenance"))
-        return (
-            admission_provenance is not None
-            and admission_provenance
-            != {
-                "admission_kind": "live",
-                "admission_channel": "live_wazuh_webhook",
-            }
         )
-
-    @staticmethod
-    def _phase19_context_explicitly_declares_provenance(context: object) -> bool:
-        if not isinstance(context, Mapping):
-            return context is not None
-        if "source_family" in context or "source" in context:
-            return True
-        if "reviewed_source_profile" in context:
-            return True
-        return "provenance" in context or "admission_provenance" in context
 
     def _normalize_linked_record_ids(
         self,

--- a/control-plane/tests/test_service_persistence.py
+++ b/control-plane/tests/test_service_persistence.py
@@ -449,6 +449,55 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
             "case-delegated-001",
         )
 
+    def test_service_routes_reviewed_slice_checks_through_policy_module(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        service._reviewed_slice_policy = mock.Mock()
+        service._reviewed_slice_policy.require_operator_case.return_value = (
+            mock.sentinel.case_record
+        )
+        service._reviewed_slice_policy.require_operator_case_record.return_value = (
+            mock.sentinel.validated_case_record
+        )
+        service._reviewed_slice_policy.context_declares_out_of_scope_provenance.return_value = (
+            True
+        )
+        context_snapshot = mock.sentinel.context_snapshot
+
+        self.assertIs(
+            service._require_reviewed_operator_case("case-reviewed-001"),
+            mock.sentinel.case_record,
+        )
+        self.assertIs(
+            service._require_reviewed_operator_case_record(mock.sentinel.case_record),
+            mock.sentinel.validated_case_record,
+        )
+        service._require_reviewed_case_scoped_advisory_read(context_snapshot)
+        self.assertTrue(
+            service._reviewed_context_declares_out_of_scope_provenance(
+                mock.sentinel.reviewed_context
+            )
+        )
+
+        service._reviewed_slice_policy.require_operator_case.assert_called_once_with(
+            "case-reviewed-001"
+        )
+        (
+            service._reviewed_slice_policy.require_operator_case_record
+            .assert_called_once_with(mock.sentinel.case_record)
+        )
+        (
+            service._reviewed_slice_policy.require_case_scoped_advisory_read
+            .assert_called_once_with(context_snapshot)
+        )
+        (
+            service._reviewed_slice_policy.context_declares_out_of_scope_provenance
+            .assert_called_once_with(mock.sentinel.reviewed_context)
+        )
+
     def _assert_authoritative_store_empty(self, store: object) -> None:
         for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
             self.assertEqual(store.list(record_type), ())
@@ -4618,7 +4667,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         _, service, _, _, _ = self._build_phase19_in_scope_case()
 
         self.assertTrue(
-            service._phase19_context_declares_out_of_scope_provenance(
+            service._reviewed_context_declares_out_of_scope_provenance(
                 "synthetic_review_fixture"
             )
         )
@@ -4627,7 +4676,7 @@ class ControlPlaneServicePersistenceTests(unittest.TestCase):
         _, service, _, _, _ = self._build_phase19_in_scope_case()
 
         self.assertTrue(
-            service._phase19_context_declares_out_of_scope_provenance(
+            service._reviewed_context_declares_out_of_scope_provenance(
                 {
                     "provenance": {
                         "admission_kind": "live",


### PR DESCRIPTION
Closes #458
This PR was opened by codex-supervisor.
Latest Codex summary:

Isolated the current live-slice gating into [reviewed_slice_policy.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-458/control-plane/aegisops_control_plane/reviewed_slice_policy.py), then rewired [service.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-458/control-plane/aegisops_control_plane/service.py), [assistant_context.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-458/control-plane/aegisops_control_plane/assistant_context.py), and [execution_coordinator.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-458/control-plane/aegisops_control_plane/execution_coordinator.py) to use reusable reviewed-slice wrappers instead of embedding the Phase 19 logic inline. I kept the existing approved behavior and restored the exact `Phase 19 ... live slice` fail-closed wording after the first focused run caught that compatibility detail.

I also added a narrow extraction test in [test_service_persistence.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-458/control-plane/tests/test_service_persistence.py) that pins the service-to-policy delegation boundary, then ran the focused and full requested verification. The checkpoint is committed on `codex/issue-458` at `414a418` with message `Extract reviewed slice policy checks`.

Summary: Extracted reviewed live-slice policy checks into a reusable policy module, updated internal call sites to generic reviewed-slice wrappers, preserved current fail-closed semantics, and committed the change as `414a418`.
State hint: implementing
Blocked re...