### PR TITLE
Add operator action-review inspection states

### DIFF
--- a/.codex-supervisor/issues/475/issue-journal.md
+++ b/.codex-supervisor/issues/475/issue-journal.md
@@ -1,0 +1,34 @@
+# Issue #475: implementation: add pending / expired / rejected / superseded action-review surfaces to the operator workflow
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/475
+- Branch: codex/issue-475
+- Workspace: .
+- Journal: .codex-supervisor/issues/475/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: aa508db389673b496a9618ee37c2dd42eee611af
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T13:09:48.154Z
+
+## Latest Codex Summary
+- Added reviewed action-review summaries to the existing queue, alert detail, and case detail surfaces so pending, expired, rejected, and superseded states remain inspectable inside AegisOps without implying execution success.
+- Added focused coverage for pending rendering in the Phase 19 HTTP workflow test plus expired/rejected/superseded rendering in service and CLI inspection tests.
+
+## Active Failure Context
+- Reproduced before implementation: `inspect-analyst-queue` omitted `current_action_review` after creating a reviewed action request, leaving queue/alert/case surfaces unable to expose pending review state.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The repo already persisted approval/action lifecycle states, but the reviewed operator surfaces only rendered alerts/cases and generic record dumps, so operators could not inspect pending/expired/rejected/superseded action-review state from the primary workflow.
+- What changed: Added a shared action-review chain summarizer in `control-plane/aegisops_control_plane/service.py`, surfaced `current_action_review` and `action_reviews` on queue/alert/case inspections, and added focused tests in Phase 19 workflow, reconciliation persistence, and CLI inspection coverage.
+- Current blocker: none
+- Next exact step: Commit the focused checkpoint on `codex/issue-475`; optionally open a draft PR from the branch if supervisor flow expects one immediately.
+- Verification gap: Manual UI-style inspection was not performed beyond the existing HTTP/CLI inspection payload tests.
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/tests/test_phase19_operator_workflow_validation.py`, `control-plane/tests/test_service_persistence_action_reconciliation.py`, `control-plane/tests/test_cli_inspection.py`
+- Rollback concern: The new queue/alert/case payload fields are additive, but downstream consumers that assumed no action-review payload may need to ignore the extra keys.
+- Last focused command: `python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_cli_inspection`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1495,6 +1495,11 @@ class AegisOpsControlPlaneService:
                     or (alert_id is not None and record.alert_id == alert_id)
                 )
             ]
+        matching_requests = [
+            record
+            for record in matching_requests
+            if self._action_request_is_review_bound(record)
+        ]
         chains = [
             self._build_action_review_chain_snapshot(
                 action_request,
@@ -1583,11 +1588,15 @@ class AegisOpsControlPlaneService:
             "recipient_identity": requested_payload.get("recipient_identity"),
             "message_intent": requested_payload.get("message_intent"),
             "escalation_reason": requested_payload.get("escalation_reason"),
-            "execution_surface_type": action_request.policy_evaluation.get(
-                "execution_surface_type"
+            "execution_surface_type": (
+                action_execution.execution_surface_type
+                if action_execution is not None
+                else action_request.policy_evaluation.get("execution_surface_type")
             ),
-            "execution_surface_id": action_request.policy_evaluation.get(
-                "execution_surface_id"
+            "execution_surface_id": (
+                action_execution.execution_surface_id
+                if action_execution is not None
+                else action_request.policy_evaluation.get("execution_surface_id")
             ),
             "action_execution_id": (
                 action_execution.action_execution_id if action_execution is not None else None
@@ -1789,10 +1798,17 @@ class AegisOpsControlPlaneService:
         action_execution: ActionExecutionRecord | None,
     ) -> str:
         lifecycle_state = action_request.lifecycle_state
+        execution_state = (
+            action_execution.lifecycle_state if action_execution is not None else None
+        )
         if lifecycle_state in {"expired", "rejected", "superseded"}:
             return lifecycle_state
         if lifecycle_state in {"completed", "failed", "unresolved"}:
             return lifecycle_state
+        if execution_state == "succeeded":
+            return "completed"
+        if execution_state in {"failed", "superseded"}:
+            return execution_state
         if lifecycle_state == "executing" or action_execution is not None:
             return "executing"
         if approval_state in {"expired", "rejected", "superseded"}:
@@ -1825,6 +1841,7 @@ class AegisOpsControlPlaneService:
                 record
                 for record in candidate_requests
                 if record.action_request_id != action_request.action_request_id
+                and self._action_request_is_review_bound(record)
                 and record.requested_at >= action_request.requested_at
                 and record.lifecycle_state != "superseded"
                 and dict(record.requested_payload).get("action_type") == action_type
@@ -1839,6 +1856,7 @@ class AegisOpsControlPlaneService:
                 record
                 for record in self._store.list(ActionRequestRecord)
                 if record.action_request_id != action_request.action_request_id
+                and self._action_request_is_review_bound(record)
                 and (
                     (
                         action_request.case_id is not None
@@ -1865,6 +1883,14 @@ class AegisOpsControlPlaneService:
             reverse=True,
         )
         return matches[0]
+
+    @staticmethod
+    def _action_request_is_review_bound(action_request: ActionRequestRecord) -> bool:
+        return not (
+            action_request.policy_evaluation.get("approval_requirement")
+            == "policy_authorized"
+            and action_request.approval_decision_id is None
+        )
 
     @staticmethod
     def _next_expected_action_for_review_state(review_state: str) -> str | None:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -192,6 +192,8 @@ class AlertDetailSnapshot:
     native_rule: dict[str, object] | None
     provenance: dict[str, str] | None
     lineage: dict[str, object]
+    current_action_review: dict[str, object] | None
+    action_reviews: tuple[dict[str, object], ...]
 
     def to_dict(self) -> dict[str, object]:
         return _json_ready(
@@ -210,6 +212,8 @@ class AlertDetailSnapshot:
                 "native_rule": self.native_rule,
                 "provenance": self.provenance,
                 "lineage": self.lineage,
+                "current_action_review": self.current_action_review,
+                "action_reviews": self.action_reviews,
             }
         )
 
@@ -233,6 +237,8 @@ class CaseDetailSnapshot:
     linked_evidence_records: tuple[dict[str, object], ...]
     linked_recommendation_records: tuple[dict[str, object], ...]
     linked_reconciliation_records: tuple[dict[str, object], ...]
+    current_action_review: dict[str, object] | None
+    action_reviews: tuple[dict[str, object], ...]
 
     def to_dict(self) -> dict[str, object]:
         return _json_ready(
@@ -254,6 +260,8 @@ class CaseDetailSnapshot:
                 "linked_evidence_records": self.linked_evidence_records,
                 "linked_recommendation_records": self.linked_recommendation_records,
                 "linked_reconciliation_records": self.linked_reconciliation_records,
+                "current_action_review": self.current_action_review,
+                "action_reviews": self.action_reviews,
             }
         )
 
@@ -1300,6 +1308,310 @@ class AegisOpsControlPlaneService:
     def _run_authoritative_restore_drill_snapshot(self) -> RestoreDrillSnapshot:
         return self._restore_readiness_service.run_authoritative_restore_drill_snapshot()
 
+    def _action_review_chains_for_scope(
+        self,
+        *,
+        case_id: str | None,
+        alert_id: str | None,
+    ) -> tuple[dict[str, object], ...]:
+        matching_requests = [
+            record
+            for record in self._store.list(ActionRequestRecord)
+            if (
+                (case_id is not None and record.case_id == case_id)
+                or (alert_id is not None and record.alert_id == alert_id)
+            )
+        ]
+        chains = [
+            self._build_action_review_chain_snapshot(action_request)
+            for action_request in matching_requests
+        ]
+        chains.sort(
+            key=lambda chain: (
+                self._action_review_priority(chain),
+                chain.get("requested_at") or datetime.min.replace(tzinfo=timezone.utc),
+                chain.get("action_request_id") or "",
+            ),
+            reverse=True,
+        )
+        return tuple(chains)
+
+    @staticmethod
+    def _action_review_priority(chain: Mapping[str, object]) -> int:
+        review_state = chain.get("review_state")
+        if review_state == "pending":
+            return 5
+        if review_state in {"approved", "executing"}:
+            return 4
+        if review_state in {"expired", "rejected"}:
+            return 3
+        if review_state == "superseded":
+            return 2
+        return 1
+
+    def _build_action_review_chain_snapshot(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> dict[str, object]:
+        approval_decision = self._action_review_approval_decision(action_request)
+        action_execution = self._action_review_execution(action_request)
+        reconciliation = self._latest_action_review_reconciliation(
+            action_request=action_request,
+            approval_decision=approval_decision,
+            action_execution=action_execution,
+        )
+        approval_state = self._action_review_approval_state(
+            action_request=action_request,
+            approval_decision=approval_decision,
+        )
+        review_state = self._action_review_state(
+            action_request=action_request,
+            approval_state=approval_state,
+            action_execution=action_execution,
+        )
+        replacement_action_request = self._replacement_action_request(action_request)
+        requested_payload = dict(action_request.requested_payload)
+
+        return {
+            "review_state": review_state,
+            "next_expected_action": self._next_expected_action_for_review_state(
+                review_state
+            ),
+            "action_request_id": action_request.action_request_id,
+            "action_request_state": action_request.lifecycle_state,
+            "approval_decision_id": (
+                approval_decision.approval_decision_id if approval_decision is not None else None
+            ),
+            "approval_state": approval_state,
+            "requester_identity": action_request.requester_identity,
+            "approver_identities": (
+                approval_decision.approver_identities if approval_decision is not None else ()
+            ),
+            "requested_at": action_request.requested_at,
+            "expires_at": action_request.expires_at,
+            "target_scope": dict(action_request.target_scope),
+            "requested_payload": requested_payload,
+            "recommendation_id": requested_payload.get("recommendation_id"),
+            "recipient_identity": requested_payload.get("recipient_identity"),
+            "message_intent": requested_payload.get("message_intent"),
+            "escalation_reason": requested_payload.get("escalation_reason"),
+            "execution_surface_type": action_request.policy_evaluation.get(
+                "execution_surface_type"
+            ),
+            "execution_surface_id": action_request.policy_evaluation.get(
+                "execution_surface_id"
+            ),
+            "action_execution_id": (
+                action_execution.action_execution_id if action_execution is not None else None
+            ),
+            "action_execution_state": (
+                action_execution.lifecycle_state if action_execution is not None else None
+            ),
+            "delegation_id": (
+                action_execution.delegation_id if action_execution is not None else None
+            ),
+            "execution_run_id": (
+                action_execution.execution_run_id if action_execution is not None else None
+            ),
+            "reconciliation_id": (
+                reconciliation.reconciliation_id if reconciliation is not None else None
+            ),
+            "reconciliation_state": (
+                reconciliation.lifecycle_state if reconciliation is not None else None
+            ),
+            "replacement_action_request_id": (
+                replacement_action_request.action_request_id
+                if replacement_action_request is not None
+                else None
+            ),
+            "replacement_approval_decision_id": (
+                replacement_action_request.approval_decision_id
+                if replacement_action_request is not None
+                else None
+            ),
+        }
+
+    def _action_review_approval_decision(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> ApprovalDecisionRecord | None:
+        if action_request.approval_decision_id:
+            decision = self._store.get(
+                ApprovalDecisionRecord,
+                action_request.approval_decision_id,
+            )
+            if decision is not None:
+                return decision
+        matches = [
+            record
+            for record in self._store.list(ApprovalDecisionRecord)
+            if record.action_request_id == action_request.action_request_id
+        ]
+        if not matches:
+            return None
+        matches.sort(
+            key=lambda record: (
+                record.decided_at or datetime.min.replace(tzinfo=timezone.utc),
+                record.approval_decision_id,
+            ),
+            reverse=True,
+        )
+        return matches[0]
+
+    def _action_review_execution(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> ActionExecutionRecord | None:
+        matches = [
+            record
+            for record in self._store.list(ActionExecutionRecord)
+            if record.action_request_id == action_request.action_request_id
+        ]
+        if not matches:
+            return None
+        matches.sort(
+            key=lambda record: (
+                record.delegated_at,
+                record.action_execution_id,
+            ),
+            reverse=True,
+        )
+        return matches[0]
+
+    def _latest_action_review_reconciliation(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord | None,
+        action_execution: ActionExecutionRecord | None,
+    ) -> ReconciliationRecord | None:
+        matches: list[ReconciliationRecord] = []
+        for reconciliation in self._store.list(ReconciliationRecord):
+            subject_action_request_ids = self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "action_request_ids",
+            )
+            if action_request.action_request_id in subject_action_request_ids:
+                matches.append(reconciliation)
+                continue
+            if approval_decision is not None:
+                subject_approval_decision_ids = self._assistant_ids_from_mapping(
+                    reconciliation.subject_linkage,
+                    "approval_decision_ids",
+                )
+                if approval_decision.approval_decision_id in subject_approval_decision_ids:
+                    matches.append(reconciliation)
+                    continue
+            if action_execution is not None:
+                subject_action_execution_ids = self._assistant_ids_from_mapping(
+                    reconciliation.subject_linkage,
+                    "action_execution_ids",
+                )
+                if action_execution.action_execution_id in subject_action_execution_ids:
+                    matches.append(reconciliation)
+                    continue
+                subject_delegation_ids = self._assistant_ids_from_mapping(
+                    reconciliation.subject_linkage,
+                    "delegation_ids",
+                )
+                if action_execution.delegation_id in subject_delegation_ids:
+                    matches.append(reconciliation)
+                    continue
+        if not matches:
+            return None
+        matches.sort(
+            key=lambda record: (
+                record.compared_at or record.last_seen_at or record.first_seen_at,
+                record.reconciliation_id,
+            ),
+            reverse=True,
+        )
+        return matches[0]
+
+    @staticmethod
+    def _action_review_approval_state(
+        *,
+        action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord | None,
+    ) -> str | None:
+        if approval_decision is not None:
+            return approval_decision.lifecycle_state
+        if action_request.lifecycle_state == "pending_approval":
+            return "pending"
+        if action_request.lifecycle_state in {"rejected", "expired", "superseded", "canceled"}:
+            return action_request.lifecycle_state
+        return None
+
+    @staticmethod
+    def _action_review_state(
+        *,
+        action_request: ActionRequestRecord,
+        approval_state: str | None,
+        action_execution: ActionExecutionRecord | None,
+    ) -> str:
+        lifecycle_state = action_request.lifecycle_state
+        if lifecycle_state == "pending_approval":
+            return "pending"
+        if lifecycle_state in {"expired", "rejected", "superseded", "approved"}:
+            return lifecycle_state
+        if lifecycle_state in {"completed", "failed", "unresolved"}:
+            return lifecycle_state
+        if lifecycle_state == "executing":
+            return "executing"
+        if action_execution is not None:
+            return "executing"
+        if approval_state in {"expired", "rejected", "superseded"}:
+            return approval_state
+        if approval_state == "approved":
+            return "approved"
+        return lifecycle_state
+
+    def _replacement_action_request(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> ActionRequestRecord | None:
+        if action_request.lifecycle_state != "superseded":
+            return None
+        requested_payload = dict(action_request.requested_payload)
+        recommendation_id = requested_payload.get("recommendation_id")
+        action_type = requested_payload.get("action_type")
+        matches = [
+            record
+            for record in self._store.list(ActionRequestRecord)
+            if record.action_request_id != action_request.action_request_id
+            and record.case_id == action_request.case_id
+            and record.alert_id == action_request.alert_id
+            and record.requested_at >= action_request.requested_at
+            and record.lifecycle_state != "superseded"
+            and dict(record.requested_payload).get("action_type") == action_type
+            and (
+                recommendation_id is None
+                or dict(record.requested_payload).get("recommendation_id")
+                == recommendation_id
+            )
+        ]
+        if not matches:
+            return None
+        matches.sort(
+            key=lambda record: (record.requested_at, record.action_request_id),
+            reverse=True,
+        )
+        return matches[0]
+
+    @staticmethod
+    def _next_expected_action_for_review_state(review_state: str) -> str | None:
+        return {
+            "pending": "await_approver_decision",
+            "approved": "await_reviewed_delegation",
+            "executing": "await_execution_reconciliation",
+            "expired": "create_replacement_or_close_case",
+            "rejected": "review_rejection_and_record_follow_up",
+            "superseded": "inspect_replacing_review_record",
+            "completed": "review_execution_outcome",
+            "failed": "investigate_execution_failure",
+            "unresolved": "investigate_reconciliation_gap",
+        }.get(review_state)
+
     def inspect_analyst_queue(self) -> AnalystQueueSnapshot:
         active_alert_states = {
             "new",
@@ -1334,6 +1646,10 @@ class AegisOpsControlPlaneService:
                 self._store.get(CaseRecord, alert.case_id)
                 if alert.case_id is not None
                 else None
+            )
+            action_reviews = self._action_review_chains_for_scope(
+                case_id=alert.case_id,
+                alert_id=alert.alert_id,
             )
             review_state = self._alert_review_state(alert)
             queue_records.append(
@@ -1371,6 +1687,9 @@ class AegisOpsControlPlaneService:
                     "correlation_key": reconciliation.correlation_key,
                     "first_seen_at": reconciliation.first_seen_at,
                     "last_seen_at": reconciliation.last_seen_at,
+                    "current_action_review": (
+                        dict(action_reviews[0]) if action_reviews else None
+                    ),
                 }
             )
 
@@ -1456,6 +1775,10 @@ class AegisOpsControlPlaneService:
             "first_seen_at": reconciliation.first_seen_at,
             "last_seen_at": reconciliation.last_seen_at,
         }
+        action_reviews = self._action_review_chains_for_scope(
+            case_id=alert.case_id,
+            alert_id=alert.alert_id,
+        )
 
         return AlertDetailSnapshot(
             read_only=True,
@@ -1484,6 +1807,8 @@ class AegisOpsControlPlaneService:
                 reconciliation.subject_linkage.get("admission_provenance")
             ),
             lineage=lineage,
+            current_action_review=dict(action_reviews[0]) if action_reviews else None,
+            action_reviews=action_reviews,
         )
 
     def inspect_assistant_context(
@@ -1508,6 +1833,10 @@ class AegisOpsControlPlaneService:
             _record_to_dict(record)
             for record in self._leads_for_case(case_id)
         )
+        action_reviews = self._action_review_chains_for_scope(
+            case_id=case_id,
+            alert_id=case.alert_id,
+        )
         return CaseDetailSnapshot(
             read_only=True,
             case_id=case_id,
@@ -1528,6 +1857,8 @@ class AegisOpsControlPlaneService:
             linked_evidence_records=context_snapshot.linked_evidence_records,
             linked_recommendation_records=context_snapshot.linked_recommendation_records,
             linked_reconciliation_records=context_snapshot.linked_reconciliation_records,
+            current_action_review=dict(action_reviews[0]) if action_reviews else None,
+            action_reviews=action_reviews,
         )
 
     def record_case_observation(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1801,17 +1801,17 @@ class AegisOpsControlPlaneService:
         execution_state = (
             action_execution.lifecycle_state if action_execution is not None else None
         )
-        if lifecycle_state in {"expired", "rejected", "superseded"}:
+        if lifecycle_state in {"expired", "rejected", "superseded", "canceled"}:
             return lifecycle_state
         if lifecycle_state in {"completed", "failed", "unresolved"}:
             return lifecycle_state
         if execution_state == "succeeded":
             return "completed"
-        if execution_state in {"failed", "superseded"}:
+        if execution_state in {"failed", "canceled", "superseded"}:
             return execution_state
         if lifecycle_state == "executing" or action_execution is not None:
             return "executing"
-        if approval_state in {"expired", "rejected", "superseded"}:
+        if approval_state in {"expired", "rejected", "superseded", "canceled"}:
             return approval_state
         if approval_state == "approved":
             return "approved"
@@ -1900,6 +1900,7 @@ class AegisOpsControlPlaneService:
             "executing": "await_execution_reconciliation",
             "expired": "create_replacement_or_close_case",
             "rejected": "review_rejection_and_record_follow_up",
+            "canceled": "investigate_execution_cancellation",
             "superseded": "inspect_replacing_review_record",
             "completed": "review_execution_outcome",
             "failed": "investigate_execution_failure",

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1801,15 +1801,24 @@ class AegisOpsControlPlaneService:
         execution_state = (
             action_execution.lifecycle_state if action_execution is not None else None
         )
+        terminal_execution_review_states = {
+            "succeeded": "completed",
+            "failed": "failed",
+            "canceled": "canceled",
+            "superseded": "superseded",
+            "unresolved": "unresolved",
+            "expired": "expired",
+            "rejected": "rejected",
+        }
         if lifecycle_state in {"expired", "rejected", "superseded", "canceled"}:
             return lifecycle_state
         if lifecycle_state in {"completed", "failed", "unresolved"}:
             return lifecycle_state
-        if execution_state == "succeeded":
-            return "completed"
-        if execution_state in {"failed", "canceled", "superseded"}:
-            return execution_state
-        if lifecycle_state == "executing" or action_execution is not None:
+        if execution_state in terminal_execution_review_states:
+            return terminal_execution_review_states[execution_state]
+        if execution_state is not None:
+            return "executing"
+        if lifecycle_state == "executing":
             return "executing"
         if approval_state in {"expired", "rejected", "superseded", "canceled"}:
             return approval_state

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1355,6 +1355,19 @@ class AegisOpsControlPlaneService:
             }
 
         action_requests = self._store.list(ActionRequestRecord)
+        if not action_requests:
+            return _ActionReviewRecordIndex(
+                requests_by_case_id={},
+                requests_by_alert_id={},
+                requests_by_scope={},
+                approvals_by_id={},
+                approvals_by_action_request_id={},
+                executions_by_action_request_id={},
+                reconciliations_by_action_request_id={},
+                reconciliations_by_approval_decision_id={},
+                reconciliations_by_action_execution_id={},
+                reconciliations_by_delegation_id={},
+            )
         approvals = self._store.list(ApprovalDecisionRecord)
         action_executions = self._store.list(ActionExecutionRecord)
         reconciliations = self._store.list(ReconciliationRecord)

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager, contextmanager
-from collections import Counter
+from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass, fields, replace
 from datetime import datetime, timezone
 import hmac
@@ -460,6 +460,43 @@ class ReadinessDiagnosticsSnapshot:
                 "latest_reconciliation": self.latest_reconciliation,
             }
         )
+
+
+@dataclass(frozen=True)
+class _ActionReviewRecordIndex:
+    requests_by_case_id: dict[str, tuple[ActionRequestRecord, ...]]
+    requests_by_alert_id: dict[str, tuple[ActionRequestRecord, ...]]
+    requests_by_scope: dict[tuple[str | None, str | None], tuple[ActionRequestRecord, ...]]
+    approvals_by_id: dict[str, ApprovalDecisionRecord]
+    approvals_by_action_request_id: dict[str, tuple[ApprovalDecisionRecord, ...]]
+    executions_by_action_request_id: dict[str, tuple[ActionExecutionRecord, ...]]
+    reconciliations_by_action_request_id: dict[str, tuple[ReconciliationRecord, ...]]
+    reconciliations_by_approval_decision_id: dict[str, tuple[ReconciliationRecord, ...]]
+    reconciliations_by_action_execution_id: dict[str, tuple[ReconciliationRecord, ...]]
+    reconciliations_by_delegation_id: dict[str, tuple[ReconciliationRecord, ...]]
+
+    def matching_requests(
+        self,
+        *,
+        case_id: str | None,
+        alert_id: str | None,
+    ) -> tuple[ActionRequestRecord, ...]:
+        matching_by_id: dict[str, ActionRequestRecord] = {}
+        if case_id is not None:
+            for record in self.requests_by_case_id.get(case_id, ()):
+                matching_by_id[record.action_request_id] = record
+        if alert_id is not None:
+            for record in self.requests_by_alert_id.get(alert_id, ()):
+                matching_by_id[record.action_request_id] = record
+        return tuple(matching_by_id.values())
+
+    def scoped_requests(
+        self,
+        *,
+        case_id: str | None,
+        alert_id: str | None,
+    ) -> tuple[ActionRequestRecord, ...]:
+        return self.requests_by_scope.get((case_id, alert_id), ())
 
 
 def _derive_readiness_status(
@@ -1308,22 +1345,148 @@ class AegisOpsControlPlaneService:
     def _run_authoritative_restore_drill_snapshot(self) -> RestoreDrillSnapshot:
         return self._restore_readiness_service.run_authoritative_restore_drill_snapshot()
 
+    def _build_action_review_record_index(self) -> _ActionReviewRecordIndex:
+        def _freeze_grouped_records(
+            grouped_records: defaultdict[object, list[object]],
+        ) -> dict[object, tuple[object, ...]]:
+            return {
+                key: tuple(records)
+                for key, records in grouped_records.items()
+            }
+
+        action_requests = self._store.list(ActionRequestRecord)
+        approvals = self._store.list(ApprovalDecisionRecord)
+        action_executions = self._store.list(ActionExecutionRecord)
+        reconciliations = self._store.list(ReconciliationRecord)
+
+        requests_by_case_id: defaultdict[str, list[ActionRequestRecord]] = defaultdict(list)
+        requests_by_alert_id: defaultdict[str, list[ActionRequestRecord]] = defaultdict(list)
+        requests_by_scope: defaultdict[
+            tuple[str | None, str | None],
+            list[ActionRequestRecord],
+        ] = defaultdict(list)
+        for action_request in action_requests:
+            requests_by_scope[
+                (action_request.case_id, action_request.alert_id)
+            ].append(action_request)
+            if action_request.case_id is not None:
+                requests_by_case_id[action_request.case_id].append(action_request)
+            if action_request.alert_id is not None:
+                requests_by_alert_id[action_request.alert_id].append(action_request)
+
+        approvals_by_action_request_id: defaultdict[
+            str,
+            list[ApprovalDecisionRecord],
+        ] = defaultdict(list)
+        approvals_by_id = {
+            approval.approval_decision_id: approval for approval in approvals
+        }
+        for approval in approvals:
+            approvals_by_action_request_id[approval.action_request_id].append(approval)
+
+        executions_by_action_request_id: defaultdict[
+            str,
+            list[ActionExecutionRecord],
+        ] = defaultdict(list)
+        for action_execution in action_executions:
+            executions_by_action_request_id[action_execution.action_request_id].append(
+                action_execution
+            )
+
+        reconciliations_by_action_request_id: defaultdict[
+            str,
+            list[ReconciliationRecord],
+        ] = defaultdict(list)
+        reconciliations_by_approval_decision_id: defaultdict[
+            str,
+            list[ReconciliationRecord],
+        ] = defaultdict(list)
+        reconciliations_by_action_execution_id: defaultdict[
+            str,
+            list[ReconciliationRecord],
+        ] = defaultdict(list)
+        reconciliations_by_delegation_id: defaultdict[
+            str,
+            list[ReconciliationRecord],
+        ] = defaultdict(list)
+        for reconciliation in reconciliations:
+            for action_request_id in self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "action_request_ids",
+            ):
+                reconciliations_by_action_request_id[action_request_id].append(
+                    reconciliation
+                )
+            for approval_decision_id in self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "approval_decision_ids",
+            ):
+                reconciliations_by_approval_decision_id[approval_decision_id].append(
+                    reconciliation
+                )
+            for action_execution_id in self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "action_execution_ids",
+            ):
+                reconciliations_by_action_execution_id[action_execution_id].append(
+                    reconciliation
+                )
+            for delegation_id in self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "delegation_ids",
+            ):
+                reconciliations_by_delegation_id[delegation_id].append(reconciliation)
+
+        return _ActionReviewRecordIndex(
+            requests_by_case_id=_freeze_grouped_records(requests_by_case_id),
+            requests_by_alert_id=_freeze_grouped_records(requests_by_alert_id),
+            requests_by_scope=_freeze_grouped_records(requests_by_scope),
+            approvals_by_id=approvals_by_id,
+            approvals_by_action_request_id=_freeze_grouped_records(
+                approvals_by_action_request_id
+            ),
+            executions_by_action_request_id=_freeze_grouped_records(
+                executions_by_action_request_id
+            ),
+            reconciliations_by_action_request_id=_freeze_grouped_records(
+                reconciliations_by_action_request_id
+            ),
+            reconciliations_by_approval_decision_id=_freeze_grouped_records(
+                reconciliations_by_approval_decision_id
+            ),
+            reconciliations_by_action_execution_id=_freeze_grouped_records(
+                reconciliations_by_action_execution_id
+            ),
+            reconciliations_by_delegation_id=_freeze_grouped_records(
+                reconciliations_by_delegation_id
+            ),
+        )
+
     def _action_review_chains_for_scope(
         self,
         *,
         case_id: str | None,
         alert_id: str | None,
+        record_index: _ActionReviewRecordIndex | None = None,
     ) -> tuple[dict[str, object], ...]:
-        matching_requests = [
-            record
-            for record in self._store.list(ActionRequestRecord)
-            if (
-                (case_id is not None and record.case_id == case_id)
-                or (alert_id is not None and record.alert_id == alert_id)
+        if record_index is not None:
+            matching_requests = list(
+                record_index.matching_requests(case_id=case_id, alert_id=alert_id)
             )
-        ]
+        else:
+            matching_requests = [
+                record
+                for record in self._store.list(ActionRequestRecord)
+                if (
+                    (case_id is not None and record.case_id == case_id)
+                    or (alert_id is not None and record.alert_id == alert_id)
+                )
+            ]
         chains = [
-            self._build_action_review_chain_snapshot(action_request)
+            self._build_action_review_chain_snapshot(
+                action_request,
+                record_index=record_index,
+            )
             for action_request in matching_requests
         ]
         chains.sort(
@@ -1352,13 +1515,22 @@ class AegisOpsControlPlaneService:
     def _build_action_review_chain_snapshot(
         self,
         action_request: ActionRequestRecord,
+        *,
+        record_index: _ActionReviewRecordIndex | None = None,
     ) -> dict[str, object]:
-        approval_decision = self._action_review_approval_decision(action_request)
-        action_execution = self._action_review_execution(action_request)
+        approval_decision = self._action_review_approval_decision(
+            action_request,
+            record_index=record_index,
+        )
+        action_execution = self._action_review_execution(
+            action_request,
+            record_index=record_index,
+        )
         reconciliation = self._latest_action_review_reconciliation(
             action_request=action_request,
             approval_decision=approval_decision,
             action_execution=action_execution,
+            record_index=record_index,
         )
         approval_state = self._action_review_approval_state(
             action_request=action_request,
@@ -1369,7 +1541,10 @@ class AegisOpsControlPlaneService:
             approval_state=approval_state,
             action_execution=action_execution,
         )
-        replacement_action_request = self._replacement_action_request(action_request)
+        replacement_action_request = self._replacement_action_request(
+            action_request,
+            record_index=record_index,
+        )
         requested_payload = dict(action_request.requested_payload)
 
         return {
@@ -1434,7 +1609,13 @@ class AegisOpsControlPlaneService:
     def _action_review_approval_decision(
         self,
         action_request: ActionRequestRecord,
+        *,
+        record_index: _ActionReviewRecordIndex | None = None,
     ) -> ApprovalDecisionRecord | None:
+        if record_index is not None and action_request.approval_decision_id:
+            decision = record_index.approvals_by_id.get(action_request.approval_decision_id)
+            if decision is not None:
+                return decision
         if action_request.approval_decision_id:
             decision = self._store.get(
                 ApprovalDecisionRecord,
@@ -1442,11 +1623,19 @@ class AegisOpsControlPlaneService:
             )
             if decision is not None:
                 return decision
-        matches = [
-            record
-            for record in self._store.list(ApprovalDecisionRecord)
-            if record.action_request_id == action_request.action_request_id
-        ]
+        if record_index is not None:
+            matches = list(
+                record_index.approvals_by_action_request_id.get(
+                    action_request.action_request_id,
+                    (),
+                )
+            )
+        else:
+            matches = [
+                record
+                for record in self._store.list(ApprovalDecisionRecord)
+                if record.action_request_id == action_request.action_request_id
+            ]
         if not matches:
             return None
         matches.sort(
@@ -1461,12 +1650,22 @@ class AegisOpsControlPlaneService:
     def _action_review_execution(
         self,
         action_request: ActionRequestRecord,
+        *,
+        record_index: _ActionReviewRecordIndex | None = None,
     ) -> ActionExecutionRecord | None:
-        matches = [
-            record
-            for record in self._store.list(ActionExecutionRecord)
-            if record.action_request_id == action_request.action_request_id
-        ]
+        if record_index is not None:
+            matches = list(
+                record_index.executions_by_action_request_id.get(
+                    action_request.action_request_id,
+                    (),
+                )
+            )
+        else:
+            matches = [
+                record
+                for record in self._store.list(ActionExecutionRecord)
+                if record.action_request_id == action_request.action_request_id
+            ]
         if not matches:
             return None
         matches.sort(
@@ -1484,39 +1683,66 @@ class AegisOpsControlPlaneService:
         action_request: ActionRequestRecord,
         approval_decision: ApprovalDecisionRecord | None,
         action_execution: ActionExecutionRecord | None,
+        record_index: _ActionReviewRecordIndex | None = None,
     ) -> ReconciliationRecord | None:
         matches: list[ReconciliationRecord] = []
-        for reconciliation in self._store.list(ReconciliationRecord):
-            subject_action_request_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "action_request_ids",
-            )
-            if action_request.action_request_id in subject_action_request_ids:
-                matches.append(reconciliation)
-                continue
+        if record_index is not None:
+            matches_by_id: dict[str, ReconciliationRecord] = {}
+            for reconciliation in record_index.reconciliations_by_action_request_id.get(
+                action_request.action_request_id,
+                (),
+            ):
+                matches_by_id[reconciliation.reconciliation_id] = reconciliation
             if approval_decision is not None:
-                subject_approval_decision_ids = self._assistant_ids_from_mapping(
-                    reconciliation.subject_linkage,
-                    "approval_decision_ids",
-                )
-                if approval_decision.approval_decision_id in subject_approval_decision_ids:
-                    matches.append(reconciliation)
-                    continue
+                for reconciliation in record_index.reconciliations_by_approval_decision_id.get(
+                    approval_decision.approval_decision_id,
+                    (),
+                ):
+                    matches_by_id[reconciliation.reconciliation_id] = reconciliation
             if action_execution is not None:
-                subject_action_execution_ids = self._assistant_ids_from_mapping(
+                for reconciliation in record_index.reconciliations_by_action_execution_id.get(
+                    action_execution.action_execution_id,
+                    (),
+                ):
+                    matches_by_id[reconciliation.reconciliation_id] = reconciliation
+                for reconciliation in record_index.reconciliations_by_delegation_id.get(
+                    action_execution.delegation_id,
+                    (),
+                ):
+                    matches_by_id[reconciliation.reconciliation_id] = reconciliation
+            matches = list(matches_by_id.values())
+        else:
+            for reconciliation in self._store.list(ReconciliationRecord):
+                subject_action_request_ids = self._assistant_ids_from_mapping(
                     reconciliation.subject_linkage,
-                    "action_execution_ids",
+                    "action_request_ids",
                 )
-                if action_execution.action_execution_id in subject_action_execution_ids:
+                if action_request.action_request_id in subject_action_request_ids:
                     matches.append(reconciliation)
                     continue
-                subject_delegation_ids = self._assistant_ids_from_mapping(
-                    reconciliation.subject_linkage,
-                    "delegation_ids",
-                )
-                if action_execution.delegation_id in subject_delegation_ids:
-                    matches.append(reconciliation)
-                    continue
+                if approval_decision is not None:
+                    subject_approval_decision_ids = self._assistant_ids_from_mapping(
+                        reconciliation.subject_linkage,
+                        "approval_decision_ids",
+                    )
+                    if approval_decision.approval_decision_id in subject_approval_decision_ids:
+                        matches.append(reconciliation)
+                        continue
+                if action_execution is not None:
+                    subject_action_execution_ids = self._assistant_ids_from_mapping(
+                        reconciliation.subject_linkage,
+                        "action_execution_ids",
+                    )
+                    if action_execution.action_execution_id in subject_action_execution_ids:
+                        matches.append(reconciliation)
+                        continue
+                    subject_delegation_ids = self._assistant_ids_from_mapping(
+                        reconciliation.subject_linkage,
+                        "delegation_ids",
+                    )
+                    if action_execution.delegation_id in subject_delegation_ids:
+                        matches.append(reconciliation)
+                        continue
         if not matches:
             return None
         matches.sort(
@@ -1550,34 +1776,43 @@ class AegisOpsControlPlaneService:
         action_execution: ActionExecutionRecord | None,
     ) -> str:
         lifecycle_state = action_request.lifecycle_state
-        if lifecycle_state == "pending_approval":
-            return "pending"
-        if lifecycle_state in {"expired", "rejected", "superseded", "approved"}:
+        if lifecycle_state in {"expired", "rejected", "superseded"}:
             return lifecycle_state
         if lifecycle_state in {"completed", "failed", "unresolved"}:
             return lifecycle_state
-        if lifecycle_state == "executing":
-            return "executing"
-        if action_execution is not None:
+        if lifecycle_state == "executing" or action_execution is not None:
             return "executing"
         if approval_state in {"expired", "rejected", "superseded"}:
             return approval_state
         if approval_state == "approved":
             return "approved"
+        if lifecycle_state == "approved":
+            return "approved"
+        if lifecycle_state == "pending_approval" or approval_state == "pending":
+            return "pending"
         return lifecycle_state
 
     def _replacement_action_request(
         self,
         action_request: ActionRequestRecord,
+        *,
+        record_index: _ActionReviewRecordIndex | None = None,
     ) -> ActionRequestRecord | None:
         if action_request.lifecycle_state != "superseded":
             return None
         requested_payload = dict(action_request.requested_payload)
         recommendation_id = requested_payload.get("recommendation_id")
         action_type = requested_payload.get("action_type")
+        if record_index is not None:
+            candidate_requests = record_index.scoped_requests(
+                case_id=action_request.case_id,
+                alert_id=action_request.alert_id,
+            )
+        else:
+            candidate_requests = self._store.list(ActionRequestRecord)
         matches = [
             record
-            for record in self._store.list(ActionRequestRecord)
+            for record in candidate_requests
             if record.action_request_id != action_request.action_request_id
             and record.case_id == action_request.case_id
             and record.alert_id == action_request.alert_id
@@ -1623,6 +1858,7 @@ class AegisOpsControlPlaneService:
         latest_reconciliation_by_alert_id = (
             self._latest_detection_reconciliations_by_alert_id()
         )
+        action_review_index = self._build_action_review_record_index()
         queue_records: list[dict[str, object]] = []
         for alert in self._store.list(AlertRecord):
             if alert.lifecycle_state not in active_alert_states:
@@ -1650,6 +1886,7 @@ class AegisOpsControlPlaneService:
             action_reviews = self._action_review_chains_for_scope(
                 case_id=alert.case_id,
                 alert_id=alert.alert_id,
+                record_index=action_review_index,
             )
             review_state = self._alert_review_state(alert)
             queue_records.append(
@@ -1778,6 +2015,7 @@ class AegisOpsControlPlaneService:
         action_reviews = self._action_review_chains_for_scope(
             case_id=alert.case_id,
             alert_id=alert.alert_id,
+            record_index=self._build_action_review_record_index(),
         )
 
         return AlertDetailSnapshot(
@@ -1836,6 +2074,7 @@ class AegisOpsControlPlaneService:
         action_reviews = self._action_review_chains_for_scope(
             case_id=case_id,
             alert_id=case.alert_id,
+            record_index=self._build_action_review_record_index(),
         )
         return CaseDetailSnapshot(
             read_only=True,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1504,8 +1504,8 @@ class AegisOpsControlPlaneService:
         ]
         chains.sort(
             key=lambda chain: (
-                self._action_review_priority(chain),
                 chain.get("requested_at") or datetime.min.replace(tzinfo=timezone.utc),
+                self._action_review_priority(chain),
                 chain.get("action_request_id") or "",
             ),
             reverse=True,
@@ -1817,27 +1817,47 @@ class AegisOpsControlPlaneService:
         recommendation_id = requested_payload.get("recommendation_id")
         action_type = requested_payload.get("action_type")
         if record_index is not None:
-            candidate_requests = record_index.scoped_requests(
+            candidate_requests = record_index.matching_requests(
                 case_id=action_request.case_id,
                 alert_id=action_request.alert_id,
             )
+            matches = [
+                record
+                for record in candidate_requests
+                if record.action_request_id != action_request.action_request_id
+                and record.requested_at >= action_request.requested_at
+                and record.lifecycle_state != "superseded"
+                and dict(record.requested_payload).get("action_type") == action_type
+                and (
+                    recommendation_id is None
+                    or dict(record.requested_payload).get("recommendation_id")
+                    == recommendation_id
+                )
+            ]
         else:
-            candidate_requests = self._store.list(ActionRequestRecord)
-        matches = [
-            record
-            for record in candidate_requests
-            if record.action_request_id != action_request.action_request_id
-            and record.case_id == action_request.case_id
-            and record.alert_id == action_request.alert_id
-            and record.requested_at >= action_request.requested_at
-            and record.lifecycle_state != "superseded"
-            and dict(record.requested_payload).get("action_type") == action_type
-            and (
-                recommendation_id is None
-                or dict(record.requested_payload).get("recommendation_id")
-                == recommendation_id
-            )
-        ]
+            matches = [
+                record
+                for record in self._store.list(ActionRequestRecord)
+                if record.action_request_id != action_request.action_request_id
+                and (
+                    (
+                        action_request.case_id is not None
+                        and record.case_id == action_request.case_id
+                    )
+                    or (
+                        action_request.alert_id is not None
+                        and record.alert_id == action_request.alert_id
+                    )
+                )
+                and record.requested_at >= action_request.requested_at
+                and record.lifecycle_state != "superseded"
+                and dict(record.requested_payload).get("action_type") == action_type
+                and (
+                    recommendation_id is None
+                    or dict(record.requested_payload).get("recommendation_id")
+                    == recommendation_id
+                )
+            ]
         if not matches:
             return None
         matches.sort(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -26,6 +26,7 @@ from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
 from aegisops_control_plane.models import (
     AITraceRecord,
+    ActionRequestRecord,
     AlertRecord,
     AnalyticSignalRecord,
     ApprovalDecisionRecord,
@@ -213,6 +214,118 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             )
         )
         return service, recommendation, ai_trace
+
+    def _seed_action_review_states_for_case(
+        self,
+        service: AegisOpsControlPlaneService,
+        promoted_case: CaseRecord,
+        reviewed_at: datetime,
+        evidence_id: str,
+    ) -> dict[str, object]:
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        base_requested_at = datetime.now(timezone.utc)
+        pending_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-pending-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=base_requested_at + timedelta(hours=4),
+            action_request_id="action-request-cli-review-pending-001",
+        )
+        base_requested_at = pending_request.requested_at
+        rejected_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-review-rejected-001",
+                action_request_id="action-request-cli-review-rejected-001",
+                approver_identities=("approver-rejected-001",),
+                target_snapshot=dict(pending_request.target_scope),
+                payload_hash=pending_request.payload_hash,
+                decided_at=base_requested_at + timedelta(minutes=10),
+                lifecycle_state="rejected",
+            )
+        )
+        rejected_request = service.persist_record(
+            replace(
+                pending_request,
+                action_request_id="action-request-cli-review-rejected-001",
+                approval_decision_id=rejected_decision.approval_decision_id,
+                idempotency_key="idempotency-cli-review-rejected-001",
+                requested_at=base_requested_at + timedelta(minutes=5),
+                lifecycle_state="rejected",
+                requester_identity="analyst-002",
+            )
+        )
+        expired_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-review-expired-001",
+                action_request_id="action-request-cli-review-expired-001",
+                approver_identities=("approver-expired-001",),
+                target_snapshot=dict(pending_request.target_scope),
+                payload_hash=pending_request.payload_hash,
+                decided_at=base_requested_at + timedelta(minutes=20),
+                lifecycle_state="expired",
+                approved_expires_at=base_requested_at + timedelta(minutes=30),
+            )
+        )
+        expired_request = service.persist_record(
+            replace(
+                pending_request,
+                action_request_id="action-request-cli-review-expired-001",
+                approval_decision_id=expired_decision.approval_decision_id,
+                idempotency_key="idempotency-cli-review-expired-001",
+                requested_at=base_requested_at + timedelta(minutes=15),
+                expires_at=base_requested_at + timedelta(minutes=30),
+                lifecycle_state="expired",
+                requester_identity="analyst-003",
+            )
+        )
+        superseded_request = service.persist_record(
+            replace(
+                pending_request,
+                action_request_id="action-request-cli-review-superseded-001",
+                idempotency_key="idempotency-cli-review-superseded-001",
+                requested_at=base_requested_at + timedelta(minutes=25),
+                lifecycle_state="superseded",
+                requester_identity="analyst-004",
+            )
+        )
+        replacement_request = service.persist_record(
+            replace(
+                pending_request,
+                action_request_id="action-request-cli-review-replacement-001",
+                idempotency_key="idempotency-cli-review-replacement-001",
+                requested_at=base_requested_at + timedelta(minutes=35),
+                requester_identity="analyst-005",
+            )
+        )
+        return {
+            "recommendation": recommendation,
+            "pending_request": pending_request,
+            "rejected_request": rejected_request,
+            "expired_request": expired_request,
+            "superseded_request": superseded_request,
+            "replacement_request": replacement_request,
+        }
 
     def test_runtime_command_uses_runtime_service_builder_when_not_injected(self) -> None:
         store, _ = make_store()
@@ -2856,6 +2969,64 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(
             payload["requested_payload"]["recommendation_id"],
             recommendation.recommendation_id,
+        )
+
+    def test_cli_inspect_case_detail_renders_action_review_states(self) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        seeded = self._seed_action_review_states_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["current_action_review"]["review_state"], "pending")
+        self.assertEqual(
+            payload["current_action_review"]["action_request_id"],
+            seeded["replacement_request"].action_request_id,
+        )
+        action_reviews_by_id = {
+            record["action_request_id"]: record for record in payload["action_reviews"]
+        }
+        self.assertEqual(
+            action_reviews_by_id[seeded["pending_request"].action_request_id]["review_state"],
+            "pending",
+        )
+        self.assertEqual(
+            action_reviews_by_id[seeded["rejected_request"].action_request_id][
+                "review_state"
+            ],
+            "rejected",
+        )
+        self.assertEqual(
+            action_reviews_by_id[seeded["rejected_request"].action_request_id][
+                "approver_identities"
+            ],
+            ["approver-rejected-001"],
+        )
+        self.assertEqual(
+            action_reviews_by_id[seeded["expired_request"].action_request_id]["review_state"],
+            "expired",
+        )
+        self.assertEqual(
+            action_reviews_by_id[seeded["superseded_request"].action_request_id][
+                "review_state"
+            ],
+            "superseded",
+        )
+        self.assertEqual(
+            action_reviews_by_id[seeded["superseded_request"].action_request_id][
+                "replacement_action_request_id"
+            ],
+            seeded["replacement_request"].action_request_id,
         )
 
     def test_cli_rejects_case_scoped_out_of_scope_advisory_reads_as_usage_errors(

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -385,6 +385,92 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     recommendation["recommendation_id"],
                 )
 
+                queue_with_pending_action = get_json("/inspect-analyst-queue")
+                self.assertEqual(
+                    queue_with_pending_action["records"][0]["current_action_review"][
+                        "review_state"
+                    ],
+                    "pending",
+                )
+                self.assertEqual(
+                    queue_with_pending_action["records"][0]["current_action_review"][
+                        "action_request_id"
+                    ],
+                    action_request["action_request_id"],
+                )
+                self.assertEqual(
+                    queue_with_pending_action["records"][0]["current_action_review"][
+                        "requester_identity"
+                    ],
+                    "analyst-001",
+                )
+                self.assertEqual(
+                    queue_with_pending_action["records"][0]["current_action_review"][
+                        "approval_state"
+                    ],
+                    "pending",
+                )
+                self.assertEqual(
+                    queue_with_pending_action["records"][0]["current_action_review"][
+                        "next_expected_action"
+                    ],
+                    "await_approver_decision",
+                )
+
+                alert_detail_with_pending_action = get_json(
+                    f"/inspect-alert-detail?alert_id={created.alert.alert_id}"
+                )
+                self.assertEqual(
+                    alert_detail_with_pending_action["current_action_review"][
+                        "review_state"
+                    ],
+                    "pending",
+                )
+                self.assertEqual(
+                    alert_detail_with_pending_action["action_reviews"][0][
+                        "action_request_state"
+                    ],
+                    "pending_approval",
+                )
+                self.assertEqual(
+                    alert_detail_with_pending_action["action_reviews"][0][
+                        "requester_identity"
+                    ],
+                    "analyst-001",
+                )
+                self.assertEqual(
+                    alert_detail_with_pending_action["action_reviews"][0][
+                        "requested_payload"
+                    ]["action_type"],
+                    "notify_identity_owner",
+                )
+
+                case_detail_with_pending_action = get_json(
+                    f"/inspect-case-detail?case_id={case_id}"
+                )
+                self.assertEqual(
+                    case_detail_with_pending_action["current_action_review"][
+                        "review_state"
+                    ],
+                    "pending",
+                )
+                self.assertEqual(
+                    case_detail_with_pending_action["action_reviews"][0][
+                        "action_request_id"
+                    ],
+                    action_request["action_request_id"],
+                )
+                self.assertEqual(
+                    case_detail_with_pending_action["action_reviews"][0]["expires_at"],
+                    action_request["expires_at"],
+                )
+                self.assertEqual(
+                    case_detail_with_pending_action["action_reviews"][0][
+                        "recommendation_id"
+                    ],
+                    recommendation["recommendation_id"],
+                )
+
                 closed_case = post_json(
                     "/operator/record-case-disposition",
                     {

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -4093,6 +4093,98 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             "investigate_execution_cancellation",
         )
 
+    def test_service_action_review_surfaces_preserve_failed_execution_state(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-failed-execution-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+            action_request_id="action-request-surface-failed-execution-001",
+        )
+        decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-surface-failed-execution-001",
+                action_request_id=request.action_request_id,
+                approver_identities=("approver-failed-execution-001",),
+                target_snapshot=dict(request.target_scope),
+                payload_hash=request.payload_hash,
+                decided_at=request.requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        request = service.persist_record(
+            replace(
+                request,
+                approval_decision_id=decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-surface-failed-001",
+                action_request_id=request.action_request_id,
+                approval_decision_id=decision.approval_decision_id,
+                delegation_id="delegation-surface-failed-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-surface-failed-001",
+                idempotency_key=request.idempotency_key,
+                target_scope=dict(request.target_scope),
+                approved_payload=dict(request.requested_payload),
+                payload_hash=request.payload_hash,
+                delegated_at=request.requested_at + timedelta(minutes=10),
+                expires_at=expires_at,
+                provenance={"initiated_by": "operator-review"},
+                lifecycle_state="failed",
+            )
+        )
+
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+        action_review = case_snapshot["current_action_review"]
+
+        self.assertEqual(
+            action_review["action_request_id"],
+            request.action_request_id,
+        )
+        self.assertEqual(action_review["review_state"], "failed")
+        self.assertEqual(
+            action_review["action_execution_state"],
+            "failed",
+        )
+        self.assertEqual(
+            action_review["next_expected_action"],
+            "investigate_execution_failure",
+        )
+
     def test_service_action_review_surfaces_use_newest_review_as_current(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -3454,6 +3454,153 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(second_request, first_request)
         self.assertEqual(store.list(ActionRequestRecord), (first_request,))
 
+    def test_service_inspects_action_review_states_on_queue_alert_and_case_surfaces(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        base_requested_at = datetime.now(timezone.utc)
+        pending_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-pending-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=base_requested_at + timedelta(hours=4),
+            action_request_id="action-request-surface-pending-001",
+        )
+        base_requested_at = pending_request.requested_at
+        rejected_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-surface-rejected-001",
+                action_request_id="action-request-surface-rejected-001",
+                approver_identities=("approver-rejected-001",),
+                target_snapshot=dict(pending_request.target_scope),
+                payload_hash=pending_request.payload_hash,
+                decided_at=base_requested_at + timedelta(minutes=10),
+                lifecycle_state="rejected",
+            )
+        )
+        rejected_request = service.persist_record(
+            replace(
+                pending_request,
+                action_request_id="action-request-surface-rejected-001",
+                approval_decision_id=rejected_decision.approval_decision_id,
+                idempotency_key="idempotency-surface-rejected-001",
+                requested_at=base_requested_at + timedelta(minutes=5),
+                lifecycle_state="rejected",
+                requester_identity="analyst-002",
+            )
+        )
+        expired_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-surface-expired-001",
+                action_request_id="action-request-surface-expired-001",
+                approver_identities=("approver-expired-001",),
+                target_snapshot=dict(pending_request.target_scope),
+                payload_hash=pending_request.payload_hash,
+                decided_at=base_requested_at + timedelta(minutes=20),
+                lifecycle_state="expired",
+                approved_expires_at=base_requested_at + timedelta(minutes=30),
+            )
+        )
+        expired_request = service.persist_record(
+            replace(
+                pending_request,
+                action_request_id="action-request-surface-expired-001",
+                approval_decision_id=expired_decision.approval_decision_id,
+                idempotency_key="idempotency-surface-expired-001",
+                requested_at=base_requested_at + timedelta(minutes=15),
+                expires_at=base_requested_at + timedelta(minutes=30),
+                lifecycle_state="expired",
+                requester_identity="analyst-003",
+            )
+        )
+        superseded_request = service.persist_record(
+            replace(
+                pending_request,
+                action_request_id="action-request-surface-superseded-001",
+                idempotency_key="idempotency-surface-superseded-001",
+                requested_at=base_requested_at + timedelta(minutes=25),
+                lifecycle_state="superseded",
+                requester_identity="analyst-004",
+            )
+        )
+        replacement_request = service.persist_record(
+            replace(
+                pending_request,
+                action_request_id="action-request-surface-replacement-001",
+                idempotency_key="idempotency-surface-replacement-001",
+                requested_at=base_requested_at + timedelta(minutes=35),
+                requester_identity="analyst-005",
+            )
+        )
+
+        queue_snapshot = service.inspect_analyst_queue().to_dict()
+        alert_snapshot = service.inspect_alert_detail(promoted_case.alert_id).to_dict()
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+
+        self.assertEqual(
+            queue_snapshot["records"][0]["current_action_review"]["action_request_id"],
+            replacement_request.action_request_id,
+        )
+        self.assertEqual(
+            queue_snapshot["records"][0]["current_action_review"]["review_state"],
+            "pending",
+        )
+        self.assertEqual(alert_snapshot["current_action_review"]["review_state"], "pending")
+        self.assertEqual(case_snapshot["current_action_review"]["review_state"], "pending")
+        action_reviews_by_id = {
+            record["action_request_id"]: record for record in case_snapshot["action_reviews"]
+        }
+        self.assertEqual(
+            action_reviews_by_id[pending_request.action_request_id]["review_state"],
+            "pending",
+        )
+        self.assertEqual(
+            action_reviews_by_id[rejected_request.action_request_id]["review_state"],
+            "rejected",
+        )
+        self.assertEqual(
+            action_reviews_by_id[rejected_request.action_request_id]["approver_identities"],
+            ["approver-rejected-001"],
+        )
+        self.assertEqual(
+            action_reviews_by_id[expired_request.action_request_id]["review_state"],
+            "expired",
+        )
+        self.assertEqual(
+            action_reviews_by_id[superseded_request.action_request_id]["review_state"],
+            "superseded",
+        )
+        self.assertEqual(
+            action_reviews_by_id[superseded_request.action_request_id][
+                "replacement_action_request_id"
+            ],
+            replacement_request.action_request_id,
+        )
+
     def test_approved_payload_binding_hash_normalizes_equivalent_datetime_offsets(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -3797,6 +3797,209 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             ],
             "action-execution-surface-stale-executing-001",
         )
+        self.assertEqual(
+            action_reviews_by_id[executing_request.action_request_id][
+                "execution_surface_type"
+            ],
+            "automation_substrate",
+        )
+        self.assertEqual(
+            action_reviews_by_id[executing_request.action_request_id][
+                "execution_surface_id"
+            ],
+            "n8n",
+        )
+
+    def test_service_action_review_surfaces_keep_policy_authorized_requests_out_of_review_chains(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        reviewed_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-reviewed-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-surface-reviewed-superseded-001",
+        )
+        reviewed_request = service.persist_record(
+            replace(
+                reviewed_request,
+                lifecycle_state="superseded",
+            )
+        )
+        reviewed_replacement = service.persist_record(
+            replace(
+                reviewed_request,
+                action_request_id="action-request-surface-reviewed-replacement-001",
+                idempotency_key="idempotency-surface-reviewed-replacement-001",
+                requested_at=reviewed_request.requested_at + timedelta(minutes=10),
+                lifecycle_state="pending_approval",
+                requester_identity="analyst-002",
+            )
+        )
+        policy_authorized_request = service.persist_record(
+            replace(
+                reviewed_request,
+                action_request_id="action-request-surface-policy-authorized-001",
+                approval_decision_id=None,
+                idempotency_key="idempotency-surface-policy-authorized-001",
+                requested_at=reviewed_request.requested_at + timedelta(minutes=20),
+                lifecycle_state="approved",
+                requester_identity="policy-engine",
+                policy_evaluation={
+                    "approval_requirement": "policy_authorized",
+                    "routing_target": "shuffle",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        queue_snapshot = service.inspect_analyst_queue().to_dict()
+        alert_snapshot = service.inspect_alert_detail(promoted_case.alert_id).to_dict()
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+        action_reviews_by_id = {
+            record["action_request_id"]: record for record in case_snapshot["action_reviews"]
+        }
+
+        self.assertEqual(
+            queue_snapshot["records"][0]["current_action_review"]["action_request_id"],
+            reviewed_replacement.action_request_id,
+        )
+        self.assertEqual(
+            alert_snapshot["current_action_review"]["action_request_id"],
+            reviewed_replacement.action_request_id,
+        )
+        self.assertEqual(
+            case_snapshot["current_action_review"]["action_request_id"],
+            reviewed_replacement.action_request_id,
+        )
+        self.assertNotIn(
+            policy_authorized_request.action_request_id,
+            action_reviews_by_id,
+        )
+        self.assertEqual(
+            action_reviews_by_id[reviewed_request.action_request_id][
+                "replacement_action_request_id"
+            ],
+            reviewed_replacement.action_request_id,
+        )
+
+    def test_service_action_review_surfaces_preserve_terminal_execution_states(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-completed-execution-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+            action_request_id="action-request-surface-completed-execution-001",
+        )
+        decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-surface-completed-execution-001",
+                action_request_id=request.action_request_id,
+                approver_identities=("approver-completed-execution-001",),
+                target_snapshot=dict(request.target_scope),
+                payload_hash=request.payload_hash,
+                decided_at=request.requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        request = service.persist_record(
+            replace(
+                request,
+                approval_decision_id=decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-surface-completed-001",
+                action_request_id=request.action_request_id,
+                approval_decision_id=decision.approval_decision_id,
+                delegation_id="delegation-surface-completed-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-surface-completed-001",
+                idempotency_key=request.idempotency_key,
+                target_scope=dict(request.target_scope),
+                approved_payload=dict(request.requested_payload),
+                payload_hash=request.payload_hash,
+                delegated_at=request.requested_at + timedelta(minutes=10),
+                expires_at=expires_at,
+                provenance={"initiated_by": "operator-review"},
+                lifecycle_state="succeeded",
+            )
+        )
+
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+        action_review = case_snapshot["current_action_review"]
+
+        self.assertEqual(
+            action_review["action_request_id"],
+            request.action_request_id,
+        )
+        self.assertEqual(action_review["review_state"], "completed")
+        self.assertEqual(
+            action_review["action_execution_state"],
+            "succeeded",
+        )
+        self.assertEqual(
+            action_review["next_expected_action"],
+            "review_execution_outcome",
+        )
 
     def test_service_action_review_surfaces_use_newest_review_as_current(
         self,

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -4001,6 +4001,98 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             "review_execution_outcome",
         )
 
+    def test_service_action_review_surfaces_preserve_canceled_execution_state(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-canceled-execution-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+            action_request_id="action-request-surface-canceled-execution-001",
+        )
+        decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-surface-canceled-execution-001",
+                action_request_id=request.action_request_id,
+                approver_identities=("approver-canceled-execution-001",),
+                target_snapshot=dict(request.target_scope),
+                payload_hash=request.payload_hash,
+                decided_at=request.requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        request = service.persist_record(
+            replace(
+                request,
+                approval_decision_id=decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-surface-canceled-001",
+                action_request_id=request.action_request_id,
+                approval_decision_id=decision.approval_decision_id,
+                delegation_id="delegation-surface-canceled-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-surface-canceled-001",
+                idempotency_key=request.idempotency_key,
+                target_scope=dict(request.target_scope),
+                approved_payload=dict(request.requested_payload),
+                payload_hash=request.payload_hash,
+                delegated_at=request.requested_at + timedelta(minutes=10),
+                expires_at=expires_at,
+                provenance={"initiated_by": "operator-review"},
+                lifecycle_state="canceled",
+            )
+        )
+
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+        action_review = case_snapshot["current_action_review"]
+
+        self.assertEqual(
+            action_review["action_request_id"],
+            request.action_request_id,
+        )
+        self.assertEqual(action_review["review_state"], "canceled")
+        self.assertEqual(
+            action_review["action_execution_state"],
+            "canceled",
+        )
+        self.assertEqual(
+            action_review["next_expected_action"],
+            "investigate_execution_cancellation",
+        )
+
     def test_service_action_review_surfaces_use_newest_review_as_current(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -2655,7 +2655,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
     def test_service_creates_approval_bound_action_request_from_reviewed_recommendation(
         self,
     ) -> None:
-        store, service, promoted_case, evidence_id, reviewed_at = (
+        _, service, promoted_case, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()
         )
         observation = service.record_case_observation(
@@ -3599,6 +3599,203 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
                 "replacement_action_request_id"
             ],
             replacement_request.action_request_id,
+        )
+
+    def test_service_analyst_queue_prefetches_action_review_records_once_per_inspection(
+        self,
+    ) -> None:
+        inner_store, _ = make_store()
+        store = _ListCountingStore(inner=inner_store)
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case(store=store)
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=service.record_case_lead(
+                case_id=promoted_case.case_id,
+                triage_owner="analyst-001",
+                triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+                observation_id=observation.observation_id,
+            ).lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        first_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+        second_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-002",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+        )
+
+        store.list_calls = 0
+        store.reconciliation_list_calls = 0
+        queue_snapshot = service.inspect_analyst_queue().to_dict()
+
+        self.assertEqual(queue_snapshot["total_records"], 1)
+        self.assertEqual(
+            queue_snapshot["records"][0]["current_action_review"]["action_request_id"],
+            second_request.action_request_id,
+        )
+        self.assertLessEqual(store.list_calls, 6)
+        self.assertEqual(store.reconciliation_list_calls, 2)
+        self.assertNotEqual(first_request.action_request_id, second_request.action_request_id)
+
+    def test_service_action_review_surfaces_prefer_live_approval_and_execution_records(
+        self,
+    ) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=service.record_case_lead(
+                case_id=promoted_case.case_id,
+                triage_owner="analyst-001",
+                triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+                observation_id=observation.observation_id,
+            ).lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        approved_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-approved-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+            action_request_id="action-request-surface-stale-approved-001",
+        )
+        approved_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-surface-stale-approved-001",
+                action_request_id=approved_request.action_request_id,
+                approver_identities=("approver-approved-001",),
+                target_snapshot=dict(approved_request.target_scope),
+                payload_hash=approved_request.payload_hash,
+                decided_at=approved_request.requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                approved_request,
+                approval_decision_id=approved_decision.approval_decision_id,
+                lifecycle_state="pending_approval",
+            )
+        )
+
+        executing_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-002",
+            recipient_identity="repo-owner-executing-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+            action_request_id="action-request-surface-stale-executing-001",
+        )
+        executing_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-surface-stale-executing-001",
+                action_request_id=executing_request.action_request_id,
+                approver_identities=("approver-executing-001",),
+                target_snapshot=dict(executing_request.target_scope),
+                payload_hash=executing_request.payload_hash,
+                decided_at=executing_request.requested_at + timedelta(minutes=10),
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                executing_request,
+                approval_decision_id=executing_decision.approval_decision_id,
+                lifecycle_state="pending_approval",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-surface-stale-executing-001",
+                action_request_id=executing_request.action_request_id,
+                approval_decision_id=executing_decision.approval_decision_id,
+                delegation_id="delegation-surface-stale-executing-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="n8n",
+                execution_run_id="execution-run-surface-stale-executing-001",
+                idempotency_key=executing_request.idempotency_key,
+                target_scope=dict(executing_request.target_scope),
+                approved_payload=dict(executing_request.requested_payload),
+                payload_hash=executing_request.payload_hash,
+                delegated_at=executing_request.requested_at + timedelta(minutes=15),
+                expires_at=expires_at,
+                provenance={"initiated_by": "operator-review"},
+                lifecycle_state="queued",
+            )
+        )
+
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+        action_reviews_by_id = {
+            record["action_request_id"]: record for record in case_snapshot["action_reviews"]
+        }
+
+        self.assertEqual(
+            action_reviews_by_id[approved_request.action_request_id]["review_state"],
+            "approved",
+        )
+        self.assertEqual(
+            action_reviews_by_id[approved_request.action_request_id]["next_expected_action"],
+            "await_reviewed_delegation",
+        )
+        self.assertEqual(
+            action_reviews_by_id[approved_request.action_request_id]["approval_state"],
+            "approved",
+        )
+        self.assertEqual(
+            action_reviews_by_id[executing_request.action_request_id]["review_state"],
+            "executing",
+        )
+        self.assertEqual(
+            action_reviews_by_id[executing_request.action_request_id][
+                "next_expected_action"
+            ],
+            "await_execution_reconciliation",
+        )
+        self.assertEqual(
+            action_reviews_by_id[executing_request.action_request_id][
+                "action_execution_id"
+            ],
+            "action-execution-surface-stale-executing-001",
         )
 
     def test_approved_payload_binding_hash_normalizes_equivalent_datetime_offsets(

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -3798,6 +3798,199 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             "action-execution-surface-stale-executing-001",
         )
 
+    def test_service_action_review_surfaces_use_newest_review_as_current(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+        rejected_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-rejected-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+            action_request_id="action-request-surface-current-rejected-001",
+        )
+        rejected_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-surface-current-rejected-001",
+                action_request_id=rejected_request.action_request_id,
+                approver_identities=("approver-rejected-001",),
+                target_snapshot=dict(rejected_request.target_scope),
+                payload_hash=rejected_request.payload_hash,
+                decided_at=rejected_request.requested_at + timedelta(minutes=5),
+                lifecycle_state="rejected",
+            )
+        )
+        rejected_request = service.persist_record(
+            replace(
+                rejected_request,
+                approval_decision_id=rejected_decision.approval_decision_id,
+                lifecycle_state="rejected",
+            )
+        )
+
+        completed_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-002",
+            recipient_identity="repo-owner-completed-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=expires_at,
+            action_request_id="action-request-surface-current-completed-001",
+        )
+        completed_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-surface-current-completed-001",
+                action_request_id=completed_request.action_request_id,
+                approver_identities=("approver-completed-001",),
+                target_snapshot=dict(completed_request.target_scope),
+                payload_hash=completed_request.payload_hash,
+                decided_at=completed_request.requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        completed_request = service.persist_record(
+            replace(
+                completed_request,
+                approval_decision_id=completed_decision.approval_decision_id,
+                lifecycle_state="completed",
+            )
+        )
+
+        queue_snapshot = service.inspect_analyst_queue().to_dict()
+        alert_snapshot = service.inspect_alert_detail(promoted_case.alert_id).to_dict()
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+
+        self.assertEqual(
+            queue_snapshot["records"][0]["current_action_review"]["action_request_id"],
+            completed_request.action_request_id,
+        )
+        self.assertEqual(
+            queue_snapshot["records"][0]["current_action_review"]["review_state"],
+            "completed",
+        )
+        self.assertEqual(
+            alert_snapshot["current_action_review"]["action_request_id"],
+            completed_request.action_request_id,
+        )
+        self.assertEqual(
+            case_snapshot["current_action_review"]["action_request_id"],
+            completed_request.action_request_id,
+        )
+        self.assertEqual(
+            case_snapshot["action_reviews"][0]["action_request_id"],
+            completed_request.action_request_id,
+        )
+        self.assertEqual(
+            case_snapshot["action_reviews"][1]["action_request_id"],
+            rejected_request.action_request_id,
+        )
+
+    def test_service_action_review_surfaces_find_cross_scope_replacement_requests(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        alert_scoped_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-superseded-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-surface-alert-superseded-001",
+        )
+        alert_scoped_request = service.persist_record(
+            replace(
+                alert_scoped_request,
+                case_id=None,
+                lifecycle_state="superseded",
+            )
+        )
+        replacement_request = service.persist_record(
+            replace(
+                alert_scoped_request,
+                action_request_id="action-request-surface-case-replacement-001",
+                case_id=promoted_case.case_id,
+                idempotency_key="idempotency-surface-case-replacement-001",
+                requested_at=alert_scoped_request.requested_at + timedelta(minutes=15),
+                lifecycle_state="pending_approval",
+                requester_identity="analyst-002",
+            )
+        )
+
+        alert_snapshot = service.inspect_alert_detail(promoted_case.alert_id).to_dict()
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+        action_reviews_by_id = {
+            record["action_request_id"]: record for record in case_snapshot["action_reviews"]
+        }
+
+        self.assertEqual(
+            case_snapshot["current_action_review"]["action_request_id"],
+            replacement_request.action_request_id,
+        )
+        self.assertEqual(
+            alert_snapshot["current_action_review"]["action_request_id"],
+            replacement_request.action_request_id,
+        )
+        self.assertEqual(
+            action_reviews_by_id[alert_scoped_request.action_request_id]["review_state"],
+            "superseded",
+        )
+        self.assertEqual(
+            action_reviews_by_id[alert_scoped_request.action_request_id][
+                "replacement_action_request_id"
+            ],
+            replacement_request.action_request_id,
+        )
+
     def test_approved_payload_binding_hash_normalizes_equivalent_datetime_offsets(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -2655,7 +2655,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
     def test_service_creates_approval_bound_action_request_from_reviewed_recommendation(
         self,
     ) -> None:
-        _, service, promoted_case, evidence_id, reviewed_at = (
+        store, service, promoted_case, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()
         )
         observation = service.record_case_observation(


### PR DESCRIPTION
## Summary
- add reviewed action-review summaries to the queue, alert detail, and case detail surfaces
- keep pending, expired, rejected, and superseded approval states visible with requester/approver/intended-action metadata
- add focused Phase 19, reconciliation, and CLI inspection coverage for the new reviewed surfaces

Closes #475


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspections (alert, case, analyst queue) now surface ordered action-review chains and a highlighted current action review with state, next expected action, replacement linkage, approver identities, and execution info.

* **Tests**
  * Added extensive tests: CLI inspection, operator workflow REST assertions, phase-specific validations, action-review lifecycle transitions (pending/rejected/expired/superseded/replacement), persistence/reconciliation, live approval/execution preference, cross-scope replacement, and inspection performance bounds.

* **Documentation**
  * Supervisor journal updated with implementation status, failure context, and verification notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->