### PR TITLE
implementation: add delegation / execution / reconciliation timeline and mismatch inspection to the reviewed operator surface (#476)

### DIFF
--- a/.codex-supervisor/issues/476/issue-journal.md
+++ b/.codex-supervisor/issues/476/issue-journal.md
@@ -5,29 +5,49 @@
 - Branch: codex/issue-476
 - Workspace: .
 - Journal: .codex-supervisor/issues/476/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 8f4aa547bf5d0109dc122b1357dba17a40916146
+- Current phase: addressing_review
+- Attempt count: 6 (implementation=1, repair=1)
+- Last head SHA: 3ba9a25eb1378acfba4a4141e1c4086aaa84e581
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-14T22:49:38.440Z
+- Last failure signature: PRRT_kwDOR2iDUc56-W_y|PRRT_kwDOR2iDUc56-dw2|PRRT_kwDOR2iDUc56-dw5
+- Repeated failure signature count: 1
+- Updated at: 2026-04-14T23:53:19.282Z
 
 ## Latest Codex Summary
-- None yet.
+**Finding**
+
+I re-checked the live review-thread state on PR `#485` and compared it to the current branch. That showed the journal thread `PRRT_kwDOR2iDUc56-W_y` is still stale against the current file, but the service thread `PRRT_kwDOR2iDUc56-dw2` and the persistence-test thread `PRRT_kwDOR2iDUc56-dw5` are still actionable on `HEAD` (`3ba9a25`). The service was still deriving `timeline[action_execution].occurred_at` from reconciliation observation timestamps, and the persistence test block still used bare names that static lint could not resolve.
+
+I removed the reconciliation timestamp fallback so the action-execution stage now keeps `occurred_at` unset unless an authoritative execution timestamp exists, updated the CLI assertions that expected the old inferred value, and qualified the flagged persistence-test symbols with `support.`. The focused reviewed-action unittest suite passed locally after the fixes. `ruff` is not installed and `python3 -m ruff` is unavailable in this environment, so lint could not be rerun here. I committed the branch update as `26b6fd5` (`Fix reviewed action timeline review feedback`) and pushed it to `origin/codex/issue-476`.
+
+Summary: Fixed the two live CodeRabbit findings on the branch, kept the stale journal thread identified as stale, and revalidated the reviewed-action suite locally.
+State hint: addressing_review
+Blocked reason: none
+Tests: `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_phase20_low_risk_action_validation control-plane.tests.test_cli_inspection`
+Next action: Wait for reviewer refresh on PR `#485`; if the stale journal thread remains after refresh, resolve or reply to it explicitly rather than changing product code again.
+Failure signature: PRRT_kwDOR2iDUc56-W_y
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 3 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/AegisOps/pull/485#discussion_r3083131158
+- Details:
+  - .codex-supervisor/issues/476/issue-journal.md:10 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Update the journal phase to match the recorded implementation state.** `Current phase: reproducing` conflicts with the rest of this entry (`i... url=https://github.com/TommyKammy/AegisOps/pull/485#discussion_r3083131158
+  - control-plane/aegisops_control_plane/service.py:2003 summary=_⚠️ Potential issue_ | _🟠 Major_ **Keep the execution stage timestamp authoritative.** Lines 1997-2003 feed `reconciliation.last_seen_at` / `reconciliation.compared_at` into Li... url=https://github.com/TommyKammy/AegisOps/pull/485#discussion_r3083168535
+  - control-plane/tests/test_service_persistence_action_reconciliation.py:3695 summary=_⚠️ Potential issue_ | _🟠 Major_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/AegisOps Length of output: 50376 --- 🏁 Script executed: Repository: TommyKammy/Ae... url=https://github.com/TommyKammy/AegisOps/pull/485#discussion_r3083168539
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The reviewed operator inspection path already had enough authoritative records to render the full action chain, but it only exposed a flattened action-review summary and dropped explicit delegation/execution/reconciliation timeline and mismatch detail.
-- What changed: Added a focused CLI regression test that reproduced the missing `timeline` field on `inspect-case-detail`, then extended the shared action-review snapshot builder to emit an ordered five-stage timeline plus preserved mismatch inspection details derived from authoritative action-request, approval, action-execution, and reconciliation records.
+- Hypothesis: The service execution-timestamp thread and the persistence-test lint thread were still live on `3ba9a25`, while the journal phase thread remains stale against the current file contents.
+- What changed: Fetched live PR `#485` review-thread state via `fetch_comments.py`, removed the reconciliation-derived `action_execution.occurred_at` fallback in `service.py`, updated the CLI assertions that depended on the old inferred timestamp, qualified the flagged persistence-test symbols with `support.`, and re-ran the focused reviewed-action verification suite successfully.
 - Current blocker: none
-- Next exact step: Commit the local implementation and test changes, then continue with any follow-on review or PR work if requested.
-- Verification gap: Manual operator-surface confirmation from queue and alert entry points was not run; coverage currently relies on the shared snapshot plumbing and targeted unittest verification.
-- Files touched: control-plane/aegisops_control_plane/service.py; control-plane/tests/test_cli_inspection.py
-- Rollback concern: Low; change is additive to action-review inspection payloads but any consumer assuming the prior exact JSON shape should be checked if external integrations exist.
-- Last focused command: python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_phase20_low_risk_action_validation control-plane.tests.test_cli_inspection
+- Next exact step: Wait for reviewer refresh on PR `#485`; if `PRRT_kwDOR2iDUc56-W_y` persists after the new head is reviewed, resolve or reply to that stale journal thread explicitly.
+- Verification gap: `ruff` is unavailable in this shell (`ruff` not on `PATH`; `python3 -m ruff` missing), so changed-file lint could not be re-run locally even though the offending F821 pattern was corrected.
+- Files touched: .codex-supervisor/issues/476/issue-journal.md; control-plane/aegisops_control_plane/service.py; control-plane/tests/test_cli_inspection.py; control-plane/tests/test_service_persistence_action_reconciliation.py
+- Rollback concern: Low; the behavioral change only removes a non-authoritative execution timestamp inference from the reviewed timeline and aligns tests with that stricter semantics.
+- Last focused command: git push origin codex/issue-476
 ### Scratchpad
-- Keep this section short. The supervisor may compact older notes automatically.
+- Live review-thread check (`fetch_comments.py`) shows three unresolved threads on PR `#485`: the journal thread `PRRT_kwDOR2iDUc56-W_y` is stale against the current file, while `PRRT_kwDOR2iDUc56-dw2` and `PRRT_kwDOR2iDUc56-dw5` matched live code on `3ba9a25` and were fixed locally in this turn.
+- Added focused CLI assertions for `current_action_review.timeline` and `mismatch_inspection` on `inspect-case-detail`, `inspect-alert-detail`, and `inspect-analyst-queue`, plus a retry/re-delegation regression that proves a later reconciliation from an older execution attempt no longer outranks the selected execution lineage.
+- Added a pre-delegation reconciliation regression that reconciles an approved request before delegation, then delegates and confirms `inspect-case-detail` still surfaces the pending reconciliation and mismatch inspection. Extended the timeline assertions to require execution-stage `actor_identities`.
+- Added a service regression proving a terminal request without a surviving approval record keeps the timeline approval stage aligned with `approval_state`, and another regression proving indexed inspection still surfaces a reconciliation that is linked only by current execution/delegation lineage when approval lookup is missing.

--- a/.codex-supervisor/issues/476/issue-journal.md
+++ b/.codex-supervisor/issues/476/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #476: implementation: add delegation / execution / reconciliation timeline and mismatch inspection to the reviewed operator surface
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/476
+- Branch: codex/issue-476
+- Workspace: .
+- Journal: .codex-supervisor/issues/476/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 8f4aa547bf5d0109dc122b1357dba17a40916146
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T22:49:38.440Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The reviewed operator inspection path already had enough authoritative records to render the full action chain, but it only exposed a flattened action-review summary and dropped explicit delegation/execution/reconciliation timeline and mismatch detail.
+- What changed: Added a focused CLI regression test that reproduced the missing `timeline` field on `inspect-case-detail`, then extended the shared action-review snapshot builder to emit an ordered five-stage timeline plus preserved mismatch inspection details derived from authoritative action-request, approval, action-execution, and reconciliation records.
+- Current blocker: none
+- Next exact step: Commit the local implementation and test changes, then continue with any follow-on review or PR work if requested.
+- Verification gap: Manual operator-surface confirmation from queue and alert entry points was not run; coverage currently relies on the shared snapshot plumbing and targeted unittest verification.
+- Files touched: control-plane/aegisops_control_plane/service.py; control-plane/tests/test_cli_inspection.py
+- Rollback concern: Low; change is additive to action-review inspection payloads but any consumer assuming the prior exact JSON shape should be checked if external integrations exist.
+- Last focused command: python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_phase20_low_risk_action_validation control-plane.tests.test_cli_inspection
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1994,14 +1994,6 @@ class AegisOpsControlPlaneService:
             adapter_base_url = action_execution.provenance.get("adapter_base_url")
             if isinstance(adapter_base_url, str) and adapter_base_url.strip():
                 action_execution_details["adapter_base_url"] = adapter_base_url
-            if reconciliation is not None and (
-                reconciliation.execution_run_id is not None
-                or reconciliation.linked_execution_run_ids
-            ):
-                action_execution_occurred_at = (
-                    reconciliation.last_seen_at or reconciliation.compared_at
-                )
-
         timeline = (
             self._action_review_stage_snapshot(
                 stage="action_request",

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1716,49 +1716,55 @@ class AegisOpsControlPlaneService:
         action_execution: ActionExecutionRecord | None,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> ReconciliationRecord | None:
+        def _dedupe(
+            reconciliations: tuple[ReconciliationRecord, ...] | list[ReconciliationRecord],
+        ) -> list[ReconciliationRecord]:
+            by_id: dict[str, ReconciliationRecord] = {}
+            for reconciliation in reconciliations:
+                by_id[reconciliation.reconciliation_id] = reconciliation
+            return list(by_id.values())
+
         matches: list[ReconciliationRecord] = []
         if record_index is not None:
-            matches_by_id: dict[str, ReconciliationRecord] = {}
-            for reconciliation in record_index.reconciliations_by_action_request_id.get(
-                action_request.action_request_id,
-                (),
-            ):
-                matches_by_id[reconciliation.reconciliation_id] = reconciliation
-            if approval_decision is not None:
-                for reconciliation in record_index.reconciliations_by_approval_decision_id.get(
-                    approval_decision.approval_decision_id,
-                    (),
-                ):
-                    matches_by_id[reconciliation.reconciliation_id] = reconciliation
             if action_execution is not None:
-                for reconciliation in record_index.reconciliations_by_action_execution_id.get(
-                    action_execution.action_execution_id,
-                    (),
-                ):
-                    matches_by_id[reconciliation.reconciliation_id] = reconciliation
-                for reconciliation in record_index.reconciliations_by_delegation_id.get(
-                    action_execution.delegation_id,
-                    (),
-                ):
-                    matches_by_id[reconciliation.reconciliation_id] = reconciliation
-            matches = list(matches_by_id.values())
+                matches = _dedupe(
+                    list(
+                        record_index.reconciliations_by_action_execution_id.get(
+                            action_execution.action_execution_id,
+                            (),
+                        )
+                    )
+                    + list(
+                        record_index.reconciliations_by_delegation_id.get(
+                            action_execution.delegation_id,
+                            (),
+                        )
+                    )
+                )
+            elif approval_decision is not None:
+                matches = _dedupe(
+                    list(
+                        record_index.reconciliations_by_approval_decision_id.get(
+                            approval_decision.approval_decision_id,
+                            (),
+                        )
+                    )
+                    + list(
+                        record_index.reconciliations_by_action_request_id.get(
+                            action_request.action_request_id,
+                            (),
+                        )
+                    )
+                )
+            else:
+                matches = list(
+                    record_index.reconciliations_by_action_request_id.get(
+                        action_request.action_request_id,
+                        (),
+                    )
+                )
         else:
             for reconciliation in self._store.list(ReconciliationRecord):
-                subject_action_request_ids = self._assistant_ids_from_mapping(
-                    reconciliation.subject_linkage,
-                    "action_request_ids",
-                )
-                if action_request.action_request_id in subject_action_request_ids:
-                    matches.append(reconciliation)
-                    continue
-                if approval_decision is not None:
-                    subject_approval_decision_ids = self._assistant_ids_from_mapping(
-                        reconciliation.subject_linkage,
-                        "approval_decision_ids",
-                    )
-                    if approval_decision.approval_decision_id in subject_approval_decision_ids:
-                        matches.append(reconciliation)
-                        continue
                 if action_execution is not None:
                     subject_action_execution_ids = self._assistant_ids_from_mapping(
                         reconciliation.subject_linkage,
@@ -1773,7 +1779,21 @@ class AegisOpsControlPlaneService:
                     )
                     if action_execution.delegation_id in subject_delegation_ids:
                         matches.append(reconciliation)
+                    continue
+                if approval_decision is not None:
+                    subject_approval_decision_ids = self._assistant_ids_from_mapping(
+                        reconciliation.subject_linkage,
+                        "approval_decision_ids",
+                    )
+                    if approval_decision.approval_decision_id in subject_approval_decision_ids:
+                        matches.append(reconciliation)
                         continue
+                subject_action_request_ids = self._assistant_ids_from_mapping(
+                    reconciliation.subject_linkage,
+                    "action_request_ids",
+                )
+                if action_request.action_request_id in subject_action_request_ids:
+                    matches.append(reconciliation)
         if not matches:
             return None
         matches.sort(
@@ -1959,7 +1979,9 @@ class AegisOpsControlPlaneService:
         delegation_details: dict[str, object] = {}
         action_execution_details: dict[str, object] = {}
         execution_actor_identities: tuple[str, ...] = ()
+        action_execution_occurred_at: datetime | None = None
         if action_execution is not None:
+            delegation_details["delegation_id"] = action_execution.delegation_id
             downstream_binding = action_execution.provenance.get("downstream_binding")
             if isinstance(downstream_binding, Mapping):
                 delegation_details["downstream_binding"] = dict(downstream_binding)
@@ -1969,6 +1991,13 @@ class AegisOpsControlPlaneService:
             adapter_base_url = action_execution.provenance.get("adapter_base_url")
             if isinstance(adapter_base_url, str) and adapter_base_url.strip():
                 action_execution_details["adapter_base_url"] = adapter_base_url
+            if reconciliation is not None and (
+                reconciliation.execution_run_id is not None
+                or reconciliation.linked_execution_run_ids
+            ):
+                action_execution_occurred_at = (
+                    reconciliation.last_seen_at or reconciliation.compared_at
+                )
 
         timeline = (
             self._action_review_stage_snapshot(
@@ -2020,7 +2049,9 @@ class AegisOpsControlPlaneService:
                 stage="delegation",
                 record_family="action_execution",
                 record_id=(
-                    None if action_execution is None else action_execution.delegation_id
+                    None
+                    if action_execution is None
+                    else action_execution.action_execution_id
                 ),
                 state=(
                     "awaiting_delegation"
@@ -2053,9 +2084,7 @@ class AegisOpsControlPlaneService:
                     if action_execution is None
                     else action_execution.lifecycle_state
                 ),
-                occurred_at=(
-                    None if action_execution is None else action_execution.delegated_at
-                ),
+                occurred_at=action_execution_occurred_at,
                 actor_identities=execution_actor_identities,
                 details=(
                     {}

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1561,6 +1561,7 @@ class AegisOpsControlPlaneService:
         )
         timeline = self._action_review_timeline(
             action_request=action_request,
+            approval_state=approval_state,
             approval_decision=approval_decision,
             action_execution=action_execution,
             reconciliation=reconciliation,
@@ -1759,44 +1760,33 @@ class AegisOpsControlPlaneService:
 
         matches: list[ReconciliationRecord] = []
         if record_index is not None:
-            if approval_decision is not None:
-                matches = _dedupe(
-                    (
-                        []
-                        if action_execution is None
-                        else list(
-                            record_index.reconciliations_by_action_execution_id.get(
-                                action_execution.action_execution_id,
-                                (),
-                            )
-                        )
-                        + list(
-                            record_index.reconciliations_by_delegation_id.get(
-                                action_execution.delegation_id,
-                                (),
-                            )
-                        )
-                    )
-                    + list(
-                        record_index.reconciliations_by_approval_decision_id.get(
-                            approval_decision.approval_decision_id,
-                            (),
-                        )
-                    )
-                    + list(
-                        record_index.reconciliations_by_action_request_id.get(
-                            action_request.action_request_id,
-                            (),
-                        )
-                    )
+            indexed_matches: list[ReconciliationRecord] = list(
+                record_index.reconciliations_by_action_request_id.get(
+                    action_request.action_request_id,
+                    (),
                 )
-            else:
-                matches = list(
-                    record_index.reconciliations_by_action_request_id.get(
-                        action_request.action_request_id,
+            )
+            if approval_decision is not None:
+                indexed_matches += list(
+                    record_index.reconciliations_by_approval_decision_id.get(
+                        approval_decision.approval_decision_id,
                         (),
                     )
                 )
+            if action_execution is not None:
+                indexed_matches += list(
+                    record_index.reconciliations_by_action_execution_id.get(
+                        action_execution.action_execution_id,
+                        (),
+                    )
+                )
+                indexed_matches += list(
+                    record_index.reconciliations_by_delegation_id.get(
+                        action_execution.delegation_id,
+                        (),
+                    )
+                )
+            matches = _dedupe(indexed_matches)
         else:
             for reconciliation in self._store.list(ReconciliationRecord):
                 if _matches_review_lineage(reconciliation):
@@ -1980,6 +1970,7 @@ class AegisOpsControlPlaneService:
         self,
         *,
         action_request: ActionRequestRecord,
+        approval_state: str | None,
         approval_decision: ApprovalDecisionRecord | None,
         action_execution: ActionExecutionRecord | None,
         reconciliation: ReconciliationRecord | None,
@@ -2044,9 +2035,9 @@ class AegisOpsControlPlaneService:
                     else approval_decision.approval_decision_id
                 ),
                 state=(
-                    "pending"
-                    if approval_decision is None
-                    else approval_decision.lifecycle_state
+                    approval_decision.lifecycle_state
+                    if approval_decision is not None
+                    else (approval_state or "pending")
                 ),
                 occurred_at=(
                     None if approval_decision is None else approval_decision.decided_at

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1724,26 +1724,60 @@ class AegisOpsControlPlaneService:
                 by_id[reconciliation.reconciliation_id] = reconciliation
             return list(by_id.values())
 
+        def _matches_current_execution_lineage(
+            reconciliation: ReconciliationRecord,
+        ) -> bool:
+            if action_execution is None:
+                return False
+            subject_action_execution_ids = self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "action_execution_ids",
+            )
+            if action_execution.action_execution_id in subject_action_execution_ids:
+                return True
+            subject_delegation_ids = self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "delegation_ids",
+            )
+            return action_execution.delegation_id in subject_delegation_ids
+
+        def _matches_review_lineage(reconciliation: ReconciliationRecord) -> bool:
+            if _matches_current_execution_lineage(reconciliation):
+                return True
+            if approval_decision is not None:
+                subject_approval_decision_ids = self._assistant_ids_from_mapping(
+                    reconciliation.subject_linkage,
+                    "approval_decision_ids",
+                )
+                if approval_decision.approval_decision_id in subject_approval_decision_ids:
+                    return True
+            subject_action_request_ids = self._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "action_request_ids",
+            )
+            return action_request.action_request_id in subject_action_request_ids
+
         matches: list[ReconciliationRecord] = []
         if record_index is not None:
-            if action_execution is not None:
+            if approval_decision is not None:
                 matches = _dedupe(
-                    list(
-                        record_index.reconciliations_by_action_execution_id.get(
-                            action_execution.action_execution_id,
-                            (),
+                    (
+                        []
+                        if action_execution is None
+                        else list(
+                            record_index.reconciliations_by_action_execution_id.get(
+                                action_execution.action_execution_id,
+                                (),
+                            )
+                        )
+                        + list(
+                            record_index.reconciliations_by_delegation_id.get(
+                                action_execution.delegation_id,
+                                (),
+                            )
                         )
                     )
                     + list(
-                        record_index.reconciliations_by_delegation_id.get(
-                            action_execution.delegation_id,
-                            (),
-                        )
-                    )
-                )
-            elif approval_decision is not None:
-                matches = _dedupe(
-                    list(
                         record_index.reconciliations_by_approval_decision_id.get(
                             approval_decision.approval_decision_id,
                             (),
@@ -1765,39 +1799,13 @@ class AegisOpsControlPlaneService:
                 )
         else:
             for reconciliation in self._store.list(ReconciliationRecord):
-                if action_execution is not None:
-                    subject_action_execution_ids = self._assistant_ids_from_mapping(
-                        reconciliation.subject_linkage,
-                        "action_execution_ids",
-                    )
-                    if action_execution.action_execution_id in subject_action_execution_ids:
-                        matches.append(reconciliation)
-                        continue
-                    subject_delegation_ids = self._assistant_ids_from_mapping(
-                        reconciliation.subject_linkage,
-                        "delegation_ids",
-                    )
-                    if action_execution.delegation_id in subject_delegation_ids:
-                        matches.append(reconciliation)
-                    continue
-                if approval_decision is not None:
-                    subject_approval_decision_ids = self._assistant_ids_from_mapping(
-                        reconciliation.subject_linkage,
-                        "approval_decision_ids",
-                    )
-                    if approval_decision.approval_decision_id in subject_approval_decision_ids:
-                        matches.append(reconciliation)
-                        continue
-                subject_action_request_ids = self._assistant_ids_from_mapping(
-                    reconciliation.subject_linkage,
-                    "action_request_ids",
-                )
-                if action_request.action_request_id in subject_action_request_ids:
+                if _matches_review_lineage(reconciliation):
                     matches.append(reconciliation)
         if not matches:
             return None
         matches.sort(
             key=lambda record: (
+                1 if _matches_current_execution_lineage(record) else 0,
                 record.compared_at or record.last_seen_at or record.first_seen_at,
                 record.reconciliation_id,
             ),
@@ -1982,6 +1990,10 @@ class AegisOpsControlPlaneService:
         action_execution_occurred_at: datetime | None = None
         if action_execution is not None:
             delegation_details["delegation_id"] = action_execution.delegation_id
+            execution_actor_identities = self._assistant_merge_ids(
+                action_execution.provenance.get("initiated_by"),
+                action_execution.provenance.get("delegation_issuer"),
+            )
             downstream_binding = action_execution.provenance.get("downstream_binding")
             if isinstance(downstream_binding, Mapping):
                 delegation_details["downstream_binding"] = dict(downstream_binding)

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1559,6 +1559,13 @@ class AegisOpsControlPlaneService:
             approval_state=approval_state,
             action_execution=action_execution,
         )
+        timeline = self._action_review_timeline(
+            action_request=action_request,
+            approval_decision=approval_decision,
+            action_execution=action_execution,
+            reconciliation=reconciliation,
+        )
+        mismatch_inspection = self._action_review_mismatch_inspection(reconciliation)
         replacement_action_request = self._replacement_action_request(
             action_request,
             record_index=record_index,
@@ -1598,6 +1605,8 @@ class AegisOpsControlPlaneService:
                 if action_execution is not None
                 else action_request.policy_evaluation.get("execution_surface_id")
             ),
+            "timeline": timeline,
+            "mismatch_inspection": mismatch_inspection,
             "action_execution_id": (
                 action_execution.action_execution_id if action_execution is not None else None
             ),
@@ -1915,6 +1924,197 @@ class AegisOpsControlPlaneService:
             "failed": "investigate_execution_failure",
             "unresolved": "investigate_reconciliation_gap",
         }.get(review_state)
+
+    @staticmethod
+    def _action_review_stage_snapshot(
+        *,
+        stage: str,
+        record_family: str,
+        record_id: str | None,
+        state: str,
+        occurred_at: datetime | None,
+        actor_identities: tuple[str, ...] = (),
+        details: Mapping[str, object] | None = None,
+    ) -> dict[str, object]:
+        snapshot = {
+            "stage": stage,
+            "record_family": record_family,
+            "record_id": record_id,
+            "state": state,
+            "occurred_at": occurred_at,
+            "actor_identities": actor_identities,
+        }
+        if details:
+            snapshot["details"] = dict(details)
+        return snapshot
+
+    def _action_review_timeline(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord | None,
+        action_execution: ActionExecutionRecord | None,
+        reconciliation: ReconciliationRecord | None,
+    ) -> tuple[dict[str, object], ...]:
+        delegation_details: dict[str, object] = {}
+        action_execution_details: dict[str, object] = {}
+        execution_actor_identities: tuple[str, ...] = ()
+        if action_execution is not None:
+            downstream_binding = action_execution.provenance.get("downstream_binding")
+            if isinstance(downstream_binding, Mapping):
+                delegation_details["downstream_binding"] = dict(downstream_binding)
+            adapter = action_execution.provenance.get("adapter")
+            if isinstance(adapter, str) and adapter.strip():
+                action_execution_details["adapter"] = adapter
+            adapter_base_url = action_execution.provenance.get("adapter_base_url")
+            if isinstance(adapter_base_url, str) and adapter_base_url.strip():
+                action_execution_details["adapter_base_url"] = adapter_base_url
+
+        timeline = (
+            self._action_review_stage_snapshot(
+                stage="action_request",
+                record_family="action_request",
+                record_id=action_request.action_request_id,
+                state=action_request.lifecycle_state,
+                occurred_at=action_request.requested_at,
+                actor_identities=(
+                    ()
+                    if action_request.requester_identity is None
+                    else (action_request.requester_identity,)
+                ),
+                details={
+                    "recipient_identity": action_request.requested_payload.get(
+                        "recipient_identity"
+                    ),
+                    "execution_surface_type": action_request.policy_evaluation.get(
+                        "execution_surface_type"
+                    ),
+                    "execution_surface_id": action_request.policy_evaluation.get(
+                        "execution_surface_id"
+                    ),
+                },
+            ),
+            self._action_review_stage_snapshot(
+                stage="approval_decision",
+                record_family="approval_decision",
+                record_id=(
+                    None
+                    if approval_decision is None
+                    else approval_decision.approval_decision_id
+                ),
+                state=(
+                    "pending"
+                    if approval_decision is None
+                    else approval_decision.lifecycle_state
+                ),
+                occurred_at=(
+                    None if approval_decision is None else approval_decision.decided_at
+                ),
+                actor_identities=(
+                    ()
+                    if approval_decision is None
+                    else approval_decision.approver_identities
+                ),
+            ),
+            self._action_review_stage_snapshot(
+                stage="delegation",
+                record_family="action_execution",
+                record_id=(
+                    None if action_execution is None else action_execution.delegation_id
+                ),
+                state=(
+                    "awaiting_delegation"
+                    if action_execution is None
+                    else "delegated"
+                ),
+                occurred_at=(
+                    None if action_execution is None else action_execution.delegated_at
+                ),
+                actor_identities=(
+                    ()
+                    if action_execution is None
+                    else self._assistant_ids_from_mapping(
+                        action_execution.provenance,
+                        "delegation_issuer",
+                    )
+                ),
+                details=delegation_details,
+            ),
+            self._action_review_stage_snapshot(
+                stage="action_execution",
+                record_family="action_execution",
+                record_id=(
+                    None
+                    if action_execution is None
+                    else action_execution.action_execution_id
+                ),
+                state=(
+                    "awaiting_execution"
+                    if action_execution is None
+                    else action_execution.lifecycle_state
+                ),
+                occurred_at=(
+                    None if action_execution is None else action_execution.delegated_at
+                ),
+                actor_identities=execution_actor_identities,
+                details=(
+                    {}
+                    if action_execution is None
+                    else {
+                        "execution_run_id": action_execution.execution_run_id,
+                        "execution_surface_type": action_execution.execution_surface_type,
+                        "execution_surface_id": action_execution.execution_surface_id,
+                        **action_execution_details,
+                    }
+                ),
+            ),
+            self._action_review_stage_snapshot(
+                stage="reconciliation",
+                record_family="reconciliation",
+                record_id=(
+                    None if reconciliation is None else reconciliation.reconciliation_id
+                ),
+                state=(
+                    "awaiting_reconciliation"
+                    if reconciliation is None
+                    else reconciliation.lifecycle_state
+                ),
+                occurred_at=(
+                    None if reconciliation is None else reconciliation.compared_at
+                ),
+                details=(
+                    {}
+                    if reconciliation is None
+                    else {
+                        "ingest_disposition": reconciliation.ingest_disposition,
+                        "execution_run_id": reconciliation.execution_run_id,
+                    }
+                ),
+            ),
+        )
+        return timeline
+
+    @staticmethod
+    def _action_review_mismatch_inspection(
+        reconciliation: ReconciliationRecord | None,
+    ) -> dict[str, object] | None:
+        if reconciliation is None:
+            return None
+        if reconciliation.lifecycle_state not in {"pending", "mismatched", "stale"}:
+            return None
+        return {
+            "reconciliation_id": reconciliation.reconciliation_id,
+            "lifecycle_state": reconciliation.lifecycle_state,
+            "ingest_disposition": reconciliation.ingest_disposition,
+            "mismatch_summary": reconciliation.mismatch_summary,
+            "correlation_key": reconciliation.correlation_key,
+            "execution_run_id": reconciliation.execution_run_id,
+            "linked_execution_run_ids": reconciliation.linked_execution_run_ids,
+            "subject_linkage": dict(reconciliation.subject_linkage),
+            "first_seen_at": reconciliation.first_seen_at,
+            "last_seen_at": reconciliation.last_seen_at,
+            "compared_at": reconciliation.compared_at,
+        }
 
     def inspect_analyst_queue(self) -> AnalystQueueSnapshot:
         active_alert_states = {

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -622,7 +622,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(review["timeline"][3]["state"], "queued")
         self.assertEqual(
             review["timeline"][3]["occurred_at"],
-            reconciliation.last_seen_at.isoformat(),
+            None,
         )
         self.assertEqual(
             review["timeline"][3]["actor_identities"],
@@ -3427,7 +3427,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
         self.assertEqual(
             review["timeline"][3]["occurred_at"],
-            seeded["selected_reconciliation"].last_seen_at.isoformat(),
+            None,
         )
         self.assertEqual(
             review["timeline"][4]["record_id"],

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -327,6 +327,100 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "replacement_request": replacement_request,
         }
 
+    def _seed_action_review_timeline_mismatch_for_case(
+        self,
+        service: AegisOpsControlPlaneService,
+        promoted_case: CaseRecord,
+        reviewed_at: datetime,
+        evidence_id: str,
+    ) -> dict[str, object]:
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-009",
+            observed_at=reviewed_at,
+            scope_statement=(
+                "Observed control-plane timeline fixture requires preserved review lineage."
+            ),
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-009",
+            triage_rationale="Timeline inspection requires approval-bound reviewed lineage.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-009",
+            intended_outcome=(
+                "Review repository owner change evidence before any approval-bound response."
+            ),
+            lead_id=lead.lead_id,
+        )
+        requested_at = datetime.now(timezone.utc)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-009",
+            recipient_identity="repo-owner-timeline-001",
+            message_intent="Notify the accountable owner using the reviewed action path.",
+            escalation_reason="Timeline inspection needs a reviewed action chain fixture.",
+            expires_at=requested_at + timedelta(hours=4),
+            action_request_id="action-request-cli-timeline-001",
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-timeline-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-timeline-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        action_execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=requested_at + timedelta(minutes=7),
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": "shuffle-run-cli-timeline-observed-002",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": action_execution.approval_decision_id,
+                    "delegation_id": action_execution.delegation_id,
+                    "payload_hash": action_execution.payload_hash,
+                    "observed_at": requested_at + timedelta(minutes=9),
+                    "status": "failed",
+                },
+            ),
+            compared_at=requested_at + timedelta(minutes=10),
+            stale_after=requested_at + timedelta(minutes=30),
+        )
+        return {
+            "recommendation": recommendation,
+            "action_request": approved_request,
+            "approval_decision": approval_decision,
+            "action_execution": action_execution,
+            "reconciliation": reconciliation,
+        }
+
     def test_runtime_command_uses_runtime_service_builder_when_not_injected(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -3027,6 +3121,86 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 "replacement_action_request_id"
             ],
             seeded["replacement_request"].action_request_id,
+        )
+
+    def test_cli_inspect_case_detail_renders_review_timeline_and_mismatch_details(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        seeded = self._seed_action_review_timeline_mismatch_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(review["action_request_id"], seeded["action_request"].action_request_id)
+        self.assertEqual(
+            [stage["stage"] for stage in review["timeline"]],
+            [
+                "action_request",
+                "approval_decision",
+                "delegation",
+                "action_execution",
+                "reconciliation",
+            ],
+        )
+        self.assertEqual(review["timeline"][0]["state"], "approved")
+        self.assertEqual(
+            review["timeline"][0]["actor_identities"],
+            ["analyst-009"],
+        )
+        self.assertEqual(review["timeline"][1]["state"], "approved")
+        self.assertEqual(
+            review["timeline"][1]["actor_identities"],
+            ["approver-timeline-001"],
+        )
+        self.assertEqual(review["timeline"][2]["state"], "delegated")
+        self.assertEqual(
+            review["timeline"][2]["actor_identities"],
+            ["control-plane-service"],
+        )
+        self.assertEqual(review["timeline"][3]["state"], "queued")
+        self.assertEqual(
+            review["timeline"][4]["state"],
+            "mismatched",
+        )
+        self.assertEqual(
+            review["timeline"][4]["record_id"],
+            seeded["reconciliation"].reconciliation_id,
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["reconciliation_id"],
+            seeded["reconciliation"].reconciliation_id,
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["lifecycle_state"],
+            "mismatched",
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["ingest_disposition"],
+            "mismatch",
+        )
+        self.assertIn(
+            "execution run identity mismatch",
+            review["mismatch_inspection"]["mismatch_summary"],
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["execution_run_id"],
+            "shuffle-run-cli-timeline-observed-002",
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["linked_execution_run_ids"],
+            ["shuffle-run-cli-timeline-observed-002"],
         )
 
     def test_cli_rejects_case_scoped_out_of_scope_advisory_reads_as_usage_errors(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -421,6 +421,89 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "reconciliation": reconciliation,
         }
 
+    def _seed_action_review_predelegation_reconciliation_for_case(
+        self,
+        service: AegisOpsControlPlaneService,
+        promoted_case: CaseRecord,
+        reviewed_at: datetime,
+        evidence_id: str,
+    ) -> dict[str, object]:
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-009",
+            observed_at=reviewed_at,
+            scope_statement=(
+                "Observed control-plane timeline fixture requires preserved pre-delegation reconciliation lineage."
+            ),
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-009",
+            triage_rationale="Timeline inspection requires approval-bound reviewed lineage.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-009",
+            intended_outcome=(
+                "Review repository owner change evidence before any approval-bound response."
+            ),
+            lead_id=lead.lead_id,
+        )
+        requested_at = datetime.now(timezone.utc)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-009",
+            recipient_identity="repo-owner-timeline-001",
+            message_intent="Notify the accountable owner using the reviewed action path.",
+            escalation_reason="Timeline inspection needs a reviewed action chain fixture.",
+            expires_at=requested_at + timedelta(hours=4),
+            action_request_id="action-request-cli-predelegation-001",
+        )
+        approval_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-predelegation-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-timeline-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        approved_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval_decision.approval_decision_id,
+                lifecycle_state="approved",
+            )
+        )
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(),
+            compared_at=requested_at + timedelta(minutes=6),
+            stale_after=requested_at + timedelta(minutes=30),
+        )
+        action_execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=requested_at + timedelta(minutes=7),
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        return {
+            "recommendation": recommendation,
+            "action_request": approved_request,
+            "approval_decision": approval_decision,
+            "action_execution": action_execution,
+            "reconciliation": reconciliation,
+        }
+
     def _seed_action_review_retried_execution_for_case(
         self,
         service: AegisOpsControlPlaneService,
@@ -540,6 +623,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(
             review["timeline"][3]["occurred_at"],
             reconciliation.last_seen_at.isoformat(),
+        )
+        self.assertEqual(
+            review["timeline"][3]["actor_identities"],
+            ["control-plane-service"],
         )
         self.assertNotEqual(
             review["timeline"][3]["occurred_at"],
@@ -3349,6 +3436,51 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(
             review["timeline"][4]["details"]["execution_run_id"],
             seeded["selected_action_execution"].execution_run_id,
+        )
+
+    def test_cli_inspect_case_detail_preserves_predelegation_reconciliation_visibility(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        seeded = self._seed_action_review_predelegation_reconciliation_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(
+            review["action_execution_id"],
+            seeded["action_execution"].action_execution_id,
+        )
+        self.assertEqual(
+            review["reconciliation_id"],
+            seeded["reconciliation"].reconciliation_id,
+        )
+        self.assertEqual(
+            review["timeline"][4]["record_id"],
+            seeded["reconciliation"].reconciliation_id,
+        )
+        self.assertEqual(
+            review["timeline"][4]["state"],
+            "pending",
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["reconciliation_id"],
+            seeded["reconciliation"].reconciliation_id,
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["lifecycle_state"],
+            "pending",
         )
 
     def test_cli_inspect_alert_detail_renders_review_timeline_and_mismatch_details(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -421,6 +421,163 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "reconciliation": reconciliation,
         }
 
+    def _seed_action_review_retried_execution_for_case(
+        self,
+        service: AegisOpsControlPlaneService,
+        promoted_case: CaseRecord,
+        reviewed_at: datetime,
+        evidence_id: str,
+    ) -> dict[str, object]:
+        seeded = self._seed_action_review_timeline_mismatch_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
+        )
+        first_execution = seeded["action_execution"]
+        first_reconciliation = seeded["reconciliation"]
+        latest_execution = service.persist_record(
+            replace(
+                first_execution,
+                action_execution_id="action-execution-cli-timeline-002",
+                delegation_id="delegation-cli-timeline-002",
+                execution_run_id="shuffle-run-cli-timeline-current-003",
+                delegated_at=first_execution.delegated_at + timedelta(minutes=4),
+                provenance={
+                    **dict(first_execution.provenance),
+                    "downstream_binding": {
+                        "approval_decision_id": first_execution.approval_decision_id,
+                        "delegation_id": "delegation-cli-timeline-002",
+                        "payload_hash": first_execution.payload_hash,
+                    },
+                },
+                lifecycle_state="queued",
+            )
+        )
+        current_reconciliation = service.persist_record(
+            replace(
+                first_reconciliation,
+                reconciliation_id="reconciliation-cli-timeline-current-003",
+                subject_linkage={
+                    **dict(first_reconciliation.subject_linkage),
+                    "action_execution_ids": (latest_execution.action_execution_id,),
+                    "delegation_ids": (latest_execution.delegation_id,),
+                },
+                execution_run_id=latest_execution.execution_run_id,
+                linked_execution_run_ids=(latest_execution.execution_run_id,),
+                last_seen_at=latest_execution.delegated_at + timedelta(minutes=2),
+                mismatch_summary="matched latest reviewed execution lineage",
+                compared_at=latest_execution.delegated_at + timedelta(minutes=3),
+                lifecycle_state="matched",
+                ingest_disposition="matched",
+            )
+        )
+        unrelated_later_reconciliation = service.persist_record(
+            replace(
+                first_reconciliation,
+                reconciliation_id="reconciliation-cli-timeline-older-004",
+                last_seen_at=latest_execution.delegated_at + timedelta(minutes=8),
+                compared_at=latest_execution.delegated_at + timedelta(minutes=9),
+                mismatch_summary=(
+                    "older execution lineage must not outrank the selected retry"
+                ),
+            )
+        )
+        return {
+            **seeded,
+            "selected_action_execution": latest_execution,
+            "selected_reconciliation": current_reconciliation,
+            "unrelated_later_reconciliation": unrelated_later_reconciliation,
+        }
+
+    def _assert_review_timeline_snapshot(
+        self,
+        review: dict[str, object],
+        seeded: dict[str, object],
+    ) -> None:
+        action_execution = seeded["action_execution"]
+        reconciliation = seeded["reconciliation"]
+        self.assertEqual(review["action_request_id"], seeded["action_request"].action_request_id)
+        self.assertEqual(
+            [stage["stage"] for stage in review["timeline"]],
+            [
+                "action_request",
+                "approval_decision",
+                "delegation",
+                "action_execution",
+                "reconciliation",
+            ],
+        )
+        self.assertEqual(review["timeline"][0]["state"], "approved")
+        self.assertEqual(
+            review["timeline"][0]["actor_identities"],
+            ["analyst-009"],
+        )
+        self.assertEqual(review["timeline"][1]["state"], "approved")
+        self.assertEqual(
+            review["timeline"][1]["actor_identities"],
+            ["approver-timeline-001"],
+        )
+        self.assertEqual(review["timeline"][2]["state"], "delegated")
+        self.assertEqual(review["timeline"][2]["record_family"], "action_execution")
+        self.assertEqual(
+            review["timeline"][2]["record_id"],
+            action_execution.action_execution_id,
+        )
+        self.assertEqual(
+            review["timeline"][2]["occurred_at"],
+            action_execution.delegated_at.isoformat(),
+        )
+        self.assertEqual(
+            review["timeline"][2]["actor_identities"],
+            ["control-plane-service"],
+        )
+        self.assertEqual(
+            review["timeline"][2]["details"]["delegation_id"],
+            action_execution.delegation_id,
+        )
+        self.assertEqual(review["timeline"][3]["state"], "queued")
+        self.assertEqual(
+            review["timeline"][3]["occurred_at"],
+            reconciliation.last_seen_at.isoformat(),
+        )
+        self.assertNotEqual(
+            review["timeline"][3]["occurred_at"],
+            action_execution.delegated_at.isoformat(),
+        )
+        self.assertEqual(
+            review["timeline"][4]["state"],
+            "mismatched",
+        )
+        self.assertEqual(
+            review["timeline"][4]["record_id"],
+            reconciliation.reconciliation_id,
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["reconciliation_id"],
+            reconciliation.reconciliation_id,
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["lifecycle_state"],
+            "mismatched",
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["ingest_disposition"],
+            "mismatch",
+        )
+        self.assertIn(
+            "execution run identity mismatch",
+            review["mismatch_inspection"]["mismatch_summary"],
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["execution_run_id"],
+            "shuffle-run-cli-timeline-observed-002",
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["linked_execution_run_ids"],
+            ["shuffle-run-cli-timeline-observed-002"],
+        )
+
     def test_runtime_command_uses_runtime_service_builder_when_not_injected(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -3143,64 +3300,97 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
 
         payload = json.loads(stdout.getvalue())
         review = payload["current_action_review"]
-        self.assertEqual(review["action_request_id"], seeded["action_request"].action_request_id)
-        self.assertEqual(
-            [stage["stage"] for stage in review["timeline"]],
-            [
-                "action_request",
-                "approval_decision",
-                "delegation",
-                "action_execution",
-                "reconciliation",
-            ],
+        self._assert_review_timeline_snapshot(review, seeded)
+
+    def test_cli_inspect_case_detail_keeps_reconciliation_bound_to_selected_execution(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        seeded = self._seed_action_review_retried_execution_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
         )
-        self.assertEqual(review["timeline"][0]["state"], "approved")
-        self.assertEqual(
-            review["timeline"][0]["actor_identities"],
-            ["analyst-009"],
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
         )
-        self.assertEqual(review["timeline"][1]["state"], "approved")
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
         self.assertEqual(
-            review["timeline"][1]["actor_identities"],
-            ["approver-timeline-001"],
+            review["action_execution_id"],
+            seeded["selected_action_execution"].action_execution_id,
         )
-        self.assertEqual(review["timeline"][2]["state"], "delegated")
         self.assertEqual(
-            review["timeline"][2]["actor_identities"],
-            ["control-plane-service"],
+            review["delegation_id"],
+            seeded["selected_action_execution"].delegation_id,
         )
-        self.assertEqual(review["timeline"][3]["state"], "queued")
         self.assertEqual(
-            review["timeline"][4]["state"],
-            "mismatched",
+            review["reconciliation_id"],
+            seeded["selected_reconciliation"].reconciliation_id,
+        )
+        self.assertEqual(
+            review["mismatch_inspection"],
+            None,
+        )
+        self.assertEqual(
+            review["timeline"][3]["occurred_at"],
+            seeded["selected_reconciliation"].last_seen_at.isoformat(),
         )
         self.assertEqual(
             review["timeline"][4]["record_id"],
-            seeded["reconciliation"].reconciliation_id,
+            seeded["selected_reconciliation"].reconciliation_id,
         )
         self.assertEqual(
-            review["mismatch_inspection"]["reconciliation_id"],
-            seeded["reconciliation"].reconciliation_id,
+            review["timeline"][4]["details"]["execution_run_id"],
+            seeded["selected_action_execution"].execution_run_id,
         )
-        self.assertEqual(
-            review["mismatch_inspection"]["lifecycle_state"],
-            "mismatched",
+
+    def test_cli_inspect_alert_detail_renders_review_timeline_and_mismatch_details(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        seeded = self._seed_action_review_timeline_mismatch_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
         )
-        self.assertEqual(
-            review["mismatch_inspection"]["ingest_disposition"],
-            "mismatch",
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-alert-detail", "--alert-id", promoted_case.alert_id],
+            stdout=stdout,
+            service=service,
         )
-        self.assertIn(
-            "execution run identity mismatch",
-            review["mismatch_inspection"]["mismatch_summary"],
+
+        payload = json.loads(stdout.getvalue())
+        self._assert_review_timeline_snapshot(payload["current_action_review"], seeded)
+
+    def test_cli_inspect_analyst_queue_renders_review_timeline_and_mismatch_details(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        seeded = self._seed_action_review_timeline_mismatch_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
         )
-        self.assertEqual(
-            review["mismatch_inspection"]["execution_run_id"],
-            "shuffle-run-cli-timeline-observed-002",
-        )
-        self.assertEqual(
-            review["mismatch_inspection"]["linked_execution_run_ids"],
-            ["shuffle-run-cli-timeline-observed-002"],
+
+        stdout = io.StringIO()
+        main.main(["inspect-analyst-queue"], stdout=stdout, service=service)
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["total_records"], 1)
+        self._assert_review_timeline_snapshot(
+            payload["records"][0]["current_action_review"],
+            seeded,
         )
 
     def test_cli_rejects_case_scoped_out_of_scope_advisory_reads_as_usage_errors(

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -3595,10 +3595,128 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             "superseded",
         )
         self.assertEqual(
+            action_reviews_by_id[superseded_request.action_request_id]["approval_state"],
+            "superseded",
+        )
+        self.assertEqual(
+            action_reviews_by_id[superseded_request.action_request_id]["timeline"][1]["state"],
+            "superseded",
+        )
+        self.assertEqual(
             action_reviews_by_id[superseded_request.action_request_id][
                 "replacement_action_request_id"
             ],
             replacement_request.action_request_id,
+        )
+
+    def test_service_action_review_surfaces_keep_execution_linked_reconciliation_when_approval_lookup_is_missing(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-indexed-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-surface-indexed-lineage-001",
+        )
+        action_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id="approval-surface-missing-indexed-001",
+                lifecycle_state="approved",
+            )
+        )
+        action_execution = service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-surface-indexed-lineage-001",
+                action_request_id=action_request.action_request_id,
+                approval_decision_id="approval-surface-missing-indexed-001",
+                delegation_id="delegation-surface-indexed-lineage-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-surface-indexed-lineage-001",
+                idempotency_key=action_request.idempotency_key,
+                target_scope=dict(action_request.target_scope),
+                approved_payload=dict(action_request.requested_payload),
+                payload_hash=action_request.payload_hash,
+                delegated_at=action_request.requested_at + timedelta(minutes=10),
+                expires_at=action_request.expires_at,
+                provenance={"initiated_by": "operator-review"},
+                lifecycle_state="queued",
+            )
+        )
+        reconciliation = service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-surface-indexed-lineage-001",
+                subject_linkage={
+                    "case_ids": (promoted_case.case_id,),
+                    "action_execution_ids": (action_execution.action_execution_id,),
+                    "delegation_ids": (action_execution.delegation_id,),
+                },
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id="execution-run-surface-indexed-lineage-observed-001",
+                linked_execution_run_ids=(
+                    "execution-run-surface-indexed-lineage-observed-001",
+                ),
+                correlation_key="surface-indexed-lineage-001",
+                first_seen_at=action_execution.delegated_at + timedelta(minutes=1),
+                last_seen_at=action_execution.delegated_at + timedelta(minutes=2),
+                ingest_disposition="mismatch",
+                mismatch_summary="execution lineage should remain visible without approval lookup",
+                compared_at=action_execution.delegated_at + timedelta(minutes=3),
+                lifecycle_state="mismatched",
+            )
+        )
+
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+        action_review = case_snapshot["current_action_review"]
+
+        self.assertEqual(
+            action_review["action_request_id"],
+            action_request.action_request_id,
+        )
+        self.assertEqual(
+            action_review["action_execution_id"],
+            action_execution.action_execution_id,
+        )
+        self.assertEqual(
+            action_review["reconciliation_id"],
+            reconciliation.reconciliation_id,
+        )
+        self.assertEqual(
+            action_review["timeline"][4]["record_id"],
+            reconciliation.reconciliation_id,
+        )
+        self.assertEqual(
+            action_review["mismatch_inspection"]["reconciliation_id"],
+            reconciliation.reconciliation_id,
         )
 
     def test_service_analyst_queue_prefetches_action_review_records_once_per_inspection(

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -3641,18 +3641,19 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             recipient_identity="repo-owner-indexed-001",
             message_intent="Notify the accountable repository owner about the reviewed permission change.",
             escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
-            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            expires_at=support.datetime.now(support.timezone.utc)
+            + support.timedelta(hours=4),
             action_request_id="action-request-surface-indexed-lineage-001",
         )
         action_request = service.persist_record(
-            replace(
+            support.replace(
                 action_request,
                 approval_decision_id="approval-surface-missing-indexed-001",
                 lifecycle_state="approved",
             )
         )
         action_execution = service.persist_record(
-            ActionExecutionRecord(
+            support.ActionExecutionRecord(
                 action_execution_id="action-execution-surface-indexed-lineage-001",
                 action_request_id=action_request.action_request_id,
                 approval_decision_id="approval-surface-missing-indexed-001",
@@ -3664,14 +3665,15 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
                 target_scope=dict(action_request.target_scope),
                 approved_payload=dict(action_request.requested_payload),
                 payload_hash=action_request.payload_hash,
-                delegated_at=action_request.requested_at + timedelta(minutes=10),
+                delegated_at=action_request.requested_at
+                + support.timedelta(minutes=10),
                 expires_at=action_request.expires_at,
                 provenance={"initiated_by": "operator-review"},
                 lifecycle_state="queued",
             )
         )
         reconciliation = service.persist_record(
-            ReconciliationRecord(
+            support.ReconciliationRecord(
                 reconciliation_id="reconciliation-surface-indexed-lineage-001",
                 subject_linkage={
                     "case_ids": (promoted_case.case_id,),
@@ -3686,11 +3688,14 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
                     "execution-run-surface-indexed-lineage-observed-001",
                 ),
                 correlation_key="surface-indexed-lineage-001",
-                first_seen_at=action_execution.delegated_at + timedelta(minutes=1),
-                last_seen_at=action_execution.delegated_at + timedelta(minutes=2),
+                first_seen_at=action_execution.delegated_at
+                + support.timedelta(minutes=1),
+                last_seen_at=action_execution.delegated_at
+                + support.timedelta(minutes=2),
                 ingest_disposition="mismatch",
                 mismatch_summary="execution lineage should remain visible without approval lookup",
-                compared_at=action_execution.delegated_at + timedelta(minutes=3),
+                compared_at=action_execution.delegated_at
+                + support.timedelta(minutes=3),
                 lifecycle_state="mismatched",
             )
         )


### PR DESCRIPTION
Closes #476
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the reviewed action-chain inspection on the shared operator snapshot path and committed it as `c89c96d` (`Add reviewed action timeline inspection`).

The change is additive on `current_action_review` / `action_reviews`: each review chain now includes an ordered five-stage `timeline` (`action_request`, `approval_decision`, `delegation`, `action_execution`, `reconciliation`) plus `mismatch_inspection` when reconciliation is still `pending`, `mismatched`, or `stale`. Because alert detail, case detail, and analyst queue already flow through the same action-review snapshot builder, the added surface is available through the existing reviewed entry points without widening the Phase 20 execution model.

Verification passed with:
`python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_phase20_low_risk_action_validation control-plane.tests.test_cli_inspection`

Summary: Added reviewed action timeline and mismatch inspection to the shared operator action-review surface; focused repro test added and passing.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_phase20_low_risk_action_validation control-plane.tests.test_cli_inspection`
Failure signature: none
Next action: Manually inspect queue and alert detail payloads if supervisor wants explicit surface confirmation beyond the passing shared-snapshot te...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspection views now show a five-stage timeline with improved lineage-aware reconciliation selection, clearer mismatch details, and correct binding to retried executions while preserving pre-delegation pending visibility.

* **Tests**
  * Added regression tests covering timeline rendering, mismatch inspection lifecycles, and CLI inspection outputs across cases.

* **Documentation**
  * Added a supervisor journal entry recording the investigation and test notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->