### PR TITLE
implementation: add handoff and manual-fallback runtime visibility for after-hours and unresolved action states (#480)

### DIFF
--- a/.codex-supervisor/issues/480/issue-journal.md
+++ b/.codex-supervisor/issues/480/issue-journal.md
@@ -1,0 +1,50 @@
+# Issue #480: implementation: add handoff and manual-fallback runtime visibility for after-hours and unresolved action states
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/480
+- Branch: codex/issue-480
+- Workspace: .
+- Journal: .codex-supervisor/issues/480/issue-journal.md
+- Current phase: local_review_fix
+- Attempt count: 4 (implementation=1, repair=3)
+- Last head SHA: a9444602c136d7fbeec3a7da59e551b69a81528c
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-15T00:53:47.318Z
+
+## Latest Codex Summary
+Implemented the local-review repair in commit `a944460` (`Add governed action-review visibility writers`).
+
+The fix adds explicit governed write surfaces for action-review `manual_fallback` and `escalation` visibility in the service, CLI, and HTTP operator API, and stores them on the authoritative reviewed record for that request’s scope: case when present, otherwise alert. I also updated the runtime-visibility read path to fall back to alert reviewed context for alert-scoped requests, and gated `after_hours_handoff` off terminal review states so historical completed/rejected/superseded chains stop inheriting the active handoff block.
+
+Focused coverage now uses the supported write path instead of raw `persist_record(replace(... reviewed_context=...))`, and adds regressions for alert-scoped visibility plus suppressing handoff visibility on completed review history. The issue journal’s Codex Working Notes section was updated locally before closing the turn.
+
+Summary: Added governed action-review visibility writers, fixed alert-scoped runtime visibility fallback, and prevented after-hours handoff from bleeding into historical terminal review chains
+State hint: local_review_fix
+Blocked reason: none
+Tests: `python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation control-plane.tests.test_service_persistence_restore_readiness control-plane.tests.test_cli_inspection`
+Next action: Run a fresh local review on commit `a944460` to verify the three saved findings are cleared
+Failure signature: none
+
+## Active Failure Context
+- Category: blocked
+- Summary: Local review found 5 actionable finding(s) across 5 root cause(s); max severity=high; verified high-severity findings=2; verified max severity=high.
+- Details:
+  - findings=5
+  - root_causes=5
+  - summary=<redacted-local-path>
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The remaining blocked findings were the missing approval gate on manual fallback plus record-fidelity gaps in escalation-note visibility; a narrow repair should enforce approved post-approval fallback writes and make escalation visibility depend on a stored note with actor/state snapshots.
+- What changed: Tightened `record_action_review_manual_fallback()` to require an approved decision and reject pending/rejected/expired/superseded chains, and mirrored that guard in the manual-fallback read path so stale bad context cannot render. Made escalation visibility record-driven by requiring stored reviewed-context lineage, persisting `escalated_by_identity` and `review_state` at note time, and returning those stored values instead of synthesizing note visibility from `requested_payload["escalation_reason"]`. Wired the reviewed reverse-proxy HTTP route and CLI command to require/pass `escalated_by_identity`, and updated focused regressions for pending/rejected fallback rejection, stored escalation actor/state fidelity, no-note/no-visibility behavior, and reverse-proxy identity enforcement.
+- Current blocker: none
+- Next exact step: Commit this repair checkpoint and run a fresh local review against the new head to verify the five saved findings are cleared.
+- Verification gap: None in the focused issue slice; the new approval/state and escalation-fidelity regressions pass in the standard issue verification slice.
+- Files touched: `control-plane/aegisops_control_plane/service.py`, `control-plane/aegisops_control_plane/cli.py`, `control-plane/aegisops_control_plane/http_surface.py`, `control-plane/tests/test_cli_inspection.py`, `control-plane/tests/test_phase19_operator_workflow_validation.py`, `control-plane/tests/test_service_persistence_restore_readiness.py`
+- Rollback concern: Low to medium. The repair narrows writer acceptance and changes escalation-note payload requirements, so any rollback would need to preserve the new `escalated_by_identity` / `review_state` expectations in CLI and HTTP callers.
+- Last focused command: `python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation control-plane.tests.test_service_persistence_restore_readiness control-plane.tests.test_cli_inspection`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Added regressions for pending/rejected manual fallback rejection, record-driven escalation visibility, escalation actor/state rendering, and reviewed reverse-proxy escalation identity enforcement.

--- a/control-plane/aegisops_control_plane/cli.py
+++ b/control-plane/aegisops_control_plane/cli.py
@@ -195,6 +195,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     record_action_review_escalation_note.add_argument("--action-request-id", required=True)
     record_action_review_escalation_note.add_argument("--escalated-at", required=True)
+    record_action_review_escalation_note.add_argument(
+        "--escalated-by-identity",
+        required=True,
+    )
     record_action_review_escalation_note.add_argument("--escalated-to", required=True)
     record_action_review_escalation_note.add_argument("--note", required=True)
     create_reviewed_action_request = subparsers.add_parser(
@@ -417,6 +421,7 @@ def run_command(
                 service.record_action_review_escalation_note(
                     action_request_id=action_request_id,
                     escalated_at=parse_datetime_arg(parsed.escalated_at, "escalated_at"),
+                    escalated_by_identity=parsed.escalated_by_identity.strip(),
                     escalated_to=parsed.escalated_to.strip(),
                     note=parsed.note.strip(),
                 )

--- a/control-plane/aegisops_control_plane/cli.py
+++ b/control-plane/aegisops_control_plane/cli.py
@@ -166,6 +166,37 @@ def build_parser() -> argparse.ArgumentParser:
     record_case_disposition.add_argument("--disposition", required=True)
     record_case_disposition.add_argument("--rationale", required=True)
     record_case_disposition.add_argument("--recorded-at", required=True)
+    record_action_review_manual_fallback = subparsers.add_parser(
+        "record-action-review-manual-fallback",
+        help="Record reviewed manual-fallback runtime visibility for one action review.",
+    )
+    record_action_review_manual_fallback.add_argument("--action-request-id", required=True)
+    record_action_review_manual_fallback.add_argument("--fallback-at", required=True)
+    record_action_review_manual_fallback.add_argument(
+        "--fallback-actor-identity",
+        required=True,
+    )
+    record_action_review_manual_fallback.add_argument("--authority-boundary", required=True)
+    record_action_review_manual_fallback.add_argument("--reason", required=True)
+    record_action_review_manual_fallback.add_argument("--action-taken", required=True)
+    record_action_review_manual_fallback.add_argument(
+        "--verification-evidence-id",
+        action="append",
+        default=[],
+        help="Verification evidence identifier to link; may be repeated.",
+    )
+    record_action_review_manual_fallback.add_argument(
+        "--residual-uncertainty",
+        help="Optional unresolved follow-up or uncertainty note.",
+    )
+    record_action_review_escalation_note = subparsers.add_parser(
+        "record-action-review-escalation-note",
+        help="Record reviewed escalation-note visibility for one action review.",
+    )
+    record_action_review_escalation_note.add_argument("--action-request-id", required=True)
+    record_action_review_escalation_note.add_argument("--escalated-at", required=True)
+    record_action_review_escalation_note.add_argument("--escalated-to", required=True)
+    record_action_review_escalation_note.add_argument("--note", required=True)
     create_reviewed_action_request = subparsers.add_parser(
         "create-reviewed-action-request",
         help="Create an approval-bound reviewed action request from cited advisory context.",
@@ -351,6 +382,43 @@ def run_command(
                     disposition=parsed.disposition.strip(),
                     rationale=parsed.rationale.strip(),
                     recorded_at=parse_datetime_arg(parsed.recorded_at, "recorded_at"),
+                )
+            )
+        except (LookupError, ValueError) as exc:
+            _usage_error(parser, str(exc))
+    if command == "record-action-review-manual-fallback":
+        action_request_id = parsed.action_request_id.strip()
+        if not action_request_id:
+            _usage_error(parser, "action_request_id must be a non-empty string")
+        try:
+            return json_ready(
+                service.record_action_review_manual_fallback(
+                    action_request_id=action_request_id,
+                    fallback_at=parse_datetime_arg(parsed.fallback_at, "fallback_at"),
+                    fallback_actor_identity=parsed.fallback_actor_identity.strip(),
+                    authority_boundary=parsed.authority_boundary.strip(),
+                    reason=parsed.reason.strip(),
+                    action_taken=parsed.action_taken.strip(),
+                    verification_evidence_ids=tuple(
+                        evidence_id.strip()
+                        for evidence_id in parsed.verification_evidence_id
+                    ),
+                    residual_uncertainty=normalize_optional_string(parsed.residual_uncertainty),
+                )
+            )
+        except (LookupError, ValueError) as exc:
+            _usage_error(parser, str(exc))
+    if command == "record-action-review-escalation-note":
+        action_request_id = parsed.action_request_id.strip()
+        if not action_request_id:
+            _usage_error(parser, "action_request_id must be a non-empty string")
+        try:
+            return json_ready(
+                service.record_action_review_escalation_note(
+                    action_request_id=action_request_id,
+                    escalated_at=parse_datetime_arg(parsed.escalated_at, "escalated_at"),
+                    escalated_to=parsed.escalated_to.strip(),
+                    note=parsed.note.strip(),
                 )
             )
         except (LookupError, ValueError) as exc:

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -555,6 +555,74 @@ def build_handler_class(
                 self._write_json(HTTPStatus.OK, json_ready(case_record))
                 return
 
+            if request_path == "/operator/record-action-review-manual-fallback":
+                try:
+                    payload = read_json_request_body(self)
+                    if getattr(principal, "access_path", "") == "reviewed_reverse_proxy":
+                        self._require_matching_identity(
+                            principal.identity,
+                            require_json_string(payload, "fallback_actor_identity"),
+                        )
+                    context_record = service.record_action_review_manual_fallback(
+                        action_request_id=require_json_string(payload, "action_request_id"),
+                        fallback_at=require_json_datetime(payload, "fallback_at"),
+                        fallback_actor_identity=require_json_string(
+                            payload,
+                            "fallback_actor_identity",
+                        ),
+                        authority_boundary=require_json_string(
+                            payload,
+                            "authority_boundary",
+                        ),
+                        reason=require_json_string(payload, "reason"),
+                        action_taken=require_json_string(payload, "action_taken"),
+                        verification_evidence_ids=require_json_string_sequence(
+                            payload,
+                            "verification_evidence_ids",
+                        ),
+                        residual_uncertainty=normalize_optional_string(
+                            payload.get("residual_uncertainty")
+                        ),
+                    )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                except (LookupError, ValueError) as exc:
+                    self._write_lookup_or_bad_request(exc)
+                    return
+                self._write_json(HTTPStatus.OK, json_ready(context_record))
+                return
+
+            if request_path == "/operator/record-action-review-escalation-note":
+                try:
+                    payload = read_json_request_body(self)
+                    context_record = service.record_action_review_escalation_note(
+                        action_request_id=require_json_string(payload, "action_request_id"),
+                        escalated_at=require_json_datetime(payload, "escalated_at"),
+                        escalated_to=require_json_string(payload, "escalated_to"),
+                        note=require_json_string(payload, "note"),
+                    )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                except (LookupError, ValueError) as exc:
+                    self._write_lookup_or_bad_request(exc)
+                    return
+                self._write_json(HTTPStatus.OK, json_ready(context_record))
+                return
+
             if request_path == "/operator/create-reviewed-action-request":
                 try:
                     payload = read_json_request_body(self)

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -602,9 +602,18 @@ def build_handler_class(
             if request_path == "/operator/record-action-review-escalation-note":
                 try:
                     payload = read_json_request_body(self)
+                    if getattr(principal, "access_path", "") == "reviewed_reverse_proxy":
+                        self._require_matching_identity(
+                            principal.identity,
+                            require_json_string(payload, "escalated_by_identity"),
+                        )
                     context_record = service.record_action_review_escalation_note(
                         action_request_id=require_json_string(payload, "action_request_id"),
                         escalated_at=require_json_datetime(payload, "escalated_at"),
+                        escalated_by_identity=require_json_string(
+                            payload,
+                            "escalated_by_identity",
+                        ),
                         escalated_to=require_json_string(payload, "escalated_to"),
                         note=require_json_string(payload, "note"),
                     )
@@ -617,8 +626,8 @@ def build_handler_class(
                         },
                     )
                     return
-                except (LookupError, ValueError) as exc:
-                    self._write_lookup_or_bad_request(exc)
+                except (LookupError, PermissionError, ValueError) as exc:
+                    self._write_permission_or_bad_request(exc)
                     return
                 self._write_json(HTTPStatus.OK, json_ready(context_record))
                 return

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -593,8 +593,11 @@ def build_handler_class(
                         },
                     )
                     return
-                except (LookupError, PermissionError, ValueError) as exc:
+                except PermissionError as exc:
                     self._write_permission_or_bad_request(exc)
+                    return
+                except (LookupError, ValueError) as exc:
+                    self._write_lookup_or_bad_request(exc)
                     return
                 self._write_json(HTTPStatus.OK, json_ready(context_record))
                 return
@@ -626,8 +629,11 @@ def build_handler_class(
                         },
                     )
                     return
-                except (LookupError, PermissionError, ValueError) as exc:
+                except PermissionError as exc:
                     self._write_permission_or_bad_request(exc)
+                    return
+                except (LookupError, ValueError) as exc:
+                    self._write_lookup_or_bad_request(exc)
                     return
                 self._write_json(HTTPStatus.OK, json_ready(context_record))
                 return

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -593,8 +593,8 @@ def build_handler_class(
                         },
                     )
                     return
-                except (LookupError, ValueError) as exc:
-                    self._write_lookup_or_bad_request(exc)
+                except (LookupError, PermissionError, ValueError) as exc:
+                    self._write_permission_or_bad_request(exc)
                     return
                 self._write_json(HTTPStatus.OK, json_ready(context_record))
                 return

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1759,7 +1759,11 @@ class AegisOpsControlPlaneService:
         review_state: str,
         allow_unscoped_context: bool,
     ) -> dict[str, object] | None:
-        manual_fallback = reviewed_context.get("manual_fallback")
+        manual_fallback = AegisOpsControlPlaneService._action_review_visibility_entry(
+            reviewed_context=reviewed_context,
+            action_request_id=action_request.action_request_id,
+            context_key="manual_fallback",
+        )
         if not isinstance(manual_fallback, Mapping):
             return None
 
@@ -1814,7 +1818,11 @@ class AegisOpsControlPlaneService:
         allow_unscoped_context: bool,
     ) -> dict[str, object] | None:
         requested_payload = action_request.requested_payload
-        escalation_context = reviewed_context.get("escalation")
+        escalation_context = AegisOpsControlPlaneService._action_review_visibility_entry(
+            reviewed_context=reviewed_context,
+            action_request_id=action_request.action_request_id,
+            context_key="escalation",
+        )
         if not isinstance(escalation_context, Mapping):
             return None
 
@@ -1883,6 +1891,40 @@ class AegisOpsControlPlaneService:
                 and scoped_approval_decision_id == approval_decision_id
             )
         return True
+
+    @staticmethod
+    def _action_review_visibility_entry(
+        *,
+        reviewed_context: Mapping[str, object],
+        action_request_id: str,
+        context_key: str,
+    ) -> Mapping[str, object] | None:
+        action_review_visibility = reviewed_context.get("action_review_visibility")
+        if isinstance(action_review_visibility, Mapping):
+            scoped_visibility = action_review_visibility.get(action_request_id)
+            if isinstance(scoped_visibility, Mapping):
+                scoped_entry = scoped_visibility.get(context_key)
+                if isinstance(scoped_entry, Mapping):
+                    return scoped_entry
+        legacy_entry = reviewed_context.get(context_key)
+        if isinstance(legacy_entry, Mapping):
+            return legacy_entry
+        return None
+
+    @staticmethod
+    def _action_review_visibility_update(
+        *,
+        action_request_id: str,
+        context_key: str,
+        context_value: Mapping[str, object],
+    ) -> dict[str, object]:
+        return {
+            "action_review_visibility": {
+                action_request_id: {
+                    context_key: dict(context_value),
+                }
+            }
+        }
 
     def _case_has_single_review_bound_action_request(
         self,
@@ -3009,7 +3051,11 @@ class AegisOpsControlPlaneService:
                 )
             return self._persist_action_review_visibility_context_record(
                 context_record=context_record,
-                reviewed_context_update={"manual_fallback": manual_fallback_context},
+                reviewed_context_update=self._action_review_visibility_update(
+                    action_request_id=action_request.action_request_id,
+                    context_key="manual_fallback",
+                    context_value=manual_fallback_context,
+                ),
             )
 
     def record_action_review_escalation_note(
@@ -3057,7 +3103,11 @@ class AegisOpsControlPlaneService:
                 )
             return self._persist_action_review_visibility_context_record(
                 context_record=context_record,
-                reviewed_context_update={"escalation": escalation_context},
+                reviewed_context_update=self._action_review_visibility_update(
+                    action_request_id=action_request.action_request_id,
+                    context_key="escalation",
+                    context_value=escalation_context,
+                ),
             )
 
     def inspect_advisory_output(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1673,6 +1673,7 @@ class AegisOpsControlPlaneService:
             reviewed_context=reviewed_context,
             action_request=action_request,
             approval_decision=approval_decision,
+            review_state=review_state,
             allow_unscoped_context=allow_unscoped_action_visibility,
         )
         if manual_fallback is not None:
@@ -1755,6 +1756,7 @@ class AegisOpsControlPlaneService:
         reviewed_context: Mapping[str, object],
         action_request: ActionRequestRecord,
         approval_decision: ApprovalDecisionRecord | None,
+        review_state: str,
         allow_unscoped_context: bool,
     ) -> dict[str, object] | None:
         manual_fallback = reviewed_context.get("manual_fallback")
@@ -1766,6 +1768,12 @@ class AegisOpsControlPlaneService:
             if approval_decision is not None
             else action_request.approval_decision_id
         )
+        if (
+            approval_decision is None
+            or approval_decision.lifecycle_state != "approved"
+            or review_state in {"pending", "rejected", "expired", "superseded"}
+        ):
+            return None
         if not AegisOpsControlPlaneService._action_review_context_matches_lineage(
             visibility_context=manual_fallback,
             action_request_id=action_request.action_request_id,
@@ -1807,9 +1815,7 @@ class AegisOpsControlPlaneService:
     ) -> dict[str, object] | None:
         requested_payload = action_request.requested_payload
         escalation_context = reviewed_context.get("escalation")
-        if not isinstance(escalation_context, Mapping) and not requested_payload.get(
-            "escalation_reason"
-        ):
+        if not isinstance(escalation_context, Mapping):
             return None
 
         approval_decision_id = (
@@ -1817,31 +1823,37 @@ class AegisOpsControlPlaneService:
             if approval_decision is not None
             else action_request.approval_decision_id
         )
+        if not AegisOpsControlPlaneService._action_review_context_matches_lineage(
+            visibility_context=escalation_context,
+            action_request_id=action_request.action_request_id,
+            approval_decision_id=approval_decision_id,
+            allow_unscoped_context=allow_unscoped_context,
+        ):
+            return None
+
+        recorded_review_state = escalation_context.get("review_state")
         visibility: dict[str, object] = {
             "action_request_id": action_request.action_request_id,
             "approval_decision_id": approval_decision_id,
             "requester_identity": action_request.requester_identity,
-            "review_state": review_state,
+            "review_state": (
+                recorded_review_state
+                if isinstance(recorded_review_state, str) and recorded_review_state.strip()
+                else review_state
+            ),
         }
         escalation_reason = requested_payload.get("escalation_reason")
         if escalation_reason is not None:
             visibility["escalation_reason"] = escalation_reason
-        if isinstance(escalation_context, Mapping):
-            if not AegisOpsControlPlaneService._action_review_context_matches_lineage(
-                visibility_context=escalation_context,
-                action_request_id=action_request.action_request_id,
-                approval_decision_id=approval_decision_id,
-                allow_unscoped_context=allow_unscoped_context,
-            ):
-                return visibility if escalation_reason is not None else None
-            for source_key, target_key in (
-                ("escalated_at", "escalated_at"),
-                ("escalated_to", "escalated_to"),
-                ("note", "note"),
-            ):
-                value = escalation_context.get(source_key)
-                if value is not None:
-                    visibility[target_key] = value
+        for source_key, target_key in (
+            ("escalated_at", "escalated_at"),
+            ("escalated_to", "escalated_to"),
+            ("escalated_by_identity", "escalated_by_identity"),
+            ("note", "note"),
+        ):
+            value = escalation_context.get(source_key)
+            if value is not None:
+                visibility[target_key] = value
         return visibility
 
     @staticmethod
@@ -2948,6 +2960,24 @@ class AegisOpsControlPlaneService:
         )
         with self._store.transaction():
             action_request = self._require_review_bound_action_request(action_request_id)
+            approval_decision = self._action_review_approval_decision(action_request)
+            approval_state = self._action_review_approval_state(
+                action_request=action_request,
+                approval_decision=approval_decision,
+            )
+            review_state = self._action_review_state(
+                action_request=action_request,
+                approval_state=approval_state,
+                action_execution=self._action_review_execution(action_request),
+            )
+            if (
+                approval_decision is None
+                or approval_decision.lifecycle_state != "approved"
+                or review_state in {"pending", "rejected", "expired", "superseded"}
+            ):
+                raise ValueError(
+                    "manual fallback requires an approved action review in a live post-approval state"
+                )
             context_record = self._require_action_review_visibility_context_record(
                 action_request
             )
@@ -2965,6 +2995,7 @@ class AegisOpsControlPlaneService:
                 )
             manual_fallback_context: dict[str, object] = {
                 "action_request_id": action_request.action_request_id,
+                "approval_decision_id": approval_decision.approval_decision_id,
                 "fallback_at": fallback_at.isoformat(),
                 "fallback_actor_identity": fallback_actor_identity,
                 "authority_boundary": authority_boundary,
@@ -2972,10 +3003,6 @@ class AegisOpsControlPlaneService:
                 "action_taken": action_taken,
                 "verification_evidence_ids": normalized_evidence_ids,
             }
-            if action_request.approval_decision_id is not None:
-                manual_fallback_context["approval_decision_id"] = (
-                    action_request.approval_decision_id
-                )
             if normalized_residual_uncertainty is not None:
                 manual_fallback_context["residual_uncertainty"] = (
                     normalized_residual_uncertainty
@@ -2990,26 +3017,43 @@ class AegisOpsControlPlaneService:
         *,
         action_request_id: str,
         escalated_at: datetime,
+        escalated_by_identity: str,
         escalated_to: str,
         note: str,
     ) -> CaseRecord | AlertRecord:
         escalated_at = self._require_aware_datetime(escalated_at, "escalated_at")
+        escalated_by_identity = self._require_non_empty_string(
+            escalated_by_identity,
+            "escalated_by_identity",
+        )
         escalated_to = self._require_non_empty_string(escalated_to, "escalated_to")
         note = self._require_non_empty_string(note, "note")
         with self._store.transaction():
             action_request = self._require_review_bound_action_request(action_request_id)
+            approval_decision = self._action_review_approval_decision(action_request)
+            approval_state = self._action_review_approval_state(
+                action_request=action_request,
+                approval_decision=approval_decision,
+            )
+            review_state = self._action_review_state(
+                action_request=action_request,
+                approval_state=approval_state,
+                action_execution=self._action_review_execution(action_request),
+            )
             context_record = self._require_action_review_visibility_context_record(
                 action_request
             )
             escalation_context: dict[str, object] = {
                 "action_request_id": action_request.action_request_id,
                 "escalated_at": escalated_at.isoformat(),
+                "escalated_by_identity": escalated_by_identity,
                 "escalated_to": escalated_to,
                 "note": note,
+                "review_state": review_state,
             }
-            if action_request.approval_decision_id is not None:
+            if approval_decision is not None:
                 escalation_context["approval_decision_id"] = (
-                    action_request.approval_decision_id
+                    approval_decision.approval_decision_id
                 )
             return self._persist_action_review_visibility_context_record(
                 context_record=context_record,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4888,7 +4888,9 @@ class AegisOpsControlPlaneService:
             evidence = self._store.get(EvidenceRecord, evidence_id)
             if evidence is None:
                 raise LookupError(f"Missing evidence {evidence_id!r}")
-            if evidence.alert_id != alert.alert_id and evidence.case_id != alert.case_id:
+            shares_alert = evidence.alert_id == alert.alert_id
+            shares_case = alert.case_id is not None and evidence.case_id == alert.case_id
+            if not shares_alert and not shares_case:
                 raise ValueError(
                     f"{field_name} contains evidence {evidence_id!r} that is not "
                     f"linked to alert {alert.alert_id!r}"

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1653,15 +1653,8 @@ class AegisOpsControlPlaneService:
         review_state: str,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> dict[str, object] | None:
-        case = (
-            self._store.get(CaseRecord, action_request.case_id)
-            if action_request.case_id is not None
-            else None
-        )
-        if case is None:
-            return None
-        reviewed_context = case.reviewed_context
-        if not isinstance(reviewed_context, Mapping):
+        reviewed_context = self._action_review_visibility_context(action_request)
+        if reviewed_context is None:
             return None
 
         allow_unscoped_action_visibility = self._case_has_single_review_bound_action_request(
@@ -1671,6 +1664,7 @@ class AegisOpsControlPlaneService:
         visibility: dict[str, object] = {}
         after_hours_handoff = self._action_review_after_hours_handoff_visibility(
             reviewed_context=reviewed_context,
+            review_state=review_state,
         )
         if after_hours_handoff is not None:
             visibility["after_hours_handoff"] = after_hours_handoff
@@ -1700,7 +1694,10 @@ class AegisOpsControlPlaneService:
     def _action_review_after_hours_handoff_visibility(
         *,
         reviewed_context: Mapping[str, object],
+        review_state: str,
     ) -> dict[str, object] | None:
+        if review_state in {"completed", "failed", "expired", "rejected", "superseded", "canceled"}:
+            return None
         handoff = reviewed_context.get("handoff")
         triage = reviewed_context.get("triage")
         if not isinstance(handoff, Mapping) and not isinstance(triage, Mapping):
@@ -1731,6 +1728,26 @@ class AegisOpsControlPlaneService:
             if rationale is not None:
                 visibility["rationale"] = rationale
         return visibility or None
+
+    def _action_review_visibility_context(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> Mapping[str, object] | None:
+        case = (
+            self._store.get(CaseRecord, action_request.case_id)
+            if action_request.case_id is not None
+            else None
+        )
+        alert = (
+            self._store.get(AlertRecord, action_request.alert_id)
+            if action_request.alert_id is not None
+            else None
+        )
+        if case is not None and isinstance(case.reviewed_context, Mapping):
+            return case.reviewed_context
+        if alert is not None and isinstance(alert.reviewed_context, Mapping):
+            return alert.reviewed_context
+        return None
 
     @staticmethod
     def _action_review_manual_fallback_visibility(
@@ -2897,6 +2914,107 @@ class AegisOpsControlPlaneService:
                         )
                     )
         return updated_case
+
+    def record_action_review_manual_fallback(
+        self,
+        *,
+        action_request_id: str,
+        fallback_at: datetime,
+        fallback_actor_identity: str,
+        authority_boundary: str,
+        reason: str,
+        action_taken: str,
+        verification_evidence_ids: tuple[str, ...] = (),
+        residual_uncertainty: str | None = None,
+    ) -> CaseRecord | AlertRecord:
+        fallback_at = self._require_aware_datetime(fallback_at, "fallback_at")
+        fallback_actor_identity = self._require_non_empty_string(
+            fallback_actor_identity,
+            "fallback_actor_identity",
+        )
+        authority_boundary = self._require_non_empty_string(
+            authority_boundary,
+            "authority_boundary",
+        )
+        reason = self._require_non_empty_string(reason, "reason")
+        action_taken = self._require_non_empty_string(action_taken, "action_taken")
+        normalized_evidence_ids = self._normalize_linked_record_ids(
+            verification_evidence_ids,
+            "verification_evidence_ids",
+        )
+        normalized_residual_uncertainty = self._normalize_optional_string(
+            residual_uncertainty,
+            "residual_uncertainty",
+        )
+        with self._store.transaction():
+            action_request = self._require_review_bound_action_request(action_request_id)
+            context_record = self._require_action_review_visibility_context_record(
+                action_request
+            )
+            if isinstance(context_record, CaseRecord):
+                self._validate_case_evidence_linkage(
+                    case=context_record,
+                    evidence_ids=normalized_evidence_ids,
+                    field_name="verification_evidence_ids",
+                )
+            else:
+                self._validate_alert_evidence_linkage(
+                    alert=context_record,
+                    evidence_ids=normalized_evidence_ids,
+                    field_name="verification_evidence_ids",
+                )
+            manual_fallback_context: dict[str, object] = {
+                "action_request_id": action_request.action_request_id,
+                "fallback_at": fallback_at.isoformat(),
+                "fallback_actor_identity": fallback_actor_identity,
+                "authority_boundary": authority_boundary,
+                "reason": reason,
+                "action_taken": action_taken,
+                "verification_evidence_ids": normalized_evidence_ids,
+            }
+            if action_request.approval_decision_id is not None:
+                manual_fallback_context["approval_decision_id"] = (
+                    action_request.approval_decision_id
+                )
+            if normalized_residual_uncertainty is not None:
+                manual_fallback_context["residual_uncertainty"] = (
+                    normalized_residual_uncertainty
+                )
+            return self._persist_action_review_visibility_context_record(
+                context_record=context_record,
+                reviewed_context_update={"manual_fallback": manual_fallback_context},
+            )
+
+    def record_action_review_escalation_note(
+        self,
+        *,
+        action_request_id: str,
+        escalated_at: datetime,
+        escalated_to: str,
+        note: str,
+    ) -> CaseRecord | AlertRecord:
+        escalated_at = self._require_aware_datetime(escalated_at, "escalated_at")
+        escalated_to = self._require_non_empty_string(escalated_to, "escalated_to")
+        note = self._require_non_empty_string(note, "note")
+        with self._store.transaction():
+            action_request = self._require_review_bound_action_request(action_request_id)
+            context_record = self._require_action_review_visibility_context_record(
+                action_request
+            )
+            escalation_context: dict[str, object] = {
+                "action_request_id": action_request.action_request_id,
+                "escalated_at": escalated_at.isoformat(),
+                "escalated_to": escalated_to,
+                "note": note,
+            }
+            if action_request.approval_decision_id is not None:
+                escalation_context["approval_decision_id"] = (
+                    action_request.approval_decision_id
+                )
+            return self._persist_action_review_visibility_context_record(
+                context_record=context_record,
+                reviewed_context_update={"escalation": escalation_context},
+            )
 
     def inspect_advisory_output(
         self,
@@ -4494,6 +4612,75 @@ class AegisOpsControlPlaneService:
             raise LookupError(f"Missing case {case_id!r}")
         return case
 
+    def _require_action_request_record(self, action_request_id: str) -> ActionRequestRecord:
+        action_request_id = self._require_non_empty_string(
+            action_request_id,
+            "action_request_id",
+        )
+        action_request = self._store.get(ActionRequestRecord, action_request_id)
+        if action_request is None:
+            raise LookupError(f"Missing action request {action_request_id!r}")
+        return action_request
+
+    def _require_review_bound_action_request(
+        self,
+        action_request_id: str,
+    ) -> ActionRequestRecord:
+        action_request = self._require_action_request_record(action_request_id)
+        if not self._action_request_is_review_bound(action_request):
+            raise ValueError(
+                "action_request_id must reference a reviewed action request"
+            )
+        return action_request
+
+    def _require_action_review_visibility_context_record(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> CaseRecord | AlertRecord:
+        if action_request.case_id is not None:
+            return self._require_reviewed_operator_case(action_request.case_id)
+        if action_request.alert_id is None:
+            raise ValueError(
+                "reviewed action request must be linked to a case or alert before "
+                "recording runtime visibility"
+            )
+        alert = self._store.get(AlertRecord, action_request.alert_id)
+        if alert is None:
+            raise LookupError(f"Missing alert {action_request.alert_id!r}")
+        return alert
+
+    def _persist_action_review_visibility_context_record(
+        self,
+        *,
+        context_record: CaseRecord | AlertRecord,
+        reviewed_context_update: Mapping[str, object],
+    ) -> CaseRecord | AlertRecord:
+        updated_reviewed_context = _merge_reviewed_context(
+            context_record.reviewed_context,
+            reviewed_context_update,
+        )
+        if isinstance(context_record, CaseRecord):
+            return self.persist_record(
+                CaseRecord(
+                    case_id=context_record.case_id,
+                    alert_id=context_record.alert_id,
+                    finding_id=context_record.finding_id,
+                    evidence_ids=context_record.evidence_ids,
+                    lifecycle_state=context_record.lifecycle_state,
+                    reviewed_context=updated_reviewed_context,
+                )
+            )
+        return self.persist_record(
+            AlertRecord(
+                alert_id=context_record.alert_id,
+                finding_id=context_record.finding_id,
+                analytic_signal_id=context_record.analytic_signal_id,
+                case_id=context_record.case_id,
+                lifecycle_state=context_record.lifecycle_state,
+                reviewed_context=updated_reviewed_context,
+            )
+        )
+
     def _require_reviewed_operator_case(self, case_id: str) -> CaseRecord:
         return self._reviewed_slice_policy.require_operator_case(case_id)
 
@@ -4594,6 +4781,23 @@ class AegisOpsControlPlaneService:
                 raise ValueError(
                     f"{field_name} contains evidence {evidence_id!r} that is not "
                     f"linked to case {case.case_id!r} or its source alert"
+                )
+
+    def _validate_alert_evidence_linkage(
+        self,
+        *,
+        alert: AlertRecord,
+        evidence_ids: tuple[str, ...],
+        field_name: str,
+    ) -> None:
+        for evidence_id in evidence_ids:
+            evidence = self._store.get(EvidenceRecord, evidence_id)
+            if evidence is None:
+                raise LookupError(f"Missing evidence {evidence_id!r}")
+            if evidence.alert_id != alert.alert_id and evidence.case_id != alert.case_id:
+                raise ValueError(
+                    f"{field_name} contains evidence {evidence_id!r} that is not "
+                    f"linked to alert {alert.alert_id!r}"
                 )
 
     def _observations_for_case(self, case_id: str) -> tuple[ObservationRecord, ...]:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -51,6 +51,13 @@ from .reviewed_slice_policy import (
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
 
+_AFTER_HOURS_HANDOFF_TRIAGE_DISPOSITIONS = frozenset(
+    {
+        "business_hours_handoff",
+        "awaiting_business_hours_review",
+    }
+)
+
 
 class ControlPlaneStore(Protocol):
     dsn: str
@@ -1701,7 +1708,11 @@ class AegisOpsControlPlaneService:
             return None
         handoff = reviewed_context.get("handoff")
         triage = reviewed_context.get("triage")
-        if not isinstance(handoff, Mapping) and not isinstance(triage, Mapping):
+        triage_disposition = triage.get("disposition") if isinstance(triage, Mapping) else None
+        if (
+            not isinstance(handoff, Mapping)
+            and triage_disposition not in _AFTER_HOURS_HANDOFF_TRIAGE_DISPOSITIONS
+        ):
             return None
 
         visibility: dict[str, object] = {}
@@ -1715,7 +1726,10 @@ class AegisOpsControlPlaneService:
                 value = handoff.get(source_key)
                 if value is not None:
                     visibility[target_key] = value
-        if isinstance(triage, Mapping):
+        if (
+            isinstance(triage, Mapping)
+            and triage_disposition in _AFTER_HOURS_HANDOFF_TRIAGE_DISPOSITIONS
+        ):
             for source_key, target_key in (
                 ("disposition", "disposition"),
                 ("recorded_at", "recorded_at"),

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1816,10 +1816,11 @@ class AegisOpsControlPlaneService:
             ("residual_uncertainty", "residual_uncertainty"),
         ):
             value = manual_fallback.get(source_key)
-            if value is not None and target_key not in visibility:
-                visibility[target_key] = value
-            elif value is not None:
-                visibility[target_key] = value
+            if value is None:
+                continue
+            if source_key == "performed_at" and target_key in visibility:
+                continue
+            visibility[target_key] = value
         return visibility
 
     @staticmethod

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1572,6 +1572,11 @@ class AegisOpsControlPlaneService:
             record_index=record_index,
         )
         requested_payload = dict(action_request.requested_payload)
+        runtime_visibility = self._action_review_runtime_visibility(
+            action_request=action_request,
+            approval_decision=approval_decision,
+            review_state=review_state,
+        )
 
         return {
             "review_state": review_state,
@@ -1596,6 +1601,7 @@ class AegisOpsControlPlaneService:
             "recipient_identity": requested_payload.get("recipient_identity"),
             "message_intent": requested_payload.get("message_intent"),
             "escalation_reason": requested_payload.get("escalation_reason"),
+            "runtime_visibility": runtime_visibility,
             "execution_surface_type": (
                 action_execution.execution_surface_type
                 if action_execution is not None
@@ -1637,6 +1643,157 @@ class AegisOpsControlPlaneService:
                 else None
             ),
         }
+
+    def _action_review_runtime_visibility(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord | None,
+        review_state: str,
+    ) -> dict[str, object] | None:
+        case = (
+            self._store.get(CaseRecord, action_request.case_id)
+            if action_request.case_id is not None
+            else None
+        )
+        if case is None:
+            return None
+        reviewed_context = case.reviewed_context
+        if not isinstance(reviewed_context, Mapping):
+            return None
+
+        visibility: dict[str, object] = {}
+        after_hours_handoff = self._action_review_after_hours_handoff_visibility(
+            reviewed_context=reviewed_context,
+        )
+        if after_hours_handoff is not None:
+            visibility["after_hours_handoff"] = after_hours_handoff
+
+        manual_fallback = self._action_review_manual_fallback_visibility(
+            reviewed_context=reviewed_context,
+            action_request=action_request,
+            approval_decision=approval_decision,
+        )
+        if manual_fallback is not None:
+            visibility["manual_fallback"] = manual_fallback
+
+        escalation_notes = self._action_review_escalation_visibility(
+            reviewed_context=reviewed_context,
+            action_request=action_request,
+            approval_decision=approval_decision,
+            review_state=review_state,
+        )
+        if escalation_notes is not None:
+            visibility["escalation_notes"] = escalation_notes
+
+        return visibility or None
+
+    @staticmethod
+    def _action_review_after_hours_handoff_visibility(
+        *,
+        reviewed_context: Mapping[str, object],
+    ) -> dict[str, object] | None:
+        handoff = reviewed_context.get("handoff")
+        triage = reviewed_context.get("triage")
+        if not isinstance(handoff, Mapping) and not isinstance(triage, Mapping):
+            return None
+
+        visibility: dict[str, object] = {}
+        if isinstance(handoff, Mapping):
+            for source_key, target_key in (
+                ("handoff_at", "handoff_at"),
+                ("handoff_owner", "handoff_owner"),
+                ("note", "note"),
+                ("follow_up_evidence_ids", "follow_up_evidence_ids"),
+            ):
+                value = handoff.get(source_key)
+                if value is not None:
+                    visibility[target_key] = value
+        if isinstance(triage, Mapping):
+            for source_key, target_key in (
+                ("disposition", "disposition"),
+                ("rationale", "rationale"),
+                ("recorded_at", "recorded_at"),
+            ):
+                value = triage.get(source_key)
+                if value is not None:
+                    visibility[target_key] = value
+        return visibility or None
+
+    @staticmethod
+    def _action_review_manual_fallback_visibility(
+        *,
+        reviewed_context: Mapping[str, object],
+        action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord | None,
+    ) -> dict[str, object] | None:
+        manual_fallback = reviewed_context.get("manual_fallback")
+        if not isinstance(manual_fallback, Mapping):
+            return None
+
+        visibility: dict[str, object] = {
+            "action_request_id": action_request.action_request_id,
+            "approval_decision_id": (
+                approval_decision.approval_decision_id
+                if approval_decision is not None
+                else action_request.approval_decision_id
+            ),
+        }
+        for source_key, target_key in (
+            ("fallback_at", "fallback_at"),
+            ("performed_at", "fallback_at"),
+            ("fallback_actor_identity", "fallback_actor_identity"),
+            ("authority_boundary", "authority_boundary"),
+            ("reason", "reason"),
+            ("action_taken", "action_taken"),
+            ("verification_evidence_ids", "verification_evidence_ids"),
+            ("residual_uncertainty", "residual_uncertainty"),
+        ):
+            value = manual_fallback.get(source_key)
+            if value is not None and target_key not in visibility:
+                visibility[target_key] = value
+            elif value is not None:
+                visibility[target_key] = value
+        return visibility
+
+    @staticmethod
+    def _action_review_escalation_visibility(
+        *,
+        reviewed_context: Mapping[str, object],
+        action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord | None,
+        review_state: str,
+    ) -> dict[str, object] | None:
+        requested_payload = action_request.requested_payload
+        escalation_context = reviewed_context.get("escalation")
+        if not isinstance(escalation_context, Mapping) and not requested_payload.get(
+            "escalation_reason"
+        ):
+            return None
+
+        visibility: dict[str, object] = {
+            "action_request_id": action_request.action_request_id,
+            "approval_decision_id": (
+                approval_decision.approval_decision_id
+                if approval_decision is not None
+                else action_request.approval_decision_id
+            ),
+            "requester_identity": action_request.requester_identity,
+            "review_state": review_state,
+        }
+        escalation_reason = requested_payload.get("escalation_reason")
+        if escalation_reason is not None:
+            visibility["escalation_reason"] = escalation_reason
+        if isinstance(escalation_context, Mapping):
+            for source_key, target_key in (
+                ("escalated_at", "escalated_at"),
+                ("escalated_to", "escalated_to"),
+                ("note", "note"),
+            ):
+                value = escalation_context.get(source_key)
+                if value is not None:
+                    visibility[target_key] = value
+        return visibility
 
     def _action_review_approval_decision(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1576,6 +1576,7 @@ class AegisOpsControlPlaneService:
             action_request=action_request,
             approval_decision=approval_decision,
             review_state=review_state,
+            record_index=record_index,
         )
 
         return {
@@ -1650,6 +1651,7 @@ class AegisOpsControlPlaneService:
         action_request: ActionRequestRecord,
         approval_decision: ApprovalDecisionRecord | None,
         review_state: str,
+        record_index: _ActionReviewRecordIndex | None = None,
     ) -> dict[str, object] | None:
         case = (
             self._store.get(CaseRecord, action_request.case_id)
@@ -1662,6 +1664,10 @@ class AegisOpsControlPlaneService:
         if not isinstance(reviewed_context, Mapping):
             return None
 
+        allow_unscoped_action_visibility = self._case_has_single_review_bound_action_request(
+            action_request.case_id,
+            record_index=record_index,
+        )
         visibility: dict[str, object] = {}
         after_hours_handoff = self._action_review_after_hours_handoff_visibility(
             reviewed_context=reviewed_context,
@@ -1673,6 +1679,7 @@ class AegisOpsControlPlaneService:
             reviewed_context=reviewed_context,
             action_request=action_request,
             approval_decision=approval_decision,
+            allow_unscoped_context=allow_unscoped_action_visibility,
         )
         if manual_fallback is not None:
             visibility["manual_fallback"] = manual_fallback
@@ -1682,6 +1689,7 @@ class AegisOpsControlPlaneService:
             action_request=action_request,
             approval_decision=approval_decision,
             review_state=review_state,
+            allow_unscoped_context=allow_unscoped_action_visibility,
         )
         if escalation_notes is not None:
             visibility["escalation_notes"] = escalation_notes
@@ -1712,12 +1720,16 @@ class AegisOpsControlPlaneService:
         if isinstance(triage, Mapping):
             for source_key, target_key in (
                 ("disposition", "disposition"),
-                ("rationale", "rationale"),
                 ("recorded_at", "recorded_at"),
             ):
                 value = triage.get(source_key)
                 if value is not None:
                     visibility[target_key] = value
+            rationale = triage.get("closure_rationale")
+            if rationale is None:
+                rationale = triage.get("rationale")
+            if rationale is not None:
+                visibility["rationale"] = rationale
         return visibility or None
 
     @staticmethod
@@ -1726,19 +1738,30 @@ class AegisOpsControlPlaneService:
         reviewed_context: Mapping[str, object],
         action_request: ActionRequestRecord,
         approval_decision: ApprovalDecisionRecord | None,
+        allow_unscoped_context: bool,
     ) -> dict[str, object] | None:
         manual_fallback = reviewed_context.get("manual_fallback")
         if not isinstance(manual_fallback, Mapping):
             return None
 
-        visibility: dict[str, object] = {
-            "action_request_id": action_request.action_request_id,
-            "approval_decision_id": (
-                approval_decision.approval_decision_id
-                if approval_decision is not None
-                else action_request.approval_decision_id
-            ),
-        }
+        approval_decision_id = (
+            approval_decision.approval_decision_id
+            if approval_decision is not None
+            else action_request.approval_decision_id
+        )
+        if not AegisOpsControlPlaneService._action_review_context_matches_lineage(
+            visibility_context=manual_fallback,
+            action_request_id=action_request.action_request_id,
+            approval_decision_id=approval_decision_id,
+            allow_unscoped_context=allow_unscoped_context,
+        ):
+            return None
+
+        visibility: dict[str, object] = {}
+        for source_key in ("action_request_id", "approval_decision_id"):
+            value = manual_fallback.get(source_key)
+            if value is not None:
+                visibility[source_key] = value
         for source_key, target_key in (
             ("fallback_at", "fallback_at"),
             ("performed_at", "fallback_at"),
@@ -1763,6 +1786,7 @@ class AegisOpsControlPlaneService:
         action_request: ActionRequestRecord,
         approval_decision: ApprovalDecisionRecord | None,
         review_state: str,
+        allow_unscoped_context: bool,
     ) -> dict[str, object] | None:
         requested_payload = action_request.requested_payload
         escalation_context = reviewed_context.get("escalation")
@@ -1771,13 +1795,14 @@ class AegisOpsControlPlaneService:
         ):
             return None
 
+        approval_decision_id = (
+            approval_decision.approval_decision_id
+            if approval_decision is not None
+            else action_request.approval_decision_id
+        )
         visibility: dict[str, object] = {
             "action_request_id": action_request.action_request_id,
-            "approval_decision_id": (
-                approval_decision.approval_decision_id
-                if approval_decision is not None
-                else action_request.approval_decision_id
-            ),
+            "approval_decision_id": approval_decision_id,
             "requester_identity": action_request.requester_identity,
             "review_state": review_state,
         }
@@ -1785,6 +1810,13 @@ class AegisOpsControlPlaneService:
         if escalation_reason is not None:
             visibility["escalation_reason"] = escalation_reason
         if isinstance(escalation_context, Mapping):
+            if not AegisOpsControlPlaneService._action_review_context_matches_lineage(
+                visibility_context=escalation_context,
+                action_request_id=action_request.action_request_id,
+                approval_decision_id=approval_decision_id,
+                allow_unscoped_context=allow_unscoped_context,
+            ):
+                return visibility if escalation_reason is not None else None
             for source_key, target_key in (
                 ("escalated_at", "escalated_at"),
                 ("escalated_to", "escalated_to"),
@@ -1794,6 +1826,57 @@ class AegisOpsControlPlaneService:
                 if value is not None:
                     visibility[target_key] = value
         return visibility
+
+    @staticmethod
+    def _action_review_context_matches_lineage(
+        *,
+        visibility_context: Mapping[str, object],
+        action_request_id: str,
+        approval_decision_id: str | None,
+        allow_unscoped_context: bool,
+    ) -> bool:
+        scoped_action_request_id = visibility_context.get("action_request_id")
+        scoped_approval_decision_id = visibility_context.get("approval_decision_id")
+
+        if scoped_action_request_id is None:
+            if scoped_approval_decision_id is not None:
+                return (
+                    approval_decision_id is not None
+                    and scoped_approval_decision_id == approval_decision_id
+                )
+            return allow_unscoped_context
+
+        if scoped_action_request_id != action_request_id:
+            return False
+        if scoped_approval_decision_id is not None:
+            return (
+                approval_decision_id is not None
+                and scoped_approval_decision_id == approval_decision_id
+            )
+        return True
+
+    def _case_has_single_review_bound_action_request(
+        self,
+        case_id: str | None,
+        *,
+        record_index: _ActionReviewRecordIndex | None = None,
+    ) -> bool:
+        if case_id is None:
+            return False
+        if record_index is not None:
+            matching_requests = record_index.requests_by_case_id.get(case_id, ())
+        else:
+            matching_requests = tuple(
+                record
+                for record in self._store.list(ActionRequestRecord)
+                if record.case_id == case_id
+            )
+        review_bound_count = sum(
+            1
+            for record in matching_requests
+            if self._action_request_is_review_bound(record)
+        )
+        return review_bound_count == 1
 
     def _action_review_approval_decision(
         self,

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -3389,6 +3389,121 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         review = payload["current_action_review"]
         self._assert_review_timeline_snapshot(review, seeded)
 
+    def test_cli_inspect_case_detail_renders_handoff_and_manual_fallback_visibility(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Waiting until the next business-hours cycle is unsafe for this repository owner change.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-cli-visibility-001",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-visibility-001",
+                action_request_id=request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(request.target_scope),
+                payload_hash=request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                request,
+                approval_decision_id=approval.approval_decision_id,
+                lifecycle_state="unresolved",
+            )
+        )
+        service.persist_record(
+            replace(
+                promoted_case,
+                reviewed_context={
+                    **dict(promoted_case.reviewed_context),
+                    "handoff": {
+                        "handoff_at": (reviewed_at + timedelta(hours=8)).isoformat(),
+                        "handoff_owner": "analyst-002",
+                        "note": "Resume the approval and fallback review at next business-hours open.",
+                        "follow_up_evidence_ids": (evidence_id,),
+                    },
+                    "triage": {
+                        "disposition": "business_hours_handoff",
+                        "rationale": "The reviewed action remains unresolved and must stay visible for the next analyst.",
+                        "recorded_at": (reviewed_at + timedelta(hours=8)).isoformat(),
+                    },
+                    "manual_fallback": {
+                        "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
+                        "fallback_actor_identity": "analyst-003",
+                        "authority_boundary": "approved_human_fallback",
+                        "reason": "The reviewed automation path was unavailable after approval.",
+                        "action_taken": "Notified the accountable repository owner using the approved manual procedure.",
+                        "verification_evidence_ids": (evidence_id,),
+                        "residual_uncertainty": "Awaiting written owner acknowledgement in the next review window.",
+                    },
+                    "escalation": {
+                        "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
+                        "escalated_to": "on-call-manager-001",
+                        "note": "On-call manager notified because the open approval could not be left unattended.",
+                    },
+                },
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(review["review_state"], "unresolved")
+        self.assertEqual(
+            review["runtime_visibility"]["after_hours_handoff"]["handoff_owner"],
+            "analyst-002",
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["after_hours_handoff"]["disposition"],
+            "business_hours_handoff",
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["manual_fallback"]["action_request_id"],
+            request.action_request_id,
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["manual_fallback"]["approval_decision_id"],
+            approval.approval_decision_id,
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["manual_fallback"]["fallback_actor_identity"],
+            "analyst-003",
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["manual_fallback"]["fallback_at"],
+            (reviewed_at + timedelta(minutes=45)).isoformat(),
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["escalation_notes"]["escalation_reason"],
+            "Waiting until the next business-hours cycle is unsafe for this repository owner change.",
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["escalation_notes"]["escalated_to"],
+            "on-call-manager-001",
+        )
+
     def test_cli_inspect_case_detail_keeps_reconciliation_bound_to_selected_execution(
         self,
     ) -> None:

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -3829,6 +3829,49 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "analyst-002",
         )
 
+    def test_cli_runtime_visibility_ignores_non_handoff_triage_dispositions(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep routine pending approval triage from being mislabeled as a handoff.",
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Routine approval follow-up remains open.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-cli-non-handoff-triage-001",
+        )
+        service.persist_record(replace(action_request, lifecycle_state="unresolved"))
+        service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="pending_approval",
+            rationale="Approval is still pending, but no after-hours handoff has been recorded.",
+            recorded_at=reviewed_at + timedelta(minutes=20),
+        )
+
+        case_stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=case_stdout,
+            service=service,
+        )
+        case_payload = json.loads(case_stdout.getvalue())
+
+        queue_stdout = io.StringIO()
+        main.main(["inspect-analyst-queue"], stdout=queue_stdout, service=service)
+        queue_payload = json.loads(queue_stdout.getvalue())
+
+        self.assertIsNone(case_payload["current_action_review"]["runtime_visibility"])
+        self.assertEqual(queue_payload["total_records"], 1)
+        self.assertIsNone(queue_payload["records"][0]["current_action_review"]["runtime_visibility"])
+
     def test_cli_inspect_alert_detail_renders_alert_scoped_runtime_visibility(
         self,
     ) -> None:

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -3472,6 +3472,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 request.action_request_id,
                 "--escalated-at",
                 (reviewed_at + timedelta(minutes=15)).isoformat(),
+                "--escalated-by-identity",
+                "analyst-003",
                 "--escalated-to",
                 "on-call-manager-001",
                 "--note",
@@ -3526,6 +3528,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(
             review["runtime_visibility"]["escalation_notes"]["escalated_to"],
             "on-call-manager-001",
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["escalation_notes"]["escalated_by_identity"],
+            "analyst-003",
         )
 
     def test_cli_inspect_case_detail_scopes_runtime_visibility_to_the_matching_action_review(
@@ -3638,6 +3644,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 second_request.action_request_id,
                 "--escalated-at",
                 (reviewed_at + timedelta(minutes=15)).isoformat(),
+                "--escalated-by-identity",
+                "analyst-003",
                 "--escalated-to",
                 "on-call-manager-001",
                 "--note",
@@ -3666,13 +3674,9 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "Keep the unresolved action review explicit for the next analyst.",
         )
         self.assertNotIn("manual_fallback", first_review["runtime_visibility"])
-        self.assertEqual(
-            first_review["runtime_visibility"]["escalation_notes"]["escalation_reason"],
-            "First reviewed request remains approval-bound.",
-        )
         self.assertNotIn(
-            "escalated_to",
-            first_review["runtime_visibility"]["escalation_notes"],
+            "escalation_notes",
+            first_review["runtime_visibility"],
         )
         self.assertEqual(
             second_review["runtime_visibility"]["manual_fallback"]["action_request_id"],
@@ -3689,6 +3693,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(
             second_review["runtime_visibility"]["escalation_notes"]["escalated_to"],
             "on-call-manager-001",
+        )
+        self.assertEqual(
+            second_review["runtime_visibility"]["escalation_notes"]["escalated_by_identity"],
+            "analyst-003",
         )
 
     def test_cli_inspect_case_detail_hides_after_hours_handoff_for_completed_review_history(
@@ -3753,10 +3761,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         reviews_by_id = {
             review["action_request_id"]: review for review in payload["action_reviews"]
         }
-        self.assertNotIn(
-            "after_hours_handoff",
-            reviews_by_id[completed_request.action_request_id]["runtime_visibility"],
+        completed_visibility = (
+            reviews_by_id[completed_request.action_request_id]["runtime_visibility"] or {}
         )
+        self.assertNotIn("after_hours_handoff", completed_visibility)
         self.assertEqual(
             reviews_by_id[unresolved_request.action_request_id]["runtime_visibility"][
                 "after_hours_handoff"
@@ -3816,6 +3824,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         service.record_action_review_escalation_note(
             action_request_id=request.action_request_id,
             escalated_at=reviewed_at + timedelta(minutes=15),
+            escalated_by_identity="analyst-004",
             escalated_to="on-call-manager-001",
             note="On-call manager notified because the alert-scoped approval could not be left unattended.",
         )
@@ -3842,6 +3851,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(
             review["runtime_visibility"]["escalation_notes"]["escalated_to"],
             "on-call-manager-001",
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["escalation_notes"]["escalated_by_identity"],
+            "analyst-004",
         )
 
     def test_cli_inspect_case_detail_keeps_reconciliation_bound_to_selected_execution(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -3427,23 +3427,27 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 lifecycle_state="unresolved",
             )
         )
+        promoted_case = service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=reviewed_at + timedelta(hours=8),
+            handoff_owner="analyst-002",
+            handoff_note="Resume the approval and fallback review at next business-hours open.",
+            follow_up_evidence_ids=(evidence_id,),
+        )
+        promoted_case = service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="The reviewed action remains unresolved and must stay visible for the next analyst.",
+            recorded_at=reviewed_at + timedelta(hours=8),
+        )
         service.persist_record(
             replace(
                 promoted_case,
                 reviewed_context={
                     **dict(promoted_case.reviewed_context),
-                    "handoff": {
-                        "handoff_at": (reviewed_at + timedelta(hours=8)).isoformat(),
-                        "handoff_owner": "analyst-002",
-                        "note": "Resume the approval and fallback review at next business-hours open.",
-                        "follow_up_evidence_ids": (evidence_id,),
-                    },
-                    "triage": {
-                        "disposition": "business_hours_handoff",
-                        "rationale": "The reviewed action remains unresolved and must stay visible for the next analyst.",
-                        "recorded_at": (reviewed_at + timedelta(hours=8)).isoformat(),
-                    },
                     "manual_fallback": {
+                        "action_request_id": request.action_request_id,
+                        "approval_decision_id": approval.approval_decision_id,
                         "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
                         "fallback_actor_identity": "analyst-003",
                         "authority_boundary": "approved_human_fallback",
@@ -3453,6 +3457,8 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                         "residual_uncertainty": "Awaiting written owner acknowledgement in the next review window.",
                     },
                     "escalation": {
+                        "action_request_id": request.action_request_id,
+                        "approval_decision_id": approval.approval_decision_id,
                         "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
                         "escalated_to": "on-call-manager-001",
                         "note": "On-call manager notified because the open approval could not be left unattended.",
@@ -3480,6 +3486,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "business_hours_handoff",
         )
         self.assertEqual(
+            review["runtime_visibility"]["after_hours_handoff"]["rationale"],
+            "The reviewed action remains unresolved and must stay visible for the next analyst.",
+        )
+        self.assertEqual(
             review["runtime_visibility"]["manual_fallback"]["action_request_id"],
             request.action_request_id,
         )
@@ -3501,6 +3511,157 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
         self.assertEqual(
             review["runtime_visibility"]["escalation_notes"]["escalated_to"],
+            "on-call-manager-001",
+        )
+
+    def test_cli_inspect_case_detail_scopes_runtime_visibility_to_the_matching_action_review(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep unresolved ownership explicit across multiple reviewed action requests.",
+        )
+        first_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the first reviewed permission change.",
+            escalation_reason="First reviewed request remains approval-bound.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-cli-visibility-scope-001",
+        )
+        first_approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-visibility-scope-001",
+                action_request_id=first_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(first_request.target_scope),
+                payload_hash=first_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=first_request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                first_request,
+                approval_decision_id=first_approval.approval_decision_id,
+                lifecycle_state="unresolved",
+            )
+        )
+        second_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-002",
+            message_intent="Notify the accountable repository owner about the second reviewed permission change.",
+            escalation_reason="Second reviewed request remains approval-bound.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-cli-visibility-scope-002",
+        )
+        second_approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-visibility-scope-002",
+                action_request_id=second_request.action_request_id,
+                approver_identities=("approver-002",),
+                target_snapshot=dict(second_request.target_scope),
+                payload_hash=second_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=10),
+                lifecycle_state="approved",
+                approved_expires_at=second_request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                second_request,
+                approval_decision_id=second_approval.approval_decision_id,
+                lifecycle_state="unresolved",
+            )
+        )
+        promoted_case = service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=reviewed_at + timedelta(hours=8),
+            handoff_owner="analyst-002",
+            handoff_note="Resume the approval review at next business-hours open.",
+            follow_up_evidence_ids=(evidence_id,),
+        )
+        promoted_case = service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Keep the unresolved action review explicit for the next analyst.",
+            recorded_at=reviewed_at + timedelta(hours=8),
+        )
+        service.persist_record(
+            replace(
+                promoted_case,
+                reviewed_context={
+                    **dict(promoted_case.reviewed_context),
+                    "manual_fallback": {
+                        "action_request_id": second_request.action_request_id,
+                        "approval_decision_id": second_approval.approval_decision_id,
+                        "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
+                        "fallback_actor_identity": "analyst-003",
+                        "authority_boundary": "approved_human_fallback",
+                        "reason": "The reviewed automation path was unavailable after approval.",
+                        "action_taken": "Used the approved manual procedure for the second request only.",
+                        "verification_evidence_ids": (evidence_id,),
+                        "residual_uncertainty": "Awaiting written owner acknowledgement in the next review window.",
+                    },
+                    "escalation": {
+                        "action_request_id": second_request.action_request_id,
+                        "approval_decision_id": second_approval.approval_decision_id,
+                        "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
+                        "escalated_to": "on-call-manager-001",
+                        "note": "On-call manager notified because the second open approval could not be left unattended.",
+                    },
+                },
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        reviews_by_id = {
+            review["action_request_id"]: review for review in payload["action_reviews"]
+        }
+        first_review = reviews_by_id[first_request.action_request_id]
+        second_review = reviews_by_id[second_request.action_request_id]
+
+        self.assertEqual(
+            first_review["runtime_visibility"]["after_hours_handoff"]["rationale"],
+            "Keep the unresolved action review explicit for the next analyst.",
+        )
+        self.assertNotIn("manual_fallback", first_review["runtime_visibility"])
+        self.assertEqual(
+            first_review["runtime_visibility"]["escalation_notes"]["escalation_reason"],
+            "First reviewed request remains approval-bound.",
+        )
+        self.assertNotIn(
+            "escalated_to",
+            first_review["runtime_visibility"]["escalation_notes"],
+        )
+        self.assertEqual(
+            second_review["runtime_visibility"]["manual_fallback"]["action_request_id"],
+            second_request.action_request_id,
+        )
+        self.assertEqual(
+            second_review["runtime_visibility"]["manual_fallback"]["approval_decision_id"],
+            second_approval.approval_decision_id,
+        )
+        self.assertEqual(
+            second_review["runtime_visibility"]["escalation_notes"]["escalation_reason"],
+            "Second reviewed request remains approval-bound.",
+        )
+        self.assertEqual(
+            second_review["runtime_visibility"]["escalation_notes"]["escalated_to"],
             "on-call-manager-001",
         )
 

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -3618,6 +3618,44 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             [
                 "record-action-review-manual-fallback",
                 "--action-request-id",
+                first_request.action_request_id,
+                "--fallback-at",
+                (reviewed_at + timedelta(minutes=30)).isoformat(),
+                "--fallback-actor-identity",
+                "analyst-002",
+                "--authority-boundary",
+                "approved_human_fallback",
+                "--reason",
+                "The first reviewed automation path was unavailable after approval.",
+                "--action-taken",
+                "Used the approved manual procedure for the first request only.",
+                "--verification-evidence-id",
+                evidence_id,
+            ],
+            stdout=io.StringIO(),
+            service=service,
+        )
+        main.main(
+            [
+                "record-action-review-escalation-note",
+                "--action-request-id",
+                first_request.action_request_id,
+                "--escalated-at",
+                (reviewed_at + timedelta(minutes=12)).isoformat(),
+                "--escalated-by-identity",
+                "analyst-002",
+                "--escalated-to",
+                "on-call-manager-000",
+                "--note",
+                "On-call manager notified because the first open approval could not be left unattended.",
+            ],
+            stdout=io.StringIO(),
+            service=service,
+        )
+        main.main(
+            [
+                "record-action-review-manual-fallback",
+                "--action-request-id",
                 second_request.action_request_id,
                 "--fallback-at",
                 (reviewed_at + timedelta(minutes=45)).isoformat(),
@@ -3673,10 +3711,29 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             first_review["runtime_visibility"]["after_hours_handoff"]["rationale"],
             "Keep the unresolved action review explicit for the next analyst.",
         )
-        self.assertNotIn("manual_fallback", first_review["runtime_visibility"])
-        self.assertNotIn(
-            "escalation_notes",
-            first_review["runtime_visibility"],
+        self.assertEqual(
+            first_review["runtime_visibility"]["manual_fallback"]["action_request_id"],
+            first_request.action_request_id,
+        )
+        self.assertEqual(
+            first_review["runtime_visibility"]["manual_fallback"]["approval_decision_id"],
+            first_approval.approval_decision_id,
+        )
+        self.assertEqual(
+            first_review["runtime_visibility"]["manual_fallback"]["fallback_actor_identity"],
+            "analyst-002",
+        )
+        self.assertEqual(
+            first_review["runtime_visibility"]["escalation_notes"]["escalation_reason"],
+            "First reviewed request remains approval-bound.",
+        )
+        self.assertEqual(
+            first_review["runtime_visibility"]["escalation_notes"]["escalated_to"],
+            "on-call-manager-000",
+        )
+        self.assertEqual(
+            first_review["runtime_visibility"]["escalation_notes"]["escalated_by_identity"],
+            "analyst-002",
         )
         self.assertEqual(
             second_review["runtime_visibility"]["manual_fallback"]["action_request_id"],

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -3440,31 +3440,45 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             rationale="The reviewed action remains unresolved and must stay visible for the next analyst.",
             recorded_at=reviewed_at + timedelta(hours=8),
         )
-        service.persist_record(
-            replace(
-                promoted_case,
-                reviewed_context={
-                    **dict(promoted_case.reviewed_context),
-                    "manual_fallback": {
-                        "action_request_id": request.action_request_id,
-                        "approval_decision_id": approval.approval_decision_id,
-                        "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
-                        "fallback_actor_identity": "analyst-003",
-                        "authority_boundary": "approved_human_fallback",
-                        "reason": "The reviewed automation path was unavailable after approval.",
-                        "action_taken": "Notified the accountable repository owner using the approved manual procedure.",
-                        "verification_evidence_ids": (evidence_id,),
-                        "residual_uncertainty": "Awaiting written owner acknowledgement in the next review window.",
-                    },
-                    "escalation": {
-                        "action_request_id": request.action_request_id,
-                        "approval_decision_id": approval.approval_decision_id,
-                        "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
-                        "escalated_to": "on-call-manager-001",
-                        "note": "On-call manager notified because the open approval could not be left unattended.",
-                    },
-                },
-            )
+        fallback_stdout = io.StringIO()
+        main.main(
+            [
+                "record-action-review-manual-fallback",
+                "--action-request-id",
+                request.action_request_id,
+                "--fallback-at",
+                (reviewed_at + timedelta(minutes=45)).isoformat(),
+                "--fallback-actor-identity",
+                "analyst-003",
+                "--authority-boundary",
+                "approved_human_fallback",
+                "--reason",
+                "The reviewed automation path was unavailable after approval.",
+                "--action-taken",
+                "Notified the accountable repository owner using the approved manual procedure.",
+                "--verification-evidence-id",
+                evidence_id,
+                "--residual-uncertainty",
+                "Awaiting written owner acknowledgement in the next review window.",
+            ],
+            stdout=fallback_stdout,
+            service=service,
+        )
+        escalation_stdout = io.StringIO()
+        main.main(
+            [
+                "record-action-review-escalation-note",
+                "--action-request-id",
+                request.action_request_id,
+                "--escalated-at",
+                (reviewed_at + timedelta(minutes=15)).isoformat(),
+                "--escalated-to",
+                "on-call-manager-001",
+                "--note",
+                "On-call manager notified because the open approval could not be left unattended.",
+            ],
+            stdout=escalation_stdout,
+            service=service,
         )
 
         stdout = io.StringIO()
@@ -3594,31 +3608,43 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             rationale="Keep the unresolved action review explicit for the next analyst.",
             recorded_at=reviewed_at + timedelta(hours=8),
         )
-        service.persist_record(
-            replace(
-                promoted_case,
-                reviewed_context={
-                    **dict(promoted_case.reviewed_context),
-                    "manual_fallback": {
-                        "action_request_id": second_request.action_request_id,
-                        "approval_decision_id": second_approval.approval_decision_id,
-                        "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
-                        "fallback_actor_identity": "analyst-003",
-                        "authority_boundary": "approved_human_fallback",
-                        "reason": "The reviewed automation path was unavailable after approval.",
-                        "action_taken": "Used the approved manual procedure for the second request only.",
-                        "verification_evidence_ids": (evidence_id,),
-                        "residual_uncertainty": "Awaiting written owner acknowledgement in the next review window.",
-                    },
-                    "escalation": {
-                        "action_request_id": second_request.action_request_id,
-                        "approval_decision_id": second_approval.approval_decision_id,
-                        "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
-                        "escalated_to": "on-call-manager-001",
-                        "note": "On-call manager notified because the second open approval could not be left unattended.",
-                    },
-                },
-            )
+        main.main(
+            [
+                "record-action-review-manual-fallback",
+                "--action-request-id",
+                second_request.action_request_id,
+                "--fallback-at",
+                (reviewed_at + timedelta(minutes=45)).isoformat(),
+                "--fallback-actor-identity",
+                "analyst-003",
+                "--authority-boundary",
+                "approved_human_fallback",
+                "--reason",
+                "The reviewed automation path was unavailable after approval.",
+                "--action-taken",
+                "Used the approved manual procedure for the second request only.",
+                "--verification-evidence-id",
+                evidence_id,
+                "--residual-uncertainty",
+                "Awaiting written owner acknowledgement in the next review window.",
+            ],
+            stdout=io.StringIO(),
+            service=service,
+        )
+        main.main(
+            [
+                "record-action-review-escalation-note",
+                "--action-request-id",
+                second_request.action_request_id,
+                "--escalated-at",
+                (reviewed_at + timedelta(minutes=15)).isoformat(),
+                "--escalated-to",
+                "on-call-manager-001",
+                "--note",
+                "On-call manager notified because the second open approval could not be left unattended.",
+            ],
+            stdout=io.StringIO(),
+            service=service,
         )
 
         stdout = io.StringIO()
@@ -3662,6 +3688,159 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
         self.assertEqual(
             second_review["runtime_visibility"]["escalation_notes"]["escalated_to"],
+            "on-call-manager-001",
+        )
+
+    def test_cli_inspect_case_detail_hides_after_hours_handoff_for_completed_review_history(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep only live unresolved review chains marked as after-hours handoff.",
+        )
+        completed_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the completed reviewed change.",
+            escalation_reason="Completed reviewed request should not inherit the active handoff note.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-cli-handoff-history-001",
+        )
+        unresolved_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-002",
+            message_intent="Notify the accountable repository owner about the unresolved reviewed change.",
+            escalation_reason="Unresolved reviewed request should retain the active handoff note.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-cli-handoff-history-002",
+        )
+        service.persist_record(
+            replace(
+                completed_request,
+                lifecycle_state="completed",
+                requested_at=completed_request.requested_at - timedelta(minutes=10),
+            )
+        )
+        service.persist_record(replace(unresolved_request, lifecycle_state="unresolved"))
+        service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=reviewed_at + timedelta(hours=8),
+            handoff_owner="analyst-002",
+            handoff_note="Resume the unresolved approval review at next business-hours open.",
+            follow_up_evidence_ids=(evidence_id,),
+        )
+        service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Keep only the unresolved reviewed action visible for the next analyst handoff.",
+            recorded_at=reviewed_at + timedelta(hours=8),
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        reviews_by_id = {
+            review["action_request_id"]: review for review in payload["action_reviews"]
+        }
+        self.assertNotIn(
+            "after_hours_handoff",
+            reviews_by_id[completed_request.action_request_id]["runtime_visibility"],
+        )
+        self.assertEqual(
+            reviews_by_id[unresolved_request.action_request_id]["runtime_visibility"][
+                "after_hours_handoff"
+            ]["handoff_owner"],
+            "analyst-002",
+        )
+
+    def test_cli_inspect_alert_detail_renders_alert_scoped_runtime_visibility(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep alert-scoped follow-up explicit when case linkage is absent.",
+        )
+        request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="The alert-scoped reviewed request cannot wait for the next shift.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-cli-alert-visibility-001",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-alert-visibility-001",
+                action_request_id=request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(request.target_scope),
+                payload_hash=request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=request.expires_at,
+            )
+        )
+        request = service.persist_record(
+            replace(
+                request,
+                approval_decision_id=approval.approval_decision_id,
+                case_id=None,
+                lifecycle_state="unresolved",
+            )
+        )
+        service.record_action_review_manual_fallback(
+            action_request_id=request.action_request_id,
+            fallback_at=reviewed_at + timedelta(minutes=45),
+            fallback_actor_identity="analyst-003",
+            authority_boundary="approved_human_fallback",
+            reason="The reviewed automation path was unavailable after approval.",
+            action_taken="Used the approved manual procedure while the alert remained unlinked to casework.",
+            verification_evidence_ids=(evidence_id,),
+            residual_uncertainty="Awaiting written owner acknowledgement in the next review window.",
+        )
+        service.record_action_review_escalation_note(
+            action_request_id=request.action_request_id,
+            escalated_at=reviewed_at + timedelta(minutes=15),
+            escalated_to="on-call-manager-001",
+            note="On-call manager notified because the alert-scoped approval could not be left unattended.",
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-alert-detail", "--alert-id", promoted_case.alert_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(review["action_request_id"], request.action_request_id)
+        self.assertEqual(review["review_state"], "unresolved")
+        self.assertEqual(
+            review["runtime_visibility"]["manual_fallback"]["approval_decision_id"],
+            approval.approval_decision_id,
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["manual_fallback"]["fallback_actor_identity"],
+            "analyst-003",
+        )
+        self.assertEqual(
+            review["runtime_visibility"]["escalation_notes"]["escalated_to"],
             "on-call-manager-001",
         )
 

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -728,12 +728,6 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     )
                     return json.loads(response.read().decode("utf-8"))
 
-                queue_payload = json.loads(
-                    request.urlopen(  # noqa: S310
-                        f"{base_url}/inspect-analyst-queue",
-                        timeout=2,
-                    ).read().decode("utf-8")
-                )
                 post_json(
                     "/operator/record-action-review-manual-fallback",
                     {
@@ -756,6 +750,12 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                         "escalated_to": "on-call-manager-001",
                         "note": "On-call manager notified because the unresolved action could not be left unattended.",
                     },
+                )
+                queue_payload = json.loads(
+                    request.urlopen(  # noqa: S310
+                        f"{base_url}/inspect-analyst-queue",
+                        timeout=2,
+                    ).read().decode("utf-8")
                 )
                 case_payload = json.loads(
                     request.urlopen(  # noqa: S310
@@ -800,6 +800,96 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     ]["escalated_by_identity"],
                     "analyst-001",
                 )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_reviewed_runtime_path_returns_not_found_for_missing_runtime_visibility_records(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+        service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
+            service
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                for path, payload in (
+                    (
+                        "/operator/record-action-review-manual-fallback",
+                        {
+                            "action_request_id": "missing-action-request-id",
+                            "fallback_at": datetime.now(timezone.utc).isoformat(),
+                            "fallback_actor_identity": "analyst-001",
+                            "authority_boundary": "approved_human_fallback",
+                            "reason": "Missing requests should produce the operator not-found envelope.",
+                            "action_taken": "No fallback should be recorded.",
+                            "verification_evidence_ids": [],
+                        },
+                    ),
+                    (
+                        "/operator/record-action-review-escalation-note",
+                        {
+                            "action_request_id": "missing-action-request-id",
+                            "escalated_at": datetime.now(timezone.utc).isoformat(),
+                            "escalated_by_identity": "analyst-001",
+                            "escalated_to": "on-call-manager-001",
+                            "note": "Missing requests should produce the operator not-found envelope.",
+                        },
+                    ),
+                ):
+                    with self.subTest(path=path):
+                        with self.assertRaises(error.HTTPError) as exc_info:
+                            request.urlopen(  # noqa: S310
+                                request.Request(  # noqa: S310
+                                    f"{base_url}{path}",
+                                    data=json.dumps(payload).encode("utf-8"),
+                                    headers={"Content-Type": "application/json"},
+                                    method="POST",
+                                ),
+                                timeout=2,
+                            )
+                        self.assertEqual(exc_info.exception.code, 404)
+                        error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
+                        self.assertEqual(error_payload["error"], "not_found")
             finally:
                 if servers:
                     servers[0].shutdown()

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -895,6 +895,117 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     servers[0].shutdown()
                 thread.join(timeout=2)
 
+    def test_reviewed_runtime_path_rejects_mismatched_manual_fallback_actor_identity(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep the reviewed fallback path attributable.",
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Use a reviewed manual fallback for the repository owner change.",
+            escalation_reason="Waiting until the next business-hours cycle is unsafe.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-phase19-manual-fallback-identity-001",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase19-manual-fallback-identity-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=admitted.reconciliation.compared_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval.approval_decision_id,
+                lifecycle_state="unresolved",
+            )
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
+            service
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                with self.assertRaises(error.HTTPError) as exc_info:
+                    request.urlopen(  # noqa: S310
+                        request.Request(  # noqa: S310
+                            f"{base_url}/operator/record-action-review-manual-fallback",
+                            data=json.dumps(
+                                {
+                                    "action_request_id": action_request.action_request_id,
+                                    "fallback_at": (
+                                        admitted.reconciliation.compared_at
+                                        + timedelta(minutes=15)
+                                    ).isoformat(),
+                                    "fallback_actor_identity": "analyst-002",
+                                    "authority_boundary": "approved_human_fallback",
+                                    "reason": "Mismatched reviewed identity should fail closed.",
+                                    "action_taken": "No manual fallback should be accepted.",
+                                    "verification_evidence_ids": list(promoted_case.evidence_ids),
+                                }
+                            ).encode("utf-8"),
+                            headers={"Content-Type": "application/json"},
+                            method="POST",
+                        ),
+                        timeout=2,
+                    )
+                self.assertEqual(exc_info.exception.code, 403)
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
     def test_reviewed_runtime_path_fails_closed_for_out_of_scope_case_reads(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -580,6 +580,18 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 self.assertTrue(servers, "expected test HTTP server to start")
                 base_url = f"http://127.0.0.1:{servers[0].server_port}"
 
+                def post_json(path: str, payload: dict[str, object]) -> dict[str, object]:
+                    response = request.urlopen(  # noqa: S310
+                        request.Request(  # noqa: S310
+                            f"{base_url}{path}",
+                            data=json.dumps(payload).encode("utf-8"),
+                            headers={"Content-Type": "application/json"},
+                            method="POST",
+                        ),
+                        timeout=2,
+                    )
+                    return json.loads(response.read().decode("utf-8"))
+
                 queue_payload = json.loads(
                     request.urlopen(  # noqa: S310
                         f"{base_url}/inspect-analyst-queue",
@@ -679,32 +691,6 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
             rationale="Keep the unresolved action visible for the next analyst handoff.",
             recorded_at=reviewed_at + timedelta(hours=8),
         )
-        service.persist_record(
-            replace(
-                promoted_case,
-                reviewed_context={
-                    **dict(promoted_case.reviewed_context),
-                    "manual_fallback": {
-                        "action_request_id": action_request.action_request_id,
-                        "approval_decision_id": approval.approval_decision_id,
-                        "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
-                        "fallback_actor_identity": "analyst-003",
-                        "authority_boundary": "approved_human_fallback",
-                        "reason": "The reviewed automation path was unavailable after approval.",
-                        "action_taken": "Notified the accountable repository owner using the approved manual procedure.",
-                        "verification_evidence_ids": promoted_case.evidence_ids,
-                        "residual_uncertainty": "Awaiting written owner acknowledgement.",
-                    },
-                    "escalation": {
-                        "action_request_id": action_request.action_request_id,
-                        "approval_decision_id": approval.approval_decision_id,
-                        "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
-                        "escalated_to": "on-call-manager-001",
-                        "note": "On-call manager notified because the unresolved action could not be left unattended.",
-                    },
-                },
-            )
-        )
 
         servers: list[main.ThreadingHTTPServer] = []
 
@@ -730,11 +716,45 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 self.assertTrue(servers, "expected test HTTP server to start")
                 base_url = f"http://127.0.0.1:{servers[0].server_port}"
 
+                def post_json(path: str, payload: dict[str, object]) -> dict[str, object]:
+                    response = request.urlopen(  # noqa: S310
+                        request.Request(  # noqa: S310
+                            f"{base_url}{path}",
+                            data=json.dumps(payload).encode("utf-8"),
+                            headers={"Content-Type": "application/json"},
+                            method="POST",
+                        ),
+                        timeout=2,
+                    )
+                    return json.loads(response.read().decode("utf-8"))
+
                 queue_payload = json.loads(
                     request.urlopen(  # noqa: S310
                         f"{base_url}/inspect-analyst-queue",
                         timeout=2,
                     ).read().decode("utf-8")
+                )
+                post_json(
+                    "/operator/record-action-review-manual-fallback",
+                    {
+                        "action_request_id": action_request.action_request_id,
+                        "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
+                        "fallback_actor_identity": "analyst-001",
+                        "authority_boundary": "approved_human_fallback",
+                        "reason": "The reviewed automation path was unavailable after approval.",
+                        "action_taken": "Notified the accountable repository owner using the approved manual procedure.",
+                        "verification_evidence_ids": list(promoted_case.evidence_ids),
+                        "residual_uncertainty": "Awaiting written owner acknowledgement.",
+                    },
+                )
+                post_json(
+                    "/operator/record-action-review-escalation-note",
+                    {
+                        "action_request_id": action_request.action_request_id,
+                        "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
+                        "escalated_to": "on-call-manager-001",
+                        "note": "On-call manager notified because the unresolved action could not be left unattended.",
+                    },
                 )
                 case_payload = json.loads(
                     request.urlopen(  # noqa: S310
@@ -759,7 +779,7 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     case_payload["current_action_review"]["runtime_visibility"][
                         "manual_fallback"
                     ]["fallback_actor_identity"],
-                    "analyst-003",
+                    "analyst-001",
                 )
                 self.assertEqual(
                     case_payload["current_action_review"]["runtime_visibility"][

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -752,6 +752,7 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     {
                         "action_request_id": action_request.action_request_id,
                         "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
+                        "escalated_by_identity": "analyst-001",
                         "escalated_to": "on-call-manager-001",
                         "note": "On-call manager notified because the unresolved action could not be left unattended.",
                     },
@@ -793,6 +794,102 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     ]["escalation_reason"],
                     "Waiting until the next business-hours cycle is unsafe for this repository owner change.",
                 )
+                self.assertEqual(
+                    case_payload["current_action_review"]["runtime_visibility"][
+                        "escalation_notes"
+                    ]["escalated_by_identity"],
+                    "analyst-001",
+                )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_reviewed_runtime_path_rejects_mismatched_escalation_actor_identity(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep the reviewed escalation path attributable.",
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Escalate the reviewed repository owner change.",
+            escalation_reason="Waiting until the next business-hours cycle is unsafe.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-phase19-escalation-identity-001",
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
+            service
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                with self.assertRaises(error.HTTPError) as exc_info:
+                    request.urlopen(  # noqa: S310
+                        request.Request(  # noqa: S310
+                            f"{base_url}/operator/record-action-review-escalation-note",
+                            data=json.dumps(
+                                {
+                                    "action_request_id": action_request.action_request_id,
+                                    "escalated_at": (
+                                        admitted.reconciliation.compared_at
+                                        + timedelta(minutes=15)
+                                    ).isoformat(),
+                                    "escalated_by_identity": "analyst-002",
+                                    "escalated_to": "on-call-manager-001",
+                                    "note": "Mismatched reviewed identity should fail closed.",
+                                }
+                            ).encode("utf-8"),
+                            headers={"Content-Type": "application/json"},
+                            method="POST",
+                        ),
+                        timeout=2,
+                    )
+                self.assertEqual(exc_info.exception.code, 403)
             finally:
                 if servers:
                     servers[0].shutdown()

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -666,23 +666,27 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 lifecycle_state="unresolved",
             )
         )
+        promoted_case = service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=reviewed_at + timedelta(hours=8),
+            handoff_owner="analyst-002",
+            handoff_note="Resume the unresolved approval review at next business-hours open.",
+            follow_up_evidence_ids=promoted_case.evidence_ids,
+        )
+        promoted_case = service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Keep the unresolved action visible for the next analyst handoff.",
+            recorded_at=reviewed_at + timedelta(hours=8),
+        )
         service.persist_record(
             replace(
                 promoted_case,
                 reviewed_context={
                     **dict(promoted_case.reviewed_context),
-                    "handoff": {
-                        "handoff_at": (reviewed_at + timedelta(hours=8)).isoformat(),
-                        "handoff_owner": "analyst-002",
-                        "note": "Resume the unresolved approval review at next business-hours open.",
-                        "follow_up_evidence_ids": promoted_case.evidence_ids,
-                    },
-                    "triage": {
-                        "disposition": "business_hours_handoff",
-                        "rationale": "Keep the unresolved action visible for the next analyst handoff.",
-                        "recorded_at": (reviewed_at + timedelta(hours=8)).isoformat(),
-                    },
                     "manual_fallback": {
+                        "action_request_id": action_request.action_request_id,
+                        "approval_decision_id": approval.approval_decision_id,
                         "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
                         "fallback_actor_identity": "analyst-003",
                         "authority_boundary": "approved_human_fallback",
@@ -692,6 +696,8 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                         "residual_uncertainty": "Awaiting written owner acknowledgement.",
                     },
                     "escalation": {
+                        "action_request_id": action_request.action_request_id,
+                        "approval_decision_id": approval.approval_decision_id,
                         "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
                         "escalated_to": "on-call-manager-001",
                         "note": "On-call manager notified because the unresolved action could not be left unattended.",
@@ -742,6 +748,12 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                         "after_hours_handoff"
                     ]["handoff_owner"],
                     "analyst-002",
+                )
+                self.assertEqual(
+                    queue_payload["records"][0]["current_action_review"]["runtime_visibility"][
+                        "after_hours_handoff"
+                    ]["rationale"],
+                    "Keep the unresolved action visible for the next analyst handoff.",
                 )
                 self.assertEqual(
                     case_payload["current_action_review"]["runtime_visibility"][

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from copy import deepcopy
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import json
 import pathlib
@@ -22,7 +23,12 @@ if str(TESTS_ROOT) not in sys.path:
 import main
 from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
 from aegisops_control_plane.config import RuntimeConfig
-from aegisops_control_plane.models import AITraceRecord, CaseRecord, RecommendationRecord
+from aegisops_control_plane.models import (
+    AITraceRecord,
+    ApprovalDecisionRecord,
+    CaseRecord,
+    RecommendationRecord,
+)
 from aegisops_control_plane.service import (
     AegisOpsControlPlaneService,
     AuthenticatedRuntimePrincipal,
@@ -596,6 +602,164 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 self.assertEqual(
                     case_payload["reviewed_context"]["source"]["source_family"],
                     "entra_id",
+                )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_reviewed_runtime_path_surfaces_handoff_and_manual_fallback_visibility(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        reviewed_at = admitted.reconciliation.compared_at
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Waiting until the next business-hours cycle is unsafe for this repository owner change.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-phase19-runtime-visibility-001",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase19-runtime-visibility-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval.approval_decision_id,
+                lifecycle_state="unresolved",
+            )
+        )
+        service.persist_record(
+            replace(
+                promoted_case,
+                reviewed_context={
+                    **dict(promoted_case.reviewed_context),
+                    "handoff": {
+                        "handoff_at": (reviewed_at + timedelta(hours=8)).isoformat(),
+                        "handoff_owner": "analyst-002",
+                        "note": "Resume the unresolved approval review at next business-hours open.",
+                        "follow_up_evidence_ids": promoted_case.evidence_ids,
+                    },
+                    "triage": {
+                        "disposition": "business_hours_handoff",
+                        "rationale": "Keep the unresolved action visible for the next analyst handoff.",
+                        "recorded_at": (reviewed_at + timedelta(hours=8)).isoformat(),
+                    },
+                    "manual_fallback": {
+                        "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
+                        "fallback_actor_identity": "analyst-003",
+                        "authority_boundary": "approved_human_fallback",
+                        "reason": "The reviewed automation path was unavailable after approval.",
+                        "action_taken": "Notified the accountable repository owner using the approved manual procedure.",
+                        "verification_evidence_ids": promoted_case.evidence_ids,
+                        "residual_uncertainty": "Awaiting written owner acknowledgement.",
+                    },
+                    "escalation": {
+                        "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
+                        "escalated_to": "on-call-manager-001",
+                        "note": "On-call manager notified because the unresolved action could not be left unattended.",
+                    },
+                },
+            )
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
+            service
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                queue_payload = json.loads(
+                    request.urlopen(  # noqa: S310
+                        f"{base_url}/inspect-analyst-queue",
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+                case_payload = json.loads(
+                    request.urlopen(  # noqa: S310
+                        f"{base_url}/inspect-case-detail?case_id={promoted_case.case_id}",
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+
+                self.assertEqual(
+                    queue_payload["records"][0]["current_action_review"]["runtime_visibility"][
+                        "after_hours_handoff"
+                    ]["handoff_owner"],
+                    "analyst-002",
+                )
+                self.assertEqual(
+                    case_payload["current_action_review"]["runtime_visibility"][
+                        "manual_fallback"
+                    ]["fallback_actor_identity"],
+                    "analyst-003",
+                )
+                self.assertEqual(
+                    case_payload["current_action_review"]["runtime_visibility"][
+                        "manual_fallback"
+                    ]["fallback_at"],
+                    (reviewed_at + timedelta(minutes=45)).isoformat(),
+                )
+                self.assertEqual(
+                    case_payload["current_action_review"]["runtime_visibility"][
+                        "escalation_notes"
+                    ]["escalation_reason"],
+                    "Waiting until the next business-hours cycle is unsafe for this repository owner change.",
                 )
             finally:
                 if servers:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -760,6 +760,12 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
                 verification_evidence_ids=(evidence_id, unrelated_evidence_id),
             )
 
+        current_action_review = service.inspect_case_detail(promoted_case.case_id).current_action_review
+        self.assertNotIn(
+            "manual_fallback",
+            current_action_review["runtime_visibility"] or {},
+        )
+
     def test_escalation_visibility_requires_recorded_note_and_preserves_recorded_state(self) -> None:
         _store, service, promoted_case, _evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -445,6 +445,7 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
         service.record_action_review_escalation_note(
             action_request_id=action_request.action_request_id,
             escalated_at=reviewed_at + timedelta(minutes=15),
+            escalated_by_identity="analyst-004",
             escalated_to="on-call-manager-001",
             note="On-call manager notified because the unresolved action could not be left unattended.",
         )
@@ -490,6 +491,142 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(
             runtime_visibility["escalation_notes"]["escalated_to"],
             "on-call-manager-001",
+        )
+        self.assertEqual(
+            runtime_visibility["escalation_notes"]["escalated_by_identity"],
+            "analyst-004",
+        )
+
+    def test_manual_fallback_requires_approved_post_approval_action_review(self) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep manual fallback approval-bound.",
+        )
+        pending_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Review before any fallback path is used.",
+            escalation_reason="Pending approval must not masquerade as manual fallback.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-phase21-manual-fallback-pending-001",
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "manual fallback requires an approved action review in a live post-approval state",
+        ):
+            service.record_action_review_manual_fallback(
+                action_request_id=pending_request.action_request_id,
+                fallback_at=reviewed_at + timedelta(minutes=15),
+                fallback_actor_identity="analyst-001",
+                authority_boundary="approved_human_fallback",
+                reason="Pending approvals must not write fallback visibility.",
+                action_taken="No manual action should be recorded.",
+                verification_evidence_ids=(evidence_id,),
+            )
+
+        rejected_decision = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-manual-fallback-rejected-001",
+                action_request_id=pending_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(pending_request.target_scope),
+                payload_hash=pending_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=20),
+                lifecycle_state="rejected",
+            )
+        )
+        rejected_request = service.persist_record(
+            replace(
+                pending_request,
+                approval_decision_id=rejected_decision.approval_decision_id,
+                lifecycle_state="rejected",
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "manual fallback requires an approved action review in a live post-approval state",
+        ):
+            service.record_action_review_manual_fallback(
+                action_request_id=rejected_request.action_request_id,
+                fallback_at=reviewed_at + timedelta(minutes=25),
+                fallback_actor_identity="analyst-001",
+                authority_boundary="approved_human_fallback",
+                reason="Rejected approvals must not write fallback visibility.",
+                action_taken="No manual action should be recorded.",
+                verification_evidence_ids=(evidence_id,),
+            )
+
+        current_action_review = service.inspect_case_detail(promoted_case.case_id).current_action_review
+        self.assertNotIn(
+            "manual_fallback",
+            current_action_review["runtime_visibility"] or {},
+        )
+
+    def test_escalation_visibility_requires_recorded_note_and_preserves_recorded_state(self) -> None:
+        _store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep escalation visibility record-driven.",
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Escalate the reviewed request if waiting is unsafe.",
+            escalation_reason="The pending review cannot wait for the next shift.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-phase21-escalation-state-001",
+        )
+
+        initial_review = service.inspect_case_detail(promoted_case.case_id).current_action_review
+        self.assertNotIn("escalation_notes", initial_review["runtime_visibility"] or {})
+
+        service.record_action_review_escalation_note(
+            action_request_id=action_request.action_request_id,
+            escalated_at=reviewed_at + timedelta(minutes=10),
+            escalated_by_identity="analyst-009",
+            escalated_to="on-call-manager-001",
+            note="Pending review escalated before any approval decision existed.",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-escalation-state-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=20),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval.approval_decision_id,
+                lifecycle_state="unresolved",
+            )
+        )
+
+        runtime_visibility = service.inspect_case_detail(promoted_case.case_id).current_action_review[
+            "runtime_visibility"
+        ]
+        self.assertEqual(runtime_visibility["escalation_notes"]["review_state"], "pending")
+        self.assertEqual(
+            runtime_visibility["escalation_notes"]["escalated_by_identity"],
+            "analyst-009",
         )
 
     def test_service_phase21_restore_drill_can_run_standalone_after_restore(

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -570,6 +570,95 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             current_action_review["runtime_visibility"] or {},
         )
 
+    def test_manual_fallback_rejects_unrelated_alert_scoped_evidence(self) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep alert-scoped fallback evidence linked to the correct alert.",
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Record the approved alert-scoped fallback without borrowing other alerts' evidence.",
+            escalation_reason="The approved alert-scoped follow-up cannot wait for the next shift.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-phase21-alert-scoped-fallback-001",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-alert-scoped-fallback-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        action_request = service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval.approval_decision_id,
+                case_id=None,
+                lifecycle_state="unresolved",
+            )
+        )
+
+        unrelated_admission = service.ingest_finding_alert(
+            finding_id="finding-phase21-alert-scoped-fallback-unrelated-001",
+            analytic_signal_id="signal-phase21-alert-scoped-fallback-unrelated-001",
+            substrate_detection_record_id=(
+                "substrate-detection-phase21-alert-scoped-fallback-unrelated-001"
+            ),
+            correlation_key="claim:asset-phase21-alert-scoped-fallback-unrelated-001:synthetic",
+            first_seen_at=reviewed_at + timedelta(minutes=1),
+            last_seen_at=reviewed_at + timedelta(minutes=1),
+            reviewed_context={
+                "asset": {"asset_id": "asset-phase21-alert-scoped-fallback-unrelated-001"},
+                "identity": {
+                    "identity_id": "principal-phase21-alert-scoped-fallback-unrelated-001"
+                },
+                "source": {
+                    "source_family": "synthetic_review_fixture",
+                    "admission_kind": "synthetic",
+                },
+            },
+        )
+        unrelated_evidence_id = "evidence-phase21-alert-scoped-fallback-unrelated-001"
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id=unrelated_evidence_id,
+                source_record_id=unrelated_admission.alert.finding_id,
+                alert_id=unrelated_admission.alert.alert_id,
+                case_id=None,
+                source_system="synthetic",
+                collector_identity="collector://synthetic/fixture",
+                acquired_at=reviewed_at + timedelta(minutes=1),
+                derivation_relationship="finding_alert",
+                lifecycle_state="collected",
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            f"verification_evidence_ids contains evidence {unrelated_evidence_id!r} that is not linked to alert {promoted_case.alert_id!r}",
+        ):
+            service.record_action_review_manual_fallback(
+                action_request_id=action_request.action_request_id,
+                fallback_at=reviewed_at + timedelta(minutes=15),
+                fallback_actor_identity="analyst-001",
+                authority_boundary="approved_human_fallback",
+                reason="Only evidence from the same alert or a real shared case should be allowed.",
+                action_taken="No manual fallback should be recorded with unrelated evidence.",
+                verification_evidence_ids=(evidence_id, unrelated_evidence_id),
+            )
+
     def test_escalation_visibility_requires_recorded_note_and_preserves_recorded_state(self) -> None:
         _store, service, promoted_case, _evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -432,31 +432,21 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             rationale="Keep the unresolved action visible for the next analyst handoff.",
             recorded_at=reviewed_at + timedelta(hours=8),
         )
-        service.persist_record(
-            replace(
-                promoted_case,
-                reviewed_context={
-                    **dict(promoted_case.reviewed_context),
-                    "manual_fallback": {
-                        "action_request_id": action_request.action_request_id,
-                        "approval_decision_id": approval.approval_decision_id,
-                        "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
-                        "fallback_actor_identity": "analyst-003",
-                        "authority_boundary": "approved_human_fallback",
-                        "reason": "The reviewed automation path was unavailable after approval.",
-                        "action_taken": "Notified the accountable repository owner using the approved manual procedure.",
-                        "verification_evidence_ids": (evidence_id,),
-                        "residual_uncertainty": "Awaiting written owner acknowledgement.",
-                    },
-                    "escalation": {
-                        "action_request_id": action_request.action_request_id,
-                        "approval_decision_id": approval.approval_decision_id,
-                        "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
-                        "escalated_to": "on-call-manager-001",
-                        "note": "On-call manager notified because the unresolved action could not be left unattended.",
-                    },
-                },
-            )
+        service.record_action_review_manual_fallback(
+            action_request_id=action_request.action_request_id,
+            fallback_at=reviewed_at + timedelta(minutes=45),
+            fallback_actor_identity="analyst-003",
+            authority_boundary="approved_human_fallback",
+            reason="The reviewed automation path was unavailable after approval.",
+            action_taken="Notified the accountable repository owner using the approved manual procedure.",
+            verification_evidence_ids=(evidence_id,),
+            residual_uncertainty="Awaiting written owner acknowledgement.",
+        )
+        service.record_action_review_escalation_note(
+            action_request_id=action_request.action_request_id,
+            escalated_at=reviewed_at + timedelta(minutes=15),
+            escalated_to="on-call-manager-001",
+            note="On-call manager notified because the unresolved action could not be left unattended.",
         )
 
         backup = service.export_authoritative_record_chain_backup()

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -419,23 +419,27 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
                 lifecycle_state="unresolved",
             )
         )
+        promoted_case = service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=reviewed_at + timedelta(hours=8),
+            handoff_owner="analyst-002",
+            handoff_note="Resume the unresolved approval review at next business-hours open.",
+            follow_up_evidence_ids=(evidence_id,),
+        )
+        promoted_case = service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Keep the unresolved action visible for the next analyst handoff.",
+            recorded_at=reviewed_at + timedelta(hours=8),
+        )
         service.persist_record(
             replace(
                 promoted_case,
                 reviewed_context={
                     **dict(promoted_case.reviewed_context),
-                    "handoff": {
-                        "handoff_at": (reviewed_at + timedelta(hours=8)).isoformat(),
-                        "handoff_owner": "analyst-002",
-                        "note": "Resume the unresolved approval review at next business-hours open.",
-                        "follow_up_evidence_ids": (evidence_id,),
-                    },
-                    "triage": {
-                        "disposition": "business_hours_handoff",
-                        "rationale": "Keep the unresolved action visible for the next analyst handoff.",
-                        "recorded_at": (reviewed_at + timedelta(hours=8)).isoformat(),
-                    },
                     "manual_fallback": {
+                        "action_request_id": action_request.action_request_id,
+                        "approval_decision_id": approval.approval_decision_id,
                         "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
                         "fallback_actor_identity": "analyst-003",
                         "authority_boundary": "approved_human_fallback",
@@ -445,6 +449,8 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
                         "residual_uncertainty": "Awaiting written owner acknowledgement.",
                     },
                     "escalation": {
+                        "action_request_id": action_request.action_request_id,
+                        "approval_decision_id": approval.approval_decision_id,
                         "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
                         "escalated_to": "on-call-manager-001",
                         "note": "On-call manager notified because the unresolved action could not be left unattended.",
@@ -478,6 +484,10 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(
             runtime_visibility["after_hours_handoff"]["recorded_at"],
             (reviewed_at + timedelta(hours=8)).isoformat(),
+        )
+        self.assertEqual(
+            runtime_visibility["after_hours_handoff"]["rationale"],
+            "Keep the unresolved action visible for the next analyst handoff.",
         )
         self.assertEqual(
             runtime_visibility["manual_fallback"]["approval_decision_id"],

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -379,6 +379,119 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             restored_approval_context.linked_reconciliation_ids,
         )
 
+    def test_service_phase21_restore_preserves_handoff_and_manual_fallback_runtime_visibility(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Waiting until the next business-hours cycle is unsafe for this repository owner change.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-phase21-restore-visibility-001",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-restore-visibility-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval.approval_decision_id,
+                lifecycle_state="unresolved",
+            )
+        )
+        service.persist_record(
+            replace(
+                promoted_case,
+                reviewed_context={
+                    **dict(promoted_case.reviewed_context),
+                    "handoff": {
+                        "handoff_at": (reviewed_at + timedelta(hours=8)).isoformat(),
+                        "handoff_owner": "analyst-002",
+                        "note": "Resume the unresolved approval review at next business-hours open.",
+                        "follow_up_evidence_ids": (evidence_id,),
+                    },
+                    "triage": {
+                        "disposition": "business_hours_handoff",
+                        "rationale": "Keep the unresolved action visible for the next analyst handoff.",
+                        "recorded_at": (reviewed_at + timedelta(hours=8)).isoformat(),
+                    },
+                    "manual_fallback": {
+                        "fallback_at": (reviewed_at + timedelta(minutes=45)).isoformat(),
+                        "fallback_actor_identity": "analyst-003",
+                        "authority_boundary": "approved_human_fallback",
+                        "reason": "The reviewed automation path was unavailable after approval.",
+                        "action_taken": "Notified the accountable repository owner using the approved manual procedure.",
+                        "verification_evidence_ids": (evidence_id,),
+                        "residual_uncertainty": "Awaiting written owner acknowledgement.",
+                    },
+                    "escalation": {
+                        "escalated_at": (reviewed_at + timedelta(minutes=15)).isoformat(),
+                        "escalated_to": "on-call-manager-001",
+                        "note": "On-call manager notified because the unresolved action could not be left unattended.",
+                    },
+                },
+            )
+        )
+
+        backup = service.export_authoritative_record_chain_backup()
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
+            store=restored_store,
+        )
+
+        restored_service.restore_authoritative_record_chain_backup(backup)
+        restored_case_detail = restored_service.inspect_case_detail(promoted_case.case_id)
+        runtime_visibility = restored_case_detail.current_action_review["runtime_visibility"]
+
+        self.assertEqual(
+            runtime_visibility["after_hours_handoff"]["handoff_owner"],
+            "analyst-002",
+        )
+        self.assertEqual(
+            runtime_visibility["after_hours_handoff"]["recorded_at"],
+            (reviewed_at + timedelta(hours=8)).isoformat(),
+        )
+        self.assertEqual(
+            runtime_visibility["manual_fallback"]["approval_decision_id"],
+            approval.approval_decision_id,
+        )
+        self.assertEqual(
+            runtime_visibility["manual_fallback"]["fallback_actor_identity"],
+            "analyst-003",
+        )
+        self.assertEqual(
+            runtime_visibility["escalation_notes"]["escalated_to"],
+            "on-call-manager-001",
+        )
+
     def test_service_phase21_restore_drill_can_run_standalone_after_restore(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -497,6 +497,107 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             "analyst-004",
         )
 
+    def test_service_phase21_restore_prefers_canonical_manual_fallback_timestamp(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep legacy manual fallback timestamps auditable after restore.",
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Legacy fallback timestamps must not rewrite the reviewed record.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-phase21-restore-fallback-alias-001",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-restore-fallback-alias-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=action_request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval.approval_decision_id,
+                lifecycle_state="unresolved",
+            )
+        )
+        service.record_action_review_manual_fallback(
+            action_request_id=action_request.action_request_id,
+            fallback_at=reviewed_at + timedelta(minutes=45),
+            fallback_actor_identity="analyst-003",
+            authority_boundary="approved_human_fallback",
+            reason="The reviewed automation path was unavailable after approval.",
+            action_taken="Notified the accountable repository owner using the approved manual procedure.",
+            verification_evidence_ids=(evidence_id,),
+            residual_uncertainty="Awaiting written owner acknowledgement.",
+        )
+
+        case_with_fallback = service.get_record(CaseRecord, promoted_case.case_id)
+        self.assertIsNotNone(case_with_fallback)
+        assert case_with_fallback is not None
+        action_review_visibility = dict(
+            case_with_fallback.reviewed_context["action_review_visibility"]
+        )
+        scoped_visibility = dict(action_review_visibility[action_request.action_request_id])
+        manual_fallback = dict(scoped_visibility["manual_fallback"])
+        manual_fallback["performed_at"] = (
+            reviewed_at + timedelta(minutes=50)
+        ).isoformat()
+        scoped_visibility["manual_fallback"] = manual_fallback
+        action_review_visibility[action_request.action_request_id] = scoped_visibility
+        service.persist_record(
+            replace(
+                case_with_fallback,
+                reviewed_context={
+                    **dict(case_with_fallback.reviewed_context),
+                    "action_review_visibility": action_review_visibility,
+                },
+            )
+        )
+
+        backup = service.export_authoritative_record_chain_backup()
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+            ),
+            store=restored_store,
+        )
+
+        restored_service.restore_authoritative_record_chain_backup(backup)
+        restored_case_detail = restored_service.inspect_case_detail(promoted_case.case_id)
+        runtime_visibility = restored_case_detail.current_action_review["runtime_visibility"]
+
+        self.assertEqual(
+            runtime_visibility["manual_fallback"]["fallback_at"],
+            (reviewed_at + timedelta(minutes=45)).isoformat(),
+        )
+        self.assertEqual(
+            runtime_visibility["manual_fallback"]["fallback_actor_identity"],
+            "analyst-003",
+        )
+
     def test_manual_fallback_requires_approved_post_approval_action_review(self) -> None:
         _store, service, promoted_case, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()


### PR DESCRIPTION
Closes #480
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a read-only `runtime_visibility` block to reviewed action-chain snapshots so `inspect-case-detail`, alert detail, and analyst queue can surface after-hours handoff, manual fallback, and escalation-note context without changing execution truth or approval semantics. The visibility is sourced narrowly from case `reviewed_context` and ties manual fallback back to the original action request and approval decision.

Coverage was added in the three supervisor-targeted areas: CLI inspection, live Phase 19 HTTP workflow validation, and Phase 21 backup/restore readiness. The focused reproducer failed on a missing `runtime_visibility` key before the implementation, and the full requested verification set now passes. Checkpoint commit: `0c15f00` (`Add runtime visibility for handoff and fallback state`).

Summary: Added reviewed runtime visibility for after-hours handoff, manual fallback, and escalation notes on action-review inspection surfaces; added focused CLI, HTTP, and restore coverage; committed as `0c15f00`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation control-plane.tests.test_service_persistence_restore_readiness control-plane.tests.test_cli_inspection`
Failure signature: none
Next action: Decide whether issue #480 also requires dedicated recording APIs for manual fallback/escalation notes, or whether the current visibility-only slice is sufficient to move toward PR creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands and HTTP endpoints to record manual-fallback actions and escalation notes for reviewed action requests.
  * Action-review views now surface after-hours handoff details, manual-fallback metadata, and escalation notes (scoped to the specific action review) for cases and alerts.

* **Tests**
  * Added tests for runtime-visibility rendering, operator endpoint validation (identity checks, not-found/forbidden), persistence/restore behavior, and validation error cases.

* **Documentation**
  * Added an issue journal documenting the investigation, changes, and verification plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->