### PR TITLE
validation: add end-to-end Phase 22 coverage for operator trust surfaces across approval, execution, and reconciliation review (#481)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Run Phase 22 operator trust boundary validation
         run: |
           bash scripts/verify-phase-22-operator-trust-boundary.sh
-          python3 -m unittest control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation
+          python3 -m unittest control-plane.tests.test_phase22_end_to_end_validation control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation
 
       - name: Run Phase 22 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-22-workflow-coverage.sh

--- a/control-plane/tests/test_phase22_end_to_end_validation.py
+++ b/control-plane/tests/test_phase22_end_to_end_validation.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import io
+import json
+import pathlib
+import sys
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))
+
+import main
+from aegisops_control_plane.models import ApprovalDecisionRecord
+import test_cli_inspection as cli_inspection_tests
+
+
+class Phase22EndToEndValidationTests(unittest.TestCase):
+    def _helpers(self) -> cli_inspection_tests.ControlPlaneCliInspectionTests:
+        return cli_inspection_tests.ControlPlaneCliInspectionTests()
+
+    def test_phase22_end_to_end_keeps_review_states_and_visibility_explicit(self) -> None:
+        helpers = self._helpers()
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            helpers._build_phase19_in_scope_case()
+        )
+        seeded = helpers._seed_action_review_states_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
+        )
+
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-phase22-001",
+            intended_outcome="Keep unresolved approval review, fallback, and handoff state explicit.",
+        )
+        unresolved_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-phase22-001",
+            recipient_identity="repo-owner-phase22-001",
+            message_intent="Notify the accountable repository owner using the reviewed path.",
+            escalation_reason="The unresolved reviewed request cannot be allowed to disappear between shifts.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-phase22-visibility-001",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase22-visibility-001",
+                action_request_id=unresolved_request.action_request_id,
+                approver_identities=("approver-phase22-001",),
+                target_snapshot=dict(unresolved_request.target_scope),
+                payload_hash=unresolved_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=unresolved_request.expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                unresolved_request,
+                approval_decision_id=approval.approval_decision_id,
+                lifecycle_state="unresolved",
+            )
+        )
+        service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=reviewed_at + timedelta(hours=8),
+            handoff_owner="analyst-phase22-002",
+            handoff_note="Resume the unresolved reviewed approval and fallback chain at next business-hours open.",
+            follow_up_evidence_ids=(evidence_id,),
+        )
+        service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Keep the unresolved reviewed action visible for the next operator review window.",
+            recorded_at=reviewed_at + timedelta(hours=8),
+        )
+        service.record_action_review_manual_fallback(
+            action_request_id=unresolved_request.action_request_id,
+            fallback_at=reviewed_at + timedelta(minutes=45),
+            fallback_actor_identity="analyst-phase22-003",
+            authority_boundary="approved_human_fallback",
+            reason="The reviewed automation path was unavailable after approval.",
+            action_taken="Used the approved manual procedure while preserving the reviewed approval lineage.",
+            verification_evidence_ids=(evidence_id,),
+            residual_uncertainty="Awaiting written owner acknowledgement in the next review window.",
+        )
+        service.record_action_review_escalation_note(
+            action_request_id=unresolved_request.action_request_id,
+            escalated_at=reviewed_at + timedelta(minutes=15),
+            escalated_by_identity="analyst-phase22-003",
+            escalated_to="on-call-manager-phase22-001",
+            note="On-call manager notified because the unresolved reviewed approval could not be left unattended.",
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        action_reviews_by_id = {
+            review["action_request_id"]: review for review in payload["action_reviews"]
+        }
+
+        self.assertEqual(
+            action_reviews_by_id[seeded["pending_request"].action_request_id]["review_state"],
+            "pending",
+        )
+        self.assertEqual(
+            action_reviews_by_id[seeded["rejected_request"].action_request_id]["review_state"],
+            "rejected",
+        )
+        self.assertEqual(
+            action_reviews_by_id[seeded["expired_request"].action_request_id]["review_state"],
+            "expired",
+        )
+        self.assertEqual(
+            action_reviews_by_id[seeded["superseded_request"].action_request_id]["review_state"],
+            "superseded",
+        )
+        self.assertEqual(
+            action_reviews_by_id[seeded["superseded_request"].action_request_id][
+                "replacement_action_request_id"
+            ],
+            seeded["replacement_request"].action_request_id,
+        )
+        self.assertIsNone(
+            action_reviews_by_id[seeded["rejected_request"].action_request_id][
+                "runtime_visibility"
+            ]
+        )
+        self.assertIsNone(
+            action_reviews_by_id[seeded["expired_request"].action_request_id][
+                "runtime_visibility"
+            ]
+        )
+        self.assertIsNone(
+            action_reviews_by_id[seeded["superseded_request"].action_request_id][
+                "runtime_visibility"
+            ]
+        )
+
+        unresolved_review = action_reviews_by_id[unresolved_request.action_request_id]
+        self.assertEqual(unresolved_review["review_state"], "unresolved")
+        self.assertEqual(
+            unresolved_review["runtime_visibility"]["after_hours_handoff"]["handoff_owner"],
+            "analyst-phase22-002",
+        )
+        self.assertEqual(
+            unresolved_review["runtime_visibility"]["after_hours_handoff"]["disposition"],
+            "business_hours_handoff",
+        )
+        self.assertEqual(
+            unresolved_review["runtime_visibility"]["manual_fallback"]["approval_decision_id"],
+            approval.approval_decision_id,
+        )
+        self.assertEqual(
+            unresolved_review["runtime_visibility"]["manual_fallback"][
+                "fallback_actor_identity"
+            ],
+            "analyst-phase22-003",
+        )
+        self.assertEqual(
+            unresolved_review["runtime_visibility"]["escalation_notes"]["escalated_to"],
+            "on-call-manager-phase22-001",
+        )
+        self.assertEqual(
+            unresolved_review["runtime_visibility"]["escalation_notes"][
+                "escalated_by_identity"
+            ],
+            "analyst-phase22-003",
+        )
+
+    def test_phase22_end_to_end_keeps_success_claims_non_authoritative_until_reconciliation_matches(
+        self,
+    ) -> None:
+        helpers = self._helpers()
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            helpers._build_phase19_in_scope_case()
+        )
+        seeded = helpers._seed_action_review_timeline_mismatch_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
+        )
+        approved_request = seeded["action_request"]
+        execution = seeded["action_execution"]
+        requested_at = approved_request.requested_at
+        service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": "shuffle-run-phase22-unexpected-001",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "observed_at": requested_at + timedelta(minutes=19),
+                    "status": "success",
+                },
+            ),
+            compared_at=requested_at + timedelta(minutes=20),
+            stale_after=requested_at + timedelta(minutes=40),
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(review["action_request_id"], approved_request.action_request_id)
+        self.assertEqual(review["review_state"], "executing")
+        self.assertEqual(review["next_expected_action"], "await_execution_reconciliation")
+        self.assertEqual(review["action_execution_state"], "queued")
+        self.assertEqual(review["reconciliation_state"], "mismatched")
+        self.assertNotEqual(review["review_state"], "completed")
+        self.assertEqual(
+            [stage["stage"] for stage in review["timeline"]],
+            [
+                "action_request",
+                "approval_decision",
+                "delegation",
+                "action_execution",
+                "reconciliation",
+            ],
+        )
+        self.assertEqual(review["timeline"][2]["state"], "delegated")
+        self.assertEqual(review["timeline"][3]["state"], "queued")
+        self.assertEqual(review["timeline"][4]["state"], "mismatched")
+        self.assertEqual(
+            review["timeline"][4]["details"]["execution_run_id"],
+            "shuffle-run-phase22-unexpected-001",
+        )
+        self.assertEqual(
+            review["mismatch_inspection"]["execution_run_id"],
+            "shuffle-run-phase22-unexpected-001",
+        )
+        self.assertIn(
+            "run identity mismatch",
+            review["mismatch_inspection"]["mismatch_summary"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase22_operator_trust_boundary_validation.py
+++ b/control-plane/tests/test_phase22_operator_trust_boundary_validation.py
@@ -27,10 +27,17 @@ class Phase22OperatorTrustBoundaryValidationTests(unittest.TestCase):
     def test_phase22_validation_artifacts_cross_reference_governing_contracts(self) -> None:
         design_doc = self._design_doc()
         validation_doc = self._validation_doc()
+        end_to_end_test = (
+            REPO_ROOT / "control-plane" / "tests" / "test_phase22_end_to_end_validation.py"
+        )
         self.assertTrue(design_doc.exists(), f"expected Phase 22 design doc at {design_doc}")
         self.assertTrue(
             validation_doc.exists(),
             f"expected Phase 22 validation doc at {validation_doc}",
+        )
+        self.assertTrue(
+            end_to_end_test.exists(),
+            f"expected Phase 22 end-to-end validation tests at {end_to_end_test}",
         )
 
         design_text = design_doc.read_text(encoding="utf-8")
@@ -50,12 +57,14 @@ class Phase22OperatorTrustBoundaryValidationTests(unittest.TestCase):
             self.assertIn(term, validation_text)
 
         for term in (
-            "python3 -m unittest control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation",
+            "control-plane/tests/test_phase22_end_to_end_validation.py",
+            "python3 -m unittest control-plane.tests.test_phase22_end_to_end_validation control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation",
             "Reviewed Approval State Semantics",
             "Mismatch Taxonomy and Inspection Expectations",
             "manual fallback",
             "after-hours handoff",
             "reviewed Phase 20 approval / delegation / reconciliation binding guarantees",
+            "Phase 22 end-to-end validation keeps pending, expired, rejected, superseded, delegation, execution, reconciliation, manual fallback, after-hours handoff, and escalation-note trust surfaces explicit without weakening Phase 19-21 fail-closed behavior.",
         ):
             self.assertIn(term, validation_text)
 

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -132,6 +132,31 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         ):
             self.assertIn(term, auth_end_to_end_and_cli_tests)
 
+    def test_phase22_regression_validation_keeps_operator_trust_runtime_coverage(
+        self,
+    ) -> None:
+        phase22_end_to_end_tests = self._defined_test_names(
+            "control-plane/tests/test_phase22_end_to_end_validation.py"
+        )
+        phase19_to_phase21_validation_tests = self._defined_test_names(
+            "control-plane/tests/test_phase19_operator_workflow_validation.py",
+            "control-plane/tests/test_phase20_low_risk_action_validation.py",
+            "control-plane/tests/test_phase21_end_to_end_validation.py",
+        )
+
+        for term in (
+            "test_phase22_end_to_end_keeps_review_states_and_visibility_explicit",
+            "test_phase22_end_to_end_keeps_success_claims_non_authoritative_until_reconciliation_matches",
+        ):
+            self.assertIn(term, phase22_end_to_end_tests)
+
+        for term in (
+            "test_reviewed_runtime_path_covers_approved_operator_workflow",
+            "test_reviewed_runtime_path_covers_phase20_low_risk_action_boundary",
+            "test_phase21_end_to_end_restore_and_readiness_preserve_phase20_live_path",
+        ):
+            self.assertIn(term, phase19_to_phase21_validation_tests)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/phase-22-operator-trust-and-workflow-ergonomics-boundary-and-sequence-validation.md
+++ b/docs/phase-22-operator-trust-and-workflow-ergonomics-boundary-and-sequence-validation.md
@@ -3,7 +3,7 @@
 - Validation date: 2026-04-14
 - Validation scope: Phase 22 review of the operator-trust and workflow-ergonomics boundary for the reviewed action chain, including state semantics, mismatch taxonomy, manual fallback visibility, after-hours handoff visibility, escalation-note visibility, actor identity display, and confirmation that Phase 19-21 fail-closed boundaries remain preserved
 - Baseline references: `docs/phase-22-operator-trust-and-workflow-ergonomics-boundary-and-sequence.md`, `docs/phase-19-thin-operator-surface-and-daily-analyst-workflow.md`, `docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md`, `docs/phase-21-production-like-hardening-boundary-and-sequence.md`, `docs/control-plane-state-model.md`, `docs/automation-substrate-contract.md`, `docs/response-action-safety-model.md`, `docs/secops-business-hours-operating-model.md`, `docs/architecture.md`
-- Verification commands: `python3 -m unittest control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation`, `bash scripts/verify-phase-22-operator-trust-boundary.sh`, `bash scripts/test-verify-phase-22-operator-trust-boundary.sh`, `bash scripts/test-verify-ci-phase-22-workflow-coverage.sh`
+- Verification commands: `python3 -m unittest control-plane.tests.test_phase22_end_to_end_validation control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation`, `bash scripts/verify-phase-22-operator-trust-boundary.sh`, `bash scripts/test-verify-phase-22-operator-trust-boundary.sh`, `bash scripts/test-verify-ci-phase-22-workflow-coverage.sh`
 - Validation status: PASS
 
 ## Required Boundary Artifacts
@@ -18,6 +18,7 @@
 - `docs/response-action-safety-model.md`
 - `docs/secops-business-hours-operating-model.md`
 - `docs/architecture.md`
+- `control-plane/tests/test_phase22_end_to_end_validation.py`
 - `control-plane/tests/test_phase22_operator_trust_boundary_docs.py`
 - `control-plane/tests/test_phase22_operator_trust_boundary_validation.py`
 - `scripts/verify-phase-22-operator-trust-boundary.sh`
@@ -42,7 +43,9 @@ Confirmed the design preserves the completed Phase 19-21 fail-closed boundaries 
 
 Confirmed the fixed execution order keeps implementation narrow by requiring approval state semantics first, mismatch inspection expectations second, handoff and fallback visibility third, actor identity display fourth, view alignment fifth, and focused validation updates last.
 
-Confirmed repository-local doc validation now asserts the required state semantics, mismatch taxonomy, handoff visibility rules, manual fallback visibility, actor identity display, and CI workflow coverage for the reviewed Phase 22 boundary.
+Confirmed repository-local doc validation now asserts the required state semantics, mismatch taxonomy, handoff visibility rules, manual fallback visibility, actor identity display, dedicated end-to-end review coverage, and CI workflow coverage for the reviewed Phase 22 boundary.
+
+Phase 22 end-to-end validation keeps pending, expired, rejected, superseded, delegation, execution, reconciliation, manual fallback, after-hours handoff, and escalation-note trust surfaces explicit without weakening Phase 19-21 fail-closed behavior.
 
 The issue requested review against `Phase 16-21 Epic Roadmap.md`, but that roadmap file was not present in the local worktree and could not be located via repository search during this validation snapshot.
 

--- a/scripts/test-verify-ci-phase-22-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-22-workflow-coverage.sh
@@ -14,7 +14,7 @@ required_tests=(
 )
 
 required_runtime_commands=(
-  "python3 -m unittest control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation"
+  "python3 -m unittest control-plane.tests.test_phase22_end_to_end_validation control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation"
 )
 
 self_guard_step_name="Run Phase 22 workflow coverage guard"

--- a/scripts/test-verify-phase-22-operator-trust-boundary.sh
+++ b/scripts/test-verify-phase-22-operator-trust-boundary.sh
@@ -24,6 +24,7 @@ required_artifacts=(
   "docs/response-action-safety-model.md"
   "docs/secops-business-hours-operating-model.md"
   "docs/architecture.md"
+  "control-plane/tests/test_phase22_end_to_end_validation.py"
   "control-plane/tests/test_phase22_operator_trust_boundary_docs.py"
   "control-plane/tests/test_phase22_operator_trust_boundary_validation.py"
   "scripts/verify-phase-22-operator-trust-boundary.sh"

--- a/scripts/verify-phase-22-operator-trust-boundary.sh
+++ b/scripts/verify-phase-22-operator-trust-boundary.sh
@@ -13,6 +13,7 @@ automation_doc="${repo_root}/docs/automation-substrate-contract.md"
 response_doc="${repo_root}/docs/response-action-safety-model.md"
 business_hours_doc="${repo_root}/docs/secops-business-hours-operating-model.md"
 architecture_doc="${repo_root}/docs/architecture.md"
+end_to_end_test="${repo_root}/control-plane/tests/test_phase22_end_to_end_validation.py"
 docs_test="${repo_root}/control-plane/tests/test_phase22_operator_trust_boundary_docs.py"
 validation_test="${repo_root}/control-plane/tests/test_phase22_operator_trust_boundary_validation.py"
 workflow_path="${repo_root}/.github/workflows/ci.yml"
@@ -47,6 +48,7 @@ require_file "${automation_doc}" "Missing automation substrate contract doc"
 require_file "${response_doc}" "Missing response action safety model doc"
 require_file "${business_hours_doc}" "Missing business-hours operating model doc"
 require_file "${architecture_doc}" "Missing architecture overview doc"
+require_file "${end_to_end_test}" "Missing Phase 22 end-to-end validation unittest"
 require_file "${docs_test}" "Missing Phase 22 doc unittest"
 require_file "${validation_test}" "Missing Phase 22 validation unittest"
 require_file "${workflow_path}" "Missing CI workflow"
@@ -111,6 +113,7 @@ required_artifacts=(
   "docs/response-action-safety-model.md"
   "docs/secops-business-hours-operating-model.md"
   "docs/architecture.md"
+  "control-plane/tests/test_phase22_end_to_end_validation.py"
   "control-plane/tests/test_phase22_operator_trust_boundary_docs.py"
   "control-plane/tests/test_phase22_operator_trust_boundary_validation.py"
   "scripts/verify-phase-22-operator-trust-boundary.sh"
@@ -123,7 +126,10 @@ for artifact in "${required_artifacts[@]}"; do
   require_fixed_line "${validation_doc}" "- \`${artifact}\`"
 done
 
-require_fixed_line "${validation_doc}" '- Verification commands: `python3 -m unittest control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation`, `bash scripts/verify-phase-22-operator-trust-boundary.sh`, `bash scripts/test-verify-phase-22-operator-trust-boundary.sh`, `bash scripts/test-verify-ci-phase-22-workflow-coverage.sh`'
+require_fixed_line "${validation_doc}" '- Verification commands: `python3 -m unittest control-plane.tests.test_phase22_end_to_end_validation control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation`, `bash scripts/verify-phase-22-operator-trust-boundary.sh`, `bash scripts/test-verify-phase-22-operator-trust-boundary.sh`, `bash scripts/test-verify-ci-phase-22-workflow-coverage.sh`'
+require_fixed_line "${end_to_end_test}" 'class Phase22EndToEndValidationTests(unittest.TestCase):'
+require_fixed_line "${end_to_end_test}" '    def test_phase22_end_to_end_keeps_review_states_and_visibility_explicit(self) -> None:'
+require_fixed_line "${end_to_end_test}" '    def test_phase22_end_to_end_keeps_success_claims_non_authoritative_until_reconciliation_matches('
 require_fixed_line "${docs_test}" 'class Phase22OperatorTrustBoundaryDocsTests(unittest.TestCase):'
 require_fixed_line "${docs_test}" '    def test_phase22_design_doc_exists(self) -> None:'
 require_fixed_line "${docs_test}" '    def test_phase22_design_doc_defines_state_semantics_mismatch_taxonomy_and_boundary('
@@ -131,7 +137,7 @@ require_fixed_line "${validation_test}" 'class Phase22OperatorTrustBoundaryValid
 require_fixed_line "${validation_test}" '    def test_phase22_validation_artifacts_cross_reference_governing_contracts(self) -> None:'
 require_fixed_line "${workflow_path}" '      - name: Run Phase 22 operator trust boundary validation'
 require_fixed_line "${workflow_path}" '          bash scripts/verify-phase-22-operator-trust-boundary.sh'
-require_fixed_line "${workflow_path}" '          python3 -m unittest control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation'
+require_fixed_line "${workflow_path}" '          python3 -m unittest control-plane.tests.test_phase22_end_to_end_validation control-plane.tests.test_phase22_operator_trust_boundary_docs control-plane.tests.test_phase22_operator_trust_boundary_validation'
 require_fixed_line "${workflow_path}" '      - name: Run Phase 22 workflow coverage guard'
 require_fixed_line "${workflow_path}" '        run: bash scripts/test-verify-ci-phase-22-workflow-coverage.sh'
 require_fixed_line "${workflow_path}" '          bash scripts/test-verify-phase-22-operator-trust-boundary.sh'


### PR DESCRIPTION
Closes #481
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a dedicated Phase 22 runtime validation module in [control-plane/tests/test_phase22_end_to_end_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-481/control-plane/tests/test_phase22_end_to_end_validation.py:1). It covers the reviewed operator trust surfaces that were previously only exercised indirectly: pending, rejected, expired, and superseded review states; manual fallback, after-hours handoff, and escalation-note visibility; and delegation/execution/reconciliation review when a substrate-local success signal drifts from authoritative lineage. I also tightened the Phase 22 validation guard in [control-plane/tests/test_phase22_operator_trust_boundary_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-481/control-plane/tests/test_phase22_operator_trust_boundary_validation.py:1), added a regression guard in [control-plane/tests/test_service_boundary_refactor_regression_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-481/control-plane/tests/test_service_boundary_refactor_regression_validation.py:1), and updated the Phase 22 validation doc, verifier scripts, and CI step so the dedicated runtime artifact is now required instead of docs-only coverage.

The focused reproducer was a new assertion in the Phase 22 validation test that failed because `control-plane/tests/test_phase22_end_to_end_validation.py` did not exist. That is now fixed and committed as `b29948c` (`Add Phase 22 end-to-end trust validation`). I also updated the issue journa...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Phase 22 end-to-end validation tests covering operator trust boundary scenarios, including action review state transitions and execution reconciliation validation.

* **Chores**
  * Updated CI/CD workflows and test verification scripts to include and validate the new end-to-end test module.
  * Updated documentation to reflect expanded Phase 22 validation requirements and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->