### PR TITLE
follow-up hardening: close state-confusion and visibility drift gaps in the Phase 22 operator trust surfaces (#482)

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1704,7 +1704,7 @@ class AegisOpsControlPlaneService:
         reviewed_context: Mapping[str, object],
         review_state: str,
     ) -> dict[str, object] | None:
-        if review_state in {"completed", "failed", "expired", "rejected", "superseded", "canceled"}:
+        if review_state in {"completed", "failed", "canceled"}:
             return None
         handoff = reviewed_context.get("handoff")
         triage = reviewed_context.get("triage")

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -3908,12 +3908,14 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             review["action_request_id"]: review for review in payload["action_reviews"]
         }
 
-        for request in (
+        for action_request in (
             seeded["expired_request"],
             seeded["rejected_request"],
             seeded["superseded_request"],
         ):
-            visibility = reviews_by_id[request.action_request_id]["runtime_visibility"] or {}
+            visibility = (
+                reviews_by_id[action_request.action_request_id]["runtime_visibility"] or {}
+            )
             self.assertEqual(
                 visibility["after_hours_handoff"]["handoff_owner"],
                 "analyst-visibility-001",

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -3872,6 +3872,61 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(queue_payload["total_records"], 1)
         self.assertIsNone(queue_payload["records"][0]["current_action_review"]["runtime_visibility"])
 
+    def test_cli_inspect_case_detail_keeps_after_hours_handoff_visible_for_non_executed_review_states(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        seeded = self._seed_action_review_states_for_case(
+            service,
+            promoted_case,
+            reviewed_at,
+            evidence_id,
+        )
+        service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=reviewed_at + timedelta(hours=8),
+            handoff_owner="analyst-visibility-001",
+            handoff_note="Keep non-executed review states explicit for the next analyst handoff.",
+            follow_up_evidence_ids=(evidence_id,),
+        )
+        service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Expired, rejected, and superseded reviewed requests must remain visibly handed off.",
+            recorded_at=reviewed_at + timedelta(hours=8),
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        reviews_by_id = {
+            review["action_request_id"]: review for review in payload["action_reviews"]
+        }
+
+        for request in (
+            seeded["expired_request"],
+            seeded["rejected_request"],
+            seeded["superseded_request"],
+        ):
+            visibility = reviews_by_id[request.action_request_id]["runtime_visibility"] or {}
+            self.assertEqual(
+                visibility["after_hours_handoff"]["handoff_owner"],
+                "analyst-visibility-001",
+            )
+            self.assertEqual(
+                visibility["after_hours_handoff"]["disposition"],
+                "business_hours_handoff",
+            )
+            self.assertEqual(
+                visibility["after_hours_handoff"]["rationale"],
+                "Expired, rejected, and superseded reviewed requests must remain visibly handed off.",
+            )
+
     def test_cli_inspect_alert_detail_renders_alert_scoped_runtime_visibility(
         self,
     ) -> None:

--- a/control-plane/tests/test_phase22_end_to_end_validation.py
+++ b/control-plane/tests/test_phase22_end_to_end_validation.py
@@ -136,21 +136,24 @@ class Phase22EndToEndValidationTests(unittest.TestCase):
             ],
             seeded["replacement_request"].action_request_id,
         )
-        self.assertIsNone(
-            action_reviews_by_id[seeded["rejected_request"].action_request_id][
-                "runtime_visibility"
-            ]
-        )
-        self.assertIsNone(
-            action_reviews_by_id[seeded["expired_request"].action_request_id][
-                "runtime_visibility"
-            ]
-        )
-        self.assertIsNone(
-            action_reviews_by_id[seeded["superseded_request"].action_request_id][
-                "runtime_visibility"
-            ]
-        )
+        for request_key in ("rejected_request", "expired_request", "superseded_request"):
+            runtime_visibility = (
+                action_reviews_by_id[seeded[request_key].action_request_id]["runtime_visibility"]
+                or {}
+            )
+            self.assertEqual(
+                runtime_visibility["after_hours_handoff"]["handoff_owner"],
+                "analyst-phase22-002",
+            )
+            self.assertEqual(
+                runtime_visibility["after_hours_handoff"]["disposition"],
+                "business_hours_handoff",
+            )
+            self.assertEqual(
+                runtime_visibility["after_hours_handoff"]["rationale"],
+                "Keep the unresolved reviewed action visible for the next operator review window.",
+            )
+            self.assertNotIn("manual_fallback", runtime_visibility)
 
         unresolved_review = action_reviews_by_id[unresolved_request.action_request_id]
         self.assertEqual(unresolved_review["review_state"], "unresolved")


### PR DESCRIPTION
Closes #482
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a focused Phase 22 hardening slice around after-hours handoff visibility. The bug was reproducible with a narrow regression: handed-off `expired`, `rejected`, and `superseded` action reviews dropped `after_hours_handoff`, which conflicted with the Phase 22 visibility contract. I fixed the shared visibility helper in [service.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-482/control-plane/aegisops_control_plane/service.py:1704) so queue, alert, and case surfaces retain handoff context for those non-executed review states, and I tightened the regressions in [test_cli_inspection.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-482/control-plane/tests/test_cli_inspection.py:3875) and [test_phase22_end_to_end_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-482/control-plane/tests/test_phase22_end_to_end_validation.py:136).

Verification passed both focused and broad. I ran the new reproducer, adjacent CLI/Phase 22 tests, and the full suite with `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` with `391` tests passing. I also committed the code change as `836f8f3` (`Harden Phase 22 handoff visibility states`).

Summary: Preserved after-hours handoff visibility for handed-off `expired`, `rejected`, and `superseded` Phase 22 review states and locked it down with regression coverage.
State hint: stabilizing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_i...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * After-hours handoff visibility is now preserved for expired, rejected, and superseded action reviews.

* **Tests**
  * Added test coverage to validate after-hours handoff visibility retention for non-executed review states.
  * Updated tests to verify full handoff details (owner, disposition, rationale) and absence of unintended fallback data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->