### PR TITLE
Follow-up: redact raw reconciliation payloads from inspect-reconciliation-status (#489)

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1315,7 +1315,9 @@ class AegisOpsControlPlaneService:
             latest_compared_at=latest_compared_at,
             by_lifecycle_state=by_lifecycle_state,
             by_ingest_disposition=by_ingest_disposition,
-            records=tuple(_record_to_dict(record) for record in records),
+            records=tuple(
+                _redacted_reconciliation_payload(record) for record in records
+            ),
         )
 
     def describe_startup_status(self) -> StartupStatusSnapshot:

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -969,7 +969,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         service.persist_record(
             ReconciliationRecord(
                 reconciliation_id="reconciliation-http-001",
-                subject_linkage={"alert_ids": ("alert-http-001",)},
+                subject_linkage={
+                    "alert_ids": ("alert-http-001",),
+                    "latest_native_payload": {"secret": "keep-in-store"},
+                },
                 alert_id="alert-http-001",
                 finding_id="finding-http-001",
                 analytic_signal_id="signal-http-001",
@@ -1030,6 +1033,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 self.assertEqual(records_payload["record_family"], "alert")
                 self.assertEqual(records_payload["records"][0]["alert_id"], "alert-http-001")
                 self.assertEqual(status_payload["by_ingest_disposition"], {"created": 1})
+                self.assertNotIn(
+                    "latest_native_payload",
+                    status_payload["records"][0]["subject_linkage"],
+                )
             finally:
                 if servers:
                     servers[0].shutdown()
@@ -2020,7 +2027,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         service.persist_record(
             ReconciliationRecord(
                 reconciliation_id="reconciliation-001",
-                subject_linkage={"alert_ids": ("alert-001",)},
+                subject_linkage={
+                    "alert_ids": ("alert-001",),
+                    "latest_native_payload": {"secret": "keep-in-store"},
+                },
                 alert_id="alert-001",
                 finding_id="finding-001",
                 analytic_signal_id="signal-001",
@@ -2081,6 +2091,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         self.assertEqual(
             status_payload["latest_compared_at"],
             "2026-04-05T12:00:00+00:00",
+        )
+        self.assertNotIn(
+            "latest_native_payload",
+            status_payload["records"][0]["subject_linkage"],
         )
 
     def test_cli_renders_wazuh_business_hours_analyst_queue_view(self) -> None:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -222,7 +222,7 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             "latest_native_payload",
             status_view.records[1]["subject_linkage"],
         )
-        stored_latest = service.get_record(ReconciliationRecord, "reconciliation-002")
+        stored_latest = service.get_record(type(stale), "reconciliation-002")
         self.assertIsNotNone(stored_latest)
         self.assertIn("latest_native_payload", stored_latest.subject_linkage)
 

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -151,7 +151,11 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
         )
         matched = ReconciliationRecord(
             reconciliation_id="reconciliation-001",
-            subject_linkage={"alert_ids": ("alert-001",), "finding_ids": ("finding-001",)},
+            subject_linkage={
+                "alert_ids": ("alert-001",),
+                "finding_ids": ("finding-001",),
+                "latest_native_payload": {"secret": "keep-in-store"},
+            },
             alert_id="alert-001",
             finding_id="finding-001",
             analytic_signal_id="signal-001",
@@ -172,6 +176,7 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
                 "finding_ids": ("finding-001",),
                 "execution_surface_types": ("automation_substrate",),
                 "execution_surface_ids": ("n8n",),
+                "latest_native_payload": {"secret": "keep-in-store"},
             },
             alert_id="alert-001",
             finding_id="finding-001",
@@ -209,6 +214,17 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             tuple(record["reconciliation_id"] for record in status_view.records),
             ("reconciliation-001", "reconciliation-002"),
         )
+        self.assertNotIn(
+            "latest_native_payload",
+            status_view.records[0]["subject_linkage"],
+        )
+        self.assertNotIn(
+            "latest_native_payload",
+            status_view.records[1]["subject_linkage"],
+        )
+        stored_latest = service.get_record(ReconciliationRecord, "reconciliation-002")
+        self.assertIsNotNone(stored_latest)
+        self.assertIn("latest_native_payload", stored_latest.subject_linkage)
 
     def test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain(
         self,


### PR DESCRIPTION
Closes #489
This PR was opened by codex-supervisor.
Latest Codex summary:

Changed `inspect_reconciliation_status()` to serialize reconciliation records through the existing reviewed-surface redaction helper, so the inspection snapshot no longer exposes `subject_linkage.latest_native_payload` while persisted `ReconciliationRecord` data remains unchanged internally. I tightened the existing service-level restore/readiness test to reproduce that leak, and added matching CLI and HTTP assertions in the inspection tests so the operator-facing surfaces stay aligned.

Committed on `codex/issue-489` as `df6334e` with message `Redact reconciliation status payloads`. I also updated the local issue journal working notes; those `.codex-supervisor` files remain untracked by design.

Summary: Redacted raw reconciliation payloads from `inspect_reconciliation_status()` and added focused service, CLI, and HTTP regression coverage.
State hint: local_review
Blocked reason: none
Tests: `python3 -m unittest discover -s control-plane/tests -p 'test_service_persistence_restore_readiness.py'`; `python3 -m unittest -v control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_renders_read_only_record_and_reconciliation_views control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_long_running_runtime_surface_exposes_runtime_and_inspection_http_views`
Failure signature: none
Next action: Open or update a draft PR for `codex/issue-489` with commit `df6334e` and let CI validate the broader branch state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status/inspection output now redacts sensitive payload details from reconciliation views while retaining full payloads in internal records.

* **Tests**
  * Updated tests to assert that status outputs omit redacted payload fields while persistence still retains them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->