### PR TITLE
design: publish the positive SMB value proposition and deployment target profile (#492)

### DIFF
--- a/.codex-supervisor/issues/492/issue-journal.md
+++ b/.codex-supervisor/issues/492/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #492: design: publish the positive SMB value proposition and deployment target profile
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/492
+- Branch: codex/issue-492
+- Workspace: .
+- Journal: .codex-supervisor/issues/492/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 38b93079845b0636375262411f85074cd8b86863
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-16T02:44:08.563Z
+
+## Latest Codex Summary
+- Added a focused SMB value-proposition verifier and test, updated `README.md` and `docs/architecture.md` with a concrete SMB deployment target profile, and created `docs/Revised Phase23-20 Epic Roadmap.md` to anchor Phase 23 scope to that profile.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The current thesis checks passed because they did not enforce the missing positive SMB value proposition or the concrete deployment target profile across README, architecture, and roadmap language.
+- What changed: Added `scripts/verify-positive-smb-value-proposition.sh` and `scripts/test-verify-positive-smb-value-proposition.sh`; inserted aligned SMB thesis and deployment-target wording into `README.md` and `docs/architecture.md`; created `docs/Revised Phase23-20 Epic Roadmap.md` as the in-repo roadmap alignment artifact for Phase 23.
+- Current blocker: none
+- Next exact step: Stage the updated docs and verifier scripts, create a checkpoint commit on `codex/issue-492`, and leave the branch ready for supervisor review or draft PR creation.
+- Verification gap: Requested commands `bash scripts/verify-architecture-doc.sh` and `bash scripts/verify-requirements-baseline-control-plane-thesis.sh` passed; new focused verifier and its test also passed. No broader CI or PR checks were run in this turn.
+- Files touched: `README.md`, `docs/architecture.md`, `docs/Revised Phase23-20 Epic Roadmap.md`, `scripts/verify-positive-smb-value-proposition.sh`, `scripts/test-verify-positive-smb-value-proposition.sh`
+- Rollback concern: Low; changes are documentation-only plus a new focused verifier/test and do not alter runtime behavior.
+- Last focused command: `bash scripts/verify-positive-smb-value-proposition.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           bash scripts/verify-phase-8-control-plane-foundation-validation.sh
           bash scripts/verify-phase-9-control-plane-runtime-boundary-validation.sh
           bash scripts/verify-phase-10-thesis-consistency.sh
+          bash scripts/verify-positive-smb-value-proposition.sh
           bash scripts/verify-phase-6-initial-telemetry-slice-doc.sh
           bash scripts/verify-phase-6-opensearch-detector-artifacts.sh
           bash scripts/verify-phase-6-replay-to-notify-validation.sh
@@ -194,6 +195,7 @@ jobs:
           bash scripts/test-verify-phase-8-control-plane-foundation-validation.sh
           bash scripts/test-verify-phase-9-control-plane-runtime-boundary-validation.sh
           bash scripts/test-verify-phase-10-thesis-consistency.sh
+          bash scripts/test-verify-positive-smb-value-proposition.sh
           bash scripts/test-verify-phase-11-control-plane-ci-validation.sh
           bash scripts/test-verify-phase-12-wazuh-ci-validation.sh
           bash scripts/test-verify-phase-13-guarded-automation-ci-validation.sh

--- a/README.md
+++ b/README.md
@@ -314,6 +314,12 @@ The following are intentionally not current goals:
 
 ## Who should use AegisOps
 
+AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
+The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners.
+
+The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC.
+
 AegisOps is best suited for:
 
 - small SecOps teams

--- a/control-plane/tests/test_phase17_boot_path_validation.py
+++ b/control-plane/tests/test_phase17_boot_path_validation.py
@@ -11,6 +11,8 @@ from unittest import mock
 
 CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
 REPO_ROOT = CONTROL_PLANE_ROOT.parent
+DOCKER_COMPOSE_RENDER_TIMEOUT_SECONDS = 30
+DOCKER_COMPOSE_DRY_RUN_TIMEOUT_SECONDS = 120
 if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
@@ -148,6 +150,20 @@ class Phase17BootPathValidationTests(unittest.TestCase):
                     )
                 )
             )
+
+    def test_first_boot_compose_timeout_policy_allows_more_time_for_dry_run(self) -> None:
+        self.assertEqual(
+            self._docker_compose_timeout_seconds("config", "--services"),
+            DOCKER_COMPOSE_RENDER_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            self._docker_compose_timeout_seconds("config"),
+            DOCKER_COMPOSE_RENDER_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            self._docker_compose_timeout_seconds("up", "--dry-run"),
+            DOCKER_COMPOSE_DRY_RUN_TIMEOUT_SECONDS,
+        )
 
     def test_postgresql_runtime_persists_records_across_service_restart(self) -> None:
         backend = FakePostgresBackend()
@@ -338,6 +354,11 @@ class Phase17BootPathValidationTests(unittest.TestCase):
             stderr=stderr,
         )
 
+    def _docker_compose_timeout_seconds(self, *compose_args: str) -> int:
+        if compose_args[:2] == ("up", "--dry-run"):
+            return DOCKER_COMPOSE_DRY_RUN_TIMEOUT_SECONDS
+        return DOCKER_COMPOSE_RENDER_TIMEOUT_SECONDS
+
     def _run_docker_compose(
         self,
         docker_bin: str,
@@ -345,6 +366,7 @@ class Phase17BootPathValidationTests(unittest.TestCase):
         env_path: pathlib.Path,
         *compose_args: str,
     ) -> subprocess.CompletedProcess[str]:
+        timeout_seconds = self._docker_compose_timeout_seconds(*compose_args)
         try:
             return subprocess.run(
                 [
@@ -360,11 +382,11 @@ class Phase17BootPathValidationTests(unittest.TestCase):
                 capture_output=True,
                 text=True,
                 cwd=REPO_ROOT,
-                timeout=30,
+                timeout=timeout_seconds,
             )
         except subprocess.TimeoutExpired as exc:
             self.fail(
-                "docker compose command timed out after 30 seconds:"
+                f"docker compose command timed out after {timeout_seconds} seconds:"
                 f" {' '.join(exc.cmd)}"
             )
 

--- a/docs/Revised Phase23-20 Epic Roadmap.md
+++ b/docs/Revised Phase23-20 Epic Roadmap.md
@@ -1,4 +1,4 @@
-# Revised Phase23-20 Epic Roadmap
+# Revised Phase 23-20 Epic Roadmap
 
 ## 1. Purpose
 

--- a/docs/Revised Phase23-20 Epic Roadmap.md
+++ b/docs/Revised Phase23-20 Epic Roadmap.md
@@ -1,0 +1,49 @@
+# Revised Phase23-20 Epic Roadmap
+
+## 1. Purpose
+
+This roadmap revision anchors the next hardening and ergonomics work to the approved AegisOps control-plane thesis and deployment target.
+
+It exists to keep Phase 23 planning aligned with the reviewed SMB operating model rather than drifting toward broad enterprise repositioning, generic SIEM replacement language, or multi-tenant packaging.
+
+## 2. Product Thesis
+
+AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
+It sits above reviewed detection and automation substrates so analysts and approvers can preserve authoritative workflow truth without asking those substrates to become the durable authority for approvals, evidence custody, or reconciliation outcomes.
+
+The positive value proposition is not broad source breadth or broad autonomous response. The value proposition is trustworthy governance over the narrow set of actions, records, and handoffs that a small SecOps team must actually review.
+
+## 3. Primary Deployment Target Profile
+
+The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners.
+
+The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC.
+
+The intended deployment shape remains a narrow on-premise control-plane environment where later footprint, reliability, and ergonomics decisions can be judged against one concrete operator model instead of vague enterprise aspirations.
+
+## 4. Roadmap Guardrails
+
+Phase 23 hardening and ergonomics work must be evaluated against this deployment target before scope expands.
+
+That means later work should prefer:
+
+- stronger approval handling, evidence quality, and reconciliation visibility for the reviewed daily path;
+- clearer operator ergonomics for small business-hours teams;
+- reliability and recovery work sized for the approved SMB footprint; and
+- narrow source and action growth that preserves the reviewed authority boundary.
+
+That means later work should avoid:
+
+- broad enterprise-market repositioning;
+- generic SIEM replacement claims;
+- multi-tenant packaging; and
+- scope growth that assumes 24x7 staffed operations by default.
+
+## 5. Alignment Notes
+
+`README.md` should describe AegisOps positively as the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
+`docs/architecture.md` should carry the same product thesis and deployment target so component-boundary decisions stay anchored to the same audience and operating assumptions.
+
+Future roadmap slices should treat this document as the control statement for who AegisOps is for before they add new hardening, ergonomics, or source-expansion work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,12 @@ It defines:
 
 AegisOps is a governed SecOps control plane above external detection and automation substrates.
 
+AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
+The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners.
+
+The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC.
+
 The approved baseline is organized around four roles:
 
 - the detection substrate,

--- a/docs/requirements-baseline.md
+++ b/docs/requirements-baseline.md
@@ -27,6 +27,8 @@ This project aims to design and build **AegisOps** as an internally managed SecO
 
 AegisOps is a governed SecOps control plane.
 
+AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
 AegisOps owns the authoritative platform records and policy decisions for:
 
 - Alert
@@ -108,6 +110,10 @@ The following items are explicitly out of scope for the initial phases:
 ### 2.3 Initial Operating Model
 
 Initial phases assume a **business-hours-oriented security operations model**, not a 24/7 fully staffed SOC.
+
+The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners.
+
+The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC.
 
 Escalation, notification, and approval design MUST reflect this assumption.
 

--- a/scripts/test-verify-ci-phase-10-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-10-workflow-coverage.sh
@@ -7,10 +7,12 @@ workflow_path="${repo_root}/.github/workflows/ci.yml"
 
 required_verifiers=(
   "bash scripts/verify-phase-10-thesis-consistency.sh"
+  "bash scripts/verify-positive-smb-value-proposition.sh"
 )
 
 required_tests=(
   "bash scripts/test-verify-phase-10-thesis-consistency.sh"
+  "bash scripts/test-verify-positive-smb-value-proposition.sh"
 )
 
 self_guard_step_name="Run Phase 10 workflow coverage guard"

--- a/scripts/test-verify-positive-smb-value-proposition.sh
+++ b/scripts/test-verify-positive-smb-value-proposition.sh
@@ -46,7 +46,7 @@ The target operating assumption is business-hours review with explicit after-hou
 EOF
 
   cat <<'EOF' > "${target}/docs/Revised Phase23-20 Epic Roadmap.md"
-# Revised Phase23-20 Epic Roadmap
+# Revised Phase 23-20 Epic Roadmap
 
 AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
 
@@ -159,5 +159,23 @@ git -C "${roadmap_contradiction_repo}" add docs/requirements-baseline.md
 append_text_to_doc "${roadmap_contradiction_repo}" "docs/Revised Phase23-20 Epic Roadmap.md" "Multi-tenant packaging is in scope for this roadmap slice."
 commit_fixture "${roadmap_contradiction_repo}"
 assert_fails_with "${roadmap_contradiction_repo}" "Forbidden roadmap out-of-scope contradiction: Multi-tenant packaging is in scope for this roadmap slice."
+
+requirements_siem_contradiction_repo="${workdir}/requirements-siem-contradiction"
+create_repo "${requirements_siem_contradiction_repo}"
+write_valid_docs "${requirements_siem_contradiction_repo}"
+cp "${repo_root}/docs/requirements-baseline.md" "${requirements_siem_contradiction_repo}/docs/requirements-baseline.md"
+git -C "${requirements_siem_contradiction_repo}" add docs/requirements-baseline.md
+append_text_to_doc "${requirements_siem_contradiction_repo}" "docs/requirements-baseline.md" "AegisOps is a generic SIEM replacement for broad enterprise operations."
+commit_fixture "${requirements_siem_contradiction_repo}"
+assert_fails_with "${requirements_siem_contradiction_repo}" "Forbidden requirements baseline contradiction marker: AegisOps is a generic SIEM replacement for broad enterprise operations."
+
+requirements_scope_contradiction_repo="${workdir}/requirements-scope-contradiction"
+create_repo "${requirements_scope_contradiction_repo}"
+write_valid_docs "${requirements_scope_contradiction_repo}"
+cp "${repo_root}/docs/requirements-baseline.md" "${requirements_scope_contradiction_repo}/docs/requirements-baseline.md"
+git -C "${requirements_scope_contradiction_repo}" add docs/requirements-baseline.md
+append_text_to_doc "${requirements_scope_contradiction_repo}" "docs/requirements-baseline.md" "Multi-tenant packaging is in scope for this roadmap slice."
+commit_fixture "${requirements_scope_contradiction_repo}"
+assert_fails_with "${requirements_scope_contradiction_repo}" "Forbidden requirements baseline out-of-scope contradiction: Multi-tenant packaging is in scope for this roadmap slice."
 
 echo "Positive SMB value proposition verifier tests passed."

--- a/scripts/test-verify-positive-smb-value-proposition.sh
+++ b/scripts/test-verify-positive-smb-value-proposition.sh
@@ -113,12 +113,30 @@ assert_fails_with() {
 valid_repo="${workdir}/valid"
 create_repo "${valid_repo}"
 write_valid_docs "${valid_repo}"
+cp "${repo_root}/docs/requirements-baseline.md" "${valid_repo}/docs/requirements-baseline.md"
+git -C "${valid_repo}" add docs/requirements-baseline.md
 commit_fixture "${valid_repo}"
 assert_passes "${valid_repo}"
+
+windows_path_repo="${workdir}/windows-path"
+create_repo "${windows_path_repo}"
+write_valid_docs "${windows_path_repo}"
+cp "${repo_root}/docs/requirements-baseline.md" "${windows_path_repo}/docs/requirements-baseline.md"
+git -C "${windows_path_repo}" add docs/requirements-baseline.md
+commit_fixture "${windows_path_repo}"
+windows_style_path="${windows_path_repo//\//\\}"
+assert_passes "${windows_path_repo}"
+if ! bash "${verifier}" "${windows_style_path}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+  echo "Expected verifier to normalize Windows-style repository roots: ${windows_style_path}" >&2
+  cat "${pass_stderr}" >&2
+  exit 1
+fi
 
 missing_roadmap_repo="${workdir}/missing-roadmap"
 create_repo "${missing_roadmap_repo}"
 write_valid_docs "${missing_roadmap_repo}"
+cp "${repo_root}/docs/requirements-baseline.md" "${missing_roadmap_repo}/docs/requirements-baseline.md"
+git -C "${missing_roadmap_repo}" add docs/requirements-baseline.md
 rm "${missing_roadmap_repo}/docs/Revised Phase23-20 Epic Roadmap.md"
 git -C "${missing_roadmap_repo}" add -u "docs/Revised Phase23-20 Epic Roadmap.md"
 commit_fixture "${missing_roadmap_repo}"
@@ -127,6 +145,8 @@ assert_fails_with "${missing_roadmap_repo}" "Missing Phase 23 roadmap document:"
 missing_target_profile_repo="${workdir}/missing-target-profile"
 create_repo "${missing_target_profile_repo}"
 write_valid_docs "${missing_target_profile_repo}"
+cp "${repo_root}/docs/requirements-baseline.md" "${missing_target_profile_repo}/docs/requirements-baseline.md"
+git -C "${missing_target_profile_repo}" add docs/requirements-baseline.md
 remove_text_from_doc "${missing_target_profile_repo}" "docs/architecture.md" "The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners."
 commit_fixture "${missing_target_profile_repo}"
 assert_fails_with "${missing_target_profile_repo}" "Missing architecture deployment target profile:"
@@ -134,6 +154,8 @@ assert_fails_with "${missing_target_profile_repo}" "Missing architecture deploym
 roadmap_contradiction_repo="${workdir}/roadmap-contradiction"
 create_repo "${roadmap_contradiction_repo}"
 write_valid_docs "${roadmap_contradiction_repo}"
+cp "${repo_root}/docs/requirements-baseline.md" "${roadmap_contradiction_repo}/docs/requirements-baseline.md"
+git -C "${roadmap_contradiction_repo}" add docs/requirements-baseline.md
 append_text_to_doc "${roadmap_contradiction_repo}" "docs/Revised Phase23-20 Epic Roadmap.md" "Multi-tenant packaging is in scope for this roadmap slice."
 commit_fixture "${roadmap_contradiction_repo}"
 assert_fails_with "${roadmap_contradiction_repo}" "Forbidden roadmap out-of-scope contradiction: Multi-tenant packaging is in scope for this roadmap slice."

--- a/scripts/test-verify-positive-smb-value-proposition.sh
+++ b/scripts/test-verify-positive-smb-value-proposition.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-positive-smb-value-proposition.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_valid_docs() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/README.md"
+# AegisOps
+
+AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
+The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners.
+
+The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC.
+EOF
+
+  cat <<'EOF' > "${target}/docs/architecture.md"
+# AegisOps Architecture Overview
+
+AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
+The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners.
+
+The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC.
+EOF
+
+  cat <<'EOF' > "${target}/docs/Revised Phase23-20 Epic Roadmap.md"
+# Revised Phase23-20 Epic Roadmap
+
+AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
+The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners.
+
+The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC.
+
+Phase 23 hardening and ergonomics work must be evaluated against this deployment target before scope expands.
+EOF
+
+  git -C "${target}" add README.md docs/architecture.md "docs/Revised Phase23-20 Epic Roadmap.md"
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local path="$2"
+  local expected_text="$3"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+append_text_to_doc() {
+  local target="$1"
+  local path="$2"
+  local text="$3"
+
+  printf '\n%s\n' "${text}" >> "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_valid_docs "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_roadmap_repo="${workdir}/missing-roadmap"
+create_repo "${missing_roadmap_repo}"
+write_valid_docs "${missing_roadmap_repo}"
+rm "${missing_roadmap_repo}/docs/Revised Phase23-20 Epic Roadmap.md"
+git -C "${missing_roadmap_repo}" add -u "docs/Revised Phase23-20 Epic Roadmap.md"
+commit_fixture "${missing_roadmap_repo}"
+assert_fails_with "${missing_roadmap_repo}" "Missing Phase 23 roadmap document:"
+
+missing_target_profile_repo="${workdir}/missing-target-profile"
+create_repo "${missing_target_profile_repo}"
+write_valid_docs "${missing_target_profile_repo}"
+remove_text_from_doc "${missing_target_profile_repo}" "docs/architecture.md" "The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners."
+commit_fixture "${missing_target_profile_repo}"
+assert_fails_with "${missing_target_profile_repo}" "Missing architecture deployment target profile:"
+
+roadmap_contradiction_repo="${workdir}/roadmap-contradiction"
+create_repo "${roadmap_contradiction_repo}"
+write_valid_docs "${roadmap_contradiction_repo}"
+append_text_to_doc "${roadmap_contradiction_repo}" "docs/Revised Phase23-20 Epic Roadmap.md" "Multi-tenant packaging is in scope for this roadmap slice."
+commit_fixture "${roadmap_contradiction_repo}"
+assert_fails_with "${roadmap_contradiction_repo}" "Forbidden roadmap out-of-scope contradiction: Multi-tenant packaging is in scope for this roadmap slice."
+
+echo "Positive SMB value proposition verifier tests passed."

--- a/scripts/verify-positive-smb-value-proposition.sh
+++ b/scripts/verify-positive-smb-value-proposition.sh
@@ -69,7 +69,9 @@ require_phrase "${roadmap_path}" "Phase 23 hardening and ergonomics work must be
 
 forbid_phrase "${readme_path}" "AegisOps is a generic SIEM replacement for broad enterprise operations." "README contradiction marker"
 forbid_phrase "${architecture_path}" "AegisOps is a generic SIEM replacement for broad enterprise operations." "architecture contradiction marker"
+forbid_phrase "${requirements_path}" "AegisOps is a generic SIEM replacement for broad enterprise operations." "requirements baseline contradiction marker"
 forbid_phrase "${roadmap_path}" "AegisOps is a generic SIEM replacement for broad enterprise operations." "roadmap contradiction marker"
+forbid_phrase "${requirements_path}" "Multi-tenant packaging is in scope for this roadmap slice." "requirements baseline out-of-scope contradiction"
 forbid_phrase "${roadmap_path}" "Multi-tenant packaging is in scope for this roadmap slice." "roadmap out-of-scope contradiction"
 
-echo "Positive SMB value proposition and deployment target profile are aligned across README, architecture, and roadmap."
+echo "Positive SMB value proposition and deployment target profile are aligned across README, architecture, requirements baseline, and roadmap."

--- a/scripts/verify-positive-smb-value-proposition.sh
+++ b/scripts/verify-positive-smb-value-proposition.sh
@@ -3,9 +3,11 @@
 set -euo pipefail
 
 repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+repo_root="${repo_root//\\//}"
 readme_path="${repo_root}/README.md"
 architecture_path="${repo_root}/docs/architecture.md"
 roadmap_path="${repo_root}/docs/Revised Phase23-20 Epic Roadmap.md"
+requirements_path="${repo_root}/docs/requirements-baseline.md"
 
 require_file() {
   local path="$1"
@@ -42,6 +44,7 @@ forbid_phrase() {
 require_file "${readme_path}" "README"
 require_file "${architecture_path}" "architecture document"
 require_file "${roadmap_path}" "Phase 23 roadmap document"
+require_file "${requirements_path}" "requirements baseline document"
 
 positive_thesis="AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model."
 target_profile="The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners."
@@ -54,6 +57,10 @@ require_phrase "${readme_path}" "${business_hours}" "README business-hours targe
 require_phrase "${architecture_path}" "${positive_thesis}" "architecture SMB value proposition statement"
 require_phrase "${architecture_path}" "${target_profile}" "architecture deployment target profile"
 require_phrase "${architecture_path}" "${business_hours}" "architecture business-hours target statement"
+
+require_phrase "${requirements_path}" "${positive_thesis}" "requirements baseline SMB value proposition statement"
+require_phrase "${requirements_path}" "${target_profile}" "requirements baseline deployment target profile"
+require_phrase "${requirements_path}" "${business_hours}" "requirements baseline business-hours target statement"
 
 require_phrase "${roadmap_path}" "${positive_thesis}" "roadmap SMB value proposition statement"
 require_phrase "${roadmap_path}" "${target_profile}" "roadmap deployment target profile"

--- a/scripts/verify-positive-smb-value-proposition.sh
+++ b/scripts/verify-positive-smb-value-proposition.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+readme_path="${repo_root}/README.md"
+architecture_path="${repo_root}/docs/architecture.md"
+roadmap_path="${repo_root}/docs/Revised Phase23-20 Epic Roadmap.md"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+forbid_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if grep -Fq -- "${phrase}" "${path}"; then
+    echo "Forbidden ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+require_file "${readme_path}" "README"
+require_file "${architecture_path}" "architecture document"
+require_file "${roadmap_path}" "Phase 23 roadmap document"
+
+positive_thesis="AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model."
+target_profile="The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners."
+business_hours="The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC."
+
+require_phrase "${readme_path}" "${positive_thesis}" "README SMB value proposition statement"
+require_phrase "${readme_path}" "${target_profile}" "README deployment target profile"
+require_phrase "${readme_path}" "${business_hours}" "README business-hours target statement"
+
+require_phrase "${architecture_path}" "${positive_thesis}" "architecture SMB value proposition statement"
+require_phrase "${architecture_path}" "${target_profile}" "architecture deployment target profile"
+require_phrase "${architecture_path}" "${business_hours}" "architecture business-hours target statement"
+
+require_phrase "${roadmap_path}" "${positive_thesis}" "roadmap SMB value proposition statement"
+require_phrase "${roadmap_path}" "${target_profile}" "roadmap deployment target profile"
+require_phrase "${roadmap_path}" "${business_hours}" "roadmap business-hours target statement"
+require_phrase "${roadmap_path}" "Phase 23 hardening and ergonomics work must be evaluated against this deployment target before scope expands." "roadmap Phase 23 anchoring statement"
+
+forbid_phrase "${readme_path}" "AegisOps is a generic SIEM replacement for broad enterprise operations." "README contradiction marker"
+forbid_phrase "${architecture_path}" "AegisOps is a generic SIEM replacement for broad enterprise operations." "architecture contradiction marker"
+forbid_phrase "${roadmap_path}" "AegisOps is a generic SIEM replacement for broad enterprise operations." "roadmap contradiction marker"
+forbid_phrase "${roadmap_path}" "Multi-tenant packaging is in scope for this roadmap slice." "roadmap out-of-scope contradiction"
+
+echo "Positive SMB value proposition and deployment target profile are aligned across README, architecture, and roadmap."

--- a/scripts/verify-requirements-baseline-control-plane-thesis.sh
+++ b/scripts/verify-requirements-baseline-control-plane-thesis.sh
@@ -10,6 +10,7 @@ required_phrases=(
   "## Platform Requirements Baseline"
   "This document defines the **non-negotiable implementation baseline** for **AegisOps** as a **governed control plane above commodity detection and automation substrates**."
   "AegisOps is a governed SecOps control plane."
+  "AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model."
   "AegisOps owns the authoritative platform records and policy decisions for:"
   "- Alert"
   "- Case"
@@ -28,6 +29,8 @@ required_phrases=(
   "n8n MAY be used as an optional, transitional, or experimental execution substrate."
   "AegisOps will **not** rebuild Wazuh-class detection breadth in-house."
   "AegisOps will **not** rebuild Shuffle-class routine automation breadth in-house."
+  "The primary deployment target is a single-company or single-business-unit deployment with roughly 250 to 1,500 managed endpoints, 2 to 6 business-hours SecOps operators, and 1 to 3 designated approvers or escalation owners."
+  "The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC."
   "The repository structure and approval boundary in this document remain reviewable baseline constraints."
   "This rebaseline does **not** by itself approve runtime implementation changes, new adapters, or repository-structure expansion."
 )


### PR DESCRIPTION
Closes #492
This PR was opened by codex-supervisor.
Latest Codex summary:

Aligned the positive SMB thesis across [README.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-492/README.md), [docs/architecture.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-492/docs/architecture.md), and the new [docs/Revised Phase23-20 Epic Roadmap.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-492/docs/Revised%20Phase23-20%20Epic%20Roadmap.md). The wording now states AegisOps positively as the reviewed control plane for approval, evidence, and reconciliation governance, and it fixes the deployment target to a narrow SMB profile: roughly `250` to `1,500` endpoints, `2` to `6` business-hours SecOps operators, and `1` to `3` approvers or escalation owners.

To make that drift reproducible before changing the docs, I added [scripts/verify-positive-smb-value-proposition.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-492/scripts/verify-positive-smb-value-proposition.sh) and [scripts/test-verify-positive-smb-value-proposition.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-492/scripts/test-verify-positive-smb-value-proposition.sh). The checkpoint is committed on `codex/issue-492` as `6d2d1f1` with message `docs: align SMB control-plane thesis`.

Summary: Added a focused SMB-thesis verifier, created the missing Phase 23 roadmap artifact, aligned README and architecture wording, and committed the checkpoint as `6d2d1f1`.
State hint: draft_pr
Blocked reason: none
Tests: `bash scripts/test-verify-positive-smb-value-proposition.sh`; `bash scripts/verify-positive-smb-valu...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README, architecture guide, and requirements baseline to define AegisOps as a control plane for SMB SecOps with explicit sizing and a business-hours operating model; added a Phase 23–20 Epic Roadmap and an issue journal entry capturing the supervision turn.

* **Tests**
  * Added a content-consistency verifier and focused test suite now run by CI to validate cross-document alignment.
  * Refined a compose-related test to allow longer timeout for dry-run scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->