### PR TITLE
implementation: add a live approval-decision grant/reject HTTP path with approver-policy enforcement (#493)

### DIFF
--- a/.codex-supervisor/issues/493/issue-journal.md
+++ b/.codex-supervisor/issues/493/issue-journal.md
@@ -1,0 +1,47 @@
+# Issue #493: implementation: add a live approval-decision grant/reject HTTP path with approver-policy enforcement
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/AegisOps/issues/493
+- Branch: codex/issue-493
+- Workspace: .
+- Journal: .codex-supervisor/issues/493/issue-journal.md
+- Current phase: local_review_fix
+- Attempt count: 3 (implementation=1, repair=2)
+- Last head SHA: 58bad0136f60b47c761f071eee00c9894f073095
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-16T03:50:08.637Z
+
+## Latest Codex Summary
+Restricted the live approval-decision surface to actual approvers in [http_surface.py](control-plane/aegisops_control_plane/http_surface.py:641), so `POST /operator/record-action-approval-decision` now fails closed unless the authenticated principal has role `approver`. That closes the local-review finding that an authenticated `analyst` could previously record a live grant/reject by supplying their own identity. I committed the code change as `58bad01` (`Restrict approval decisions to approvers`).
+
+Added focused regression coverage in [test_phase23_approval_surface_validation.py](control-plane/tests/test_phase23_approval_surface_validation.py:41) so the runtime harness can run under alternate principals and now verifies an authenticated reviewed-reverse-proxy `analyst` gets `403` and leaves the request pending. I also updated the local issue journal working notes for the repair pass.
+
+Summary: Restricted the live approval-decision HTTP route to `approver` principals only, added an analyst-`403` regression test, verified both focused suites, and committed the repair as `58bad01`.
+State hint: local_review_fix
+Blocked reason: none
+Tests: `python3 -m unittest control-plane.tests.test_phase23_approval_surface_validation`; `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation`
+Next action: Run a fresh local review on `58bad01`, or perform the pending manual operator-path validation if the supervisor wants runtime confirmation before re-review.
+Failure signature: none
+
+## Active Failure Context
+- Category: blocked
+- Summary: Local review found 3 actionable finding(s) across 3 root cause(s); max severity=high; verified high-severity findings=3; verified max severity=high.
+- Details:
+  - findings=3
+  - root_causes=3
+  - summary=<redacted-local-path>
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The remaining blocked review findings were the missing PostgreSQL persistence contract for `ApprovalDecisionRecord.decision_rationale` and missing decision-time approver-policy enforcement inside `record_action_approval_decision(...)`.
+- What changed: Added request-side approver-policy revalidation in `control-plane/aegisops_control_plane/service.py` so live approval decisions now fail closed unless the reviewed action class is still the supported `notify` class and any request-specific `policy_evaluation.authorized_approver_identities` allowlist includes the current approver. Added the missing `decision_rationale` column to `postgres/control-plane/schema.sql`, the bootstrap schema migration `0001_control_plane_schema_skeleton.sql`, and a new forward migration `0005_phase_23_approval_decision_rationale.sql`. Extended `control-plane/tests/test_phase23_approval_surface_validation.py` with a reviewed runtime regression that an `approver` outside the request allowlist receives `403`, and added `control-plane/tests/test_postgres_store.py` coverage that the forward migration asset and checked-in schema both carry the new column.
+- Current blocker: none
+- Next exact step: Commit the persistence plus approver-policy repair on `codex/issue-493`, then hand the branch back for a fresh local review or any requested manual operator-path validation.
+- Verification gap: Manual end-to-end operator-path validation is still not run; automated coverage now includes live grant/reject, self-approval denial, analyst-role denial, request-specific approver-policy denial, the action-reconciliation persistence suite, and the PostgreSQL schema/migration asset checks.
+- Files touched: control-plane/aegisops_control_plane/service.py; control-plane/tests/test_phase23_approval_surface_validation.py; control-plane/tests/test_postgres_store.py; postgres/control-plane/schema.sql; postgres/control-plane/migrations/0001_control_plane_schema_skeleton.sql; postgres/control-plane/migrations/0005_phase_23_approval_decision_rationale.sql; .codex-supervisor/issues/493/issue-journal.md
+- Rollback concern: `ApprovalDecisionRecord` now includes persisted `decision_rationale`; rollback must account for any rows serialized with the new field in stores used during verification.
+- Last focused commands: `python3 -m unittest control-plane.tests.test_phase23_approval_surface_validation`; `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation`; `python3 -m unittest control-plane.tests.test_postgres_store`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -640,6 +640,10 @@ def build_handler_class(
 
             if request_path == "/operator/record-action-approval-decision":
                 try:
+                    if getattr(principal, "role", None) != "approver":
+                        raise PermissionError(
+                            "approval decisions require approver role authority"
+                        )
                     payload = read_json_request_body(self)
                     if getattr(principal, "access_path", "") == "reviewed_reverse_proxy":
                         self._require_matching_identity(

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -645,17 +645,27 @@ def build_handler_class(
                             "approval decisions require approver role authority"
                         )
                     payload = read_json_request_body(self)
+                    approver_identity = require_json_string(
+                        payload,
+                        "approver_identity",
+                    )
+                    authenticated_approver_identity = getattr(
+                        principal,
+                        "identity",
+                        None,
+                    )
+                    if authenticated_approver_identity is None:
+                        raise PermissionError(
+                            "approval decisions require an authenticated approver identity"
+                        )
+                    self._require_matching_identity(
+                        authenticated_approver_identity,
+                        approver_identity,
+                    )
                     approval_decision = service.record_action_approval_decision(
                         action_request_id=require_json_string(payload, "action_request_id"),
-                        approver_identity=require_json_string(
-                            payload,
-                            "approver_identity",
-                        ),
-                        authenticated_approver_identity=getattr(
-                            principal,
-                            "identity",
-                            None,
-                        ),
+                        approver_identity=authenticated_approver_identity,
+                        authenticated_approver_identity=authenticated_approver_identity,
                         decision=require_json_string(payload, "decision"),
                         decision_rationale=require_json_string(
                             payload,

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -645,16 +645,16 @@ def build_handler_class(
                             "approval decisions require approver role authority"
                         )
                     payload = read_json_request_body(self)
-                    if getattr(principal, "access_path", "") == "reviewed_reverse_proxy":
-                        self._require_matching_identity(
-                            principal.identity,
-                            require_json_string(payload, "approver_identity"),
-                        )
                     approval_decision = service.record_action_approval_decision(
                         action_request_id=require_json_string(payload, "action_request_id"),
                         approver_identity=require_json_string(
                             payload,
                             "approver_identity",
+                        ),
+                        authenticated_approver_identity=getattr(
+                            principal,
+                            "identity",
+                            None,
                         ),
                         decision=require_json_string(payload, "decision"),
                         decision_rationale=require_json_string(

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -638,6 +638,48 @@ def build_handler_class(
                 self._write_json(HTTPStatus.OK, json_ready(context_record))
                 return
 
+            if request_path == "/operator/record-action-approval-decision":
+                try:
+                    payload = read_json_request_body(self)
+                    if getattr(principal, "access_path", "") == "reviewed_reverse_proxy":
+                        self._require_matching_identity(
+                            principal.identity,
+                            require_json_string(payload, "approver_identity"),
+                        )
+                    approval_decision = service.record_action_approval_decision(
+                        action_request_id=require_json_string(payload, "action_request_id"),
+                        approver_identity=require_json_string(
+                            payload,
+                            "approver_identity",
+                        ),
+                        decision=require_json_string(payload, "decision"),
+                        decision_rationale=require_json_string(
+                            payload,
+                            "decision_rationale",
+                        ),
+                        decided_at=require_json_datetime(payload, "decided_at"),
+                        approval_decision_id=normalize_optional_string(
+                            payload.get("approval_decision_id")
+                        ),
+                    )
+                except RequestTooLargeError as exc:
+                    self._write_json(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        {
+                            "error": "request_too_large",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                except PermissionError as exc:
+                    self._write_permission_or_bad_request(exc)
+                    return
+                except (LookupError, ValueError) as exc:
+                    self._write_lookup_or_bad_request(exc)
+                    return
+                self._write_json(HTTPStatus.OK, json_ready(approval_decision))
+                return
+
             if request_path == "/operator/create-reviewed-action-request":
                 try:
                     payload = read_json_request_body(self)

--- a/control-plane/aegisops_control_plane/models.py
+++ b/control-plane/aegisops_control_plane/models.py
@@ -200,6 +200,7 @@ class ApprovalDecisionRecord(ControlPlaneRecord):
     payload_hash: str
     decided_at: datetime | None
     lifecycle_state: str
+    decision_rationale: str | None = None
     approved_expires_at: datetime | None = None
 
     def __post_init__(self) -> None:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1603,6 +1603,11 @@ class AegisOpsControlPlaneService:
             "approver_identities": (
                 approval_decision.approver_identities if approval_decision is not None else ()
             ),
+            "decision_rationale": (
+                approval_decision.decision_rationale
+                if approval_decision is not None
+                else None
+            ),
             "requested_at": action_request.requested_at,
             "expires_at": action_request.expires_at,
             "target_scope": dict(action_request.target_scope),
@@ -2366,6 +2371,14 @@ class AegisOpsControlPlaneService:
                     ()
                     if approval_decision is None
                     else approval_decision.approver_identities
+                ),
+                details=(
+                    {}
+                    if approval_decision is None
+                    or approval_decision.decision_rationale is None
+                    else {
+                        "decision_rationale": approval_decision.decision_rationale,
+                    }
                 ),
             ),
             self._action_review_stage_snapshot(
@@ -3169,6 +3182,117 @@ class AegisOpsControlPlaneService:
             expires_at=expires_at,
             action_request_id=action_request_id,
         )
+
+    def record_action_approval_decision(
+        self,
+        *,
+        action_request_id: str,
+        approver_identity: str,
+        decision: str,
+        decision_rationale: str,
+        decided_at: datetime,
+        approval_decision_id: str | None = None,
+    ) -> ApprovalDecisionRecord:
+        approver_identity = self._require_non_empty_string(
+            approver_identity,
+            "approver_identity",
+        )
+        normalized_decision = self._require_non_empty_string(
+            decision,
+            "decision",
+        ).lower()
+        if normalized_decision not in {"grant", "reject"}:
+            raise ValueError("decision must be 'grant' or 'reject'")
+        decision_rationale = self._require_non_empty_string(
+            decision_rationale,
+            "decision_rationale",
+        )
+        decided_at = self._require_aware_datetime(decided_at, "decided_at")
+
+        with self._store.transaction():
+            action_request = self._require_review_bound_action_request(action_request_id)
+            if action_request.lifecycle_state != "pending_approval":
+                raise ValueError(
+                    "approval decisions can only be recorded for pending reviewed action requests"
+                )
+            if action_request.approval_decision_id is not None:
+                raise ValueError(
+                    f"action request {action_request.action_request_id!r} already has an approval decision"
+                )
+            if (
+                action_request.requester_identity is not None
+                and action_request.requester_identity == approver_identity
+            ):
+                raise PermissionError(
+                    "approver identity must be distinct from requester identity"
+                )
+            if decided_at < action_request.requested_at:
+                raise ValueError("decided_at must be on or after requested_at")
+
+            policy_evaluation = self._apply_action_policy_evaluation_overrides(
+                computed_policy_evaluation=self._determine_action_policy(
+                    self._normalize_action_policy_basis(action_request.policy_basis)
+                ),
+                persisted_policy_evaluation=action_request.policy_evaluation,
+            )
+            if policy_evaluation.get("approval_requirement") != "human_required":
+                raise PermissionError(
+                    "reviewed approval decisions require a human-required action policy"
+                )
+
+            now = datetime.now(timezone.utc)
+            if action_request.expires_at is not None and (
+                now > action_request.expires_at or decided_at > action_request.expires_at
+            ):
+                self.persist_record(replace(action_request, lifecycle_state="expired"))
+                raise ValueError(
+                    "reviewed action request expired before the approval decision was recorded"
+                )
+
+            resolved_approval_decision_id = self._resolve_new_record_identifier(
+                ApprovalDecisionRecord,
+                approval_decision_id,
+                "approval_decision_id",
+                "approval-decision",
+            )
+            decision_state = (
+                "approved" if normalized_decision == "grant" else "rejected"
+            )
+            approval_decision = self.persist_record(
+                ApprovalDecisionRecord(
+                    approval_decision_id=resolved_approval_decision_id,
+                    action_request_id=action_request.action_request_id,
+                    approver_identities=(approver_identity,),
+                    target_snapshot=dict(action_request.target_scope),
+                    payload_hash=action_request.payload_hash,
+                    decided_at=decided_at,
+                    lifecycle_state=decision_state,
+                    decision_rationale=decision_rationale,
+                    approved_expires_at=(
+                        action_request.expires_at
+                        if decision_state == "approved"
+                        else None
+                    ),
+                )
+            )
+            self.persist_record(
+                replace(
+                    action_request,
+                    approval_decision_id=approval_decision.approval_decision_id,
+                    lifecycle_state=decision_state,
+                    policy_evaluation=policy_evaluation,
+                )
+            )
+        self._emit_structured_event(
+            logging.INFO,
+            "action_approval_decision_recorded",
+            approval_decision_id=approval_decision.approval_decision_id,
+            action_request_id=approval_decision.action_request_id,
+            decision=normalized_decision,
+            approver_identity=approver_identity,
+            lifecycle_state=approval_decision.lifecycle_state,
+        )
+        return approval_decision
 
     def attach_assistant_advisory_draft(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3239,6 +3239,10 @@ class AegisOpsControlPlaneService:
                 raise PermissionError(
                     "reviewed approval decisions require a human-required action policy"
                 )
+            self._require_reviewed_action_approver_policy(
+                action_request=action_request,
+                approver_identity=approver_identity,
+            )
 
             now = datetime.now(timezone.utc)
             if action_request.expires_at is not None and (
@@ -3293,6 +3297,66 @@ class AegisOpsControlPlaneService:
             lifecycle_state=approval_decision.lifecycle_state,
         )
         return approval_decision
+
+    def _require_reviewed_action_approver_policy(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approver_identity: str,
+    ) -> None:
+        action_class = self._reviewed_action_class_for_request(action_request)
+        if action_class != "notify":
+            raise PermissionError(
+                "approval decisions are not authorized for the reviewed action class"
+            )
+
+        authorized_approver_identities = self._authorized_approver_identities_for_request(
+            action_request
+        )
+        if (
+            authorized_approver_identities is not None
+            and approver_identity not in authorized_approver_identities
+        ):
+            raise PermissionError(
+                "approver identity is not authorized by the reviewed action approver policy"
+            )
+
+    @staticmethod
+    def _reviewed_action_class_for_request(action_request: ActionRequestRecord) -> str:
+        action_type = action_request.requested_payload.get("action_type")
+        if action_type == "notify_identity_owner":
+            return "notify"
+        raise PermissionError(
+            "approval decisions are not authorized for the reviewed action class"
+        )
+
+    def _authorized_approver_identities_for_request(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> tuple[str, ...] | None:
+        configured_identities = action_request.policy_evaluation.get(
+            "authorized_approver_identities"
+        )
+        if configured_identities is None:
+            return None
+        if not isinstance(configured_identities, (list, tuple)):
+            raise ValueError(
+                "policy_evaluation.authorized_approver_identities must be a sequence of identities"
+            )
+
+        normalized_identities: list[str] = []
+        for index, identity in enumerate(configured_identities):
+            normalized_identity = self._require_non_empty_string(
+                identity,
+                f"policy_evaluation.authorized_approver_identities[{index}]",
+            )
+            if normalized_identity not in normalized_identities:
+                normalized_identities.append(normalized_identity)
+        if not normalized_identities:
+            raise ValueError(
+                "policy_evaluation.authorized_approver_identities must contain at least one identity"
+            )
+        return tuple(normalized_identities)
 
     def attach_assistant_advisory_draft(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3188,6 +3188,7 @@ class AegisOpsControlPlaneService:
         *,
         action_request_id: str,
         approver_identity: str,
+        authenticated_approver_identity: str | None = None,
         decision: str,
         decision_rationale: str,
         decided_at: datetime,
@@ -3208,8 +3209,19 @@ class AegisOpsControlPlaneService:
             "decision_rationale",
         )
         decided_at = self._require_aware_datetime(decided_at, "decided_at")
+        if authenticated_approver_identity is not None:
+            authenticated_approver_identity = self._require_non_empty_string(
+                authenticated_approver_identity,
+                "authenticated_approver_identity",
+            )
+            if authenticated_approver_identity != approver_identity:
+                raise PermissionError(
+                    "authenticated approver identity must match the asserted control-plane approver identity"
+                )
 
-        with self._store.transaction():
+        approval_decision: ApprovalDecisionRecord | None = None
+        request_expired = False
+        with self._store.transaction(isolation_level="SERIALIZABLE"):
             action_request = self._require_review_bound_action_request(action_request_id)
             if action_request.lifecycle_state != "pending_approval":
                 raise ValueError(
@@ -3235,6 +3247,10 @@ class AegisOpsControlPlaneService:
                 ),
                 persisted_policy_evaluation=action_request.policy_evaluation,
             )
+            if policy_evaluation.get("approval_requirement") == "policy_authorized":
+                raise PermissionError(
+                    "reviewed approval decisions are not authorized when the re-evaluated action policy is policy_authorized"
+                )
             if policy_evaluation.get("approval_requirement") != "human_required":
                 raise PermissionError(
                     "reviewed approval decisions require a human-required action policy"
@@ -3249,43 +3265,49 @@ class AegisOpsControlPlaneService:
                 now > action_request.expires_at or decided_at > action_request.expires_at
             ):
                 self.persist_record(replace(action_request, lifecycle_state="expired"))
-                raise ValueError(
-                    "reviewed action request expired before the approval decision was recorded"
+                request_expired = True
+            else:
+                resolved_approval_decision_id = self._resolve_new_record_identifier(
+                    ApprovalDecisionRecord,
+                    approval_decision_id,
+                    "approval_decision_id",
+                    "approval-decision",
                 )
-
-            resolved_approval_decision_id = self._resolve_new_record_identifier(
-                ApprovalDecisionRecord,
-                approval_decision_id,
-                "approval_decision_id",
-                "approval-decision",
-            )
-            decision_state = (
-                "approved" if normalized_decision == "grant" else "rejected"
-            )
-            approval_decision = self.persist_record(
-                ApprovalDecisionRecord(
-                    approval_decision_id=resolved_approval_decision_id,
-                    action_request_id=action_request.action_request_id,
-                    approver_identities=(approver_identity,),
-                    target_snapshot=dict(action_request.target_scope),
-                    payload_hash=action_request.payload_hash,
-                    decided_at=decided_at,
-                    lifecycle_state=decision_state,
-                    decision_rationale=decision_rationale,
-                    approved_expires_at=(
-                        action_request.expires_at
-                        if decision_state == "approved"
-                        else None
-                    ),
+                decision_state = (
+                    "approved" if normalized_decision == "grant" else "rejected"
                 )
-            )
-            self.persist_record(
-                replace(
-                    action_request,
-                    approval_decision_id=approval_decision.approval_decision_id,
-                    lifecycle_state=decision_state,
-                    policy_evaluation=policy_evaluation,
+                approval_decision = self.persist_record(
+                    ApprovalDecisionRecord(
+                        approval_decision_id=resolved_approval_decision_id,
+                        action_request_id=action_request.action_request_id,
+                        approver_identities=(approver_identity,),
+                        target_snapshot=dict(action_request.target_scope),
+                        payload_hash=action_request.payload_hash,
+                        decided_at=decided_at,
+                        lifecycle_state=decision_state,
+                        decision_rationale=decision_rationale,
+                        approved_expires_at=(
+                            action_request.expires_at
+                            if decision_state == "approved"
+                            else None
+                        ),
+                    )
                 )
+                self.persist_record(
+                    replace(
+                        action_request,
+                        approval_decision_id=approval_decision.approval_decision_id,
+                        lifecycle_state=decision_state,
+                        policy_evaluation=policy_evaluation,
+                    )
+                )
+        if request_expired:
+            raise PermissionError(
+                "reviewed action request expired before the approval decision was recorded"
+            )
+        if approval_decision is None:
+            raise RuntimeError(
+                "approval decision transaction completed without recording a decision"
             )
         self._emit_structured_event(
             logging.INFO,

--- a/control-plane/tests/test_phase23_approval_surface_validation.py
+++ b/control-plane/tests/test_phase23_approval_surface_validation.py
@@ -491,7 +491,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
                 )
             )
 
-    def test_reviewed_runtime_path_rejects_mismatched_authenticated_approver_identity(
+    def test_reviewed_runtime_path_rejects_mismatched_approver_identity_assertion(
         self,
     ) -> None:
         service = self._build_service()
@@ -534,7 +534,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
             error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
             self.assertEqual(error_payload["error"], "forbidden")
-            self.assertIn("authenticated approver identity", error_payload["message"])
+            self.assertIn("authenticated identity", error_payload["message"])
             stored_request = service.get_record(
                 type(action_request),
                 action_request.action_request_id,

--- a/control-plane/tests/test_phase23_approval_surface_validation.py
+++ b/control-plane/tests/test_phase23_approval_surface_validation.py
@@ -22,6 +22,7 @@ if str(TESTS_ROOT) not in sys.path:
 
 import main
 from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.models import ApprovalDecisionRecord
 from aegisops_control_plane.service import (
     AegisOpsControlPlaneService,
     AuthenticatedRuntimePrincipal,
@@ -237,6 +238,11 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             service,
             action_request_id="action-request-phase23-live-reject-001",
         )
+        approval_decision_id = "approval-phase23-live-reject-001"
+        decision_rationale = (
+            "Approver rejected the notification because the reviewed evidence is incomplete."
+        )
+        decided_at = action_request.requested_at + timedelta(minutes=10)
 
         with self._run_runtime(service) as (base_url, _authenticate_mock):
             response = request.urlopen(  # noqa: S310
@@ -245,13 +251,11 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
                     data=json.dumps(
                         {
                             "action_request_id": action_request.action_request_id,
-                            "approval_decision_id": "approval-phase23-live-reject-001",
+                            "approval_decision_id": approval_decision_id,
                             "decision": "reject",
                             "approver_identity": "approver-001",
-                            "decision_rationale": "Approver rejected the notification because the reviewed evidence is incomplete.",
-                            "decided_at": (
-                                action_request.requested_at + timedelta(minutes=10)
-                            ).isoformat(),
+                            "decision_rationale": decision_rationale,
+                            "decided_at": decided_at.isoformat(),
                         }
                     ).encode("utf-8"),
                     headers={"Content-Type": "application/json"},
@@ -264,9 +268,24 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertEqual(response.status, HTTPStatus.OK)
             self.assertEqual(payload["lifecycle_state"], "rejected")
             self.assertIsNone(payload["approved_expires_at"])
-            stored_request = service.get_record(type(action_request), action_request.action_request_id)
+            stored_request = service.get_record(
+                type(action_request),
+                action_request.action_request_id,
+            )
             self.assertIsNotNone(stored_request)
+            self.assertEqual(stored_request.approval_decision_id, approval_decision_id)
             self.assertEqual(stored_request.lifecycle_state, "rejected")
+            stored_decision = service.get_record(
+                ApprovalDecisionRecord,
+                approval_decision_id,
+            )
+            self.assertIsNotNone(stored_decision)
+            self.assertEqual(stored_decision.action_request_id, action_request.action_request_id)
+            self.assertEqual(stored_decision.approver_identities, ("approver-001",))
+            self.assertEqual(stored_decision.lifecycle_state, "rejected")
+            self.assertEqual(stored_decision.decision_rationale, decision_rationale)
+            self.assertEqual(stored_decision.decided_at, decided_at)
+            self.assertIsNone(stored_decision.approved_expires_at)
 
     def test_reviewed_runtime_path_records_decisions_with_serializable_transaction(
         self,
@@ -305,9 +324,11 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
                 )
 
             self.assertEqual(response.status, HTTPStatus.OK)
-            self.assertEqual(
-                transaction_mock.call_args_list[0].kwargs["isolation_level"],
-                "SERIALIZABLE",
+            self.assertTrue(
+                any(
+                    call.kwargs.get("isolation_level") == "SERIALIZABLE"
+                    for call in transaction_mock.call_args_list
+                )
             )
 
     def test_reviewed_runtime_path_rejects_self_approval(self) -> None:
@@ -341,10 +362,19 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
                     timeout=2,
                 )
             self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
-            stored_request = service.get_record(type(action_request), action_request.action_request_id)
+            stored_request = service.get_record(
+                type(action_request),
+                action_request.action_request_id,
+            )
             self.assertIsNotNone(stored_request)
             self.assertIsNone(stored_request.approval_decision_id)
             self.assertEqual(stored_request.lifecycle_state, "pending_approval")
+            self.assertIsNone(
+                service.get_record(
+                    ApprovalDecisionRecord,
+                    "approval-phase23-self-approval-001",
+                )
+            )
 
     def test_reviewed_runtime_path_rejects_analyst_decision_authority(self) -> None:
         service = self._build_service()
@@ -394,6 +424,12 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertIsNotNone(stored_request)
             self.assertIsNone(stored_request.approval_decision_id)
             self.assertEqual(stored_request.lifecycle_state, "pending_approval")
+            self.assertIsNone(
+                service.get_record(
+                    ApprovalDecisionRecord,
+                    "approval-phase23-analyst-authority-001",
+                )
+            )
 
     def test_reviewed_runtime_path_rejects_approver_outside_request_policy(self) -> None:
         service = self._build_service()
@@ -448,6 +484,12 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertIsNotNone(stored_request)
             self.assertIsNone(stored_request.approval_decision_id)
             self.assertEqual(stored_request.lifecycle_state, "pending_approval")
+            self.assertIsNone(
+                service.get_record(
+                    ApprovalDecisionRecord,
+                    "approval-phase23-approver-policy-001",
+                )
+            )
 
     def test_reviewed_runtime_path_rejects_mismatched_authenticated_approver_identity(
         self,
@@ -500,6 +542,12 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertIsNotNone(stored_request)
             self.assertIsNone(stored_request.approval_decision_id)
             self.assertEqual(stored_request.lifecycle_state, "pending_approval")
+            self.assertIsNone(
+                service.get_record(
+                    ApprovalDecisionRecord,
+                    "approval-phase23-auth-identity-mismatch-001",
+                )
+            )
 
     def test_reviewed_runtime_path_rejects_expired_request_decisions(self) -> None:
         service = self._build_service()
@@ -551,6 +599,12 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertIsNotNone(stored_request)
             self.assertIsNone(stored_request.approval_decision_id)
             self.assertEqual(stored_request.lifecycle_state, "expired")
+            self.assertIsNone(
+                service.get_record(
+                    ApprovalDecisionRecord,
+                    "approval-phase23-expired-decision-001",
+                )
+            )
 
     def test_reviewed_runtime_path_rejects_re_evaluated_policy_authorized_decisions(
         self,
@@ -605,3 +659,9 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertIsNotNone(stored_request)
             self.assertIsNone(stored_request.approval_decision_id)
             self.assertEqual(stored_request.lifecycle_state, "pending_approval")
+            self.assertIsNone(
+                service.get_record(
+                    ApprovalDecisionRecord,
+                    "approval-phase23-policy-authorized-001",
+                )
+            )

--- a/control-plane/tests/test_phase23_approval_surface_validation.py
+++ b/control-plane/tests/test_phase23_approval_surface_validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 import json
@@ -41,6 +42,12 @@ REVIEWED_APPROVER_PRINCIPAL = AuthenticatedRuntimePrincipal(
 REVIEWED_ANALYST_PRINCIPAL = AuthenticatedRuntimePrincipal(
     identity="analyst-002",
     role="analyst",
+    access_path="reviewed_reverse_proxy",
+    proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+)
+REVIEWED_SECONDARY_APPROVER_PRINCIPAL = AuthenticatedRuntimePrincipal(
+    identity="approver-002",
+    role="approver",
     access_path="reviewed_reverse_proxy",
     proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
 )
@@ -319,6 +326,60 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
             self.assertEqual(error_payload["error"], "forbidden")
             self.assertIn("approver role authority", error_payload["message"])
+            stored_request = service.get_record(
+                type(action_request),
+                action_request.action_request_id,
+            )
+            self.assertIsNotNone(stored_request)
+            self.assertIsNone(stored_request.approval_decision_id)
+            self.assertEqual(stored_request.lifecycle_state, "pending_approval")
+
+    def test_reviewed_runtime_path_rejects_approver_outside_request_policy(self) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(
+            service,
+            action_request_id="action-request-phase23-approver-policy-001",
+        )
+        action_request = service.persist_record(
+            replace(
+                action_request,
+                policy_evaluation={
+                    **dict(action_request.policy_evaluation),
+                    "authorized_approver_identities": ("approver-001",),
+                },
+            )
+        )
+
+        with self._run_runtime(
+            service,
+            principal=REVIEWED_SECONDARY_APPROVER_PRINCIPAL,
+        ) as base_url:
+            with self.assertRaises(error.HTTPError) as exc_info:
+                request.urlopen(  # noqa: S310
+                    request.Request(  # noqa: S310
+                        f"{base_url}/operator/record-action-approval-decision",
+                        data=json.dumps(
+                            {
+                                "action_request_id": action_request.action_request_id,
+                                "approval_decision_id": "approval-phase23-approver-policy-001",
+                                "decision": "grant",
+                                "approver_identity": "approver-002",
+                                "decision_rationale": "Approver must be denied outside the request policy.",
+                                "decided_at": (
+                                    action_request.requested_at + timedelta(minutes=10)
+                                ).isoformat(),
+                            }
+                        ).encode("utf-8"),
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    ),
+                    timeout=2,
+                )
+
+            self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
+            error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
+            self.assertEqual(error_payload["error"], "forbidden")
+            self.assertIn("not authorized", error_payload["message"])
             stored_request = service.get_record(
                 type(action_request),
                 action_request.action_request_id,

--- a/control-plane/tests/test_phase23_approval_surface_validation.py
+++ b/control-plane/tests/test_phase23_approval_surface_validation.py
@@ -169,6 +169,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
     def test_reviewed_runtime_path_records_live_grant_decision(self) -> None:
         service = self._build_service()
         action_request = self._build_pending_action_request(service)
+        decided_at = action_request.requested_at + timedelta(minutes=10)
         with self._run_runtime(service) as (base_url, _authenticate_mock):
             response = request.urlopen(  # noqa: S310
                 request.Request(  # noqa: S310
@@ -180,9 +181,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
                             "decision": "grant",
                             "approver_identity": "approver-001",
                             "decision_rationale": "Approver validated the reviewed owner notification scope.",
-                            "decided_at": (
-                                action_request.requested_at + timedelta(minutes=10)
-                            ).isoformat(),
+                            "decided_at": decided_at.isoformat(),
                         }
                     ).encode("utf-8"),
                     headers={"Content-Type": "application/json"},
@@ -215,6 +214,24 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertIsNotNone(stored_request)
             self.assertEqual(stored_request.approval_decision_id, payload["approval_decision_id"])
             self.assertEqual(stored_request.lifecycle_state, "approved")
+            stored_decision = service.get_record(
+                ApprovalDecisionRecord,
+                payload["approval_decision_id"],
+            )
+            self.assertIsNotNone(stored_decision)
+            self.assertEqual(
+                stored_decision.approval_decision_id,
+                payload["approval_decision_id"],
+            )
+            self.assertEqual(stored_decision.action_request_id, action_request.action_request_id)
+            self.assertEqual(stored_decision.approver_identities, ("approver-001",))
+            self.assertEqual(stored_decision.lifecycle_state, "approved")
+            self.assertEqual(
+                stored_decision.decision_rationale,
+                "Approver validated the reviewed owner notification scope.",
+            )
+            self.assertEqual(stored_decision.decided_at, decided_at)
+            self.assertEqual(stored_decision.approved_expires_at, action_request.expires_at)
 
             case_detail = json.loads(
                 request.urlopen(  # noqa: S310

--- a/control-plane/tests/test_phase23_approval_surface_validation.py
+++ b/control-plane/tests/test_phase23_approval_surface_validation.py
@@ -163,6 +163,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             finally:
                 if servers:
                     servers[0].shutdown()
+                    servers[0].server_close()
                 thread.join(timeout=2)
 
     def test_reviewed_runtime_path_records_live_grant_decision(self) -> None:

--- a/control-plane/tests/test_phase23_approval_surface_validation.py
+++ b/control-plane/tests/test_phase23_approval_surface_validation.py
@@ -38,6 +38,12 @@ REVIEWED_APPROVER_PRINCIPAL = AuthenticatedRuntimePrincipal(
     access_path="reviewed_reverse_proxy",
     proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
 )
+REVIEWED_ANALYST_PRINCIPAL = AuthenticatedRuntimePrincipal(
+    identity="analyst-002",
+    role="analyst",
+    access_path="reviewed_reverse_proxy",
+    proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+)
 
 
 class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
@@ -45,11 +51,13 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
     @contextlib.contextmanager
     def _mock_authenticated_surface_access(
         service: AegisOpsControlPlaneService,
+        *,
+        principal: AuthenticatedRuntimePrincipal = REVIEWED_APPROVER_PRINCIPAL,
     ) -> object:
         with mock.patch.object(
             service,
             "authenticate_protected_surface_request",
-            return_value=REVIEWED_APPROVER_PRINCIPAL,
+            return_value=principal,
         ):
             yield
 
@@ -101,6 +109,8 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
     def _run_runtime(
         self,
         service: AegisOpsControlPlaneService,
+        *,
+        principal: AuthenticatedRuntimePrincipal = REVIEWED_APPROVER_PRINCIPAL,
     ) -> object:
         servers: list[main.ThreadingHTTPServer] = []
 
@@ -109,8 +119,13 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
                 super().__init__(server_address, handler_class)
                 servers.append(self)
 
-        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
-            service
+        with mock.patch.object(
+            main,
+            "ThreadingHTTPServer",
+            RecordingServer,
+        ), self._mock_authenticated_surface_access(
+            service,
+            principal=principal,
         ):
             thread = threading.Thread(
                 target=main.run_control_plane_service,
@@ -266,6 +281,48 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
                 )
             self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
             stored_request = service.get_record(type(action_request), action_request.action_request_id)
+            self.assertIsNotNone(stored_request)
+            self.assertIsNone(stored_request.approval_decision_id)
+            self.assertEqual(stored_request.lifecycle_state, "pending_approval")
+
+    def test_reviewed_runtime_path_rejects_analyst_decision_authority(self) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(
+            service,
+            action_request_id="action-request-phase23-analyst-authority-001",
+        )
+
+        with self._run_runtime(service, principal=REVIEWED_ANALYST_PRINCIPAL) as base_url:
+            with self.assertRaises(error.HTTPError) as exc_info:
+                request.urlopen(  # noqa: S310
+                    request.Request(  # noqa: S310
+                        f"{base_url}/operator/record-action-approval-decision",
+                        data=json.dumps(
+                            {
+                                "action_request_id": action_request.action_request_id,
+                                "approval_decision_id": "approval-phase23-analyst-authority-001",
+                                "decision": "grant",
+                                "approver_identity": "analyst-002",
+                                "decision_rationale": "Analysts must not record approval decisions.",
+                                "decided_at": (
+                                    action_request.requested_at + timedelta(minutes=10)
+                                ).isoformat(),
+                            }
+                        ).encode("utf-8"),
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    ),
+                    timeout=2,
+                )
+
+            self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
+            error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
+            self.assertEqual(error_payload["error"], "forbidden")
+            self.assertIn("approver role authority", error_payload["message"])
+            stored_request = service.get_record(
+                type(action_request),
+                action_request.action_request_id,
+            )
             self.assertIsNotNone(stored_request)
             self.assertIsNone(stored_request.approval_decision_id)
             self.assertEqual(stored_request.lifecycle_state, "pending_approval")

--- a/control-plane/tests/test_phase23_approval_surface_validation.py
+++ b/control-plane/tests/test_phase23_approval_surface_validation.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+import json
+import pathlib
+import sys
+import threading
+import unittest
+from unittest import mock
+from urllib import error, request
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))
+
+import main
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.service import (
+    AegisOpsControlPlaneService,
+    AuthenticatedRuntimePrincipal,
+)
+from postgres_test_support import make_store
+from support.fixtures import load_wazuh_fixture
+
+
+REVIEWED_SHARED_SECRET = "reviewed-shared-secret"  # noqa: S105
+REVIEWED_PROXY_SECRET = "reviewed-proxy-secret"  # noqa: S105
+REVIEWED_PROXY_SERVICE_ACCOUNT = "svc-aegisops-proxy-control-plane"
+REVIEWED_APPROVER_PRINCIPAL = AuthenticatedRuntimePrincipal(
+    identity="approver-001",
+    role="approver",
+    access_path="reviewed_reverse_proxy",
+    proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+)
+
+
+class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
+    @staticmethod
+    @contextlib.contextmanager
+    def _mock_authenticated_surface_access(
+        service: AegisOpsControlPlaneService,
+    ) -> object:
+        with mock.patch.object(
+            service,
+            "authenticate_protected_surface_request",
+            return_value=REVIEWED_APPROVER_PRINCIPAL,
+        ):
+            yield
+
+    def _build_service(self) -> AegisOpsControlPlaneService:
+        store, _ = make_store()
+        return AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+    def _build_pending_action_request(
+        self,
+        service: AegisOpsControlPlaneService,
+        *,
+        requester_identity: str = "analyst-001",
+        action_request_id: str = "action-request-phase23-live-grant-001",
+    ) -> object:
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Require a reviewed approval decision inside the runtime boundary.",
+        )
+        return service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity=requester_identity,
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id=action_request_id,
+        )
+
+    @contextlib.contextmanager
+    def _run_runtime(
+        self,
+        service: AegisOpsControlPlaneService,
+    ) -> object:
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
+            service
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                yield f"http://127.0.0.1:{servers[0].server_port}"
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_reviewed_runtime_path_records_live_grant_decision(self) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(service)
+        with self._run_runtime(service) as base_url:
+                response = request.urlopen(  # noqa: S310
+                    request.Request(  # noqa: S310
+                        f"{base_url}/operator/record-action-approval-decision",
+                        data=json.dumps(
+                            {
+                                "action_request_id": action_request.action_request_id,
+                                "approval_decision_id": "approval-phase23-live-grant-001",
+                                "decision": "grant",
+                                "approver_identity": "approver-001",
+                                "decision_rationale": "Approver validated the reviewed owner notification scope.",
+                                "decided_at": (
+                                    action_request.requested_at + timedelta(minutes=10)
+                                ).isoformat(),
+                            }
+                        ).encode("utf-8"),
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    ),
+                    timeout=2,
+                )
+                payload = json.loads(response.read().decode("utf-8"))
+
+                self.assertEqual(response.status, HTTPStatus.OK)
+                self.assertEqual(
+                    payload["approval_decision_id"],
+                    "approval-phase23-live-grant-001",
+                )
+                self.assertEqual(payload["action_request_id"], action_request.action_request_id)
+                self.assertEqual(payload["lifecycle_state"], "approved")
+                self.assertEqual(payload["approver_identities"], ["approver-001"])
+                self.assertEqual(
+                    payload["decision_rationale"],
+                    "Approver validated the reviewed owner notification scope.",
+                )
+                self.assertEqual(
+                    payload["approved_expires_at"],
+                    action_request.expires_at.isoformat(),
+                )
+                stored_request = service.get_record(
+                    type(action_request),
+                    action_request.action_request_id,
+                )
+                self.assertIsNotNone(stored_request)
+                self.assertEqual(stored_request.approval_decision_id, payload["approval_decision_id"])
+                self.assertEqual(stored_request.lifecycle_state, "approved")
+
+                case_detail = json.loads(
+                    request.urlopen(  # noqa: S310
+                        f"{base_url}/inspect-case-detail?case_id={stored_request.case_id}",
+                        timeout=2,
+                    ).read().decode("utf-8")
+                )
+                self.assertEqual(
+                    case_detail["current_action_review"]["decision_rationale"],
+                    "Approver validated the reviewed owner notification scope.",
+                )
+                self.assertEqual(
+                    case_detail["current_action_review"]["timeline"][1]["details"][
+                        "decision_rationale"
+                    ],
+                    "Approver validated the reviewed owner notification scope.",
+                )
+
+    def test_reviewed_runtime_path_records_live_reject_decision(self) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(
+            service,
+            action_request_id="action-request-phase23-live-reject-001",
+        )
+
+        with self._run_runtime(service) as base_url:
+            response = request.urlopen(  # noqa: S310
+                request.Request(  # noqa: S310
+                    f"{base_url}/operator/record-action-approval-decision",
+                    data=json.dumps(
+                        {
+                            "action_request_id": action_request.action_request_id,
+                            "approval_decision_id": "approval-phase23-live-reject-001",
+                            "decision": "reject",
+                            "approver_identity": "approver-001",
+                            "decision_rationale": "Approver rejected the notification because the reviewed evidence is incomplete.",
+                            "decided_at": (
+                                action_request.requested_at + timedelta(minutes=10)
+                            ).isoformat(),
+                        }
+                    ).encode("utf-8"),
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                ),
+                timeout=2,
+            )
+            payload = json.loads(response.read().decode("utf-8"))
+
+            self.assertEqual(response.status, HTTPStatus.OK)
+            self.assertEqual(payload["lifecycle_state"], "rejected")
+            self.assertIsNone(payload["approved_expires_at"])
+            stored_request = service.get_record(type(action_request), action_request.action_request_id)
+            self.assertIsNotNone(stored_request)
+            self.assertEqual(stored_request.lifecycle_state, "rejected")
+
+    def test_reviewed_runtime_path_rejects_self_approval(self) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(
+            service,
+            requester_identity="approver-001",
+            action_request_id="action-request-phase23-self-approval-001",
+        )
+
+        with self._run_runtime(service) as base_url:
+            with self.assertRaises(error.HTTPError) as exc_info:
+                request.urlopen(  # noqa: S310
+                    request.Request(  # noqa: S310
+                        f"{base_url}/operator/record-action-approval-decision",
+                        data=json.dumps(
+                            {
+                                "action_request_id": action_request.action_request_id,
+                                "approval_decision_id": "approval-phase23-self-approval-001",
+                                "decision": "grant",
+                                "approver_identity": "approver-001",
+                                "decision_rationale": "Self approval must fail closed.",
+                                "decided_at": (
+                                    action_request.requested_at + timedelta(minutes=5)
+                                ).isoformat(),
+                            }
+                        ).encode("utf-8"),
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    ),
+                    timeout=2,
+                )
+            self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
+            stored_request = service.get_record(type(action_request), action_request.action_request_id)
+            self.assertIsNotNone(stored_request)
+            self.assertIsNone(stored_request.approval_decision_id)
+            self.assertEqual(stored_request.lifecycle_state, "pending_approval")

--- a/control-plane/tests/test_phase23_approval_surface_validation.py
+++ b/control-plane/tests/test_phase23_approval_surface_validation.py
@@ -61,12 +61,24 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
         *,
         principal: AuthenticatedRuntimePrincipal = REVIEWED_APPROVER_PRINCIPAL,
     ) -> object:
+        def _authenticate_surface_access(**kwargs: object) -> AuthenticatedRuntimePrincipal:
+            allowed_roles = kwargs.get("allowed_roles")
+            if not isinstance(allowed_roles, tuple):
+                raise AssertionError("expected authenticate_protected_surface_request to receive allowed_roles")
+            if principal.role not in allowed_roles:
+                joined_roles = ", ".join(sorted(allowed_roles))
+                raise PermissionError(
+                    "protected control-plane surface role is not authorized for this endpoint; "
+                    f"expected one of: {joined_roles}"
+                )
+            return principal
+
         with mock.patch.object(
             service,
             "authenticate_protected_surface_request",
-            return_value=principal,
-        ):
-            yield
+            side_effect=_authenticate_surface_access,
+        ) as authenticate_mock:
+            yield authenticate_mock
 
     def _build_service(self) -> AegisOpsControlPlaneService:
         store, _ = make_store()
@@ -133,7 +145,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
         ), self._mock_authenticated_surface_access(
             service,
             principal=principal,
-        ):
+        ) as authenticate_mock:
             thread = threading.Thread(
                 target=main.run_control_plane_service,
                 args=(service,),
@@ -146,7 +158,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
                         break
                     thread.join(0.01)
                 self.assertTrue(servers, "expected test HTTP server to start")
-                yield f"http://127.0.0.1:{servers[0].server_port}"
+                yield f"http://127.0.0.1:{servers[0].server_port}", authenticate_mock
             finally:
                 if servers:
                     servers[0].shutdown()
@@ -155,69 +167,69 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
     def test_reviewed_runtime_path_records_live_grant_decision(self) -> None:
         service = self._build_service()
         action_request = self._build_pending_action_request(service)
-        with self._run_runtime(service) as base_url:
-                response = request.urlopen(  # noqa: S310
-                    request.Request(  # noqa: S310
-                        f"{base_url}/operator/record-action-approval-decision",
-                        data=json.dumps(
-                            {
-                                "action_request_id": action_request.action_request_id,
-                                "approval_decision_id": "approval-phase23-live-grant-001",
-                                "decision": "grant",
-                                "approver_identity": "approver-001",
-                                "decision_rationale": "Approver validated the reviewed owner notification scope.",
-                                "decided_at": (
-                                    action_request.requested_at + timedelta(minutes=10)
-                                ).isoformat(),
-                            }
-                        ).encode("utf-8"),
-                        headers={"Content-Type": "application/json"},
-                        method="POST",
-                    ),
+        with self._run_runtime(service) as (base_url, _authenticate_mock):
+            response = request.urlopen(  # noqa: S310
+                request.Request(  # noqa: S310
+                    f"{base_url}/operator/record-action-approval-decision",
+                    data=json.dumps(
+                        {
+                            "action_request_id": action_request.action_request_id,
+                            "approval_decision_id": "approval-phase23-live-grant-001",
+                            "decision": "grant",
+                            "approver_identity": "approver-001",
+                            "decision_rationale": "Approver validated the reviewed owner notification scope.",
+                            "decided_at": (
+                                action_request.requested_at + timedelta(minutes=10)
+                            ).isoformat(),
+                        }
+                    ).encode("utf-8"),
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                ),
+                timeout=2,
+            )
+            payload = json.loads(response.read().decode("utf-8"))
+
+            self.assertEqual(response.status, HTTPStatus.OK)
+            self.assertEqual(
+                payload["approval_decision_id"],
+                "approval-phase23-live-grant-001",
+            )
+            self.assertEqual(payload["action_request_id"], action_request.action_request_id)
+            self.assertEqual(payload["lifecycle_state"], "approved")
+            self.assertEqual(payload["approver_identities"], ["approver-001"])
+            self.assertEqual(
+                payload["decision_rationale"],
+                "Approver validated the reviewed owner notification scope.",
+            )
+            self.assertEqual(
+                payload["approved_expires_at"],
+                action_request.expires_at.isoformat(),
+            )
+            stored_request = service.get_record(
+                type(action_request),
+                action_request.action_request_id,
+            )
+            self.assertIsNotNone(stored_request)
+            self.assertEqual(stored_request.approval_decision_id, payload["approval_decision_id"])
+            self.assertEqual(stored_request.lifecycle_state, "approved")
+
+            case_detail = json.loads(
+                request.urlopen(  # noqa: S310
+                    f"{base_url}/inspect-case-detail?case_id={stored_request.case_id}",
                     timeout=2,
-                )
-                payload = json.loads(response.read().decode("utf-8"))
-
-                self.assertEqual(response.status, HTTPStatus.OK)
-                self.assertEqual(
-                    payload["approval_decision_id"],
-                    "approval-phase23-live-grant-001",
-                )
-                self.assertEqual(payload["action_request_id"], action_request.action_request_id)
-                self.assertEqual(payload["lifecycle_state"], "approved")
-                self.assertEqual(payload["approver_identities"], ["approver-001"])
-                self.assertEqual(
-                    payload["decision_rationale"],
-                    "Approver validated the reviewed owner notification scope.",
-                )
-                self.assertEqual(
-                    payload["approved_expires_at"],
-                    action_request.expires_at.isoformat(),
-                )
-                stored_request = service.get_record(
-                    type(action_request),
-                    action_request.action_request_id,
-                )
-                self.assertIsNotNone(stored_request)
-                self.assertEqual(stored_request.approval_decision_id, payload["approval_decision_id"])
-                self.assertEqual(stored_request.lifecycle_state, "approved")
-
-                case_detail = json.loads(
-                    request.urlopen(  # noqa: S310
-                        f"{base_url}/inspect-case-detail?case_id={stored_request.case_id}",
-                        timeout=2,
-                    ).read().decode("utf-8")
-                )
-                self.assertEqual(
-                    case_detail["current_action_review"]["decision_rationale"],
-                    "Approver validated the reviewed owner notification scope.",
-                )
-                self.assertEqual(
-                    case_detail["current_action_review"]["timeline"][1]["details"][
-                        "decision_rationale"
-                    ],
-                    "Approver validated the reviewed owner notification scope.",
-                )
+                ).read().decode("utf-8")
+            )
+            self.assertEqual(
+                case_detail["current_action_review"]["decision_rationale"],
+                "Approver validated the reviewed owner notification scope.",
+            )
+            self.assertEqual(
+                case_detail["current_action_review"]["timeline"][1]["details"][
+                    "decision_rationale"
+                ],
+                "Approver validated the reviewed owner notification scope.",
+            )
 
     def test_reviewed_runtime_path_records_live_reject_decision(self) -> None:
         service = self._build_service()
@@ -226,7 +238,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             action_request_id="action-request-phase23-live-reject-001",
         )
 
-        with self._run_runtime(service) as base_url:
+        with self._run_runtime(service) as (base_url, _authenticate_mock):
             response = request.urlopen(  # noqa: S310
                 request.Request(  # noqa: S310
                     f"{base_url}/operator/record-action-approval-decision",
@@ -256,6 +268,48 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertIsNotNone(stored_request)
             self.assertEqual(stored_request.lifecycle_state, "rejected")
 
+    def test_reviewed_runtime_path_records_decisions_with_serializable_transaction(
+        self,
+    ) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(
+            service,
+            action_request_id="action-request-phase23-serializable-001",
+        )
+
+        with mock.patch.object(
+            service._store,
+            "transaction",
+            wraps=service._store.transaction,
+        ) as transaction_mock:
+            with self._run_runtime(service) as (base_url, _authenticate_mock):
+                response = request.urlopen(  # noqa: S310
+                    request.Request(  # noqa: S310
+                        f"{base_url}/operator/record-action-approval-decision",
+                        data=json.dumps(
+                            {
+                                "action_request_id": action_request.action_request_id,
+                                "approval_decision_id": "approval-phase23-serializable-001",
+                                "decision": "grant",
+                                "approver_identity": "approver-001",
+                                "decision_rationale": "Decision writes must hold the strongest transaction boundary in this path.",
+                                "decided_at": (
+                                    action_request.requested_at + timedelta(minutes=10)
+                                ).isoformat(),
+                            }
+                        ).encode("utf-8"),
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    ),
+                    timeout=2,
+                )
+
+            self.assertEqual(response.status, HTTPStatus.OK)
+            self.assertEqual(
+                transaction_mock.call_args_list[0].kwargs["isolation_level"],
+                "SERIALIZABLE",
+            )
+
     def test_reviewed_runtime_path_rejects_self_approval(self) -> None:
         service = self._build_service()
         action_request = self._build_pending_action_request(
@@ -264,7 +318,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             action_request_id="action-request-phase23-self-approval-001",
         )
 
-        with self._run_runtime(service) as base_url:
+        with self._run_runtime(service) as (base_url, _authenticate_mock):
             with self.assertRaises(error.HTTPError) as exc_info:
                 request.urlopen(  # noqa: S310
                     request.Request(  # noqa: S310
@@ -299,7 +353,10 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             action_request_id="action-request-phase23-analyst-authority-001",
         )
 
-        with self._run_runtime(service, principal=REVIEWED_ANALYST_PRINCIPAL) as base_url:
+        with self._run_runtime(
+            service,
+            principal=REVIEWED_ANALYST_PRINCIPAL,
+        ) as (base_url, authenticate_mock):
             with self.assertRaises(error.HTTPError) as exc_info:
                 request.urlopen(  # noqa: S310
                     request.Request(  # noqa: S310
@@ -326,6 +383,10 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
             self.assertEqual(error_payload["error"], "forbidden")
             self.assertIn("approver role authority", error_payload["message"])
+            self.assertEqual(
+                authenticate_mock.call_args_list[0].kwargs["allowed_roles"],
+                ("analyst", "approver", "platform_admin"),
+            )
             stored_request = service.get_record(
                 type(action_request),
                 action_request.action_request_id,
@@ -353,7 +414,7 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
         with self._run_runtime(
             service,
             principal=REVIEWED_SECONDARY_APPROVER_PRINCIPAL,
-        ) as base_url:
+        ) as (base_url, _authenticate_mock):
             with self.assertRaises(error.HTTPError) as exc_info:
                 request.urlopen(  # noqa: S310
                     request.Request(  # noqa: S310
@@ -380,6 +441,163 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
             self.assertEqual(error_payload["error"], "forbidden")
             self.assertIn("not authorized", error_payload["message"])
+            stored_request = service.get_record(
+                type(action_request),
+                action_request.action_request_id,
+            )
+            self.assertIsNotNone(stored_request)
+            self.assertIsNone(stored_request.approval_decision_id)
+            self.assertEqual(stored_request.lifecycle_state, "pending_approval")
+
+    def test_reviewed_runtime_path_rejects_mismatched_authenticated_approver_identity(
+        self,
+    ) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(
+            service,
+            action_request_id="action-request-phase23-auth-identity-mismatch-001",
+        )
+        direct_approver_principal = AuthenticatedRuntimePrincipal(
+            identity="approver-001",
+            role="approver",
+            access_path="loopback_direct",
+        )
+
+        with self._run_runtime(
+            service,
+            principal=direct_approver_principal,
+        ) as (base_url, _authenticate_mock):
+            with self.assertRaises(error.HTTPError) as exc_info:
+                request.urlopen(  # noqa: S310
+                    request.Request(  # noqa: S310
+                        f"{base_url}/operator/record-action-approval-decision",
+                        data=json.dumps(
+                            {
+                                "action_request_id": action_request.action_request_id,
+                                "approval_decision_id": "approval-phase23-auth-identity-mismatch-001",
+                                "decision": "grant",
+                                "approver_identity": "approver-002",
+                                "decision_rationale": "Authenticated approvers must not impersonate other approvers.",
+                                "decided_at": (
+                                    action_request.requested_at + timedelta(minutes=10)
+                                ).isoformat(),
+                            }
+                        ).encode("utf-8"),
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    ),
+                    timeout=2,
+                )
+
+            self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
+            error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
+            self.assertEqual(error_payload["error"], "forbidden")
+            self.assertIn("authenticated approver identity", error_payload["message"])
+            stored_request = service.get_record(
+                type(action_request),
+                action_request.action_request_id,
+            )
+            self.assertIsNotNone(stored_request)
+            self.assertIsNone(stored_request.approval_decision_id)
+            self.assertEqual(stored_request.lifecycle_state, "pending_approval")
+
+    def test_reviewed_runtime_path_rejects_expired_request_decisions(self) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(
+            service,
+            action_request_id="action-request-phase23-expired-decision-001",
+        )
+        requested_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+        expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        action_request = service.persist_record(
+            replace(
+                action_request,
+                requested_at=requested_at,
+                expires_at=expires_at,
+            )
+        )
+
+        with self._run_runtime(service) as (base_url, _authenticate_mock):
+            with self.assertRaises(error.HTTPError) as exc_info:
+                request.urlopen(  # noqa: S310
+                    request.Request(  # noqa: S310
+                        f"{base_url}/operator/record-action-approval-decision",
+                        data=json.dumps(
+                            {
+                                "action_request_id": action_request.action_request_id,
+                                "approval_decision_id": "approval-phase23-expired-decision-001",
+                                "decision": "grant",
+                                "approver_identity": "approver-001",
+                                "decision_rationale": "Expired requests must fail closed at decision time.",
+                                "decided_at": (
+                                    requested_at + timedelta(minutes=5)
+                                ).isoformat(),
+                            }
+                        ).encode("utf-8"),
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    ),
+                    timeout=2,
+                )
+
+            self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
+            error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
+            self.assertEqual(error_payload["error"], "forbidden")
+            self.assertIn("expired", error_payload["message"])
+            stored_request = service.get_record(
+                type(action_request),
+                action_request.action_request_id,
+            )
+            self.assertIsNotNone(stored_request)
+            self.assertIsNone(stored_request.approval_decision_id)
+            self.assertEqual(stored_request.lifecycle_state, "expired")
+
+    def test_reviewed_runtime_path_rejects_re_evaluated_policy_authorized_decisions(
+        self,
+    ) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(
+            service,
+            action_request_id="action-request-phase23-policy-authorized-001",
+        )
+        action_request = service.persist_record(
+            replace(
+                action_request,
+                policy_evaluation={
+                    key: value
+                    for key, value in dict(action_request.policy_evaluation).items()
+                    if key != "approval_requirement_override"
+                },
+            )
+        )
+
+        with self._run_runtime(service) as (base_url, _authenticate_mock):
+            with self.assertRaises(error.HTTPError) as exc_info:
+                request.urlopen(  # noqa: S310
+                    request.Request(  # noqa: S310
+                        f"{base_url}/operator/record-action-approval-decision",
+                        data=json.dumps(
+                            {
+                                "action_request_id": action_request.action_request_id,
+                                "approval_decision_id": "approval-phase23-policy-authorized-001",
+                                "decision": "grant",
+                                "approver_identity": "approver-001",
+                                "decision_rationale": "Policy-authorized requests must reject redundant approval decisions.",
+                                "decided_at": (
+                                    action_request.requested_at + timedelta(minutes=10)
+                                ).isoformat(),
+                            }
+                        ).encode("utf-8"),
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    ),
+                    timeout=2,
+                )
+
+            self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
+            error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
+            self.assertEqual(error_payload["error"], "forbidden")
+            self.assertIn("policy_authorized", error_payload["message"])
             stored_request = service.get_record(
                 type(action_request),
                 action_request.action_request_id,

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -174,6 +174,45 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
             schema_sql,
         )
 
+    def test_phase23_approval_decision_rationale_forward_migration_asset_exists(self) -> None:
+        migration_path = (
+            CONTROL_PLANE_ROOT.parent
+            / "postgres"
+            / "control-plane"
+            / "migrations"
+            / "0005_phase_23_approval_decision_rationale.sql"
+        )
+
+        self.assertTrue(
+            migration_path.exists(),
+            f"Missing Phase 23 forward migration asset: {migration_path}",
+        )
+
+        migration_sql = migration_path.read_text(encoding="utf-8").lower()
+        schema_sql = (
+            CONTROL_PLANE_ROOT.parent / "postgres" / "control-plane" / "schema.sql"
+        ).read_text(encoding="utf-8").lower()
+        bootstrap_sql = (
+            CONTROL_PLANE_ROOT.parent
+            / "postgres"
+            / "control-plane"
+            / "migrations"
+            / "0001_control_plane_schema_skeleton.sql"
+        ).read_text(encoding="utf-8").lower()
+
+        self.assertIn("begin;", migration_sql)
+        self.assertIn("commit;", migration_sql)
+        self.assertIn(
+            "alter table if exists aegisops_control.approval_decision_records",
+            migration_sql,
+        )
+        self.assertIn(
+            "add column if not exists decision_rationale text;",
+            migration_sql,
+        )
+        self.assertIn("decision_rationale text", schema_sql)
+        self.assertIn("decision_rationale text", bootstrap_sql)
+
     def test_store_round_trips_reviewed_record_families_by_aegisops_ids(self) -> None:
         store, _ = make_store()
         timestamp = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)

--- a/postgres/control-plane/migrations/0001_control_plane_schema_skeleton.sql
+++ b/postgres/control-plane/migrations/0001_control_plane_schema_skeleton.sql
@@ -124,6 +124,7 @@ create table if not exists aegisops_control.approval_decision_records (
   target_snapshot jsonb not null,
   payload_hash text not null,
   decided_at timestamptz,
+  decision_rationale text,
   approved_expires_at timestamptz,
   lifecycle_state text not null,
   created_at timestamptz not null default timezone('utc', now()),

--- a/postgres/control-plane/migrations/0005_phase_23_approval_decision_rationale.sql
+++ b/postgres/control-plane/migrations/0005_phase_23_approval_decision_rationale.sql
@@ -1,0 +1,6 @@
+begin;
+
+alter table if exists aegisops_control.approval_decision_records
+  add column if not exists decision_rationale text;
+
+commit;

--- a/postgres/control-plane/schema.sql
+++ b/postgres/control-plane/schema.sql
@@ -126,6 +126,7 @@ create table if not exists aegisops_control.approval_decision_records (
   target_snapshot jsonb not null,
   payload_hash text not null,
   decided_at timestamptz,
+  decision_rationale text,
   approved_expires_at timestamptz,
   lifecycle_state text not null,
   created_at timestamptz not null default timezone('utc', now()),


### PR DESCRIPTION
Closes #493
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the live approval-decision runtime surface on `codex/issue-493` and committed it as `e046f24` (`Add live approval decision runtime path`).

The change adds `POST /operator/record-action-approval-decision` in [http_surface.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-493/control-plane/aegisops_control_plane/http_surface.py), backed by `record_action_approval_decision(...)` in [service.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-493/control-plane/aegisops_control_plane/service.py). That service path now re-evaluates the action policy at decision time, rejects non-human-required approvals, blocks self-approval by enforcing requester/approver separation, fails closed on expired requests, persists grant/reject decisions authoritatively, and updates the linked action request atomically. I also extended [models.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-493/control-plane/aegisops_control_plane/models.py) so `ApprovalDecisionRecord` carries `decision_rationale`, and surfaced that rationale in action-review snapshots/timeline for case/detail inspection.

Focused coverage lives in [test_phase23_approval_surface_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-493/control-plane/tests/test_phase23_approval_surface_validation.py). It reproduces and now verifies the live grant path, the live reject path, and fail-closed self-approval at the HTTP surface. I also reran the action-reconciliation persistence suite to confirm the new approval record fiel...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store and display an optional decision rationale with approval/rejection decisions; appears in case timelines and action snapshots.
  * Approver-role users can record live approval decisions via the operator endpoint with strict validation (timing, self-approval, approver identity match, policy/authorization).

* **Chores**
  * Database migration added to persist the new rationale column.

* **Tests**
  * Integration and unit tests covering success/failure flows, authorization, expiry, policy re-evaluation, and SERIALIZABLE transaction isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->