### PR TITLE
implementation: remove n8n from the security mainline and declare Shuffle the single reviewed routine-automation substrate (#496)

### DIFF
--- a/control-plane/tests/test_phase23_substrate_simplification_validation.py
+++ b/control-plane/tests/test_phase23_substrate_simplification_validation.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase23SubstrateSimplificationValidationTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected document at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_reviewed_security_mainline_declares_shuffle_as_single_routine_substrate(
+        self,
+    ) -> None:
+        expected_terms = {
+            "README.md": (
+                "Shuffle",
+                "reviewed routine automation substrate",
+                "n8n",
+                "optional, transitional, or experimental orchestration substrate",
+            ),
+            "docs/architecture.md": (
+                "The initial standard routine automation substrate is Shuffle.",
+                "n8n may still be used as an optional, transitional, or experimental executor or orchestration substrate outside the reviewed security mainline.",
+            ),
+            "docs/automation-substrate-contract.md": (
+                "reviewed Shuffle automation substrate",
+                "reviewed downstream execution surface",
+            ),
+            "docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md": (
+                "reviewed Shuffle delegation",
+                "Shuffle is delegated only the bounded transport task",
+                "the request is routed to any execution surface other than `automation_substrate` on `shuffle`",
+            ),
+        }
+
+        for relative_path, terms in expected_terms.items():
+            with self.subTest(path=relative_path):
+                text = self._read(relative_path)
+                for term in terms:
+                    self.assertIn(term, text)
+
+    def test_phase23_validation_note_records_single_reviewed_security_substrate(self) -> None:
+        text = self._read("docs/phase-23-substrate-simplification-validation.md")
+
+        for term in (
+            "Phase 23 Substrate Simplification Validation",
+            "Validation status: PASS",
+            "Shuffle is the single reviewed routine-automation substrate for the security mainline.",
+            "n8n remains optional, experimental, or transitional and is not part of the reviewed security authority path.",
+            "README.md",
+            "docs/architecture.md",
+            "docs/automation-substrate-contract.md",
+            "docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md",
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,8 @@ The initial standard detection substrate is Wazuh.
 
 The initial standard routine automation substrate is Shuffle.
 
+Shuffle is the single reviewed routine-automation substrate on the approved security mainline.
+
 The AegisOps control plane is the authoritative owner of policy-sensitive records, approval decisions, evidence linkage, action intent, and reconciliation truth across substrate boundaries.
 
 The controlled execution surface is the isolated executor path for higher-risk actions that require tighter execution controls than routine automation should own.
@@ -93,11 +95,13 @@ The routine automation substrate performs approved automation that the control p
 
 Shuffle is the initial standard routine automation substrate in the approved baseline.
 
+Shuffle is the only reviewed routine-automation substrate on the approved security path.
+
 Its approved boundary is routine enrichment, routing, integration handling, and approved automation execution after the control plane has produced the governing action request and approval decision context.
 
 The routine automation substrate must not mint or overwrite approval truth, action intent, evidence truth, or reconciliation truth.
 
-n8n may still be used as an optional, transitional, or experimental executor or orchestration substrate.
+n8n may still be used as an optional, transitional, or experimental executor or orchestration substrate outside the reviewed security mainline.
 
 That status does not make it a product core or an authority surface.
 

--- a/docs/automation-substrate-contract.md
+++ b/docs/automation-substrate-contract.md
@@ -2,7 +2,7 @@
 
 ## 1. Purpose
 
-This document defines the reviewed contract for delegating approved AegisOps actions into external automation substrates and controlled executor surfaces.
+This document defines the reviewed contract for delegating approved AegisOps actions into the reviewed Shuffle automation substrate and controlled executor surfaces.
 
 It supplements `docs/secops-domain-model.md`, `docs/response-action-safety-model.md`, and `docs/control-plane-state-model.md` by making the approved handoff contract explicit before Phase 13 implementation work introduces live adapters or executor code.
 
@@ -10,7 +10,7 @@ This document defines delegation, binding, provenance, and reconciliation requir
 
 ## 2. Control-Plane Authority Boundary
 
-AegisOps remains the authority for `Action Request`, `Approval Decision`, evidence linkage, `Action Execution` correlation, and `Reconciliation` state even when a reviewed automation substrate or executor surface performs downstream work.
+AegisOps remains the authority for `Action Request`, `Approval Decision`, evidence linkage, `Action Execution` correlation, and `Reconciliation` state even when the reviewed Shuffle automation substrate or a controlled executor surface performs downstream work.
 
 Neither an automation substrate nor an executor surface may mint, overwrite, or become the system of record for approval truth, action-request truth, evidence custody, or reconciliation truth.
 
@@ -18,11 +18,15 @@ Delegation is allowed only after AegisOps has a bounded `Action Request` and a s
 
 The approval record must persist an immutable approved expiry value or equivalent approved time bound so delegation can reject post-approval expiry drift against the approved record rather than trusting only mutable request state.
 
+For the approved security mainline, Shuffle is the single reviewed routine-automation substrate. n8n may still exist as an optional, transitional, or experimental orchestration surface, but it is not part of the reviewed security authority path.
+
 Substrate-local queued jobs, workflow definitions, connector payload history, and executor-local run logs may provide downstream evidence, but they do not become the approval authority or the reconciliation authority for the approved action path.
 
 ## 3. Approved Delegation Contract
 
 The reviewed delegation record is the control-plane handoff artifact that binds approved response intent to one reviewed downstream execution surface.
+
+When the reviewed surface is routine automation rather than a higher-risk executor, that reviewed downstream execution surface is the reviewed Shuffle automation substrate.
 
 At minimum, the contract must preserve:
 
@@ -76,6 +80,8 @@ If the execution surface cannot prove whether a received duplicate is the same a
 ## 6. Baseline Alignment Notes
 
 This contract aligns the approved handoff model to the shipped vendor-neutral execution-surface vocabulary rather than reintroducing substrate-local approval or reconciliation authority.
+
+That vendor-neutral vocabulary does not create multiple reviewed routine-automation authorities on the security mainline; Shuffle remains the reviewed routine-automation substrate for the approved path, while executor surfaces remain a separate category for tighter-controlled actions.
 
 It keeps concrete Shuffle adapter code, isolated-executor implementation, and Phase 13 CI expansion out of scope for this baseline.
 

--- a/docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md
+++ b/docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md
@@ -20,6 +20,8 @@ The approved first live path is intentionally narrower than a general notificati
 
 The approved first live action must remain anchored to the completed Phase 19 operator slice and the reviewed Phase 13 delegation model rather than creating a new standalone automation surface.
 
+For the approved security mainline, that routine automation surface is Shuffle only.
+
 ## 3. Approved Action Shape
 
 The reviewed `notify_identity_owner` payload must stay specific enough that approval and reconciliation remain bound to one reviewed intent.

--- a/docs/phase-23-substrate-simplification-validation.md
+++ b/docs/phase-23-substrate-simplification-validation.md
@@ -1,0 +1,33 @@
+# Phase 23 Substrate Simplification Validation
+
+- Validation status: PASS
+- Reviewed on: 2026-04-17
+- Scope: confirm the reviewed security mainline names one routine-automation substrate and removes n8n from the reviewed authority path.
+- Reviewed sources: `README.md`, `docs/architecture.md`, `docs/automation-substrate-contract.md`, `docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md`
+
+## Validation Summary
+
+Shuffle is the single reviewed routine-automation substrate for the security mainline.
+
+n8n remains optional, experimental, or transitional and is not part of the reviewed security authority path.
+
+The reviewed wording now keeps three boundaries explicit:
+
+- AegisOps remains the authority for request, approval, execution correlation, and reconciliation truth.
+- Shuffle is the only reviewed routine-automation substrate on the approved path.
+- Executor surfaces remain a separate reviewed category for tighter-controlled actions rather than a second routine-automation authority.
+
+## Document Review Result
+
+`README.md` now presents Shuffle as the reviewed routine automation substrate, keeps n8n in the optional or transitional set, and no longer frames n8n as part of the mainline security orchestration path.
+
+`docs/architecture.md` now states that Shuffle is the single reviewed routine-automation substrate on the approved security mainline and that n8n stays outside that reviewed authority path.
+
+`docs/automation-substrate-contract.md` now makes the approved contract explicit for the reviewed Shuffle automation substrate while preserving executor surfaces as a separate category and keeping n8n out of the reviewed security path.
+
+`docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md` now states directly that the approved routine automation surface for the security mainline is Shuffle only.
+
+## Verification
+
+- `python3 -m unittest control-plane.tests.test_phase23_substrate_simplification_validation`
+- `bash scripts/verify-architecture-doc.sh`

--- a/scripts/test-verify-automation-substrate-contract-doc.sh
+++ b/scripts/test-verify-automation-substrate-contract-doc.sh
@@ -30,19 +30,21 @@ write_valid_doc() {
 
 ## 1. Purpose
 
-This document defines the reviewed contract for delegating approved AegisOps actions into external automation substrates and controlled executor surfaces.
+This document defines the reviewed contract for delegating approved AegisOps actions into the reviewed Shuffle automation substrate and controlled executor surfaces.
 
 This document defines delegation, binding, provenance, and reconciliation requirements only. It does not introduce adapter code, isolated-executor implementation, or CI expansion in this phase.
 
 ## 2. Control-Plane Authority Boundary
 
-AegisOps remains the authority for `Action Request`, `Approval Decision`, evidence linkage, `Action Execution` correlation, and `Reconciliation` state even when a reviewed automation substrate or executor surface performs downstream work.
+AegisOps remains the authority for `Action Request`, `Approval Decision`, evidence linkage, `Action Execution` correlation, and `Reconciliation` state even when the reviewed Shuffle automation substrate or a controlled executor surface performs downstream work.
 
 Neither an automation substrate nor an executor surface may mint, overwrite, or become the system of record for approval truth, action-request truth, evidence custody, or reconciliation truth.
 
 Delegation is allowed only after AegisOps has a bounded `Action Request` and a still-valid `Approval Decision` whose binding fields exactly match the downstream execution intent.
 
 The approval record must persist an immutable approved expiry value or equivalent approved time bound so delegation can reject post-approval expiry drift against the approved record rather than trusting only mutable request state.
+
+For the approved security mainline, Shuffle is the single reviewed routine-automation substrate. n8n may still exist as an optional, transitional, or experimental orchestration surface, but it is not part of the reviewed security authority path.
 
 ## 3. Approved Delegation Contract
 

--- a/scripts/verify-automation-substrate-contract-doc.sh
+++ b/scripts/verify-automation-substrate-contract-doc.sh
@@ -16,12 +16,13 @@ required_headings=(
 )
 
 required_phrases=(
-  "This document defines the reviewed contract for delegating approved AegisOps actions into external automation substrates and controlled executor surfaces."
+  "This document defines the reviewed contract for delegating approved AegisOps actions into the reviewed Shuffle automation substrate and controlled executor surfaces."
   "This document defines delegation, binding, provenance, and reconciliation requirements only. It does not introduce adapter code, isolated-executor implementation, or CI expansion in this phase."
-  'AegisOps remains the authority for `Action Request`, `Approval Decision`, evidence linkage, `Action Execution` correlation, and `Reconciliation` state even when a reviewed automation substrate or executor surface performs downstream work.'
+  'AegisOps remains the authority for `Action Request`, `Approval Decision`, evidence linkage, `Action Execution` correlation, and `Reconciliation` state even when the reviewed Shuffle automation substrate or a controlled executor surface performs downstream work.'
   "Neither an automation substrate nor an executor surface may mint, overwrite, or become the system of record for approval truth, action-request truth, evidence custody, or reconciliation truth."
   'Delegation is allowed only after AegisOps has a bounded `Action Request` and a still-valid `Approval Decision` whose binding fields exactly match the downstream execution intent.'
   "The approval record must persist an immutable approved expiry value or equivalent approved time bound so delegation can reject post-approval expiry drift against the approved record rather than trusting only mutable request state."
+  "For the approved security mainline, Shuffle is the single reviewed routine-automation substrate. n8n may still exist as an optional, transitional, or experimental orchestration surface, but it is not part of the reviewed security authority path."
   '| `delegation_id` | Immutable AegisOps delegation record identifier for one approved handoff into an automation substrate or executor surface. |'
   '| `action_request_id` | Required AegisOps identifier for the exact request whose approved intent is being delegated. |'
   '| `approval_decision_id` | Required AegisOps identifier for the approval outcome that authorizes the delegated intent. |'


### PR DESCRIPTION
Closes #496
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused Phase 23 validation test and tightened the reviewed wording so the security mainline now points to Shuffle alone as the reviewed routine-automation substrate. The main contract change is in [docs/automation-substrate-contract.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-496/docs/automation-substrate-contract.md), with supporting clarification in [docs/architecture.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-496/docs/architecture.md) and [docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-496/docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md). I also added [docs/phase-23-substrate-simplification-validation.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-496/docs/phase-23-substrate-simplification-validation.md) and the new guard test at [control-plane/tests/test_phase23_substrate_simplification_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-496/control-plane/tests/test_phase23_substrate_simplification_validation.py).

The narrow reproduction path was: add the test, run it, confirm failure on the missing Phase 23 validation note and the too-generic automation contract wording, then fix those exact gaps. Focused verification now passes, and I committed the checkpoint as `f758672` with message `Clarify Shuffle as the reviewed security substrate`.

Summary: Added a focused Phase 23 validation test and aligned the reviewed docs so Shuffle is th...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Phase 23 Substrate Simplification Validation test suite verifying documentation consistency across architecture specifications.

* **Documentation**
  * Updated architecture and automation substrate contract documentation with clarified policies and approved pathway boundaries.
  * Added Phase 23 Substrate Simplification Validation documentation including review status and verification commands.

* **Chores**
  * Updated verification scripts to align with revised documentation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->