### PR TITLE
design: publish an SMB footprint and deployment-profile baseline (#497)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ The primary deployment target is a single-company or single-business-unit deploy
 
 The target operating assumption is business-hours review with explicit after-hours escalation, not a 24x7 staffed SOC.
 
+The reviewed footprint and deployment-profile baseline for that target lives in `docs/smb-footprint-and-deployment-profile-baseline.md`.
+
 AegisOps is best suited for:
 
 - small SecOps teams
@@ -337,6 +339,7 @@ It is trying to be a safer way to operate a narrow but trustworthy SecOps contro
 Recommended starting points for a new reader:
 
 - `docs/requirements-baseline.md`
+- `docs/smb-footprint-and-deployment-profile-baseline.md`
 - `docs/control-plane-state-model.md`
 - `docs/automation-substrate-contract.md`
 - `docs/response-action-safety-model.md`

--- a/docs/Revised Phase23-20 Epic Roadmap.md
+++ b/docs/Revised Phase23-20 Epic Roadmap.md
@@ -46,4 +46,6 @@ That means later work should avoid:
 
 `docs/architecture.md` should carry the same product thesis and deployment target so component-boundary decisions stay anchored to the same audience and operating assumptions.
 
+`docs/smb-footprint-and-deployment-profile-baseline.md` should publish the concrete reviewed footprint, backup, restore, and operator-burden expectations that keep later hardening and ergonomics work honest for the approved SMB target.
+
 Future roadmap slices should treat this document as the control statement for who AegisOps is for before they add new hardening, ergonomics, or source-expansion work.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -14,6 +14,8 @@ The current content is intentionally limited to placeholders, constraints, and d
 
 Any future operational detail added here must remain consistent with the approved architecture, repository assets, and validation requirements.
 
+Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.
+
 ## 2. Startup
 
 Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist.
@@ -21,6 +23,8 @@ Detailed startup steps are intentionally deferred until implementation artifacts
 Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.
 
 Operators must not treat optional OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path as first-boot prerequisites.
+
+Operators should size startup expectations, maintenance windows, and review burden against `docs/smb-footprint-and-deployment-profile-baseline.md` rather than against enterprise-cluster assumptions.
 
 Future startup guidance should describe:
 
@@ -56,6 +60,8 @@ Future restore guidance should describe:
 - what evidence must be retained for audit and review.
 
 This section must not imply that hypervisor snapshots alone are a sufficient recovery procedure unless an approved ADR changes that baseline.
+
+Restore planning should remain inside the backup and restore expectations published in `docs/smb-footprint-and-deployment-profile-baseline.md`.
 
 ## 5. Approval Handling
 

--- a/docs/smb-footprint-and-deployment-profile-baseline.md
+++ b/docs/smb-footprint-and-deployment-profile-baseline.md
@@ -1,0 +1,92 @@
+# SMB Footprint and Deployment-Profile Baseline
+
+## 1. Purpose
+
+This baseline publishes the reviewed SMB deployment profiles that future footprint, reliability, and operator-experience work must target.
+
+Use this baseline to replace intuition-only sizing discussions with a concrete, reviewable deployment floor and ceiling for the approved Phase 23 operating model.
+
+This document is a planning and review artifact. It does not authorize new runtime dependencies, high-availability topology changes, or live deployment commands.
+
+## 2. Scope and Decision Rule
+
+Use this baseline to judge whether AegisOps remains operable for the approved small-team deployment target before later work adds substrate, reliability, or ergonomics scope.
+
+A profile is acceptable only if it preserves the positive SMB value proposition and remains realistic for a small business-hours SecOps team to operate.
+
+The decision rule is practical: if a proposed change requires materially more infrastructure, more frequent operator touch, or more recovery complexity than the reviewed profiles below can tolerate, that change needs explicit re-review before it becomes part of the baseline.
+
+## 3. Reviewed Deployment Profiles
+
+### 3.1 Lab Profile
+
+The lab profile is the minimum reviewable footprint for first-boot exercises, restore rehearsal, and operator training.
+
+It is intended for a single internal environment where reviewers can validate startup, backup, restore, and daily-path ergonomics without assuming full production telemetry breadth or nonstop staffing.
+
+### 3.2 Consultant-Managed Single-Customer Profile
+
+The consultant-managed single-customer profile is the default reviewed deployment shape for a small external operator team managing one customer environment.
+
+This profile assumes the environment is still narrow, business-hours oriented, and governed by explicit approvals, but it must tolerate a steadier daily operational rhythm than the lab profile.
+
+### 3.3 Small-Production SMB Operation Profile
+
+The small-production SMB operation profile is the maximum reviewed baseline for Phase 23 roadmap decisions.
+
+It represents a serious SMB deployment with enough scale to justify disciplined backup, restore, and operator workflows, while still staying inside the approved narrow-team and narrow-footprint product thesis.
+
+## 4. Baseline Expectations by Profile
+
+The table below is the reviewed planning baseline for whole-environment sizing. It is deliberately conservative enough to keep recovery and operator load honest, but narrow enough to avoid drifting into enterprise-cluster assumptions.
+
+| Profile | Managed endpoints | vCPU | Memory | Primary storage | Backup and restore expectation | Operator overhead expectation |
+| --- | --- | --- | --- | --- | --- | --- |
+| Lab | 250 to 500 | 8 to 10 | 24 to 32 GB | 400 to 600 GB usable persistent storage | Daily PostgreSQL-aware backup, configuration backup after reviewed changes, and at least one restore rehearsal per quarter | Roughly 2 to 4 operator-hours per week for startup checks, queue review, backup review, and restore-readiness confirmation |
+| Consultant-managed single-customer | 500 to 1,000 | 12 to 16 | 40 to 56 GB | 0.8 to 1.5 TB usable persistent storage | Daily PostgreSQL-aware backup, weekly backup review, and monthly restore rehearsal against the reviewed customer environment | Roughly 4 to 6 operator-hours per week for queue review, approval handling, backup validation, and customer-facing exception follow-up |
+| Small-production SMB operation | 1,000 to 1,500 | 16 to 24 | 56 to 96 GB | 1.5 to 3 TB usable persistent storage | Daily PostgreSQL-aware backup, configuration backup before reviewed platform changes, and monthly restore rehearsal with documented recovery timing | Roughly 6 to 8 operator-hours per week for daily queue handling, approval coordination, backup review, restore rehearsal, and platform hygiene |
+
+CPU and memory expectations must be read as whole-environment planning guidance for the approved control-plane footprint, not as per-container reservations.
+
+Primary storage assumptions include PostgreSQL state, approved configuration artifacts, logs required for the reviewed control-plane path, and reasonable growth headroom for replay and audit readiness. They do not authorize large analytics clusters or indefinite retention expansion.
+
+Backup expectations must include PostgreSQL-aware backups, configuration backup, and a restore rehearsal expectation rather than relying on hypervisor snapshots alone.
+
+Restore expectations assume operators are recovering a narrow, reviewed control-plane environment and validating that the approval, evidence, execution, and reconciliation record chain is intact before normal operations resume.
+
+## 5. Operational Burden Baseline
+
+Operator-overhead expectations are part of the footprint baseline because a deployment that fits on paper but requires enterprise-style staffing is out of scope.
+
+The approved small-team operating assumption remains 2 to 6 business-hours SecOps operators with 1 to 3 designated approvers or escalation owners.
+
+For this baseline, operator overhead includes:
+
+- daily queue and alert review for the approved control-plane path;
+- explicit approval handling for reviewed write-capable actions;
+- backup review and restore-readiness checks;
+- narrow platform hygiene work such as cert rotation, reviewed configuration updates, and health validation; and
+- after-hours escalation coordination rather than continuous overnight staffing.
+
+Any future design that assumes a dedicated database team, a full-time platform SRE rotation, or 24x7 analyst staffing is no longer targeting the reviewed SMB footprint.
+
+## 6. Alignment to Phase 23 Product Thesis
+
+Phase 23 hardening and ergonomics work must stay inside these reviewed profiles unless a later ADR approves a new target footprint.
+
+This baseline supports the product thesis that AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
+It keeps later reliability and substrate decisions anchored to the same question: does this change make the reviewed daily path more trustworthy for a small team, or does it quietly convert AegisOps into an enterprise-overbuilt platform that no longer matches the intended audience.
+
+The baseline therefore favors:
+
+- reliable backup and restore over HA overbuild;
+- operator-visible recovery and reconciliation over opaque automation complexity;
+- incremental hardening for one reviewed deployment target over broad market repositioning; and
+- clear business-hours operational expectations over implied 24x7 staffing.
+
+## 7. Explicitly Out of Scope
+
+High-availability overbuild, large-cluster sizing, and generic enterprise capacity planning are explicitly out of scope for this baseline.
+
+Also out of scope are multi-tenant packaging assumptions, MSSP fleet-wide aggregation sizing, unlimited telemetry-retention planning, and environment-specific benchmark claims that are not yet backed by reviewed runtime measurements.

--- a/scripts/test-verify-smb-footprint-baseline.sh
+++ b/scripts/test-verify-smb-footprint-baseline.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-smb-footprint-baseline.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_shared_docs() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/README.md"
+# AegisOps
+
+See `docs/smb-footprint-and-deployment-profile-baseline.md` for the reviewed SMB footprint baseline that anchors roadmap and runbook decisions.
+EOF
+
+  cat <<'EOF' > "${target}/docs/runbook.md"
+# AegisOps Runbook Skeleton
+
+Startup, restore, and operator burden assumptions must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.
+EOF
+
+  cat <<'EOF' > "${target}/docs/Revised Phase23-20 Epic Roadmap.md"
+# Revised Phase 23-20 Epic Roadmap
+
+Phase 23 planning remains anchored to `docs/smb-footprint-and-deployment-profile-baseline.md`.
+EOF
+}
+
+write_valid_baseline_doc() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/smb-footprint-and-deployment-profile-baseline.md"
+# SMB Footprint and Deployment-Profile Baseline
+
+## 1. Purpose
+
+This baseline publishes the reviewed SMB deployment profiles that future footprint, reliability, and operator-experience work must target.
+
+## 2. Scope and Decision Rule
+
+Use this baseline to judge whether AegisOps remains operable for the approved small-team deployment target before later work adds substrate, reliability, or ergonomics scope.
+
+A profile is acceptable only if it preserves the positive SMB value proposition and remains realistic for a small business-hours SecOps team to operate.
+
+## 3. Reviewed Deployment Profiles
+
+### 3.1 Lab Profile
+
+The lab profile is the minimum reviewable footprint for first-boot exercises, restore rehearsal, and operator training.
+
+### 3.2 Consultant-Managed Single-Customer Profile
+
+The consultant-managed single-customer profile is the default reviewed deployment shape for a small external operator team managing one customer environment.
+
+### 3.3 Small-Production SMB Operation Profile
+
+The small-production SMB operation profile is the maximum reviewed baseline for Phase 23 roadmap decisions.
+
+## 4. Baseline Expectations by Profile
+
+| Profile | Managed endpoints | vCPU | Memory | Primary storage | Backup and restore expectation | Operator overhead expectation |
+| --- | --- | --- | --- | --- | --- | --- |
+| Lab | 250 | 8 | 24 GB | 400 GB | PostgreSQL-aware backup plus restore rehearsal | 2 to 4 operator-hours per week |
+| Consultant-managed single-customer | 750 | 14 | 48 GB | 1 TB | PostgreSQL-aware backup plus monthly restore rehearsal | 4 to 6 operator-hours per week |
+| Small-production SMB operation | 1500 | 20 | 64 GB | 2 TB | PostgreSQL-aware backup plus quarterly restore rehearsal | 6 to 8 operator-hours per week |
+
+CPU and memory expectations must be read as whole-environment planning guidance for the approved control-plane footprint, not as per-container reservations.
+
+Backup expectations must include PostgreSQL-aware backups, configuration backup, and a restore rehearsal expectation rather than relying on hypervisor snapshots alone.
+
+## 5. Operational Burden Baseline
+
+Operator-overhead expectations are part of the footprint baseline because a deployment that fits on paper but requires enterprise-style staffing is out of scope.
+
+The approved small-team operating assumption remains 2 to 6 business-hours SecOps operators with 1 to 3 designated approvers or escalation owners.
+
+## 6. Alignment to Phase 23 Product Thesis
+
+Phase 23 hardening and ergonomics work must stay inside these reviewed profiles unless a later ADR approves a new target footprint.
+
+This baseline supports the product thesis that AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model.
+
+## 7. Explicitly Out of Scope
+
+High-availability overbuild, large-cluster sizing, and generic enterprise capacity planning are explicitly out of scope for this baseline.
+EOF
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" add .
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_shared_docs "${valid_repo}"
+write_valid_baseline_doc "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+write_shared_docs "${missing_doc_repo}"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing SMB footprint baseline document:"
+
+missing_heading_repo="${workdir}/missing-heading"
+create_repo "${missing_heading_repo}"
+write_shared_docs "${missing_heading_repo}"
+write_valid_baseline_doc "${missing_heading_repo}"
+python3 - <<'PY' "${missing_heading_repo}/docs/smb-footprint-and-deployment-profile-baseline.md"
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+text = text.replace("## 5. Operational Burden Baseline\n", "", 1)
+path.write_text(text)
+PY
+commit_fixture "${missing_heading_repo}"
+assert_fails_with "${missing_heading_repo}" "Missing SMB footprint baseline heading: ## 5. Operational Burden Baseline"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_repo "${missing_readme_link_repo}"
+write_shared_docs "${missing_readme_link_repo}"
+write_valid_baseline_doc "${missing_readme_link_repo}"
+python3 - <<'PY' "${missing_readme_link_repo}/README.md"
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+text = text.replace("docs/smb-footprint-and-deployment-profile-baseline.md", "docs/other-doc.md", 1)
+path.write_text(text)
+PY
+commit_fixture "${missing_readme_link_repo}"
+assert_fails_with "${missing_readme_link_repo}" "Missing README SMB footprint baseline reference: docs/smb-footprint-and-deployment-profile-baseline.md"
+
+missing_scope_repo="${workdir}/missing-scope"
+create_repo "${missing_scope_repo}"
+write_shared_docs "${missing_scope_repo}"
+write_valid_baseline_doc "${missing_scope_repo}"
+python3 - <<'PY' "${missing_scope_repo}/docs/smb-footprint-and-deployment-profile-baseline.md"
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+text = text.replace(
+    "High-availability overbuild, large-cluster sizing, and generic enterprise capacity planning are explicitly out of scope for this baseline.\n",
+    "",
+    1,
+)
+path.write_text(text)
+PY
+commit_fixture "${missing_scope_repo}"
+assert_fails_with "${missing_scope_repo}" "Missing SMB footprint baseline statement: High-availability overbuild, large-cluster sizing, and generic enterprise capacity planning are explicitly out of scope for this baseline."
+
+echo "SMB footprint baseline verifier tests passed."

--- a/scripts/verify-smb-footprint-baseline.sh
+++ b/scripts/verify-smb-footprint-baseline.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/smb-footprint-and-deployment-profile-baseline.md"
+readme_path="${repo_root}/README.md"
+runbook_path="${repo_root}/docs/runbook.md"
+roadmap_path="${repo_root}/docs/Revised Phase23-20 Epic Roadmap.md"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+require_file "${doc_path}" "SMB footprint baseline document"
+require_file "${readme_path}" "README"
+require_file "${runbook_path}" "runbook document"
+require_file "${roadmap_path}" "Phase 23 roadmap document"
+
+required_headings=(
+  "# SMB Footprint and Deployment-Profile Baseline"
+  "## 1. Purpose"
+  "## 2. Scope and Decision Rule"
+  "## 3. Reviewed Deployment Profiles"
+  "### 3.1 Lab Profile"
+  "### 3.2 Consultant-Managed Single-Customer Profile"
+  "### 3.3 Small-Production SMB Operation Profile"
+  "## 4. Baseline Expectations by Profile"
+  "## 5. Operational Burden Baseline"
+  "## 6. Alignment to Phase 23 Product Thesis"
+  "## 7. Explicitly Out of Scope"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${doc_path}" "${heading}" "SMB footprint baseline heading"
+done
+
+required_phrases=(
+  "This baseline publishes the reviewed SMB deployment profiles that future footprint, reliability, and operator-experience work must target."
+  "Use this baseline to judge whether AegisOps remains operable for the approved small-team deployment target before later work adds substrate, reliability, or ergonomics scope."
+  "A profile is acceptable only if it preserves the positive SMB value proposition and remains realistic for a small business-hours SecOps team to operate."
+  "The lab profile is the minimum reviewable footprint for first-boot exercises, restore rehearsal, and operator training."
+  "The consultant-managed single-customer profile is the default reviewed deployment shape for a small external operator team managing one customer environment."
+  "The small-production SMB operation profile is the maximum reviewed baseline for Phase 23 roadmap decisions."
+  "| Profile | Managed endpoints | vCPU | Memory | Primary storage | Backup and restore expectation | Operator overhead expectation |"
+  "| Lab |"
+  "| Consultant-managed single-customer |"
+  "| Small-production SMB operation |"
+  "CPU and memory expectations must be read as whole-environment planning guidance for the approved control-plane footprint, not as per-container reservations."
+  "Backup expectations must include PostgreSQL-aware backups, configuration backup, and a restore rehearsal expectation rather than relying on hypervisor snapshots alone."
+  "Operator-overhead expectations are part of the footprint baseline because a deployment that fits on paper but requires enterprise-style staffing is out of scope."
+  "The approved small-team operating assumption remains 2 to 6 business-hours SecOps operators with 1 to 3 designated approvers or escalation owners."
+  "Phase 23 hardening and ergonomics work must stay inside these reviewed profiles unless a later ADR approves a new target footprint."
+  "This baseline supports the product thesis that AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance for a narrow SMB SecOps operating model."
+  "High-availability overbuild, large-cluster sizing, and generic enterprise capacity planning are explicitly out of scope for this baseline."
+)
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${doc_path}" "${phrase}" "SMB footprint baseline statement"
+done
+
+require_phrase "${readme_path}" "docs/smb-footprint-and-deployment-profile-baseline.md" "README SMB footprint baseline reference"
+require_phrase "${runbook_path}" "docs/smb-footprint-and-deployment-profile-baseline.md" "runbook SMB footprint baseline reference"
+require_phrase "${roadmap_path}" "docs/smb-footprint-and-deployment-profile-baseline.md" "roadmap SMB footprint baseline reference"
+
+echo "SMB footprint baseline document is present, structured, and linked from the README, runbook, and Phase 23 roadmap."


### PR DESCRIPTION
Closes #497
This PR was opened by codex-supervisor.
Latest Codex summary:

Published the SMB footprint baseline in [docs/smb-footprint-and-deployment-profile-baseline.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-497/docs/smb-footprint-and-deployment-profile-baseline.md) and anchored it from [README.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-497/README.md), [docs/runbook.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-497/docs/runbook.md), and [docs/Revised Phase23-20 Epic Roadmap.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-497/docs/Revised%20Phase23-20%20Epic%20Roadmap.md). The new baseline defines the three reviewed profiles, concrete CPU/memory/storage/backup/restore expectations, and explicit operator-overhead assumptions, while keeping HA overbuild and enterprise sizing out of scope.

I added a focused verifier and self-test first, reproduced the missing-doc failure against the live repo, then implemented the doc and alignment updates. The checkpoint is committed as `3d52266` (`Add SMB footprint baseline`).

Summary: Added a reviewed SMB footprint/deployment-profile baseline with focused verification and linked it into the README, runbook, and Phase 23 roadmap.
State hint: local_review
Blocked reason: none
Tests: `bash scripts/test-verify-smb-footprint-baseline.sh`; `bash scripts/verify-smb-footprint-baseline.sh`; `bash scripts/verify-runbook-doc.sh`; `bash scripts/verify-architecture-doc.sh`; `bash scripts/verify-positive-smb-value-proposition.sh`
Failure signature: none
Next action: Open a draft PR for commit `3d52266` and c...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive SMB deployment planning baseline establishing requirements for system footprint, backup/restore capabilities, and operator expectations in small-team environments.
  * Updated README and operational guides with cross-references to the new baseline for easier navigation and consistency.

* **Tests**
  * Added verification tests to ensure deployment baseline documentation remains complete and properly linked across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->