### PR TITLE
validation: add end-to-end coverage for approval grant, transition logging, and degraded-mode visibility (#498)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,14 @@ jobs:
       - name: Run Phase 22 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-22-workflow-coverage.sh
 
+      - name: Run Phase 23 authority-closure validation
+        run: |
+          bash scripts/verify-phase-23-authority-closure.sh
+          python3 -m unittest control-plane.tests.test_phase23_end_to_end_validation control-plane.tests.test_phase23_approval_surface_validation control-plane.tests.test_phase23_transition_logging_validation control-plane.tests.test_phase23_substrate_simplification_validation
+
+      - name: Run Phase 23 workflow coverage guard
+        run: bash scripts/test-verify-ci-phase-23-workflow-coverage.sh
+
       - name: Run control-plane runtime unit tests
         run: python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
 
@@ -215,12 +223,14 @@ jobs:
           bash scripts/test-verify-phase-20-low-risk-action-boundary.sh
           bash scripts/test-verify-phase-21-production-like-hardening-boundary.sh
           bash scripts/test-verify-phase-22-operator-trust-boundary.sh
+          bash scripts/test-verify-phase-23-authority-closure.sh
           bash scripts/test-verify-ci-phase-14-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-15-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-19-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-20-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-21-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-22-workflow-coverage.sh
+          bash scripts/test-verify-ci-phase-23-workflow-coverage.sh
           bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
           bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
           bash scripts/test-verify-phase-6-replay-to-notify-validation.sh

--- a/control-plane/tests/test_phase23_end_to_end_validation.py
+++ b/control-plane/tests/test_phase23_end_to_end_validation.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import contextlib
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+import json
+import pathlib
+import sys
+import threading
+import unittest
+from unittest import mock
+from urllib import request
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))
+
+import main
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.models import ApprovalDecisionRecord
+from aegisops_control_plane.service import (
+    AegisOpsControlPlaneService,
+    AuthenticatedRuntimePrincipal,
+)
+from postgres_test_support import make_store
+from support.fixtures import load_wazuh_fixture
+
+
+REVIEWED_SHARED_SECRET = "reviewed-shared-secret"  # noqa: S105
+REVIEWED_PROXY_SECRET = "reviewed-proxy-secret"  # noqa: S105
+REVIEWED_PROXY_SERVICE_ACCOUNT = "svc-aegisops-proxy-control-plane"
+REVIEWED_APPROVER_PRINCIPAL = AuthenticatedRuntimePrincipal(
+    identity="approver-001",
+    role="approver",
+    access_path="reviewed_reverse_proxy",
+    proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+)
+
+
+class Phase23EndToEndValidationTests(unittest.TestCase):
+    @staticmethod
+    @contextlib.contextmanager
+    def _mock_authenticated_surface_access(
+        service: AegisOpsControlPlaneService,
+        *,
+        principal: AuthenticatedRuntimePrincipal = REVIEWED_APPROVER_PRINCIPAL,
+    ) -> object:
+        def _authenticate_surface_access(**kwargs: object) -> AuthenticatedRuntimePrincipal:
+            allowed_roles = kwargs.get("allowed_roles")
+            if not isinstance(allowed_roles, tuple):
+                raise AssertionError(
+                    "expected authenticate_protected_surface_request to receive allowed_roles"
+                )
+            if principal.role not in allowed_roles:
+                joined_roles = ", ".join(sorted(allowed_roles))
+                raise PermissionError(
+                    "protected control-plane surface role is not authorized for this endpoint; "
+                    f"expected one of: {joined_roles}"
+                )
+            return principal
+
+        with mock.patch.object(
+            service,
+            "authenticate_protected_surface_request",
+            side_effect=_authenticate_surface_access,
+        ) as authenticate_mock:
+            yield authenticate_mock
+
+    def _build_service(self) -> AegisOpsControlPlaneService:
+        store, _ = make_store()
+        return AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+    def _build_pending_action_request(
+        self,
+        service: AegisOpsControlPlaneService,
+        *,
+        requester_identity: str = "analyst-001",
+        action_request_id: str = "action-request-phase23-e2e-001",
+    ) -> object:
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome=(
+                "Validate the live approval, transition logging, and degraded visibility chain."
+            ),
+        )
+        return service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity=requester_identity,
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Phase 23 validation must keep approval and degraded visibility explicit.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id=action_request_id,
+        )
+
+    @contextlib.contextmanager
+    def _run_runtime(
+        self,
+        service: AegisOpsControlPlaneService,
+        *,
+        principal: AuthenticatedRuntimePrincipal = REVIEWED_APPROVER_PRINCIPAL,
+    ) -> object:
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(
+            main,
+            "ThreadingHTTPServer",
+            RecordingServer,
+        ), self._mock_authenticated_surface_access(
+            service,
+            principal=principal,
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                yield f"http://127.0.0.1:{servers[0].server_port}"
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                    servers[0].server_close()
+                thread.join(timeout=2)
+
+    def test_phase23_end_to_end_live_grant_keeps_transition_history_and_degraded_visibility_explicit(
+        self,
+    ) -> None:
+        service = self._build_service()
+        action_request = self._build_pending_action_request(service)
+        decided_at = action_request.requested_at + timedelta(minutes=10)
+        approval_decision_id = "approval-phase23-e2e-001"
+
+        with self._run_runtime(service) as base_url:
+            response = request.urlopen(  # noqa: S310
+                request.Request(  # noqa: S310
+                    f"{base_url}/operator/record-action-approval-decision",
+                    data=json.dumps(
+                        {
+                            "action_request_id": action_request.action_request_id,
+                            "approval_decision_id": approval_decision_id,
+                            "decision": "grant",
+                            "approver_identity": "approver-001",
+                            "decision_rationale": (
+                                "The reviewed change is approved, but Phase 23 must keep any "
+                                "missing delegation visible."
+                            ),
+                            "decided_at": decided_at.isoformat(),
+                        }
+                    ).encode("utf-8"),
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                ),
+                timeout=2,
+            )
+            payload = json.loads(response.read().decode("utf-8"))
+
+        self.assertEqual(response.status, HTTPStatus.OK)
+        self.assertEqual(payload["lifecycle_state"], "approved")
+        self.assertEqual(payload["approval_decision_id"], approval_decision_id)
+
+        stored_request = service.get_record(type(action_request), action_request.action_request_id)
+        self.assertIsNotNone(stored_request)
+        self.assertEqual(stored_request.lifecycle_state, "approved")
+        stored_decision = service.get_record(ApprovalDecisionRecord, approval_decision_id)
+        self.assertIsNotNone(stored_decision)
+        self.assertEqual(stored_decision.lifecycle_state, "approved")
+
+        self.assertEqual(
+            [
+                transition.lifecycle_state
+                for transition in service.list_lifecycle_transitions(
+                    "action_request",
+                    action_request.action_request_id,
+                )
+            ],
+            ["pending_approval", "approved"],
+        )
+        self.assertEqual(
+            [
+                transition.lifecycle_state
+                for transition in service.list_lifecycle_transitions(
+                    "approval_decision",
+                    approval_decision_id,
+                )
+            ],
+            ["approved"],
+        )
+
+        stale_approved_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        service.persist_record(
+            replace(
+                stored_decision,
+                approved_expires_at=stale_approved_expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                stored_request,
+                expires_at=stale_approved_expires_at,
+            )
+        )
+
+        case_detail = service.inspect_case_detail(stored_request.case_id)
+        current_review = case_detail.current_action_review
+
+        self.assertIsNotNone(current_review)
+        assert current_review is not None
+        self.assertEqual(current_review["review_state"], "approved")
+        self.assertEqual(current_review["path_health"]["overall_state"], "degraded")
+        self.assertEqual(
+            current_review["path_health"]["paths"]["ingest"]["reason"],
+            "ingest_signal_missing_after_approval",
+        )
+        self.assertEqual(
+            current_review["path_health"]["paths"]["delegation"]["reason"],
+            "reviewed_delegation_missing_after_approval",
+        )
+        self.assertEqual(
+            current_review["path_health"]["paths"]["provider"]["reason"],
+            "provider_signal_missing_after_approval",
+        )
+        self.assertEqual(
+            current_review["path_health"]["paths"]["persistence"]["reason"],
+            "reconciliation_missing_after_approval",
+        )
+        self.assertEqual(
+            [entry["stage"] for entry in current_review["timeline"]],
+            [
+                "action_request",
+                "approval_decision",
+                "delegation",
+                "action_execution",
+                "reconciliation",
+            ],
+        )
+        self.assertEqual(current_review["timeline"][0]["state"], "approved")
+        self.assertEqual(current_review["timeline"][1]["state"], "approved")
+        self.assertEqual(current_review["timeline"][2]["state"], "awaiting_delegation")
+        self.assertEqual(current_review["timeline"][3]["state"], "awaiting_execution")
+        self.assertEqual(current_review["timeline"][4]["state"], "awaiting_reconciliation")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-verify-ci-phase-23-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-23-workflow-coverage.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+required_verifiers=(
+  "bash scripts/verify-phase-23-authority-closure.sh"
+)
+
+required_tests=(
+  "bash scripts/test-verify-phase-23-authority-closure.sh"
+)
+
+required_runtime_commands=(
+  "python3 -m unittest control-plane.tests.test_phase23_end_to_end_validation control-plane.tests.test_phase23_approval_surface_validation control-plane.tests.test_phase23_transition_logging_validation control-plane.tests.test_phase23_substrate_simplification_validation"
+)
+
+self_guard_step_name="Run Phase 23 workflow coverage guard"
+self_guard_command="bash scripts/test-verify-ci-phase-23-workflow-coverage.sh"
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+collect_active_run_commands() {
+  awk '
+    {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent > block_indent) {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          if (line != "" && line !~ /^#/) {
+            print line
+          }
+          next
+        }
+
+        in_block = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+        block_indent = match($0, /[^ ]/) - 1
+        in_block = 1
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[^|>]/) {
+        line = $0
+        sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+        if (line != "" && line !~ /^#/) {
+          print line
+        }
+      }
+    }
+  ' "${workflow_path}"
+}
+
+extract_self_guard_step_run_command() {
+  awk -v step_name="${self_guard_step_name}" '
+    function line_indent(line) {
+      return match(line, /[^ ]/) - 1
+    }
+
+    BEGIN {
+      in_step = 0
+      step_indent = -1
+    }
+
+    {
+      if (in_step) {
+        if ($0 ~ /^[[:space:]]*-[[:space:]]name:[[:space:]]+/ && line_indent($0) <= step_indent) {
+          exit 0
+        }
+
+        if ($0 ~ /^[[:space:]]*run:[[:space:]]*/) {
+          line = $0
+          sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+          print line
+          exit 0
+        }
+      }
+
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line == "- name: " step_name) {
+        in_step = 1
+        step_indent = line_indent($0)
+      }
+    }
+  ' "${workflow_path}"
+}
+
+active_run_commands="$(collect_active_run_commands)"
+
+for command in "${required_verifiers[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 23 verifier command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_tests[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 23 focused shell test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_runtime_commands[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 23 focused runtime command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+self_guard_step_run_command="$(extract_self_guard_step_run_command)"
+if [[ -z "${self_guard_step_run_command}" ]]; then
+  echo "Missing dedicated Phase 23 workflow coverage guard step in CI workflow: ${self_guard_step_name}" >&2
+  exit 1
+fi
+
+if [[ "${self_guard_step_run_command}" != "${self_guard_command}" ]]; then
+  echo "Dedicated Phase 23 workflow coverage guard step must run exactly: ${self_guard_command}" >&2
+  echo "Found: ${self_guard_step_run_command}" >&2
+  exit 1
+fi
+
+self_guard_count="$(grep -Fxc -- "${self_guard_command}" <<<"${active_run_commands}" || true)"
+if [[ "${self_guard_count}" -lt 2 ]]; then
+  echo "Phase 23 workflow coverage checker must run both as a dedicated guard and within focused shell tests." >&2
+  exit 1
+fi
+
+echo "CI workflow includes the required Phase 23 verifier, focused shell test, and focused runtime command."

--- a/scripts/test-verify-phase-23-authority-closure.sh
+++ b/scripts/test-verify-phase-23-authority-closure.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-23-authority-closure.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+required_artifacts=(
+  "control-plane/tests/test_phase23_end_to_end_validation.py"
+  "control-plane/tests/test_phase23_approval_surface_validation.py"
+  "control-plane/tests/test_phase23_transition_logging_validation.py"
+  "control-plane/tests/test_phase23_substrate_simplification_validation.py"
+  "scripts/verify-phase-23-authority-closure.sh"
+  "scripts/test-verify-phase-23-authority-closure.sh"
+  "scripts/test-verify-ci-phase-23-workflow-coverage.sh"
+  ".github/workflows/ci.yml"
+)
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/control-plane/tests" "${target}/scripts" "${target}/.github/workflows"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_required_artifacts() {
+  local target="$1"
+  local artifact=""
+
+  for artifact in "${required_artifacts[@]}"; do
+    mkdir -p "${target}/$(dirname "${artifact}")"
+    cp "${repo_root}/${artifact}" "${target}/${artifact}"
+    git -C "${target}" add "${artifact}"
+  done
+}
+
+remove_text_from_file() {
+  local target="$1"
+  local path="$2"
+  local expected_text="$3"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_required_artifacts "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_e2e_repo="${workdir}/missing-e2e"
+create_repo "${missing_e2e_repo}"
+write_required_artifacts "${missing_e2e_repo}"
+rm "${missing_e2e_repo}/control-plane/tests/test_phase23_end_to_end_validation.py"
+git -C "${missing_e2e_repo}" add -u control-plane/tests/test_phase23_end_to_end_validation.py
+commit_fixture "${missing_e2e_repo}"
+assert_fails_with "${missing_e2e_repo}" "Missing Phase 23 end-to-end validation unittest:"
+
+missing_degraded_repo="${workdir}/missing-degraded"
+create_repo "${missing_degraded_repo}"
+write_required_artifacts "${missing_degraded_repo}"
+remove_text_from_file \
+  "${missing_degraded_repo}" \
+  "control-plane/tests/test_phase23_end_to_end_validation.py" \
+  '            "reviewed_delegation_missing_after_approval",'
+commit_fixture "${missing_degraded_repo}"
+assert_fails_with "${missing_degraded_repo}" "Missing required line in ${missing_degraded_repo}/control-plane/tests/test_phase23_end_to_end_validation.py:             \"reviewed_delegation_missing_after_approval\","
+
+missing_self_approval_repo="${workdir}/missing-self-approval"
+create_repo "${missing_self_approval_repo}"
+write_required_artifacts "${missing_self_approval_repo}"
+remove_text_from_file \
+  "${missing_self_approval_repo}" \
+  "control-plane/tests/test_phase23_approval_surface_validation.py" \
+  "    def test_reviewed_runtime_path_rejects_self_approval(self) -> None:"
+commit_fixture "${missing_self_approval_repo}"
+assert_fails_with "${missing_self_approval_repo}" "Missing required line in ${missing_self_approval_repo}/control-plane/tests/test_phase23_approval_surface_validation.py:     def test_reviewed_runtime_path_rejects_self_approval(self) -> None:"
+
+missing_ci_repo="${workdir}/missing-ci"
+create_repo "${missing_ci_repo}"
+write_required_artifacts "${missing_ci_repo}"
+remove_text_from_file \
+  "${missing_ci_repo}" \
+  ".github/workflows/ci.yml" \
+  "      - name: Run Phase 23 workflow coverage guard"
+commit_fixture "${missing_ci_repo}"
+assert_fails_with "${missing_ci_repo}" "Missing required line in ${missing_ci_repo}/.github/workflows/ci.yml:       - name: Run Phase 23 workflow coverage guard"
+
+echo "Phase 23 authority-closure verifier fails closed for missing runtime coverage and CI wiring."

--- a/scripts/verify-phase-23-authority-closure.sh
+++ b/scripts/verify-phase-23-authority-closure.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+e2e_test="${repo_root}/control-plane/tests/test_phase23_end_to_end_validation.py"
+approval_test="${repo_root}/control-plane/tests/test_phase23_approval_surface_validation.py"
+transition_test="${repo_root}/control-plane/tests/test_phase23_transition_logging_validation.py"
+substrate_test="${repo_root}/control-plane/tests/test_phase23_substrate_simplification_validation.py"
+workflow_guard="${repo_root}/scripts/test-verify-ci-phase-23-workflow-coverage.sh"
+shell_test="${repo_root}/scripts/test-verify-phase-23-authority-closure.sh"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_line() {
+  local path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${path}" >/dev/null; then
+    echo "Missing required line in ${path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${e2e_test}" "Missing Phase 23 end-to-end validation unittest"
+require_file "${approval_test}" "Missing Phase 23 approval surface validation unittest"
+require_file "${transition_test}" "Missing Phase 23 transition logging validation unittest"
+require_file "${substrate_test}" "Missing Phase 23 substrate simplification validation unittest"
+require_file "${workflow_guard}" "Missing Phase 23 workflow coverage guard"
+require_file "${shell_test}" "Missing Phase 23 authority-closure shell test"
+require_file "${workflow_path}" "Missing CI workflow"
+
+require_fixed_line "${e2e_test}" "class Phase23EndToEndValidationTests(unittest.TestCase):"
+require_fixed_line "${e2e_test}" "    def test_phase23_end_to_end_live_grant_keeps_transition_history_and_degraded_visibility_explicit("
+require_fixed_line "${e2e_test}" '            ["pending_approval", "approved"],'
+require_fixed_line "${e2e_test}" '            "reviewed_delegation_missing_after_approval",'
+require_fixed_line "${approval_test}" "class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):"
+require_fixed_line "${approval_test}" "    def test_reviewed_runtime_path_records_live_grant_decision(self) -> None:"
+require_fixed_line "${approval_test}" "    def test_reviewed_runtime_path_rejects_self_approval(self) -> None:"
+require_fixed_line "${transition_test}" "class Phase23TransitionLoggingValidationTests(ServicePersistenceTestBase):"
+require_fixed_line "${transition_test}" "    def test_transition_logging_rolls_back_current_state_when_append_only_save_fails("
+require_fixed_line "${transition_test}" "    def test_transition_logging_rejects_current_state_drift_from_authoritative_history("
+require_fixed_line "${substrate_test}" "class Phase23SubstrateSimplificationValidationTests(unittest.TestCase):"
+require_fixed_line "${substrate_test}" "    def test_reviewed_security_mainline_declares_shuffle_as_single_routine_substrate("
+
+require_fixed_line "${workflow_path}" "      - name: Run Phase 23 authority-closure validation"
+require_fixed_line "${workflow_path}" "          bash scripts/verify-phase-23-authority-closure.sh"
+require_fixed_line "${workflow_path}" "          python3 -m unittest control-plane.tests.test_phase23_end_to_end_validation control-plane.tests.test_phase23_approval_surface_validation control-plane.tests.test_phase23_transition_logging_validation control-plane.tests.test_phase23_substrate_simplification_validation"
+require_fixed_line "${workflow_path}" "      - name: Run Phase 23 workflow coverage guard"
+require_fixed_line "${workflow_path}" "        run: bash scripts/test-verify-ci-phase-23-workflow-coverage.sh"
+require_fixed_line "${workflow_path}" "          bash scripts/test-verify-phase-23-authority-closure.sh"
+
+echo "Phase 23 authority-closure validation artifacts and CI wiring are present and aligned."


### PR DESCRIPTION
Closes #498
This PR was opened by codex-supervisor.
Latest Codex summary:

Added Phase 23 runtime validation coverage and the missing CI-visible verifier entrypoints. The main change is [test_phase23_end_to_end_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-498/control-plane/tests/test_phase23_end_to_end_validation.py:1), which drives a live approval grant through the HTTP surface, asserts append-only transition history for the request and decision records, and then forces the approved-but-undelivered review into degraded visibility so the silent-failure path stays explicit. I also added [verify-phase-23-authority-closure.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-498/scripts/verify-phase-23-authority-closure.sh:1), [test-verify-phase-23-authority-closure.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-498/scripts/test-verify-phase-23-authority-closure.sh:1), and [test-verify-ci-phase-23-workflow-coverage.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-498/scripts/test-verify-ci-phase-23-workflow-coverage.sh:1), then wired the Phase 23 validation and workflow guard into [.github/workflows/ci.yml](/Users/jp.infra/Dev/AegisOps-worktrees/issue-498/.github/workflows/ci.yml:171).

Focused verification passed:
`python3 -m unittest control-plane.tests.test_phase23_end_to_end_validation`
`python3 -m unittest discover -s control-plane/tests -p 'test_phase23_*.py'`
`bash scripts/verify-phase-23-authority-closure.sh`
`bash scripts/test-verify-phase-23-authority-closure.sh`
`bash scripts/test-verify-ci-phase-23-workflow-coverage.sh`

Che...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Phase 23 validation test coverage with end-to-end testing of approval workflows and authority-closure verification.
  * Added CI workflow integration tests to verify proper test execution and coverage alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->