### PR TITLE
Follow-up: align approval-interface docs with the Phase 23 reviewed authority path (#506)

### DIFF
--- a/control-plane/tests/test_phase23_substrate_simplification_validation.py
+++ b/control-plane/tests/test_phase23_substrate_simplification_validation.py
@@ -61,6 +61,21 @@ class Phase23SubstrateSimplificationValidationTests(unittest.TestCase):
         ):
             self.assertIn(term, text)
 
+    def test_requirements_baseline_keeps_approval_authority_on_reviewed_control_plane_path(
+        self,
+    ) -> None:
+        text = self._read("docs/requirements-baseline.md")
+
+        self.assertIn(
+            "AegisOps is the reviewed control plane for approval, evidence, and reconciliation governance",
+            text,
+        )
+        self.assertIn(
+            "other explicitly approved AegisOps-reviewed approval interfaces",
+            text,
+        )
+        self.assertNotIn("* n8n UI when n8n is the approved execution substrate", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/requirements-baseline.md
+++ b/docs/requirements-baseline.md
@@ -601,9 +601,11 @@ Permanent suppressions without recorded rationale are prohibited.
 
 Approval MAY be performed through:
 
-* n8n UI when n8n is the approved execution substrate
-* Teams Adaptive Cards
-* other explicitly approved controlled approval interfaces
+* AegisOps-reviewed approval interfaces exposed on the approved control-plane path
+* Teams Adaptive Cards when they act as an AegisOps-reviewed approval interface rather than an independent authority surface
+* other explicitly approved AegisOps-reviewed approval interfaces
+
+Optional or transitional execution substrates, including n8n, MAY assist with downstream execution or notification handling but MUST NOT become the reviewed approval authority on the security mainline.
 
 The following approval metadata MUST be logged:
 


### PR DESCRIPTION
Closes #506
This PR was opened by codex-supervisor.
Latest Codex summary:

Aligned the remaining approval-authority wording with the reviewed Phase 23 path. In [docs/requirements-baseline.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-506/docs/requirements-baseline.md:600) I replaced the old `n8n UI` approval bullet with AegisOps-reviewed approval-interface language and added an explicit sentence that optional/transitional substrates like `n8n` may assist downstream execution or notification only, not become the reviewed approval authority. I also tightened [control-plane/tests/test_phase23_substrate_simplification_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-506/control-plane/tests/test_phase23_substrate_simplification_validation.py:64) so this specific documentation regression is now enforced.

The change is committed on `codex/issue-506` as `5bfd0a4` with message `Align approval docs with reviewed authority path`. I also updated the local supervisor journal with the reproduced failure, fix, and verification notes.

Summary: Tightened Phase 23 doc validation and updated `docs/requirements-baseline.md` so the reviewed approval authority stays on the AegisOps control-plane path and no longer implies `n8n UI` is an approved mainline authority.
State hint: local_review
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase23_substrate_simplification_validation`; `bash scripts/verify-phase-23-authority-closure.sh`
Failure signature: none
Next action: Manually review the updated approval-authority wording alo...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated approval mechanism policy to require AegisOps-reviewed approval interfaces on the approved control-plane path
  * Removed n8n UI support as an approval authority
  * Added constraints on optional execution substrates in the approval process

* **Tests**
  * Added validation test for approval authority requirements in documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->