### PR TITLE
design: define the first live assistant workflow family and trusted output contract (#511)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,14 @@ jobs:
       - name: Run Phase 23 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-23-workflow-coverage.sh
 
+      - name: Run Phase 24 live assistant workflow contract validation
+        run: |
+          bash scripts/verify-phase-24-live-assistant-workflow-contract.sh
+          python3 -m unittest control-plane.tests.test_phase24_live_assistant_workflow_docs
+
+      - name: Run Phase 24 workflow coverage guard
+        run: bash scripts/test-verify-ci-phase-24-workflow-coverage.sh
+
       - name: Run control-plane runtime unit tests
         run: python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
 
@@ -224,6 +232,7 @@ jobs:
           bash scripts/test-verify-phase-21-production-like-hardening-boundary.sh
           bash scripts/test-verify-phase-22-operator-trust-boundary.sh
           bash scripts/test-verify-phase-23-authority-closure.sh
+          bash scripts/test-verify-phase-24-live-assistant-workflow-contract.sh
           bash scripts/test-verify-ci-phase-14-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-15-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-19-workflow-coverage.sh
@@ -231,6 +240,7 @@ jobs:
           bash scripts/test-verify-ci-phase-21-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-22-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-23-workflow-coverage.sh
+          bash scripts/test-verify-ci-phase-24-workflow-coverage.sh
           bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
           bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
           bash scripts/test-verify-phase-6-replay-to-notify-validation.sh

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ flowchart LR
 ### Assistant path
 
 The assistant is downstream of reviewed records and remains advisory-only.
+The assistant remains advisory-only.
+
+The first bounded live assistant workflow family is limited to queue triage summary and case summary.
 
 ```mermaid
 flowchart TD
@@ -125,6 +128,7 @@ Important:
 - the assistant does **not** approve actions
 - the assistant does **not** execute actions
 - the assistant does **not** become reconciliation truth
+- the bounded live assistant workflow family remains queue triage summary and case summary only
 - optional OpenSearch enrichment is secondary and must never outrank reviewed control-plane truth
 
 ---
@@ -192,6 +196,7 @@ Within the current reviewed live slice, an operator can:
 - review case details
 - inspect evidence provenance and reviewed context
 - review cited advisory output
+- review the bounded live assistant workflow family for queue triage summary and case summary
 - create a reviewed action request from a cited recommendation
 - send the first reviewed live low-risk action (`notify_identity_owner`) through the approved path
 - inspect authoritative execution and reconciliation state
@@ -344,6 +349,7 @@ Recommended starting points for a new reader:
 - `docs/automation-substrate-contract.md`
 - `docs/response-action-safety-model.md`
 - `docs/phase-15-identity-grounded-analyst-assistant-boundary.md`
+- `docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md`
 - `docs/runbook.md`
 
 If you want the shortest mental model, remember this:

--- a/control-plane/tests/test_phase24_live_assistant_workflow_docs.py
+++ b/control-plane/tests/test_phase24_live_assistant_workflow_docs.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase24LiveAssistantWorkflowDocsTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected document at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_phase24_design_doc_exists_and_bounds_first_live_workflow_family(self) -> None:
+        text = self._read(
+            "docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md"
+        )
+
+        for term in (
+            "AegisOps Phase 24 First Live Assistant Workflow Family and Trusted Output Contract",
+            "first live assistant workflow family",
+            "queue triage summary",
+            "case summary",
+            "advisory-only",
+            "must force `unresolved`",
+            "approval, delegation, execution, and policy authority outside the assistant boundary",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase24_design_doc_defines_trusted_output_contract_and_fail_closed_conditions(
+        self,
+    ) -> None:
+        text = self._read(
+            "docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md"
+        )
+
+        for term in (
+            "Trusted Output Contract",
+            "`workflow_family`",
+            "`workflow_task`",
+            "`status`",
+            "`summary`",
+            "`citations`",
+            "`unresolved_reasons`",
+            "reviewed record inputs",
+            "required citation fields",
+            "allowed fields",
+            "If required citations are missing",
+            "If reviewed records conflict",
+            "If the operator request asks for approval, delegation, execution, or policy interpretation",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase24_validation_doc_records_alignment_with_roadmap_readme_and_phase15_boundary(
+        self,
+    ) -> None:
+        text = self._read(
+            "docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract-validation.md"
+        )
+
+        for term in (
+            "Phase 24 First Live Assistant Workflow Family and Trusted Output Contract Validation",
+            "Validation status: PASS",
+            "docs/Revised Phase23-20 Epic Roadmap.md",
+            "README.md",
+            "docs/phase-15-identity-grounded-analyst-assistant-boundary.md",
+            "workflow contract",
+            "authority model",
+            "advisory-only",
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract-validation.md
+++ b/docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract-validation.md
@@ -1,0 +1,32 @@
+# Phase 24 First Live Assistant Workflow Family and Trusted Output Contract Validation
+
+- Validation status: PASS
+- Reviewed on: 2026-04-17
+- Scope: confirm the first live assistant workflow family stays bounded to two narrow summary tasks, keeps the assistant advisory-only, and forces unresolved output when trusted reviewed grounding is missing or authority would otherwise widen.
+- Reviewed sources: `docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md`, `docs/Revised Phase23-20 Epic Roadmap.md`, `README.md`, `docs/phase-15-identity-grounded-analyst-assistant-boundary.md`, `docs/control-plane-state-model.md`
+
+## Validation Summary
+
+The workflow contract defines one first live assistant workflow family and limits it to `queue triage summary` and `case summary`.
+
+The workflow contract keeps the assistant advisory-only and does not allow approval, delegation, execution, reconciliation, or policy authority to move onto the assistant path.
+
+The trusted output contract is intentionally narrow, requires explicit citations, and forces unresolved output when reviewed grounding is incomplete or authority pressure appears in the request.
+
+## Authority Model Review
+
+`docs/Revised Phase23-20 Epic Roadmap.md` remains aligned because the selected workflow family is a small business-hours operator loop rather than a broad AI expansion.
+
+`README.md` remains aligned because the assistant path still sits downstream of reviewed records and operator review.
+
+`docs/phase-15-identity-grounded-analyst-assistant-boundary.md` remains aligned because the workflow contract preserves reviewed grounding, explicit citations, fail-closed handling, and the advisory-only ceiling.
+
+`docs/control-plane-state-model.md` remains aligned because authoritative workflow truth stays on reviewed control-plane records rather than on workflow contract output.
+
+## Review Outcome
+
+The first live assistant workflow family is reviewable end-to-end.
+
+The workflow contract and authority model remain consistent.
+
+No deviations found.

--- a/docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md
+++ b/docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md
@@ -1,0 +1,159 @@
+# AegisOps Phase 24 First Live Assistant Workflow Family and Trusted Output Contract
+
+## 1. Purpose
+
+This document defines the first live assistant workflow family and the trusted output contract for that family.
+
+It supplements `docs/Revised Phase23-20 Epic Roadmap.md`, `README.md`, `docs/phase-15-identity-grounded-analyst-assistant-boundary.md`, and `docs/control-plane-state-model.md` by narrowing the first operator-facing assistant loop to a reviewed, bounded, advisory-only workflow family.
+
+This document defines reviewed workflow scope and trusted output rules only. It does not approve live assistant authority over approval, delegation, execution, reconciliation, or policy interpretation.
+
+## 2. First Live Assistant Workflow Family
+
+The first live assistant workflow family is a bounded reviewed summarization family.
+
+It is intentionally limited to two narrow operator tasks:
+
+- `queue triage summary`
+- `case summary`
+
+This first live assistant workflow family does not include next-step recommendation draft generation, approval suggestions, delegation suggestions, action execution instructions, or policy interpretation.
+
+The assistant remains advisory-only.
+
+The bounded family is small enough to review end-to-end because both tasks render from one reviewed record chain and return operator-facing summaries rather than authority-bearing decisions.
+
+## 3. Reviewed Record Inputs
+
+This section defines the reviewed record inputs for the first live assistant workflow family.
+
+The workflow family may ground only on reviewed record inputs that already exist in the authoritative AegisOps control-plane chain.
+
+### 3.1 Queue Triage Summary Inputs
+
+`queue triage summary` may render only from reviewed records already linked to the queued item:
+
+- `Alert`
+- `Case`, when one already exists for the queued alert
+- linked `Evidence`
+- linked `Observation` or `Lead`, when already reviewed
+- linked `Recommendation`, only as cited context and not as live recommendation generation authority
+- linked `Analytic Signal` or `substrate_detection_record_id`, only when already attached to a reviewed record
+
+### 3.2 Case Summary Inputs
+
+`case summary` may render only from reviewed records already linked to the case:
+
+- `Case`
+- linked `Alert`
+- linked `Evidence`
+- linked `Observation`
+- linked `Lead`
+- linked `Recommendation`
+- linked `Action Request`, `Approval Decision`, `Action Execution`, and `Reconciliation`, when those records already exist on the reviewed case chain
+
+The workflow family must prefer reviewed records and linked evidence over substrate-local summaries, analytics rows, or prompt-provided narrative.
+
+If a requested summary cannot be grounded in reviewed record inputs, the workflow must force `unresolved`.
+
+## 4. Workflow Task Boundaries
+
+`queue triage summary` is the skim surface for the current queue item. It may summarize reviewed severity, reviewed state, linked evidence posture, and visible unresolved gaps for the next human reviewer.
+
+`case summary` is the durable coordination surface for the current case. It may summarize reviewed scope, linked evidence, current lifecycle state, already-recorded recommendation context, and any already-recorded approval or reconciliation state.
+
+Neither task may create a new recommendation, interpret policy, approve a request, delegate a request, execute an action, or resolve a reconciliation mismatch.
+
+If the operator request asks for approval, delegation, execution, or policy interpretation, the assistant must force `unresolved` instead of returning a weak answer.
+
+## 5. Trusted Output Contract
+
+The trusted output contract for this workflow family is intentionally narrow and only allows summary-shaped fields.
+
+Allowed fields:
+
+The trusted output contract explicitly defines the allowed fields for this family and no other summary fields are permitted.
+
+| Field | Rule |
+| --- | --- |
+| `workflow_family` | Must be `first_live_assistant_summary_family`. |
+| `workflow_task` | Must be either `queue_triage_summary` or `case_summary`. |
+| `status` | Must be `ready` or `unresolved`. |
+| `summary` | A concise reviewed summary with no authority-bearing language. |
+| `citations` | Required citations for every material claim in `summary`. |
+| `unresolved_reasons` | Required when `status` is `unresolved`. |
+| `operator_follow_up` | Optional next review prompt for the human operator, framed as review work rather than action authority. |
+
+No additional fields are allowed for the first live workflow family.
+
+The contract must not include approval decisions, delegation instructions, execution commands, policy conclusions, free-form tool requests, or hidden confidence fields.
+
+## 6. Required Citation Fields
+
+This section defines the required citation fields for the trusted output contract.
+
+The `citations` field is required for every material claim and each citation entry must preserve the reviewed record chain.
+
+Required citation fields:
+
+| Citation field | Minimum rule |
+| --- | --- |
+| `record_family` | The reviewed source family such as `Alert`, `Case`, `Evidence`, `Recommendation`, or `Reconciliation`. |
+| `record_id` | The stable reviewed identifier for the cited record. |
+| `claim` | The specific supported claim or observation tied to that record. |
+| `evidence_id` | Required when the claim depends on linked evidence rather than only the parent record state. |
+| `reviewed_context_field` | Required when the claim depends on an explicit reviewed context identifier or lifecycle field. |
+
+The trusted output contract must keep citations explicit enough that a reviewer can trace each claim back to reviewed record inputs without consulting hidden prompt state.
+
+If required citations are missing, the workflow must force `unresolved`.
+
+## 7. Unresolved Conditions
+
+The workflow family must fail closed.
+
+Trust-blocking conditions that must force `unresolved` include:
+
+- If required citations are missing.
+- If reviewed records conflict on lifecycle state, ownership, scope, or evidence-backed facts.
+- If linked evidence is referenced in the summary but the corresponding reviewed `evidence_id` is absent.
+- If the operator request asks for approval, delegation, execution, or policy interpretation.
+- If the request depends on prompt-only facts, substrate-local summaries, or uncited analyst narrative that is not already preserved as reviewed record input.
+- If the requested answer would require the assistant to collapse identity ambiguity or choose between conflicting reviewed records.
+
+`unresolved_reasons` must name the blocking condition directly instead of softening it into a weak or speculative answer.
+
+## 8. Authority Boundary
+
+The assistant remains advisory-only for the first live assistant workflow family.
+
+Approval, delegation, execution, and policy authority outside the assistant boundary must remain on the reviewed human and control-plane path.
+
+This preserves approval, delegation, execution, and policy authority outside the assistant boundary.
+
+The workflow family may summarize reviewed state, but it must not become approval authority, delegation authority, execution authority, reconciliation authority, or policy authority.
+
+The trusted output contract exists to preserve operator review, not to create a new authority surface.
+
+## 9. Live Rollout Non-Expansion Rules
+
+This first live assistant workflow family does not authorize:
+
+- next-step recommendation draft generation as a live workflow;
+- approval recommendation or approval routing authority;
+- delegation or execution proposal payload construction;
+- policy interpretation or policy exception handling;
+- broad search-driven assistance outside the reviewed record chain; or
+- any workflow family with more than the two narrow tasks listed in this document.
+
+Future expansion must be reviewed as a separate workflow-family decision rather than inferred from this contract.
+
+## 10. Alignment Notes
+
+This Phase 24 workflow contract stays aligned with `docs/Revised Phase23-20 Epic Roadmap.md` by preferring a small business-hours operator loop over broad AI surface growth.
+
+It stays aligned with `README.md` by keeping the assistant downstream of reviewed records and advisory-only.
+
+It stays aligned with `docs/phase-15-identity-grounded-analyst-assistant-boundary.md` by preserving reviewed grounding, explicit citations, and fail-closed unresolved handling.
+
+It stays aligned with `docs/control-plane-state-model.md` by keeping authoritative workflow truth on the AegisOps record chain rather than on assistant output.

--- a/scripts/test-verify-ci-phase-24-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-24-workflow-coverage.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+required_verifiers=(
+  "bash scripts/verify-phase-24-live-assistant-workflow-contract.sh"
+)
+
+required_tests=(
+  "bash scripts/test-verify-phase-24-live-assistant-workflow-contract.sh"
+)
+
+required_runtime_commands=(
+  "python3 -m unittest control-plane.tests.test_phase24_live_assistant_workflow_docs"
+)
+
+self_guard_step_name="Run Phase 24 workflow coverage guard"
+self_guard_command="bash scripts/test-verify-ci-phase-24-workflow-coverage.sh"
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+collect_active_run_commands() {
+  awk '
+    {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent > block_indent) {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          if (line != "" && line !~ /^#/) {
+            print line
+          }
+          next
+        }
+
+        in_block = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+        block_indent = match($0, /[^ ]/) - 1
+        in_block = 1
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[^|>]/) {
+        line = $0
+        sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+        if (line != "" && line !~ /^#/) {
+          print line
+        }
+      }
+    }
+  ' "${workflow_path}"
+}
+
+extract_self_guard_step_run_command() {
+  awk -v step_name="${self_guard_step_name}" '
+    function line_indent(line) {
+      return match(line, /[^ ]/) - 1
+    }
+
+    BEGIN {
+      in_step = 0
+      step_indent = -1
+    }
+
+    {
+      if (in_step) {
+        if ($0 ~ /^[[:space:]]*-[[:space:]]name:[[:space:]]+/ && line_indent($0) <= step_indent) {
+          exit 0
+        }
+
+        if ($0 ~ /^[[:space:]]*run:[[:space:]]*/) {
+          line = $0
+          sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+          print line
+          exit 0
+        }
+      }
+
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line == "- name: " step_name) {
+        in_step = 1
+        step_indent = line_indent($0)
+      }
+    }
+  ' "${workflow_path}"
+}
+
+active_run_commands="$(collect_active_run_commands)"
+
+for command in "${required_verifiers[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 24 verifier command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_tests[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 24 focused shell test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_runtime_commands[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 24 focused runtime command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+self_guard_step_run_command="$(extract_self_guard_step_run_command)"
+if [[ -z "${self_guard_step_run_command}" ]]; then
+  echo "Missing dedicated Phase 24 workflow coverage guard step in CI workflow: ${self_guard_step_name}" >&2
+  exit 1
+fi
+
+if [[ "${self_guard_step_run_command}" != "${self_guard_command}" ]]; then
+  echo "Dedicated Phase 24 workflow coverage guard step must run exactly: ${self_guard_command}" >&2
+  echo "Found: ${self_guard_step_run_command}" >&2
+  exit 1
+fi
+
+self_guard_count="$(grep -Fxc -- "${self_guard_command}" <<<"${active_run_commands}" || true)"
+if [[ "${self_guard_count}" -lt 2 ]]; then
+  echo "Phase 24 workflow coverage checker must run both as a dedicated guard and within focused shell tests." >&2
+  exit 1
+fi
+
+echo "CI workflow includes the required Phase 24 verifier, focused shell test, and focused runtime command."

--- a/scripts/test-verify-phase-24-live-assistant-workflow-contract.sh
+++ b/scripts/test-verify-phase-24-live-assistant-workflow-contract.sh
@@ -56,6 +56,17 @@ remove_text_from_file() {
   git -C "${target}" add "${path}"
 }
 
+replace_text_in_file() {
+  local target="$1"
+  local path="$2"
+  local original_text="$3"
+  local replacement_text="$4"
+
+  ORIGINAL_TEXT="${original_text}" REPLACEMENT_TEXT="${replacement_text}" \
+    perl -0pi -e 's/\Q$ENV{ORIGINAL_TEXT}\E/$ENV{REPLACEMENT_TEXT}/g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
 commit_fixture() {
   local target="$1"
 
@@ -118,8 +129,19 @@ write_required_artifacts "${missing_ci_repo}"
 remove_text_from_file \
   "${missing_ci_repo}" \
   ".github/workflows/ci.yml" \
-  "      - name: Run Phase 24 workflow coverage guard"
+  "        run: bash scripts/test-verify-ci-phase-24-workflow-coverage.sh"
 commit_fixture "${missing_ci_repo}"
-assert_fails_with "${missing_ci_repo}" "Missing required text in ${missing_ci_repo}/.github/workflows/ci.yml:       - name: Run Phase 24 workflow coverage guard"
+assert_fails_with "${missing_ci_repo}" "Missing active command in CI step \"Run Phase 24 workflow coverage guard\": bash scripts/test-verify-ci-phase-24-workflow-coverage.sh"
+
+commented_validation_command_repo="${workdir}/commented-validation-command"
+create_repo "${commented_validation_command_repo}"
+write_required_artifacts "${commented_validation_command_repo}"
+replace_text_in_file \
+  "${commented_validation_command_repo}" \
+  ".github/workflows/ci.yml" \
+  "          bash scripts/verify-phase-24-live-assistant-workflow-contract.sh" \
+  "          # bash scripts/verify-phase-24-live-assistant-workflow-contract.sh"
+commit_fixture "${commented_validation_command_repo}"
+assert_fails_with "${commented_validation_command_repo}" "Missing active command in CI step \"Run Phase 24 live assistant workflow contract validation\": bash scripts/verify-phase-24-live-assistant-workflow-contract.sh"
 
 echo "Phase 24 workflow contract verifier fails closed for missing docs, README alignment, and CI wiring."

--- a/scripts/test-verify-phase-24-live-assistant-workflow-contract.sh
+++ b/scripts/test-verify-phase-24-live-assistant-workflow-contract.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-24-live-assistant-workflow-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+required_artifacts=(
+  "README.md"
+  "docs/Revised Phase23-20 Epic Roadmap.md"
+  "docs/control-plane-state-model.md"
+  "docs/phase-15-identity-grounded-analyst-assistant-boundary.md"
+  "docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md"
+  "docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract-validation.md"
+  "control-plane/tests/test_phase24_live_assistant_workflow_docs.py"
+  "scripts/verify-phase-24-live-assistant-workflow-contract.sh"
+  "scripts/test-verify-phase-24-live-assistant-workflow-contract.sh"
+  "scripts/test-verify-ci-phase-24-workflow-coverage.sh"
+  ".github/workflows/ci.yml"
+)
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/control-plane/tests" "${target}/docs" "${target}/scripts" "${target}/.github/workflows"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_required_artifacts() {
+  local target="$1"
+  local artifact=""
+
+  for artifact in "${required_artifacts[@]}"; do
+    mkdir -p "${target}/$(dirname "${artifact}")"
+    cp "${repo_root}/${artifact}" "${target}/${artifact}"
+    git -C "${target}" add "${artifact}"
+  done
+}
+
+remove_text_from_file() {
+  local target="$1"
+  local path="$2"
+  local expected_text="$3"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_required_artifacts "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_design_repo="${workdir}/missing-design"
+create_repo "${missing_design_repo}"
+write_required_artifacts "${missing_design_repo}"
+rm "${missing_design_repo}/docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md"
+git -C "${missing_design_repo}" add -u docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md
+commit_fixture "${missing_design_repo}"
+assert_fails_with "${missing_design_repo}" "Missing Phase 24 workflow contract design document:"
+
+missing_readme_alignment_repo="${workdir}/missing-readme-alignment"
+create_repo "${missing_readme_alignment_repo}"
+write_required_artifacts "${missing_readme_alignment_repo}"
+remove_text_from_file \
+  "${missing_readme_alignment_repo}" \
+  "README.md" \
+  "bounded live assistant workflow family"
+commit_fixture "${missing_readme_alignment_repo}"
+assert_fails_with "${missing_readme_alignment_repo}" "Missing required text in ${missing_readme_alignment_repo}/README.md: bounded live assistant workflow family"
+
+missing_ci_repo="${workdir}/missing-ci"
+create_repo "${missing_ci_repo}"
+write_required_artifacts "${missing_ci_repo}"
+remove_text_from_file \
+  "${missing_ci_repo}" \
+  ".github/workflows/ci.yml" \
+  "      - name: Run Phase 24 workflow coverage guard"
+commit_fixture "${missing_ci_repo}"
+assert_fails_with "${missing_ci_repo}" "Missing required text in ${missing_ci_repo}/.github/workflows/ci.yml:       - name: Run Phase 24 workflow coverage guard"
+
+echo "Phase 24 workflow contract verifier fails closed for missing docs, README alignment, and CI wiring."

--- a/scripts/verify-phase-24-live-assistant-workflow-contract.sh
+++ b/scripts/verify-phase-24-live-assistant-workflow-contract.sh
@@ -32,6 +32,88 @@ require_contains() {
   fi
 }
 
+collect_active_step_run_commands() {
+  awk '
+    {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent > block_indent) {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          if (line != "" && line !~ /^#/) {
+            print current_step "\t" line
+          }
+          next
+        }
+
+        in_block = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*-[[:space:]]name:[[:space:]]+/) {
+        current_step = $0
+        sub(/^[[:space:]]*-[[:space:]]name:[[:space:]]+/, "", current_step)
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+        block_indent = match($0, /[^ ]/) - 1
+        in_block = 1
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[^|>]/) {
+        line = $0
+        sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+        if (line != "" && line !~ /^#/) {
+          print current_step "\t" line
+        }
+      }
+    }
+  ' "${workflow_path}"
+}
+
+collect_active_run_commands() {
+  collect_active_step_run_commands | cut -f2-
+}
+
+collect_active_step_commands() {
+  local step_name="$1"
+
+  collect_active_step_run_commands |
+    awk -F $'\t' -v step_name="${step_name}" '$1 == step_name { print $2 }'
+}
+
+require_active_run_command() {
+  local active_commands="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" <<<"${active_commands}" >/dev/null; then
+    echo "Missing active CI command in ${workflow_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_active_step_command() {
+  local step_name="$1"
+  local expected="$2"
+  local step_commands=""
+
+  step_commands="$(collect_active_step_commands "${step_name}")"
+  if [[ -z "${step_commands}" ]]; then
+    echo "Missing active command in CI step \"${step_name}\": ${expected}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fqx -- "${expected}" <<<"${step_commands}" >/dev/null; then
+    echo "Missing active command in CI step \"${step_name}\": ${expected}" >&2
+    exit 1
+  fi
+}
+
 require_file "${design_doc}" "Missing Phase 24 workflow contract design document"
 require_file "${validation_doc}" "Missing Phase 24 workflow contract validation note"
 require_file "${readme_doc}" "Missing README"
@@ -72,11 +154,19 @@ require_contains "${readme_doc}" "bounded live assistant workflow family"
 require_contains "${readme_doc}" "queue triage summary and case summary"
 require_contains "${readme_doc}" "The assistant remains advisory-only"
 
-require_contains "${workflow_path}" "      - name: Run Phase 24 live assistant workflow contract validation"
-require_contains "${workflow_path}" "          bash scripts/verify-phase-24-live-assistant-workflow-contract.sh"
-require_contains "${workflow_path}" "          python3 -m unittest control-plane.tests.test_phase24_live_assistant_workflow_docs"
-require_contains "${workflow_path}" "      - name: Run Phase 24 workflow coverage guard"
-require_contains "${workflow_path}" "        run: bash scripts/test-verify-ci-phase-24-workflow-coverage.sh"
-require_contains "${workflow_path}" "          bash scripts/test-verify-phase-24-live-assistant-workflow-contract.sh"
+active_run_commands="$(collect_active_run_commands)"
+
+require_active_step_command \
+  "Run Phase 24 live assistant workflow contract validation" \
+  "bash scripts/verify-phase-24-live-assistant-workflow-contract.sh"
+require_active_step_command \
+  "Run Phase 24 live assistant workflow contract validation" \
+  "python3 -m unittest control-plane.tests.test_phase24_live_assistant_workflow_docs"
+require_active_step_command \
+  "Run Phase 24 workflow coverage guard" \
+  "bash scripts/test-verify-ci-phase-24-workflow-coverage.sh"
+require_active_run_command \
+  "${active_run_commands}" \
+  "bash scripts/test-verify-phase-24-live-assistant-workflow-contract.sh"
 
 echo "Phase 24 live assistant workflow family remains bounded, cited, and advisory-only."

--- a/scripts/verify-phase-24-live-assistant-workflow-contract.sh
+++ b/scripts/verify-phase-24-live-assistant-workflow-contract.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+design_doc="${repo_root}/docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md"
+validation_doc="${repo_root}/docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract-validation.md"
+readme_doc="${repo_root}/README.md"
+roadmap_doc="${repo_root}/docs/Revised Phase23-20 Epic Roadmap.md"
+phase15_doc="${repo_root}/docs/phase-15-identity-grounded-analyst-assistant-boundary.md"
+state_model_doc="${repo_root}/docs/control-plane-state-model.md"
+phase24_tests="${repo_root}/control-plane/tests/test_phase24_live_assistant_workflow_docs.py"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_contains() {
+  local path="$1"
+  local expected="$2"
+
+  if ! grep -F -- "${expected}" "${path}" >/dev/null; then
+    echo "Missing required text in ${path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${design_doc}" "Missing Phase 24 workflow contract design document"
+require_file "${validation_doc}" "Missing Phase 24 workflow contract validation note"
+require_file "${readme_doc}" "Missing README"
+require_file "${roadmap_doc}" "Missing revised roadmap"
+require_file "${phase15_doc}" "Missing Phase 15 assistant boundary doc"
+require_file "${state_model_doc}" "Missing control-plane state model"
+require_file "${phase24_tests}" "Missing Phase 24 workflow contract doc tests"
+require_file "${workflow_path}" "Missing CI workflow"
+
+require_contains "${design_doc}" "# AegisOps Phase 24 First Live Assistant Workflow Family and Trusted Output Contract"
+require_contains "${design_doc}" "The first live assistant workflow family is a bounded reviewed summarization family."
+require_contains "${design_doc}" "- \`queue triage summary\`"
+require_contains "${design_doc}" "- \`case summary\`"
+require_contains "${design_doc}" "This first live assistant workflow family does not include next-step recommendation draft generation"
+require_contains "${design_doc}" "The assistant remains advisory-only."
+require_contains "${design_doc}" "Allowed fields:"
+require_contains "${design_doc}" "| \`workflow_family\` |"
+require_contains "${design_doc}" "| \`workflow_task\` |"
+require_contains "${design_doc}" "| \`status\` |"
+require_contains "${design_doc}" "| \`summary\` |"
+require_contains "${design_doc}" "| \`citations\` |"
+require_contains "${design_doc}" "| \`unresolved_reasons\` |"
+require_contains "${design_doc}" "Required citation fields:"
+require_contains "${design_doc}" "If required citations are missing, the workflow must force \`unresolved\`."
+require_contains "${design_doc}" "If reviewed records conflict on lifecycle state, ownership, scope, or evidence-backed facts."
+require_contains "${design_doc}" "If the operator request asks for approval, delegation, execution, or policy interpretation."
+require_contains "${design_doc}" "Approval, delegation, execution, and policy authority outside the assistant boundary must remain on the reviewed human and control-plane path."
+
+require_contains "${validation_doc}" "# Phase 24 First Live Assistant Workflow Family and Trusted Output Contract Validation"
+require_contains "${validation_doc}" "Validation status: PASS"
+require_contains "${validation_doc}" "docs/Revised Phase23-20 Epic Roadmap.md"
+require_contains "${validation_doc}" "README.md"
+require_contains "${validation_doc}" "docs/phase-15-identity-grounded-analyst-assistant-boundary.md"
+require_contains "${validation_doc}" "authority model"
+require_contains "${validation_doc}" "No deviations found."
+
+require_contains "${readme_doc}" "bounded live assistant workflow family"
+require_contains "${readme_doc}" "queue triage summary and case summary"
+require_contains "${readme_doc}" "The assistant remains advisory-only"
+
+require_contains "${workflow_path}" "      - name: Run Phase 24 live assistant workflow contract validation"
+require_contains "${workflow_path}" "          bash scripts/verify-phase-24-live-assistant-workflow-contract.sh"
+require_contains "${workflow_path}" "          python3 -m unittest control-plane.tests.test_phase24_live_assistant_workflow_docs"
+require_contains "${workflow_path}" "      - name: Run Phase 24 workflow coverage guard"
+require_contains "${workflow_path}" "        run: bash scripts/test-verify-ci-phase-24-workflow-coverage.sh"
+require_contains "${workflow_path}" "          bash scripts/test-verify-phase-24-live-assistant-workflow-contract.sh"
+
+echo "Phase 24 live assistant workflow family remains bounded, cited, and advisory-only."


### PR DESCRIPTION
Closes #511
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a bounded Phase 24 documentation slice and committed it as `4db7f27` (`Add Phase 24 assistant workflow contract docs`).

The change introduces a new Phase 24 design doc that selects the first live assistant workflow family as `queue triage summary` and `case summary` only, defines a narrow trusted output contract with explicit citation requirements and `unresolved` triggers, and keeps approval, delegation, execution, reconciliation, and policy authority outside the assistant boundary. I also added a validation note, a focused unittest, a verifier, a workflow-coverage guard, CI wiring, and a small README alignment update so the repo narrative matches the same authority model. The supervisor journal was updated locally in `.codex-supervisor/issues/511/issue-journal.md`; that path is ignored, so it was not included in the commit.

Tests I ran passed:
`python3 -m unittest control-plane.tests.test_phase24_live_assistant_workflow_docs`
`bash scripts/verify-phase-24-live-assistant-workflow-contract.sh`
`bash scripts/test-verify-phase-24-live-assistant-workflow-contract.sh`
`bash scripts/test-verify-ci-phase-24-workflow-coverage.sh`

Summary: Added and verified the Phase 24 first live assistant workflow-family design, trusted output contract, validation note, and CI/doc-test coverage; committed as `4db7f27`.
State hint: local_review
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase24_live_assistant_workflow_docs`; `bash scripts/verify-phase-24-l...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase 24 live assistant workflow family launched for advisory-only queue triage summary and case summary.

* **Documentation**
  * Added detailed Phase 24 design and validation docs specifying scope, trusted output contract, fail-closed rules, and alignment notes.
  * Updated README with operator guidance and links.

* **Tests**
  * Added validation tests and CI verification checks to enforce docs, contract, and CI wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->