### PR TITLE
implementation: add a provider adapter with timeout, retry, explicit no-memory policy, and transcript provenance (#512)

### DIFF
--- a/control-plane/aegisops_control_plane/assistant_provider.py
+++ b/control-plane/aegisops_control_plane/assistant_provider.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping, Protocol
+
+from .models import AITraceRecord
+
+
+class AssistantProviderTransport(Protocol):
+    def send_request(self, *, request: Mapping[str, object]) -> Mapping[str, object]:
+        """Send a provider request and return the provider response payload."""
+
+
+class AssistantProviderTimeout(RuntimeError):
+    """Raised when the provider transport exceeds the reviewed timeout budget."""
+
+
+@dataclass(frozen=True)
+class AssistantProviderAttemptFailure:
+    attempt_number: int
+    failure_kind: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class AssistantProviderResult:
+    status: str
+    provider_identity: str
+    model_identity: str
+    prompt_version: str
+    workflow_family: str
+    workflow_task: str
+    generated_at: datetime
+    reviewed_input_refs: tuple[str, ...]
+    output_text: str | None
+    attempt_count: int
+    request_provenance: Mapping[str, object]
+    response_provenance: Mapping[str, object]
+    failures: tuple[AssistantProviderAttemptFailure, ...]
+    failure_summary: str | None
+
+
+@dataclass(frozen=True)
+class AssistantProviderFailure(AssistantProviderResult):
+    pass
+
+
+class AssistantProviderAdapter:
+    def __init__(
+        self,
+        *,
+        provider_identity: str,
+        model_identity: str,
+        prompt_version: str,
+        request_timeout_seconds: float,
+        max_attempts: int,
+        transport: AssistantProviderTransport,
+    ) -> None:
+        if request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be greater than zero")
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be at least one")
+        self._provider_identity = provider_identity
+        self._model_identity = model_identity
+        self._prompt_version = prompt_version
+        self._request_timeout_seconds = float(request_timeout_seconds)
+        self._max_attempts = max_attempts
+        self._transport = transport
+
+    def generate(
+        self,
+        *,
+        workflow_family: str,
+        workflow_task: str,
+        transcript: list[Mapping[str, object]],
+        reviewed_input_refs: tuple[str, ...],
+        metadata: Mapping[str, object],
+    ) -> AssistantProviderResult:
+        generated_at = datetime.now(timezone.utc)
+        failures: list[AssistantProviderAttemptFailure] = []
+        request_provenance = {
+            "provider_identity": self._provider_identity,
+            "model_identity": self._model_identity,
+            "prompt_version": self._prompt_version,
+            "workflow_family": workflow_family,
+            "workflow_task": workflow_task,
+            "memory_policy": "no_memory",
+            "allow_provider_memory": False,
+            "timeout_seconds": self._request_timeout_seconds,
+            "max_attempts": self._max_attempts,
+            "transcript_messages": len(transcript),
+            "reviewed_input_refs": tuple(reviewed_input_refs),
+            "request_metadata": dict(metadata),
+        }
+        request = {
+            **request_provenance,
+            "transcript": tuple(dict(message) for message in transcript),
+        }
+
+        for attempt_number in range(1, self._max_attempts + 1):
+            try:
+                response = self._transport.send_request(request=request)
+                output_text = self._require_non_empty_string(
+                    response.get("output_text"),
+                    "provider response output_text",
+                )
+                response_provenance = {
+                    "provider_request_id": self._string_or_none(
+                        response.get("provider_request_id")
+                    ),
+                    "provider_response_id": self._string_or_none(
+                        response.get("provider_response_id")
+                    ),
+                    "provider_transcript_id": self._string_or_none(
+                        response.get("provider_transcript_id")
+                    ),
+                    "model_version": self._string_or_none(response.get("model_version"))
+                    or self._model_identity,
+                }
+                return AssistantProviderResult(
+                    status="ready",
+                    provider_identity=self._provider_identity,
+                    model_identity=self._model_identity,
+                    prompt_version=self._prompt_version,
+                    workflow_family=workflow_family,
+                    workflow_task=workflow_task,
+                    generated_at=generated_at,
+                    reviewed_input_refs=tuple(reviewed_input_refs),
+                    output_text=output_text,
+                    attempt_count=attempt_number,
+                    request_provenance=request_provenance,
+                    response_provenance=response_provenance,
+                    failures=tuple(failures),
+                    failure_summary=None,
+                )
+            except AssistantProviderTimeout as exc:
+                failures.append(
+                    AssistantProviderAttemptFailure(
+                        attempt_number=attempt_number,
+                        failure_kind="timeout",
+                        detail=str(exc),
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001
+                failures.append(
+                    AssistantProviderAttemptFailure(
+                        attempt_number=attempt_number,
+                        failure_kind="provider_error",
+                        detail=str(exc),
+                    )
+                )
+
+        failure_summary = "; ".join(
+            f"attempt {failure.attempt_number}: {failure.failure_kind}: {failure.detail}"
+            for failure in failures
+        )
+        return AssistantProviderFailure(
+            status="failed",
+            provider_identity=self._provider_identity,
+            model_identity=self._model_identity,
+            prompt_version=self._prompt_version,
+            workflow_family=workflow_family,
+            workflow_task=workflow_task,
+            generated_at=generated_at,
+            reviewed_input_refs=tuple(reviewed_input_refs),
+            output_text=None,
+            attempt_count=self._max_attempts,
+            request_provenance=request_provenance,
+            response_provenance={},
+            failures=tuple(failures),
+            failure_summary=failure_summary,
+        )
+
+    def build_ai_trace_record(
+        self,
+        *,
+        ai_trace_id: str,
+        reviewer_identity: str,
+        generated_at: datetime,
+        result: AssistantProviderResult,
+        subject_linkage: Mapping[str, object],
+    ) -> AITraceRecord:
+        linked_subjects = dict(subject_linkage)
+        linked_subjects.update(
+            {
+                "provider_identity": result.provider_identity,
+                "provider_model_identity": result.model_identity,
+                "provider_request_provenance": dict(result.request_provenance),
+                "provider_response_provenance": dict(result.response_provenance),
+                "provider_failures": tuple(
+                    {
+                        "attempt_number": failure.attempt_number,
+                        "failure_kind": failure.failure_kind,
+                        "detail": failure.detail,
+                    }
+                    for failure in result.failures
+                ),
+                "provider_failure_summary": result.failure_summary,
+                "provider_status": result.status,
+                "provider_workflow_family": result.workflow_family,
+                "provider_workflow_task": result.workflow_task,
+            }
+        )
+        return AITraceRecord(
+            ai_trace_id=ai_trace_id,
+            subject_linkage=linked_subjects,
+            model_identity=f"{result.provider_identity}/{result.model_identity}",
+            prompt_version=result.prompt_version,
+            generated_at=generated_at,
+            material_input_refs=result.reviewed_input_refs,
+            reviewer_identity=reviewer_identity,
+            lifecycle_state="generated" if result.status == "ready" else "failed",
+        )
+
+    @staticmethod
+    def _require_non_empty_string(value: object, field_name: str) -> str:
+        if not isinstance(value, str) or value.strip() == "":
+            raise ValueError(f"{field_name} must be a non-empty string")
+        return value
+
+    @staticmethod
+    def _string_or_none(value: object) -> str | None:
+        if isinstance(value, str) and value.strip():
+            return value
+        return None

--- a/control-plane/aegisops_control_plane/assistant_provider.py
+++ b/control-plane/aegisops_control_plane/assistant_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Mapping, Protocol
@@ -93,13 +94,11 @@ class AssistantProviderAdapter:
             "reviewed_input_refs": tuple(reviewed_input_refs),
             "request_metadata": dict(metadata),
         }
-        request = {
-            **request_provenance,
-            "transcript": tuple(dict(message) for message in transcript),
-        }
 
         for attempt_number in range(1, self._max_attempts + 1):
             try:
+                request = deepcopy(request_provenance)
+                request["transcript"] = tuple(dict(message) for message in transcript)
                 response = self._transport.send_request(request=request)
                 output_text = self._require_non_empty_string(
                     response.get("output_text"),

--- a/control-plane/tests/test_phase24_live_assistant_provider_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_provider_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 import pathlib
 import sys
 import unittest
@@ -81,6 +82,55 @@ class AssistantProviderAdapterValidationTests(unittest.TestCase):
         self.assertEqual(first_request["timeout_seconds"], 5.0)
         self.assertEqual(first_request["workflow_task"], "case_summary")
 
+    def test_adapter_rebuilds_request_payload_for_each_attempt(self) -> None:
+        recorded_requests: list[dict[str, object]] = []
+        mutated_requests: list[dict[str, object]] = []
+
+        def mutate_request_then_retry(*, request: dict[str, object]) -> dict[str, object]:
+            recorded_requests.append(deepcopy(request))
+            request["request_metadata"]["mutated"] = True
+            request["transcript"][0]["content"] = "Mutated by transport."
+            mutated_requests.append(deepcopy(request))
+            if len(recorded_requests) == 1:
+                raise AssistantProviderTimeout("provider timed out")
+            return {
+                "provider_request_id": "provider-request-004",
+                "provider_response_id": "provider-response-004",
+                "provider_transcript_id": "provider-transcript-004",
+                "model_version": "model-version-2026-04-17",
+                "output_text": "Reviewed case summary.",
+            }
+
+        adapter = AssistantProviderAdapter(
+            provider_identity="openai",
+            model_identity="gpt-5.4",
+            prompt_version="phase24-case-summary-v1",
+            request_timeout_seconds=5.0,
+            max_attempts=2,
+            transport=mock.Mock(send_request=mutate_request_then_retry),
+        )
+
+        result = adapter.generate(
+            workflow_family="first_live_assistant_summary_family",
+            workflow_task="case_summary",
+            transcript=[{"role": "user", "content": "Summarize case-001."}],
+            reviewed_input_refs=("case-001",),
+            metadata={"record_family": "case", "record_id": "case-001"},
+        )
+
+        self.assertEqual(result.status, "ready")
+        self.assertEqual(len(recorded_requests), 2)
+        self.assertIn("mutated", mutated_requests[0]["request_metadata"])
+        self.assertNotIn("mutated", recorded_requests[0]["request_metadata"])
+        self.assertNotIn("mutated", recorded_requests[1]["request_metadata"])
+        self.assertEqual(mutated_requests[0]["transcript"][0]["content"], "Mutated by transport.")
+        self.assertEqual(recorded_requests[0]["transcript"][0]["content"], "Summarize case-001.")
+        self.assertEqual(
+            recorded_requests[1]["transcript"][0]["content"],
+            "Summarize case-001.",
+        )
+        self.assertNotIn("mutated", result.request_provenance["request_metadata"])
+
     def test_adapter_returns_explicit_failure_without_fabricating_output(self) -> None:
         transport = mock.Mock()
         transport.send_request.side_effect = RuntimeError("malformed provider output")
@@ -105,7 +155,9 @@ class AssistantProviderAdapterValidationTests(unittest.TestCase):
         self.assertIsNone(result.output_text)
         self.assertEqual(result.attempt_count, 2)
         self.assertEqual(len(result.failures), 2)
-        self.assertTrue(all(failure.failure_kind == "provider_error" for failure in result.failures))
+        self.assertTrue(
+            all(failure.failure_kind == "provider_error" for failure in result.failures)
+        )
         self.assertIn("malformed provider output", result.failure_summary)
 
     def test_adapter_builds_ai_trace_with_request_response_and_failure_provenance(
@@ -162,7 +214,9 @@ class AssistantProviderAdapterValidationTests(unittest.TestCase):
             "no_memory",
         )
         self.assertEqual(
-            ai_trace.subject_linkage["provider_response_provenance"]["provider_response_id"],
+            ai_trace.subject_linkage["provider_response_provenance"][
+                "provider_response_id"
+            ],
             "provider-response-003",
         )
         self.assertEqual(

--- a/control-plane/tests/test_phase24_live_assistant_provider_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_provider_validation.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from aegisops_control_plane.assistant_provider import (  # type: ignore[attr-defined]
+    AssistantProviderAdapter,
+    AssistantProviderAttemptFailure,
+    AssistantProviderFailure,
+    AssistantProviderTimeout,
+)
+
+
+class AssistantProviderAdapterValidationTests(unittest.TestCase):
+    def test_adapter_retries_bounded_timeout_failures_and_records_no_memory_provenance(
+        self,
+    ) -> None:
+        transport = mock.Mock()
+        transport.send_request.side_effect = [
+            AssistantProviderTimeout("provider timed out"),
+            {
+                "provider_request_id": "provider-request-002",
+                "provider_response_id": "provider-response-002",
+                "provider_transcript_id": "provider-transcript-002",
+                "model_version": "model-version-2026-04-17",
+                "output_text": "Reviewed case summary.",
+            },
+        ]
+        adapter = AssistantProviderAdapter(
+            provider_identity="openai",
+            model_identity="gpt-5.4",
+            prompt_version="phase24-case-summary-v1",
+            request_timeout_seconds=5.0,
+            max_attempts=2,
+            transport=transport,
+        )
+
+        result = adapter.generate(
+            workflow_family="first_live_assistant_summary_family",
+            workflow_task="case_summary",
+            transcript=[
+                {"role": "system", "content": "Summarize reviewed case state only."},
+                {"role": "user", "content": "Summarize case-001."},
+            ],
+            reviewed_input_refs=("case-001", "evidence-001"),
+            metadata={"record_family": "case", "record_id": "case-001"},
+        )
+
+        self.assertEqual(result.status, "ready")
+        self.assertEqual(result.output_text, "Reviewed case summary.")
+        self.assertEqual(result.attempt_count, 2)
+        self.assertEqual(
+            result.request_provenance["memory_policy"],
+            "no_memory",
+        )
+        self.assertEqual(
+            result.request_provenance["transcript_messages"],
+            2,
+        )
+        self.assertEqual(
+            result.response_provenance["provider_transcript_id"],
+            "provider-transcript-002",
+        )
+        self.assertEqual(
+            result.response_provenance["model_version"],
+            "model-version-2026-04-17",
+        )
+        self.assertEqual(len(result.failures), 1)
+        self.assertEqual(result.failures[0].failure_kind, "timeout")
+        self.assertEqual(transport.send_request.call_count, 2)
+        first_request = transport.send_request.call_args_list[0].kwargs["request"]
+        self.assertEqual(first_request["memory_policy"], "no_memory")
+        self.assertFalse(first_request["allow_provider_memory"])
+        self.assertEqual(first_request["timeout_seconds"], 5.0)
+        self.assertEqual(first_request["workflow_task"], "case_summary")
+
+    def test_adapter_returns_explicit_failure_without_fabricating_output(self) -> None:
+        transport = mock.Mock()
+        transport.send_request.side_effect = RuntimeError("malformed provider output")
+        adapter = AssistantProviderAdapter(
+            provider_identity="openai",
+            model_identity="gpt-5.4",
+            prompt_version="phase24-case-summary-v1",
+            request_timeout_seconds=5.0,
+            max_attempts=2,
+            transport=transport,
+        )
+
+        result = adapter.generate(
+            workflow_family="first_live_assistant_summary_family",
+            workflow_task="case_summary",
+            transcript=[{"role": "user", "content": "Summarize case-001."}],
+            reviewed_input_refs=("case-001",),
+            metadata={"record_family": "case", "record_id": "case-001"},
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIsNone(result.output_text)
+        self.assertEqual(result.attempt_count, 2)
+        self.assertEqual(len(result.failures), 2)
+        self.assertTrue(all(failure.failure_kind == "provider_error" for failure in result.failures))
+        self.assertIn("malformed provider output", result.failure_summary)
+
+    def test_adapter_builds_ai_trace_with_request_response_and_failure_provenance(
+        self,
+    ) -> None:
+        transport = mock.Mock()
+        transport.send_request.return_value = {
+            "provider_request_id": "provider-request-003",
+            "provider_response_id": "provider-response-003",
+            "provider_transcript_id": "provider-transcript-003",
+            "model_version": "model-version-2026-04-17",
+            "output_text": "Queue triage summary.",
+        }
+        adapter = AssistantProviderAdapter(
+            provider_identity="openai",
+            model_identity="gpt-5.4",
+            prompt_version="phase24-queue-summary-v1",
+            request_timeout_seconds=7.5,
+            max_attempts=1,
+            transport=transport,
+        )
+
+        result = adapter.generate(
+            workflow_family="first_live_assistant_summary_family",
+            workflow_task="queue_triage_summary",
+            transcript=[{"role": "user", "content": "Summarize alert-001."}],
+            reviewed_input_refs=("alert-001", "evidence-001"),
+            metadata={"record_family": "alert", "record_id": "alert-001"},
+        )
+
+        ai_trace = adapter.build_ai_trace_record(
+            ai_trace_id="ai-trace-provider-001",
+            reviewer_identity="reviewer-001",
+            generated_at=result.generated_at,
+            result=result,
+            subject_linkage={
+                "alert_ids": ("alert-001",),
+                "recommendation_ids": ("recommendation-001",),
+            },
+        )
+
+        self.assertEqual(ai_trace.model_identity, "openai/gpt-5.4")
+        self.assertEqual(ai_trace.prompt_version, "phase24-queue-summary-v1")
+        self.assertEqual(
+            ai_trace.material_input_refs,
+            ("alert-001", "evidence-001"),
+        )
+        self.assertEqual(
+            ai_trace.subject_linkage["provider_identity"],
+            "openai",
+        )
+        self.assertEqual(
+            ai_trace.subject_linkage["provider_request_provenance"]["memory_policy"],
+            "no_memory",
+        )
+        self.assertEqual(
+            ai_trace.subject_linkage["provider_response_provenance"]["provider_response_id"],
+            "provider-response-003",
+        )
+        self.assertEqual(
+            ai_trace.subject_linkage["provider_failures"],
+            (),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #512
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a standalone Phase 24 assistant provider contract in [assistant_provider.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-512/control-plane/aegisops_control_plane/assistant_provider.py) and a focused validation suite in [test_phase24_live_assistant_provider_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-512/control-plane/tests/test_phase24_live_assistant_provider_validation.py). The adapter now enforces explicit `no_memory` request policy, bounded retry, timeout-classified failures, explicit failed results instead of fabricated output, and `AITraceRecord` construction with request, response, and failure provenance.

I verified the new contract directly and confirmed the existing assistant persistence suite still passes. The checkpoint is committed as `f419dc2` with message `Add phase24 assistant provider adapter contract`.

Summary: Added a focused Phase 24 provider adapter plus validation coverage for timeout, retry, no-memory policy, explicit failure handling, and AI Trace provenance; committed as `f419dc2`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase24_live_assistant_provider_validation`; `python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory`
Failure signature: none
Next action: Decide whether to wire the new provider adapter into a live service/HTTP entrypoint in this branch or leave this turn as the validated provider-contract checkpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added assistant provider integration with retry and timeout handling, robust error categorization, and detailed response provenance for generated content.
  * Generates trace records capturing request/response provenance and lifecycle state for each generation.

* **Tests**
  * Added validation tests for retry/timeout behavior, request immutability across attempts, explicit failure handling, and trace record construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->