### PR TITLE
implementation: add unresolved-first fallback for missing citations, conflicting context, ambiguity, or provider failure (#514)

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4781,6 +4781,10 @@ class AegisOpsControlPlaneService:
 
         advisory_output = dict(context_snapshot.advisory_output)
         citations = _phase24_live_assistant_citations_from_context(context_snapshot)
+        trusted_summary = str(
+            advisory_output.get("cited_summary", {}).get("text")
+            or f"Reviewed {workflow_task.replace('_', ' ')} for {record_id} remains unresolved."
+        )
         if advisory_output.get("status") != "ready":
             unresolved_reasons = _phase24_live_assistant_unresolved_reasons(
                 advisory_output.get("uncertainty_flags", ())
@@ -4789,9 +4793,7 @@ class AegisOpsControlPlaneService:
                 unresolved_reasons = ("required citations are missing",)
             return _phase24_live_assistant_snapshot(
                 workflow_task=workflow_task,
-                summary=(
-                    f"Reviewed {workflow_task.replace('_', ' ')} for {record_id} remains unresolved."
-                ),
+                summary=trusted_summary,
                 citations=citations,
                 unresolved_reasons=unresolved_reasons,
             )
@@ -4840,7 +4842,6 @@ class AegisOpsControlPlaneService:
                 "advisory_output": advisory_output,
             }
         )
-        trusted_summary = str(advisory_output["cited_summary"]["text"])
         provider_result = None
         unresolved_reasons: list[str] = []
         try:

--- a/control-plane/tests/test_phase24_live_assistant_fallback_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_fallback_validation.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+CONTROL_PLANE_ROOT = TESTS_ROOT.parents[0]
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from _service_persistence_support import (
+    ServicePersistenceTestBase,
+    mock,
+    replace,
+)
+
+
+class Phase24LiveAssistantFallbackValidationTests(ServicePersistenceTestBase):
+    def test_workflow_preserves_reviewed_unresolved_summary_for_missing_citations(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+        context_snapshot = service.inspect_assistant_context(
+            "case",
+            promoted_case.case_id,
+        )
+        expected_summary = "Reviewed case summary remains unresolved until citations are restored."
+        unresolved_context = replace(
+            context_snapshot,
+            advisory_output={
+                **dict(context_snapshot.advisory_output),
+                "status": "unresolved",
+                "cited_summary": {
+                    "text": expected_summary,
+                    "citations": (promoted_case.case_id,),
+                },
+                "uncertainty_flags": ("missing_supporting_citations",),
+            },
+        )
+        service._assistant_provider_adapter = mock.Mock()
+
+        with mock.patch.object(
+            service,
+            "inspect_assistant_context",
+            return_value=unresolved_context,
+        ):
+            snapshot = service.run_live_assistant_workflow(
+                workflow_task="case_summary",
+                record_family="case",
+                record_id=promoted_case.case_id,
+            )
+
+        self.assertEqual(snapshot.status, "unresolved")
+        self.assertEqual(snapshot.summary, expected_summary)
+        self.assertEqual(
+            snapshot.unresolved_reasons,
+            ("required citations are missing",),
+        )
+        service._assistant_provider_adapter.generate.assert_not_called()
+
+    def test_workflow_preserves_reviewed_unresolved_summary_for_ambiguity(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+        case_record = service.get_record(type(promoted_case), promoted_case.case_id)
+        assert case_record is not None
+        service.persist_record(
+            replace(
+                case_record,
+                reviewed_context={
+                    **dict(case_record.reviewed_context),
+                    "identity": {"aliases": ("svc-prod-shared",)},
+                },
+            )
+        )
+        expected_summary = service.inspect_assistant_context(
+            "case",
+            promoted_case.case_id,
+        ).advisory_output["cited_summary"]["text"]
+        service._assistant_provider_adapter = mock.Mock()
+
+        snapshot = service.run_live_assistant_workflow(
+            workflow_task="case_summary",
+            record_family="case",
+            record_id=promoted_case.case_id,
+        )
+
+        self.assertEqual(snapshot.status, "unresolved")
+        self.assertEqual(snapshot.summary, expected_summary)
+        self.assertEqual(
+            snapshot.unresolved_reasons,
+            (
+                "the requested summary would require the assistant to collapse identity ambiguity",
+            ),
+        )
+        service._assistant_provider_adapter.generate.assert_not_called()
+
+    def test_workflow_preserves_reviewed_unresolved_summary_for_conflicting_context(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+        context_snapshot = service.inspect_assistant_context(
+            "case",
+            promoted_case.case_id,
+        )
+        expected_summary = (
+            "Reviewed case summary remains unresolved until conflicting reviewed context is reconciled."
+        )
+        unresolved_context = replace(
+            context_snapshot,
+            advisory_output={
+                **dict(context_snapshot.advisory_output),
+                "status": "unresolved",
+                "cited_summary": {
+                    "text": expected_summary,
+                    "citations": (promoted_case.case_id,),
+                },
+                "uncertainty_flags": ("conflicting_reviewed_context",),
+            },
+        )
+        service._assistant_provider_adapter = mock.Mock()
+
+        with mock.patch.object(
+            service,
+            "inspect_assistant_context",
+            return_value=unresolved_context,
+        ):
+            snapshot = service.run_live_assistant_workflow(
+                workflow_task="case_summary",
+                record_family="case",
+                record_id=promoted_case.case_id,
+            )
+
+        self.assertEqual(snapshot.status, "unresolved")
+        self.assertEqual(snapshot.summary, expected_summary)
+        self.assertEqual(
+            snapshot.unresolved_reasons,
+            (
+                "reviewed records conflict on lifecycle state, ownership, scope, or evidence-backed facts",
+            ),
+        )
+        service._assistant_provider_adapter.generate.assert_not_called()
+
+    def test_workflow_preserves_reviewed_summary_for_provider_failure(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+        expected_summary = service.inspect_assistant_context(
+            "case",
+            promoted_case.case_id,
+        ).advisory_output["cited_summary"]["text"]
+        service._assistant_provider_adapter = mock.Mock()
+        service._assistant_provider_adapter.generate.side_effect = RuntimeError(
+            "provider transport failed"
+        )
+
+        snapshot = service.run_live_assistant_workflow(
+            workflow_task="case_summary",
+            record_family="case",
+            record_id=promoted_case.case_id,
+        )
+
+        self.assertEqual(snapshot.status, "unresolved")
+        self.assertEqual(snapshot.summary, expected_summary)
+        self.assertEqual(
+            snapshot.unresolved_reasons,
+            (
+                "the bounded live assistant did not return a trusted summary within the reviewed retry budget",
+            ),
+        )
+        service._assistant_provider_adapter.generate.assert_called_once()
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
Closes #514
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the fallback fix in [service.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-514/control-plane/aegisops_control_plane/service.py:4754) so the live assistant now preserves the reviewed advisory `cited_summary.text` whenever the reviewed path is already `unresolved`. That closes the weak placeholder path for citation gaps, ambiguity, and conflicting reviewed context while keeping provider-failure fallback behavior unchanged.

Added focused coverage in [test_phase24_live_assistant_fallback_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-514/control-plane/tests/test_phase24_live_assistant_fallback_validation.py:1) for missing citations, ambiguity, conflicting context, and provider failure. The journal was updated locally in `.codex-supervisor/issues/514/issue-journal.md`, and the code changes were committed as `b2ba9b7` with message `Preserve reviewed unresolved live assistant summaries`.

Summary: Preserved reviewed unresolved summaries on the live assistant path and added focused fallback tests for citation gaps, ambiguity, conflicting context, and provider failure
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase24_live_assistant_fallback_validation`; `python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory`; `python3 -m unittest control-plane.tests.test_phase24_live_assistant_surface_validation`
Failure signature: none
Next action: Open or update a draft PR checkpoin...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in the live assistant workflow to gracefully manage missing summary data and provider communication failures.
  * Enhanced fallback mechanisms to maintain consistent workflow execution when citation data is unavailable.

* **Tests**
  * Added comprehensive test coverage for live assistant fallback and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->