### PR TITLE
Follow-up: allow queue triage summary on reviewed in-scope alerts without requiring case linkage (#523)

### DIFF
--- a/control-plane/aegisops_control_plane/reviewed_slice_policy.py
+++ b/control-plane/aegisops_control_plane/reviewed_slice_policy.py
@@ -56,6 +56,14 @@ class ReviewedSlicePolicy:
         case = self._service._require_case_record(case_id)
         return self.require_operator_case_record(case)
 
+    def require_operator_alert_record(self, alert: AlertRecord) -> AlertRecord:
+        if not self.alert_is_in_operator_slice(alert):
+            raise ValueError(
+                f"alert {alert.alert_id!r} is outside the approved "
+                f"{REVIEWED_LIVE_SLICE_LABEL}"
+            )
+        return alert
+
     def require_case_scoped_advisory_read(self, context_snapshot: object) -> None:
         record_family = str(getattr(context_snapshot, "record_family"))
         record_id = str(getattr(context_snapshot, "record_id"))
@@ -97,6 +105,17 @@ class ReviewedSlicePolicy:
                     approved_cases=approved_cases,
                     error_message=error_message,
                 )
+
+    def require_alert_scoped_queue_summary_read(self, context_snapshot: object) -> None:
+        record_family = str(getattr(context_snapshot, "record_family"))
+        record_id = str(getattr(context_snapshot, "record_id"))
+        if record_family != "alert":
+            raise ValueError(self.case_scoped_read_error(record_family, record_id))
+
+        alert = self._service._store.get(AlertRecord, record_id)
+        if alert is None:
+            raise LookupError(f"Missing alert record {record_id!r} for reviewed slice validation")
+        self.require_operator_alert_record(alert)
 
     @staticmethod
     def case_scoped_read_error(record_family: str, record_id: str) -> str:
@@ -188,6 +207,37 @@ class ReviewedSlicePolicy:
         return (
             self.source_family(case.reviewed_context)
             or self.source_family(alert.reviewed_context)
+            or self.source_family(reconciliation.subject_linkage.get("reviewed_source_profile"))
+        ) in REVIEWED_LIVE_SOURCE_FAMILIES
+
+    def alert_is_in_operator_slice(self, alert: AlertRecord) -> bool:
+        reconciliation = self._service._latest_detection_reconciliation_for_alert(
+            alert.alert_id
+        )
+        if reconciliation is None or not self._service._reconciliation_is_wazuh_origin(
+            reconciliation
+        ):
+            return False
+        if not self._service._linked_id_exists(
+            reconciliation.subject_linkage.get("alert_ids"),
+            alert.alert_id,
+        ):
+            return False
+
+        admission_provenance = (
+            self._normalize_admission_provenance(
+                reconciliation.subject_linkage.get("admission_provenance")
+            )
+            or self._normalize_admission_provenance(alert.reviewed_context.get("provenance"))
+        )
+        if admission_provenance != {
+            "admission_kind": "live",
+            "admission_channel": "live_wazuh_webhook",
+        }:
+            return False
+
+        return (
+            self.source_family(alert.reviewed_context)
             or self.source_family(reconciliation.subject_linkage.get("reviewed_source_profile"))
         ) in REVIEWED_LIVE_SOURCE_FAMILIES
 

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4808,7 +4808,10 @@ class AegisOpsControlPlaneService:
             )
 
         context_snapshot = self.inspect_assistant_context(record_family, record_id)
-        self._require_reviewed_case_scoped_advisory_read(context_snapshot)
+        if workflow_task == "queue_triage_summary":
+            self._require_reviewed_alert_scoped_queue_summary_read(context_snapshot)
+        else:
+            self._require_reviewed_case_scoped_advisory_read(context_snapshot)
 
         advisory_output = dict(context_snapshot.advisory_output)
         reviewed_input_refs = _dedupe_strings(
@@ -7069,6 +7072,14 @@ class AegisOpsControlPlaneService:
     ) -> None:
         self._reviewed_slice_policy.require_case_scoped_advisory_read(context_snapshot)
 
+    def _require_reviewed_alert_scoped_queue_summary_read(
+        self,
+        context_snapshot: AnalystAssistantContextSnapshot,
+    ) -> None:
+        self._reviewed_slice_policy.require_alert_scoped_queue_summary_read(
+            context_snapshot
+        )
+
     @staticmethod
     def _reviewed_case_scoped_read_error(record_family: str, record_id: str) -> str:
         return ReviewedSlicePolicy.case_scoped_read_error(record_family, record_id)
@@ -7097,8 +7108,14 @@ class AegisOpsControlPlaneService:
     def _require_reviewed_operator_case_record(self, case: CaseRecord) -> CaseRecord:
         return self._reviewed_slice_policy.require_operator_case_record(case)
 
+    def _require_reviewed_operator_alert_record(self, alert: AlertRecord) -> AlertRecord:
+        return self._reviewed_slice_policy.require_operator_alert_record(alert)
+
     def _case_is_in_reviewed_operator_slice(self, case: CaseRecord) -> bool:
         return self._reviewed_slice_policy.case_is_in_operator_slice(case)
+
+    def _alert_is_in_reviewed_operator_slice(self, alert: AlertRecord) -> bool:
+        return self._reviewed_slice_policy.alert_is_in_operator_slice(alert)
 
     def _reviewed_context_declares_out_of_scope_provenance(self, context: object) -> bool:
         return self._reviewed_slice_policy.context_declares_out_of_scope_provenance(

--- a/control-plane/tests/support/service_persistence.py
+++ b/control-plane/tests/support/service_persistence.py
@@ -67,6 +67,43 @@ class ServicePersistenceTestBase(unittest.TestCase):
         ].transitioned_at
         return store, service, promoted_case, promoted_case.evidence_ids[0], reviewed_at
 
+    def _build_phase19_in_scope_alert_without_case(
+        self,
+        *,
+        store: object | None = None,
+    ) -> tuple[object, AegisOpsControlPlaneService, object, str, datetime]:
+        if store is None:
+            store, _ = make_store()
+        shared_secret = secrets.token_urlsafe(24)
+        reverse_proxy_secret = secrets.token_urlsafe(24)
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=shared_secret,
+                wazuh_ingest_reverse_proxy_secret=reverse_proxy_secret,
+            ),
+            store=store,
+        )
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {shared_secret}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=reverse_proxy_secret,
+            peer_addr="127.0.0.1",
+        )
+        alert = admitted.alert
+        evidence_records = tuple(
+            evidence
+            for evidence in store.list(EvidenceRecord)
+            if evidence.alert_id == alert.alert_id
+        )
+        if not evidence_records:
+            raise AssertionError("expected reviewed alert fixture to persist linked evidence")
+        reviewed_at = service.list_lifecycle_transitions("alert", alert.alert_id)[
+            -1
+        ].transitioned_at
+        return store, service, alert, evidence_records[0].evidence_id, reviewed_at
+
     def _build_phase19_out_of_scope_case(
         self,
         *,
@@ -101,6 +138,40 @@ class ServicePersistenceTestBase(unittest.TestCase):
             -1
         ].transitioned_at
         return service, promoted_case, admitted.alert.alert_id, reviewed_at
+
+    def _build_phase19_out_of_scope_alert_without_case(
+        self,
+        *,
+        fixture_name: str,
+    ) -> tuple[AegisOpsControlPlaneService, object, str, datetime]:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
+        adapter = WazuhAlertAdapter()
+        admitted = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(load_wazuh_fixture(fixture_name)),
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id=f"evidence-{fixture_name}",
+                source_record_id=admitted.alert.finding_id,
+                alert_id=admitted.alert.alert_id,
+                case_id=None,
+                source_system="wazuh",
+                collector_identity="collector://wazuh/replay",
+                acquired_at=reviewed_at,
+                derivation_relationship="native_detection_record",
+                lifecycle_state="collected",
+            )
+        )
+        reviewed_at = service.list_lifecycle_transitions("alert", admitted.alert.alert_id)[
+            -1
+        ].transitioned_at
+        return service, admitted.alert, f"evidence-{fixture_name}", reviewed_at
 
     def _build_phase19_synthetic_out_of_scope_case(
         self,

--- a/control-plane/tests/test_phase24_live_assistant_surface_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_surface_validation.py
@@ -22,6 +22,110 @@ from aegisops_control_plane.assistant_provider import AssistantProviderResult
 
 
 class Phase24LiveAssistantSurfaceValidationTests(ServicePersistenceTestBase):
+    def test_cli_runs_queue_triage_summary_for_reviewed_in_scope_alert_without_case_linkage(
+        self,
+    ) -> None:
+        _, service, alert, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_alert_without_case()
+        )
+        self.assertEqual(alert.case_id, None)
+        service._assistant_provider_adapter = mock.Mock()
+        service._assistant_provider_adapter.generate.return_value = AssistantProviderResult(
+            status="ready",
+            provider_identity="openai",
+            model_identity="gpt-5.4",
+            prompt_version="phase24-queue-summary-v1",
+            workflow_family="first_live_assistant_summary_family",
+            workflow_task="queue_triage_summary",
+            generated_at=reviewed_at,
+            reviewed_input_refs=(alert.alert_id, evidence_id),
+            output_text="Reviewed queue alert scope remains bounded to the cited evidence.",
+            attempt_count=1,
+            request_provenance={
+                "memory_policy": "no_memory",
+                "request_metadata": {
+                    "record_family": "alert",
+                    "record_id": alert.alert_id,
+                },
+            },
+            response_provenance={
+                "provider_response_id": "provider-response-queue-001",
+                "provider_transcript_id": "provider-transcript-queue-001",
+                "model_version": "model-version-2026-04-18",
+            },
+            failures=(),
+            failure_summary=None,
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            [
+                "run-live-assistant-workflow",
+                "--workflow-task",
+                "queue_triage_summary",
+                "--family",
+                "alert",
+                "--record-id",
+                alert.alert_id,
+            ],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["workflow_task"], "queue_triage_summary")
+        self.assertEqual(payload["status"], "ready")
+        self.assertEqual(
+            payload["summary"],
+            "Reviewed queue alert scope remains bounded to the cited evidence.",
+        )
+        self.assertEqual(payload["unresolved_reasons"], [])
+        self.assertTrue(payload["operator_follow_up"])
+        self.assertIn(
+            {
+                "record_family": "alert",
+                "record_id": alert.alert_id,
+                "claim": "Reviewed alert lifecycle remains anchored on the alert record.",
+                "evidence_id": None,
+                "reviewed_context_field": None,
+            },
+            payload["citations"],
+        )
+        self.assertIn(
+            {
+                "record_family": "evidence",
+                "record_id": evidence_id,
+                "claim": "Linked reviewed evidence supports the live assistant summary.",
+                "evidence_id": evidence_id,
+                "reviewed_context_field": None,
+            },
+            payload["citations"],
+        )
+        self.assertFalse(
+            any(citation["record_family"] == "case" for citation in payload["citations"])
+        )
+        service._assistant_provider_adapter.generate.assert_called_once()
+
+    def test_queue_triage_summary_rejects_out_of_scope_alert_without_case_linkage(
+        self,
+    ) -> None:
+        service, alert, _, _ = self._build_phase19_out_of_scope_alert_without_case(
+            fixture_name="agent-origin-alert.json"
+        )
+        service._assistant_provider_adapter = mock.Mock()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            rf"alert {alert.alert_id!r} is outside the approved .* live slice",
+        ):
+            service.run_live_assistant_workflow(
+                workflow_task="queue_triage_summary",
+                record_family="alert",
+                record_id=alert.alert_id,
+            )
+
+        service._assistant_provider_adapter.generate.assert_not_called()
+
     def test_cli_runs_case_summary_workflow_with_phase24_trusted_output_contract(
         self,
     ) -> None:

--- a/control-plane/tests/test_phase24_live_assistant_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_validation.py
@@ -5,6 +5,7 @@ import unittest
 
 
 _PHASE24_RUNTIME_MODULES = (
+    # Surface validation includes both case-scoped and alert-only queue summary coverage.
     "control-plane.tests.test_phase24_live_assistant_surface_validation",
     "control-plane.tests.test_phase24_live_assistant_fallback_validation",
     "control-plane.tests.test_phase24_live_assistant_provider_validation",


### PR DESCRIPTION
Closes #523
This PR was opened by codex-supervisor.
Latest Codex summary:

Narrowed the Phase 24 live assistant gate so `queue_triage_summary` can run on reviewed in-scope alerts without a linked case, while `case_summary` and the existing case-scoped assistant paths still use the stricter reviewed case-chain guard. The change is centered in [reviewed_slice_policy.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-523/control-plane/aegisops_control_plane/reviewed_slice_policy.py) and [service.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-523/control-plane/aegisops_control_plane/service.py), with focused alert-only and out-of-scope regressions in [test_phase24_live_assistant_surface_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-523/control-plane/tests/test_phase24_live_assistant_surface_validation.py) plus supporting fixture helpers in [service_persistence.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-523/control-plane/tests/support/service_persistence.py).

I first reproduced the failure on a real reviewed in-scope alert: the assistant context was `ready` with `linked_case_ids=()`, but `run_live_assistant_workflow("queue_triage_summary", "alert", ...)` failed at the case-scoped reviewed-slice gate. After the fix, the focused suite passes and the checkpoint is committed at `669cc6e` with message `Allow queue summaries without case linkage`.

Summary: Allowed reviewed in-scope alert-only queue triage summaries by adding an alert-scoped reviewed-slice guard, while preserving case-chain enforcement for case-scoped assistant paths; a...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Live assistant now supports queue triage summary workflows with enhanced alert validation checks.
  * Alerts are validated for approval compliance before processing in queue operations.

* **Tests**
  * Expanded test coverage for alert-scoped queue summary workflows and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->