### PR TITLE
Follow-up: enforce the live assistant provider timeout budget inside the adapter (#524)

### DIFF
--- a/control-plane/aegisops_control_plane/assistant_provider.py
+++ b/control-plane/aegisops_control_plane/assistant_provider.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from queue import Queue
+import threading
 from typing import Mapping, Protocol
 
 from .models import AITraceRecord
@@ -99,7 +101,7 @@ class AssistantProviderAdapter:
             try:
                 request = deepcopy(request_provenance)
                 request["transcript"] = tuple(dict(message) for message in transcript)
-                response = self._transport.send_request(request=request)
+                response = self._send_request_with_timeout(request=request)
                 output_text = self._require_non_empty_string(
                     response.get("output_text"),
                     "provider response output_text",
@@ -170,6 +172,39 @@ class AssistantProviderAdapter:
             failures=tuple(failures),
             failure_summary=failure_summary,
         )
+
+    def _send_request_with_timeout(
+        self,
+        *,
+        request: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        result_queue: Queue[tuple[str, object]] = Queue(maxsize=1)
+
+        def run_transport() -> None:
+            try:
+                response = self._transport.send_request(request=request)
+            except Exception as exc:  # noqa: BLE001
+                result_queue.put(("error", exc))
+                return
+            result_queue.put(("response", response))
+
+        worker = threading.Thread(
+            target=run_transport,
+            name="assistant-provider-request",
+            daemon=True,
+        )
+        worker.start()
+        worker.join(timeout=self._request_timeout_seconds)
+        if worker.is_alive():
+            raise AssistantProviderTimeout(
+                f"provider request timed out after {self._request_timeout_seconds:g} seconds"
+            )
+        outcome_kind, outcome_value = result_queue.get_nowait()
+        if outcome_kind == "error":
+            raise outcome_value  # type: ignore[misc]
+        if not isinstance(outcome_value, Mapping):
+            raise TypeError("provider response must be a mapping")
+        return outcome_value
 
     def build_ai_trace_record(
         self,

--- a/control-plane/tests/test_phase24_live_assistant_adversarial_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_adversarial_validation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 import pathlib
 import sys
+import time
 from unittest import mock
 
 
@@ -14,10 +15,60 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
 from _service_persistence_support import ServicePersistenceTestBase
-from aegisops_control_plane.assistant_provider import AssistantProviderResult
+from aegisops_control_plane.assistant_provider import (
+    AssistantProviderAdapter,
+    AssistantProviderResult,
+)
 
 
 class Phase24LiveAssistantAdversarialValidationTests(ServicePersistenceTestBase):
+    def test_workflow_returns_unresolved_when_adapter_enforces_provider_timeout_budget(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+        expected_summary = service.inspect_assistant_context(
+            "case",
+            promoted_case.case_id,
+        ).advisory_output["cited_summary"]["text"]
+
+        def slow_transport(*, request: dict[str, object]) -> dict[str, object]:
+            self.assertEqual(request["request_metadata"]["record_id"], promoted_case.case_id)
+            time.sleep(0.2)
+            return {
+                "provider_request_id": "provider-request-slow-002",
+                "provider_response_id": "provider-response-slow-002",
+                "provider_transcript_id": "provider-transcript-slow-002",
+                "model_version": "model-version-2026-04-18",
+                "output_text": "This response should never be trusted because it exceeded budget.",
+            }
+
+        service._assistant_provider_adapter = AssistantProviderAdapter(
+            provider_identity="openai",
+            model_identity="gpt-5.4",
+            prompt_version="phase24-case-summary-v1",
+            request_timeout_seconds=0.01,
+            max_attempts=1,
+            transport=mock.Mock(send_request=slow_transport),
+        )
+
+        started_at = time.perf_counter()
+        snapshot = service.run_live_assistant_workflow(
+            workflow_task="case_summary",
+            record_family="case",
+            record_id=promoted_case.case_id,
+        )
+        elapsed = time.perf_counter() - started_at
+
+        self.assertEqual(snapshot.status, "unresolved")
+        self.assertEqual(snapshot.summary, expected_summary)
+        self.assertEqual(
+            snapshot.unresolved_reasons,
+            (
+                "the bounded live assistant did not return a trusted summary within the reviewed retry budget",
+            ),
+        )
+        self.assertLess(elapsed, 0.15)
+
     def test_workflow_fails_closed_when_provider_output_contains_prompt_injection_text(
         self,
     ) -> None:

--- a/control-plane/tests/test_phase24_live_assistant_provider_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_provider_validation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 import pathlib
 import sys
+import time
 import unittest
 from unittest import mock
 
@@ -20,6 +21,46 @@ from aegisops_control_plane.assistant_provider import (  # type: ignore[attr-def
 
 
 class AssistantProviderAdapterValidationTests(unittest.TestCase):
+    def test_adapter_enforces_timeout_budget_for_non_cooperative_transport(self) -> None:
+        def slow_transport(*, request: dict[str, object]) -> dict[str, object]:
+            self.assertEqual(request["timeout_seconds"], 0.01)
+            time.sleep(0.2)
+            return {
+                "provider_request_id": "provider-request-slow-001",
+                "provider_response_id": "provider-response-slow-001",
+                "provider_transcript_id": "provider-transcript-slow-001",
+                "model_version": "model-version-2026-04-18",
+                "output_text": "This response should arrive too late.",
+            }
+
+        adapter = AssistantProviderAdapter(
+            provider_identity="openai",
+            model_identity="gpt-5.4",
+            prompt_version="phase24-case-summary-v1",
+            request_timeout_seconds=0.01,
+            max_attempts=1,
+            transport=mock.Mock(send_request=slow_transport),
+        )
+
+        started_at = time.perf_counter()
+        result = adapter.generate(
+            workflow_family="first_live_assistant_summary_family",
+            workflow_task="case_summary",
+            transcript=[{"role": "user", "content": "Summarize case-001."}],
+            reviewed_input_refs=("case-001",),
+            metadata={"record_family": "case", "record_id": "case-001"},
+        )
+        elapsed = time.perf_counter() - started_at
+
+        self.assertEqual(result.status, "failed")
+        self.assertIsNone(result.output_text)
+        self.assertEqual(result.attempt_count, 1)
+        self.assertEqual(len(result.failures), 1)
+        self.assertEqual(result.failures[0].failure_kind, "timeout")
+        self.assertIn("timed out", result.failures[0].detail)
+        self.assertIn("attempt 1: timeout", result.failure_summary)
+        self.assertLess(elapsed, 0.15)
+
     def test_adapter_retries_bounded_timeout_failures_and_records_no_memory_provenance(
         self,
     ) -> None:


### PR DESCRIPTION
Closes #524
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the timeout at the adapter boundary instead of relying on the transport to cooperate. `AssistantProviderAdapter.generate(...)` now routes `send_request` through a daemon-thread timeout wrapper, so over-budget calls become explicit `AssistantProviderTimeout` failures and feed the existing failed/unresolved path rather than returning late `ready` output. The focused changes are in [assistant_provider.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-524/control-plane/aegisops_control_plane/assistant_provider.py:74), with the new reproducer in [test_phase24_live_assistant_provider_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-524/control-plane/tests/test_phase24_live_assistant_provider_validation.py:23) and the workflow-level fallback regression in [test_phase24_live_assistant_adversarial_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-524/control-plane/tests/test_phase24_live_assistant_adversarial_validation.py:24).

I updated the local issue journal and created checkpoint commit `5d2dabd` on `codex/issue-524` with message `Enforce assistant provider timeout budget`.

Summary: Adapter now enforces the live assistant provider timeout budget internally, converts slow non-cooperative transports into explicit timeout failures, and preserves the existing unresolved-first fallback path with focused regression coverage.
State hint: local_review
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase24_live_assistant_provi...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented per-request timeout enforcement with configurable duration to prevent indefinite hangs on provider responses
  * Timeout violations now result in immediate failure categorization and quick error handling

* **Tests**
  * Added validation tests for timeout enforcement under various transport conditions
  * Added tests confirming proper error categorization and performance when timeouts occur

<!-- end of auto-generated comment: release notes by coderabbit.ai -->