### PR TITLE
implementation: add cross-source case timeline and provenance summary surface (#530)

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/osquery.py
+++ b/control-plane/aegisops_control_plane/adapters/osquery.py
@@ -196,6 +196,7 @@ class OsqueryHostContextAdapter:
             "timestamp": collected_at.isoformat(),
             "reviewed_by": reviewed_by,
             "adapter": "osquery_host_context",
+            "source_system": self.source_system,
             "derived_from_source_id": source_id,
             "host_identifier": host_identifier,
             "ambiguity_badge": "related-entity",

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -333,6 +333,8 @@ class CaseDetailSnapshot:
     linked_recommendation_records: tuple[dict[str, object], ...]
     linked_reconciliation_records: tuple[dict[str, object], ...]
     lifecycle_transitions: tuple[dict[str, object], ...]
+    cross_source_timeline: tuple[dict[str, object], ...]
+    provenance_summary: dict[str, object]
     current_action_review: dict[str, object] | None
     action_reviews: tuple[dict[str, object], ...]
 
@@ -357,6 +359,8 @@ class CaseDetailSnapshot:
                 "linked_recommendation_records": self.linked_recommendation_records,
                 "linked_reconciliation_records": self.linked_reconciliation_records,
                 "lifecycle_transitions": self.lifecycle_transitions,
+                "cross_source_timeline": self.cross_source_timeline,
+                "provenance_summary": self.provenance_summary,
                 "current_action_review": self.current_action_review,
                 "action_reviews": self.action_reviews,
             }
@@ -4332,6 +4336,14 @@ class AegisOpsControlPlaneService:
             alert_id=case.alert_id,
             record_index=self._build_action_review_record_index(),
         )
+        cross_source_timeline, provenance_summary = (
+            self._build_case_cross_source_surfaces(
+                case=case,
+                linked_alert_records=context_snapshot.linked_alert_records,
+                linked_evidence_records=context_snapshot.linked_evidence_records,
+                linked_observation_records=observation_records,
+            )
+        )
         return CaseDetailSnapshot(
             read_only=True,
             case_id=case_id,
@@ -4353,9 +4365,230 @@ class AegisOpsControlPlaneService:
             linked_recommendation_records=context_snapshot.linked_recommendation_records,
             linked_reconciliation_records=context_snapshot.linked_reconciliation_records,
             lifecycle_transitions=context_snapshot.lifecycle_transitions,
+            cross_source_timeline=cross_source_timeline,
+            provenance_summary=provenance_summary,
             current_action_review=dict(action_reviews[0]) if action_reviews else None,
             action_reviews=action_reviews,
         )
+
+    def _build_case_cross_source_surfaces(
+        self,
+        *,
+        case: CaseRecord,
+        linked_alert_records: tuple[dict[str, object], ...],
+        linked_evidence_records: tuple[dict[str, object], ...],
+        linked_observation_records: tuple[dict[str, object], ...],
+    ) -> tuple[tuple[dict[str, object], ...], dict[str, object]]:
+        anchor = self._build_case_cross_source_anchor(
+            case=case,
+            linked_alert_records=linked_alert_records,
+        )
+        attached_entries = [
+            entry
+            for entry in (
+                *(
+                    self._build_case_cross_source_attached_entry(
+                        record_family="evidence",
+                        record=record,
+                        case_id=case.case_id,
+                    )
+                    for record in linked_evidence_records
+                ),
+                *(
+                    self._build_case_cross_source_attached_entry(
+                        record_family="observation",
+                        record=record,
+                        case_id=case.case_id,
+                    )
+                    for record in linked_observation_records
+                ),
+            )
+            if entry is not None
+        ]
+        attached_entries.sort(
+            key=lambda entry: (
+                entry.get("_sort_occurred_at")
+                or datetime.max.replace(tzinfo=timezone.utc),
+                str(entry["record_family"]),
+                str(entry["record_id"]),
+            )
+        )
+        timeline = tuple(
+            self._case_cross_source_public_entry(entry)
+            for entry in (anchor, *attached_entries)
+        )
+        source_families = _dedupe_strings(
+            str(source_family)
+            for source_family in (
+                entry.get("source_family") for entry in (anchor, *attached_entries)
+            )
+            if isinstance(source_family, str) and source_family.strip()
+        )
+        provenance_summary = {
+            "authoritative_anchor": {
+                "record_family": anchor["record_family"],
+                "record_id": anchor["record_id"],
+                "source_family": anchor["source_family"],
+                "provenance_classification": anchor["provenance_classification"],
+                "reviewed_linkage": anchor["reviewed_linkage"],
+            },
+            "source_families": source_families,
+            "attached_records": tuple(
+                {
+                    "record_family": entry["record_family"],
+                    "record_id": entry["record_id"],
+                    "source_family": entry["source_family"],
+                    "evidence_origin": entry["evidence_origin"],
+                    "provenance_classification": entry["provenance_classification"],
+                    "ambiguity_badge": entry["ambiguity_badge"],
+                    "reviewed_linkage": entry["reviewed_linkage"],
+                    "blocking_reason": entry["blocking_reason"],
+                }
+                for entry in attached_entries
+            ),
+        }
+        return timeline, provenance_summary
+
+    def _build_case_cross_source_anchor(
+        self,
+        *,
+        case: CaseRecord,
+        linked_alert_records: tuple[dict[str, object], ...],
+    ) -> dict[str, object]:
+        anchor_record = next(
+            (
+                dict(record)
+                for record in linked_alert_records
+                if record.get("alert_id") == case.alert_id
+            ),
+            {
+                "alert_id": case.alert_id,
+                "case_id": case.case_id,
+                "reviewed_context": dict(case.reviewed_context),
+            },
+        )
+        source_family = self._reviewed_operator_source_family(
+            anchor_record.get("reviewed_context")
+        ) or self._reviewed_operator_source_family(case.reviewed_context)
+        return {
+            "record_family": "alert",
+            "record_id": case.alert_id,
+            "source_family": source_family or "unknown",
+            "evidence_origin": case.alert_id,
+            "provenance_classification": "authoritative-anchor",
+            "ambiguity_badge": None,
+            "reviewed_linkage": {
+                "case_id": case.case_id,
+                "alert_id": case.alert_id,
+            },
+            "blocking_reason": None,
+            "occurred_at": None,
+            "_sort_occurred_at": None,
+        }
+
+    def _build_case_cross_source_attached_entry(
+        self,
+        *,
+        record_family: str,
+        record: Mapping[str, object],
+        case_id: str,
+    ) -> dict[str, object] | None:
+        provenance = record.get("provenance")
+        if not isinstance(provenance, Mapping) or not provenance:
+            return None
+
+        record_id_field = f"{record_family}_id"
+        record_id = self._normalize_optional_string(record.get(record_id_field), record_id_field)
+        if record_id is None:
+            return None
+
+        explicit_source_family = self._normalize_optional_string(
+            provenance.get("source_family"),
+            f"{record_family}.provenance.source_family",
+        )
+        source_system = self._normalize_optional_string(
+            provenance.get("source_system"),
+            f"{record_family}.provenance.source_system",
+        ) or self._normalize_optional_string(
+            record.get("source_system"),
+            f"{record_family}.source_system",
+        )
+        source_family = explicit_source_family or source_system or "unknown"
+
+        classification = self._normalize_optional_string(
+            provenance.get("classification"),
+            f"{record_family}.provenance.classification",
+        )
+        source_id = self._normalize_optional_string(
+            provenance.get("source_id"),
+            f"{record_family}.provenance.source_id",
+        )
+        timestamp = self._normalize_optional_string(
+            provenance.get("timestamp"),
+            f"{record_family}.provenance.timestamp",
+        )
+        reviewed_by = self._normalize_optional_string(
+            provenance.get("reviewed_by"),
+            f"{record_family}.provenance.reviewed_by",
+        )
+        blocking_reason = self._normalize_optional_string(
+            provenance.get("blocking_reason"),
+            f"{record_family}.provenance.blocking_reason",
+        )
+        if None in (classification, source_id, timestamp, reviewed_by):
+            classification = "unresolved-linkage"
+            if blocking_reason is None:
+                blocking_reason = "missing_required_provenance_fields"
+
+        ambiguity_badge = self._normalize_optional_string(
+            provenance.get("ambiguity_badge"),
+            f"{record_family}.provenance.ambiguity_badge",
+        )
+        if ambiguity_badge not in {"same-entity", "related-entity", "unresolved"}:
+            ambiguity_badge = "unresolved"
+
+        occurred_at = None
+        if isinstance(record.get("acquired_at"), datetime):
+            occurred_at = record.get("acquired_at")
+        elif isinstance(record.get("observed_at"), datetime):
+            occurred_at = record.get("observed_at")
+
+        reviewed_linkage: dict[str, object] = {"case_id": case_id}
+        if record_family == "observation":
+            supporting_evidence_ids = tuple(record.get("supporting_evidence_ids", ()))
+            reviewed_linkage["supporting_evidence_ids"] = supporting_evidence_ids
+
+        evidence_origin = self._normalize_optional_string(
+            record.get("source_record_id"),
+            f"{record_family}.source_record_id",
+        ) or source_id
+
+        return {
+            "record_family": record_family,
+            "record_id": record_id,
+            "source_family": source_family,
+            "evidence_origin": evidence_origin,
+            "provenance_classification": classification,
+            "ambiguity_badge": ambiguity_badge,
+            "reviewed_linkage": reviewed_linkage,
+            "blocking_reason": blocking_reason,
+            "occurred_at": occurred_at,
+            "_sort_occurred_at": occurred_at,
+        }
+
+    @staticmethod
+    def _case_cross_source_public_entry(entry: Mapping[str, object]) -> dict[str, object]:
+        return {
+            "record_family": entry["record_family"],
+            "record_id": entry["record_id"],
+            "occurred_at": entry["occurred_at"],
+            "source_family": entry["source_family"],
+            "evidence_origin": entry["evidence_origin"],
+            "provenance_classification": entry["provenance_classification"],
+            "ambiguity_badge": entry["ambiguity_badge"],
+            "reviewed_linkage": entry["reviewed_linkage"],
+            "blocking_reason": entry["blocking_reason"],
+        }
 
     def attach_osquery_host_context(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4500,6 +4500,8 @@ class AegisOpsControlPlaneService:
         provenance = raw_provenance if isinstance(raw_provenance, Mapping) else {}
 
         def _safe_optional_string(value: object, field_name: str) -> str | None:
+            if isinstance(value, str):
+                value = value.strip()
             try:
                 return self._normalize_optional_string(value, field_name)
             except ValueError:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4493,54 +4493,64 @@ class AegisOpsControlPlaneService:
         record: Mapping[str, object],
         case_id: str,
     ) -> dict[str, object] | None:
-        provenance = record.get("provenance")
-        if not isinstance(provenance, Mapping) or not provenance:
-            return None
+        raw_provenance = record.get("provenance")
+        provenance_missing = not isinstance(raw_provenance, Mapping) or not raw_provenance
+        provenance = raw_provenance if isinstance(raw_provenance, Mapping) else {}
+
+        def _safe_optional_string(value: object, field_name: str) -> str | None:
+            try:
+                return self._normalize_optional_string(value, field_name)
+            except ValueError:
+                return None
 
         record_id_field = f"{record_family}_id"
         record_id = self._normalize_optional_string(record.get(record_id_field), record_id_field)
         if record_id is None:
             return None
 
-        explicit_source_family = self._normalize_optional_string(
+        explicit_source_family = _safe_optional_string(
             provenance.get("source_family"),
             f"{record_family}.provenance.source_family",
         )
-        source_system = self._normalize_optional_string(
+        source_system = _safe_optional_string(
             provenance.get("source_system"),
             f"{record_family}.provenance.source_system",
-        ) or self._normalize_optional_string(
+        ) or _safe_optional_string(
             record.get("source_system"),
             f"{record_family}.source_system",
         )
         source_family = explicit_source_family or source_system or "unknown"
 
-        classification = self._normalize_optional_string(
+        classification = _safe_optional_string(
             provenance.get("classification"),
             f"{record_family}.provenance.classification",
         )
-        source_id = self._normalize_optional_string(
+        source_id = _safe_optional_string(
             provenance.get("source_id"),
             f"{record_family}.provenance.source_id",
         )
-        timestamp = self._normalize_optional_string(
+        timestamp = _safe_optional_string(
             provenance.get("timestamp"),
             f"{record_family}.provenance.timestamp",
         )
-        reviewed_by = self._normalize_optional_string(
+        reviewed_by = _safe_optional_string(
             provenance.get("reviewed_by"),
             f"{record_family}.provenance.reviewed_by",
         )
-        blocking_reason = self._normalize_optional_string(
+        blocking_reason = _safe_optional_string(
             provenance.get("blocking_reason"),
             f"{record_family}.provenance.blocking_reason",
         )
         if None in (classification, source_id, timestamp, reviewed_by):
             classification = "unresolved-linkage"
             if blocking_reason is None:
-                blocking_reason = "missing_required_provenance_fields"
+                blocking_reason = (
+                    "missing_provenance"
+                    if provenance_missing
+                    else "missing_or_invalid_required_provenance_fields"
+                )
 
-        ambiguity_badge = self._normalize_optional_string(
+        ambiguity_badge = _safe_optional_string(
             provenance.get("ambiguity_badge"),
             f"{record_family}.provenance.ambiguity_badge",
         )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -12,6 +12,8 @@ import re
 import uuid
 from typing import Iterable, Iterator, Mapping, Protocol, Type, TypeVar
 
+_DATETIME_TYPE = datetime
+
 from .adapters.executor import IsolatedExecutorAdapter
 from .adapters.n8n import N8NReconciliationAdapter
 from .adapters.osquery import OsqueryHostContextAdapter
@@ -784,7 +786,7 @@ _ACTION_POLICY_RANKS: dict[str, dict[str, int]] = {
 
 
 def _json_ready(value: object) -> object:
-    if isinstance(value, datetime):
+    if isinstance(value, _DATETIME_TYPE):
         return value.isoformat()
     if isinstance(value, Mapping):
         return {str(key): _json_ready(item) for key, item in value.items()}
@@ -4558,9 +4560,9 @@ class AegisOpsControlPlaneService:
             ambiguity_badge = "unresolved"
 
         occurred_at = None
-        if isinstance(record.get("acquired_at"), datetime):
+        if isinstance(record.get("acquired_at"), _DATETIME_TYPE):
             occurred_at = record.get("acquired_at")
-        elif isinstance(record.get("observed_at"), datetime):
+        elif isinstance(record.get("observed_at"), _DATETIME_TYPE):
             occurred_at = record.get("observed_at")
 
         reviewed_linkage: dict[str, object] = {"case_id": case_id}
@@ -6319,7 +6321,7 @@ class AegisOpsControlPlaneService:
 
     @staticmethod
     def _require_aware_datetime(value: object, field_name: str) -> datetime:
-        if not isinstance(value, datetime):
+        if not isinstance(value, _DATETIME_TYPE):
             raise ValueError(f"{field_name} must be a datetime")
         if value.tzinfo is None or value.utcoffset() is None:
             raise ValueError(f"{field_name} must be timezone-aware")

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -2473,6 +2473,22 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             payload["linked_reconciliation_records"][0]["reconciliation_id"],
             payload["linked_reconciliation_ids"],
         )
+        self.assertEqual(
+            payload["cross_source_timeline"][0]["record_family"],
+            "alert",
+        )
+        self.assertEqual(
+            payload["cross_source_timeline"][0]["provenance_classification"],
+            "authoritative-anchor",
+        )
+        self.assertEqual(
+            payload["provenance_summary"]["authoritative_anchor"]["record_id"],
+            promoted_case.alert_id,
+        )
+        self.assertEqual(
+            payload["provenance_summary"]["source_families"],
+            ["github_audit"],
+        )
 
     def test_cli_records_bounded_operator_casework_actions(self) -> None:
         _, service, promoted_case, evidence_id, reviewed_at = (

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -2482,12 +2482,28 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "authoritative-anchor",
         )
         self.assertEqual(
+            payload["cross_source_timeline"][1]["record_family"],
+            "evidence",
+        )
+        self.assertEqual(
+            payload["cross_source_timeline"][1]["blocking_reason"],
+            "missing_provenance",
+        )
+        self.assertEqual(
+            payload["cross_source_timeline"][2]["record_family"],
+            "observation",
+        )
+        self.assertEqual(
+            payload["cross_source_timeline"][2]["blocking_reason"],
+            "missing_provenance",
+        )
+        self.assertEqual(
             payload["provenance_summary"]["authoritative_anchor"]["record_id"],
             promoted_case.alert_id,
         )
         self.assertEqual(
             payload["provenance_summary"]["source_families"],
-            ["github_audit"],
+            ["github_audit", "wazuh", "unknown"],
         )
 
     def test_cli_records_bounded_operator_casework_actions(self) -> None:

--- a/control-plane/tests/test_phase25_osquery_host_context_validation.py
+++ b/control-plane/tests/test_phase25_osquery_host_context_validation.py
@@ -291,7 +291,7 @@ class Phase25OsqueryHostContextValidationTests(unittest.TestCase):
 
         self.assertEqual(
             [entry["record_family"] for entry in case_detail.cross_source_timeline],
-            ["alert", "evidence", "evidence", "observation"],
+            ["alert", "evidence", "evidence", "evidence", "observation"],
         )
         self.assertEqual(
             case_detail.cross_source_timeline[0]["provenance_classification"],
@@ -303,38 +303,50 @@ class Phase25OsqueryHostContextValidationTests(unittest.TestCase):
         )
         self.assertEqual(
             case_detail.cross_source_timeline[1]["record_id"],
-            second_source_evidence.evidence_id,
+            promoted_case.evidence_ids[0],
         )
         self.assertEqual(
             case_detail.cross_source_timeline[1]["source_family"],
-            "entra_id",
-        )
-        self.assertEqual(
-            case_detail.cross_source_timeline[1]["ambiguity_badge"],
-            "unresolved",
+            "wazuh",
         )
         self.assertEqual(
             case_detail.cross_source_timeline[1]["blocking_reason"],
-            "stable_identifier_mismatch",
+            "missing_provenance",
         )
         self.assertEqual(
             case_detail.cross_source_timeline[2]["record_id"],
-            osquery_evidence.evidence_id,
+            second_source_evidence.evidence_id,
         )
         self.assertEqual(
             case_detail.cross_source_timeline[2]["source_family"],
-            "osquery",
+            "entra_id",
         )
         self.assertEqual(
             case_detail.cross_source_timeline[2]["ambiguity_badge"],
-            "related-entity",
+            "unresolved",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[2]["blocking_reason"],
+            "stable_identifier_mismatch",
         )
         self.assertEqual(
             case_detail.cross_source_timeline[3]["record_id"],
+            osquery_evidence.evidence_id,
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[3]["source_family"],
+            "osquery",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[3]["ambiguity_badge"],
+            "related-entity",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[4]["record_id"],
             osquery_observation.observation_id,
         )
         self.assertEqual(
-            case_detail.cross_source_timeline[3]["provenance_classification"],
+            case_detail.cross_source_timeline[4]["provenance_classification"],
             "reviewed-derived",
         )
 
@@ -344,12 +356,16 @@ class Phase25OsqueryHostContextValidationTests(unittest.TestCase):
         )
         self.assertEqual(
             case_detail.provenance_summary["source_families"],
-            ("github_audit", "entra_id", "osquery"),
+            ("github_audit", "wazuh", "entra_id", "osquery"),
         )
         attached_records = {
             record["record_id"]: record
             for record in case_detail.provenance_summary["attached_records"]
         }
+        self.assertEqual(
+            attached_records[promoted_case.evidence_ids[0]]["blocking_reason"],
+            "missing_provenance",
+        )
         self.assertEqual(
             attached_records[second_source_evidence.evidence_id][
                 "provenance_classification"
@@ -369,6 +385,141 @@ class Phase25OsqueryHostContextValidationTests(unittest.TestCase):
                 "supporting_evidence_ids"
             ],
             (osquery_evidence.evidence_id,),
+        )
+
+    def test_inspect_case_detail_surfaces_missing_provenance_as_unresolved_linkage(
+        self,
+    ) -> None:
+        _store, service, promoted_case, reviewed_at = self._build_host_bound_case(
+            host_identifier="host-001"
+        )
+        second_source_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-entra-case-missing-provenance",
+                source_record_id="wazuh://entra/record/missing-provenance",
+                alert_id=None,
+                case_id=promoted_case.case_id,
+                source_system="wazuh",
+                collector_identity="wazuh-reviewed-second-source-adapter",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_case_attachment",
+                lifecycle_state="linked",
+                content={"attachment_reason": "Persisted without reviewed provenance."},
+            )
+        )
+        service.persist_record(
+            CaseRecord(
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                evidence_ids=(
+                    *promoted_case.evidence_ids,
+                    second_source_evidence.evidence_id,
+                ),
+                lifecycle_state=promoted_case.lifecycle_state,
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+
+        attached_records = {
+            record["record_id"]: record
+            for record in case_detail.provenance_summary["attached_records"]
+        }
+        self.assertIn(second_source_evidence.evidence_id, attached_records)
+        self.assertEqual(
+            attached_records[second_source_evidence.evidence_id][
+                "provenance_classification"
+            ],
+            "unresolved-linkage",
+        )
+        self.assertEqual(
+            attached_records[second_source_evidence.evidence_id]["blocking_reason"],
+            "missing_provenance",
+        )
+        self.assertEqual(
+            attached_records[second_source_evidence.evidence_id]["source_family"],
+            "wazuh",
+        )
+
+    def test_inspect_case_detail_tolerates_malformed_persisted_provenance(
+        self,
+    ) -> None:
+        store, service, promoted_case, reviewed_at = self._build_host_bound_case(
+            host_identifier="host-001"
+        )
+        second_source_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-entra-case-malformed-provenance",
+                source_record_id="wazuh://entra/record/malformed-provenance",
+                alert_id=None,
+                case_id=promoted_case.case_id,
+                source_system="wazuh",
+                collector_identity="wazuh-reviewed-second-source-adapter",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_case_attachment",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "reviewed-derived",
+                    "source_id": "entra-record-002",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "source_family": "entra_id",
+                    "ambiguity_badge": "unresolved",
+                },
+                content={
+                    "attachment_reason": "Persisted before provenance corruption test."
+                },
+            )
+        )
+        service.persist_record(
+            CaseRecord(
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                evidence_ids=(
+                    *promoted_case.evidence_ids,
+                    second_source_evidence.evidence_id,
+                ),
+                lifecycle_state=promoted_case.lifecycle_state,
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+
+        backend = getattr(store.connection_factory, "__self__", None)
+        assert backend is not None
+        backend.tables["evidence_records"][second_source_evidence.evidence_id][
+            "provenance"
+        ] = {
+            "classification": 123,
+            "source_id": ["entra-record-002"],
+            "timestamp": {"unexpected": "shape"},
+            "reviewed_by": 456,
+            "source_family": ["entra_id"],
+            "blocking_reason": {"unexpected": "shape"},
+            "ambiguity_badge": ["related-entity"],
+        }
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+
+        attached_records = {
+            record["record_id"]: record
+            for record in case_detail.provenance_summary["attached_records"]
+        }
+        self.assertEqual(
+            attached_records[second_source_evidence.evidence_id][
+                "provenance_classification"
+            ],
+            "unresolved-linkage",
+        )
+        self.assertEqual(
+            attached_records[second_source_evidence.evidence_id]["blocking_reason"],
+            "missing_or_invalid_required_provenance_fields",
+        )
+        self.assertEqual(
+            attached_records[second_source_evidence.evidence_id]["source_family"],
+            "wazuh",
         )
 
     def test_osquery_adapter_canonicalizes_source_record_id_segments(self) -> None:

--- a/control-plane/tests/test_phase25_osquery_host_context_validation.py
+++ b/control-plane/tests/test_phase25_osquery_host_context_validation.py
@@ -215,6 +215,162 @@ class Phase25OsqueryHostContextValidationTests(unittest.TestCase):
             evidence.evidence_id,
         )
 
+    def test_inspect_case_detail_exposes_cross_source_timeline_and_provenance_summary(
+        self,
+    ) -> None:
+        _store, service, promoted_case, reviewed_at = self._build_host_bound_case(
+            host_identifier="host-001"
+        )
+        second_source_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-entra-case-001",
+                source_record_id="wazuh://entra/record/001",
+                alert_id=None,
+                case_id=promoted_case.case_id,
+                source_system="wazuh",
+                collector_identity="wazuh-reviewed-second-source-adapter",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_case_attachment",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "unresolved-linkage",
+                    "source_id": "entra-record-001",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "source_family": "entra_id",
+                    "ambiguity_badge": "unresolved",
+                    "blocking_reason": "stable_identifier_mismatch",
+                },
+                content={
+                    "attachment_reason": (
+                        "Reviewed second-source context remains candidate-only until "
+                        "stable identifiers are reconciled."
+                    )
+                },
+            )
+        )
+        promoted_case = service.persist_record(
+            CaseRecord(
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                evidence_ids=(
+                    *promoted_case.evidence_ids,
+                    second_source_evidence.evidence_id,
+                ),
+                lifecycle_state=promoted_case.lifecycle_state,
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+
+        osquery_evidence, osquery_observation = service.attach_osquery_host_context(
+            case_id=promoted_case.case_id,
+            host_identifier="host-001",
+            query_name="running_processes",
+            query_sql="SELECT pid, name, path FROM processes;",
+            result_kind="process",
+            rows=(
+                {
+                    "pid": "123",
+                    "name": "sshd",
+                    "path": "/usr/sbin/sshd",
+                },
+            ),
+            collected_at=reviewed_at.replace(minute=reviewed_at.minute + 1),
+            reviewed_by="analyst-001",
+            source_id="query-result-001",
+            collection_path="pack/osquery-defense/processes/running_processes",
+            query_context={"pack": "osquery-defense", "platform": "linux"},
+            observation_scope_statement=(
+                "Observed reviewed osquery host context on the explicitly scoped host."
+            ),
+        )
+        assert osquery_observation is not None
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+
+        self.assertEqual(
+            [entry["record_family"] for entry in case_detail.cross_source_timeline],
+            ["alert", "evidence", "evidence", "observation"],
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[0]["provenance_classification"],
+            "authoritative-anchor",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[0]["source_family"],
+            "github_audit",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[1]["record_id"],
+            second_source_evidence.evidence_id,
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[1]["source_family"],
+            "entra_id",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[1]["ambiguity_badge"],
+            "unresolved",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[1]["blocking_reason"],
+            "stable_identifier_mismatch",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[2]["record_id"],
+            osquery_evidence.evidence_id,
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[2]["source_family"],
+            "osquery",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[2]["ambiguity_badge"],
+            "related-entity",
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[3]["record_id"],
+            osquery_observation.observation_id,
+        )
+        self.assertEqual(
+            case_detail.cross_source_timeline[3]["provenance_classification"],
+            "reviewed-derived",
+        )
+
+        self.assertEqual(
+            case_detail.provenance_summary["authoritative_anchor"]["record_id"],
+            promoted_case.alert_id,
+        )
+        self.assertEqual(
+            case_detail.provenance_summary["source_families"],
+            ("github_audit", "entra_id", "osquery"),
+        )
+        attached_records = {
+            record["record_id"]: record
+            for record in case_detail.provenance_summary["attached_records"]
+        }
+        self.assertEqual(
+            attached_records[second_source_evidence.evidence_id][
+                "provenance_classification"
+            ],
+            "unresolved-linkage",
+        )
+        self.assertEqual(
+            attached_records[second_source_evidence.evidence_id]["blocking_reason"],
+            "stable_identifier_mismatch",
+        )
+        self.assertEqual(
+            attached_records[osquery_evidence.evidence_id]["evidence_origin"],
+            osquery_evidence.source_record_id,
+        )
+        self.assertEqual(
+            attached_records[osquery_observation.observation_id]["reviewed_linkage"][
+                "supporting_evidence_ids"
+            ],
+            (osquery_evidence.evidence_id,),
+        )
+
     def test_osquery_adapter_canonicalizes_source_record_id_segments(self) -> None:
         adapter = OsqueryHostContextAdapter()
         collected_at = datetime(2026, 4, 18, 0, 0, tzinfo=timezone.utc)

--- a/control-plane/tests/test_phase25_osquery_host_context_validation.py
+++ b/control-plane/tests/test_phase25_osquery_host_context_validation.py
@@ -522,6 +522,99 @@ class Phase25OsqueryHostContextValidationTests(unittest.TestCase):
             "wazuh",
         )
 
+    def test_inspect_case_detail_trims_persisted_provenance_strings(self) -> None:
+        _store, service, promoted_case, reviewed_at = self._build_host_bound_case(
+            host_identifier="host-001"
+        )
+        trimmed_source_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-entra-case-trimmed-provenance",
+                source_record_id="wazuh://entra/record/trimmed-provenance",
+                alert_id=None,
+                case_id=promoted_case.case_id,
+                source_system="entra_id",
+                collector_identity="wazuh-reviewed-second-source-adapter",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_case_attachment",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": " reviewed-derived ",
+                    "source_id": " entra-record-003 ",
+                    "timestamp": f" {reviewed_at.isoformat()} ",
+                    "reviewed_by": " analyst-001 ",
+                    "source_family": " entra_id ",
+                    "ambiguity_badge": " related-entity ",
+                    "blocking_reason": " stable_identifier_mismatch ",
+                },
+                content={"attachment_reason": "Whitespace-padded provenance values."},
+            )
+        )
+        canonical_source_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-entra-case-canonical-provenance",
+                source_record_id="wazuh://entra/record/canonical-provenance",
+                alert_id=None,
+                case_id=promoted_case.case_id,
+                source_system="entra_id",
+                collector_identity="wazuh-reviewed-second-source-adapter",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_case_attachment",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "reviewed-derived",
+                    "source_id": "entra-record-004",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "source_family": "entra_id",
+                    "ambiguity_badge": "related-entity",
+                },
+                content={"attachment_reason": "Canonical provenance values."},
+            )
+        )
+        service.persist_record(
+            CaseRecord(
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                evidence_ids=(
+                    *promoted_case.evidence_ids,
+                    trimmed_source_evidence.evidence_id,
+                    canonical_source_evidence.evidence_id,
+                ),
+                lifecycle_state=promoted_case.lifecycle_state,
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+
+        attached_records = {
+            record["record_id"]: record
+            for record in case_detail.provenance_summary["attached_records"]
+        }
+        self.assertEqual(
+            attached_records[trimmed_source_evidence.evidence_id]["source_family"],
+            "entra_id",
+        )
+        self.assertEqual(
+            attached_records[trimmed_source_evidence.evidence_id][
+                "provenance_classification"
+            ],
+            "reviewed-derived",
+        )
+        self.assertEqual(
+            attached_records[trimmed_source_evidence.evidence_id]["ambiguity_badge"],
+            "related-entity",
+        )
+        self.assertEqual(
+            attached_records[trimmed_source_evidence.evidence_id]["blocking_reason"],
+            "stable_identifier_mismatch",
+        )
+        self.assertEqual(
+            case_detail.provenance_summary["source_families"],
+            ("github_audit", "wazuh", "entra_id"),
+        )
+
     def test_osquery_adapter_canonicalizes_source_record_id_segments(self) -> None:
         adapter = OsqueryHostContextAdapter()
         collected_at = datetime(2026, 4, 18, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
Closes #530
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the case-detail boundary for Issue #530 and committed it as `4e0744f` on `codex/issue-530`.

`inspect_case_detail()` now derives two new authoritative surfaces: `cross_source_timeline` and `provenance_summary`. The case alert stays the `authoritative-anchor`, explicitly provenance-bearing evidence and observations are included as attached cross-source records, and incomplete provenance fails closed to `unresolved-linkage` instead of being promoted. I also added `source_system` to osquery-derived observation provenance so osquery-backed host context renders cleanly in the same summary model.

Focused verification passed with:
`python3 -m unittest control-plane/tests/test_phase25_osquery_host_context_validation.py -k cross_source_timeline_and_provenance_summary`
`python3 -m unittest control-plane/tests/test_phase25_osquery_host_context_validation.py`
`python3 -m unittest control-plane/tests/test_cli_inspection.py -k case_detail_with_evidence_provenance_and_cited_advisory_output`

Summary: Added authoritative case-detail cross-source timeline and provenance summary surfaces, plus focused service and CLI regression coverage; committed as `4e0744f`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane/tests/test_phase25_osquery_host_context_validation.py -k cross_source_timeline_and_provenance_summary`; `python3 -m unittest control-plane/tests/test_phase25_osquery_host_context_validation.py`; `python3 -m unittest control-plane/test...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-source timeline consolidating alerts, evidence, and observations with occurrence timestamps
  * Provenance summary showing authoritative alert anchor, ordered source families, and per-record provenance details
  * Evidence and observation attachments now include source-system provenance metadata

* **Tests**
  * Added/extended tests validating timeline ordering, provenance classifications, blocking reasons, and tolerance for malformed provenance data
<!-- end of auto-generated comment: release notes by coderabbit.ai -->