### PR TITLE
implementation: add identity / alias ambiguity badges and unresolved handling (#531)

### DIFF
--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -279,6 +279,8 @@ def _build_assistant_advisory_output(
     uncertainty_flags = ["advisory_only"]
     unresolved_questions: list[dict[str, object]] = []
     fail_closed = False
+    unresolved_summary_override: str | None = None
+    unresolved_summary_citations: tuple[str, ...] | None = None
     intended_outcome = record.get("intended_outcome")
     unsafe_intended_outcome_flags = _advisory_text_claims_authority_or_scope_expansion(
         intended_outcome
@@ -346,6 +348,12 @@ def _build_assistant_advisory_output(
             f"{entry['evidence_id']} ({entry['blocking_reason']})"
             for entry in linked_casework_identity_ambiguity
         )
+        unresolved_summary_override = (
+            f"{output_kind.replace('_', ' ').capitalize()} {record_id} remains unresolved "
+            "because reviewed multi-source casework still contains unresolved identity "
+            f"ambiguity: {ambiguity_details}."
+        )
+        unresolved_summary_citations = ambiguity_citations
         unresolved_questions.append(
             {
                 "text": (
@@ -416,7 +424,7 @@ def _build_assistant_advisory_output(
                 f"linked evidence, and stable reviewed-context identifiers."
             )
     else:
-        summary_text = (
+        summary_text = unresolved_summary_override or (
             f"{output_kind.replace('_', ' ').capitalize()} {record_id} remains unresolved "
             "because citation completeness or reviewed-context consistency is incomplete."
         )
@@ -449,7 +457,8 @@ def _build_assistant_advisory_output(
         "status": status,
         "cited_summary": {
             "text": summary_text,
-            "citations": _dedupe_strings((record_id, *supporting_citations)),
+            "citations": unresolved_summary_citations
+            or _dedupe_strings((record_id, *supporting_citations)),
         },
         "key_observations": tuple(key_observations),
         "unresolved_questions": tuple(unresolved_questions),

--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -113,6 +113,48 @@ def _reviewed_identity_is_alias_only(reviewed_context: Mapping[str, object]) -> 
     return any(identity.get(key) for key in alias_like_keys)
 
 
+def _normalized_optional_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _linked_casework_identity_ambiguity_records(
+    linked_evidence_records: tuple[dict[str, object], ...],
+) -> tuple[dict[str, str], ...]:
+    blocking_reasons = {
+        "stable_identifier_mismatch",
+        "alias_like_overlap",
+        "alias_overlap",
+        "identity_alias_overlap",
+    }
+    unresolved_records: list[dict[str, str]] = []
+    seen_record_ids: set[str] = set()
+    for evidence in linked_evidence_records:
+        evidence_id = _normalized_optional_string(evidence.get("evidence_id"))
+        if evidence_id is None or evidence_id in seen_record_ids:
+            continue
+        provenance = evidence.get("provenance")
+        if not isinstance(provenance, Mapping):
+            continue
+        ambiguity_badge = _normalized_optional_string(provenance.get("ambiguity_badge"))
+        classification = _normalized_optional_string(provenance.get("classification"))
+        blocking_reason = _normalized_optional_string(provenance.get("blocking_reason"))
+        if ambiguity_badge != "unresolved" and classification != "unresolved-linkage":
+            continue
+        if blocking_reason not in blocking_reasons:
+            continue
+        seen_record_ids.add(evidence_id)
+        unresolved_records.append(
+            {
+                "evidence_id": evidence_id,
+                "blocking_reason": blocking_reason,
+            }
+        )
+    return tuple(unresolved_records)
+
+
 def _recommendation_draft_review_summary(
     record_family: str,
     record_id: str,
@@ -195,6 +237,7 @@ def _build_assistant_advisory_output(
     linked_recommendation_ids: tuple[str, ...],
     linked_alert_records: tuple[dict[str, object], ...],
     linked_case_records: tuple[dict[str, object], ...],
+    linked_evidence_records: tuple[dict[str, object], ...],
     linked_recommendation_records: tuple[dict[str, object], ...],
 ) -> dict[str, object]:
     output_kind = _assistant_advisory_output_kind(record_family)
@@ -282,6 +325,35 @@ def _build_assistant_advisory_output(
                     "alias-style identity metadata for this advisory output?"
                 ),
                 "citations": citations,
+            }
+        )
+    linked_casework_identity_ambiguity = _linked_casework_identity_ambiguity_records(
+        linked_evidence_records
+    )
+    if linked_casework_identity_ambiguity:
+        fail_closed = True
+        uncertainty_flags.append("reviewed_casework_identity_ambiguity")
+        ambiguity_citations = _dedupe_strings(
+            (
+                record_id,
+                *(
+                    entry["evidence_id"]
+                    for entry in linked_casework_identity_ambiguity
+                ),
+            )
+        )
+        ambiguity_details = ", ".join(
+            f"{entry['evidence_id']} ({entry['blocking_reason']})"
+            for entry in linked_casework_identity_ambiguity
+        )
+        unresolved_questions.append(
+            {
+                "text": (
+                    "Which stable identity identifier or explicit reviewed linkage resolves "
+                    "the multi-source identity ambiguity attached to: "
+                    f"{ambiguity_details}?"
+                ),
+                "citations": ambiguity_citations,
             }
         )
     if unsafe_intended_outcome_flags:
@@ -785,6 +857,9 @@ class AssistantContextAssembler:
                 linked_recommendation_ids=linked_recommendation_ids,
                 linked_alert_records=linked_alert_records,
                 linked_case_records=linked_case_records,
+                linked_evidence_records=tuple(
+                    self._record_to_dict(evidence) for evidence in linked_evidence_records
+                ),
                 linked_recommendation_records=linked_recommendation_payloads,
             ),
             reviewed_context=reviewed_context,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1070,6 +1070,9 @@ def _phase24_live_assistant_unresolved_reasons(
         "ambiguous_identity_alias_only": (
             "the requested summary would require the assistant to collapse identity ambiguity"
         ),
+        "reviewed_casework_identity_ambiguity": (
+            "reviewed multi-source casework still contains unresolved identity ambiguity"
+        ),
         "authority_overreach": (
             "the requested summary would widen into approval, delegation, execution, or policy interpretation"
         ),

--- a/control-plane/tests/test_phase24_live_assistant_fallback_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_fallback_validation.py
@@ -144,6 +144,53 @@ class Phase24LiveAssistantFallbackValidationTests(ServicePersistenceTestBase):
         )
         service._assistant_provider_adapter.generate.assert_not_called()
 
+    def test_workflow_preserves_reviewed_unresolved_summary_for_casework_identity_ambiguity(
+        self,
+    ) -> None:
+        _, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+        context_snapshot = service.inspect_assistant_context(
+            "case",
+            promoted_case.case_id,
+        )
+        expected_summary = (
+            "Reviewed case summary remains unresolved until multi-source identity "
+            "ambiguity is reconciled."
+        )
+        unresolved_context = replace(
+            context_snapshot,
+            advisory_output={
+                **dict(context_snapshot.advisory_output),
+                "status": "unresolved",
+                "cited_summary": {
+                    "text": expected_summary,
+                    "citations": (promoted_case.case_id,),
+                },
+                "uncertainty_flags": ("reviewed_casework_identity_ambiguity",),
+            },
+        )
+        service._assistant_provider_adapter = mock.Mock()
+
+        with mock.patch.object(
+            service,
+            "inspect_assistant_context",
+            return_value=unresolved_context,
+        ):
+            snapshot = service.run_live_assistant_workflow(
+                workflow_task="case_summary",
+                record_family="case",
+                record_id=promoted_case.case_id,
+            )
+
+        self.assertEqual(snapshot.status, "unresolved")
+        self.assertEqual(snapshot.summary, expected_summary)
+        self.assertEqual(
+            snapshot.unresolved_reasons,
+            (
+                "reviewed multi-source casework still contains unresolved identity ambiguity",
+            ),
+        )
+        service._assistant_provider_adapter.generate.assert_not_called()
+
     def test_workflow_preserves_reviewed_summary_for_provider_failure(
         self,
     ) -> None:

--- a/control-plane/tests/test_phase25_osquery_host_context_validation.py
+++ b/control-plane/tests/test_phase25_osquery_host_context_validation.py
@@ -517,9 +517,119 @@ class Phase25OsqueryHostContextValidationTests(unittest.TestCase):
             attached_records[second_source_evidence.evidence_id]["blocking_reason"],
             "missing_or_invalid_required_provenance_fields",
         )
+
+    def test_case_assistant_context_fails_closed_on_unresolved_identity_ambiguity(
+        self,
+    ) -> None:
+        _store, service, promoted_case, reviewed_at = self._build_host_bound_case(
+            host_identifier="host-001"
+        )
+        stable_id_mismatch_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-entra-case-stable-id-mismatch",
+                source_record_id="wazuh://entra/record/stable-id-mismatch",
+                alert_id=None,
+                case_id=promoted_case.case_id,
+                source_system="wazuh",
+                collector_identity="wazuh-reviewed-second-source-adapter",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_case_attachment",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "unresolved-linkage",
+                    "source_id": "entra-record-stable-id-mismatch",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "source_family": "entra_id",
+                    "ambiguity_badge": "unresolved",
+                    "blocking_reason": "stable_identifier_mismatch",
+                },
+                content={
+                    "attachment_reason": (
+                        "Reviewed Entra ID context remains unresolved until stable "
+                        "identifiers are reconciled."
+                    )
+                },
+            )
+        )
+        alias_overlap_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-entra-case-alias-overlap",
+                source_record_id="wazuh://entra/record/alias-overlap",
+                alert_id=None,
+                case_id=promoted_case.case_id,
+                source_system="wazuh",
+                collector_identity="wazuh-reviewed-second-source-adapter",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_case_attachment",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "unresolved-linkage",
+                    "source_id": "entra-record-alias-overlap",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "source_family": "entra_id",
+                    "ambiguity_badge": "unresolved",
+                    "blocking_reason": "alias_like_overlap",
+                },
+                content={
+                    "attachment_reason": (
+                        "Alias-style overlap remains reviewed context only and must "
+                        "not be collapsed into one identity."
+                    )
+                },
+            )
+        )
+        service.persist_record(
+            CaseRecord(
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                evidence_ids=(
+                    *promoted_case.evidence_ids,
+                    stable_id_mismatch_evidence.evidence_id,
+                    alias_overlap_evidence.evidence_id,
+                ),
+                lifecycle_state=promoted_case.lifecycle_state,
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+        attached_records = {
+            record["record_id"]: record
+            for record in case_detail.provenance_summary["attached_records"]
+        }
         self.assertEqual(
-            attached_records[second_source_evidence.evidence_id]["source_family"],
-            "wazuh",
+            attached_records[stable_id_mismatch_evidence.evidence_id]["ambiguity_badge"],
+            "unresolved",
+        )
+        self.assertEqual(
+            attached_records[stable_id_mismatch_evidence.evidence_id]["blocking_reason"],
+            "stable_identifier_mismatch",
+        )
+        self.assertEqual(
+            attached_records[alias_overlap_evidence.evidence_id]["ambiguity_badge"],
+            "unresolved",
+        )
+        self.assertEqual(
+            attached_records[alias_overlap_evidence.evidence_id]["blocking_reason"],
+            "alias_like_overlap",
+        )
+
+        snapshot = service.inspect_assistant_context("case", promoted_case.case_id)
+
+        self.assertEqual(snapshot.advisory_output["status"], "unresolved")
+        self.assertIn(
+            "reviewed_casework_identity_ambiguity",
+            snapshot.advisory_output["uncertainty_flags"],
+        )
+        self.assertTrue(
+            any(
+                stable_id_mismatch_evidence.evidence_id in question.get("text", "")
+                and alias_overlap_evidence.evidence_id in question.get("text", "")
+                for question in snapshot.advisory_output["unresolved_questions"]
+            )
         )
 
     def test_inspect_case_detail_trims_persisted_provenance_strings(self) -> None:

--- a/control-plane/tests/test_phase25_osquery_host_context_validation.py
+++ b/control-plane/tests/test_phase25_osquery_host_context_validation.py
@@ -624,6 +624,34 @@ class Phase25OsqueryHostContextValidationTests(unittest.TestCase):
             "reviewed_casework_identity_ambiguity",
             snapshot.advisory_output["uncertainty_flags"],
         )
+        summary_text = snapshot.advisory_output["cited_summary"]["text"]
+        self.assertIn(
+            f"Case summary {promoted_case.case_id} remains unresolved because reviewed "
+            "multi-source casework still contains unresolved identity ambiguity:",
+            summary_text,
+        )
+        self.assertIn(
+            (
+                f"{stable_id_mismatch_evidence.evidence_id} "
+                "(stable_identifier_mismatch)"
+            ),
+            summary_text,
+        )
+        self.assertIn(
+            f"{alias_overlap_evidence.evidence_id} (alias_like_overlap)",
+            summary_text,
+        )
+        self.assertEqual(
+            snapshot.advisory_output["cited_summary"]["citations"][0],
+            promoted_case.case_id,
+        )
+        self.assertCountEqual(
+            snapshot.advisory_output["cited_summary"]["citations"][1:],
+            (
+                stable_id_mismatch_evidence.evidence_id,
+                alias_overlap_evidence.evidence_id,
+            ),
+        )
         self.assertTrue(
             any(
                 stable_id_mismatch_evidence.evidence_id in question.get("text", "")


### PR DESCRIPTION
Closes #531
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Phase 25/assistant alignment fix on `codex/issue-531` and committed it as `15142fc` (`Fail closed on unresolved casework identity ambiguity`).

The reproduced bug was that case detail already surfaced unresolved multi-source identity ambiguity, but `inspect_assistant_context("case", ...)` still returned `ready`. The fix now makes assistant advisory generation fail closed when directly linked reviewed evidence is explicitly marked unresolved for identity ambiguity, including `stable_identifier_mismatch` and alias-overlap reasons. I also added focused regressions for the case-detail/assistant mismatch and the Phase 24 unresolved-reason mapping. The issue journal was updated locally before finish; it is under an ignored path, so it is not part of the git commit.

Summary: Fixed assistant/casework semantic drift so unresolved Phase 25 identity ambiguity now forces assistant case summaries to stay unresolved, with focused regression coverage and checkpoint commit `15142fc`.
State hint: stabilizing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase25_osquery_host_context_validation`; `python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory`; `python3 -m unittest control-plane.tests.test_phase24_live_assistant_fallback_validation control-plane.tests.test_phase24_live_assistant_adversarial_validation`
Failure signature: none
Next action: open a draft PR from `codex/issue-531` and continue broader Phase 24/25 ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced case analysis: when unresolved identity conflicts are found during assistant context evaluation the workflow now fails closed, surfaces a clear unresolved summary that cites affected evidence and lists blocking reasons, and produces targeted unresolved questions to guide manual review.

* **Tests**
  * Added tests verifying fail-closed behavior, preservation of unresolved summaries, flagged uncertainty, and citation of ambiguous evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->