### PR TITLE
Follow-up: align Phase 25 validation artifacts with the current reviewed roadmap note (#540)

### DIFF
--- a/control-plane/tests/test_phase25_multi_source_case_admission_docs.py
+++ b/control-plane/tests/test_phase25_multi_source_case_admission_docs.py
@@ -76,7 +76,7 @@ class Phase25MultiSourceCaseAdmissionDocsTests(unittest.TestCase):
         for term in (
             "Phase 25 Reviewed Multi-Source Case Admission and Ambiguity Taxonomy Validation",
             "Validation status: PASS",
-            "Old Revised Phase23-20 Epic Roadmap.md",
+            "docs/Revised Phase23-20 Epic Roadmap.md",
             "README.md",
             "docs/architecture.md",
             "docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md",
@@ -84,6 +84,8 @@ class Phase25MultiSourceCaseAdmissionDocsTests(unittest.TestCase):
             "unresolved model",
         ):
             self.assertIn(term, text)
+
+        self.assertNotIn("Archive/Old Revised Phase23-20 Epic Roadmap.md", text)
 
     def test_phase25_operator_runbook_exists_and_defines_multi_source_review_posture(
         self,

--- a/docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy-validation.md
+++ b/docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy-validation.md
@@ -3,7 +3,7 @@
 - Validation status: PASS
 - Reviewed on: 2026-04-18
 - Scope: confirm the reviewed multi-source case admission contract defines bounded source admission, explicit provenance, and one fail-closed same-entity / related-entity / unresolved taxonomy without widening authority or weakening the advisory-only unresolved model.
-- Reviewed sources: `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `Archive/Old Revised Phase23-20 Epic Roadmap.md` (Obsidian roadmap note; the issue-body `Plan&Roadmap/Revised Phase23-20 Epic Roadmap.md` path does not exist on this host), `README.md`, `docs/architecture.md`, `docs/phase-15-identity-grounded-analyst-assistant-boundary.md`, `docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md`, `docs/control-plane-state-model.md`
+- Reviewed sources: `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/Revised Phase23-20 Epic Roadmap.md` (current reviewed roadmap note present on this host), `README.md`, `docs/architecture.md`, `docs/phase-15-identity-grounded-analyst-assistant-boundary.md`, `docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md`, `docs/control-plane-state-model.md`
 
 ## Validation Summary
 
@@ -15,7 +15,7 @@ The design keeps osquery-backed host evidence in an augmenting evidence role and
 
 ## Roadmap Alignment Review
 
-The reviewed roadmap source, `Archive/Old Revised Phase23-20 Epic Roadmap.md`, describes the accepted slice as reviewed multi-source casework with osquery-backed host context, ambiguity-preserving review, and a same-entity / related-entity / unresolved taxonomy.
+The reviewed roadmap source, `docs/Revised Phase23-20 Epic Roadmap.md`, describes the accepted slice as reviewed multi-source casework with osquery-backed host context, ambiguity-preserving review, and a same-entity / related-entity / unresolved taxonomy.
 
 The Phase 25 design stays aligned with that roadmap intent by defining bounded admission rules, ambiguity preservation, and reviewed provenance rather than broad source-spanning correlation.
 


### PR DESCRIPTION
Closes #540
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the Phase 25 validation artifact to cite the current host-visible reviewed roadmap note, [docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy-validation.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-540/docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy-validation.md), replacing the archived `Archive/Old Revised Phase23-20 Epic Roadmap.md` reference with `docs/Revised Phase23-20 Epic Roadmap.md`. I also tightened [control-plane/tests/test_phase25_multi_source_case_admission_docs.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-540/control-plane/tests/test_phase25_multi_source_case_admission_docs.py) so it now requires the docs-based roadmap reference and explicitly rejects the archived path.

Focused verification passed with `python3 -m unittest control-plane.tests.test_phase25_multi_source_case_admission_docs`, and I recorded the reproducer/result in the issue journal before creating checkpoint commit `1b14297` (`Refresh Phase 25 roadmap validation reference`).

Summary: Refreshed the Phase 25 validation doc and focused test to use the current host-visible reviewed roadmap note `docs/Revised Phase23-20 Epic Roadmap.md`, then committed the change as `1b14297`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase25_multi_source_case_admission_docs`
Failure signature: none
Next action: Push `codex/issue-540` and open or update the draft PR with commit `1b14297` if supe...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation references to point to the current Phase23-20 Epic Roadmap location, ensuring users access the active version rather than archived materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->