### PR TITLE
Follow-up: align Phase 25 validation artifacts with a roadmap source that actually covers Phase 25 (#544)

### DIFF
--- a/control-plane/aegisops_control_plane/publishable_paths.py
+++ b/control-plane/aegisops_control_plane/publishable_paths.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pathlib
+import re
+from pathlib import PureWindowsPath
+
+
+REDACTED_LOCAL_PATH_TOKEN = "<redacted-local-path>"
+ALLOWLIST_MARKER = "publishable-path-hygiene: allowlist"
+
+_WINDOWS_USER_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]+Users[\\/]+[^\\/]+(?:[\\/](?P<rest>.*))?$")
+
+
+def _is_relative_to(path: pathlib.Path, root: pathlib.Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def is_workstation_local_path(text: str) -> bool:
+    return "/Users/" in text or "/home/" in text or bool(re.search(r"[A-Za-z]:\\Users\\", text))
+
+
+def normalize_publishable_path(
+    path: str | pathlib.Path,
+    *,
+    repo_root: str | pathlib.Path | None = None,
+    home: str | pathlib.Path | None = None,
+) -> str:
+    raw = str(path).strip()
+    if not raw:
+        return raw
+
+    windows_match = _WINDOWS_USER_PATH_RE.match(raw.replace("/", "\\"))
+    if windows_match:
+        rest = windows_match.group("rest") or ""
+        rest = PureWindowsPath(rest).as_posix() if rest else ""
+        return (
+            f"{REDACTED_LOCAL_PATH_TOKEN}/{rest}"
+            if rest
+            else REDACTED_LOCAL_PATH_TOKEN
+        )
+
+    candidate = pathlib.Path(raw).expanduser()
+    if not candidate.is_absolute():
+        return candidate.as_posix() if isinstance(path, pathlib.Path) else raw
+
+    resolved = candidate.resolve(strict=False)
+    repo_root_path = pathlib.Path(repo_root).resolve(strict=False) if repo_root else None
+    if repo_root_path and _is_relative_to(resolved, repo_root_path):
+        return resolved.relative_to(repo_root_path).as_posix()
+
+    home_path = pathlib.Path(home).expanduser().resolve(strict=False) if home else pathlib.Path.home().resolve(strict=False)
+    if _is_relative_to(resolved, home_path):
+        relative = resolved.relative_to(home_path).as_posix()
+        return (
+            f"{REDACTED_LOCAL_PATH_TOKEN}/{relative}"
+            if relative and relative != "."
+            else REDACTED_LOCAL_PATH_TOKEN
+        )
+
+    return REDACTED_LOCAL_PATH_TOKEN

--- a/control-plane/aegisops_control_plane/publishable_paths.py
+++ b/control-plane/aegisops_control_plane/publishable_paths.py
@@ -9,6 +9,12 @@ REDACTED_LOCAL_PATH_TOKEN = "<redacted-local-path>"
 ALLOWLIST_MARKER = "publishable-path-hygiene: allowlist"
 
 _WINDOWS_USER_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]+Users[\\/]+[^\\/]+(?:[\\/](?P<rest>.*))?$")
+_UNIX_USER_PATH_IN_TEXT_RE = re.compile(
+    r"(?<![A-Za-z0-9_./:\\-])/(?:Users|home)/[^/\s]+(?:/[^\s]*)?"
+)
+_WINDOWS_USER_PATH_IN_TEXT_RE = re.compile(
+    r"(?i)(?<![A-Za-z0-9_./:\\-])[A-Z]:[\\/]+Users[\\/]+[^\\/\s]+(?:[\\/][^\s]*)?"
+)
 
 
 def _is_relative_to(path: pathlib.Path, root: pathlib.Path) -> bool:
@@ -20,7 +26,10 @@ def _is_relative_to(path: pathlib.Path, root: pathlib.Path) -> bool:
 
 
 def is_workstation_local_path(text: str) -> bool:
-    return "/Users/" in text or "/home/" in text or bool(re.search(r"[A-Za-z]:\\Users\\", text))
+    return bool(
+        _UNIX_USER_PATH_IN_TEXT_RE.search(text)
+        or _WINDOWS_USER_PATH_IN_TEXT_RE.search(text)
+    )
 
 
 def normalize_publishable_path(

--- a/control-plane/aegisops_control_plane/publishable_paths.py
+++ b/control-plane/aegisops_control_plane/publishable_paths.py
@@ -9,12 +9,14 @@ REDACTED_LOCAL_PATH_TOKEN = "<redacted-local-path>"
 ALLOWLIST_MARKER = "publishable-path-hygiene: allowlist"
 
 _WINDOWS_USER_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]+Users[\\/]+[^\\/]+(?:[\\/](?P<rest>.*))?$")
-_UNIX_USER_PATH_IN_TEXT_RE = re.compile(
-    r"(?<![A-Za-z0-9_./:\\-])/(?:Users|home)/[^/\s]+(?:/[^\s]*)?"
-)
+_UNIX_USER_PATH_IN_TEXT_RE = re.compile(r"/(?:Users|home)/[^/\s]+(?:/[^\s]*)?")
 _WINDOWS_USER_PATH_IN_TEXT_RE = re.compile(
-    r"(?i)(?<![A-Za-z0-9_./:\\-])[A-Z]:[\\/]+Users[\\/]+[^\\/\s]+(?:[\\/][^\s]*)?"
+    r"(?i)[A-Z]:[\\/]+Users[\\/]+[^\\/\s]+(?:[\\/][^\s]*)?"
 )
+_BLOCKED_TEXT_PATH_PREFIX_CHARACTERS = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_./\\-"
+)
+_WINDOWS_DRIVE_PREFIX_RE = re.compile(r"(?:^|[^A-Za-z0-9_])[A-Za-z]:$")
 
 
 def _is_relative_to(path: pathlib.Path, root: pathlib.Path) -> bool:
@@ -25,11 +27,29 @@ def _is_relative_to(path: pathlib.Path, root: pathlib.Path) -> bool:
     return True
 
 
+def _has_text_path_boundary(text: str, start: int) -> bool:
+    return start == 0 or text[start - 1] not in _BLOCKED_TEXT_PATH_PREFIX_CHARACTERS
+
+
+def _has_windows_drive_prefix(text: str, start: int) -> bool:
+    return bool(_WINDOWS_DRIVE_PREFIX_RE.search(text[:start]))
+
+
 def is_workstation_local_path(text: str) -> bool:
-    return bool(
-        _UNIX_USER_PATH_IN_TEXT_RE.search(text)
-        or _WINDOWS_USER_PATH_IN_TEXT_RE.search(text)
-    )
+    for match in _WINDOWS_USER_PATH_IN_TEXT_RE.finditer(text):
+        if _has_text_path_boundary(text, match.start()):
+            return True
+
+    for match in _UNIX_USER_PATH_IN_TEXT_RE.finditer(text):
+        if not _has_text_path_boundary(text, match.start()):
+            continue
+        if match.group(0).startswith("/Users/") and _has_windows_drive_prefix(
+            text, match.start()
+        ):
+            continue
+        return True
+
+    return False
 
 
 def normalize_publishable_path(

--- a/control-plane/tests/test_phase25_multi_source_case_admission_docs.py
+++ b/control-plane/tests/test_phase25_multi_source_case_admission_docs.py
@@ -76,7 +76,7 @@ class Phase25MultiSourceCaseAdmissionDocsTests(unittest.TestCase):
         for term in (
             "Phase 25 Reviewed Multi-Source Case Admission and Ambiguity Taxonomy Validation",
             "Validation status: PASS",
-            "/Users/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md",
+            "ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md",
             "Epic: Phase 23 reviewed multi-source casework and osquery-backed host context",
             "README.md",
             "docs/architecture.md",

--- a/control-plane/tests/test_phase25_multi_source_case_admission_docs.py
+++ b/control-plane/tests/test_phase25_multi_source_case_admission_docs.py
@@ -76,7 +76,8 @@ class Phase25MultiSourceCaseAdmissionDocsTests(unittest.TestCase):
         for term in (
             "Phase 25 Reviewed Multi-Source Case Admission and Ambiguity Taxonomy Validation",
             "Validation status: PASS",
-            "docs/Revised Phase23-20 Epic Roadmap.md",
+            "/Users/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md",
+            "Epic: Phase 23 reviewed multi-source casework and osquery-backed host context",
             "README.md",
             "docs/architecture.md",
             "docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md",
@@ -85,6 +86,7 @@ class Phase25MultiSourceCaseAdmissionDocsTests(unittest.TestCase):
         ):
             self.assertIn(term, text)
 
+        self.assertNotIn("docs/Revised Phase23-20 Epic Roadmap.md", text)
         self.assertNotIn("Archive/Old Revised Phase23-20 Epic Roadmap.md", text)
 
     def test_phase25_operator_runbook_exists_and_defines_multi_source_review_posture(

--- a/control-plane/tests/test_publishable_path_hygiene.py
+++ b/control-plane/tests/test_publishable_path_hygiene.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from aegisops_control_plane.publishable_paths import is_workstation_local_path
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+VERIFY_SCRIPT = REPO_ROOT / "scripts/verify-publishable-path-hygiene.sh"
+
+
+class PublishablePathHygieneTests(unittest.TestCase):
+    def test_detects_unix_and_windows_workstation_paths_in_text(self) -> None:
+        self.assertTrue(is_workstation_local_path("/Users/alice/project/docs"))
+        self.assertTrue(is_workstation_local_path("see /home/alice/project/docs for details"))
+        self.assertTrue(is_workstation_local_path(r"C:\Users\alice\project\docs"))
+        self.assertTrue(is_workstation_local_path("path=C:/Users/alice/project/docs"))
+
+    def test_ignores_urls_and_non_user_windows_paths(self) -> None:
+        self.assertFalse(
+            is_workstation_local_path("https://example.com/home/alice/project/docs")
+        )
+        self.assertFalse(
+            is_workstation_local_path("https://example.com/C:/Users/alice/project/docs")
+        )
+        self.assertFalse(is_workstation_local_path(r"D:\Program Files\AegisOps"))
+        self.assertFalse(is_workstation_local_path("relative/path/to/docs"))
+
+    def test_verify_script_skips_binary_files_and_redacts_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = pathlib.Path(tmpdir)
+            subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
+
+            docs_dir = repo_root / "docs"
+            docs_dir.mkdir()
+            (repo_root / "control-plane" / "tests").mkdir(parents=True)
+            (repo_root / ".github" / "workflows").mkdir(parents=True)
+
+            (repo_root / "README.md").write_text("No local paths here.\n", encoding="utf-8")
+            (docs_dir / "binary.bin").write_bytes(b"\x00\x01\x02/home/alice/private")
+            (docs_dir / "offender.md").write_text(
+                "operator note: /Users/alice/private/project\n",
+                encoding="utf-8",
+            )
+
+            subprocess.run(
+                [
+                    "git",
+                    "add",
+                    "README.md",
+                    "docs/binary.bin",
+                    "docs/offender.md",
+                ],
+                cwd=repo_root,
+                check=True,
+                capture_output=True,
+            )
+
+            env = os.environ.copy()
+            existing_pythonpath = env.get("PYTHONPATH")
+            control_plane_path = str(REPO_ROOT / "control-plane")
+            env["PYTHONPATH"] = (
+                f"{control_plane_path}:{existing_pythonpath}"
+                if existing_pythonpath
+                else control_plane_path
+            )
+
+            result = subprocess.run(
+                ["bash", str(VERIFY_SCRIPT), str(repo_root)],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                env=env,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(
+                "docs/offender.md:1: contains workstation-local absolute path",
+                result.stderr,
+            )
+            self.assertNotIn("/Users/alice/private/project", result.stderr)
+            self.assertNotIn("binary.bin", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_publishable_path_hygiene.py
+++ b/control-plane/tests/test_publishable_path_hygiene.py
@@ -17,14 +17,22 @@ from aegisops_control_plane.publishable_paths import is_workstation_local_path
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 VERIFY_SCRIPT = REPO_ROOT / "scripts/verify-publishable-path-hygiene.sh"
+UNIX_USERS_PATH = "/Users/alice/project/docs"  # publishable-path-hygiene: allowlist
+UNIX_HOME_PATH = "/home/alice/project/docs"  # publishable-path-hygiene: allowlist
+WINDOWS_USERS_PATH = r"C:\Users\alice\project\docs"  # publishable-path-hygiene: allowlist
+WINDOWS_USERS_PATH_POSIX = "C:/Users/alice/project/docs"  # publishable-path-hygiene: allowlist
+OFFENDER_PATH = "/Users/alice/private/project"  # publishable-path-hygiene: allowlist
 
 
 class PublishablePathHygieneTests(unittest.TestCase):
     def test_detects_unix_and_windows_workstation_paths_in_text(self) -> None:
-        self.assertTrue(is_workstation_local_path("/Users/alice/project/docs"))
-        self.assertTrue(is_workstation_local_path("see /home/alice/project/docs for details"))
-        self.assertTrue(is_workstation_local_path(r"C:\Users\alice\project\docs"))
-        self.assertTrue(is_workstation_local_path("path=C:/Users/alice/project/docs"))
+        self.assertTrue(is_workstation_local_path(UNIX_USERS_PATH))
+        self.assertTrue(is_workstation_local_path(f"see {UNIX_HOME_PATH} for details"))
+        self.assertTrue(is_workstation_local_path(f"path:{UNIX_HOME_PATH}"))
+        self.assertTrue(is_workstation_local_path(f"path:{UNIX_USERS_PATH}"))
+        self.assertTrue(is_workstation_local_path(WINDOWS_USERS_PATH))
+        self.assertTrue(is_workstation_local_path(f"path={WINDOWS_USERS_PATH_POSIX}"))
+        self.assertTrue(is_workstation_local_path(f"path:{WINDOWS_USERS_PATH_POSIX}"))
 
     def test_ignores_urls_and_non_user_windows_paths(self) -> None:
         self.assertFalse(
@@ -49,7 +57,7 @@ class PublishablePathHygieneTests(unittest.TestCase):
             (repo_root / "README.md").write_text("No local paths here.\n", encoding="utf-8")
             (docs_dir / "binary.bin").write_bytes(b"\x00\x01\x02/home/alice/private")
             (docs_dir / "offender.md").write_text(
-                "operator note: /Users/alice/private/project\n",
+                f"operator note: {OFFENDER_PATH}\n",
                 encoding="utf-8",
             )
 
@@ -89,7 +97,7 @@ class PublishablePathHygieneTests(unittest.TestCase):
                 "docs/offender.md:1: contains workstation-local absolute path",
                 result.stderr,
             )
-            self.assertNotIn("/Users/alice/private/project", result.stderr)
+            self.assertNotIn(OFFENDER_PATH, result.stderr)
             self.assertNotIn("binary.bin", result.stderr)
 
 

--- a/docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy-validation.md
+++ b/docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy-validation.md
@@ -3,7 +3,7 @@
 - Validation status: PASS
 - Reviewed on: 2026-04-18
 - Scope: confirm the reviewed multi-source case admission contract defines bounded source admission, explicit provenance, and one fail-closed same-entity / related-entity / unresolved taxonomy without widening authority or weakening the advisory-only unresolved model.
-- Reviewed sources: `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/Revised Phase23-20 Epic Roadmap.md` (current reviewed roadmap note present on this host), `README.md`, `docs/architecture.md`, `docs/phase-15-identity-grounded-analyst-assistant-boundary.md`, `docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md`, `docs/control-plane-state-model.md`
+- Reviewed sources: `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `/Users/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` (reviewed roadmap note present on this host; it captures the accepted multi-source casework and osquery-backed host-context slice under the revised roadmap numbering as Phase 23), `README.md`, `docs/architecture.md`, `docs/phase-15-identity-grounded-analyst-assistant-boundary.md`, `docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md`, `docs/control-plane-state-model.md`
 
 ## Validation Summary
 
@@ -15,11 +15,11 @@ The design keeps osquery-backed host evidence in an augmenting evidence role and
 
 ## Roadmap Alignment Review
 
-The reviewed roadmap source, `docs/Revised Phase23-20 Epic Roadmap.md`, describes the accepted slice as reviewed multi-source casework with osquery-backed host context, ambiguity-preserving review, and a same-entity / related-entity / unresolved taxonomy.
+The reviewed roadmap source, `/Users/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md`, explicitly defines `Epic: Phase 23 reviewed multi-source casework and osquery-backed host context`.
 
-The Phase 25 design stays aligned with that roadmap intent by defining bounded admission rules, ambiguity preservation, and reviewed provenance rather than broad source-spanning correlation.
+That reviewed roadmap slice also enumerates the accepted follow-on work for multi-source case admission taxonomy, osquery-backed host evidence attachment, cross-source timeline and provenance rendering, identity / alias ambiguity handling, operator runbooks, and focused validation coverage.
 
-The numbering has shifted in current issue tracking, but the reviewed design intent remains the same: add cross-source casework without silently stitching entities or weakening unresolved handling.
+The current issue and validation numbering has shifted since that roadmap revision, but the reviewed design intent remains the same: add cross-source casework plus osquery-backed host context without silently stitching entities, weakening unresolved handling, or promoting augmenting evidence into case truth.
 
 ## Authority and Provenance Review
 

--- a/docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy-validation.md
+++ b/docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy-validation.md
@@ -3,7 +3,7 @@
 - Validation status: PASS
 - Reviewed on: 2026-04-18
 - Scope: confirm the reviewed multi-source case admission contract defines bounded source admission, explicit provenance, and one fail-closed same-entity / related-entity / unresolved taxonomy without widening authority or weakening the advisory-only unresolved model.
-- Reviewed sources: `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `/Users/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` (reviewed roadmap note present on this host; it captures the accepted multi-source casework and osquery-backed host-context slice under the revised roadmap numbering as Phase 23), `README.md`, `docs/architecture.md`, `docs/phase-15-identity-grounded-analyst-assistant-boundary.md`, `docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md`, `docs/control-plane-state-model.md`
+- Reviewed sources: `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` (vault-relative path for the reviewed roadmap note; it captures the accepted multi-source casework and osquery-backed host-context slice under the revised roadmap numbering as Phase 23), `README.md`, `docs/architecture.md`, `docs/phase-15-identity-grounded-analyst-assistant-boundary.md`, `docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md`, `docs/control-plane-state-model.md`
 
 ## Validation Summary
 
@@ -15,7 +15,7 @@ The design keeps osquery-backed host evidence in an augmenting evidence role and
 
 ## Roadmap Alignment Review
 
-The reviewed roadmap source, `/Users/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md`, explicitly defines `Epic: Phase 23 reviewed multi-source casework and osquery-backed host context`.
+The reviewed roadmap source, `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md`, explicitly defines `Epic: Phase 23 reviewed multi-source casework and osquery-backed host context`.
 
 That reviewed roadmap slice also enumerates the accepted follow-on work for multi-source case admission taxonomy, osquery-backed host evidence attachment, cross-source timeline and provenance rendering, identity / alias ambiguity handling, operator runbooks, and focused validation coverage.
 

--- a/scripts/verify-publishable-path-hygiene.sh
+++ b/scripts/verify-publishable-path-hygiene.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tool_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${tool_root}}"
+
+if ! git -C "${repo_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not a Git working tree: ${repo_root}" >&2
+  exit 1
+fi
+
+export AEGISOPS_TOOL_ROOT="${tool_root}"
+export AEGISOPS_REPO_ROOT="${repo_root}"
+export PYTHONPATH="${tool_root}/control-plane${PYTHONPATH:+:${PYTHONPATH}}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+
+from aegisops_control_plane.publishable_paths import ALLOWLIST_MARKER, is_workstation_local_path
+
+repo_root = pathlib.Path(os.environ["AEGISOPS_REPO_ROOT"])
+
+tracked_paths = subprocess.run(
+    [
+        "git",
+        "-C",
+        str(repo_root),
+        "ls-files",
+        "--",
+        "README.md",
+        ".github/workflows",
+        "docs",
+        "control-plane/tests",
+    ],
+    capture_output=True,
+    text=True,
+    check=True,
+).stdout.splitlines()
+
+offenders: list[tuple[str, int, str]] = []
+for relative_path in tracked_paths:
+    path = repo_root / relative_path
+    if not path.is_file():
+        continue
+
+    text = path.read_text(encoding="utf-8")
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if ALLOWLIST_MARKER in line:
+            continue
+        if is_workstation_local_path(line):
+            offenders.append((relative_path, line_number, line.strip()))
+
+if offenders:
+    print("Publishable docs and tests must not contain workstation-local absolute paths.", file=sys.stderr)
+    for relative_path, line_number, line in offenders:
+        print(f"{relative_path}:{line_number}: {line}", file=sys.stderr)
+    sys.exit(1)
+
+print("Publishable docs and tests do not contain workstation-local absolute paths.")
+PY

--- a/scripts/verify-publishable-path-hygiene.sh
+++ b/scripts/verify-publishable-path-hygiene.sh
@@ -43,23 +43,30 @@ tracked_paths = subprocess.run(
     check=True,
 ).stdout.splitlines()
 
-offenders: list[tuple[str, int, str]] = []
+offenders: list[tuple[str, int]] = []
 for relative_path in tracked_paths:
     path = repo_root / relative_path
     if not path.is_file():
         continue
 
-    text = path.read_text(encoding="utf-8")
+    raw_bytes = path.read_bytes()
+    if b"\x00" in raw_bytes:
+        continue
+
+    text = raw_bytes.decode("utf-8", errors="replace")
     for line_number, line in enumerate(text.splitlines(), start=1):
         if ALLOWLIST_MARKER in line:
             continue
         if is_workstation_local_path(line):
-            offenders.append((relative_path, line_number, line.strip()))
+            offenders.append((relative_path, line_number))
 
 if offenders:
     print("Publishable docs and tests must not contain workstation-local absolute paths.", file=sys.stderr)
-    for relative_path, line_number, line in offenders:
-        print(f"{relative_path}:{line_number}: {line}", file=sys.stderr)
+    for relative_path, line_number in offenders:
+        print(
+            f"{relative_path}:{line_number}: contains workstation-local absolute path",
+            file=sys.stderr,
+        )
     sys.exit(1)
 
 print("Publishable docs and tests do not contain workstation-local absolute paths.")


### PR DESCRIPTION
Closes #544
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the Phase 25 validation artifact to cite the reviewed roadmap source that actually contains the accepted multi-source and osquery slice: `/Users/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md`. The validation text now explains that the roadmap captures this slice under revised numbering as Phase 23, instead of incorrectly claiming the repo-local `docs/Revised Phase23-20 Epic Roadmap.md` proves it.

I also tightened the focused doc test so it requires that exact roadmap path plus the explicit roadmap epic title, and rejects both stale references. Focused verification passed with `python3 -m unittest control-plane.tests.test_phase25_multi_source_case_admission_docs`. The fix is committed on `codex/issue-544` as `3ec757d` (`Fix Phase 25 roadmap validation source`).

Summary: Corrected the Phase 25 validation evidence chain to point at the reviewed 23-29 Obsidian roadmap that explicitly defines the accepted multi-source and osquery slice, and tightened the focused doc test to enforce that source.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase25_multi_source_case_admission_docs`
Failure signature: none
Next action: Push commit `3ec757d` on `codex/issue-544` and open or update the draft PR if supervisor expects a PR-backed checkpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated phase‑25 case admission docs with refined roadmap references and expanded validation alignment details.

* **New Features**
  * Added publishable‑path redaction & normalization to prevent exposing workstation-local paths.
  * Added a repository verification script that scans tracked docs/tests and fails on leaked local paths (output is redacted).

* **Tests**
  * Added tests for path detection, ignoring binaries/URLs, and for the verification script’s redaction and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->