### PR TITLE
[codex] Add CI coverage for publishable path hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           bash scripts/verify-phase-6-replay-to-notify-validation.sh
           bash scripts/verify-phase-25-multi-source-case-review-runbook.sh
           bash scripts/verify-postgres-compose-skeleton.sh
+          bash scripts/verify-publishable-path-hygiene.sh
           bash scripts/verify-proxy-compose-skeleton.sh
           bash scripts/verify-response-action-safety-model-doc.sh
           bash scripts/verify-requirements-baseline-control-plane-thesis.sh
@@ -209,7 +210,9 @@ jobs:
           bash scripts/test-verify-ingest-compose-skeleton.sh
           bash scripts/test-verify-opensearch-compose-skeleton.sh
           bash scripts/test-verify-architecture-runbook-validation.sh
+          bash scripts/test-verify-ci-publishable-path-hygiene.sh
           bash scripts/test-verify-postgres-compose-skeleton.sh
+          bash scripts/test-verify-publishable-path-hygiene.sh
           bash scripts/test-verify-proxy-compose-skeleton.sh
           bash scripts/test-verify-compose-skeleton-validation.sh
           bash scripts/test-verify-compose-skeleton-overview-doc.sh

--- a/scripts/test-verify-ci-publishable-path-hygiene.sh
+++ b/scripts/test-verify-ci-publishable-path-hygiene.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+required_commands=(
+  "bash scripts/verify-publishable-path-hygiene.sh"
+  "bash scripts/test-verify-publishable-path-hygiene.sh"
+  "bash scripts/test-verify-ci-publishable-path-hygiene.sh"
+)
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+collect_active_run_commands() {
+  awk '
+    {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent > block_indent) {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          sub(/\r$/, "", line)
+          if (line != "" && line !~ /^#/) {
+            print line
+          }
+          next
+        }
+
+        in_block = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+        block_indent = match($0, /[^ ]/) - 1
+        in_block = 1
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[^|>]/) {
+        line = $0
+        sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+        sub(/\r$/, "", line)
+        if (line != "" && line !~ /^#/) {
+          print line
+        }
+      }
+    }
+  ' "${workflow_path}"
+}
+
+active_run_commands="$(collect_active_run_commands)"
+
+for command in "${required_commands[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing publishable path hygiene CI command: ${command}" >&2
+    exit 1
+  fi
+done
+
+echo "CI workflow includes the publishable path hygiene verifier and focused shell tests."

--- a/scripts/test-verify-publishable-path-hygiene.sh
+++ b/scripts/test-verify-publishable-path-hygiene.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-publishable-path-hygiene.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+  shift
+
+  mkdir -p "${target}"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+
+  while (($#)); do
+    local path="$1"
+    local content="$2"
+    shift 2
+
+    mkdir -p "${target}/$(dirname "${path}")"
+    printf '%s\n' "${content}" > "${target}/${path}"
+    git -C "${target}" add "${path}"
+  done
+
+  git -C "${target}" commit -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+clean_repo="${workdir}/clean"
+create_repo \
+  "${clean_repo}" \
+  "README.md" "# Clean fixture" \
+  "docs/phase-25.md" "Reviewed roadmap reference: ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md" \
+  "control-plane/tests/test_docs.py" "EXPECTED_PATH = 'docs/phase-25.md'"
+assert_passes "${clean_repo}"
+
+allowlisted_repo="${workdir}/allowlisted"
+create_repo \
+  "${allowlisted_repo}" \
+  "README.md" "# Allowlisted fixture" \
+  "control-plane/tests/test_publishable_path_hygiene.py" "PATH = '/Users/jp.infra/tmp'  # publishable-path-hygiene: allowlist fixture" \
+  "docs/phase-25.md" "Reviewed roadmap reference stays vault-relative."
+assert_passes "${allowlisted_repo}"
+
+failing_repo="${workdir}/failing"
+create_repo \
+  "${failing_repo}" \
+  "README.md" "# Failing fixture" \
+  "docs/phase-25.md" "Leaked path: /Users/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md" \
+  "control-plane/tests/test_docs.py" "EXPECTED_PATH = 'docs/phase-25.md'"
+assert_fails_with "${failing_repo}" "docs/phase-25.md:1:"
+
+echo "verify-publishable-path-hygiene tests passed"


### PR DESCRIPTION
## What changed
- wire `scripts/verify-publishable-path-hygiene.sh` into the main CI workflow
- add `scripts/test-verify-publishable-path-hygiene.sh` so the hygiene verifier has a focused shell regression test
- add `scripts/test-verify-ci-publishable-path-hygiene.sh` so CI coverage is self-validated and cannot silently drop the new gate

## Why it changed
The Phase 25 follow-up merged the publishable path hygiene helper and verifier into `main`, but the CI wiring and its self-tests were still only present in local workspace changes on this host. That left the repo-level recurrence guard incomplete even though the underlying verifier existed.

## Impact
This makes workstation-local absolute path leaks fail earlier in repo-owned CI instead of relying only on the supervisor publication gate. It also keeps the CI contract reviewable by adding focused shell coverage for the new gate.

## Root cause
The root-cause fix landed in pieces: the repo gained the helper and verifier first, while the workflow wiring and shell-based regression coverage remained uncommitted local changes. This PR publishes that missing CI coverage slice.

## Validation
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash scripts/test-verify-publishable-path-hygiene.sh`
- `bash scripts/test-verify-ci-publishable-path-hygiene.sh`
- `python3 -m unittest control-plane.tests.test_publishable_path_hygiene control-plane.tests.test_phase25_multi_source_case_admission_docs`
- `bash scripts/test-verify-ci-phase-25-workflow-coverage.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI pipeline with additional verification checks to ensure repository integrity and compliance.

* **Tests**
  * Added automated validation tests for CI workflow configuration and path standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->