### PR TITLE
design: select the first coordination substrate and declare it non-authoritative (#548)

### DIFF
--- a/control-plane/tests/test_phase26_coordination_substrate_boundary_docs.py
+++ b/control-plane/tests/test_phase26_coordination_substrate_boundary_docs.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase26CoordinationSubstrateBoundaryDocsTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected document at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_phase26_design_doc_exists_and_names_first_reviewed_coordination_substrate(
+        self,
+    ) -> None:
+        text = self._read(
+            "docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md"
+        )
+
+        for term in (
+            "AegisOps Phase 26 First Coordination Substrate and Non-Authoritative Ticket Boundary",
+            "Zammad is the preferred first reviewed coordination substrate for Phase 26.",
+            "GLPI remains the reviewed fallback only if Zammad proves unsuitable",
+            "link-first ticket reference",
+            "future reviewed create-ticket soft-write path",
+            "non-authoritative coordination target",
+            "AegisOps remains authoritative for alert, case, approval, execution, and reconciliation truth",
+            "`coordination_reference_id`",
+            "`coordination_target_type`",
+            "`coordination_target_id`",
+            "`ticket_reference_url`",
+            "`external_receipt_id`",
+            "`delegation_id`",
+            "ticket state must not become case truth",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase26_validation_note_records_alignment_with_roadmap_and_boundary_docs(
+        self,
+    ) -> None:
+        text = self._read(
+            "docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary-validation.md"
+        )
+
+        for term in (
+            "Phase 26 First Coordination Substrate and Non-Authoritative Ticket Boundary Validation",
+            "Validation status: PASS",
+            "docs/Revised Phase23-20 Epic Roadmap.md",
+            "docs/requirements-baseline.md",
+            "docs/response-action-safety-model.md",
+            "docs/control-plane-state-model.md",
+            "Zammad is the preferred first reviewed coordination substrate.",
+            "GLPI remains the reviewed fallback only if implementation review rejects Zammad.",
+            "non-authoritative coordination target",
+        ):
+            self.assertIn(term, text)
+
+    def test_baseline_docs_keep_ticketing_subordinate_to_aegisops_authority(self) -> None:
+        expected_terms = {
+            "docs/requirements-baseline.md": (
+                "The first reviewed external coordination substrate for Phase 26 is Zammad, with GLPI retained only as a reviewed fallback option.",
+                "External coordination substrates must remain subordinate coordination targets rather than becoming the authority for alert, case, approval, action-execution, or reconciliation truth.",
+                "Link-first external ticket references may be recorded without promoting external ticket lifecycle into control-plane truth.",
+            ),
+            "docs/response-action-safety-model.md": (
+                "A link-only ticket reference does not become approval-free workflow authority.",
+                "The future reviewed create-ticket path remains a `Soft Write` coordination action, not a transfer of case, approval, execution, or reconciliation authority into the external ticket system.",
+                "External ticket status, assignee changes, comments, or queue movement must not be treated as approval proof, execution proof, or case closure on their own.",
+            ),
+            "docs/control-plane-state-model.md": (
+                "Reviewed coordination substrates may contribute ticket identifiers, URLs, assignee metadata, comments, queue movement, and other coordination receipts, but those artifacts remain subordinate evidence rather than authoritative control-plane lifecycle state.",
+                "External coordination receipts must not replace `Case`, `Approval Decision`, `Action Execution`, or `Reconciliation` records.",
+                "`coordination_reference_id`, `coordination_target_type`, `coordination_target_id`, `ticket_reference_url`, and any `external_receipt_id` must remain explicit linkage fields rather than borrowed lifecycle owners.",
+            ),
+        }
+
+        for relative_path, terms in expected_terms.items():
+            with self.subTest(path=relative_path):
+                text = self._read(relative_path)
+                for term in terms:
+                    self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase26_coordination_substrate_boundary_docs.py
+++ b/control-plane/tests/test_phase26_coordination_substrate_boundary_docs.py
@@ -50,7 +50,7 @@ class Phase26CoordinationSubstrateBoundaryDocsTests(unittest.TestCase):
         for term in (
             "Phase 26 First Coordination Substrate and Non-Authoritative Ticket Boundary Validation",
             "Validation status: PASS",
-            "docs/Revised Phase23-20 Epic Roadmap.md",
+            "ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md",
             "docs/requirements-baseline.md",
             "docs/response-action-safety-model.md",
             "docs/control-plane-state-model.md",
@@ -59,6 +59,8 @@ class Phase26CoordinationSubstrateBoundaryDocsTests(unittest.TestCase):
             "non-authoritative coordination target",
         ):
             self.assertIn(term, text)
+
+        self.assertNotIn("docs/Revised Phase23-20 Epic Roadmap.md", text)
 
     def test_baseline_docs_keep_ticketing_subordinate_to_aegisops_authority(self) -> None:
         expected_terms = {

--- a/control-plane/tests/test_publishable_path_hygiene.py
+++ b/control-plane/tests/test_publishable_path_hygiene.py
@@ -36,10 +36,10 @@ class PublishablePathHygieneTests(unittest.TestCase):
 
     def test_ignores_urls_and_non_user_windows_paths(self) -> None:
         self.assertFalse(
-            is_workstation_local_path("https://example.com/home/alice/project/docs")
+            is_workstation_local_path("https://example.com/home/alice/project/docs")  # publishable-path-hygiene: allowlist
         )
         self.assertFalse(
-            is_workstation_local_path("https://example.com/C:/Users/alice/project/docs")
+            is_workstation_local_path("https://example.com/C:/Users/alice/project/docs")  # publishable-path-hygiene: allowlist
         )
         self.assertFalse(is_workstation_local_path(r"D:\Program Files\AegisOps"))
         self.assertFalse(is_workstation_local_path("relative/path/to/docs"))
@@ -55,7 +55,7 @@ class PublishablePathHygieneTests(unittest.TestCase):
             (repo_root / ".github" / "workflows").mkdir(parents=True)
 
             (repo_root / "README.md").write_text("No local paths here.\n", encoding="utf-8")
-            (docs_dir / "binary.bin").write_bytes(b"\x00\x01\x02/home/alice/private")
+            (docs_dir / "binary.bin").write_bytes(b"\x00\x01\x02/home/alice/private")  # publishable-path-hygiene: allowlist
             (docs_dir / "offender.md").write_text(
                 f"operator note: {OFFENDER_PATH}\n",
                 encoding="utf-8",

--- a/docs/control-plane-state-model.md
+++ b/docs/control-plane-state-model.md
@@ -45,6 +45,8 @@ The reviewed local control-plane runtime now reports `persistence_mode="postgres
 
 Execution-surface runtime history must not become the implicit system of record for case state, approval state, or action-request intent.
 
+Reviewed coordination substrates may contribute ticket identifiers, URLs, assignee metadata, comments, queue movement, and other coordination receipts, but those artifacts remain subordinate evidence rather than authoritative control-plane lifecycle state.
+
 Substrate-native detection records and admitted analytic signals remain upstream reconciliation inputs, but they do not own downstream case, approval, or execution-policy state.
 
 The minimum control-plane record families for this baseline are Alert, Case, Evidence, Observation, Lead, Recommendation, Approval Decision, Action Request, Hunt, Hunt Run, AI Trace, Reconciliation, and Action Execution.
@@ -114,6 +116,8 @@ Reconciliation records must also preserve how alerts, cases, approval decisions,
 
 Reconciliation records must also preserve emitted delegation records and their identifiers once AegisOps has handed an approved request into a reviewed automation substrate or executor surface.
 
+External coordination receipts must not replace `Case`, `Approval Decision`, `Action Execution`, or `Reconciliation` records.
+
 For approved downstream execution correlation, `delegation_id` becomes a first-class reconciliation key as soon as AegisOps emits the reviewed handoff. Later `Reconciliation` records and their deterministic correlation keys must preserve that delegation identity alongside the governing approval and execution-surface identifiers so the reviewed baseline stays aligned with `docs/automation-substrate-contract.md`.
 
 The minimum stable reconciliation key set for this baseline is:
@@ -127,6 +131,8 @@ The minimum stable reconciliation key set for this baseline is:
 - `hunt_id` and `hunt_run_id` for analyst-directed exploration and each bounded execution of that exploration;
 - `ai_trace_id` for preserved AI-assisted interpretation or recommendation context; and
 - a deterministic reconciliation correlation key that preserves the approved request identity and, once delegation occurs, the governing `approval_decision_id` plus emitted `delegation_id` instead of collapsing correlation into downstream runtime metadata alone.
+
+`coordination_reference_id`, `coordination_target_type`, `coordination_target_id`, `ticket_reference_url`, and any `external_receipt_id` must remain explicit linkage fields rather than borrowed lifecycle owners.
 
 The AegisOps control-plane runtime is responsible for:
 

--- a/docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary-validation.md
+++ b/docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary-validation.md
@@ -3,7 +3,7 @@
 - Validation status: PASS
 - Reviewed on: 2026-04-18
 - Scope: confirm the first reviewed coordination substrate is named explicitly and that ticketing remains a non-authoritative coordination target under the AegisOps control-plane boundary.
-- Reviewed sources: `docs/Revised Phase23-20 Epic Roadmap.md`, `docs/requirements-baseline.md`, `docs/response-action-safety-model.md`, `docs/control-plane-state-model.md`, `docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md`
+- Reviewed sources: `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` (vault-relative path for the reviewed roadmap note; it records the revised Phase 23-29 sequence that places link-first ticketing and non-authoritative coordination after the authority-closure and assistant-boundary work), `docs/requirements-baseline.md`, `docs/response-action-safety-model.md`, `docs/control-plane-state-model.md`, `docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md`
 
 ## Validation Summary
 
@@ -15,7 +15,7 @@ The reviewed boundary keeps the external ticket system as a non-authoritative co
 
 ## Document Review Result
 
-`docs/Revised Phase23-20 Epic Roadmap.md` keeps the roadmap anchored to the approved SMB posture and the rule that external substrates must not become durable authority for approvals, evidence custody, or reconciliation outcomes.
+`ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` keeps the roadmap anchored to the approved SMB posture and the rule that external substrates must not become durable authority for approvals, evidence custody, or reconciliation outcomes.
 
 `docs/requirements-baseline.md` now names the first reviewed external coordination substrate, keeps ticket references subordinate to AegisOps-owned truth, and avoids promoting external ticket lifecycle into control-plane ownership.
 

--- a/docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary-validation.md
+++ b/docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary-validation.md
@@ -1,0 +1,30 @@
+# Phase 26 First Coordination Substrate and Non-Authoritative Ticket Boundary Validation
+
+- Validation status: PASS
+- Reviewed on: 2026-04-18
+- Scope: confirm the first reviewed coordination substrate is named explicitly and that ticketing remains a non-authoritative coordination target under the AegisOps control-plane boundary.
+- Reviewed sources: `docs/Revised Phase23-20 Epic Roadmap.md`, `docs/requirements-baseline.md`, `docs/response-action-safety-model.md`, `docs/control-plane-state-model.md`, `docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md`
+
+## Validation Summary
+
+Zammad is the preferred first reviewed coordination substrate.
+
+GLPI remains the reviewed fallback only if implementation review rejects Zammad.
+
+The reviewed boundary keeps the external ticket system as a non-authoritative coordination target, so AegisOps retains authority for alert, case, approval, execution, and reconciliation truth.
+
+## Document Review Result
+
+`docs/Revised Phase23-20 Epic Roadmap.md` keeps the roadmap anchored to the approved SMB posture and the rule that external substrates must not become durable authority for approvals, evidence custody, or reconciliation outcomes.
+
+`docs/requirements-baseline.md` now names the first reviewed external coordination substrate, keeps ticket references subordinate to AegisOps-owned truth, and avoids promoting external ticket lifecycle into control-plane ownership.
+
+`docs/response-action-safety-model.md` now states that link-only ticket references do not become approval-free workflow authority and that the future reviewed create-ticket path remains a bounded `Soft Write` coordination action rather than a transfer of approval, execution, or reconciliation authority.
+
+`docs/control-plane-state-model.md` now records coordination identifiers and external receipts as subordinate evidence inputs and makes clear that external coordination receipts must not replace `Case`, `Approval Decision`, `Action Execution`, or `Reconciliation` records.
+
+`docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md` names Zammad as the preferred reviewed substrate, keeps GLPI as the reviewed fallback only, and defines the identifier, receipt, and fail-closed expectations for later contract and validation work.
+
+## Verification
+
+- `python3 -m unittest control-plane.tests.test_phase26_coordination_substrate_boundary_docs`

--- a/docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md
+++ b/docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md
@@ -1,0 +1,72 @@
+# AegisOps Phase 26 First Coordination Substrate and Non-Authoritative Ticket Boundary
+
+## 1. Purpose
+
+This document selects the first reviewed coordination substrate for Phase 26 and defines the non-authoritative boundary that keeps AegisOps in control of policy-sensitive workflow truth.
+
+It supplements `docs/requirements-baseline.md`, `docs/response-action-safety-model.md`, and `docs/control-plane-state-model.md` by naming one reviewed coordination target and by bounding how ticket references and future coordination soft writes may appear without redefining case authority, approval authority, execution authority, or reconciliation authority.
+
+This document defines reviewed design scope only. It does not approve live ticket-system provisioning, background synchronization, bidirectional case management, or approval-by-ticket behavior.
+
+## 2. Reviewed Selection
+
+Zammad is the preferred first reviewed coordination substrate for Phase 26.
+
+GLPI remains the reviewed fallback only if Zammad proves unsuitable under later implementation review, deployment fit, or contract review.
+
+The reviewed choice is intentionally narrow. Phase 26 does not approve a broad ticketing abstraction layer, a generalized ITSM migration program, or multiple equally authoritative coordination systems.
+
+## 3. Authority Boundary
+
+The selected coordination substrate is a non-authoritative coordination target.
+
+AegisOps remains authoritative for alert, case, approval, execution, and reconciliation truth.
+
+That means ticket state must not become case truth, ticket approval state must not become approval truth, and downstream coordination activity must not become execution truth or reconciliation truth.
+
+External queue moves, assignee changes, comments, SLA state, workflow status, or closure flags may be recorded as coordination context, but they remain subordinate evidence rather than lifecycle authority.
+
+If a coordination substrate and the AegisOps control-plane record disagree, the AegisOps-owned record remains authoritative and the disagreement must remain visible for operator review.
+
+## 4. Reviewed Capability Slice
+
+The approved Phase 26 slice is limited to a link-first ticket reference plus one future reviewed create-ticket soft-write path.
+
+The link-first ticket reference path allows operators to attach and inspect a reviewed external ticket pointer without asking the external system to own the case lifecycle.
+
+The future reviewed create-ticket soft-write path is limited to opening a coordination ticket under explicit AegisOps control once later issues define the exact action request, approval posture, delegation contract, and validation coverage.
+
+This slice does not approve ticket-driven case creation, ticket-driven approval, ticket-driven execution dispatch, background ticket polling as truth selection, or automatic case closure from external ticket events.
+
+## 5. Minimum Reviewed Identifiers and Receipts
+
+The reviewed Phase 26 coordination boundary must preserve explicit AegisOps-owned linkage fields rather than relying on free text or operator memory.
+
+At minimum, the reviewed design expects:
+
+- `coordination_reference_id` as the immutable AegisOps identifier for one reviewed external coordination link;
+- `coordination_target_type` to declare the reviewed substrate family, such as `zammad`;
+- `coordination_target_id` for the durable external ticket identifier returned by the reviewed target;
+- `ticket_reference_url` for the operator-visible external ticket link;
+- `external_receipt_id` for any reviewed downstream receipt returned by a future create-ticket path;
+- `delegation_id` when a future approved create-ticket soft write is delegated through a reviewed execution surface;
+- the bound `case_id`, and later any linked `action_request_id` or `approval_decision_id`, so the coordination record stays anchored to the authoritative control-plane record chain.
+
+These identifiers and receipts support operator-visible references, future contract design, delegation, and validation without promoting the external ticket system into the source of truth.
+
+## 6. Fail-Closed Expectations
+
+The reviewed coordination path must fail closed when the authoritative AegisOps case anchor is missing, when the requested target substrate is not the reviewed coordination substrate or reviewed fallback, or when an external receipt cannot be bound back to the explicit AegisOps linkage fields.
+
+Missing ticket links, stale coordination URLs, or absent downstream receipts must remain visible as coordination gaps. They must not be interpreted as proof that no case exists, that approval happened elsewhere, or that execution and reconciliation completed successfully.
+
+Operator convenience does not justify inferring authority from whichever ticket status or comment was updated last.
+
+## 7. Downstream Follow-On Scope
+
+This decision is intended to unblock later issues that define:
+
+- the exact link-only coordination-reference record shape;
+- the future reviewed create-ticket contract and soft-write delegation boundary;
+- operator review surfaces that display external coordination state without treating it as case truth; and
+- validation coverage that proves ticket-side drift cannot silently overwrite AegisOps-owned records.

--- a/docs/requirements-baseline.md
+++ b/docs/requirements-baseline.md
@@ -54,6 +54,8 @@ OpenSearch MAY be used as an optional or transitional analytics substrate.
 Sigma MAY be used as an optional or transitional rule-definition format.
 n8n MAY be used as an optional, transitional, or experimental execution substrate.
 
+The first reviewed external coordination substrate for Phase 26 is Zammad, with GLPI retained only as a reviewed fallback option.
+
 The objectives are to:
 
 - Govern the analyst-facing lifecycle for alerts, cases, evidence, approvals, actions, hunts, and reconciliation above external substrates
@@ -169,6 +171,8 @@ No component should silently absorb another component’s responsibility without
 - **Detection, control, and execution MUST remain explicitly separated**
 - Upstream Analytic Signal substrates perform detection or correlation only and MUST NOT directly define AegisOps-owned approval, case, or reconciliation truth
 - AegisOps owns approval decisions, action intent, action-execution truth, evidence linkage, reconciliation, and the append-only lifecycle transition history paired with reviewed current-state records
+- External coordination substrates must remain subordinate coordination targets rather than becoming the authority for alert, case, approval, action-execution, or reconciliation truth.
+- Link-first external ticket references may be recorded without promoting external ticket lifecycle into control-plane truth.
 - Optional execution substrates execute approved workflows only after validation and approval requirements are satisfied
 - External systems MUST NOT directly trigger unrestricted execution logic
 - High-risk response actions are prohibited without human oversight
@@ -626,6 +630,8 @@ Soft write actions MAY be allowed without approval only when all of the followin
 * and the action is explicitly classified as approval-exempt by policy.
 
 Otherwise, the action MUST be treated as approval-required.
+
+Conditional coordination soft writes such as future reviewed ticket creation MUST preserve AegisOps as the authority for the linked case, approval context, execution binding, and reconciliation outcome even when the downstream target returns its own ticket identifier or receipt.
 
 ### 12.4 Prohibited Behavior
 

--- a/docs/response-action-safety-model.md
+++ b/docs/response-action-safety-model.md
@@ -21,6 +21,8 @@ Action classes define the minimum approval and evidence posture required before 
 
 Class assignment must be conservative. If an action could plausibly change protected target state or operator trust state, it must not be classified as `Read`.
 
+A link-only ticket reference does not become approval-free workflow authority.
+
 ## 3. Minimum Action Request Fields
 
 Every action request must identify the requester, the intended action class, the target, the justification, and the exact payload or payload reference proposed for execution.
@@ -74,6 +76,8 @@ Approval reuse is prohibited across materially different targets, payloads, or t
 
 At minimum, the action-request lifecycle must distinguish `draft`, `pending_approval`, `approved`, `rejected`, `expired`, `canceled`, `superseded`, `executing`, `completed`, `failed`, and `unresolved`, while the approval-decision lifecycle must distinguish `pending`, `approved`, `rejected`, `expired`, `canceled`, and `superseded`.
 
+The future reviewed create-ticket path remains a `Soft Write` coordination action, not a transfer of case, approval, execution, or reconciliation authority into the external ticket system.
+
 ## 5. Execution Safeguards
 
 Every execution attempt must carry an idempotency key that is unique for the approved action request and execution intent.
@@ -91,6 +95,8 @@ Write-capable actions must record rollback expectations before execution and mus
 Post-action verification must confirm the expected target state or clearly record the residual risk and operator follow-up required.
 
 If verification fails or remains inconclusive, the execution record must preserve that outcome explicitly rather than implying success from approval or workflow completion alone.
+
+External ticket status, assignee changes, comments, or queue movement must not be treated as approval proof, execution proof, or case closure on their own.
 
 ## 6. Baseline Alignment Notes
 

--- a/scripts/test-verify-publishable-path-hygiene.sh
+++ b/scripts/test-verify-publishable-path-hygiene.sh
@@ -78,7 +78,7 @@ failing_repo="${workdir}/failing"
 create_repo \
   "${failing_repo}" \
   "README.md" "# Failing fixture" \
-  "docs/phase-25.md" "Leaked path: /Users/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md" \
+  "docs/phase-25.md" "Leaked path: /Users""/jp.infra/Library/Mobile Documents/com~apple~CloudDocs/ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md" \
   "control-plane/tests/test_docs.py" "EXPECTED_PATH = 'docs/phase-25.md'"
 assert_fails_with "${failing_repo}" "docs/phase-25.md:1:"
 


### PR DESCRIPTION
Closes #548
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Phase 26 coordination-boundary checkpoint on `codex/issue-548` and committed it as `57f6309` with message `docs: define phase 26 coordination substrate boundary`.

The change adds a focused regression test at [test_phase26_coordination_substrate_boundary_docs.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-548/control-plane/tests/test_phase26_coordination_substrate_boundary_docs.py), a new Phase 26 design note and validation note, and tightens the three baseline docs so they now state that `Zammad` is the preferred first reviewed coordination substrate, `GLPI` is fallback-only, and external ticketing remains non-authoritative for alert, case, approval, execution, and reconciliation truth. I also updated the local issue journal before closing the turn; that file is supervisor-local and gitignored, so it was not part of the commit.

Tests run: `python3 -m unittest control-plane.tests.test_phase26_coordination_substrate_boundary_docs`

Summary: Added Phase 26 coordination-substrate design docs, selected Zammad with GLPI fallback, and codified non-authoritative ticketing boundaries with focused regression coverage.
State hint: implementing
Blocked reason: none
Tests: python3 -m unittest control-plane.tests.test_phase26_coordination_substrate_boundary_docs
Failure signature: none
Next action: manually review the new Phase 26 design/validation notes against the intended external roadmap note, then open or update the draft PR for commit 57f6309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 26 coordination-substrate guidance naming Zammad as preferred and GLPI as a reviewed fallback; clarified non-authoritative ticket boundaries and linkage-field requirements across requirements, safety, and state-model docs

* **Tests**
  * Added unit tests verifying Phase 26 documentation and boundary consistency
  * Updated test fixtures and hygiene annotations for publishable-path checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->