### PR TITLE
implementation: add link-only external ticket reference on alert and case (#549)

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import importlib
 import json
 from typing import Any, Callable, Iterator, Mapping, Protocol, Type, TypeVar
+from urllib.parse import urlparse
 
 from ..models import (
     AITraceRecord,
@@ -300,6 +301,13 @@ _RECONCILIATION_INGEST_DISPOSITIONS = frozenset(
         "stale",
     }
 )
+_REVIEWED_COORDINATION_TARGET_TYPES = frozenset({"glpi", "zammad"})
+_COORDINATION_REFERENCE_FIELD_MAX_LENGTHS = {
+    "coordination_reference_id": 128,
+    "coordination_target_type": 32,
+    "coordination_target_id": 256,
+    "ticket_reference_url": 2048,
+}
 
 _LIFECYCLE_TRANSITION_SUBJECT_FAMILIES = frozenset(
     family
@@ -501,6 +509,7 @@ def _validate_record(record: ControlPlaneRecord) -> None:
                 )
         return
     if isinstance(record, CaseRecord):
+        _validate_coordination_reference_fields(record)
         _require_any_linkage(record, ("finding_id", "alert_id"))
         _require_non_empty_tuple(record, "evidence_ids")
         return
@@ -571,10 +580,79 @@ def _validate_record(record: ControlPlaneRecord) -> None:
         return
     if isinstance(
         record,
-        (AlertRecord, HuntRecord, HuntRunRecord, AITraceRecord),
+        (HuntRecord, HuntRunRecord, AITraceRecord),
     ):
         return
+    if isinstance(record, AlertRecord):
+        _validate_coordination_reference_fields(record)
+        return
     raise TypeError(f"Unsupported control-plane record type: {type(record).__name__}")
+
+
+def _validate_coordination_reference_fields(
+    record: AlertRecord | CaseRecord,
+) -> None:
+    normalized_values: dict[str, str | None] = {}
+    present_fields: list[str] = []
+    for field_name, max_length in _COORDINATION_REFERENCE_FIELD_MAX_LENGTHS.items():
+        raw_value = getattr(record, field_name)
+        if raw_value is None:
+            normalized_values[field_name] = None
+            continue
+        if not isinstance(raw_value, str):
+            raise ValueError(
+                f"{record.record_family} record {record.record_id!r} requires "
+                f"{field_name} to be a string when provided"
+            )
+        normalized_value = raw_value.strip()
+        if not normalized_value:
+            raise ValueError(
+                f"{record.record_family} record {record.record_id!r} requires "
+                f"{field_name} to be non-blank when provided"
+            )
+        if len(normalized_value) > max_length:
+            raise ValueError(
+                f"{record.record_family} record {record.record_id!r} requires "
+                f"{field_name} length <= {max_length}"
+            )
+        normalized_values[field_name] = normalized_value
+        present_fields.append(field_name)
+
+    if not present_fields:
+        return
+
+    missing_fields = tuple(
+        field_name
+        for field_name in _COORDINATION_REFERENCE_FIELD_MAX_LENGTHS
+        if normalized_values[field_name] is None
+    )
+    if missing_fields:
+        raise ValueError(
+            f"{record.record_family} record {record.record_id!r} requires a complete "
+            f"external ticket reference when any coordination field is present; "
+            f"missing {missing_fields!r}"
+        )
+
+    coordination_target_type = normalized_values["coordination_target_type"]
+    assert coordination_target_type is not None
+    if coordination_target_type not in _REVIEWED_COORDINATION_TARGET_TYPES:
+        raise ValueError(
+            f"{record.record_family} record {record.record_id!r} has unsupported "
+            f"coordination_target_type {coordination_target_type!r}; expected one of "
+            f"{sorted(_REVIEWED_COORDINATION_TARGET_TYPES)!r}"
+        )
+
+    ticket_reference_url = normalized_values["ticket_reference_url"]
+    assert ticket_reference_url is not None
+    parsed_ticket_reference_url = urlparse(ticket_reference_url)
+    if (
+        parsed_ticket_reference_url.scheme != "https"
+        or not parsed_ticket_reference_url.netloc
+    ):
+        raise ValueError(
+            f"{record.record_family} record {record.record_id!r} requires "
+            "ticket_reference_url to be an https URL with a network location"
+        )
 
 
 def _load_default_connection_factory() -> ConnectionFactory:

--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timezone
 import importlib
 import json
+import re
 from typing import Any, Callable, Iterator, Mapping, Protocol, Type, TypeVar
 from urllib.parse import urlparse
 
@@ -115,6 +116,10 @@ def _readiness_reconciliation_sort_key(
 ConnectionFactory = Callable[[str], ConnectionProtocol]
 _ALLOWED_TRANSACTION_ISOLATION_LEVELS = frozenset(
     {"READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"}
+)
+_TICKET_REFERENCE_URL_PATTERN = re.compile(
+    r"^https://[^/?#\s]+([/?#][^\s]*)?$",
+    re.IGNORECASE,
 )
 
 
@@ -650,6 +655,11 @@ def _normalize_coordination_reference_record(
 
     ticket_reference_url = normalized_values["ticket_reference_url"]
     assert ticket_reference_url is not None
+    if _TICKET_REFERENCE_URL_PATTERN.fullmatch(ticket_reference_url) is None:
+        raise ValueError(
+            f"{record.record_family} record {record.record_id!r} requires "
+            "ticket_reference_url to be an https URL with a network location"
+        )
     parsed_ticket_reference_url = urlparse(ticket_reference_url)
     if (
         parsed_ticket_reference_url.scheme != "https"

--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextvars import ContextVar
 from contextlib import contextmanager
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timezone
 import importlib
 import json
@@ -592,6 +592,12 @@ def _validate_record(record: ControlPlaneRecord) -> None:
 def _validate_coordination_reference_fields(
     record: AlertRecord | CaseRecord,
 ) -> None:
+    _normalize_coordination_reference_record(record)
+
+
+def _normalize_coordination_reference_record(
+    record: AlertRecord | CaseRecord,
+) -> AlertRecord | CaseRecord:
     normalized_values: dict[str, str | None] = {}
     present_fields: list[str] = []
     for field_name, max_length in _COORDINATION_REFERENCE_FIELD_MAX_LENGTHS.items():
@@ -619,7 +625,7 @@ def _validate_coordination_reference_fields(
         present_fields.append(field_name)
 
     if not present_fields:
-        return
+        return record
 
     missing_fields = tuple(
         field_name
@@ -653,6 +659,8 @@ def _validate_coordination_reference_fields(
             f"{record.record_family} record {record.record_id!r} requires "
             "ticket_reference_url to be an https URL with a network location"
         )
+
+    return replace(record, **normalized_values)
 
 
 def _load_default_connection_factory() -> ConnectionFactory:
@@ -859,6 +867,8 @@ class PostgresControlPlaneStore:
         return record_type(**kwargs)
 
     def save(self, record: RecordT) -> RecordT:
+        if isinstance(record, (AlertRecord, CaseRecord)):
+            record = _normalize_coordination_reference_record(record)
         _validate_record(record)
         table = self._table_config(type(record))
         field_names = table.record_fields

--- a/control-plane/aegisops_control_plane/models.py
+++ b/control-plane/aegisops_control_plane/models.py
@@ -45,6 +45,10 @@ class AlertRecord(ControlPlaneRecord):
     analytic_signal_id: str | None
     case_id: str | None
     lifecycle_state: str
+    coordination_reference_id: str | None = None
+    coordination_target_type: str | None = None
+    coordination_target_id: str | None = None
+    ticket_reference_url: str | None = None
     reviewed_context: Mapping[str, object] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -107,6 +111,10 @@ class CaseRecord(ControlPlaneRecord):
     finding_id: str | None
     evidence_ids: tuple[str, ...]
     lifecycle_state: str
+    coordination_reference_id: str | None = None
+    coordination_target_type: str | None = None
+    coordination_target_id: str | None = None
+    ticket_reference_url: str | None = None
     reviewed_context: Mapping[str, object] = field(default_factory=dict)
 
     def __post_init__(self) -> None:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -290,6 +290,7 @@ class AlertDetailSnapshot:
     lifecycle_transitions: tuple[dict[str, object], ...]
     current_action_review: dict[str, object] | None
     action_reviews: tuple[dict[str, object], ...]
+    external_ticket_reference: dict[str, object]
 
     def to_dict(self) -> dict[str, object]:
         return _json_ready(
@@ -311,6 +312,7 @@ class AlertDetailSnapshot:
                 "lifecycle_transitions": self.lifecycle_transitions,
                 "current_action_review": self.current_action_review,
                 "action_reviews": self.action_reviews,
+                "external_ticket_reference": self.external_ticket_reference,
             }
         )
 
@@ -339,6 +341,7 @@ class CaseDetailSnapshot:
     provenance_summary: dict[str, object]
     current_action_review: dict[str, object] | None
     action_reviews: tuple[dict[str, object], ...]
+    external_ticket_reference: dict[str, object]
 
     def to_dict(self) -> dict[str, object]:
         return _json_ready(
@@ -365,6 +368,7 @@ class CaseDetailSnapshot:
                 "provenance_summary": self.provenance_summary,
                 "current_action_review": self.current_action_review,
                 "action_reviews": self.action_reviews,
+                "external_ticket_reference": self.external_ticket_reference,
             }
         )
 
@@ -849,6 +853,51 @@ def _record_to_dict(record: ControlPlaneRecord) -> dict[str, object]:
         field.name: getattr(record, field.name)
         for field in fields(record)
     }
+
+
+def _coordination_reference_payload(
+    record: Mapping[str, object] | ControlPlaneRecord | None,
+) -> dict[str, str] | None:
+    if record is None:
+        return None
+    if isinstance(record, Mapping):
+        payload = record
+    else:
+        payload = _record_to_dict(record)
+
+    coordination_reference_id = payload.get("coordination_reference_id")
+    coordination_target_type = payload.get("coordination_target_type")
+    coordination_target_id = payload.get("coordination_target_id")
+    ticket_reference_url = payload.get("ticket_reference_url")
+    if not all(
+        isinstance(value, str) and value.strip()
+        for value in (
+            coordination_reference_id,
+            coordination_target_type,
+            coordination_target_id,
+            ticket_reference_url,
+        )
+    ):
+        return None
+    return {
+        "coordination_reference_id": coordination_reference_id.strip(),
+        "coordination_target_type": coordination_target_type.strip(),
+        "coordination_target_id": coordination_target_id.strip(),
+        "ticket_reference_url": ticket_reference_url.strip(),
+    }
+
+
+def _coordination_target_signature(
+    record: Mapping[str, object] | ControlPlaneRecord | None,
+) -> tuple[str, str, str] | None:
+    payload = _coordination_reference_payload(record)
+    if payload is None:
+        return None
+    return (
+        payload["coordination_target_type"],
+        payload["coordination_target_id"],
+        payload["ticket_reference_url"],
+    )
 
 
 def _redacted_reconciliation_payload(
@@ -4206,6 +4255,127 @@ class AegisOpsControlPlaneService:
             records=tuple(queue_records),
         )
 
+    def _build_alert_external_ticket_reference_surface(
+        self,
+        *,
+        alert: AlertRecord,
+        case_record: CaseRecord | None,
+    ) -> dict[str, object]:
+        alert_reference = _coordination_reference_payload(alert)
+        case_reference = _coordination_reference_payload(case_record)
+        if alert_reference is None and case_reference is None:
+            status = "missing"
+        elif alert_reference is None:
+            status = "linked_case_reference_only"
+        elif case_record is None:
+            status = "present"
+        elif case_reference is None:
+            status = "linked_case_reference_missing"
+        elif _coordination_target_signature(alert) != _coordination_target_signature(
+            case_record
+        ):
+            status = "linked_case_reference_mismatch"
+        else:
+            status = "present"
+        return {
+            "authority": "non_authoritative",
+            "status": status,
+            "coordination_reference_id": (
+                alert_reference["coordination_reference_id"]
+                if alert_reference is not None
+                else None
+            ),
+            "coordination_target_type": (
+                alert_reference["coordination_target_type"]
+                if alert_reference is not None
+                else None
+            ),
+            "coordination_target_id": (
+                alert_reference["coordination_target_id"]
+                if alert_reference is not None
+                else None
+            ),
+            "ticket_reference_url": (
+                alert_reference["ticket_reference_url"]
+                if alert_reference is not None
+                else None
+            ),
+            "linked_case_id": case_record.case_id if case_record is not None else None,
+            "linked_case_reference": case_reference,
+        }
+
+    def _build_case_external_ticket_reference_surface(
+        self,
+        *,
+        case: CaseRecord,
+        linked_alert_records: tuple[dict[str, object], ...],
+    ) -> dict[str, object]:
+        case_reference = _coordination_reference_payload(case)
+        linked_alert_references = tuple(
+            {
+                "alert_id": str(record.get("alert_id")),
+                **reference,
+            }
+            for record in linked_alert_records
+            for reference in (_coordination_reference_payload(record),)
+            if reference is not None
+        )
+        if case_reference is None and not linked_alert_references:
+            status = "missing"
+        elif case_reference is None:
+            status = "linked_alert_reference_only"
+        else:
+            linked_alert_signatures = {
+                (
+                    reference["coordination_target_type"],
+                    reference["coordination_target_id"],
+                    reference["ticket_reference_url"],
+                )
+                for reference in linked_alert_references
+            }
+            linked_alert_ids = {
+                str(record.get("alert_id"))
+                for record in linked_alert_records
+                if isinstance(record.get("alert_id"), str)
+            }
+            linked_alert_ids_with_reference = {
+                reference["alert_id"] for reference in linked_alert_references
+            }
+            if linked_alert_ids - linked_alert_ids_with_reference:
+                status = "linked_alert_reference_missing"
+            elif linked_alert_signatures and linked_alert_signatures != {
+                _coordination_target_signature(case)
+            }:
+                status = "linked_alert_reference_mismatch"
+            else:
+                status = "present"
+
+        return {
+            "authority": "non_authoritative",
+            "status": status,
+            "coordination_reference_id": (
+                case_reference["coordination_reference_id"]
+                if case_reference is not None
+                else None
+            ),
+            "coordination_target_type": (
+                case_reference["coordination_target_type"]
+                if case_reference is not None
+                else None
+            ),
+            "coordination_target_id": (
+                case_reference["coordination_target_id"]
+                if case_reference is not None
+                else None
+            ),
+            "ticket_reference_url": (
+                case_reference["ticket_reference_url"]
+                if case_reference is not None
+                else None
+            ),
+            "linked_alert_references": linked_alert_references,
+        }
+
     def inspect_alert_detail(self, alert_id: str) -> AlertDetailSnapshot:
         alert_id = self._require_non_empty_string(alert_id, "alert_id")
         alert = self._store.get(AlertRecord, alert_id)
@@ -4312,6 +4482,10 @@ class AegisOpsControlPlaneService:
             ),
             current_action_review=dict(action_reviews[0]) if action_reviews else None,
             action_reviews=action_reviews,
+            external_ticket_reference=self._build_alert_external_ticket_reference_surface(
+                alert=alert,
+                case_record=case_record,
+            ),
         )
 
     def inspect_assistant_context(
@@ -4374,6 +4548,10 @@ class AegisOpsControlPlaneService:
             provenance_summary=provenance_summary,
             current_action_review=dict(action_reviews[0]) if action_reviews else None,
             action_reviews=action_reviews,
+            external_ticket_reference=self._build_case_external_ticket_reference_surface(
+                case=case,
+                linked_alert_records=context_snapshot.linked_alert_records,
+            ),
         )
 
     def _build_case_cross_source_surfaces(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4321,29 +4321,34 @@ class AegisOpsControlPlaneService:
             for reference in (_coordination_reference_payload(record),)
             if reference is not None
         )
+        linked_alert_signatures = {
+            (
+                reference["coordination_reference_id"],
+                reference["coordination_target_type"],
+                reference["coordination_target_id"],
+                reference["ticket_reference_url"],
+            )
+            for reference in linked_alert_references
+        }
+        linked_alert_ids = {
+            str(record.get("alert_id"))
+            for record in linked_alert_records
+            if isinstance(record.get("alert_id"), str)
+        }
+        linked_alert_ids_with_reference = {
+            reference["alert_id"] for reference in linked_alert_references
+        }
+        missing_linked_alert_ids = linked_alert_ids - linked_alert_ids_with_reference
         if case_reference is None and not linked_alert_references:
             status = "missing"
+        elif case_reference is None and missing_linked_alert_ids:
+            status = "linked_alert_reference_missing"
+        elif case_reference is None and len(linked_alert_signatures) > 1:
+            status = "linked_alert_reference_mismatch"
         elif case_reference is None:
             status = "linked_alert_reference_only"
         else:
-            linked_alert_signatures = {
-                (
-                    reference["coordination_reference_id"],
-                    reference["coordination_target_type"],
-                    reference["coordination_target_id"],
-                    reference["ticket_reference_url"],
-                )
-                for reference in linked_alert_references
-            }
-            linked_alert_ids = {
-                str(record.get("alert_id"))
-                for record in linked_alert_records
-                if isinstance(record.get("alert_id"), str)
-            }
-            linked_alert_ids_with_reference = {
-                reference["alert_id"] for reference in linked_alert_references
-            }
-            if linked_alert_ids - linked_alert_ids_with_reference:
+            if missing_linked_alert_ids:
                 status = "linked_alert_reference_missing"
             elif linked_alert_signatures and linked_alert_signatures != {
                 _coordination_reference_signature(case)

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -887,13 +887,14 @@ def _coordination_reference_payload(
     }
 
 
-def _coordination_target_signature(
+def _coordination_reference_signature(
     record: Mapping[str, object] | ControlPlaneRecord | None,
-) -> tuple[str, str, str] | None:
+) -> tuple[str, str, str, str] | None:
     payload = _coordination_reference_payload(record)
     if payload is None:
         return None
     return (
+        payload["coordination_reference_id"],
         payload["coordination_target_type"],
         payload["coordination_target_id"],
         payload["ticket_reference_url"],
@@ -4271,9 +4272,9 @@ class AegisOpsControlPlaneService:
             status = "present"
         elif case_reference is None:
             status = "linked_case_reference_missing"
-        elif _coordination_target_signature(alert) != _coordination_target_signature(
-            case_record
-        ):
+        elif _coordination_reference_signature(
+            alert
+        ) != _coordination_reference_signature(case_record):
             status = "linked_case_reference_mismatch"
         else:
             status = "present"
@@ -4327,6 +4328,7 @@ class AegisOpsControlPlaneService:
         else:
             linked_alert_signatures = {
                 (
+                    reference["coordination_reference_id"],
                     reference["coordination_target_type"],
                     reference["coordination_target_id"],
                     reference["ticket_reference_url"],
@@ -4344,7 +4346,7 @@ class AegisOpsControlPlaneService:
             if linked_alert_ids - linked_alert_ids_with_reference:
                 status = "linked_alert_reference_missing"
             elif linked_alert_signatures and linked_alert_signatures != {
-                _coordination_target_signature(case)
+                _coordination_reference_signature(case)
             }:
                 status = "linked_alert_reference_mismatch"
             else:
@@ -4858,13 +4860,9 @@ class AegisOpsControlPlaneService:
             )
             if merged_case_evidence_ids != current_case.evidence_ids:
                 self.persist_record(
-                    CaseRecord(
-                        case_id=current_case.case_id,
-                        alert_id=current_case.alert_id,
-                        finding_id=current_case.finding_id,
+                    replace(
+                        current_case,
                         evidence_ids=merged_case_evidence_ids,
-                        lifecycle_state=current_case.lifecycle_state,
-                        reviewed_context=current_case.reviewed_context,
                     )
                 )
 
@@ -5106,12 +5104,8 @@ class AegisOpsControlPlaneService:
                 },
             )
             return self.persist_record(
-                CaseRecord(
-                    case_id=case.case_id,
-                    alert_id=case.alert_id,
-                    finding_id=case.finding_id,
-                    evidence_ids=case.evidence_ids,
-                    lifecycle_state=case.lifecycle_state,
+                replace(
+                    case,
                     reviewed_context=updated_reviewed_context,
                 )
             )
@@ -5141,11 +5135,8 @@ class AegisOpsControlPlaneService:
                 },
             )
             updated_case = self.persist_record(
-                CaseRecord(
-                    case_id=case.case_id,
-                    alert_id=case.alert_id,
-                    finding_id=case.finding_id,
-                    evidence_ids=case.evidence_ids,
+                replace(
+                    case,
                     lifecycle_state=lifecycle_state,
                     reviewed_context=updated_reviewed_context,
                 ),
@@ -5155,11 +5146,8 @@ class AegisOpsControlPlaneService:
                 alert = self._store.get(AlertRecord, case.alert_id)
                 if alert is not None:
                     self.persist_record(
-                        AlertRecord(
-                            alert_id=alert.alert_id,
-                            finding_id=alert.finding_id,
-                            analytic_signal_id=alert.analytic_signal_id,
-                            case_id=alert.case_id,
+                        replace(
+                            alert,
                             lifecycle_state="closed",
                             reviewed_context=_merge_reviewed_context(
                                 alert.reviewed_context,
@@ -6679,30 +6667,31 @@ class AegisOpsControlPlaneService:
                 )
 
             promoted_case = self.persist_record(
-                CaseRecord(
+                replace(
+                    existing_case,
+                    alert_id=alert.alert_id,
+                    finding_id=alert.finding_id,
+                    evidence_ids=merged_case_evidence_ids,
+                    reviewed_context=_merge_reviewed_context(
+                        existing_case.reviewed_context,
+                        alert.reviewed_context,
+                    ),
+                )
+                if existing_case is not None
+                else CaseRecord(
                     case_id=resolved_case_id,
                     alert_id=alert.alert_id,
                     finding_id=alert.finding_id,
                     evidence_ids=merged_case_evidence_ids,
-                    lifecycle_state=(
-                        existing_case.lifecycle_state
-                        if existing_case is not None
-                        else case_lifecycle_state
-                    ),
-                    reviewed_context=_merge_reviewed_context(
-                        existing_case.reviewed_context if existing_case is not None else {},
-                        alert.reviewed_context,
-                    ),
+                    lifecycle_state=case_lifecycle_state,
+                    reviewed_context=alert.reviewed_context,
                 )
             )
             promoted_alert = self.persist_record(
-                AlertRecord(
-                    alert_id=alert.alert_id,
-                    finding_id=alert.finding_id,
-                    analytic_signal_id=alert.analytic_signal_id,
+                replace(
+                    alert,
                     case_id=promoted_case.case_id,
                     lifecycle_state="escalated_to_case",
-                    reviewed_context=alert.reviewed_context,
                 )
             )
             if promoted_alert.analytic_signal_id is not None:
@@ -6918,24 +6907,18 @@ class AegisOpsControlPlaneService:
             )
             if materially_new_work:
                 alert = self.persist_record(
-                    AlertRecord(
-                        alert_id=alert.alert_id,
+                    replace(
+                        alert,
                         finding_id=finding_id,
                         analytic_signal_id=analytic_signal_id,
-                        case_id=alert.case_id,
-                        lifecycle_state=alert.lifecycle_state,
                         reviewed_context=merged_reviewed_context,
                     )
                 )
                 disposition = "updated"
             elif merged_reviewed_context != alert.reviewed_context:
                 alert = self.persist_record(
-                    AlertRecord(
-                        alert_id=alert.alert_id,
-                        finding_id=alert.finding_id,
-                        analytic_signal_id=alert.analytic_signal_id,
-                        case_id=alert.case_id,
-                        lifecycle_state=alert.lifecycle_state,
+                    replace(
+                        alert,
                         reviewed_context=merged_reviewed_context,
                     )
                 )
@@ -6954,12 +6937,8 @@ class AegisOpsControlPlaneService:
                     )
                     if merged_case_reviewed_context != existing_case.reviewed_context:
                         self.persist_record(
-                            CaseRecord(
-                                case_id=existing_case.case_id,
-                                alert_id=existing_case.alert_id,
-                                finding_id=existing_case.finding_id,
-                                evidence_ids=existing_case.evidence_ids,
-                                lifecycle_state=existing_case.lifecycle_state,
+                            replace(
+                                existing_case,
                                 reviewed_context=merged_case_reviewed_context,
                             )
                         )
@@ -7088,12 +7067,9 @@ class AegisOpsControlPlaneService:
                     or merged_case_reviewed_context != existing_case.reviewed_context
                 ):
                     self.persist_record(
-                        CaseRecord(
-                            case_id=existing_case.case_id,
-                            alert_id=existing_case.alert_id,
-                            finding_id=existing_case.finding_id,
+                        replace(
+                            existing_case,
                             evidence_ids=merged_case_evidence_ids,
-                            lifecycle_state=existing_case.lifecycle_state,
                             reviewed_context=merged_case_reviewed_context,
                         )
                     )
@@ -7582,24 +7558,9 @@ class AegisOpsControlPlaneService:
             context_record.reviewed_context,
             reviewed_context_update,
         )
-        if isinstance(context_record, CaseRecord):
-            return self.persist_record(
-                CaseRecord(
-                    case_id=context_record.case_id,
-                    alert_id=context_record.alert_id,
-                    finding_id=context_record.finding_id,
-                    evidence_ids=context_record.evidence_ids,
-                    lifecycle_state=context_record.lifecycle_state,
-                    reviewed_context=updated_reviewed_context,
-                )
-            )
         return self.persist_record(
-            AlertRecord(
-                alert_id=context_record.alert_id,
-                finding_id=context_record.finding_id,
-                analytic_signal_id=context_record.analytic_signal_id,
-                case_id=context_record.case_id,
-                lifecycle_state=context_record.lifecycle_state,
+            replace(
+                context_record,
                 reviewed_context=updated_reviewed_context,
             )
         )

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -292,7 +292,7 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
         ):
             self.assertIn(required_column, schema_sql)
         https_host_pattern = (
-            "or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'"
+            "or ticket_reference_url ~* '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'"
         )
         self.assertIn(https_host_pattern, migration_sql)
         self.assertIn(https_host_pattern, schema_sql)

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -256,6 +256,42 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
         self.assertIn("decision_rationale text", schema_sql)
         self.assertIn("decision_rationale text", bootstrap_sql)
 
+    def test_phase26_external_ticket_reference_forward_migration_asset_exists(
+        self,
+    ) -> None:
+        migration_path = (
+            CONTROL_PLANE_ROOT.parent
+            / "postgres"
+            / "control-plane"
+            / "migrations"
+            / "0009_phase_26_external_ticket_reference_columns.sql"
+        )
+
+        self.assertTrue(
+            migration_path.exists(),
+            f"Missing Phase 26 forward migration asset: {migration_path}",
+        )
+
+        migration_sql = migration_path.read_text(encoding="utf-8").lower()
+        schema_sql = (
+            CONTROL_PLANE_ROOT.parent / "postgres" / "control-plane" / "schema.sql"
+        ).read_text(encoding="utf-8").lower()
+
+        self.assertIn("begin;", migration_sql)
+        self.assertIn("commit;", migration_sql)
+        for table_name in ("alert_records", "case_records"):
+            self.assertIn(
+                f"alter table if exists aegisops_control.{table_name}",
+                migration_sql,
+            )
+        for required_column in (
+            "coordination_reference_id text",
+            "coordination_target_type text",
+            "coordination_target_id text",
+            "ticket_reference_url text",
+        ):
+            self.assertIn(required_column, schema_sql)
+
     def test_phase23_lifecycle_transition_forward_migration_asset_exists(self) -> None:
         migration_path = (
             CONTROL_PLANE_ROOT.parent

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -1739,6 +1739,49 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
         )
         self.assertEqual(reloaded, persisted)
 
+    def test_store_allows_uppercase_https_ticket_reference_scheme(self) -> None:
+        store, _ = make_store()
+
+        persisted = store.save(
+            AlertRecord(
+                alert_id="alert-ticket-link-uppercase-001",
+                finding_id="finding-ticket-link-uppercase-001",
+                analytic_signal_id="signal-ticket-link-uppercase-001",
+                case_id=None,
+                lifecycle_state="new",
+                coordination_reference_id="coord-ref-uppercase-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-5150",
+                ticket_reference_url="HTTPS://tickets.example.test/#ticket/5150",
+            )
+        )
+
+        self.assertEqual(
+            persisted.ticket_reference_url,
+            "HTTPS://tickets.example.test/#ticket/5150",
+        )
+
+    def test_store_rejects_ticket_reference_url_with_embedded_spaces(self) -> None:
+        store, _ = make_store()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "ticket_reference_url to be an https URL with a network location",
+        ):
+            store.save(
+                AlertRecord(
+                    alert_id="alert-ticket-link-space-001",
+                    finding_id="finding-ticket-link-space-001",
+                    analytic_signal_id="signal-ticket-link-space-001",
+                    case_id=None,
+                    lifecycle_state="new",
+                    coordination_reference_id="coord-ref-space-001",
+                    coordination_target_type="zammad",
+                    coordination_target_id="ZM-5151",
+                    ticket_reference_url="https://tickets.example.test/ticket 5151",
+                )
+            )
+
     def test_store_rejects_nested_isolation_level_requests(self) -> None:
         store, _ = make_store()
 

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -291,6 +291,11 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
             "ticket_reference_url text",
         ):
             self.assertIn(required_column, schema_sql)
+        https_host_pattern = (
+            "or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'"
+        )
+        self.assertIn(https_host_pattern, migration_sql)
+        self.assertIn(https_host_pattern, schema_sql)
 
     def test_phase23_lifecycle_transition_forward_migration_asset_exists(self) -> None:
         migration_path = (
@@ -1704,6 +1709,35 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
 
         self.assertIsNone(store.get(AlertRecord, "alert-001"))
         self.assertEqual(store.list(AlertRecord), ())
+
+    def test_store_normalizes_external_ticket_reference_fields_before_persistence(
+        self,
+    ) -> None:
+        store, _ = make_store()
+
+        persisted = store.save(
+            AlertRecord(
+                alert_id="alert-ticket-link-001",
+                finding_id="finding-ticket-link-001",
+                analytic_signal_id="signal-ticket-link-001",
+                case_id=None,
+                lifecycle_state="new",
+                coordination_reference_id=" coord-ref-001 ",
+                coordination_target_type=" zammad ",
+                coordination_target_id=" ZM-4242 ",
+                ticket_reference_url=" https://tickets.example.test/#ticket/4242 ",
+            )
+        )
+        reloaded = store.get(AlertRecord, persisted.alert_id)
+
+        self.assertEqual(persisted.coordination_reference_id, "coord-ref-001")
+        self.assertEqual(persisted.coordination_target_type, "zammad")
+        self.assertEqual(persisted.coordination_target_id, "ZM-4242")
+        self.assertEqual(
+            persisted.ticket_reference_url,
+            "https://tickets.example.test/#ticket/4242",
+        )
+        self.assertEqual(reloaded, persisted)
 
     def test_store_rejects_nested_isolation_level_requests(self) -> None:
         store, _ = make_store()

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -2827,6 +2827,108 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             "ZM-4242",
         )
 
+    def test_service_detail_flags_missing_linked_alert_reference_when_case_has_none(
+        self,
+    ) -> None:
+        store, service, promoted_case, _, reviewed_at = self._build_phase19_in_scope_case()
+        primary_alert = service.get_record(AlertRecord, promoted_case.alert_id)
+        assert primary_alert is not None
+        service.persist_record(
+            replace(
+                primary_alert,
+                coordination_reference_id="coord-ref-alert-004",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+        service.persist_record(
+            replace(
+                primary_alert,
+                alert_id="alert-phase26-linked-missing-002",
+                finding_id="finding-phase26-linked-missing-002",
+                analytic_signal_id="signal-phase26-linked-missing-002",
+            )
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase26-linked-missing-002",
+                source_record_id="source-phase26-linked-missing-002",
+                alert_id="alert-phase26-linked-missing-002",
+                case_id=promoted_case.case_id,
+                source_system="reviewed-source",
+                collector_identity="control-plane-test",
+                acquired_at=reviewed_at,
+                derivation_relationship="correlated_case_context",
+                lifecycle_state="linked",
+            )
+        )
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+
+        self.assertEqual(
+            case_detail.external_ticket_reference["status"],
+            "linked_alert_reference_missing",
+        )
+        self.assertEqual(len(case_detail.linked_alert_records), 2)
+
+    def test_service_detail_flags_mismatched_linked_alert_references_when_case_has_none(
+        self,
+    ) -> None:
+        store, service, promoted_case, _, reviewed_at = self._build_phase19_in_scope_case()
+        primary_alert = service.get_record(AlertRecord, promoted_case.alert_id)
+        assert primary_alert is not None
+        service.persist_record(
+            replace(
+                primary_alert,
+                coordination_reference_id="coord-ref-alert-005",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+        service.persist_record(
+            replace(
+                primary_alert,
+                alert_id="alert-phase26-linked-mismatch-002",
+                finding_id="finding-phase26-linked-mismatch-002",
+                analytic_signal_id="signal-phase26-linked-mismatch-002",
+                coordination_reference_id="coord-ref-alert-006",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-5150",
+                ticket_reference_url="https://tickets.example.test/#ticket/5150",
+            )
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase26-linked-mismatch-002",
+                source_record_id="source-phase26-linked-mismatch-002",
+                alert_id="alert-phase26-linked-mismatch-002",
+                case_id=promoted_case.case_id,
+                source_system="reviewed-source",
+                collector_identity="control-plane-test",
+                acquired_at=reviewed_at,
+                derivation_relationship="correlated_case_context",
+                lifecycle_state="linked",
+            )
+        )
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+
+        self.assertEqual(
+            case_detail.external_ticket_reference["status"],
+            "linked_alert_reference_mismatch",
+        )
+        self.assertEqual(
+            {
+                reference["coordination_target_id"]
+                for reference in case_detail.external_ticket_reference[
+                    "linked_alert_references"
+                ]
+            },
+            {"ZM-4242", "ZM-5150"},
+        )
+
     def test_service_rejects_unreviewed_external_ticket_target_type(self) -> None:
         store, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
 

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+from datetime import timedelta
 import pathlib
 import sys
 
@@ -9,6 +11,7 @@ if str(TESTS_ROOT) not in sys.path:
 
 import _service_persistence_support as support
 from _service_persistence_support import ServicePersistenceTestBase
+from aegisops_control_plane.models import AlertRecord, AnalyticSignalRecord, CaseRecord
 
 for name, value in vars(support).items():
     if not (name.startswith("__") and name.endswith("__")):
@@ -2681,7 +2684,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         service.persist_record(
             replace(
                 service.get_record(CaseRecord, promoted_case.case_id),
-                coordination_reference_id="coord-ref-case-001",
+                coordination_reference_id="coord-ref-alert-001",
                 coordination_target_type="zammad",
                 coordination_target_id="ZM-4242",
                 ticket_reference_url="https://tickets.example.test/#ticket/4242",
@@ -2709,11 +2712,11 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         )
         self.assertEqual(
             alert_detail.case_record["coordination_reference_id"],
-            "coord-ref-case-001",
+            "coord-ref-alert-001",
         )
         self.assertEqual(
             case_detail.case_record["coordination_reference_id"],
-            "coord-ref-case-001",
+            "coord-ref-alert-001",
         )
         self.assertEqual(
             case_detail.case_record["coordination_target_type"],
@@ -2738,6 +2741,48 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(
             case_detail.external_ticket_reference["status"],
             "present",
+        )
+
+    def test_service_detail_treats_distinct_coordination_reference_ids_as_mismatch(
+        self,
+    ) -> None:
+        store, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+
+        service.persist_record(
+            replace(
+                service.get_record(AlertRecord, promoted_case.alert_id),
+                coordination_reference_id="coord-ref-alert-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+        service.persist_record(
+            replace(
+                service.get_record(CaseRecord, promoted_case.case_id),
+                coordination_reference_id="coord-ref-case-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+
+        alert_detail = service.inspect_alert_detail(promoted_case.alert_id)
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+
+        self.assertEqual(
+            alert_detail.external_ticket_reference["status"],
+            "linked_case_reference_mismatch",
+        )
+        self.assertEqual(
+            case_detail.external_ticket_reference["status"],
+            "linked_alert_reference_mismatch",
+        )
+        self.assertEqual(
+            case_detail.external_ticket_reference["linked_alert_references"][0][
+                "coordination_reference_id"
+            ],
+            "coord-ref-alert-001",
         )
 
     def test_service_detail_keeps_mismatched_external_ticket_reference_explicit(
@@ -2798,6 +2843,119 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
                     ticket_reference_url="https://tickets.example.test/browse/JIRA-123",
                 )
             )
+
+    def test_service_preserves_external_ticket_reference_during_ingest_updates(
+        self,
+    ) -> None:
+        store, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+
+        service.persist_record(
+            replace(
+                service.get_record(AlertRecord, promoted_case.alert_id),
+                coordination_reference_id="coord-ref-shared-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+        service.persist_record(
+            replace(
+                service.get_record(CaseRecord, promoted_case.case_id),
+                coordination_reference_id="coord-ref-shared-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+
+        alert = service.get_record(AlertRecord, promoted_case.alert_id)
+        signal = service.get_record(AnalyticSignalRecord, alert.analytic_signal_id)
+        self.assertIsNotNone(signal)
+
+        updated = service.ingest_finding_alert(
+            finding_id=alert.finding_id,
+            analytic_signal_id=alert.analytic_signal_id,
+            substrate_detection_record_id=signal.substrate_detection_record_id,
+            correlation_key=signal.correlation_key,
+            first_seen_at=signal.first_seen_at,
+            last_seen_at=signal.last_seen_at,
+            materially_new_work=True,
+            reviewed_context={"triage": {"owner": "coordination-review"}},
+        )
+
+        refreshed_alert = service.get_record(AlertRecord, updated.alert.alert_id)
+        refreshed_case = service.get_record(CaseRecord, promoted_case.case_id)
+
+        self.assertEqual(
+            refreshed_alert.coordination_reference_id,
+            "coord-ref-shared-001",
+        )
+        self.assertEqual(
+            refreshed_case.coordination_reference_id,
+            "coord-ref-shared-001",
+        )
+        self.assertEqual(refreshed_alert.coordination_target_type, "zammad")
+        self.assertEqual(refreshed_case.coordination_target_id, "ZM-4242")
+        self.assertEqual(
+            refreshed_case.ticket_reference_url,
+            "https://tickets.example.test/#ticket/4242",
+        )
+
+    def test_service_preserves_external_ticket_reference_during_case_rewrites(
+        self,
+    ) -> None:
+        store, service, promoted_case, _, reviewed_at = self._build_phase19_in_scope_case()
+
+        service.persist_record(
+            replace(
+                service.get_record(AlertRecord, promoted_case.alert_id),
+                coordination_reference_id="coord-ref-shared-002",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-5150",
+                ticket_reference_url="https://tickets.example.test/#ticket/5150",
+            )
+        )
+        service.persist_record(
+            replace(
+                service.get_record(CaseRecord, promoted_case.case_id),
+                coordination_reference_id="coord-ref-shared-002",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-5150",
+                ticket_reference_url="https://tickets.example.test/#ticket/5150",
+            )
+        )
+
+        handed_off_case = service.record_case_handoff(
+            case_id=promoted_case.case_id,
+            handoff_at=reviewed_at,
+            handoff_owner="analyst-002",
+            handoff_note="Escalated to coordination review.",
+        )
+        closed_case = service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="closed_resolved",
+            rationale="Linked ticket reviewed and closed.",
+            recorded_at=reviewed_at + timedelta(minutes=1),
+        )
+        closed_alert = service.get_record(AlertRecord, promoted_case.alert_id)
+
+        self.assertEqual(
+            handed_off_case.coordination_reference_id,
+            "coord-ref-shared-002",
+        )
+        self.assertEqual(
+            closed_case.coordination_reference_id,
+            "coord-ref-shared-002",
+        )
+        self.assertEqual(
+            closed_alert.coordination_reference_id,
+            "coord-ref-shared-002",
+        )
+        self.assertEqual(closed_alert.coordination_target_id, "ZM-5150")
+        self.assertEqual(
+            closed_alert.ticket_reference_url,
+            "https://tickets.example.test/#ticket/5150",
+        )
 
     def test_service_analyst_queue_ignores_newer_action_execution_reconciliation(self) -> None:
         store, _ = make_store()

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -2663,15 +2663,141 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         }
 
         self.assertNotIn(sibling_evidence.evidence_id, linked_evidence_ids)
-        self.assertNotIn(sibling_evidence.evidence_id, detail.lineage["evidence_ids"])
-        self.assertEqual(
-            linked_evidence_ids,
-            {
-                evidence.evidence_id
-                for evidence in store.list(EvidenceRecord)
-                if evidence.alert_id == admitted.alert.alert_id
-            },
+
+    def test_service_detail_surfaces_link_only_external_ticket_reference_on_alert_and_case(
+        self,
+    ) -> None:
+        store, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+
+        service.persist_record(
+            replace(
+                service.get_record(AlertRecord, promoted_case.alert_id),
+                coordination_reference_id="coord-ref-alert-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
         )
+        service.persist_record(
+            replace(
+                service.get_record(CaseRecord, promoted_case.case_id),
+                coordination_reference_id="coord-ref-case-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+
+        alert_detail = service.inspect_alert_detail(promoted_case.alert_id)
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+
+        self.assertEqual(
+            alert_detail.alert["coordination_reference_id"],
+            "coord-ref-alert-001",
+        )
+        self.assertEqual(
+            alert_detail.alert["coordination_target_type"],
+            "zammad",
+        )
+        self.assertEqual(
+            alert_detail.alert["coordination_target_id"],
+            "ZM-4242",
+        )
+        self.assertEqual(
+            alert_detail.alert["ticket_reference_url"],
+            "https://tickets.example.test/#ticket/4242",
+        )
+        self.assertEqual(
+            alert_detail.case_record["coordination_reference_id"],
+            "coord-ref-case-001",
+        )
+        self.assertEqual(
+            case_detail.case_record["coordination_reference_id"],
+            "coord-ref-case-001",
+        )
+        self.assertEqual(
+            case_detail.case_record["coordination_target_type"],
+            "zammad",
+        )
+        self.assertEqual(
+            case_detail.case_record["coordination_target_id"],
+            "ZM-4242",
+        )
+        self.assertEqual(
+            case_detail.case_record["ticket_reference_url"],
+            "https://tickets.example.test/#ticket/4242",
+        )
+        self.assertEqual(
+            case_detail.linked_alert_records[0]["coordination_reference_id"],
+            "coord-ref-alert-001",
+        )
+        self.assertEqual(
+            alert_detail.external_ticket_reference["status"],
+            "present",
+        )
+        self.assertEqual(
+            case_detail.external_ticket_reference["status"],
+            "present",
+        )
+
+    def test_service_detail_keeps_mismatched_external_ticket_reference_explicit(
+        self,
+    ) -> None:
+        store, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+
+        service.persist_record(
+            replace(
+                service.get_record(AlertRecord, promoted_case.alert_id),
+                coordination_reference_id="coord-ref-alert-002",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+        service.persist_record(
+            replace(
+                service.get_record(CaseRecord, promoted_case.case_id),
+                coordination_reference_id="coord-ref-case-002",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-5150",
+                ticket_reference_url="https://tickets.example.test/#ticket/5150",
+            )
+        )
+
+        alert_detail = service.inspect_alert_detail(promoted_case.alert_id)
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+
+        self.assertEqual(
+            alert_detail.external_ticket_reference["status"],
+            "linked_case_reference_mismatch",
+        )
+        self.assertEqual(
+            case_detail.external_ticket_reference["status"],
+            "linked_alert_reference_mismatch",
+        )
+        self.assertEqual(
+            case_detail.external_ticket_reference["linked_alert_references"][0][
+                "coordination_target_id"
+            ],
+            "ZM-4242",
+        )
+
+    def test_service_rejects_unreviewed_external_ticket_target_type(self) -> None:
+        store, service, promoted_case, _, _ = self._build_phase19_in_scope_case()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"unsupported coordination_target_type 'jira'",
+        ):
+            service.persist_record(
+                replace(
+                    service.get_record(AlertRecord, promoted_case.alert_id),
+                    coordination_reference_id="coord-ref-alert-003",
+                    coordination_target_type="jira",
+                    coordination_target_id="JIRA-123",
+                    ticket_reference_url="https://tickets.example.test/browse/JIRA-123",
+                )
+            )
 
     def test_service_analyst_queue_ignores_newer_action_execution_reconciliation(self) -> None:
         store, _ = make_store()

--- a/postgres/control-plane/migrations/0009_phase_26_external_ticket_reference_columns.sql
+++ b/postgres/control-plane/migrations/0009_phase_26_external_ticket_reference_columns.sql
@@ -45,7 +45,7 @@ alter table if exists aegisops_control.alert_records
 alter table if exists aegisops_control.alert_records
   add constraint alert_records_ticket_reference_url_https check (
     ticket_reference_url is null
-    or ticket_reference_url ~ '^https://[^[:space:]]+$'
+    or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
   );
 
 alter table if exists aegisops_control.alert_records
@@ -129,7 +129,7 @@ alter table if exists aegisops_control.case_records
 alter table if exists aegisops_control.case_records
   add constraint case_records_ticket_reference_url_https check (
     ticket_reference_url is null
-    or ticket_reference_url ~ '^https://[^[:space:]]+$'
+    or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
   );
 
 alter table if exists aegisops_control.case_records

--- a/postgres/control-plane/migrations/0009_phase_26_external_ticket_reference_columns.sql
+++ b/postgres/control-plane/migrations/0009_phase_26_external_ticket_reference_columns.sql
@@ -1,0 +1,171 @@
+begin;
+
+alter table if exists aegisops_control.alert_records
+  add column if not exists coordination_reference_id text;
+
+alter table if exists aegisops_control.alert_records
+  add column if not exists coordination_target_type text;
+
+alter table if exists aegisops_control.alert_records
+  add column if not exists coordination_target_id text;
+
+alter table if exists aegisops_control.alert_records
+  add column if not exists ticket_reference_url text;
+
+alter table if exists aegisops_control.alert_records
+  drop constraint if exists alert_records_coordination_reference_fields_complete;
+
+alter table if exists aegisops_control.alert_records
+  add constraint alert_records_coordination_reference_fields_complete check (
+    (
+      coordination_reference_id is null
+      and coordination_target_type is null
+      and coordination_target_id is null
+      and ticket_reference_url is null
+    ) or (
+      nullif(btrim(coordination_reference_id), '') is not null
+      and nullif(btrim(coordination_target_type), '') is not null
+      and nullif(btrim(coordination_target_id), '') is not null
+      and nullif(btrim(ticket_reference_url), '') is not null
+    )
+  );
+
+alter table if exists aegisops_control.alert_records
+  drop constraint if exists alert_records_coordination_target_type_reviewed;
+
+alter table if exists aegisops_control.alert_records
+  add constraint alert_records_coordination_target_type_reviewed check (
+    coordination_target_type is null
+    or coordination_target_type in ('glpi', 'zammad')
+  );
+
+alter table if exists aegisops_control.alert_records
+  drop constraint if exists alert_records_ticket_reference_url_https;
+
+alter table if exists aegisops_control.alert_records
+  add constraint alert_records_ticket_reference_url_https check (
+    ticket_reference_url is null
+    or ticket_reference_url ~ '^https://[^[:space:]]+$'
+  );
+
+alter table if exists aegisops_control.alert_records
+  drop constraint if exists alert_records_coordination_reference_id_bounded;
+
+alter table if exists aegisops_control.alert_records
+  add constraint alert_records_coordination_reference_id_bounded check (
+    coordination_reference_id is null
+    or char_length(coordination_reference_id) <= 128
+  );
+
+alter table if exists aegisops_control.alert_records
+  drop constraint if exists alert_records_coordination_target_type_bounded;
+
+alter table if exists aegisops_control.alert_records
+  add constraint alert_records_coordination_target_type_bounded check (
+    coordination_target_type is null
+    or char_length(coordination_target_type) <= 32
+  );
+
+alter table if exists aegisops_control.alert_records
+  drop constraint if exists alert_records_coordination_target_id_bounded;
+
+alter table if exists aegisops_control.alert_records
+  add constraint alert_records_coordination_target_id_bounded check (
+    coordination_target_id is null
+    or char_length(coordination_target_id) <= 256
+  );
+
+alter table if exists aegisops_control.alert_records
+  drop constraint if exists alert_records_ticket_reference_url_bounded;
+
+alter table if exists aegisops_control.alert_records
+  add constraint alert_records_ticket_reference_url_bounded check (
+    ticket_reference_url is null
+    or char_length(ticket_reference_url) <= 2048
+  );
+
+alter table if exists aegisops_control.case_records
+  add column if not exists coordination_reference_id text;
+
+alter table if exists aegisops_control.case_records
+  add column if not exists coordination_target_type text;
+
+alter table if exists aegisops_control.case_records
+  add column if not exists coordination_target_id text;
+
+alter table if exists aegisops_control.case_records
+  add column if not exists ticket_reference_url text;
+
+alter table if exists aegisops_control.case_records
+  drop constraint if exists case_records_coordination_reference_fields_complete;
+
+alter table if exists aegisops_control.case_records
+  add constraint case_records_coordination_reference_fields_complete check (
+    (
+      coordination_reference_id is null
+      and coordination_target_type is null
+      and coordination_target_id is null
+      and ticket_reference_url is null
+    ) or (
+      nullif(btrim(coordination_reference_id), '') is not null
+      and nullif(btrim(coordination_target_type), '') is not null
+      and nullif(btrim(coordination_target_id), '') is not null
+      and nullif(btrim(ticket_reference_url), '') is not null
+    )
+  );
+
+alter table if exists aegisops_control.case_records
+  drop constraint if exists case_records_coordination_target_type_reviewed;
+
+alter table if exists aegisops_control.case_records
+  add constraint case_records_coordination_target_type_reviewed check (
+    coordination_target_type is null
+    or coordination_target_type in ('glpi', 'zammad')
+  );
+
+alter table if exists aegisops_control.case_records
+  drop constraint if exists case_records_ticket_reference_url_https;
+
+alter table if exists aegisops_control.case_records
+  add constraint case_records_ticket_reference_url_https check (
+    ticket_reference_url is null
+    or ticket_reference_url ~ '^https://[^[:space:]]+$'
+  );
+
+alter table if exists aegisops_control.case_records
+  drop constraint if exists case_records_coordination_reference_id_bounded;
+
+alter table if exists aegisops_control.case_records
+  add constraint case_records_coordination_reference_id_bounded check (
+    coordination_reference_id is null
+    or char_length(coordination_reference_id) <= 128
+  );
+
+alter table if exists aegisops_control.case_records
+  drop constraint if exists case_records_coordination_target_type_bounded;
+
+alter table if exists aegisops_control.case_records
+  add constraint case_records_coordination_target_type_bounded check (
+    coordination_target_type is null
+    or char_length(coordination_target_type) <= 32
+  );
+
+alter table if exists aegisops_control.case_records
+  drop constraint if exists case_records_coordination_target_id_bounded;
+
+alter table if exists aegisops_control.case_records
+  add constraint case_records_coordination_target_id_bounded check (
+    coordination_target_id is null
+    or char_length(coordination_target_id) <= 256
+  );
+
+alter table if exists aegisops_control.case_records
+  drop constraint if exists case_records_ticket_reference_url_bounded;
+
+alter table if exists aegisops_control.case_records
+  add constraint case_records_ticket_reference_url_bounded check (
+    ticket_reference_url is null
+    or char_length(ticket_reference_url) <= 2048
+  );
+
+commit;

--- a/postgres/control-plane/migrations/0009_phase_26_external_ticket_reference_columns.sql
+++ b/postgres/control-plane/migrations/0009_phase_26_external_ticket_reference_columns.sql
@@ -45,7 +45,7 @@ alter table if exists aegisops_control.alert_records
 alter table if exists aegisops_control.alert_records
   add constraint alert_records_ticket_reference_url_https check (
     ticket_reference_url is null
-    or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
+    or ticket_reference_url ~* '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
   );
 
 alter table if exists aegisops_control.alert_records
@@ -129,7 +129,7 @@ alter table if exists aegisops_control.case_records
 alter table if exists aegisops_control.case_records
   add constraint case_records_ticket_reference_url_https check (
     ticket_reference_url is null
-    or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
+    or ticket_reference_url ~* '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
   );
 
 alter table if exists aegisops_control.case_records

--- a/postgres/control-plane/schema.sql
+++ b/postgres/control-plane/schema.sql
@@ -36,7 +36,7 @@ create table if not exists aegisops_control.alert_records (
   ),
   constraint alert_records_ticket_reference_url_https check (
     ticket_reference_url is null
-    or ticket_reference_url ~ '^https://[^[:space:]]+$'
+    or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
   ),
   constraint alert_records_coordination_reference_id_bounded check (
     coordination_reference_id is null
@@ -112,7 +112,7 @@ create table if not exists aegisops_control.case_records (
   ),
   constraint case_records_ticket_reference_url_https check (
     ticket_reference_url is null
-    or ticket_reference_url ~ '^https://[^[:space:]]+$'
+    or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
   ),
   constraint case_records_coordination_reference_id_bounded check (
     coordination_reference_id is null

--- a/postgres/control-plane/schema.sql
+++ b/postgres/control-plane/schema.sql
@@ -36,7 +36,7 @@ create table if not exists aegisops_control.alert_records (
   ),
   constraint alert_records_ticket_reference_url_https check (
     ticket_reference_url is null
-    or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
+    or ticket_reference_url ~* '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
   ),
   constraint alert_records_coordination_reference_id_bounded check (
     coordination_reference_id is null
@@ -112,7 +112,7 @@ create table if not exists aegisops_control.case_records (
   ),
   constraint case_records_ticket_reference_url_https check (
     ticket_reference_url is null
-    or ticket_reference_url ~ '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
+    or ticket_reference_url ~* '^https://[^/?#[:space:]]+([/?#][^[:space:]]*)?$'
   ),
   constraint case_records_coordination_reference_id_bounded check (
     coordination_reference_id is null

--- a/postgres/control-plane/schema.sql
+++ b/postgres/control-plane/schema.sql
@@ -9,10 +9,51 @@ create table if not exists aegisops_control.alert_records (
   finding_id text not null,
   analytic_signal_id text,
   case_id text,
+  coordination_reference_id text,
+  coordination_target_type text,
+  coordination_target_id text,
+  ticket_reference_url text,
   reviewed_context jsonb not null default '{}'::jsonb,
   lifecycle_state text not null,
   created_at timestamptz not null default timezone('utc', now()),
   updated_at timestamptz not null default timezone('utc', now()),
+  constraint alert_records_coordination_reference_fields_complete check (
+    (
+      coordination_reference_id is null
+      and coordination_target_type is null
+      and coordination_target_id is null
+      and ticket_reference_url is null
+    ) or (
+      nullif(btrim(coordination_reference_id), '') is not null
+      and nullif(btrim(coordination_target_type), '') is not null
+      and nullif(btrim(coordination_target_id), '') is not null
+      and nullif(btrim(ticket_reference_url), '') is not null
+    )
+  ),
+  constraint alert_records_coordination_target_type_reviewed check (
+    coordination_target_type is null
+    or coordination_target_type in ('glpi', 'zammad')
+  ),
+  constraint alert_records_ticket_reference_url_https check (
+    ticket_reference_url is null
+    or ticket_reference_url ~ '^https://[^[:space:]]+$'
+  ),
+  constraint alert_records_coordination_reference_id_bounded check (
+    coordination_reference_id is null
+    or char_length(coordination_reference_id) <= 128
+  ),
+  constraint alert_records_coordination_target_type_bounded check (
+    coordination_target_type is null
+    or char_length(coordination_target_type) <= 32
+  ),
+  constraint alert_records_coordination_target_id_bounded check (
+    coordination_target_id is null
+    or char_length(coordination_target_id) <= 256
+  ),
+  constraint alert_records_ticket_reference_url_bounded check (
+    ticket_reference_url is null
+    or char_length(ticket_reference_url) <= 2048
+  ),
   check (lifecycle_state in ('new','triaged','investigating','escalated_to_case','closed','reopened','superseded'))
 );
 
@@ -42,12 +83,53 @@ create table if not exists aegisops_control.case_records (
   alert_id text,
   finding_id text,
   evidence_ids text[] not null,
+  coordination_reference_id text,
+  coordination_target_type text,
+  coordination_target_id text,
+  ticket_reference_url text,
   reviewed_context jsonb not null default '{}'::jsonb,
   lifecycle_state text not null,
   created_at timestamptz not null default timezone('utc', now()),
   updated_at timestamptz not null default timezone('utc', now()),
   check (finding_id is not null or alert_id is not null),
   check (cardinality(evidence_ids) >= 1),
+  constraint case_records_coordination_reference_fields_complete check (
+    (
+      coordination_reference_id is null
+      and coordination_target_type is null
+      and coordination_target_id is null
+      and ticket_reference_url is null
+    ) or (
+      nullif(btrim(coordination_reference_id), '') is not null
+      and nullif(btrim(coordination_target_type), '') is not null
+      and nullif(btrim(coordination_target_id), '') is not null
+      and nullif(btrim(ticket_reference_url), '') is not null
+    )
+  ),
+  constraint case_records_coordination_target_type_reviewed check (
+    coordination_target_type is null
+    or coordination_target_type in ('glpi', 'zammad')
+  ),
+  constraint case_records_ticket_reference_url_https check (
+    ticket_reference_url is null
+    or ticket_reference_url ~ '^https://[^[:space:]]+$'
+  ),
+  constraint case_records_coordination_reference_id_bounded check (
+    coordination_reference_id is null
+    or char_length(coordination_reference_id) <= 128
+  ),
+  constraint case_records_coordination_target_type_bounded check (
+    coordination_target_type is null
+    or char_length(coordination_target_type) <= 32
+  ),
+  constraint case_records_coordination_target_id_bounded check (
+    coordination_target_id is null
+    or char_length(coordination_target_id) <= 256
+  ),
+  constraint case_records_ticket_reference_url_bounded check (
+    ticket_reference_url is null
+    or char_length(ticket_reference_url) <= 2048
+  ),
   check (lifecycle_state in ('open','investigating','pending_action','contained_pending_validation','closed','reopened','superseded'))
 );
 


### PR DESCRIPTION
Closes #549
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the link-only external ticket reference slice on `codex/issue-549` and checkpointed it in commit `73f3d75` (`Add link-only external ticket references to alerts and cases`).

The change adds explicit nullable ticket-link fields to `AlertRecord` and `CaseRecord`, persists them through the PostgreSQL contract and Phase 26 migration, and surfaces a dedicated non-authoritative `external_ticket_reference` summary on alert/case detail inspection. Validation fails closed for partial references, unsupported target types, and non-HTTPS URLs. Focused tests also cover explicit mismatch visibility between alert and case references so operator surfaces do not silently normalize drift into case truth.

Summary: Added explicit link-only external ticket reference fields on alert and case, persisted them with schema/migration support, and exposed non-authoritative detail-surface status with mismatch visibility.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence_ingest_case_lifecycle.IngestCaseLifecyclePersistenceTests.test_service_detail_surfaces_link_only_external_ticket_reference_on_alert_and_case control-plane.tests.test_service_persistence_ingest_case_lifecycle.IngestCaseLifecyclePersistenceTests.test_service_detail_keeps_mismatched_external_ticket_reference_explicit control-plane.tests.test_service_persistence_ingest_case_lifecycle.IngestCaseLifecyclePersistenceTests.test_service_rejects_unreviewed_external...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External ticket reference support for alerts and cases: add coordination fields, URL handling, and status indicators in inspection responses.
  * Validation enforces HTTPS ticket URLs, trimmed text, allowed target types (glpi, zammad), length limits, and completeness across linked records.

* **Tests**
  * Added tests for validation, persistence/normalization, schema migration, and status behavior between linked alerts and cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->