### PR TITLE
design: define the first reviewed soft-write contract for create-tracking-ticket (#550)

### DIFF
--- a/control-plane/tests/test_phase26_create_tracking_ticket_soft_write_contract_docs.py
+++ b/control-plane/tests/test_phase26_create_tracking_ticket_soft_write_contract_docs.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase26CreateTrackingTicketSoftWriteContractDocsTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected document at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_create_tracking_ticket_contract_doc_exists_and_stays_narrow(self) -> None:
+        text = self._read(
+            "docs/phase-26-create-tracking-ticket-soft-write-contract.md"
+        )
+
+        for term in (
+            "# AegisOps Phase 26 First Reviewed Create-Tracking-Ticket Soft-Write Contract",
+            "This document defines the first reviewed `create_tracking_ticket` soft-write contract for the Phase 26 coordination boundary.",
+            "`create_tracking_ticket` remains a bounded `Soft Write` coordination action.",
+            "AegisOps remains authoritative for case, approval, action-execution, and reconciliation truth.",
+            "`case_id`",
+            "`coordination_reference_id`",
+            "`coordination_target_type`",
+            "`requested_payload`",
+            "`payload_hash`",
+            "`idempotency_key`",
+            "`external_receipt_id`",
+            "Only the reviewed coordination ticket create payload may leave AegisOps.",
+            "The first reviewed payload is limited to reviewed coordination fields and must not export AegisOps-owned lifecycle truth.",
+            "The downstream receipt must prove which reviewed coordination target accepted which bounded create request.",
+            "If the downstream target cannot prove whether a duplicate create request matches the same approved intent, AegisOps must fail closed",
+            "A failed, rejected, expired, or unbound create attempt must not leave durable partial truth behind inside AegisOps.",
+            "Human approval is required for the first reviewed `create_tracking_ticket` path.",
+            "This contract does not approve status synchronization, close or reopen delegation, comment synchronization, downstream case ownership, or downstream approval authority.",
+        ):
+            self.assertIn(term, text)
+
+    def test_create_tracking_ticket_contract_validation_note_records_alignment(self) -> None:
+        text = self._read(
+            "docs/phase-26-create-tracking-ticket-soft-write-contract-validation.md"
+        )
+
+        for term in (
+            "# Phase 26 First Reviewed Create-Tracking-Ticket Soft-Write Contract Validation",
+            "Validation status: PASS",
+            "docs/phase-26-create-tracking-ticket-soft-write-contract.md",
+            "docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md",
+            "docs/response-action-safety-model.md",
+            "docs/control-plane-state-model.md",
+            "`create_tracking_ticket` remains a bounded `Soft Write` coordination action.",
+            "AegisOps remains authoritative for case, approval, action-execution, and reconciliation truth.",
+            "The reviewed contract excludes status sync, close or reopen control, comment sync, and downstream truth ownership.",
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase26_create_tracking_ticket_soft_write_contract_docs.py
+++ b/control-plane/tests/test_phase26_create_tracking_ticket_soft_write_contract_docs.py
@@ -31,7 +31,6 @@ class Phase26CreateTrackingTicketSoftWriteContractDocsTests(unittest.TestCase):
             "`requested_payload`",
             "`payload_hash`",
             "`idempotency_key`",
-            "`external_receipt_id`",
             "Only the reviewed coordination ticket create payload may leave AegisOps.",
             "The first reviewed payload is limited to reviewed coordination fields and must not export AegisOps-owned lifecycle truth.",
             "The downstream receipt must prove which reviewed coordination target accepted which bounded create request.",
@@ -41,6 +40,17 @@ class Phase26CreateTrackingTicketSoftWriteContractDocsTests(unittest.TestCase):
             "This contract does not approve status synchronization, close or reopen delegation, comment synchronization, downstream case ownership, or downstream approval authority.",
         ):
             self.assertIn(term, text)
+
+        outbound_section = text.split("## 4. Idempotency, Receipt, and Reconciliation Contract")[0]
+        self.assertIn(
+            "Allowed values for this phase: `zammad` for the preferred reviewed coordination substrate or `glpi` for the reviewed fallback only.",
+            outbound_section,
+        )
+        self.assertNotIn("| `external_receipt_id` |", outbound_section)
+        self.assertIn(
+            "`external_receipt_id` is mandatory for receipt binding once the reviewed downstream target accepts the create request, and it is not part of the outbound create request payload.",
+            text,
+        )
 
     def test_create_tracking_ticket_contract_validation_note_records_alignment(self) -> None:
         text = self._read(
@@ -57,6 +67,7 @@ class Phase26CreateTrackingTicketSoftWriteContractDocsTests(unittest.TestCase):
             "`create_tracking_ticket` remains a bounded `Soft Write` coordination action.",
             "AegisOps remains authoritative for case, approval, action-execution, and reconciliation truth.",
             "The reviewed contract excludes status sync, close or reopen control, comment sync, and downstream truth ownership.",
+            'python3 -m unittest discover -s control-plane/tests -p "test_phase26_create_tracking_ticket_soft_write_contract_docs.py"',
         ):
             self.assertIn(term, text)
 

--- a/docs/phase-26-create-tracking-ticket-soft-write-contract-validation.md
+++ b/docs/phase-26-create-tracking-ticket-soft-write-contract-validation.md
@@ -27,4 +27,4 @@ The reviewed contract excludes status sync, close or reopen control, comment syn
 
 ## Verification
 
-- `python3 -m unittest control-plane.tests.test_phase26_create_tracking_ticket_soft_write_contract_docs`
+- `python3 -m unittest discover -s control-plane/tests -p "test_phase26_create_tracking_ticket_soft_write_contract_docs.py"`

--- a/docs/phase-26-create-tracking-ticket-soft-write-contract-validation.md
+++ b/docs/phase-26-create-tracking-ticket-soft-write-contract-validation.md
@@ -1,0 +1,30 @@
+# Phase 26 First Reviewed Create-Tracking-Ticket Soft-Write Contract Validation
+
+- Validation status: PASS
+- Reviewed on: 2026-04-18
+- Scope: confirm the first reviewed `create_tracking_ticket` contract stays bounded to one coordination-ticket create path, preserves AegisOps authority, and excludes broader downstream lifecycle control.
+- Reviewed sources: `docs/phase-26-create-tracking-ticket-soft-write-contract.md`, `docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md`, `docs/response-action-safety-model.md`, `docs/control-plane-state-model.md`, `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md`
+
+## Validation Summary
+
+`create_tracking_ticket` remains a bounded `Soft Write` coordination action.
+
+AegisOps remains authoritative for case, approval, action-execution, and reconciliation truth.
+
+The reviewed contract excludes status sync, close or reopen control, comment sync, and downstream truth ownership.
+
+## Document Review Result
+
+`docs/phase-26-create-tracking-ticket-soft-write-contract.md` defines one reviewed outbound create payload, explicit idempotency and receipt binding, fail-closed duplicate handling, and conservative rollback posture for ambiguous downstream outcomes.
+
+`docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md` keeps the coordination target non-authoritative and limits the broader Phase 26 slice to link-first coordination plus one future reviewed create-ticket path.
+
+`docs/response-action-safety-model.md` keeps the ticket create path inside the `Soft Write` class and preserves approval-bound execution expectations instead of allowing downstream ticket state to stand in for approval or completion.
+
+`docs/control-plane-state-model.md` keeps external coordination receipts subordinate to the authoritative `Case`, `Approval Decision`, `Action Execution`, and `Reconciliation` record families.
+
+`ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` is the roadmap anchor referenced by the existing Phase 26 validation notes for the narrowed coordination boundary and reviewed sequencing.
+
+## Verification
+
+- `python3 -m unittest control-plane.tests.test_phase26_create_tracking_ticket_soft_write_contract_docs`

--- a/docs/phase-26-create-tracking-ticket-soft-write-contract.md
+++ b/docs/phase-26-create-tracking-ticket-soft-write-contract.md
@@ -30,11 +30,10 @@ The reviewed contract is intentionally narrow. At minimum, the outbound create c
 | ---- | ---- |
 | `case_id` | Required authoritative AegisOps case anchor for the coordination action. |
 | `coordination_reference_id` | Required immutable AegisOps coordination-link identifier for the reviewed outbound create attempt. |
-| `coordination_target_type` | Required reviewed target family, constrained to the reviewed coordination substrate or reviewed fallback. |
-| `requested_payload` | Required reviewed coordination-ticket create payload or reviewed payload reference that approval covers exactly. |
+| `coordination_target_type` | Required reviewed target family. Allowed values for this phase: `zammad` for the preferred reviewed coordination substrate or `glpi` for the reviewed fallback only. |
+| `requested_payload` | Required coordination-ticket create payload or reviewed payload reference that approval covers exactly. |
 | `payload_hash` | Required integrity value that binds approval, delegation, receipt, and reconciliation to the same reviewed create payload. |
 | `idempotency_key` | Required replay-safe key for the exact approved create intent. |
-| `external_receipt_id` | Required downstream receipt identifier once the reviewed target accepts the create request. |
 
 The first reviewed payload may include only the coordination content needed to open and later inspect one external coordination ticket under explicit AegisOps control.
 
@@ -46,7 +45,9 @@ The first reviewed payload must not export approval outcomes as downstream-owned
 
 The downstream receipt must prove which reviewed coordination target accepted which bounded create request.
 
-At minimum, the downstream receipt must remain bindable to the reviewed `case_id`, `coordination_reference_id`, `coordination_target_type`, `payload_hash`, and `idempotency_key`, plus the reviewed downstream ticket identifier and operator-visible link returned by the target.
+`external_receipt_id` is mandatory for receipt binding once the reviewed downstream target accepts the create request, and it is not part of the outbound create request payload.
+
+At minimum, the downstream receipt must remain bindable to the reviewed `case_id`, `coordination_reference_id`, `coordination_target_type`, `payload_hash`, `idempotency_key`, and `external_receipt_id`, plus the reviewed downstream ticket identifier and operator-visible link returned by the target.
 
 The receipt is sufficient only for proving that a reviewed coordination target accepted or rejected one reviewed create request. It is not sufficient to prove case closure, approval satisfaction, execution success, or reconciliation completion.
 

--- a/docs/phase-26-create-tracking-ticket-soft-write-contract.md
+++ b/docs/phase-26-create-tracking-ticket-soft-write-contract.md
@@ -1,0 +1,85 @@
+# AegisOps Phase 26 First Reviewed Create-Tracking-Ticket Soft-Write Contract
+
+## 1. Purpose
+
+This document defines the first reviewed `create_tracking_ticket` soft-write contract for the Phase 26 coordination boundary.
+
+It supplements `docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md`, `docs/response-action-safety-model.md`, and `docs/control-plane-state-model.md` by making the first bounded outbound coordination write explicit before later implementation issues introduce adapters, approval wiring, or live downstream ticket creation.
+
+This document defines the reviewed soft-write contract only. It does not approve generalized ticket lifecycle control, bidirectional synchronization, approval by ticket state, or downstream case ownership.
+
+## 2. Authority and Safety Boundary
+
+`create_tracking_ticket` remains a bounded `Soft Write` coordination action.
+
+AegisOps remains authoritative for case, approval, action-execution, and reconciliation truth.
+
+The downstream coordination target is allowed to receive one reviewed create request and return one reviewed receipt. That downstream receipt is coordination evidence only; it must not become the lifecycle owner for the linked case, approval decision, action execution, or reconciliation outcome.
+
+Only the reviewed coordination ticket create payload may leave AegisOps.
+
+The first reviewed payload is limited to reviewed coordination fields and must not export AegisOps-owned lifecycle truth.
+
+That means the first reviewed path may create a coordination ticket reference, but it must not make external status, assignee, queue, closure, SLA, or comment state authoritative for AegisOps decisions.
+
+## 3. Reviewed Outbound Payload
+
+The reviewed contract is intentionally narrow. At minimum, the outbound create contract must preserve and bind:
+
+| Field | Required meaning for the first reviewed path |
+| ---- | ---- |
+| `case_id` | Required authoritative AegisOps case anchor for the coordination action. |
+| `coordination_reference_id` | Required immutable AegisOps coordination-link identifier for the reviewed outbound create attempt. |
+| `coordination_target_type` | Required reviewed target family, constrained to the reviewed coordination substrate or reviewed fallback. |
+| `requested_payload` | Required reviewed coordination-ticket create payload or reviewed payload reference that approval covers exactly. |
+| `payload_hash` | Required integrity value that binds approval, delegation, receipt, and reconciliation to the same reviewed create payload. |
+| `idempotency_key` | Required replay-safe key for the exact approved create intent. |
+| `external_receipt_id` | Required downstream receipt identifier once the reviewed target accepts the create request. |
+
+The first reviewed payload may include only the coordination content needed to open and later inspect one external coordination ticket under explicit AegisOps control.
+
+Allowed outbound content is limited to the reviewed coordination target selection, reviewed operator-visible summary and description content for the coordination ticket, reviewed severity or routing hints that remain subordinate to AegisOps truth, and the explicit AegisOps linkage values needed for later receipt binding and reconciliation.
+
+The first reviewed payload must not export approval outcomes as downstream-owned truth, must not export mutable case lifecycle as if the ticket now owns it, and must not rely on free text alone for the authoritative linkage back to AegisOps.
+
+## 4. Idempotency, Receipt, and Reconciliation Contract
+
+The downstream receipt must prove which reviewed coordination target accepted which bounded create request.
+
+At minimum, the downstream receipt must remain bindable to the reviewed `case_id`, `coordination_reference_id`, `coordination_target_type`, `payload_hash`, and `idempotency_key`, plus the reviewed downstream ticket identifier and operator-visible link returned by the target.
+
+The receipt is sufficient only for proving that a reviewed coordination target accepted or rejected one reviewed create request. It is not sufficient to prove case closure, approval satisfaction, execution success, or reconciliation completion.
+
+If the downstream target cannot prove whether a duplicate create request matches the same approved intent, AegisOps must fail closed and preserve the result as an explicit reconciliation concern instead of inferring safe deduplication.
+
+If a create attempt returns a receipt that cannot be bound back to the approved `case_id`, `coordination_reference_id`, `coordination_target_type`, `payload_hash`, and `idempotency_key`, AegisOps must reject the result as authoritative evidence for the reviewed create path and keep the mismatch visible.
+
+If a reviewed create attempt is rejected, times out, expires, or returns an ambiguous duplicate outcome, the control plane must preserve the authoritative AegisOps state chain and record the unresolved downstream outcome explicitly rather than implying success from partial downstream activity.
+
+A failed, rejected, expired, or unbound create attempt must not leave durable partial truth behind inside AegisOps.
+
+Rollback posture for the first reviewed path is conservative: do not invent downstream success, do not auto-close or auto-delete on ambiguous outcomes, and require explicit operator follow-up whenever the reviewed receipt cannot prove one clean create result for one approved intent.
+
+## 5. Approval and Policy Posture
+
+Human approval is required for the first reviewed `create_tracking_ticket` path.
+
+The approval must remain bound to one bounded create request, one reviewed coordination target, one reviewed payload hash, one reviewed idempotency key, and one authoritative `case_id`.
+
+No policy shortcut is approved in this phase for inferring that a ticket create is safe because it looks reversible, because a downstream operator asked for it in free text, or because a similar create happened previously.
+
+If provenance, target scope, approval context, or target-family binding is missing, malformed, or only partially trusted, the create path must fail closed rather than guessing the missing context.
+
+## 6. Explicit Out of Scope
+
+This contract does not approve status synchronization, close or reopen delegation, comment synchronization, downstream case ownership, or downstream approval authority.
+
+It also does not approve ticket-driven case creation, downstream truth selection based on queue or assignee state, background polling as lifecycle authority, or any broadened write path beyond one reviewed create-ticket delegation path.
+
+The first reviewed contract is intentionally limited to outbound coordination-ticket creation plus explicit receipt and reconciliation handling so later phases cannot smuggle in bidirectional truth or broad lifecycle control under the same label.
+
+## 7. Baseline Alignment Notes
+
+This contract keeps the first reviewed ticket create path aligned with the existing response-action safety model and the control-plane reconciliation model by treating the outbound create as a bounded `Soft Write`, preserving AegisOps-owned authority, and rejecting ambiguous or partially trusted receipt state.
+
+It leaves broader synchronization, closure, reopen, comment, and downstream authority questions out of scope until a later reviewed issue defines them explicitly and proves they do not weaken the current authority boundary.


### PR DESCRIPTION
Closes #550
This PR was opened by codex-supervisor.
Latest Codex summary:

Added the first reviewed `create_tracking_ticket` soft-write contract as a test-first checkpoint on `codex/issue-550`.

The change starts with a focused reproducer in [test_phase26_create_tracking_ticket_soft_write_contract_docs.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-550/control-plane/tests/test_phase26_create_tracking_ticket_soft_write_contract_docs.py), which initially failed because the contract docs did not exist. I then added [phase-26-create-tracking-ticket-soft-write-contract.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-550/docs/phase-26-create-tracking-ticket-soft-write-contract.md) and [phase-26-create-tracking-ticket-soft-write-contract-validation.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-550/docs/phase-26-create-tracking-ticket-soft-write-contract-validation.md). The contract keeps the path narrow: bounded outbound create only, explicit allowed fields and receipts, approval-bound idempotency, fail-closed duplicate/ambiguous receipt handling, and explicit exclusion of status sync, close/reopen, comment sync, and downstream truth ownership.

I also updated the local issue journal before finishing and committed the repo changes as `9aef029` with message `Add create tracking ticket soft-write contract docs`.

Summary: Added a focused failing test, implemented the first reviewed `create_tracking_ticket` soft-write contract and validation note, and verified the Phase 26 doc boundary still passes.
State hint: implementing
Blocked reason: none
Tests...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added soft-write contract documentation for Phase 26 create_tracking_ticket coordination, specifying safety boundaries, payload constraints, idempotency rules, and reconciliation requirements
  * Added contract validation documentation recording review status and enforcement boundaries

* **Tests**
  * Added automated test coverage to validate contract documentation structure and content requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->