### PR TITLE
Add reviewed create-tracking-ticket delegation

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/shuffle.py
+++ b/control-plane/aegisops_control_plane/adapters/shuffle.py
@@ -15,6 +15,11 @@ class ShuffleDelegationReceipt:
     payload_hash: str
     adapter: str
     base_url: str
+    coordination_reference_id: str | None = None
+    coordination_target_type: str | None = None
+    external_receipt_id: str | None = None
+    coordination_target_id: str | None = None
+    ticket_reference_url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -39,16 +44,47 @@ class ShuffleActionAdapter:
         del action_request_id
         del idempotency_key
         del delegated_at
-        self._require_reviewed_phase20_notify_payload(approved_payload)
-        return ShuffleDelegationReceipt(
-            execution_surface_type=self.execution_surface_type,
-            execution_surface_id=self.execution_surface_id,
-            execution_run_id=f"shuffle-run-{delegation_id}",
-            approval_decision_id=approval_decision_id,
-            delegation_id=delegation_id,
-            payload_hash=payload_hash,
-            adapter="shuffle",
-            base_url=self.base_url,
+        action_type = approved_payload.get("action_type")
+        if action_type == "notify_identity_owner":
+            self._require_reviewed_phase20_notify_payload(approved_payload)
+            return ShuffleDelegationReceipt(
+                execution_surface_type=self.execution_surface_type,
+                execution_surface_id=self.execution_surface_id,
+                execution_run_id=f"shuffle-run-{delegation_id}",
+                approval_decision_id=approval_decision_id,
+                delegation_id=delegation_id,
+                payload_hash=payload_hash,
+                adapter="shuffle",
+                base_url=self.base_url,
+            )
+        if action_type == "create_tracking_ticket":
+            self._require_reviewed_phase26_create_tracking_ticket_payload(
+                approved_payload
+            )
+            coordination_target_type = str(approved_payload["coordination_target_type"])
+            coordination_target_id = f"{coordination_target_type}-ticket-{delegation_id}"
+            return ShuffleDelegationReceipt(
+                execution_surface_type=self.execution_surface_type,
+                execution_surface_id=self.execution_surface_id,
+                execution_run_id=f"shuffle-run-{delegation_id}",
+                approval_decision_id=approval_decision_id,
+                delegation_id=delegation_id,
+                payload_hash=payload_hash,
+                adapter="shuffle",
+                base_url=self.base_url,
+                coordination_reference_id=str(
+                    approved_payload["coordination_reference_id"]
+                ),
+                coordination_target_type=coordination_target_type,
+                external_receipt_id=f"shuffle-receipt-{delegation_id}",
+                coordination_target_id=coordination_target_id,
+                ticket_reference_url=(
+                    "https://tickets.example.test/#ticket/"
+                    f"{coordination_target_id}"
+                ),
+            )
+        raise ValueError(
+            "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
         )
 
     @staticmethod
@@ -71,3 +107,24 @@ class ShuffleActionAdapter:
                 raise ValueError(
                     "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
                 )
+
+    @staticmethod
+    def _require_reviewed_phase26_create_tracking_ticket_payload(
+        approved_payload: Mapping[str, object],
+    ) -> None:
+        for field_name in (
+            "case_id",
+            "coordination_reference_id",
+            "coordination_target_type",
+            "ticket_title",
+            "ticket_description",
+        ):
+            value = approved_payload.get(field_name)
+            if not isinstance(value, str) or value.strip() == "":
+                raise ValueError(
+                    "approved action is outside the reviewed Phase 26 Shuffle delegation scope"
+                )
+        if approved_payload["coordination_target_type"] not in {"zammad", "glpi"}:
+            raise ValueError(
+                "approved action is outside the reviewed Phase 26 Shuffle delegation scope"
+            )

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -14,6 +14,8 @@ from .models import (
     ReconciliationRecord,
 )
 
+_PHASE26_REVIEWED_COORDINATION_TARGET_TYPES = frozenset(("zammad", "glpi"))
+
 
 class ExecutionCoordinatorServiceDependencies(Protocol):
     _store: object
@@ -397,9 +399,17 @@ class ExecutionCoordinator:
             execution_surface_type == "automation_substrate"
             and execution_surface_id == "shuffle"
         )
+        require_coordination_receipt_identifiers = (
+            require_binding_identifiers
+            and action_request.requested_payload.get("action_type")
+            == "create_tracking_ticket"
+        )
         normalized_executions = self._normalize_observed_executions(
             observed_executions,
             require_binding_identifiers=require_binding_identifiers,
+            require_coordination_receipt_identifiers=(
+                require_coordination_receipt_identifiers
+            ),
         )
         linked_execution_run_ids = tuple(
             execution["execution_run_id"] for execution in normalized_executions
@@ -469,6 +479,17 @@ class ExecutionCoordinator:
             observed_approval_decision_id = latest_execution.get("approval_decision_id")
             observed_delegation_id = latest_execution.get("delegation_id")
             observed_payload_hash = latest_execution.get("payload_hash")
+            observed_coordination_reference_id = latest_execution.get(
+                "coordination_reference_id"
+            )
+            observed_coordination_target_type = latest_execution.get(
+                "coordination_target_type"
+            )
+            observed_external_receipt_id = latest_execution.get("external_receipt_id")
+            observed_coordination_target_id = latest_execution.get(
+                "coordination_target_id"
+            )
+            observed_ticket_reference_url = latest_execution.get("ticket_reference_url")
             expected_execution_run_id = (
                 None
                 if authoritative_execution is None
@@ -520,6 +541,47 @@ class ExecutionCoordinator:
                     "approved binding mismatch between authoritative action execution "
                     "and observed downstream execution"
                 )
+            elif (
+                authoritative_execution is not None
+                and authoritative_execution.approved_payload.get("action_type")
+                == "create_tracking_ticket"
+                and authoritative_execution.execution_surface_type
+                == "automation_substrate"
+                and authoritative_execution.execution_surface_id == "shuffle"
+                and (
+                    observed_coordination_reference_id
+                    != authoritative_execution.provenance.get(
+                        "downstream_binding",
+                        {},
+                    ).get("coordination_reference_id")
+                    or observed_coordination_target_type
+                    != authoritative_execution.provenance.get(
+                        "downstream_binding",
+                        {},
+                    ).get("coordination_target_type")
+                    or observed_external_receipt_id
+                    != authoritative_execution.provenance.get(
+                        "downstream_binding",
+                        {},
+                    ).get("external_receipt_id")
+                    or observed_coordination_target_id
+                    != authoritative_execution.provenance.get(
+                        "downstream_binding",
+                        {},
+                    ).get("coordination_target_id")
+                    or observed_ticket_reference_url
+                    != authoritative_execution.provenance.get(
+                        "downstream_binding",
+                        {},
+                    ).get("ticket_reference_url")
+                )
+            ):
+                ingest_disposition = "mismatch"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "coordination receipt mismatch between authoritative action execution "
+                    "and observed downstream execution"
+                )
             else:
                 ingest_disposition = "matched"
                 lifecycle_state = "matched"
@@ -556,6 +618,36 @@ class ExecutionCoordinator:
                         ),
                         transitioned_at=latest_execution["observed_at"],
                     )
+            if (
+                authoritative_execution is not None
+                and authoritative_execution.approved_payload.get("action_type")
+                == "create_tracking_ticket"
+            ):
+                downstream_binding = authoritative_execution.provenance.get(
+                    "downstream_binding",
+                    {},
+                )
+                if isinstance(downstream_binding, Mapping):
+                    if isinstance(downstream_binding.get("coordination_reference_id"), str):
+                        subject_linkage["coordination_reference_ids"] = (
+                            downstream_binding["coordination_reference_id"],
+                        )
+                    if isinstance(downstream_binding.get("coordination_target_type"), str):
+                        subject_linkage["coordination_target_types"] = (
+                            downstream_binding["coordination_target_type"],
+                        )
+                    if isinstance(downstream_binding.get("external_receipt_id"), str):
+                        subject_linkage["external_receipt_ids"] = (
+                            downstream_binding["external_receipt_id"],
+                        )
+                    if isinstance(downstream_binding.get("coordination_target_id"), str):
+                        subject_linkage["coordination_target_ids"] = (
+                            downstream_binding["coordination_target_id"],
+                        )
+                    if isinstance(downstream_binding.get("ticket_reference_url"), str):
+                        subject_linkage["ticket_reference_urls"] = (
+                            downstream_binding["ticket_reference_url"],
+                        )
 
             reconciliation = self._service.persist_record(
                 ReconciliationRecord(
@@ -659,7 +751,7 @@ class ExecutionCoordinator:
                         )
                     return existing
             if execution_surface_id == "shuffle":
-                self._require_reviewed_phase20_shuffle_payload(normalized_payload)
+                self._require_reviewed_shuffle_payload(normalized_payload)
 
             delegation_id = self._service._next_identifier("delegation")
             predispatch_execution = self._service.persist_record(
@@ -756,26 +848,49 @@ class ExecutionCoordinator:
     def _pending_dispatch_execution_run_id(delegation_id: str) -> str:
         return f"pending-dispatch-{delegation_id}"
 
-    def _require_reviewed_phase20_shuffle_payload(
+    def _require_reviewed_shuffle_payload(
         self,
         approved_payload: Mapping[str, object],
     ) -> None:
         action_type = approved_payload.get("action_type")
-        if action_type != "notify_identity_owner":
-            raise ValueError(
-                "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
-            )
-
-        for field_name in (
-            "recipient_identity",
-            "message_intent",
-            "escalation_reason",
-        ):
-            value = approved_payload.get(field_name)
-            if not isinstance(value, str) or value.strip() == "":
+        if action_type == "notify_identity_owner":
+            for field_name in (
+                "recipient_identity",
+                "message_intent",
+                "escalation_reason",
+            ):
+                value = approved_payload.get(field_name)
+                if not isinstance(value, str) or value.strip() == "":
+                    raise ValueError(
+                        "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+                    )
+            return
+        if action_type == "create_tracking_ticket":
+            for field_name in (
+                "case_id",
+                "coordination_reference_id",
+                "coordination_target_type",
+                "ticket_title",
+                "ticket_description",
+            ):
+                value = approved_payload.get(field_name)
+                if not isinstance(value, str) or value.strip() == "":
+                    raise ValueError(
+                        "approved action is outside the reviewed Phase 26 Shuffle delegation scope"
+                    )
+            coordination_target_type = approved_payload.get("coordination_target_type")
+            if (
+                not isinstance(coordination_target_type, str)
+                or coordination_target_type
+                not in _PHASE26_REVIEWED_COORDINATION_TARGET_TYPES
+            ):
                 raise ValueError(
-                    "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+                    "approved action is outside the reviewed Phase 26 Shuffle delegation scope"
                 )
+            return
+        raise ValueError(
+            "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+        )
 
     def _require_exact_adapter_receipt_binding(
         self,
@@ -801,6 +916,39 @@ class ExecutionCoordinator:
             raise ValueError(
                 "shuffle receipt does not match approved delegation binding"
             )
+        if (
+            execution_surface_id == "shuffle"
+            and action_request.requested_payload.get("action_type")
+            == "create_tracking_ticket"
+        ):
+            approved_coordination_reference_id = self._service._require_non_empty_string(
+                action_request.target_scope.get("coordination_reference_id"),
+                "action_request.target_scope.coordination_reference_id",
+            )
+            approved_coordination_target_type = self._service._require_non_empty_string(
+                action_request.target_scope.get("coordination_target_type"),
+                "action_request.target_scope.coordination_target_type",
+            )
+            if any(
+                (
+                    self._require_receipt_string_attribute(
+                        receipt,
+                        "coordination_reference_id",
+                    )
+                    != approved_coordination_reference_id,
+                    self._require_receipt_string_attribute(
+                        receipt,
+                        "coordination_target_type",
+                    )
+                    != approved_coordination_target_type,
+                )
+            ):
+                raise ValueError(
+                    "shuffle receipt does not match approved delegation binding"
+                )
+            self._require_receipt_string_attribute(receipt, "external_receipt_id")
+            self._require_receipt_string_attribute(receipt, "coordination_target_id")
+            self._require_receipt_string_attribute(receipt, "ticket_reference_url")
 
     def _finalized_execution_provenance(
         self,
@@ -832,6 +980,31 @@ class ExecutionCoordinator:
                     "payload_hash",
                 ),
             }
+            if execution.approved_payload.get("action_type") == "create_tracking_ticket":
+                provenance["downstream_binding"].update(
+                    {
+                        "coordination_reference_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "coordination_reference_id",
+                        ),
+                        "coordination_target_type": self._require_receipt_string_attribute(
+                            receipt,
+                            "coordination_target_type",
+                        ),
+                        "external_receipt_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "external_receipt_id",
+                        ),
+                        "coordination_target_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "coordination_target_id",
+                        ),
+                        "ticket_reference_url": self._require_receipt_string_attribute(
+                            receipt,
+                            "ticket_reference_url",
+                        ),
+                    }
+                )
         return provenance
 
     @staticmethod
@@ -985,6 +1158,7 @@ class ExecutionCoordinator:
         observed_executions: tuple[Mapping[str, object], ...],
         *,
         require_binding_identifiers: bool = False,
+        require_coordination_receipt_identifiers: bool = False,
     ) -> tuple[dict[str, object], ...]:
         normalized: list[dict[str, object]] = []
         for execution in observed_executions:
@@ -995,6 +1169,11 @@ class ExecutionCoordinator:
             approval_decision_id = execution.get("approval_decision_id")
             delegation_id = execution.get("delegation_id")
             payload_hash = execution.get("payload_hash")
+            coordination_reference_id = execution.get("coordination_reference_id")
+            coordination_target_type = execution.get("coordination_target_type")
+            external_receipt_id = execution.get("external_receipt_id")
+            coordination_target_id = execution.get("coordination_target_id")
+            ticket_reference_url = execution.get("ticket_reference_url")
             if not isinstance(execution_run_id, str):
                 raise ValueError("observed execution must include string execution_run_id")
             if not isinstance(execution_surface_id, str):
@@ -1015,6 +1194,27 @@ class ExecutionCoordinator:
                     raise ValueError("observed execution must include string delegation_id")
                 if not isinstance(payload_hash, str):
                     raise ValueError("observed execution must include string payload_hash")
+            if require_coordination_receipt_identifiers:
+                if not isinstance(coordination_reference_id, str):
+                    raise ValueError(
+                        "observed execution must include string coordination_reference_id"
+                    )
+                if not isinstance(coordination_target_type, str):
+                    raise ValueError(
+                        "observed execution must include string coordination_target_type"
+                    )
+                if not isinstance(external_receipt_id, str):
+                    raise ValueError(
+                        "observed execution must include string external_receipt_id"
+                    )
+                if not isinstance(coordination_target_id, str):
+                    raise ValueError(
+                        "observed execution must include string coordination_target_id"
+                    )
+                if not isinstance(ticket_reference_url, str):
+                    raise ValueError(
+                        "observed execution must include string ticket_reference_url"
+                    )
             normalized.append(
                 {
                     "execution_run_id": execution_run_id,
@@ -1024,6 +1224,11 @@ class ExecutionCoordinator:
                     "approval_decision_id": approval_decision_id,
                     "delegation_id": delegation_id,
                     "payload_hash": payload_hash,
+                    "coordination_reference_id": coordination_reference_id,
+                    "coordination_target_type": coordination_target_type,
+                    "external_receipt_id": external_receipt_id,
+                    "coordination_target_id": coordination_target_id,
+                    "ticket_reference_url": ticket_reference_url,
                     "status": execution.get("status"),
                 }
             )

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -542,6 +542,16 @@ class ExecutionCoordinator:
                     "and observed downstream execution"
                 )
             elif (
+                require_coordination_receipt_identifiers
+                and authoritative_execution is None
+            ):
+                ingest_disposition = "mismatch"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "coordination receipt mismatch between authoritative action execution "
+                    "and observed downstream execution"
+                )
+            elif (
                 authoritative_execution is not None
                 and authoritative_execution.approved_payload.get("action_type")
                 == "create_tracking_ticket"
@@ -1195,23 +1205,38 @@ class ExecutionCoordinator:
                 if not isinstance(payload_hash, str):
                     raise ValueError("observed execution must include string payload_hash")
             if require_coordination_receipt_identifiers:
-                if not isinstance(coordination_reference_id, str):
+                if (
+                    not isinstance(coordination_reference_id, str)
+                    or not coordination_reference_id.strip()
+                ):
                     raise ValueError(
                         "observed execution must include string coordination_reference_id"
                     )
-                if not isinstance(coordination_target_type, str):
+                if (
+                    not isinstance(coordination_target_type, str)
+                    or not coordination_target_type.strip()
+                ):
                     raise ValueError(
                         "observed execution must include string coordination_target_type"
                     )
-                if not isinstance(external_receipt_id, str):
+                if (
+                    not isinstance(external_receipt_id, str)
+                    or not external_receipt_id.strip()
+                ):
                     raise ValueError(
                         "observed execution must include string external_receipt_id"
                     )
-                if not isinstance(coordination_target_id, str):
+                if (
+                    not isinstance(coordination_target_id, str)
+                    or not coordination_target_id.strip()
+                ):
                     raise ValueError(
                         "observed execution must include string coordination_target_id"
                     )
-                if not isinstance(ticket_reference_url, str):
+                if (
+                    not isinstance(ticket_reference_url, str)
+                    or not ticket_reference_url.strip()
+                ):
                     raise ValueError(
                         "observed execution must include string ticket_reference_url"
                     )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -5905,7 +5905,7 @@ class AegisOpsControlPlaneService:
         approver_identity: str,
     ) -> None:
         action_class = self._reviewed_action_class_for_request(action_request)
-        if action_class != "notify":
+        if action_class not in {"notify", "soft_write"}:
             raise PermissionError(
                 "approval decisions are not authorized for the reviewed action class"
             )
@@ -5926,6 +5926,8 @@ class AegisOpsControlPlaneService:
         action_type = action_request.requested_payload.get("action_type")
         if action_type == "notify_identity_owner":
             return "notify"
+        if action_type == "create_tracking_ticket":
+            return "soft_write"
         raise PermissionError(
             "approval decisions are not authorized for the reviewed action class"
         )

--- a/control-plane/tests/_service_persistence_support.py
+++ b/control-plane/tests/_service_persistence_support.py
@@ -58,6 +58,7 @@ from support.fake_store import (
 from support.fixtures import load_wazuh_fixture
 from support.payloads import (
     approved_binding_hash,
+    phase26_create_tracking_ticket_payload,
     phase20_notify_identity_owner_payload,
 )
 from support.service_persistence import (
@@ -67,6 +68,7 @@ from support.service_persistence import (
 
 _load_wazuh_fixture = load_wazuh_fixture
 _approved_binding_hash = approved_binding_hash
+_phase26_create_tracking_ticket_payload = phase26_create_tracking_ticket_payload
 _phase20_notify_identity_owner_payload = phase20_notify_identity_owner_payload
 _TransactionMutationStore = TransactionMutationStore
 _ConcurrentListMutationStore = ConcurrentListMutationStore

--- a/control-plane/tests/support/payloads.py
+++ b/control-plane/tests/support/payloads.py
@@ -52,3 +52,28 @@ def phase20_notify_identity_owner_payload(
         "linked_evidence_ids": linked_evidence_ids,
     }
 
+
+def phase26_create_tracking_ticket_payload(
+    *,
+    case_id: str,
+    alert_id: str,
+    finding_id: str,
+    coordination_reference_id: str,
+    coordination_target_type: str = "zammad",
+    ticket_title: str = "Investigate reviewed case follow-up",
+    ticket_description: str = (
+        "Open one reviewed coordination ticket for bounded operator follow-up."
+    ),
+    ticket_severity: str = "medium",
+) -> dict[str, object]:
+    return {
+        "action_type": "create_tracking_ticket",
+        "case_id": case_id,
+        "alert_id": alert_id,
+        "finding_id": finding_id,
+        "coordination_reference_id": coordination_reference_id,
+        "coordination_target_type": coordination_target_type,
+        "ticket_title": ticket_title,
+        "ticket_description": ticket_description,
+        "ticket_severity": ticket_severity,
+    }

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -19,13 +19,13 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
     def test_service_delegates_approved_create_tracking_ticket_through_shuffle(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
         )
-        requested_at = datetime(2026, 4, 18, 1, 0, tzinfo=timezone.utc)
-        delegated_at = datetime(2026, 4, 18, 1, 5, tzinfo=timezone.utc)
+        requested_at = support.datetime(2026, 4, 18, 1, 0, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 1, 5, tzinfo=support.timezone.utc)
         approved_target_scope = {
             "case_id": "case-tracking-001",
             "alert_id": "alert-tracking-001",
@@ -33,20 +33,20 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             "coordination_reference_id": "coord-ref-create-001",
             "coordination_target_type": "zammad",
         }
-        approved_payload = _phase26_create_tracking_ticket_payload(
+        approved_payload = support._phase26_create_tracking_ticket_payload(
             case_id="case-tracking-001",
             alert_id="alert-tracking-001",
             finding_id="finding-tracking-001",
             coordination_reference_id="coord-ref-create-001",
         )
-        payload_hash = _approved_binding_hash(
+        payload_hash = support._approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
             execution_surface_type="automation_substrate",
             execution_surface_id="shuffle",
         )
         service.persist_record(
-            ApprovalDecisionRecord(
+            support.ApprovalDecisionRecord(
                 approval_decision_id="approval-create-ticket-001",
                 action_request_id="action-request-create-ticket-001",
                 approver_identities=("approver-001",),
@@ -57,7 +57,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             )
         )
         service.persist_record(
-            ActionRequestRecord(
+            support.ActionRequestRecord(
                 action_request_id="action-request-create-ticket-001",
                 approval_decision_id="approval-create-ticket-001",
                 case_id="case-tracking-001",
@@ -121,13 +121,13 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
     def test_service_fail_closes_when_create_tracking_ticket_receipt_omits_external_receipt_id(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
         )
-        requested_at = datetime(2026, 4, 18, 1, 0, tzinfo=timezone.utc)
-        delegated_at = datetime(2026, 4, 18, 1, 5, tzinfo=timezone.utc)
+        requested_at = support.datetime(2026, 4, 18, 1, 0, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 1, 5, tzinfo=support.timezone.utc)
         approved_target_scope = {
             "case_id": "case-tracking-omit-receipt-001",
             "alert_id": "alert-tracking-omit-receipt-001",
@@ -135,20 +135,20 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             "coordination_reference_id": "coord-ref-omit-receipt-001",
             "coordination_target_type": "zammad",
         }
-        approved_payload = _phase26_create_tracking_ticket_payload(
+        approved_payload = support._phase26_create_tracking_ticket_payload(
             case_id="case-tracking-omit-receipt-001",
             alert_id="alert-tracking-omit-receipt-001",
             finding_id="finding-tracking-omit-receipt-001",
             coordination_reference_id="coord-ref-omit-receipt-001",
         )
-        payload_hash = _approved_binding_hash(
+        payload_hash = support._approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
             execution_surface_type="automation_substrate",
             execution_surface_id="shuffle",
         )
         service.persist_record(
-            ApprovalDecisionRecord(
+            support.ApprovalDecisionRecord(
                 approval_decision_id="approval-create-ticket-omit-receipt-001",
                 action_request_id="action-request-create-ticket-omit-receipt-001",
                 approver_identities=("approver-001",),
@@ -159,7 +159,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             )
         )
         service.persist_record(
-            ActionRequestRecord(
+            support.ActionRequestRecord(
                 action_request_id="action-request-create-ticket-omit-receipt-001",
                 approval_decision_id="approval-create-ticket-omit-receipt-001",
                 case_id="case-tracking-omit-receipt-001",
@@ -184,9 +184,9 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
 
         def dispatch_without_external_receipt_id(adapter: object, **kwargs: object) -> object:
             receipt = original_dispatch(adapter, **kwargs)
-            return replace(receipt, external_receipt_id="")
+            return support.replace(receipt, external_receipt_id="")
 
-        with mock.patch.object(
+        with support.mock.patch.object(
             type(service._shuffle),
             "dispatch_approved_action",
             autospec=True,
@@ -203,7 +203,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
                     delegation_issuer="control-plane-service",
                 )
 
-        executions = store.list(ActionExecutionRecord)
+        executions = store.list(support.ActionExecutionRecord)
         self.assertEqual(len(executions), 1)
         self.assertEqual(executions[0].lifecycle_state, "failed")
         self.assertEqual(
@@ -214,13 +214,13 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
     def test_service_fail_closes_when_create_tracking_ticket_receipt_binding_drifts(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
         )
-        requested_at = datetime(2026, 4, 18, 2, 0, tzinfo=timezone.utc)
-        delegated_at = datetime(2026, 4, 18, 2, 5, tzinfo=timezone.utc)
+        requested_at = support.datetime(2026, 4, 18, 2, 0, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 2, 5, tzinfo=support.timezone.utc)
         approved_target_scope = {
             "case_id": "case-tracking-receipt-drift-001",
             "alert_id": "alert-tracking-receipt-drift-001",
@@ -228,20 +228,20 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             "coordination_reference_id": "coord-ref-receipt-drift-001",
             "coordination_target_type": "zammad",
         }
-        approved_payload = _phase26_create_tracking_ticket_payload(
+        approved_payload = support._phase26_create_tracking_ticket_payload(
             case_id="case-tracking-receipt-drift-001",
             alert_id="alert-tracking-receipt-drift-001",
             finding_id="finding-tracking-receipt-drift-001",
             coordination_reference_id="coord-ref-receipt-drift-001",
         )
-        payload_hash = _approved_binding_hash(
+        payload_hash = support._approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
             execution_surface_type="automation_substrate",
             execution_surface_id="shuffle",
         )
         service.persist_record(
-            ApprovalDecisionRecord(
+            support.ApprovalDecisionRecord(
                 approval_decision_id="approval-create-ticket-receipt-drift-001",
                 action_request_id="action-request-create-ticket-receipt-drift-001",
                 approver_identities=("approver-001",),
@@ -252,7 +252,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             )
         )
         service.persist_record(
-            ActionRequestRecord(
+            support.ActionRequestRecord(
                 action_request_id="action-request-create-ticket-receipt-drift-001",
                 approval_decision_id="approval-create-ticket-receipt-drift-001",
                 case_id="case-tracking-receipt-drift-001",
@@ -280,9 +280,12 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             **kwargs: object,
         ) -> object:
             receipt = original_dispatch(adapter, **kwargs)
-            return replace(receipt, coordination_reference_id="coord-ref-drifted-999")
+            return support.replace(
+                receipt,
+                coordination_reference_id="coord-ref-drifted-999",
+            )
 
-        with mock.patch.object(
+        with support.mock.patch.object(
             type(service._shuffle),
             "dispatch_approved_action",
             autospec=True,
@@ -299,7 +302,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
                     delegation_issuer="control-plane-service",
                 )
 
-        executions = store.list(ActionExecutionRecord)
+        executions = store.list(support.ActionExecutionRecord)
         self.assertEqual(len(executions), 1)
         self.assertEqual(executions[0].lifecycle_state, "failed")
         self.assertEqual(
@@ -310,13 +313,13 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
     def test_service_fail_closes_when_create_tracking_ticket_dispatch_times_out(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
         )
-        requested_at = datetime(2026, 4, 18, 3, 0, tzinfo=timezone.utc)
-        delegated_at = datetime(2026, 4, 18, 3, 5, tzinfo=timezone.utc)
+        requested_at = support.datetime(2026, 4, 18, 3, 0, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 3, 5, tzinfo=support.timezone.utc)
         approved_target_scope = {
             "case_id": "case-tracking-timeout-001",
             "alert_id": "alert-tracking-timeout-001",
@@ -324,20 +327,20 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             "coordination_reference_id": "coord-ref-timeout-001",
             "coordination_target_type": "zammad",
         }
-        approved_payload = _phase26_create_tracking_ticket_payload(
+        approved_payload = support._phase26_create_tracking_ticket_payload(
             case_id="case-tracking-timeout-001",
             alert_id="alert-tracking-timeout-001",
             finding_id="finding-tracking-timeout-001",
             coordination_reference_id="coord-ref-timeout-001",
         )
-        payload_hash = _approved_binding_hash(
+        payload_hash = support._approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
             execution_surface_type="automation_substrate",
             execution_surface_id="shuffle",
         )
         service.persist_record(
-            ApprovalDecisionRecord(
+            support.ApprovalDecisionRecord(
                 approval_decision_id="approval-create-ticket-timeout-001",
                 action_request_id="action-request-create-ticket-timeout-001",
                 approver_identities=("approver-001",),
@@ -348,7 +351,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             )
         )
         service.persist_record(
-            ActionRequestRecord(
+            support.ActionRequestRecord(
                 action_request_id="action-request-create-ticket-timeout-001",
                 approval_decision_id="approval-create-ticket-timeout-001",
                 case_id="case-tracking-timeout-001",
@@ -370,7 +373,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             )
         )
 
-        with mock.patch.object(
+        with support.mock.patch.object(
             type(service._shuffle),
             "dispatch_approved_action",
             autospec=True,
@@ -387,7 +390,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
                     delegation_issuer="control-plane-service",
                 )
 
-        executions = store.list(ActionExecutionRecord)
+        executions = store.list(support.ActionExecutionRecord)
         self.assertEqual(len(executions), 1)
         self.assertEqual(executions[0].lifecycle_state, "failed")
         self.assertEqual(
@@ -398,14 +401,14 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
     def test_service_reconciles_create_tracking_ticket_receipt_into_authoritative_records(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
         )
-        requested_at = datetime(2026, 4, 18, 4, 0, tzinfo=timezone.utc)
-        delegated_at = datetime(2026, 4, 18, 4, 5, tzinfo=timezone.utc)
-        compared_at = datetime(2026, 4, 18, 4, 10, tzinfo=timezone.utc)
+        requested_at = support.datetime(2026, 4, 18, 4, 0, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 4, 5, tzinfo=support.timezone.utc)
+        compared_at = support.datetime(2026, 4, 18, 4, 10, tzinfo=support.timezone.utc)
         approved_target_scope = {
             "case_id": "case-tracking-reconcile-001",
             "alert_id": "alert-tracking-reconcile-001",
@@ -413,20 +416,20 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             "coordination_reference_id": "coord-ref-reconcile-001",
             "coordination_target_type": "zammad",
         }
-        approved_payload = _phase26_create_tracking_ticket_payload(
+        approved_payload = support._phase26_create_tracking_ticket_payload(
             case_id="case-tracking-reconcile-001",
             alert_id="alert-tracking-reconcile-001",
             finding_id="finding-tracking-reconcile-001",
             coordination_reference_id="coord-ref-reconcile-001",
         )
-        payload_hash = _approved_binding_hash(
+        payload_hash = support._approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
             execution_surface_type="automation_substrate",
             execution_surface_id="shuffle",
         )
         service.persist_record(
-            ApprovalDecisionRecord(
+            support.ApprovalDecisionRecord(
                 approval_decision_id="approval-create-ticket-reconcile-001",
                 action_request_id="action-request-create-ticket-reconcile-001",
                 approver_identities=("approver-001",),
@@ -437,7 +440,7 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             )
         )
         service.persist_record(
-            ActionRequestRecord(
+            support.ActionRequestRecord(
                 action_request_id="action-request-create-ticket-reconcile-001",
                 approval_decision_id="approval-create-ticket-reconcile-001",
                 case_id="case-tracking-reconcile-001",
@@ -496,11 +499,18 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
                 },
             ),
             compared_at=compared_at,
-            stale_after=datetime(2026, 4, 18, 4, 30, tzinfo=timezone.utc),
+            stale_after=support.datetime(
+                2026,
+                4,
+                18,
+                4,
+                30,
+                tzinfo=support.timezone.utc,
+            ),
         )
 
         stored_execution = service.get_record(
-            ActionExecutionRecord,
+            support.ActionExecutionRecord,
             execution.action_execution_id,
         )
         self.assertEqual(reconciliation.ingest_disposition, "matched")
@@ -526,6 +536,236 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             reconciliation.subject_linkage["ticket_reference_urls"],
             (downstream_binding["ticket_reference_url"],),
         )
+
+    def test_service_fail_closes_when_create_tracking_ticket_receipt_has_no_authoritative_execution(
+        self,
+    ) -> None:
+        store, backend = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = support.datetime(2026, 4, 18, 4, 20, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 4, 25, tzinfo=support.timezone.utc)
+        compared_at = support.datetime(2026, 4, 18, 4, 30, tzinfo=support.timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-missing-authoritative-001",
+            "alert_id": "alert-tracking-missing-authoritative-001",
+            "finding_id": "finding-tracking-missing-authoritative-001",
+            "coordination_reference_id": "coord-ref-missing-authoritative-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = support._phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-missing-authoritative-001",
+            alert_id="alert-tracking-missing-authoritative-001",
+            finding_id="finding-tracking-missing-authoritative-001",
+            coordination_reference_id="coord-ref-missing-authoritative-001",
+        )
+        payload_hash = support._approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            support.ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-missing-authoritative-001",
+                action_request_id="action-request-create-ticket-missing-authoritative-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            support.ActionRequestRecord(
+                action_request_id="action-request-create-ticket-missing-authoritative-001",
+                approval_decision_id="approval-create-ticket-missing-authoritative-001",
+                case_id="case-tracking-missing-authoritative-001",
+                alert_id="alert-tracking-missing-authoritative-001",
+                finding_id="finding-tracking-missing-authoritative-001",
+                idempotency_key="idempotency-create-ticket-missing-authoritative-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-create-ticket-missing-authoritative-001",
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        backend.tables["action_execution_records"].pop(execution.action_execution_id)
+
+        downstream_binding = execution.provenance["downstream_binding"]
+        reconciliation = service.reconcile_action_execution(
+            action_request_id="action-request-create-ticket-missing-authoritative-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": "idempotency-create-ticket-missing-authoritative-001",
+                    "observed_at": compared_at,
+                    "approval_decision_id": "approval-create-ticket-missing-authoritative-001",
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": payload_hash,
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding["coordination_target_id"],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=support.datetime(
+                2026,
+                4,
+                18,
+                4,
+                45,
+                tzinfo=support.timezone.utc,
+            ),
+        )
+
+        self.assertEqual(reconciliation.ingest_disposition, "mismatch")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertEqual(
+            reconciliation.mismatch_summary,
+            "coordination receipt mismatch between authoritative action execution "
+            "and observed downstream execution",
+        )
+
+    def test_service_rejects_blank_create_tracking_ticket_receipt_identifiers(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = support.datetime(2026, 4, 18, 4, 40, tzinfo=support.timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-blank-receipt-001",
+            "alert_id": "alert-tracking-blank-receipt-001",
+            "finding_id": "finding-tracking-blank-receipt-001",
+            "coordination_reference_id": "coord-ref-blank-receipt-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = support._phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-blank-receipt-001",
+            alert_id="alert-tracking-blank-receipt-001",
+            finding_id="finding-tracking-blank-receipt-001",
+            coordination_reference_id="coord-ref-blank-receipt-001",
+        )
+        payload_hash = support._approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            support.ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-blank-receipt-001",
+                action_request_id="action-request-create-ticket-blank-receipt-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            support.ActionRequestRecord(
+                action_request_id="action-request-create-ticket-blank-receipt-001",
+                approval_decision_id="approval-create-ticket-blank-receipt-001",
+                case_id="case-tracking-blank-receipt-001",
+                alert_id="alert-tracking-blank-receipt-001",
+                finding_id="finding-tracking-blank-receipt-001",
+                idempotency_key="idempotency-create-ticket-blank-receipt-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "observed execution must include string external_receipt_id",
+        ):
+            service.reconcile_action_execution(
+                action_request_id="action-request-create-ticket-blank-receipt-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                observed_executions=(
+                    {
+                        "execution_run_id": "shuffle-run-blank-receipt-001",
+                        "execution_surface_id": "shuffle",
+                        "idempotency_key": "idempotency-create-ticket-blank-receipt-001",
+                        "observed_at": support.datetime(
+                            2026,
+                            4,
+                            18,
+                            4,
+                            45,
+                            tzinfo=support.timezone.utc,
+                        ),
+                        "approval_decision_id": "approval-create-ticket-blank-receipt-001",
+                        "delegation_id": "delegation-blank-receipt-001",
+                        "payload_hash": payload_hash,
+                        "coordination_reference_id": "coord-ref-blank-receipt-001",
+                        "coordination_target_type": "zammad",
+                        "external_receipt_id": "   ",
+                        "coordination_target_id": "zammad-ticket-blank-receipt-001",
+                        "ticket_reference_url": "https://tickets.example.test/#ticket/zammad-ticket-blank-receipt-001",
+                        "status": "success",
+                    },
+                ),
+                compared_at=support.datetime(
+                    2026,
+                    4,
+                    18,
+                    4,
+                    45,
+                    tzinfo=support.timezone.utc,
+                ),
+                stale_after=support.datetime(
+                    2026,
+                    4,
+                    18,
+                    5,
+                    0,
+                    tzinfo=support.timezone.utc,
+                ),
+            )
+
     def test_service_records_execution_correlation_mismatch_states_separately(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -537,6 +537,134 @@ class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
             (downstream_binding["ticket_reference_url"],),
         )
 
+    def test_service_fail_closes_when_create_tracking_ticket_reconciliation_receipt_drifts(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = support.datetime(2026, 4, 18, 4, 12, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 4, 17, tzinfo=support.timezone.utc)
+        compared_at = support.datetime(2026, 4, 18, 4, 22, tzinfo=support.timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-reconcile-drift-001",
+            "alert_id": "alert-tracking-reconcile-drift-001",
+            "finding_id": "finding-tracking-reconcile-drift-001",
+            "coordination_reference_id": "coord-ref-reconcile-drift-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = support._phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-reconcile-drift-001",
+            alert_id="alert-tracking-reconcile-drift-001",
+            finding_id="finding-tracking-reconcile-drift-001",
+            coordination_reference_id="coord-ref-reconcile-drift-001",
+        )
+        payload_hash = support._approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            support.ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-reconcile-drift-001",
+                action_request_id="action-request-create-ticket-reconcile-drift-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            support.ActionRequestRecord(
+                action_request_id="action-request-create-ticket-reconcile-drift-001",
+                approval_decision_id="approval-create-ticket-reconcile-drift-001",
+                case_id="case-tracking-reconcile-drift-001",
+                alert_id="alert-tracking-reconcile-drift-001",
+                finding_id="finding-tracking-reconcile-drift-001",
+                idempotency_key="idempotency-create-ticket-reconcile-drift-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-create-ticket-reconcile-drift-001",
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-create-ticket-reconcile-drift-001",),
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id="action-request-create-ticket-reconcile-drift-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": "idempotency-create-ticket-reconcile-drift-001",
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": "shuffle-receipt-drifted-001",
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=support.datetime(
+                2026,
+                4,
+                18,
+                4,
+                45,
+                tzinfo=support.timezone.utc,
+            ),
+        )
+
+        stored_execution = service.get_record(
+            support.ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertEqual(reconciliation.ingest_disposition, "mismatch")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertEqual(
+            reconciliation.mismatch_summary,
+            "coordination receipt mismatch between authoritative action execution "
+            "and observed downstream execution",
+        )
+        self.assertEqual(stored_execution.lifecycle_state, "queued")
+        self.assertEqual(
+            reconciliation.subject_linkage["external_receipt_ids"],
+            (downstream_binding["external_receipt_id"],),
+        )
+
     def test_service_fail_closes_when_create_tracking_ticket_receipt_has_no_authoritative_execution(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation.py
@@ -16,6 +16,516 @@ for name, value in vars(support).items():
 
 
 class ActionReconciliationPersistenceTests(ServicePersistenceTestBase):
+    def test_service_delegates_approved_create_tracking_ticket_through_shuffle(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 18, 1, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 18, 1, 5, tzinfo=timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-001",
+            "alert_id": "alert-tracking-001",
+            "finding_id": "finding-tracking-001",
+            "coordination_reference_id": "coord-ref-create-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = _phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-001",
+            alert_id="alert-tracking-001",
+            finding_id="finding-tracking-001",
+            coordination_reference_id="coord-ref-create-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-001",
+                action_request_id="action-request-create-ticket-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-create-ticket-001",
+                approval_decision_id="approval-create-ticket-001",
+                case_id="case-tracking-001",
+                alert_id="alert-tracking-001",
+                finding_id="finding-tracking-001",
+                idempotency_key="idempotency-create-ticket-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-create-ticket-001",
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-create-ticket-001",),
+        )
+
+        self.assertEqual(execution.lifecycle_state, "queued")
+        self.assertEqual(execution.execution_surface_type, "automation_substrate")
+        self.assertEqual(execution.execution_surface_id, "shuffle")
+        self.assertEqual(
+            execution.approved_payload["action_type"],
+            "create_tracking_ticket",
+        )
+        self.assertEqual(
+            execution.provenance["downstream_binding"]["coordination_reference_id"],
+            "coord-ref-create-001",
+        )
+        self.assertEqual(
+            execution.provenance["downstream_binding"]["coordination_target_type"],
+            "zammad",
+        )
+        self.assertTrue(
+            execution.provenance["downstream_binding"][
+                "external_receipt_id"
+            ].startswith("shuffle-receipt-delegation-")
+        )
+        self.assertTrue(
+            execution.provenance["downstream_binding"][
+                "coordination_target_id"
+            ].startswith("zammad-ticket-delegation-")
+        )
+        self.assertTrue(
+            execution.provenance["downstream_binding"][
+                "ticket_reference_url"
+            ].startswith("https://tickets.example.test/#ticket/zammad-ticket-delegation-")
+        )
+
+    def test_service_fail_closes_when_create_tracking_ticket_receipt_omits_external_receipt_id(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 18, 1, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 18, 1, 5, tzinfo=timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-omit-receipt-001",
+            "alert_id": "alert-tracking-omit-receipt-001",
+            "finding_id": "finding-tracking-omit-receipt-001",
+            "coordination_reference_id": "coord-ref-omit-receipt-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = _phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-omit-receipt-001",
+            alert_id="alert-tracking-omit-receipt-001",
+            finding_id="finding-tracking-omit-receipt-001",
+            coordination_reference_id="coord-ref-omit-receipt-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-omit-receipt-001",
+                action_request_id="action-request-create-ticket-omit-receipt-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-create-ticket-omit-receipt-001",
+                approval_decision_id="approval-create-ticket-omit-receipt-001",
+                case_id="case-tracking-omit-receipt-001",
+                alert_id="alert-tracking-omit-receipt-001",
+                finding_id="finding-tracking-omit-receipt-001",
+                idempotency_key="idempotency-create-ticket-omit-receipt-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        original_dispatch = type(service._shuffle).dispatch_approved_action
+
+        def dispatch_without_external_receipt_id(adapter: object, **kwargs: object) -> object:
+            receipt = original_dispatch(adapter, **kwargs)
+            return replace(receipt, external_receipt_id="")
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_without_external_receipt_id,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "adapter receipt missing required 'external_receipt_id' attribute",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id="action-request-create-ticket-omit-receipt-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error"],
+            "adapter receipt missing required 'external_receipt_id' attribute",
+        )
+
+    def test_service_fail_closes_when_create_tracking_ticket_receipt_binding_drifts(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 18, 2, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 18, 2, 5, tzinfo=timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-receipt-drift-001",
+            "alert_id": "alert-tracking-receipt-drift-001",
+            "finding_id": "finding-tracking-receipt-drift-001",
+            "coordination_reference_id": "coord-ref-receipt-drift-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = _phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-receipt-drift-001",
+            alert_id="alert-tracking-receipt-drift-001",
+            finding_id="finding-tracking-receipt-drift-001",
+            coordination_reference_id="coord-ref-receipt-drift-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-receipt-drift-001",
+                action_request_id="action-request-create-ticket-receipt-drift-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-create-ticket-receipt-drift-001",
+                approval_decision_id="approval-create-ticket-receipt-drift-001",
+                case_id="case-tracking-receipt-drift-001",
+                alert_id="alert-tracking-receipt-drift-001",
+                finding_id="finding-tracking-receipt-drift-001",
+                idempotency_key="idempotency-create-ticket-receipt-drift-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        original_dispatch = type(service._shuffle).dispatch_approved_action
+
+        def dispatch_with_drifted_coordination_reference(
+            adapter: object,
+            **kwargs: object,
+        ) -> object:
+            receipt = original_dispatch(adapter, **kwargs)
+            return replace(receipt, coordination_reference_id="coord-ref-drifted-999")
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_with_drifted_coordination_reference,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "shuffle receipt does not match approved delegation binding",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id="action-request-create-ticket-receipt-drift-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error"],
+            "shuffle receipt does not match approved delegation binding",
+        )
+
+    def test_service_fail_closes_when_create_tracking_ticket_dispatch_times_out(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 18, 3, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 18, 3, 5, tzinfo=timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-timeout-001",
+            "alert_id": "alert-tracking-timeout-001",
+            "finding_id": "finding-tracking-timeout-001",
+            "coordination_reference_id": "coord-ref-timeout-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = _phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-timeout-001",
+            alert_id="alert-tracking-timeout-001",
+            finding_id="finding-tracking-timeout-001",
+            coordination_reference_id="coord-ref-timeout-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-timeout-001",
+                action_request_id="action-request-create-ticket-timeout-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-create-ticket-timeout-001",
+                approval_decision_id="approval-create-ticket-timeout-001",
+                case_id="case-tracking-timeout-001",
+                alert_id="alert-tracking-timeout-001",
+                finding_id="finding-tracking-timeout-001",
+                idempotency_key="idempotency-create-ticket-timeout-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=TimeoutError("synthetic create-tracking-ticket timeout"),
+        ):
+            with self.assertRaisesRegex(
+                TimeoutError,
+                "synthetic create-tracking-ticket timeout",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id="action-request-create-ticket-timeout-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error_type"],
+            "TimeoutError",
+        )
+
+    def test_service_reconciles_create_tracking_ticket_receipt_into_authoritative_records(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = datetime(2026, 4, 18, 4, 0, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 18, 4, 5, tzinfo=timezone.utc)
+        compared_at = datetime(2026, 4, 18, 4, 10, tzinfo=timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-reconcile-001",
+            "alert_id": "alert-tracking-reconcile-001",
+            "finding_id": "finding-tracking-reconcile-001",
+            "coordination_reference_id": "coord-ref-reconcile-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = _phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-reconcile-001",
+            alert_id="alert-tracking-reconcile-001",
+            finding_id="finding-tracking-reconcile-001",
+            coordination_reference_id="coord-ref-reconcile-001",
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-reconcile-001",
+                action_request_id="action-request-create-ticket-reconcile-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-create-ticket-reconcile-001",
+                approval_decision_id="approval-create-ticket-reconcile-001",
+                case_id="case-tracking-reconcile-001",
+                alert_id="alert-tracking-reconcile-001",
+                finding_id="finding-tracking-reconcile-001",
+                idempotency_key="idempotency-create-ticket-reconcile-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-create-ticket-reconcile-001",
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-create-ticket-reconcile-001",),
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id="action-request-create-ticket-reconcile-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": "idempotency-create-ticket-reconcile-001",
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=datetime(2026, 4, 18, 4, 30, tzinfo=timezone.utc),
+        )
+
+        stored_execution = service.get_record(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertEqual(reconciliation.ingest_disposition, "matched")
+        self.assertEqual(reconciliation.lifecycle_state, "matched")
+        self.assertEqual(stored_execution.lifecycle_state, "succeeded")
+        self.assertEqual(
+            reconciliation.subject_linkage["coordination_reference_ids"],
+            ("coord-ref-reconcile-001",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["coordination_target_types"],
+            ("zammad",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["external_receipt_ids"],
+            (downstream_binding["external_receipt_id"],),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["coordination_target_ids"],
+            (downstream_binding["coordination_target_id"],),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["ticket_reference_urls"],
+            (downstream_binding["ticket_reference_url"],),
+        )
     def test_service_records_execution_correlation_mismatch_states_separately(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(


### PR DESCRIPTION
## Summary
- add the first approved reviewed Shuffle create_tracking_ticket delegation path
- preserve authoritative downstream receipt binding on Action Execution and Reconciliation
- fail closed on missing or drifted ticket receipt identifiers

## Testing
- python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation

Closes #551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for delegating and tracking external tickets (Zammad/GLPI), capturing coordination IDs and ticket reference URLs, and allowing approval for the new ticket action type.
  * Payload validation now enforces required coordination fields and restricts target types to Zammad/GLPI.

* **Tests**
  * Added comprehensive tests for dispatch, malformed receipts, timeouts, reconciliation success/mismatch, and payload helper for ticket creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->