### PR TITLE
implementation: add operator review surface for link/create ticket outcomes (#552)

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2384,6 +2384,7 @@ class AegisOpsControlPlaneService:
         )
         coordination_ticket_outcome = self._action_review_coordination_ticket_outcome(
             action_request=action_request,
+            approval_decision=approval_decision,
             action_execution=action_execution,
             reconciliation=reconciliation,
             runtime_visibility=runtime_visibility,
@@ -4170,6 +4171,7 @@ class AegisOpsControlPlaneService:
         self,
         *,
         action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord | None,
         action_execution: ActionExecutionRecord | None,
         reconciliation: ReconciliationRecord | None,
         runtime_visibility: Mapping[str, object] | None,
@@ -4216,7 +4218,7 @@ class AegisOpsControlPlaneService:
             status = "timeout"
             summary = str(terminal_issue["reason"]).replace("_", " ")
         elif terminal_issue is not None:
-            status = "failed"
+            status = "timeout"
             summary = str(terminal_issue["reason"]).replace("_", " ")
         else:
             status = "pending"
@@ -4227,7 +4229,9 @@ class AegisOpsControlPlaneService:
             "status": status,
             "summary": summary,
             "action_request_id": action_request.action_request_id,
-            "approval_decision_id": action_request.approval_decision_id,
+            "approval_decision_id": (
+                None if approval_decision is None else approval_decision.approval_decision_id
+            ),
             "action_execution_id": (
                 None if action_execution is None else action_execution.action_execution_id
             ),
@@ -4271,12 +4275,12 @@ class AegisOpsControlPlaneService:
             }
             outcome["timeout"] = timeout
         elif terminal_issue is not None:
-            failure = {
+            timeout = {
                 key: value
                 for key, value in terminal_issue.items()
                 if key != "category"
             }
-            outcome["failure"] = failure
+            outcome["timeout"] = timeout
         if mismatch is not None:
             outcome["mismatch"] = mismatch
         if manual_fallback is not None:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4193,17 +4193,7 @@ class AegisOpsControlPlaneService:
             if isinstance(manual_fallback_entry, Mapping):
                 manual_fallback = dict(manual_fallback_entry)
 
-        if manual_fallback is not None:
-            status = "manual_fallback"
-            summary = str(
-                manual_fallback.get("action_taken")
-                or manual_fallback.get("reason")
-                or "reviewed create-ticket outcome recorded as manual fallback"
-            )
-        elif mismatch is not None:
-            status = "mismatch"
-            summary = str(mismatch["mismatch_summary"])
-        elif (
+        if (
             reconciliation is not None
             and reconciliation.lifecycle_state == "matched"
             and action_execution is not None
@@ -4214,6 +4204,16 @@ class AegisOpsControlPlaneService:
                 "reviewed create-ticket outcome recorded from authoritative "
                 "execution and reconciliation"
             )
+        elif manual_fallback is not None:
+            status = "manual_fallback"
+            summary = str(
+                manual_fallback.get("action_taken")
+                or manual_fallback.get("reason")
+                or "reviewed create-ticket outcome recorded as manual fallback"
+            )
+        elif mismatch is not None:
+            status = "mismatch"
+            summary = str(mismatch["mismatch_summary"])
         elif terminal_issue is not None and terminal_issue["category"] == "timeout":
             status = "timeout"
             summary = str(terminal_issue["reason"]).replace("_", " ")

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4181,7 +4181,7 @@ class AegisOpsControlPlaneService:
 
         downstream_binding = self._action_review_downstream_binding(action_execution)
         mismatch = self._action_review_coordination_ticket_mismatch(reconciliation)
-        timeout = self._action_review_coordination_ticket_timeout(
+        terminal_issue = self._action_review_coordination_ticket_terminal_issue(
             action_execution=action_execution,
             path_health=path_health,
         )
@@ -4191,7 +4191,14 @@ class AegisOpsControlPlaneService:
             if isinstance(manual_fallback_entry, Mapping):
                 manual_fallback = dict(manual_fallback_entry)
 
-        if mismatch is not None:
+        if manual_fallback is not None:
+            status = "manual_fallback"
+            summary = str(
+                manual_fallback.get("action_taken")
+                or manual_fallback.get("reason")
+                or "reviewed create-ticket outcome recorded as manual fallback"
+            )
+        elif mismatch is not None:
             status = "mismatch"
             summary = str(mismatch["mismatch_summary"])
         elif (
@@ -4205,9 +4212,12 @@ class AegisOpsControlPlaneService:
                 "reviewed create-ticket outcome recorded from authoritative "
                 "execution and reconciliation"
             )
-        elif timeout is not None:
+        elif terminal_issue is not None and terminal_issue["category"] == "timeout":
             status = "timeout"
-            summary = str(timeout["reason"]).replace("_", " ")
+            summary = str(terminal_issue["reason"]).replace("_", " ")
+        elif terminal_issue is not None:
+            status = "failed"
+            summary = str(terminal_issue["reason"]).replace("_", " ")
         else:
             status = "pending"
             summary = "reviewed create-ticket outcome still awaiting authoritative result"
@@ -4253,8 +4263,20 @@ class AegisOpsControlPlaneService:
                 else downstream_binding.get("ticket_reference_url")
             ),
         }
-        if timeout is not None:
+        if terminal_issue is not None and terminal_issue["category"] == "timeout":
+            timeout = {
+                key: value
+                for key, value in terminal_issue.items()
+                if key != "category"
+            }
             outcome["timeout"] = timeout
+        elif terminal_issue is not None:
+            failure = {
+                key: value
+                for key, value in terminal_issue.items()
+                if key != "category"
+            }
+            outcome["failure"] = failure
         if mismatch is not None:
             outcome["mismatch"] = mismatch
         if manual_fallback is not None:
@@ -4289,7 +4311,7 @@ class AegisOpsControlPlaneService:
         return mismatch
 
     @staticmethod
-    def _action_review_coordination_ticket_timeout(
+    def _action_review_coordination_ticket_terminal_issue(
         *,
         action_execution: ActionExecutionRecord | None,
         path_health: Mapping[str, object],
@@ -4302,6 +4324,7 @@ class AegisOpsControlPlaneService:
             dispatch_failure = action_execution.provenance["dispatch_failure"]
             if dispatch_failure.get("error_type") == "TimeoutError":
                 timeout = {
+                    "category": "timeout",
                     "path": "provider",
                     "reason": "dispatch_timeout",
                 }
@@ -4320,13 +4343,28 @@ class AegisOpsControlPlaneService:
             "authoritative_outcome_timeout",
             "reconciliation_timeout",
         }
+        terminal_failure_reasons = {
+            "execution_failed",
+            "execution_canceled",
+            "execution_expired",
+            "execution_rejected",
+        }
         for path_name in ("ingest", "delegation", "provider", "persistence"):
             path = paths.get(path_name)
             if not isinstance(path, Mapping):
                 continue
             reason = path.get("reason")
-            if isinstance(reason, str) and reason in timeout_reasons:
+            if not isinstance(reason, str):
+                continue
+            if reason in timeout_reasons:
                 return {
+                    "category": "timeout",
+                    "path": path_name,
+                    "reason": reason,
+                }
+            if path_name == "provider" and reason in terminal_failure_reasons:
+                return {
+                    "category": "failed",
                     "path": path_name,
                     "reason": reason,
                 }

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2389,6 +2389,7 @@ class AegisOpsControlPlaneService:
             reconciliation=reconciliation,
             runtime_visibility=runtime_visibility,
             path_health=path_health,
+            review_state=review_state,
         )
 
         return {
@@ -4176,9 +4177,16 @@ class AegisOpsControlPlaneService:
         reconciliation: ReconciliationRecord | None,
         runtime_visibility: Mapping[str, object] | None,
         path_health: Mapping[str, object],
+        review_state: str,
     ) -> dict[str, object] | None:
         requested_payload = action_request.requested_payload
         if requested_payload.get("action_type") != "create_tracking_ticket":
+            return None
+        if (
+            action_execution is None
+            and reconciliation is None
+            and review_state in {"rejected", "expired", "superseded", "canceled"}
+        ):
             return None
 
         downstream_binding = self._action_review_downstream_binding(action_execution)
@@ -4353,6 +4361,18 @@ class AegisOpsControlPlaneService:
             "execution_expired",
             "execution_rejected",
         }
+        provider_path = paths.get("provider")
+        if isinstance(provider_path, Mapping):
+            provider_reason = provider_path.get("reason")
+            if (
+                isinstance(provider_reason, str)
+                and provider_reason in terminal_failure_reasons
+            ):
+                return {
+                    "category": "failed",
+                    "path": "provider",
+                    "reason": provider_reason,
+                }
         for path_name in ("ingest", "delegation", "provider", "persistence"):
             path = paths.get(path_name)
             if not isinstance(path, Mapping):
@@ -4363,12 +4383,6 @@ class AegisOpsControlPlaneService:
             if reason in timeout_reasons:
                 return {
                     "category": "timeout",
-                    "path": path_name,
-                    "reason": reason,
-                }
-            if path_name == "provider" and reason in terminal_failure_reasons:
-                return {
-                    "category": "failed",
                     "path": path_name,
                     "reason": reason,
                 }

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2382,6 +2382,13 @@ class AegisOpsControlPlaneService:
             reconciliation=reconciliation,
             review_state=review_state,
         )
+        coordination_ticket_outcome = self._action_review_coordination_ticket_outcome(
+            action_request=action_request,
+            action_execution=action_execution,
+            reconciliation=reconciliation,
+            runtime_visibility=runtime_visibility,
+            path_health=path_health,
+        )
 
         return {
             "review_state": review_state,
@@ -2413,6 +2420,7 @@ class AegisOpsControlPlaneService:
             "escalation_reason": requested_payload.get("escalation_reason"),
             "runtime_visibility": runtime_visibility,
             "path_health": path_health,
+            "coordination_ticket_outcome": coordination_ticket_outcome,
             "execution_surface_type": (
                 action_execution.execution_surface_type
                 if action_execution is not None
@@ -4157,6 +4165,172 @@ class AegisOpsControlPlaneService:
             "last_seen_at": reconciliation.last_seen_at,
             "compared_at": reconciliation.compared_at,
         }
+
+    def _action_review_coordination_ticket_outcome(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        action_execution: ActionExecutionRecord | None,
+        reconciliation: ReconciliationRecord | None,
+        runtime_visibility: Mapping[str, object] | None,
+        path_health: Mapping[str, object],
+    ) -> dict[str, object] | None:
+        requested_payload = action_request.requested_payload
+        if requested_payload.get("action_type") != "create_tracking_ticket":
+            return None
+
+        downstream_binding = self._action_review_downstream_binding(action_execution)
+        mismatch = self._action_review_coordination_ticket_mismatch(reconciliation)
+        timeout = self._action_review_coordination_ticket_timeout(
+            action_execution=action_execution,
+            path_health=path_health,
+        )
+        manual_fallback = None
+        if isinstance(runtime_visibility, Mapping):
+            manual_fallback_entry = runtime_visibility.get("manual_fallback")
+            if isinstance(manual_fallback_entry, Mapping):
+                manual_fallback = dict(manual_fallback_entry)
+
+        if mismatch is not None:
+            status = "mismatch"
+            summary = str(mismatch["mismatch_summary"])
+        elif (
+            reconciliation is not None
+            and reconciliation.lifecycle_state == "matched"
+            and action_execution is not None
+            and action_execution.lifecycle_state == "succeeded"
+        ):
+            status = "created"
+            summary = (
+                "reviewed create-ticket outcome recorded from authoritative "
+                "execution and reconciliation"
+            )
+        elif timeout is not None:
+            status = "timeout"
+            summary = str(timeout["reason"]).replace("_", " ")
+        else:
+            status = "pending"
+            summary = "reviewed create-ticket outcome still awaiting authoritative result"
+
+        outcome = {
+            "authority": "authoritative_aegisops_review",
+            "status": status,
+            "summary": summary,
+            "action_request_id": action_request.action_request_id,
+            "approval_decision_id": action_request.approval_decision_id,
+            "action_execution_id": (
+                None if action_execution is None else action_execution.action_execution_id
+            ),
+            "execution_run_id": (
+                None if action_execution is None else action_execution.execution_run_id
+            ),
+            "reconciliation_id": (
+                None if reconciliation is None else reconciliation.reconciliation_id
+            ),
+            "coordination_reference_id": (
+                action_request.target_scope.get("coordination_reference_id")
+                if isinstance(action_request.target_scope.get("coordination_reference_id"), str)
+                else requested_payload.get("coordination_reference_id")
+            ),
+            "coordination_target_type": (
+                action_request.target_scope.get("coordination_target_type")
+                if isinstance(action_request.target_scope.get("coordination_target_type"), str)
+                else requested_payload.get("coordination_target_type")
+            ),
+            "coordination_target_id": (
+                None
+                if downstream_binding is None
+                else downstream_binding.get("coordination_target_id")
+            ),
+            "external_receipt_id": (
+                None
+                if downstream_binding is None
+                else downstream_binding.get("external_receipt_id")
+            ),
+            "ticket_reference_url": (
+                None
+                if downstream_binding is None
+                else downstream_binding.get("ticket_reference_url")
+            ),
+        }
+        if timeout is not None:
+            outcome["timeout"] = timeout
+        if mismatch is not None:
+            outcome["mismatch"] = mismatch
+        if manual_fallback is not None:
+            outcome["manual_fallback"] = manual_fallback
+        return outcome
+
+    @staticmethod
+    def _action_review_downstream_binding(
+        action_execution: ActionExecutionRecord | None,
+    ) -> Mapping[str, object] | None:
+        if action_execution is None or not isinstance(action_execution.provenance, Mapping):
+            return None
+        downstream_binding = action_execution.provenance.get("downstream_binding")
+        if not isinstance(downstream_binding, Mapping):
+            return None
+        return downstream_binding
+
+    @staticmethod
+    def _action_review_coordination_ticket_mismatch(
+        reconciliation: ReconciliationRecord | None,
+    ) -> dict[str, object] | None:
+        mismatch = AegisOpsControlPlaneService._action_review_mismatch_inspection(
+            reconciliation
+        )
+        if mismatch is None:
+            return None
+        if (
+            mismatch["lifecycle_state"] != "mismatched"
+            and mismatch["ingest_disposition"] != "mismatch"
+        ):
+            return None
+        return mismatch
+
+    @staticmethod
+    def _action_review_coordination_ticket_timeout(
+        *,
+        action_execution: ActionExecutionRecord | None,
+        path_health: Mapping[str, object],
+    ) -> dict[str, object] | None:
+        if (
+            action_execution is not None
+            and isinstance(action_execution.provenance, Mapping)
+            and isinstance(action_execution.provenance.get("dispatch_failure"), Mapping)
+        ):
+            dispatch_failure = action_execution.provenance["dispatch_failure"]
+            if dispatch_failure.get("error_type") == "TimeoutError":
+                timeout = {
+                    "path": "provider",
+                    "reason": "dispatch_timeout",
+                }
+                error = dispatch_failure.get("error")
+                if isinstance(error, str) and error:
+                    timeout["error"] = error
+                return timeout
+
+        paths = path_health.get("paths")
+        if not isinstance(paths, Mapping):
+            return None
+        timeout_reasons = {
+            "ingest_signal_timeout",
+            "delegation_receipt_timeout",
+            "provider_receipt_timeout",
+            "authoritative_outcome_timeout",
+            "reconciliation_timeout",
+        }
+        for path_name in ("ingest", "delegation", "provider", "persistence"):
+            path = paths.get(path_name)
+            if not isinstance(path, Mapping):
+                continue
+            reason = path.get("reason")
+            if isinstance(reason, str) and reason in timeout_reasons:
+                return {
+                    "path": path_name,
+                    "reason": reason,
+                }
+        return None
 
     def inspect_analyst_queue(self) -> AnalystQueueSnapshot:
         active_alert_states = {

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -4703,6 +4703,89 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "analyst-003",
         )
 
+    def test_cli_inspect_case_detail_keeps_created_status_when_manual_fallback_is_recorded_after_success(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        delegated_at = reviewed_at + timedelta(minutes=15)
+        compared_at = reviewed_at + timedelta(minutes=20)
+        seeded = self._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="created-with-fallback-001",
+            coordination_reference_id="coord-ref-cli-create-ticket-created-with-fallback-001",
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        service.reconcile_action_execution(
+            action_request_id=seeded["action_request"].action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": seeded["action_request"].idempotency_key,
+                    "approval_decision_id": seeded["approval"].approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": seeded["payload_hash"],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+        service.record_action_review_manual_fallback(
+            action_request_id=seeded["action_request"].action_request_id,
+            fallback_at=reviewed_at + timedelta(minutes=45),
+            fallback_actor_identity="analyst-004",
+            authority_boundary="approved_human_fallback",
+            reason="Business-hours operator added manual fallback notes after a completed create-ticket review.",
+            action_taken="Captured manual ticket fallback instructions for the reviewed coordination flow.",
+            verification_evidence_ids=(evidence_id,),
+            residual_uncertainty="Awaiting operator acknowledgement during the next review window.",
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(review["coordination_ticket_outcome"]["status"], "created")
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["manual_fallback"]["action_taken"],
+            "Captured manual ticket fallback instructions for the reviewed coordination flow.",
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["manual_fallback"][
+                "fallback_actor_identity"
+            ],
+            "analyst-004",
+        )
+
     def test_cli_inspect_case_detail_keeps_after_hours_handoff_visible_for_non_executed_review_states(
         self,
     ) -> None:

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -4539,6 +4539,43 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "and observed downstream execution",
         )
 
+    def test_cli_inspect_case_detail_omits_create_tracking_ticket_outcome_for_terminal_non_delegated_reviews(
+        self,
+    ) -> None:
+        for review_state in ("rejected", "expired", "superseded", "canceled"):
+            with self.subTest(review_state=review_state):
+                _, service, promoted_case, _evidence_id, reviewed_at = (
+                    self._build_phase19_in_scope_case()
+                )
+                seeded = self._seed_create_tracking_ticket_request(
+                    service=service,
+                    promoted_case=promoted_case,
+                    reviewed_at=reviewed_at,
+                    suffix=f"closed-without-delegation-{review_state}",
+                    coordination_reference_id=(
+                        f"coord-ref-cli-create-ticket-closed-without-delegation-{review_state}"
+                    ),
+                )
+                if review_state in {"rejected", "expired"}:
+                    service.persist_record(
+                        replace(seeded["approval"], lifecycle_state=review_state)
+                    )
+                service.persist_record(
+                    replace(seeded["action_request"], lifecycle_state=review_state)
+                )
+
+                stdout = io.StringIO()
+                main.main(
+                    ["inspect-case-detail", "--case-id", promoted_case.case_id],
+                    stdout=stdout,
+                    service=service,
+                )
+
+                payload = json.loads(stdout.getvalue())
+                review = payload["current_action_review"]
+                self.assertEqual(review["review_state"], review_state)
+                self.assertIsNone(review["coordination_ticket_outcome"])
+
     def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_timeout(
         self,
     ) -> None:
@@ -4618,6 +4655,80 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
 
         payload = json.loads(stdout.getvalue())
         review = payload["current_action_review"]
+        self.assertEqual(review["coordination_ticket_outcome"]["status"], "timeout")
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["timeout"]["reason"],
+            "execution_failed",
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["timeout"]["path"],
+            "provider",
+        )
+
+    def test_cli_inspect_case_detail_prefers_provider_failure_over_derived_timeouts(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        delegated_at = reviewed_at + timedelta(minutes=15)
+        overdue_requested_at = datetime.now(timezone.utc) - timedelta(hours=2)
+        overdue_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        seeded = self._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="failure-precedence-001",
+            coordination_reference_id="coord-ref-cli-create-ticket-failure-precedence-001",
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        service.persist_record(
+            replace(
+                seeded["approval"],
+                decided_at=overdue_requested_at + timedelta(minutes=5),
+                approved_expires_at=overdue_expires_at,
+            )
+        )
+        action_request = service.get_record(
+            ActionRequestRecord, seeded["action_request"].action_request_id
+        )
+        service.persist_record(
+            replace(
+                action_request,
+                requested_at=overdue_requested_at,
+                expires_at=overdue_expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                execution,
+                delegated_at=overdue_requested_at + timedelta(minutes=10),
+                expires_at=overdue_expires_at,
+                lifecycle_state="failed",
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(
+            review["path_health"]["paths"]["ingest"]["reason"],
+            "ingest_signal_timeout",
+        )
+        self.assertEqual(
+            review["path_health"]["paths"]["persistence"]["reason"],
+            "reconciliation_timeout",
+        )
         self.assertEqual(review["coordination_ticket_outcome"]["status"], "timeout")
         self.assertEqual(
             review["coordination_ticket_outcome"]["timeout"]["reason"],

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -4510,6 +4510,46 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "provider",
         )
 
+    def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_failure(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        delegated_at = reviewed_at + timedelta(minutes=15)
+        seeded = self._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="failure-001",
+            coordination_reference_id="coord-ref-cli-create-ticket-failure-001",
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        service.persist_record(replace(execution, lifecycle_state="failed"))
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(review["coordination_ticket_outcome"]["status"], "failed")
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["failure"]["reason"],
+            "execution_failed",
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["failure"]["path"],
+            "provider",
+        )
+
     def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_manual_fallback(
         self,
     ) -> None:
@@ -4570,6 +4610,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         payload = json.loads(stdout.getvalue())
         review = payload["current_action_review"]
         self.assertEqual(payload["external_ticket_reference"]["status"], "present")
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["status"],
+            "manual_fallback",
+        )
         self.assertEqual(
             review["coordination_ticket_outcome"]["manual_fallback"]["action_taken"],
             "Opened the reviewed tracking ticket manually using the approved procedure.",

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -24,6 +24,7 @@ if str(TESTS_ROOT) not in sys.path:
 import main
 from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
+from aegisops_control_plane.execution_coordinator import _approved_payload_binding_hash
 from aegisops_control_plane.models import (
     AITraceRecord,
     ActionExecutionRecord,
@@ -47,6 +48,7 @@ from support.auth import (
     REVIEWED_PROXY_SERVICE_ACCOUNT,
 )
 from support.fixtures import load_wazuh_fixture
+from support.payloads import phase26_create_tracking_ticket_payload
 
 
 _load_wazuh_fixture = load_wazuh_fixture
@@ -127,6 +129,77 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
         )
         promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
         return service, promoted_case
+
+    def _seed_create_tracking_ticket_request(
+        self,
+        *,
+        service: AegisOpsControlPlaneService,
+        promoted_case: CaseRecord,
+        reviewed_at: datetime,
+        suffix: str,
+        coordination_reference_id: str,
+    ) -> dict[str, object]:
+        requested_at = reviewed_at + timedelta(minutes=10)
+        expires_at = reviewed_at + timedelta(hours=4)
+        approved_target_scope = {
+            "case_id": promoted_case.case_id,
+            "alert_id": promoted_case.alert_id,
+            "finding_id": promoted_case.finding_id,
+            "coordination_reference_id": coordination_reference_id,
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = phase26_create_tracking_ticket_payload(
+            case_id=promoted_case.case_id,
+            alert_id=promoted_case.alert_id,
+            finding_id=promoted_case.finding_id,
+            coordination_reference_id=coordination_reference_id,
+        )
+        payload_hash = _approved_payload_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id=f"approval-cli-create-ticket-{suffix}",
+                action_request_id=f"action-request-cli-create-ticket-{suffix}",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+                approved_expires_at=expires_at,
+            )
+        )
+        action_request = service.persist_record(
+            ActionRequestRecord(
+                action_request_id=f"action-request-cli-create-ticket-{suffix}",
+                approval_decision_id=approval.approval_decision_id,
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                idempotency_key=f"idempotency-cli-create-ticket-{suffix}",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=expires_at,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        return {
+            "action_request": action_request,
+            "approval": approval,
+            "approved_payload": approved_payload,
+            "payload_hash": payload_hash,
+        }
 
     def _build_out_of_scope_case_advisory_review_records(
         self,
@@ -4188,6 +4261,324 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     "reason": "reconciliation_timeout",
                 },
             },
+        )
+
+    def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_outcome(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        requested_at = reviewed_at + timedelta(minutes=10)
+        delegated_at = reviewed_at + timedelta(minutes=15)
+        compared_at = reviewed_at + timedelta(minutes=20)
+        approved_target_scope = {
+            "case_id": promoted_case.case_id,
+            "alert_id": promoted_case.alert_id,
+            "finding_id": promoted_case.finding_id,
+            "coordination_reference_id": "coord-ref-cli-create-ticket-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = phase26_create_tracking_ticket_payload(
+            case_id=promoted_case.case_id,
+            alert_id=promoted_case.alert_id,
+            finding_id=promoted_case.finding_id,
+            coordination_reference_id="coord-ref-cli-create-ticket-001",
+        )
+        payload_hash = _approved_payload_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-cli-create-ticket-outcome-001",
+                action_request_id="action-request-cli-create-ticket-outcome-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+                approved_expires_at=reviewed_at + timedelta(hours=4),
+            )
+        )
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-cli-create-ticket-outcome-001",
+                approval_decision_id=approval.approval_decision_id,
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                idempotency_key="idempotency-cli-create-ticket-outcome-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=reviewed_at + timedelta(hours=4),
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-cli-create-ticket-outcome-001",
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        service.reconcile_action_execution(
+            action_request_id="action-request-cli-create-ticket-outcome-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": "idempotency-cli-create-ticket-outcome-001",
+                    "approval_decision_id": approval.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": payload_hash,
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["status"],
+            "created",
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["coordination_reference_id"],
+            "coord-ref-cli-create-ticket-001",
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["coordination_target_type"],
+            "zammad",
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["external_receipt_id"],
+            downstream_binding["external_receipt_id"],
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["ticket_reference_url"],
+            downstream_binding["ticket_reference_url"],
+        )
+
+    def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_mismatch(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        delegated_at = reviewed_at + timedelta(minutes=15)
+        compared_at = reviewed_at + timedelta(minutes=20)
+        seeded = self._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="mismatch-001",
+            coordination_reference_id="coord-ref-cli-create-ticket-mismatch-001",
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        service.reconcile_action_execution(
+            action_request_id=seeded["action_request"].action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": seeded["action_request"].idempotency_key,
+                    "approval_decision_id": seeded["approval"].approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": seeded["payload_hash"],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": "shuffle-receipt-cli-drifted-001",
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(review["coordination_ticket_outcome"]["status"], "mismatch")
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["mismatch"]["mismatch_summary"],
+            "coordination receipt mismatch between authoritative action execution "
+            "and observed downstream execution",
+        )
+
+    def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_timeout(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        delegated_at = datetime.now(timezone.utc)
+        seeded = self._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="timeout-001",
+            coordination_reference_id="coord-ref-cli-create-ticket-timeout-001",
+        )
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=TimeoutError("synthetic create-tracking-ticket timeout"),
+        ):
+            with self.assertRaisesRegex(
+                TimeoutError,
+                "synthetic create-tracking-ticket timeout",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id=seeded["action_request"].action_request_id,
+                    approved_payload=seeded["approved_payload"],
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(review["coordination_ticket_outcome"]["status"], "timeout")
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["timeout"]["reason"],
+            "dispatch_timeout",
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["timeout"]["path"],
+            "provider",
+        )
+
+    def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_manual_fallback(
+        self,
+    ) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        seeded = self._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="manual-fallback-001",
+            coordination_reference_id="coord-ref-cli-create-ticket-manual-fallback-001",
+        )
+        service.persist_record(
+            replace(
+                seeded["action_request"],
+                lifecycle_state="unresolved",
+            )
+        )
+        service.record_action_review_manual_fallback(
+            action_request_id=seeded["action_request"].action_request_id,
+            fallback_at=reviewed_at + timedelta(minutes=45),
+            fallback_actor_identity="analyst-003",
+            authority_boundary="approved_human_fallback",
+            reason="The reviewed create-ticket automation path was unavailable after approval.",
+            action_taken="Opened the reviewed tracking ticket manually using the approved procedure.",
+            verification_evidence_ids=(evidence_id,),
+            residual_uncertainty="Awaiting downstream operator acknowledgement in the next review window.",
+        )
+        service.persist_record(
+            replace(
+                service.get_record(AlertRecord, promoted_case.alert_id),
+                coordination_reference_id=(
+                    "coord-ref-cli-create-ticket-manual-fallback-001"
+                ),
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+        service.persist_record(
+            replace(
+                service.get_record(CaseRecord, promoted_case.case_id),
+                coordination_reference_id=(
+                    "coord-ref-cli-create-ticket-manual-fallback-001"
+                ),
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(payload["external_ticket_reference"]["status"], "present")
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["manual_fallback"]["action_taken"],
+            "Opened the reviewed tracking ticket manually using the approved procedure.",
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["manual_fallback"][
+                "fallback_actor_identity"
+            ],
+            "analyst-003",
         )
 
     def test_cli_inspect_case_detail_keeps_after_hours_handoff_visible_for_non_executed_review_states(

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -4377,6 +4377,10 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "created",
         )
         self.assertEqual(
+            review["coordination_ticket_outcome"]["approval_decision_id"],
+            approval.approval_decision_id,
+        )
+        self.assertEqual(
             review["coordination_ticket_outcome"]["coordination_reference_id"],
             "coord-ref-cli-create-ticket-001",
         )
@@ -4392,6 +4396,80 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             review["coordination_ticket_outcome"]["ticket_reference_url"],
             downstream_binding["ticket_reference_url"],
         )
+
+    def test_cli_inspect_case_detail_repairs_nested_create_tracking_ticket_approval_linkage(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = self._build_phase19_in_scope_case()
+        delegated_at = reviewed_at + timedelta(minutes=15)
+        compared_at = reviewed_at + timedelta(minutes=20)
+        seeded = self._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="repaired-approval-001",
+            coordination_reference_id="coord-ref-cli-create-ticket-repaired-approval-001",
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        service.reconcile_action_execution(
+            action_request_id=seeded["action_request"].action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": seeded["action_request"].idempotency_key,
+                    "approval_decision_id": seeded["approval"].approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": seeded["payload_hash"],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+        service.persist_record(
+            replace(seeded["action_request"], approval_decision_id=None)
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", promoted_case.case_id],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        review = payload["current_action_review"]
+        self.assertEqual(
+            review["approval_decision_id"],
+            seeded["approval"].approval_decision_id,
+        )
+        self.assertEqual(
+            review["coordination_ticket_outcome"]["approval_decision_id"],
+            seeded["approval"].approval_decision_id,
+        )
+        self.assertEqual(review["coordination_ticket_outcome"]["status"], "created")
 
     def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_mismatch(
         self,
@@ -4510,7 +4588,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
             "provider",
         )
 
-    def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_failure(
+    def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_provider_failure_as_timeout(
         self,
     ) -> None:
         _, service, promoted_case, _evidence_id, reviewed_at = self._build_phase19_in_scope_case()
@@ -4540,13 +4618,13 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
 
         payload = json.loads(stdout.getvalue())
         review = payload["current_action_review"]
-        self.assertEqual(review["coordination_ticket_outcome"]["status"], "failed")
+        self.assertEqual(review["coordination_ticket_outcome"]["status"], "timeout")
         self.assertEqual(
-            review["coordination_ticket_outcome"]["failure"]["reason"],
+            review["coordination_ticket_outcome"]["timeout"]["reason"],
             "execution_failed",
         )
         self.assertEqual(
-            review["coordination_ticket_outcome"]["failure"]["path"],
+            review["coordination_ticket_outcome"]["timeout"]["path"],
             "provider",
         )
 


### PR DESCRIPTION
Closes #552
This PR was opened by codex-supervisor.
Latest Codex summary:

Added an authoritative `coordination_ticket_outcome` surface to action-review snapshots in [service.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-552/control-plane/aegisops_control_plane/service.py:2382). It is only populated for `create_tracking_ticket` reviews and derives status from AegisOps-owned records: matched reconciliation yields `created`, reconciliation drift yields `mismatch`, timeout/failure evidence yields `timeout`, and recorded fallback remains explicit under `manual_fallback`. Link-only ticket references remain on the existing top-level `external_ticket_reference` alert/case surfaces.

Focused coverage was added in [test_cli_inspection.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-552/control-plane/tests/test_cli_inspection.py:4263) for create-ticket success, mismatch, timeout, and manual fallback inspection, and I re-ran the existing link-only reference test. The branch is checkpointed at commit `6d5f5b9` with a clean worktree.

Summary: Added authoritative create-ticket outcome inspection surfaces and focused CLI coverage for success, mismatch, timeout, and manual fallback; committed as `6d5f5b9`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence_ingest_case_lifecycle.IngestCaseLifecyclePersistenceTests.test_service_detail_surfaces_link_only_external_ticket_reference_on_alert_and_case control-plane.tests.test_cli_inspection.ControlPlaneCliInspectionTests.test_cli_inspect_case_deta...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action-review snapshots now include a computed coordination-ticket outcome: authority, status, summary, related IDs, coordination reference/target info, downstream ticket data, and conditional timeout/mismatch/manual-fallback details.

* **Tests**
  * Expanded CLI inspection tests covering created, nested-approval repair, mismatch, timeout (dispatch and provider failure), manual-fallback, and manual-fallback-after-created scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->