### PR TITLE
validation: add end-to-end link-first and first-soft-write ticket coverage (#553)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,14 @@ jobs:
       - name: Run Phase 25 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-25-workflow-coverage.sh
 
+      - name: Run Phase 26 ticket coordination validation
+        run: |
+          bash scripts/verify-phase-26-ticket-coordination-validation.sh
+          python3 -m unittest control-plane.tests.test_phase26_end_to_end_validation control-plane.tests.test_phase26_coordination_substrate_boundary_docs control-plane.tests.test_phase26_create_tracking_ticket_soft_write_contract_docs
+
+      - name: Run Phase 26 workflow coverage guard
+        run: bash scripts/test-verify-ci-phase-26-workflow-coverage.sh
+
       - name: Run control-plane runtime unit tests
         run: python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
 
@@ -248,6 +256,7 @@ jobs:
           bash scripts/test-verify-phase-23-authority-closure.sh
           bash scripts/test-verify-phase-24-live-assistant-workflow-contract.sh
           bash scripts/test-verify-phase-25-multi-source-case-review-runbook.sh
+          bash scripts/test-verify-phase-26-ticket-coordination-validation.sh
           bash scripts/test-verify-ci-phase-14-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-15-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-19-workflow-coverage.sh
@@ -257,6 +266,7 @@ jobs:
           bash scripts/test-verify-ci-phase-23-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-24-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-25-workflow-coverage.sh
+          bash scripts/test-verify-ci-phase-26-workflow-coverage.sh
           bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
           bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
           bash scripts/test-verify-phase-6-replay-to-notify-validation.sh

--- a/control-plane/tests/test_phase26_end_to_end_validation.py
+++ b/control-plane/tests/test_phase26_end_to_end_validation.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta, timezone
+import io
+import json
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))
+
+import main
+import test_cli_inspection as cli_inspection_tests
+
+
+class Phase26EndToEndValidationTests(unittest.TestCase):
+    def _helpers(self) -> cli_inspection_tests.ControlPlaneCliInspectionTests:
+        return cli_inspection_tests.ControlPlaneCliInspectionTests()
+
+    def _inspect_case_detail(
+        self,
+        *,
+        service: cli_inspection_tests.AegisOpsControlPlaneService,
+        case_id: str,
+    ) -> dict[str, object]:
+        stdout = io.StringIO()
+        main.main(
+            ["inspect-case-detail", "--case-id", case_id],
+            stdout=stdout,
+            service=service,
+        )
+        return json.loads(stdout.getvalue())
+
+    def test_phase26_end_to_end_surfaces_link_first_ticket_reference_without_authority_drift(
+        self,
+    ) -> None:
+        helpers = self._helpers()
+        _, service, promoted_case, _evidence_id, _reviewed_at = (
+            helpers._build_phase19_in_scope_case()
+        )
+        service.persist_record(
+            replace(
+                service.get_record(
+                    cli_inspection_tests.AlertRecord, promoted_case.alert_id
+                ),
+                coordination_reference_id="coord-ref-phase26-link-first-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+        service.persist_record(
+            replace(
+                service.get_record(
+                    cli_inspection_tests.CaseRecord, promoted_case.case_id
+                ),
+                coordination_reference_id="coord-ref-phase26-link-first-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+
+        payload = self._inspect_case_detail(service=service, case_id=promoted_case.case_id)
+        external_ticket_reference = payload["external_ticket_reference"]
+
+        self.assertEqual(external_ticket_reference["authority"], "non_authoritative")
+        self.assertEqual(external_ticket_reference["status"], "present")
+        self.assertEqual(
+            external_ticket_reference["coordination_reference_id"],
+            "coord-ref-phase26-link-first-001",
+        )
+        self.assertEqual(
+            external_ticket_reference["coordination_target_type"],
+            "zammad",
+        )
+        self.assertEqual(
+            external_ticket_reference["coordination_target_id"],
+            "ZM-4242",
+        )
+        self.assertEqual(
+            external_ticket_reference["ticket_reference_url"],
+            "https://tickets.example.test/#ticket/4242",
+        )
+        self.assertIsNone(payload["current_action_review"])
+
+    def test_phase26_end_to_end_surfaces_create_tracking_ticket_created_outcome(
+        self,
+    ) -> None:
+        helpers = self._helpers()
+        store, service, promoted_case, _evidence_id, reviewed_at = (
+            helpers._build_phase19_in_scope_case()
+        )
+        delegated_at = reviewed_at + timedelta(minutes=15)
+        compared_at = reviewed_at + timedelta(minutes=20)
+        seeded = helpers._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="phase26-created-001",
+            coordination_reference_id="coord-ref-phase26-created-001",
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        service.reconcile_action_execution(
+            action_request_id=seeded["action_request"].action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": seeded["action_request"].idempotency_key,
+                    "approval_decision_id": seeded["approval"].approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": seeded["payload_hash"],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+
+        payload = self._inspect_case_detail(service=service, case_id=promoted_case.case_id)
+        outcome = payload["current_action_review"]["coordination_ticket_outcome"]
+
+        self.assertEqual(outcome["status"], "created")
+        self.assertEqual(
+            outcome["coordination_reference_id"],
+            "coord-ref-phase26-created-001",
+        )
+        self.assertEqual(outcome["coordination_target_type"], "zammad")
+        self.assertEqual(
+            outcome["external_receipt_id"],
+            downstream_binding["external_receipt_id"],
+        )
+        self.assertEqual(
+            outcome["ticket_reference_url"],
+            downstream_binding["ticket_reference_url"],
+        )
+
+    def test_phase26_end_to_end_fail_closes_missing_receipt_before_user_facing_success(
+        self,
+    ) -> None:
+        helpers = self._helpers()
+        store, service, promoted_case, _evidence_id, reviewed_at = (
+            helpers._build_phase19_in_scope_case()
+        )
+        delegated_at = cli_inspection_tests.datetime.now(timezone.utc)
+        seeded = helpers._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="phase26-missing-receipt-001",
+            coordination_reference_id="coord-ref-phase26-missing-receipt-001",
+        )
+        original_dispatch = type(service._shuffle).dispatch_approved_action
+
+        def dispatch_without_external_receipt_id(
+            adapter: object,
+            **kwargs: object,
+        ) -> object:
+            receipt = original_dispatch(adapter, **kwargs)
+            return cli_inspection_tests.replace(receipt, external_receipt_id="")
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_without_external_receipt_id,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "adapter receipt missing required 'external_receipt_id' attribute",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id=seeded["action_request"].action_request_id,
+                    approved_payload=seeded["approved_payload"],
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        payload = self._inspect_case_detail(service=service, case_id=promoted_case.case_id)
+        review = payload["current_action_review"]
+        outcome = review["coordination_ticket_outcome"]
+
+        self.assertEqual(review["action_execution_state"], "failed")
+        self.assertEqual(outcome["status"], "timeout")
+        self.assertEqual(outcome["timeout"]["path"], "provider")
+        self.assertEqual(outcome["timeout"]["reason"], "execution_failed")
+        self.assertEqual(
+            store.list(cli_inspection_tests.ActionExecutionRecord)[0].provenance[
+                "dispatch_failure"
+            ]["error"],
+            "adapter receipt missing required 'external_receipt_id' attribute",
+        )
+
+    def test_phase26_end_to_end_surfaces_duplicate_create_attempt_as_mismatch(
+        self,
+    ) -> None:
+        helpers = self._helpers()
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            helpers._build_phase19_in_scope_case()
+        )
+        delegated_at = reviewed_at + timedelta(minutes=15)
+        compared_at = reviewed_at + timedelta(minutes=20)
+        seeded = helpers._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="phase26-duplicate-001",
+            coordination_reference_id="coord-ref-phase26-duplicate-001",
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        service.reconcile_action_execution(
+            action_request_id=seeded["action_request"].action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": seeded["action_request"].idempotency_key,
+                    "approval_decision_id": seeded["approval"].approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": seeded["payload_hash"],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+                {
+                    "execution_run_id": "shuffle-run-phase26-duplicate-secondary-001",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": seeded["action_request"].idempotency_key,
+                    "approval_decision_id": seeded["approval"].approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": seeded["payload_hash"],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": "shuffle-receipt-phase26-duplicate-secondary-001",
+                    "coordination_target_id": "zammad-ticket-phase26-duplicate-secondary-001",
+                    "ticket_reference_url": (
+                        "https://tickets.example.test/#ticket/"
+                        "zammad-ticket-phase26-duplicate-secondary-001"
+                    ),
+                    "observed_at": compared_at + timedelta(seconds=1),
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at + timedelta(seconds=1),
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+
+        payload = self._inspect_case_detail(service=service, case_id=promoted_case.case_id)
+        outcome = payload["current_action_review"]["coordination_ticket_outcome"]
+
+        self.assertEqual(outcome["status"], "mismatch")
+        self.assertEqual(
+            outcome["mismatch"]["mismatch_summary"],
+            "duplicate downstream executions observed for one approved request",
+        )
+
+    def test_phase26_end_to_end_surfaces_create_tracking_ticket_identifier_mismatch(
+        self,
+    ) -> None:
+        helpers = self._helpers()
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            helpers._build_phase19_in_scope_case()
+        )
+        delegated_at = reviewed_at + timedelta(minutes=15)
+        compared_at = reviewed_at + timedelta(minutes=20)
+        seeded = helpers._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="phase26-mismatch-001",
+            coordination_reference_id="coord-ref-phase26-mismatch-001",
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        service.reconcile_action_execution(
+            action_request_id=seeded["action_request"].action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": seeded["action_request"].idempotency_key,
+                    "approval_decision_id": seeded["approval"].approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": seeded["payload_hash"],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": "shuffle-receipt-phase26-drifted-001",
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+
+        payload = self._inspect_case_detail(service=service, case_id=promoted_case.case_id)
+        outcome = payload["current_action_review"]["coordination_ticket_outcome"]
+
+        self.assertEqual(outcome["status"], "mismatch")
+        self.assertEqual(
+            outcome["mismatch"]["mismatch_summary"],
+            "coordination receipt mismatch between authoritative action execution "
+            "and observed downstream execution",
+        )
+
+    def test_phase26_end_to_end_surfaces_create_tracking_ticket_timeout(
+        self,
+    ) -> None:
+        helpers = self._helpers()
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            helpers._build_phase19_in_scope_case()
+        )
+        delegated_at = cli_inspection_tests.datetime.now(timezone.utc)
+        seeded = helpers._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="phase26-timeout-001",
+            coordination_reference_id="coord-ref-phase26-timeout-001",
+        )
+
+        with mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=TimeoutError("synthetic create-tracking-ticket timeout"),
+        ):
+            with self.assertRaisesRegex(
+                TimeoutError,
+                "synthetic create-tracking-ticket timeout",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id=seeded["action_request"].action_request_id,
+                    approved_payload=seeded["approved_payload"],
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        payload = self._inspect_case_detail(service=service, case_id=promoted_case.case_id)
+        outcome = payload["current_action_review"]["coordination_ticket_outcome"]
+
+        self.assertEqual(outcome["status"], "timeout")
+        self.assertEqual(outcome["timeout"]["reason"], "dispatch_timeout")
+        self.assertEqual(outcome["timeout"]["path"], "provider")
+
+    def test_phase26_end_to_end_surfaces_create_tracking_ticket_manual_fallback(
+        self,
+    ) -> None:
+        helpers = self._helpers()
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            helpers._build_phase19_in_scope_case()
+        )
+        seeded = helpers._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="phase26-manual-fallback-001",
+            coordination_reference_id="coord-ref-phase26-manual-fallback-001",
+        )
+        service.persist_record(
+            replace(
+                seeded["action_request"],
+                lifecycle_state="unresolved",
+            )
+        )
+        service.record_action_review_manual_fallback(
+            action_request_id=seeded["action_request"].action_request_id,
+            fallback_at=reviewed_at + timedelta(minutes=45),
+            fallback_actor_identity="analyst-phase26-001",
+            authority_boundary="approved_human_fallback",
+            reason="The reviewed create-ticket automation path was unavailable after approval.",
+            action_taken="Opened the reviewed tracking ticket manually using the approved procedure.",
+            verification_evidence_ids=(evidence_id,),
+            residual_uncertainty="Awaiting downstream operator acknowledgement in the next review window.",
+        )
+        service.persist_record(
+            replace(
+                service.get_record(
+                    cli_inspection_tests.AlertRecord, promoted_case.alert_id
+                ),
+                coordination_reference_id="coord-ref-phase26-manual-fallback-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+        service.persist_record(
+            replace(
+                service.get_record(
+                    cli_inspection_tests.CaseRecord, promoted_case.case_id
+                ),
+                coordination_reference_id="coord-ref-phase26-manual-fallback-001",
+                coordination_target_type="zammad",
+                coordination_target_id="ZM-4242",
+                ticket_reference_url="https://tickets.example.test/#ticket/4242",
+            )
+        )
+
+        payload = self._inspect_case_detail(service=service, case_id=promoted_case.case_id)
+        outcome = payload["current_action_review"]["coordination_ticket_outcome"]
+
+        self.assertEqual(payload["external_ticket_reference"]["status"], "present")
+        self.assertEqual(outcome["status"], "manual_fallback")
+        self.assertEqual(
+            outcome["manual_fallback"]["fallback_actor_identity"],
+            "analyst-phase26-001",
+        )
+        self.assertEqual(
+            outcome["manual_fallback"]["action_taken"],
+            "Opened the reviewed tracking ticket manually using the approved procedure.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase26_end_to_end_validation.py
+++ b/control-plane/tests/test_phase26_end_to_end_validation.py
@@ -96,7 +96,7 @@ class Phase26EndToEndValidationTests(unittest.TestCase):
         self,
     ) -> None:
         helpers = self._helpers()
-        store, service, promoted_case, _evidence_id, reviewed_at = (
+        _store, service, promoted_case, _evidence_id, reviewed_at = (
             helpers._build_phase19_in_scope_case()
         )
         delegated_at = reviewed_at + timedelta(minutes=15)

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -157,6 +157,42 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         ):
             self.assertIn(term, phase19_to_phase21_validation_tests)
 
+    def test_phase26_regression_validation_keeps_link_first_and_soft_write_ticket_coverage(
+        self,
+    ) -> None:
+        phase26_end_to_end_tests = self._defined_test_names(
+            "control-plane/tests/test_phase26_end_to_end_validation.py"
+        )
+        phase26_supporting_tests = self._defined_test_names(
+            "control-plane/tests/test_service_persistence_ingest_case_lifecycle.py",
+            "control-plane/tests/test_service_persistence_action_reconciliation.py",
+            "control-plane/tests/test_cli_inspection.py",
+        )
+
+        for term in (
+            "test_phase26_end_to_end_surfaces_link_first_ticket_reference_without_authority_drift",
+            "test_phase26_end_to_end_surfaces_create_tracking_ticket_created_outcome",
+            "test_phase26_end_to_end_fail_closes_missing_receipt_before_user_facing_success",
+            "test_phase26_end_to_end_surfaces_duplicate_create_attempt_as_mismatch",
+            "test_phase26_end_to_end_surfaces_create_tracking_ticket_identifier_mismatch",
+            "test_phase26_end_to_end_surfaces_create_tracking_ticket_timeout",
+            "test_phase26_end_to_end_surfaces_create_tracking_ticket_manual_fallback",
+        ):
+            self.assertIn(term, phase26_end_to_end_tests)
+
+        for term in (
+            "test_service_detail_surfaces_link_only_external_ticket_reference_on_alert_and_case",
+            "test_service_detail_keeps_mismatched_external_ticket_reference_explicit",
+            "test_service_fail_closes_when_create_tracking_ticket_receipt_omits_external_receipt_id",
+            "test_service_fail_closes_when_create_tracking_ticket_reconciliation_receipt_drifts",
+            "test_service_delegates_approved_create_tracking_ticket_through_shuffle",
+            "test_cli_inspect_case_detail_surfaces_create_tracking_ticket_outcome",
+            "test_cli_inspect_case_detail_surfaces_create_tracking_ticket_mismatch",
+            "test_cli_inspect_case_detail_surfaces_create_tracking_ticket_timeout",
+            "test_cli_inspect_case_detail_surfaces_create_tracking_ticket_manual_fallback",
+        ):
+            self.assertIn(term, phase26_supporting_tests)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test-verify-ci-phase-26-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-26-workflow-coverage.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+required_verifiers=(
+  "bash scripts/verify-phase-26-ticket-coordination-validation.sh"
+)
+
+required_tests=(
+  "bash scripts/test-verify-phase-26-ticket-coordination-validation.sh"
+)
+
+required_runtime_commands=(
+  "python3 -m unittest control-plane.tests.test_phase26_end_to_end_validation control-plane.tests.test_phase26_coordination_substrate_boundary_docs control-plane.tests.test_phase26_create_tracking_ticket_soft_write_contract_docs"
+)
+
+self_guard_step_name="Run Phase 26 workflow coverage guard"
+self_guard_command="bash scripts/test-verify-ci-phase-26-workflow-coverage.sh"
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+collect_active_run_commands() {
+  awk '
+    {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent > block_indent) {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          if (line != "" && line !~ /^#/) {
+            print line
+          }
+          next
+        }
+
+        in_block = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+        block_indent = match($0, /[^ ]/) - 1
+        in_block = 1
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[^|>]/) {
+        line = $0
+        sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+        if (line != "" && line !~ /^#/) {
+          print line
+        }
+      }
+    }
+  ' "${workflow_path}"
+}
+
+extract_self_guard_step_run_command() {
+  awk -v step_name="${self_guard_step_name}" '
+    function line_indent(line) {
+      return match(line, /[^ ]/) - 1
+    }
+
+    BEGIN {
+      in_step = 0
+      step_indent = -1
+    }
+
+    {
+      if (in_step) {
+        if ($0 ~ /^[[:space:]]*-[[:space:]]name:[[:space:]]+/ && line_indent($0) <= step_indent) {
+          exit 0
+        }
+
+        if ($0 ~ /^[[:space:]]*run:[[:space:]]*/) {
+          line = $0
+          sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+          print line
+          exit 0
+        }
+      }
+
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line == "- name: " step_name) {
+        in_step = 1
+        step_indent = line_indent($0)
+      }
+    }
+  ' "${workflow_path}"
+}
+
+active_run_commands="$(collect_active_run_commands)"
+
+for command in "${required_verifiers[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 26 verifier command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_tests[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 26 focused shell test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_runtime_commands[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 26 focused runtime command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+self_guard_step_run_command="$(extract_self_guard_step_run_command)"
+if [[ -z "${self_guard_step_run_command}" ]]; then
+  echo "Missing dedicated Phase 26 workflow coverage guard step in CI workflow: ${self_guard_step_name}" >&2
+  exit 1
+fi
+
+if [[ "${self_guard_step_run_command}" != "${self_guard_command}" ]]; then
+  echo "Dedicated Phase 26 workflow coverage guard step must run exactly: ${self_guard_command}" >&2
+  echo "Found: ${self_guard_step_run_command}" >&2
+  exit 1
+fi
+
+self_guard_count="$(grep -Fxc -- "${self_guard_command}" <<<"${active_run_commands}" || true)"
+if [[ "${self_guard_count}" -lt 2 ]]; then
+  echo "Phase 26 workflow coverage checker must run both as a dedicated guard and within focused shell tests." >&2
+  exit 1
+fi
+
+echo "CI workflow includes the required Phase 26 verifier, focused shell test, and focused runtime command."

--- a/scripts/test-verify-phase-26-ticket-coordination-validation.sh
+++ b/scripts/test-verify-phase-26-ticket-coordination-validation.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-26-ticket-coordination-validation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+required_artifacts=(
+  "control-plane/tests/test_phase26_end_to_end_validation.py"
+  "control-plane/tests/test_phase26_coordination_substrate_boundary_docs.py"
+  "control-plane/tests/test_phase26_create_tracking_ticket_soft_write_contract_docs.py"
+  "scripts/verify-phase-26-ticket-coordination-validation.sh"
+  "scripts/test-verify-phase-26-ticket-coordination-validation.sh"
+  "scripts/test-verify-ci-phase-26-workflow-coverage.sh"
+  ".github/workflows/ci.yml"
+)
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/control-plane/tests" "${target}/scripts" "${target}/.github/workflows"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_required_artifacts() {
+  local target="$1"
+  local artifact=""
+
+  for artifact in "${required_artifacts[@]}"; do
+    mkdir -p "${target}/$(dirname "${artifact}")"
+    cp "${repo_root}/${artifact}" "${target}/${artifact}"
+    git -C "${target}" add "${artifact}"
+  done
+}
+
+remove_text_from_file() {
+  local target="$1"
+  local path="$2"
+  local expected_text="$3"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_required_artifacts "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_e2e_repo="${workdir}/missing-e2e"
+create_repo "${missing_e2e_repo}"
+write_required_artifacts "${missing_e2e_repo}"
+rm "${missing_e2e_repo}/control-plane/tests/test_phase26_end_to_end_validation.py"
+git -C "${missing_e2e_repo}" add -u control-plane/tests/test_phase26_end_to_end_validation.py
+commit_fixture "${missing_e2e_repo}"
+assert_fails_with "${missing_e2e_repo}" "Missing Phase 26 end-to-end validation unittest:"
+
+missing_duplicate_repo="${workdir}/missing-duplicate"
+create_repo "${missing_duplicate_repo}"
+write_required_artifacts "${missing_duplicate_repo}"
+remove_text_from_file \
+  "${missing_duplicate_repo}" \
+  "control-plane/tests/test_phase26_end_to_end_validation.py" \
+  "    def test_phase26_end_to_end_surfaces_duplicate_create_attempt_as_mismatch("
+commit_fixture "${missing_duplicate_repo}"
+assert_fails_with "${missing_duplicate_repo}" "Missing required line in ${missing_duplicate_repo}/control-plane/tests/test_phase26_end_to_end_validation.py:     def test_phase26_end_to_end_surfaces_duplicate_create_attempt_as_mismatch("
+
+missing_ci_repo="${workdir}/missing-ci"
+create_repo "${missing_ci_repo}"
+write_required_artifacts "${missing_ci_repo}"
+remove_text_from_file \
+  "${missing_ci_repo}" \
+  ".github/workflows/ci.yml" \
+  "      - name: Run Phase 26 workflow coverage guard"
+commit_fixture "${missing_ci_repo}"
+assert_fails_with "${missing_ci_repo}" "Missing required line in ${missing_ci_repo}/.github/workflows/ci.yml:       - name: Run Phase 26 workflow coverage guard"
+
+echo "Phase 26 ticket coordination verifier fails closed for missing runtime coverage and CI wiring."

--- a/scripts/verify-phase-26-ticket-coordination-validation.sh
+++ b/scripts/verify-phase-26-ticket-coordination-validation.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+e2e_test="${repo_root}/control-plane/tests/test_phase26_end_to_end_validation.py"
+coordination_doc_test="${repo_root}/control-plane/tests/test_phase26_coordination_substrate_boundary_docs.py"
+soft_write_doc_test="${repo_root}/control-plane/tests/test_phase26_create_tracking_ticket_soft_write_contract_docs.py"
+workflow_guard="${repo_root}/scripts/test-verify-ci-phase-26-workflow-coverage.sh"
+shell_test="${repo_root}/scripts/test-verify-phase-26-ticket-coordination-validation.sh"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_line() {
+  local path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${path}" >/dev/null; then
+    echo "Missing required line in ${path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${e2e_test}" "Missing Phase 26 end-to-end validation unittest"
+require_file "${coordination_doc_test}" "Missing Phase 26 coordination substrate doc unittest"
+require_file "${soft_write_doc_test}" "Missing Phase 26 soft-write contract doc unittest"
+require_file "${workflow_guard}" "Missing Phase 26 workflow coverage guard"
+require_file "${shell_test}" "Missing Phase 26 ticket coordination shell test"
+require_file "${workflow_path}" "Missing CI workflow"
+
+require_fixed_line "${e2e_test}" "class Phase26EndToEndValidationTests(unittest.TestCase):"
+require_fixed_line "${e2e_test}" "    def test_phase26_end_to_end_surfaces_link_first_ticket_reference_without_authority_drift("
+require_fixed_line "${e2e_test}" "    def test_phase26_end_to_end_surfaces_create_tracking_ticket_created_outcome("
+require_fixed_line "${e2e_test}" "    def test_phase26_end_to_end_fail_closes_missing_receipt_before_user_facing_success("
+require_fixed_line "${e2e_test}" "    def test_phase26_end_to_end_surfaces_duplicate_create_attempt_as_mismatch("
+require_fixed_line "${e2e_test}" "    def test_phase26_end_to_end_surfaces_create_tracking_ticket_identifier_mismatch("
+require_fixed_line "${e2e_test}" "    def test_phase26_end_to_end_surfaces_create_tracking_ticket_timeout("
+require_fixed_line "${e2e_test}" "    def test_phase26_end_to_end_surfaces_create_tracking_ticket_manual_fallback("
+require_fixed_line "${coordination_doc_test}" "class Phase26CoordinationSubstrateBoundaryDocsTests(unittest.TestCase):"
+require_fixed_line "${soft_write_doc_test}" "class Phase26CreateTrackingTicketSoftWriteContractDocsTests(unittest.TestCase):"
+
+require_fixed_line "${workflow_path}" "      - name: Run Phase 26 ticket coordination validation"
+require_fixed_line "${workflow_path}" "          bash scripts/verify-phase-26-ticket-coordination-validation.sh"
+require_fixed_line "${workflow_path}" "          python3 -m unittest control-plane.tests.test_phase26_end_to_end_validation control-plane.tests.test_phase26_coordination_substrate_boundary_docs control-plane.tests.test_phase26_create_tracking_ticket_soft_write_contract_docs"
+require_fixed_line "${workflow_path}" "      - name: Run Phase 26 workflow coverage guard"
+require_fixed_line "${workflow_path}" "        run: bash scripts/test-verify-ci-phase-26-workflow-coverage.sh"
+require_fixed_line "${workflow_path}" "          bash scripts/test-verify-phase-26-ticket-coordination-validation.sh"
+
+echo "Phase 26 ticket coordination validation artifacts and CI wiring are present and aligned."


### PR DESCRIPTION
Closes #553
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused Phase 26 validation slice and wired it into the repo-owned verification path. The new coverage is in `control-plane/tests/test_phase26_end_to_end_validation.py` and exercises the link-first case-detail surface plus the first reviewed `create_tracking_ticket` flow across created, missing-receipt fail-closed, duplicate create mismatch, identifier mismatch, timeout, and manual-fallback states. I also added the Phase 26 verifier and workflow guard scripts, updated `.github/workflows/ci.yml`, and extended the regression validation to keep this slice from drifting.

The changes are committed on `codex/issue-553` as `dff1f24` with message `Add Phase 26 end-to-end ticket coordination validation`. The issue journal was updated in the worktree, but it remains outside the git commit because `.codex-supervisor/issues` is ignored.

Summary: Added Phase 26 end-to-end ticket coordination validation, CI workflow wiring, and verifier/guard scripts; committed as `dff1f24`.
State hint: draft_pr
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase26_end_to_end_validation`; `python3 -m unittest control-plane.tests.test_phase26_end_to_end_validation control-plane.tests.test_phase26_coordination_substrate_boundary_docs control-plane.tests.test_phase26_create_tracking_ticket_soft_write_contract_docs`; `python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation`; `bash scripts/verify-phase-26-ticket-coordination-validatio...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Phase 26 end-to-end and regression tests covering ticket coordination: creation, success/failure paths, identifier mismatches, timeouts, duplicate detection, and manual fallback scenarios.

* **Chores**
  * Strengthened CI with Phase 26 validation stages and self-checking workflow coverage guards, plus a local verification harness to assert required Phase 26 test and workflow coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->