### PR TITLE
implementation: add source-health and automation-substrate health surfaces (#563)

### DIFF
--- a/control-plane/aegisops_control_plane/operations.py
+++ b/control-plane/aegisops_control_plane/operations.py
@@ -928,11 +928,15 @@ class RestoreReadinessService:
         self._inspect_reconciliation_status()
         startup = self.describe_startup_status()
         readiness_aggregates = self.inspect_readiness_aggregates()
+        readiness_review_snapshots = self._collect_readiness_review_snapshots(
+            readiness_aggregates
+        )
         readiness_status = self._derive_readiness_status(
             startup_ready=startup.startup_ready,
             reconciliation_lifecycle_counts=readiness_aggregates.reconciliation_lifecycle_counts,
             review_path_health_overall_state=self._build_readiness_review_path_health(
-                readiness_aggregates
+                readiness_aggregates,
+                readiness_review_snapshots,
             )["overall_state"],
         )
 

--- a/control-plane/aegisops_control_plane/operations.py
+++ b/control-plane/aegisops_control_plane/operations.py
@@ -362,6 +362,12 @@ class RestoreReadinessService:
         build_readiness_review_path_health: Callable[
             [ReadinessDiagnosticsAggregates], dict[str, object]
         ],
+        build_readiness_source_health: Callable[
+            [ReadinessDiagnosticsAggregates], dict[str, object]
+        ],
+        build_readiness_automation_substrate_health: Callable[
+            [ReadinessDiagnosticsAggregates], dict[str, object]
+        ],
         build_shutdown_status_snapshot: Callable[..., Any],
         derive_readiness_status: Callable[..., str],
         record_from_backup_payload: Callable[[Type[ControlPlaneRecord], Mapping[str, object]], ControlPlaneRecord],
@@ -393,6 +399,10 @@ class RestoreReadinessService:
         self._redacted_reconciliation_payload = redacted_reconciliation_payload
         self._build_readiness_review_path_health = (
             build_readiness_review_path_health
+        )
+        self._build_readiness_source_health = build_readiness_source_health
+        self._build_readiness_automation_substrate_health = (
+            build_readiness_automation_substrate_health
         )
         self._build_shutdown_status_snapshot = build_shutdown_status_snapshot
         self._derive_readiness_status = derive_readiness_status
@@ -498,6 +508,12 @@ class RestoreReadinessService:
             review_path_health = self._build_readiness_review_path_health(
                 readiness_aggregates
             )
+            source_health = self._build_readiness_source_health(readiness_aggregates)
+            automation_substrate_health = (
+                self._build_readiness_automation_substrate_health(
+                    readiness_aggregates
+                )
+            )
 
         shutdown = self._build_shutdown_status_snapshot(
             open_case_ids=readiness_aggregates.open_case_ids,
@@ -581,6 +597,8 @@ class RestoreReadinessService:
                 "reconciled_executions": readiness_aggregates.phase20_reconciled_executions,
             },
             "review_path_health": review_path_health,
+            "source_health": source_health,
+            "automation_substrate_health": automation_substrate_health,
         }
 
         return self._readiness_diagnostics_snapshot_factory(

--- a/control-plane/aegisops_control_plane/operations.py
+++ b/control-plane/aegisops_control_plane/operations.py
@@ -359,14 +359,17 @@ class RestoreReadinessService:
         record_to_dict: Callable[[ControlPlaneRecord], dict[str, object]],
         json_ready: Callable[[object], object],
         redacted_reconciliation_payload: Callable[[ReconciliationRecord], dict[str, object]],
+        collect_readiness_review_snapshots: Callable[
+            [ReadinessDiagnosticsAggregates], list[dict[str, object]]
+        ],
         build_readiness_review_path_health: Callable[
-            [ReadinessDiagnosticsAggregates], dict[str, object]
+            [ReadinessDiagnosticsAggregates, list[dict[str, object]]], dict[str, object]
         ],
         build_readiness_source_health: Callable[
-            [ReadinessDiagnosticsAggregates], dict[str, object]
+            [ReadinessDiagnosticsAggregates, list[dict[str, object]]], dict[str, object]
         ],
         build_readiness_automation_substrate_health: Callable[
-            [ReadinessDiagnosticsAggregates], dict[str, object]
+            [ReadinessDiagnosticsAggregates, list[dict[str, object]]], dict[str, object]
         ],
         build_shutdown_status_snapshot: Callable[..., Any],
         derive_readiness_status: Callable[..., str],
@@ -397,6 +400,9 @@ class RestoreReadinessService:
         self._record_to_dict = record_to_dict
         self._json_ready = json_ready
         self._redacted_reconciliation_payload = redacted_reconciliation_payload
+        self._collect_readiness_review_snapshots = (
+            collect_readiness_review_snapshots
+        )
         self._build_readiness_review_path_health = (
             build_readiness_review_path_health
         )
@@ -505,13 +511,21 @@ class RestoreReadinessService:
         with self._store.transaction(isolation_level="REPEATABLE READ"):
             startup = self.describe_startup_status()
             readiness_aggregates = self.inspect_readiness_aggregates()
-            review_path_health = self._build_readiness_review_path_health(
+            readiness_review_snapshots = self._collect_readiness_review_snapshots(
                 readiness_aggregates
             )
-            source_health = self._build_readiness_source_health(readiness_aggregates)
+            review_path_health = self._build_readiness_review_path_health(
+                readiness_aggregates,
+                readiness_review_snapshots,
+            )
+            source_health = self._build_readiness_source_health(
+                readiness_aggregates,
+                readiness_review_snapshots,
+            )
             automation_substrate_health = (
                 self._build_readiness_automation_substrate_health(
-                    readiness_aggregates
+                    readiness_aggregates,
+                    readiness_review_snapshots,
                 )
             )
 

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3264,7 +3264,7 @@ class AegisOpsControlPlaneService:
         readiness_review_snapshots = self._collect_readiness_review_snapshots(
             readiness_aggregates
         )
-        surface_reviews: defaultdict[str, list[Mapping[str, object]]] = defaultdict(list)
+        surface_reviews: defaultdict[str, list[dict[str, object]]] = defaultdict(list)
         surface_metadata: dict[str, tuple[str, str]] = {}
         for snapshot in readiness_review_snapshots:
             execution_surface_type = snapshot.get("execution_surface_type")
@@ -3277,7 +3277,7 @@ class AegisOpsControlPlaneService:
                 else "unknown"
             )
             surface_key = f"automation_substrate:{normalized_surface_id}"
-            surface_reviews[surface_key].append(snapshot["path_health"])
+            surface_reviews[surface_key].append(snapshot)
             surface_metadata[surface_key] = ("automation_substrate", normalized_surface_id)
 
         if not surface_reviews:
@@ -3289,7 +3289,10 @@ class AegisOpsControlPlaneService:
             }
 
         surfaces: dict[str, dict[str, object]] = {}
-        for surface_key, review_path_health in sorted(surface_reviews.items()):
+        for surface_key, surface_review_snapshots in sorted(surface_reviews.items()):
+            review_path_health = [
+                snapshot["path_health"] for snapshot in surface_review_snapshots
+            ]
             aggregated_paths = {
                 path_name: self._aggregate_readiness_path_health(
                     path_name=path_name,
@@ -3309,9 +3312,10 @@ class AegisOpsControlPlaneService:
                     aggregated_paths.values(),
                     overall_state=overall_state,
                 ),
-                "tracked_reviews": len(review_path_health),
-                "affected_reviews": max(
-                    path["affected_reviews"] for path in aggregated_paths.values()
+                "tracked_reviews": len(surface_review_snapshots),
+                "affected_reviews": self._count_readiness_affected_reviews(
+                    surface_review_snapshots,
+                    path_names=("delegation", "provider", "persistence"),
                 ),
                 "paths": aggregated_paths,
             }
@@ -3539,6 +3543,24 @@ class AegisOpsControlPlaneService:
                 "failed": state_counts.get("failed", 0),
             },
         }
+
+    @staticmethod
+    def _count_readiness_affected_reviews(
+        readiness_review_snapshots: Iterable[Mapping[str, object]],
+        *,
+        path_names: Iterable[str],
+    ) -> int:
+        relevant_path_names = tuple(path_names)
+        return len(
+            {
+                str(snapshot["action_request_id"])
+                for snapshot in readiness_review_snapshots
+                if any(
+                    snapshot["path_health"]["paths"][path_name]["state"] != "healthy"
+                    for path_name in relevant_path_names
+                )
+            }
+        )
 
     def _action_review_runtime_visibility(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3339,11 +3339,17 @@ class AegisOpsControlPlaneService:
         *,
         overall_state: str,
     ) -> str:
-        reason_counts = Counter(
-            str(path["reason"])
-            for path in paths
-            if path.get("state") == overall_state
-        )
+        reason_counts: Counter[str] = Counter()
+        for path in paths:
+            if path.get("state") != overall_state:
+                continue
+            by_state = path.get("by_state")
+            weight = (
+                int(by_state.get(overall_state, 0))
+                if isinstance(by_state, Mapping)
+                else int(path.get("affected_reviews", 0))
+            )
+            reason_counts[str(path["reason"])] += max(weight, 1)
         return sorted(
             reason_counts.items(),
             key=lambda item: (-item[1], item[0]),

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1370,6 +1370,14 @@ class AegisOpsControlPlaneService:
             build_readiness_review_path_health=(
                 lambda aggregates: self._build_readiness_review_path_health(aggregates)
             ),
+            build_readiness_source_health=(
+                lambda aggregates: self._build_readiness_source_health(aggregates)
+            ),
+            build_readiness_automation_substrate_health=(
+                lambda aggregates: self._build_readiness_automation_substrate_health(
+                    aggregates
+                )
+            ),
             build_shutdown_status_snapshot=_build_shutdown_status_snapshot,
             derive_readiness_status=_derive_readiness_status,
             record_from_backup_payload=_record_from_backup_payload,
@@ -2884,6 +2892,56 @@ class AegisOpsControlPlaneService:
         self,
         readiness_aggregates: ReadinessDiagnosticsAggregates,
     ) -> dict[str, object]:
+        readiness_review_snapshots = self._collect_readiness_review_snapshots(
+            readiness_aggregates
+        )
+        review_path_health = [
+            snapshot["path_health"] for snapshot in readiness_review_snapshots
+        ]
+
+        if not review_path_health:
+            return {
+                "review_count": 0,
+                "overall_state": "healthy",
+                "summary": "no active reviewed execution visibility gaps",
+                "paths": {
+                    path_name: {
+                        "state": "healthy",
+                        "reason": "no_reviewed_paths_tracked",
+                        "affected_reviews": 0,
+                        "by_state": {
+                            "healthy": 0,
+                            "delayed": 0,
+                            "degraded": 0,
+                            "failed": 0,
+                        },
+                    }
+                    for path_name in ("ingest", "delegation", "provider", "persistence")
+                },
+            }
+
+        paths = {
+            path_name: self._aggregate_readiness_path_health(
+                path_name=path_name,
+                review_path_health=review_path_health,
+            )
+            for path_name in ("ingest", "delegation", "provider", "persistence")
+        }
+        overall_state = self._action_review_overall_path_state(paths.values())
+        return {
+            "review_count": len(review_path_health),
+            "overall_state": overall_state,
+            "summary": self._action_review_path_health_summary(
+                overall_state=overall_state,
+                paths=paths,
+            ),
+            "paths": paths,
+        }
+
+    def _collect_readiness_review_snapshots(
+        self,
+        readiness_aggregates: ReadinessDiagnosticsAggregates,
+    ) -> list[dict[str, object]]:
         execution_ids = set(readiness_aggregates.active_action_execution_ids)
         execution_ids.update(readiness_aggregates.terminal_action_execution_ids)
         candidate_action_request_ids: set[str] = set()
@@ -3103,7 +3161,7 @@ class AegisOpsControlPlaneService:
                             reconciliation
                         )
 
-        review_path_health: list[dict[str, object]] = []
+        readiness_review_snapshots: list[dict[str, object]] = []
         for action_request_id, action_request in sorted(candidate_action_requests.items()):
             approval_decision = approval_decisions_by_action_request_id.get(action_request_id)
             action_execution = executions_by_action_request_id.get(action_request_id)
@@ -3117,54 +3175,190 @@ class AegisOpsControlPlaneService:
                 approval_state=approval_state,
                 action_execution=action_execution,
             )
-            review_path_health.append(
-                self._action_review_path_health(
-                    action_request=action_request,
-                    approval_decision=approval_decision,
-                    action_execution=action_execution,
-                    reconciliation=reconciliation,
-                    review_state=review_state,
-                )
+            reviewed_context = self._action_review_visibility_context(action_request)
+            path_health = self._action_review_path_health(
+                action_request=action_request,
+                approval_decision=approval_decision,
+                action_execution=action_execution,
+                reconciliation=reconciliation,
+                review_state=review_state,
             )
+            readiness_review_snapshots.append(
+                {
+                    "action_request_id": action_request_id,
+                    "source_family": (
+                        self._reviewed_operator_source_family(reviewed_context)
+                        if reviewed_context is not None
+                        else None
+                    ),
+                    "execution_surface_type": (
+                        action_execution.execution_surface_type
+                        if action_execution is not None
+                        else action_request.policy_evaluation.get("execution_surface_type")
+                    ),
+                    "execution_surface_id": (
+                        action_execution.execution_surface_id
+                        if action_execution is not None
+                        else action_request.policy_evaluation.get("execution_surface_id")
+                    ),
+                    "path_health": path_health,
+                }
+            )
+        return readiness_review_snapshots
 
-        if not review_path_health:
+    def _build_readiness_source_health(
+        self,
+        readiness_aggregates: ReadinessDiagnosticsAggregates,
+    ) -> dict[str, object]:
+        readiness_review_snapshots = self._collect_readiness_review_snapshots(
+            readiness_aggregates
+        )
+        source_reviews: defaultdict[str, list[Mapping[str, object]]] = defaultdict(list)
+        for snapshot in readiness_review_snapshots:
+            source_family = snapshot.get("source_family")
+            normalized_source_family = (
+                str(source_family).strip()
+                if isinstance(source_family, str) and source_family.strip()
+                else "unknown_reviewed_source"
+            )
+            source_reviews[normalized_source_family].append(snapshot["path_health"])
+
+        if not source_reviews:
             return {
-                "review_count": 0,
+                "tracked_sources": 0,
                 "overall_state": "healthy",
-                "summary": "no active reviewed execution visibility gaps",
-                "paths": {
-                    path_name: {
-                        "state": "healthy",
-                        "reason": "no_reviewed_paths_tracked",
-                        "affected_reviews": 0,
-                        "by_state": {
-                            "healthy": 0,
-                            "delayed": 0,
-                            "degraded": 0,
-                            "failed": 0,
-                        },
-                    }
-                    for path_name in ("ingest", "delegation", "provider", "persistence")
-                },
+                "summary": "no reviewed source health tracked",
+                "sources": {},
             }
 
-        paths = {
-            path_name: self._aggregate_readiness_path_health(
-                path_name=path_name,
+        sources: dict[str, dict[str, object]] = {}
+        for source_family, review_path_health in sorted(source_reviews.items()):
+            ingest_path = self._aggregate_readiness_path_health(
+                path_name="ingest",
                 review_path_health=review_path_health,
             )
-            for path_name in ("ingest", "delegation", "provider", "persistence")
-        }
-        overall_state = self._action_review_overall_path_state(paths.values())
+            sources[source_family] = {
+                "state": ingest_path["state"],
+                "reason": ingest_path["reason"],
+                "tracked_reviews": len(review_path_health),
+                "affected_reviews": ingest_path["affected_reviews"],
+                "by_state": ingest_path["by_state"],
+            }
+
+        overall_state = self._action_review_overall_path_state(sources.values())
         return {
-            "review_count": len(review_path_health),
+            "tracked_sources": len(sources),
             "overall_state": overall_state,
-            "summary": self._action_review_path_health_summary(
+            "summary": self._readiness_surface_health_summary(
                 overall_state=overall_state,
-                paths=paths,
+                entries=sources,
+                kind="source",
             ),
-            "paths": paths,
+            "sources": sources,
         }
+
+    def _build_readiness_automation_substrate_health(
+        self,
+        readiness_aggregates: ReadinessDiagnosticsAggregates,
+    ) -> dict[str, object]:
+        readiness_review_snapshots = self._collect_readiness_review_snapshots(
+            readiness_aggregates
+        )
+        surface_reviews: defaultdict[str, list[Mapping[str, object]]] = defaultdict(list)
+        surface_metadata: dict[str, tuple[str, str]] = {}
+        for snapshot in readiness_review_snapshots:
+            execution_surface_type = snapshot.get("execution_surface_type")
+            if execution_surface_type != "automation_substrate":
+                continue
+            execution_surface_id = snapshot.get("execution_surface_id")
+            normalized_surface_id = (
+                str(execution_surface_id).strip()
+                if isinstance(execution_surface_id, str) and execution_surface_id.strip()
+                else "unknown"
+            )
+            surface_key = f"automation_substrate:{normalized_surface_id}"
+            surface_reviews[surface_key].append(snapshot["path_health"])
+            surface_metadata[surface_key] = ("automation_substrate", normalized_surface_id)
+
+        if not surface_reviews:
+            return {
+                "tracked_surfaces": 0,
+                "overall_state": "healthy",
+                "summary": "no reviewed automation substrate health tracked",
+                "surfaces": {},
+            }
+
+        surfaces: dict[str, dict[str, object]] = {}
+        for surface_key, review_path_health in sorted(surface_reviews.items()):
+            aggregated_paths = {
+                path_name: self._aggregate_readiness_path_health(
+                    path_name=path_name,
+                    review_path_health=review_path_health,
+                )
+                for path_name in ("delegation", "provider", "persistence")
+            }
+            overall_state = self._action_review_overall_path_state(
+                aggregated_paths.values()
+            )
+            execution_surface_type, execution_surface_id = surface_metadata[surface_key]
+            surfaces[surface_key] = {
+                "execution_surface_type": execution_surface_type,
+                "execution_surface_id": execution_surface_id,
+                "state": overall_state,
+                "reason": self._readiness_dominant_reason(
+                    aggregated_paths.values(),
+                    overall_state=overall_state,
+                ),
+                "tracked_reviews": len(review_path_health),
+                "affected_reviews": max(
+                    path["affected_reviews"] for path in aggregated_paths.values()
+                ),
+                "paths": aggregated_paths,
+            }
+
+        overall_state = self._action_review_overall_path_state(surfaces.values())
+        return {
+            "tracked_surfaces": len(surfaces),
+            "overall_state": overall_state,
+            "summary": self._readiness_surface_health_summary(
+                overall_state=overall_state,
+                entries=surfaces,
+                kind="automation substrate",
+            ),
+            "surfaces": surfaces,
+        }
+
+    @staticmethod
+    def _readiness_dominant_reason(
+        paths: Iterable[Mapping[str, object]],
+        *,
+        overall_state: str,
+    ) -> str:
+        reason_counts = Counter(
+            str(path["reason"])
+            for path in paths
+            if path.get("state") == overall_state
+        )
+        return sorted(
+            reason_counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )[0][0]
+
+    def _readiness_surface_health_summary(
+        self,
+        *,
+        overall_state: str,
+        entries: Mapping[str, Mapping[str, object]],
+        kind: str,
+    ) -> str:
+        active_entries = [
+            f"{entry_name} {entry['reason'].replace('_', ' ')}"
+            for entry_name, entry in entries.items()
+            if entry.get("state") != "healthy"
+        ]
+        if not active_entries:
+            return f"all reviewed {kind} health surfaces are healthy"
+        return f"{overall_state} {kind} health: {'; '.join(active_entries[:2])}"
 
     def _readiness_candidate_action_request_ids_for_delegations(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2378,12 +2378,14 @@ class AegisOpsControlPlaneService:
             review_state=review_state,
             record_index=record_index,
         )
+        path_health_as_of = datetime.now(timezone.utc)
         path_health = self._action_review_path_health(
             action_request=action_request,
             approval_decision=approval_decision,
             action_execution=action_execution,
             reconciliation=reconciliation,
             review_state=review_state,
+            as_of=path_health_as_of,
         )
         coordination_ticket_outcome = self._action_review_coordination_ticket_outcome(
             action_request=action_request,
@@ -2476,6 +2478,7 @@ class AegisOpsControlPlaneService:
         action_execution: ActionExecutionRecord | None,
         reconciliation: ReconciliationRecord | None,
         review_state: str,
+        as_of: datetime,
     ) -> dict[str, object]:
         if action_execution is None and reconciliation is None:
             if review_state in {"rejected", "expired", "superseded", "canceled"}:
@@ -2524,7 +2527,7 @@ class AegisOpsControlPlaneService:
             approval_decision=approval_decision,
             action_execution=action_execution,
         )
-        if deadline is not None and deadline <= datetime.now(timezone.utc):
+        if deadline is not None and deadline <= as_of:
             paths = self._action_review_overdue_path_health(
                 review_state=review_state,
                 action_execution=action_execution,
@@ -3159,6 +3162,7 @@ class AegisOpsControlPlaneService:
                         )
 
         readiness_review_snapshots: list[dict[str, object]] = []
+        path_health_as_of = datetime.now(timezone.utc)
         for action_request_id, action_request in sorted(candidate_action_requests.items()):
             approval_decision = approval_decisions_by_action_request_id.get(action_request_id)
             action_execution = executions_by_action_request_id.get(action_request_id)
@@ -3179,6 +3183,7 @@ class AegisOpsControlPlaneService:
                 action_execution=action_execution,
                 reconciliation=reconciliation,
                 review_state=review_state,
+                as_of=path_health_as_of,
             )
             readiness_review_snapshots.append(
                 {

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3193,6 +3193,9 @@ class AegisOpsControlPlaneService:
                         if reviewed_context is not None
                         else None
                     ),
+                    "ingest_expected": (
+                        action_execution is not None or reconciliation is not None
+                    ),
                     "execution_surface_type": (
                         action_execution.execution_surface_type
                         if action_execution is not None
@@ -3219,6 +3222,8 @@ class AegisOpsControlPlaneService:
             )
         source_reviews: defaultdict[str, list[Mapping[str, object]]] = defaultdict(list)
         for snapshot in readiness_review_snapshots:
+            if not snapshot.get("ingest_expected", False):
+                continue
             source_family = snapshot.get("source_family")
             normalized_source_family = (
                 str(source_family).strip()

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1367,16 +1367,11 @@ class AegisOpsControlPlaneService:
             record_to_dict=_record_to_dict,
             json_ready=_json_ready,
             redacted_reconciliation_payload=_redacted_reconciliation_payload,
-            build_readiness_review_path_health=(
-                lambda aggregates: self._build_readiness_review_path_health(aggregates)
-            ),
-            build_readiness_source_health=(
-                lambda aggregates: self._build_readiness_source_health(aggregates)
-            ),
+            collect_readiness_review_snapshots=self._collect_readiness_review_snapshots,
+            build_readiness_review_path_health=self._build_readiness_review_path_health,
+            build_readiness_source_health=self._build_readiness_source_health,
             build_readiness_automation_substrate_health=(
-                lambda aggregates: self._build_readiness_automation_substrate_health(
-                    aggregates
-                )
+                self._build_readiness_automation_substrate_health
             ),
             build_shutdown_status_snapshot=_build_shutdown_status_snapshot,
             derive_readiness_status=_derive_readiness_status,
@@ -2891,10 +2886,12 @@ class AegisOpsControlPlaneService:
     def _build_readiness_review_path_health(
         self,
         readiness_aggregates: ReadinessDiagnosticsAggregates,
+        readiness_review_snapshots: list[dict[str, object]] | None = None,
     ) -> dict[str, object]:
-        readiness_review_snapshots = self._collect_readiness_review_snapshots(
-            readiness_aggregates
-        )
+        if readiness_review_snapshots is None:
+            readiness_review_snapshots = self._collect_readiness_review_snapshots(
+                readiness_aggregates
+            )
         review_path_health = [
             snapshot["path_health"] for snapshot in readiness_review_snapshots
         ]
@@ -3209,10 +3206,12 @@ class AegisOpsControlPlaneService:
     def _build_readiness_source_health(
         self,
         readiness_aggregates: ReadinessDiagnosticsAggregates,
+        readiness_review_snapshots: list[dict[str, object]] | None = None,
     ) -> dict[str, object]:
-        readiness_review_snapshots = self._collect_readiness_review_snapshots(
-            readiness_aggregates
-        )
+        if readiness_review_snapshots is None:
+            readiness_review_snapshots = self._collect_readiness_review_snapshots(
+                readiness_aggregates
+            )
         source_reviews: defaultdict[str, list[Mapping[str, object]]] = defaultdict(list)
         for snapshot in readiness_review_snapshots:
             source_family = snapshot.get("source_family")
@@ -3260,10 +3259,12 @@ class AegisOpsControlPlaneService:
     def _build_readiness_automation_substrate_health(
         self,
         readiness_aggregates: ReadinessDiagnosticsAggregates,
+        readiness_review_snapshots: list[dict[str, object]] | None = None,
     ) -> dict[str, object]:
-        readiness_review_snapshots = self._collect_readiness_review_snapshots(
-            readiness_aggregates
-        )
+        if readiness_review_snapshots is None:
+            readiness_review_snapshots = self._collect_readiness_review_snapshots(
+                readiness_aggregates
+            )
         surface_reviews: defaultdict[str, list[dict[str, object]]] = defaultdict(list)
         surface_metadata: dict[str, tuple[str, str]] = {}
         for snapshot in readiness_review_snapshots:

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -1277,6 +1277,28 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                     1,
                 )
                 self.assertEqual(
+                    diagnostics_payload["metrics"]["source_health"]["tracked_sources"],
+                    1,
+                )
+                self.assertEqual(
+                    diagnostics_payload["metrics"]["source_health"]["sources"][
+                        "github_audit"
+                    ]["state"],
+                    "healthy",
+                )
+                self.assertEqual(
+                    diagnostics_payload["metrics"]["automation_substrate_health"][
+                        "tracked_surfaces"
+                    ],
+                    1,
+                )
+                self.assertEqual(
+                    diagnostics_payload["metrics"]["automation_substrate_health"][
+                        "surfaces"
+                    ]["automation_substrate:shuffle"]["state"],
+                    "healthy",
+                )
+                self.assertEqual(
                     diagnostics_payload["metrics"]["review_path_health"]["paths"],
                     {
                         "ingest": {

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -3431,6 +3431,165 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             "reconciliation_timeout",
         )
 
+    def test_service_phase21_readiness_counts_unique_affected_reviews_per_automation_surface(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        expires_at = reviewed_at + timedelta(hours=4)
+
+        def persist_review(
+            *,
+            suffix: str,
+            requested_offset_minutes: int,
+            request_state: str,
+            execution_state: str,
+            reconciliation_state: str,
+            mismatch_summary: str,
+        ) -> None:
+            recommendation = service.record_case_recommendation(
+                case_id=promoted_case.case_id,
+                review_owner="analyst-001",
+                intended_outcome=(
+                    "Keep automation substrate impact counts aligned with unique"
+                    f" reviewed requests ({suffix})."
+                ),
+            )
+            requested_at = reviewed_at + timedelta(minutes=requested_offset_minutes)
+            delegated_at = requested_at + timedelta(minutes=10)
+            action_request = service.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id=recommendation.recommendation_id,
+                requester_identity="analyst-001",
+                recipient_identity="repo-owner-001",
+                message_intent=(
+                    "Keep unique affected review counts on automation substrate"
+                    f" readiness explicit ({suffix})."
+                ),
+                escalation_reason=(
+                    "Operators must see distinct reviewed requests impacted on the"
+                    " same automation surface."
+                ),
+                expires_at=expires_at,
+                action_request_id=(
+                    f"action-request-phase21-readiness-automation-impact-{suffix}"
+                ),
+            )
+            approval = service.persist_record(
+                ApprovalDecisionRecord(
+                    approval_decision_id=(
+                        f"approval-phase21-readiness-automation-impact-{suffix}"
+                    ),
+                    action_request_id=action_request.action_request_id,
+                    approver_identities=("approver-001",),
+                    target_snapshot=dict(action_request.target_scope),
+                    payload_hash=action_request.payload_hash,
+                    decided_at=requested_at + timedelta(minutes=5),
+                    lifecycle_state="approved",
+                    approved_expires_at=expires_at,
+                )
+            )
+            service.persist_record(
+                replace(
+                    action_request,
+                    approval_decision_id=approval.approval_decision_id,
+                    requested_at=requested_at,
+                    expires_at=expires_at,
+                    lifecycle_state=request_state,
+                )
+            )
+            action_execution = service.persist_record(
+                ActionExecutionRecord(
+                    action_execution_id=(
+                        f"action-execution-phase21-readiness-automation-impact-{suffix}"
+                    ),
+                    action_request_id=action_request.action_request_id,
+                    approval_decision_id=approval.approval_decision_id,
+                    delegation_id=(
+                        f"delegation-phase21-readiness-automation-impact-{suffix}"
+                    ),
+                    execution_surface_type="automation_substrate",
+                    execution_surface_id="shuffle",
+                    execution_run_id=(
+                        f"execution-run-phase21-readiness-automation-impact-{suffix}"
+                    ),
+                    idempotency_key=action_request.idempotency_key,
+                    target_scope=dict(action_request.target_scope),
+                    approved_payload=dict(action_request.requested_payload),
+                    payload_hash=action_request.payload_hash,
+                    delegated_at=delegated_at,
+                    expires_at=expires_at,
+                    provenance={"initiated_by": "operator-review"},
+                    lifecycle_state=execution_state,
+                )
+            )
+            service.persist_record(
+                ReconciliationRecord(
+                    reconciliation_id=(
+                        f"reconciliation-phase21-readiness-automation-impact-{suffix}"
+                    ),
+                    subject_linkage={
+                        "action_request_ids": (action_request.action_request_id,),
+                        "latest_native_payload": {"secret": "keep-in-store"},
+                    },
+                    alert_id=promoted_case.alert_id,
+                    finding_id=promoted_case.finding_id,
+                    analytic_signal_id=None,
+                    execution_run_id=action_execution.execution_run_id,
+                    linked_execution_run_ids=(action_execution.execution_run_id,),
+                    correlation_key=(
+                        f"phase21-readiness-automation-impact-{suffix}"
+                    ),
+                    first_seen_at=delegated_at + timedelta(minutes=1),
+                    last_seen_at=delegated_at + timedelta(minutes=2),
+                    ingest_disposition="matched",
+                    mismatch_summary=mismatch_summary,
+                    compared_at=delegated_at + timedelta(minutes=3),
+                    lifecycle_state=reconciliation_state,
+                )
+            )
+
+        persist_review(
+            suffix="provider-001",
+            requested_offset_minutes=0,
+            request_state="failed",
+            execution_state="failed",
+            reconciliation_state="matched",
+            mismatch_summary="provider failure remained tied to reviewed execution lineage",
+        )
+        persist_review(
+            suffix="persistence-001",
+            requested_offset_minutes=20,
+            request_state="completed",
+            execution_state="succeeded",
+            reconciliation_state="stale",
+            mismatch_summary="persistence drift remained tied to reviewed execution lineage",
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        automation_health = readiness.metrics["automation_substrate_health"]
+        shuffle_surface = automation_health["surfaces"]["automation_substrate:shuffle"]
+
+        self.assertEqual(automation_health["overall_state"], "failed")
+        self.assertEqual(automation_health["tracked_surfaces"], 1)
+        self.assertEqual(shuffle_surface["tracked_reviews"], 2)
+        self.assertEqual(shuffle_surface["affected_reviews"], 2)
+        self.assertEqual(shuffle_surface["state"], "failed")
+        self.assertEqual(shuffle_surface["reason"], "execution_failed")
+        self.assertEqual(
+            shuffle_surface["paths"]["delegation"]["affected_reviews"],
+            0,
+        )
+        self.assertEqual(
+            shuffle_surface["paths"]["provider"]["affected_reviews"],
+            1,
+        )
+        self.assertEqual(
+            shuffle_surface["paths"]["persistence"]["affected_reviews"],
+            1,
+        )
+
     def test_service_phase21_readiness_prefers_higher_reconciliation_id_when_compared_at_ties(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -3383,10 +3383,16 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             )
         )
 
-        readiness = service.inspect_readiness_diagnostics()
+        with mock.patch.object(
+            service._restore_readiness_service,
+            "_collect_readiness_review_snapshots",
+            wraps=service._collect_readiness_review_snapshots,
+        ) as collect_readiness_review_snapshots:
+            readiness = service.inspect_readiness_diagnostics()
         source_health = readiness.metrics["source_health"]
         automation_health = readiness.metrics["automation_substrate_health"]
 
+        self.assertEqual(collect_readiness_review_snapshots.call_count, 1)
         self.assertEqual(source_health["overall_state"], "degraded")
         self.assertEqual(source_health["tracked_sources"], 1)
         self.assertEqual(

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -3596,6 +3596,179 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             1,
         )
 
+    def test_service_phase21_readiness_weights_automation_reason_by_impacted_reviews(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        future_expires_at = reviewed_at + timedelta(hours=4)
+
+        def persist_review(
+            *,
+            suffix: str,
+            requested_at: datetime,
+            delegated_at: datetime,
+            expires_at: datetime,
+            request_state: str,
+            execution_state: str,
+            reconciliation_state: str | None,
+            mismatch_summary: str,
+        ) -> None:
+            recommendation = service.record_case_recommendation(
+                case_id=promoted_case.case_id,
+                review_owner="analyst-001",
+                intended_outcome=(
+                    "Keep automation substrate dominant reasons aligned with the"
+                    f" most impacted reviewed requests ({suffix})."
+                ),
+            )
+            action_request = service.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id=recommendation.recommendation_id,
+                requester_identity="analyst-001",
+                recipient_identity="repo-owner-001",
+                message_intent=(
+                    "Keep the dominant automation surface reason weighted by"
+                    f" reviewed impact ({suffix})."
+                ),
+                escalation_reason=(
+                    "Operators must see the readiness reason affecting the most"
+                    " reviewed requests on the same automation surface."
+                ),
+                expires_at=future_expires_at,
+                action_request_id=(
+                    f"action-request-phase21-readiness-automation-weighted-{suffix}"
+                ),
+            )
+            approval = service.persist_record(
+                ApprovalDecisionRecord(
+                    approval_decision_id=(
+                        f"approval-phase21-readiness-automation-weighted-{suffix}"
+                    ),
+                    action_request_id=action_request.action_request_id,
+                    approver_identities=("approver-001",),
+                    target_snapshot=dict(action_request.target_scope),
+                    payload_hash=action_request.payload_hash,
+                    decided_at=requested_at + timedelta(minutes=5),
+                    lifecycle_state="approved",
+                    approved_expires_at=expires_at,
+                )
+            )
+            service.persist_record(
+                replace(
+                    action_request,
+                    approval_decision_id=approval.approval_decision_id,
+                    requested_at=requested_at,
+                    expires_at=expires_at,
+                    lifecycle_state=request_state,
+                )
+            )
+            action_execution = service.persist_record(
+                ActionExecutionRecord(
+                    action_execution_id=(
+                        f"action-execution-phase21-readiness-automation-weighted-{suffix}"
+                    ),
+                    action_request_id=action_request.action_request_id,
+                    approval_decision_id=approval.approval_decision_id,
+                    delegation_id=(
+                        f"delegation-phase21-readiness-automation-weighted-{suffix}"
+                    ),
+                    execution_surface_type="automation_substrate",
+                    execution_surface_id="shuffle",
+                    execution_run_id=(
+                        f"execution-run-phase21-readiness-automation-weighted-{suffix}"
+                    ),
+                    idempotency_key=action_request.idempotency_key,
+                    target_scope=dict(action_request.target_scope),
+                    approved_payload=dict(action_request.requested_payload),
+                    payload_hash=action_request.payload_hash,
+                    delegated_at=delegated_at,
+                    expires_at=expires_at,
+                    provenance={"initiated_by": "operator-review"},
+                    lifecycle_state=execution_state,
+                )
+            )
+            if reconciliation_state is not None:
+                service.persist_record(
+                    ReconciliationRecord(
+                        reconciliation_id=(
+                            f"reconciliation-phase21-readiness-automation-weighted-{suffix}"
+                        ),
+                        subject_linkage={
+                            "action_request_ids": (action_request.action_request_id,),
+                            "latest_native_payload": {"secret": "keep-in-store"},
+                        },
+                        alert_id=promoted_case.alert_id,
+                        finding_id=promoted_case.finding_id,
+                        analytic_signal_id=None,
+                        execution_run_id=action_execution.execution_run_id,
+                        linked_execution_run_ids=(action_execution.execution_run_id,),
+                        correlation_key=(
+                            f"phase21-readiness-automation-weighted-{suffix}"
+                        ),
+                        first_seen_at=delegated_at + timedelta(minutes=1),
+                        last_seen_at=delegated_at + timedelta(minutes=2),
+                        ingest_disposition="matched",
+                        mismatch_summary=mismatch_summary,
+                        compared_at=delegated_at + timedelta(minutes=3),
+                        lifecycle_state=reconciliation_state,
+                    )
+                )
+
+        persist_review(
+            suffix="dispatching-001",
+            requested_at=reviewed_at - timedelta(hours=2),
+            delegated_at=reviewed_at - timedelta(hours=1, minutes=50),
+            expires_at=reviewed_at - timedelta(hours=1),
+            request_state="executing",
+            execution_state="dispatching",
+            reconciliation_state=None,
+            mismatch_summary="dispatch lag remained tied to reviewed execution lineage",
+        )
+        persist_review(
+            suffix="persistence-001",
+            requested_at=reviewed_at + timedelta(minutes=5),
+            delegated_at=reviewed_at + timedelta(minutes=15),
+            expires_at=reviewed_at + timedelta(hours=4),
+            request_state="completed",
+            execution_state="succeeded",
+            reconciliation_state="stale",
+            mismatch_summary="persistence drift remained tied to reviewed execution lineage",
+        )
+        persist_review(
+            suffix="persistence-002",
+            requested_at=reviewed_at + timedelta(minutes=10),
+            delegated_at=reviewed_at + timedelta(minutes=20),
+            expires_at=reviewed_at + timedelta(hours=4),
+            request_state="completed",
+            execution_state="succeeded",
+            reconciliation_state="stale",
+            mismatch_summary="persistence drift remained tied to reviewed execution lineage",
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        automation_health = readiness.metrics["automation_substrate_health"]
+        shuffle_surface = automation_health["surfaces"]["automation_substrate:shuffle"]
+
+        self.assertEqual(automation_health["overall_state"], "degraded")
+        self.assertEqual(shuffle_surface["state"], "degraded")
+        self.assertEqual(shuffle_surface["tracked_reviews"], 3)
+        self.assertEqual(shuffle_surface["affected_reviews"], 3)
+        self.assertEqual(shuffle_surface["reason"], "reconciliation_stale")
+        self.assertEqual(
+            shuffle_surface["paths"]["delegation"]["affected_reviews"],
+            1,
+        )
+        self.assertEqual(
+            shuffle_surface["paths"]["provider"]["affected_reviews"],
+            1,
+        )
+        self.assertEqual(
+            shuffle_surface["paths"]["persistence"]["affected_reviews"],
+            3,
+        )
+
     def test_service_phase21_readiness_prefers_higher_reconciliation_id_when_compared_at_ties(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -3437,6 +3437,158 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             "reconciliation_timeout",
         )
 
+    def test_service_phase21_readiness_source_health_ignores_predelegation_backlog(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        future_expires_at = reviewed_at + timedelta(hours=4)
+        expired_at = reviewed_at - timedelta(hours=1)
+
+        predelegation_recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome=(
+                "Keep pre-delegation backlog out of reviewed source health rollups."
+            ),
+        )
+        predelegation_action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=predelegation_recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent=(
+                "Keep source health scoped to reviews where ingest is actually expected."
+            ),
+            escalation_reason=(
+                "Operators must not read delegation backlog as source-family silence."
+            ),
+            expires_at=future_expires_at,
+            action_request_id=(
+                "action-request-phase21-readiness-source-health-predelegation-001"
+            ),
+        )
+        predelegation_approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id=(
+                    "approval-phase21-readiness-source-health-predelegation-001"
+                ),
+                action_request_id=predelegation_action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(predelegation_action_request.target_scope),
+                payload_hash=predelegation_action_request.payload_hash,
+                decided_at=reviewed_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=future_expires_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                predelegation_action_request,
+                approval_decision_id=predelegation_approval.approval_decision_id,
+                requested_at=reviewed_at,
+                expires_at=future_expires_at,
+                lifecycle_state="approved",
+            )
+        )
+
+        delegated_recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome=(
+                "Keep actual ingest silence visible once delegation exists."
+            ),
+        )
+        delegated_requested_at = reviewed_at - timedelta(hours=2)
+        delegated_at = reviewed_at - timedelta(hours=1, minutes=50)
+        delegated_action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=delegated_recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Keep delegated ingest silence explicit on readiness.",
+            escalation_reason=(
+                "Operators still need the real source-health signal after delegation."
+            ),
+            expires_at=reviewed_at + timedelta(hours=6),
+            action_request_id=(
+                "action-request-phase21-readiness-source-health-delegated-001"
+            ),
+        )
+        delegated_approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id=(
+                    "approval-phase21-readiness-source-health-delegated-001"
+                ),
+                action_request_id=delegated_action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(delegated_action_request.target_scope),
+                payload_hash=delegated_action_request.payload_hash,
+                decided_at=delegated_requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=expired_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                delegated_action_request,
+                approval_decision_id=delegated_approval.approval_decision_id,
+                requested_at=delegated_requested_at,
+                expires_at=expired_at,
+                lifecycle_state="executing",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id=(
+                    "action-execution-phase21-readiness-source-health-delegated-001"
+                ),
+                action_request_id=delegated_action_request.action_request_id,
+                approval_decision_id=delegated_approval.approval_decision_id,
+                delegation_id=(
+                    "delegation-phase21-readiness-source-health-delegated-001"
+                ),
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id=(
+                    "execution-run-phase21-readiness-source-health-delegated-001"
+                ),
+                idempotency_key=delegated_action_request.idempotency_key,
+                target_scope=dict(delegated_action_request.target_scope),
+                approved_payload=dict(delegated_action_request.requested_payload),
+                payload_hash=delegated_action_request.payload_hash,
+                delegated_at=delegated_at,
+                expires_at=expired_at,
+                provenance={"initiated_by": "operator-review"},
+                lifecycle_state="dispatching",
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        review_path_health = readiness.metrics["review_path_health"]
+        source_health = readiness.metrics["source_health"]
+        github_audit = source_health["sources"]["github_audit"]
+
+        self.assertEqual(review_path_health["review_count"], 2)
+        self.assertEqual(source_health["tracked_sources"], 1)
+        self.assertEqual(source_health["overall_state"], "degraded")
+        self.assertEqual(github_audit["tracked_reviews"], 1)
+        self.assertEqual(github_audit["affected_reviews"], 1)
+        self.assertEqual(
+            github_audit["reason"],
+            "ingest_signal_timeout",
+        )
+        self.assertEqual(
+            github_audit["by_state"],
+            {
+                "healthy": 0,
+                "delayed": 0,
+                "degraded": 1,
+                "failed": 0,
+            },
+        )
+
     def test_service_phase21_readiness_counts_unique_affected_reviews_per_automation_surface(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -3769,6 +3769,122 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             3,
         )
 
+    def test_service_phase21_readiness_freezes_review_path_health_as_of_across_snapshot_collection(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        expires_at = reviewed_at + timedelta(hours=4)
+
+        def persist_review(*, suffix: str, requested_offset_minutes: int) -> None:
+            recommendation = service.record_case_recommendation(
+                case_id=promoted_case.case_id,
+                review_owner="analyst-001",
+                intended_outcome=(
+                    "Keep one frozen review-path evaluation timestamp across"
+                    f" readiness snapshots ({suffix})."
+                ),
+            )
+            requested_at = reviewed_at + timedelta(minutes=requested_offset_minutes)
+            delegated_at = requested_at + timedelta(minutes=10)
+            action_request = service.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id=recommendation.recommendation_id,
+                requester_identity="analyst-001",
+                recipient_identity="repo-owner-001",
+                message_intent=(
+                    "Keep readiness review-path health evaluated at one instant"
+                    f" across reviewed requests ({suffix})."
+                ),
+                escalation_reason=(
+                    "Operators must not see mixed review-path states caused only"
+                    " by crossing an expiry boundary mid-snapshot."
+                ),
+                expires_at=expires_at,
+                action_request_id=(
+                    f"action-request-phase21-readiness-frozen-as-of-{suffix}"
+                ),
+            )
+            approval = service.persist_record(
+                ApprovalDecisionRecord(
+                    approval_decision_id=(
+                        f"approval-phase21-readiness-frozen-as-of-{suffix}"
+                    ),
+                    action_request_id=action_request.action_request_id,
+                    approver_identities=("approver-001",),
+                    target_snapshot=dict(action_request.target_scope),
+                    payload_hash=action_request.payload_hash,
+                    decided_at=requested_at + timedelta(minutes=5),
+                    lifecycle_state="approved",
+                    approved_expires_at=expires_at,
+                )
+            )
+            service.persist_record(
+                replace(
+                    action_request,
+                    approval_decision_id=approval.approval_decision_id,
+                    requested_at=requested_at,
+                    expires_at=expires_at,
+                    lifecycle_state="executing",
+                )
+            )
+            service.persist_record(
+                ActionExecutionRecord(
+                    action_execution_id=(
+                        f"action-execution-phase21-readiness-frozen-as-of-{suffix}"
+                    ),
+                    action_request_id=action_request.action_request_id,
+                    approval_decision_id=approval.approval_decision_id,
+                    delegation_id=(
+                        f"delegation-phase21-readiness-frozen-as-of-{suffix}"
+                    ),
+                    execution_surface_type="automation_substrate",
+                    execution_surface_id="shuffle",
+                    execution_run_id=(
+                        f"execution-run-phase21-readiness-frozen-as-of-{suffix}"
+                    ),
+                    idempotency_key=action_request.idempotency_key,
+                    target_scope=dict(action_request.target_scope),
+                    approved_payload=dict(action_request.requested_payload),
+                    payload_hash=action_request.payload_hash,
+                    delegated_at=delegated_at,
+                    expires_at=expires_at,
+                    provenance={"initiated_by": "operator-review"},
+                    lifecycle_state="dispatching",
+                )
+            )
+
+        persist_review(suffix="001", requested_offset_minutes=0)
+        persist_review(suffix="002", requested_offset_minutes=15)
+
+        counter = {"value": 0}
+
+        def advancing_now(_tz: timezone | None = None) -> datetime:
+            current = reviewed_at + timedelta(seconds=counter["value"])
+            counter["value"] += 1
+            return current
+
+        with mock.patch(
+            "aegisops_control_plane.service.datetime", wraps=datetime
+        ) as mocked_datetime:
+            mocked_datetime.now.side_effect = advancing_now
+            with mock.patch.object(
+                service,
+                "_action_review_path_health",
+                wraps=service._action_review_path_health,
+            ) as action_review_path_health:
+                readiness = service.inspect_readiness_diagnostics()
+
+        recorded_as_of = [
+            call.kwargs["as_of"] for call in action_review_path_health.call_args_list
+        ]
+
+        self.assertEqual(readiness.metrics["review_path_health"]["review_count"], 2)
+        self.assertEqual(action_review_path_health.call_count, 2)
+        self.assertEqual(len(recorded_as_of), 2)
+        self.assertEqual(recorded_as_of[0], recorded_as_of[1])
+
     def test_service_phase21_readiness_prefers_higher_reconciliation_id_when_compared_at_ties(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -3316,6 +3316,121 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(readiness.metrics["action_executions"]["dispatching"], 1)
         self.assertEqual(readiness.metrics["action_executions"]["terminal"], 0)
 
+    def test_service_phase21_readiness_surfaces_source_and_automation_health(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep source silence and substrate lag visible on readiness.",
+        )
+        requested_at = reviewed_at - timedelta(hours=2)
+        delegated_at = reviewed_at - timedelta(hours=1, minutes=50)
+        expired_at = reviewed_at - timedelta(hours=1)
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Show degraded source and automation health in readiness.",
+            escalation_reason="Operators must not infer healthy ingest or delegation from silence.",
+            expires_at=reviewed_at + timedelta(hours=4),
+            action_request_id="action-request-phase21-readiness-health-surfaces-001",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase21-readiness-health-surfaces-001",
+                action_request_id=action_request.action_request_id,
+                approver_identities=("approver-001",),
+                target_snapshot=dict(action_request.target_scope),
+                payload_hash=action_request.payload_hash,
+                decided_at=requested_at + timedelta(minutes=5),
+                lifecycle_state="approved",
+                approved_expires_at=expired_at,
+            )
+        )
+        service.persist_record(
+            replace(
+                action_request,
+                approval_decision_id=approval.approval_decision_id,
+                requested_at=requested_at,
+                expires_at=expired_at,
+                lifecycle_state="executing",
+            )
+        )
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id=(
+                    "action-execution-phase21-readiness-health-surfaces-001"
+                ),
+                action_request_id=action_request.action_request_id,
+                approval_decision_id=approval.approval_decision_id,
+                delegation_id="delegation-phase21-readiness-health-surfaces-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="execution-run-phase21-readiness-health-surfaces-001",
+                idempotency_key=action_request.idempotency_key,
+                target_scope=dict(action_request.target_scope),
+                approved_payload=dict(action_request.requested_payload),
+                payload_hash=action_request.payload_hash,
+                delegated_at=delegated_at,
+                expires_at=expired_at,
+                provenance={"initiated_by": "operator-review"},
+                lifecycle_state="dispatching",
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        source_health = readiness.metrics["source_health"]
+        automation_health = readiness.metrics["automation_substrate_health"]
+
+        self.assertEqual(source_health["overall_state"], "degraded")
+        self.assertEqual(source_health["tracked_sources"], 1)
+        self.assertEqual(
+            source_health["sources"]["github_audit"]["reason"],
+            "ingest_signal_timeout",
+        )
+        self.assertEqual(
+            source_health["sources"]["github_audit"]["affected_reviews"],
+            1,
+        )
+        self.assertEqual(
+            source_health["sources"]["github_audit"]["by_state"],
+            {
+                "healthy": 0,
+                "delayed": 0,
+                "degraded": 1,
+                "failed": 0,
+            },
+        )
+        self.assertEqual(automation_health["overall_state"], "degraded")
+        self.assertEqual(automation_health["tracked_surfaces"], 1)
+        self.assertEqual(
+            automation_health["surfaces"]["automation_substrate:shuffle"]["state"],
+            "degraded",
+        )
+        self.assertEqual(
+            automation_health["surfaces"]["automation_substrate:shuffle"]["paths"][
+                "delegation"
+            ]["reason"],
+            "delegation_receipt_timeout",
+        )
+        self.assertEqual(
+            automation_health["surfaces"]["automation_substrate:shuffle"]["paths"][
+                "provider"
+            ]["reason"],
+            "provider_receipt_timeout",
+        )
+        self.assertEqual(
+            automation_health["surfaces"]["automation_substrate:shuffle"]["paths"][
+                "persistence"
+            ]["reason"],
+            "reconciliation_timeout",
+        )
+
     def test_service_phase21_readiness_prefers_higher_reconciliation_id_when_compared_at_ties(
         self,
     ) -> None:


### PR DESCRIPTION
Closes #563
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the readiness surface change on `codex/issue-563` and committed it as `07e26da` (`Add readiness source and automation health surfaces`).

`inspect_readiness_diagnostics()` now exposes two new operator-facing metrics derived from the same authoritative reviewed-action snapshot selection used for `review_path_health`:
- `metrics.source_health`: aggregates ingest-path health by reviewed source family so silence and degradation remain explicit.
- `metrics.automation_substrate_health`: aggregates delegation/provider/persistence health by automation substrate surface so receipt lag, provider outage, and persistence anomalies stay visible.

I added the focused regression first for the missing readiness fields, then tightened the authenticated `/diagnostics/readiness` HTTP test so the new surfaces are verified on the operator path as well.

Summary: Added readiness `source_health` and `automation_substrate_health` surfaces, with focused service and HTTP regression coverage, and committed the change as `07e26da`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_surfaces_source_and_automation_health control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_treats_dispatching_executions_as_active`; `python3 -m unittest control-plane.tests.test_cli_inspect...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Readiness diagnostics now include per-source and per-automation-surface health (overall state, tracked/affected counts, per-path breakdowns, dominant non-healthy reasons) alongside existing review-path health; explicit empty-state reporting added.
  * Snapshot collection now uses a single consistent timestamp when evaluating review-path health.

* **Tests**
  * Inspection API tests updated; new service tests verify snapshot timestamp consistency, surface-level counts, unique affected-review counting, and path-level reason reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->