### PR TITLE
Issue #564: tighten reviewed IdP runtime boundary

### DIFF
--- a/control-plane/aegisops_control_plane/config.py
+++ b/control-plane/aegisops_control_plane/config.py
@@ -52,6 +52,7 @@ class RuntimeConfig:
     protected_surface_reverse_proxy_secret: str = field(default="", repr=False)
     protected_surface_trusted_proxy_cidrs: tuple[str, ...] = ()
     protected_surface_proxy_service_account: str = ""
+    protected_surface_reviewed_identity_provider: str = ""
     admin_bootstrap_token: str = field(default="", repr=False)
     break_glass_token: str = field(default="", repr=False)
 
@@ -128,6 +129,10 @@ class RuntimeConfig:
             protected_surface_proxy_service_account=source.get(
                 "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT",
                 cls.protected_surface_proxy_service_account,
+            ).strip(),
+            protected_surface_reviewed_identity_provider=source.get(
+                "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER",
+                cls.protected_surface_reviewed_identity_provider,
             ).strip(),
             admin_bootstrap_token=_load_bound_string(
                 source,

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -58,6 +58,12 @@ def build_handler_class(
                 proxy_service_account_header=self.headers.get(
                     "X-AegisOps-Proxy-Service-Account"
                 ),
+                authenticated_identity_provider_header=self.headers.get(
+                    "X-AegisOps-Authenticated-IdP"
+                ),
+                authenticated_subject_header=self.headers.get(
+                    "X-AegisOps-Authenticated-Subject"
+                ),
                 authenticated_identity_header=self.headers.get(
                     "X-AegisOps-Authenticated-Identity"
                 ),
@@ -355,13 +361,33 @@ def build_handler_class(
             request_target = urlsplit(self.path)
             request_path = request_target.path
 
-            if request_path.startswith("/operator/"):
+            operator_analyst_paths = {
+                "/operator/promote-alert-to-case",
+                "/operator/record-case-observation",
+                "/operator/record-case-lead",
+                "/operator/record-case-recommendation",
+                "/operator/record-case-handoff",
+                "/operator/record-case-disposition",
+                "/operator/record-action-review-manual-fallback",
+                "/operator/record-action-review-escalation-note",
+                "/operator/create-reviewed-action-request",
+            }
+            operator_approver_paths = {
+                "/operator/record-action-approval-decision",
+            }
+
+            if request_path in operator_analyst_paths | operator_approver_paths:
                 try:
                     peer_addr = self.client_address[0] if self.client_address else None
                     if peer_addr_is_loopback(peer_addr):
                         require_loopback_operator_request_fn(self)
+                    allowed_roles = (
+                        ("analyst",)
+                        if request_path in operator_analyst_paths
+                        else ("approver",)
+                    )
                     principal = self._require_authenticated_surface_access(
-                        allowed_roles=("analyst", "approver", "platform_admin"),
+                        allowed_roles=allowed_roles,
                     )
                 except PermissionError as exc:
                     self._write_forbidden(str(exc))

--- a/control-plane/aegisops_control_plane/operations.py
+++ b/control-plane/aegisops_control_plane/operations.py
@@ -477,6 +477,7 @@ class RestoreReadinessService:
                 (
                     "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET",
                     "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT",
+                    "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER",
                 )
                 if protected_surface_proxy_bindings_required
                 else ()
@@ -496,6 +497,9 @@ class RestoreReadinessService:
             ),
             "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT": (
                 self._config.protected_surface_proxy_service_account
+            ),
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER": (
+                self._config.protected_surface_reviewed_identity_provider
             ),
             "AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN": (
                 self._config.admin_bootstrap_token

--- a/control-plane/aegisops_control_plane/operations.py
+++ b/control-plane/aegisops_control_plane/operations.py
@@ -199,6 +199,13 @@ class RuntimeBoundaryService:
                     "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT must be set "
                     "before admitting reviewed reverse-proxy traffic to protected control-plane surfaces"
                 )
+            if _is_missing_runtime_binding(
+                self._config.protected_surface_reviewed_identity_provider
+            ):
+                raise ValueError(
+                    "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER must be set "
+                    "before admitting reviewed reverse-proxy traffic to protected control-plane surfaces"
+                )
 
     def authenticate_protected_surface_request(
         self,
@@ -207,6 +214,8 @@ class RuntimeBoundaryService:
         forwarded_proto: str | None,
         reverse_proxy_secret_header: str | None,
         proxy_service_account_header: str | None,
+        authenticated_identity_provider_header: str | None,
+        authenticated_subject_header: str | None,
         authenticated_identity_header: str | None,
         authenticated_role_header: str | None,
         allowed_roles: tuple[str, ...],
@@ -243,6 +252,28 @@ class RuntimeBoundaryService:
                 raise PermissionError(
                     "protected control-plane surfaces require the reviewed reverse proxy service account identity"
                 )
+            reviewed_identity_provider = (
+                self._config.protected_surface_reviewed_identity_provider.strip().lower()
+            )
+            supplied_identity_provider = (
+                (authenticated_identity_provider_header or "").strip().lower()
+            )
+            if supplied_identity_provider == "":
+                raise PermissionError(
+                    "protected control-plane surfaces require an attributed reviewed identity provider header"
+                )
+            if not hmac.compare_digest(
+                supplied_identity_provider,
+                reviewed_identity_provider,
+            ):
+                raise PermissionError(
+                    "protected control-plane surfaces require the reviewed identity provider boundary"
+                )
+            authenticated_subject = (authenticated_subject_header or "").strip()
+            if authenticated_subject == "":
+                raise PermissionError(
+                    "protected control-plane surfaces require an attributed authenticated subject header"
+                )
 
             identity = (authenticated_identity_header or "").strip()
             if identity == "":
@@ -265,6 +296,8 @@ class RuntimeBoundaryService:
                 role=role,
                 access_path="reviewed_reverse_proxy",
                 proxy_service_account=supplied_proxy_service_account,
+                identity_provider=supplied_identity_provider,
+                subject=authenticated_subject,
             )
 
         if principal.role not in allowed_roles:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -211,6 +211,8 @@ class AuthenticatedRuntimePrincipal:
     role: str
     access_path: str
     proxy_service_account: str | None = None
+    identity_provider: str | None = None
+    subject: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1843,6 +1845,8 @@ class AegisOpsControlPlaneService:
         forwarded_proto: str | None,
         reverse_proxy_secret_header: str | None,
         proxy_service_account_header: str | None,
+        authenticated_identity_provider_header: str | None,
+        authenticated_subject_header: str | None,
         authenticated_identity_header: str | None,
         authenticated_role_header: str | None,
         allowed_roles: tuple[str, ...],
@@ -1852,6 +1856,8 @@ class AegisOpsControlPlaneService:
             forwarded_proto=forwarded_proto,
             reverse_proxy_secret_header=reverse_proxy_secret_header,
             proxy_service_account_header=proxy_service_account_header,
+            authenticated_identity_provider_header=authenticated_identity_provider_header,
+            authenticated_subject_header=authenticated_subject_header,
             authenticated_identity_header=authenticated_identity_header,
             authenticated_role_header=authenticated_role_header,
             allowed_roles=allowed_roles,

--- a/control-plane/tests/test_cli_inspection.py
+++ b/control-plane/tests/test_cli_inspection.py
@@ -816,6 +816,7 @@ class ControlPlaneCliInspectionTests(unittest.TestCase):
                 protected_surface_reverse_proxy_secret="reviewed-surface-secret",  # noqa: S106 - test fixture secret
                 protected_surface_trusted_proxy_cidrs=("10.10.0.5/32",),
                 protected_surface_proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+                protected_surface_reviewed_identity_provider="authentik",
                 admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
                 break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
             ),

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -46,6 +46,12 @@ REVIEWED_ANALYST_PRINCIPAL = AuthenticatedRuntimePrincipal(
     access_path="reviewed_reverse_proxy",
     proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
 )
+REVIEWED_PLATFORM_ADMIN_PRINCIPAL = AuthenticatedRuntimePrincipal(
+    identity="platform-admin-001",
+    role="platform_admin",
+    access_path="reviewed_reverse_proxy",
+    proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+)
 
 
 _load_wazuh_fixture = load_wazuh_fixture
@@ -56,11 +62,25 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
     @contextlib.contextmanager
     def _mock_authenticated_surface_access(
         service: AegisOpsControlPlaneService,
+        *,
+        principal: AuthenticatedRuntimePrincipal = REVIEWED_ANALYST_PRINCIPAL,
     ) -> object:
+        def _authenticate_surface_access(**kwargs: object) -> AuthenticatedRuntimePrincipal:
+            allowed_roles = kwargs.get("allowed_roles")
+            if not isinstance(allowed_roles, tuple):
+                raise AssertionError("expected authenticate_protected_surface_request to receive allowed_roles")
+            if principal.role not in allowed_roles:
+                joined_roles = ", ".join(sorted(allowed_roles))
+                raise PermissionError(
+                    "protected control-plane surface role is not authorized for this endpoint; "
+                    f"expected one of: {joined_roles}"
+                )
+            return principal
+
         with mock.patch.object(
             service,
             "authenticate_protected_surface_request",
-            return_value=REVIEWED_ANALYST_PRINCIPAL,
+            side_effect=_authenticate_surface_access,
         ):
             yield
 
@@ -1337,6 +1357,91 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                             "outside the approved Phase 19 Wazuh-backed GitHub audit and Entra ID live slice",
                             payload["message"],
                         )
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
+    def test_create_reviewed_action_request_rejects_platform_admin_identity(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+        created = service.ingest_wazuh_alert(
+            raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {REVIEWED_SHARED_SECRET}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(created.alert.alert_id)
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Require a reviewed approval decision inside the runtime boundary.",
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(
+            main,
+            "ThreadingHTTPServer",
+            RecordingServer,
+        ), self._mock_authenticated_surface_access(
+            service,
+            principal=REVIEWED_PLATFORM_ADMIN_PRINCIPAL,
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+                with self.assertRaises(error.HTTPError) as request_error:
+                    request.urlopen(
+                        request.Request(
+                            f"{base_url}/operator/create-reviewed-action-request",
+                            data=json.dumps(
+                                {
+                                    "family": "recommendation",
+                                    "record_id": recommendation.recommendation_id,
+                                    "requester_identity": "platform-admin-001",
+                                    "recipient_identity": "repo-owner-001",
+                                    "message_intent": "Notify the accountable repository owner about the reviewed permission change.",
+                                    "escalation_reason": "Platform administrators must not replace the reviewed analyst request path.",
+                                    "expires_at": (
+                                        datetime.now(timezone.utc) + timedelta(hours=4)
+                                    ).isoformat(),
+                                }
+                            ).encode("utf-8"),
+                            headers={"Content-Type": "application/json"},
+                            method="POST",
+                        ),
+                        timeout=2,
+                    )
+                self.assertEqual(request_error.exception.code, 403)
+                payload = json.loads(request_error.exception.read().decode("utf-8"))
+                self.assertIn("expected one of: analyst", payload["message"])
             finally:
                 if servers:
                     servers[0].shutdown()

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -1418,8 +1418,8 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 self.assertTrue(servers, "expected test HTTP server to start")
                 base_url = f"http://127.0.0.1:{servers[0].server_port}"
                 with self.assertRaises(error.HTTPError) as request_error:
-                    request.urlopen(
-                        request.Request(
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                        request.Request(  # noqa: S310 - local in-process test HTTP server
                             f"{base_url}/operator/create-reviewed-action-request",
                             data=json.dumps(
                                 {

--- a/control-plane/tests/test_phase21_end_to_end_validation.py
+++ b/control-plane/tests/test_phase21_end_to_end_validation.py
@@ -58,6 +58,7 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
                 protected_surface_reverse_proxy_secret=REVIEWED_SURFACE_PROXY_SECRET,
                 protected_surface_trusted_proxy_cidrs=("10.10.0.5/32",),
                 protected_surface_proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+                protected_surface_reviewed_identity_provider="authentik",
                 admin_bootstrap_token=REVIEWED_ADMIN_BOOTSTRAP_TOKEN,
                 break_glass_token=REVIEWED_BREAK_GLASS_TOKEN,
             ),

--- a/control-plane/tests/test_phase21_runtime_auth_validation.py
+++ b/control-plane/tests/test_phase21_runtime_auth_validation.py
@@ -56,6 +56,7 @@ def _build_service(*, host: str = "127.0.0.1") -> AegisOpsControlPlaneService:
             protected_surface_reverse_proxy_secret=REVIEWED_SURFACE_PROXY_SECRET,
             protected_surface_trusted_proxy_cidrs=("10.10.0.5/32",),
             protected_surface_proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+            protected_surface_reviewed_identity_provider="authentik",
             admin_bootstrap_token=REVIEWED_ADMIN_BOOTSTRAP_TOKEN,
             break_glass_token=REVIEWED_BREAK_GLASS_TOKEN,
         ),
@@ -85,6 +86,8 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
                 forwarded_proto="https",
                 reverse_proxy_secret_header=REVIEWED_SURFACE_PROXY_SECRET,
                 proxy_service_account_header=REVIEWED_PROXY_SERVICE_ACCOUNT,
+                authenticated_identity_provider_header="authentik",
+                authenticated_subject_header="authentik-user-001",
                 authenticated_identity_header="platform-admin-001",
                 authenticated_role_header="platform_admin",
                 allowed_roles=("platform_admin",),
@@ -96,6 +99,8 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
             forwarded_proto="https",
             reverse_proxy_secret_header=REVIEWED_SURFACE_PROXY_SECRET,
             proxy_service_account_header=REVIEWED_PROXY_SERVICE_ACCOUNT,
+            authenticated_identity_provider_header="authentik",
+            authenticated_subject_header="authentik-user-001",
             authenticated_identity_header="platform-admin-001",
             authenticated_role_header="platform_admin",
             allowed_roles=("platform_admin",),
@@ -182,9 +187,53 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
                 forwarded_proto="https",
                 reverse_proxy_secret_header=REVIEWED_SURFACE_PROXY_SECRET,
                 proxy_service_account_header=REVIEWED_PROXY_SERVICE_ACCOUNT,
+                authenticated_identity_provider_header="authentik",
+                authenticated_subject_header="authentik-user-001",
                 authenticated_identity_header=None,
                 authenticated_role_header="analyst",
                 allowed_roles=("analyst", "approver", "platform_admin"),
+            )
+
+    def test_protected_surface_request_rejects_missing_reviewed_identity_provider_header(
+        self,
+    ) -> None:
+        service = _build_service(host=TEST_NON_LOOPBACK_HOST)
+
+        with self.assertRaisesRegex(
+            PermissionError,
+            "protected control-plane surfaces require an attributed reviewed identity provider header",
+        ):
+            service.authenticate_protected_surface_request(
+                peer_addr="10.10.0.5",
+                forwarded_proto="https",
+                reverse_proxy_secret_header=REVIEWED_SURFACE_PROXY_SECRET,
+                proxy_service_account_header=REVIEWED_PROXY_SERVICE_ACCOUNT,
+                authenticated_identity_provider_header=None,
+                authenticated_subject_header="authentik-user-001",
+                authenticated_identity_header="analyst-001",
+                authenticated_role_header="analyst",
+                allowed_roles=("analyst",),
+            )
+
+    def test_protected_surface_request_rejects_unreviewed_identity_provider_boundary(
+        self,
+    ) -> None:
+        service = _build_service(host=TEST_NON_LOOPBACK_HOST)
+
+        with self.assertRaisesRegex(
+            PermissionError,
+            "protected control-plane surfaces require the reviewed identity provider boundary",
+        ):
+            service.authenticate_protected_surface_request(
+                peer_addr="10.10.0.5",
+                forwarded_proto="https",
+                reverse_proxy_secret_header=REVIEWED_SURFACE_PROXY_SECRET,
+                proxy_service_account_header=REVIEWED_PROXY_SERVICE_ACCOUNT,
+                authenticated_identity_provider_header="entra-id",
+                authenticated_subject_header="entra-user-001",
+                authenticated_identity_header="analyst-001",
+                authenticated_role_header="analyst",
+                allowed_roles=("analyst",),
             )
 
     def test_protected_surface_request_accepts_reviewed_reverse_proxy_identity_headers(
@@ -197,6 +246,8 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
             forwarded_proto="https",
             reverse_proxy_secret_header=REVIEWED_SURFACE_PROXY_SECRET,
             proxy_service_account_header=REVIEWED_PROXY_SERVICE_ACCOUNT,
+            authenticated_identity_provider_header="authentik",
+            authenticated_subject_header="authentik-user-001",
             authenticated_identity_header="analyst-001",
             authenticated_role_header="analyst",
             allowed_roles=("analyst", "approver", "platform_admin"),
@@ -209,6 +260,8 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
             principal.proxy_service_account,
             REVIEWED_PROXY_SERVICE_ACCOUNT,
         )
+        self.assertEqual(principal.identity_provider, "authentik")
+        self.assertEqual(principal.subject, "authentik-user-001")
 
     def test_protected_surface_loopback_request_honors_allowed_roles(self) -> None:
         service = _build_service()
@@ -222,6 +275,8 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
                 forwarded_proto=None,
                 reverse_proxy_secret_header=None,
                 proxy_service_account_header=None,
+                authenticated_identity_provider_header=None,
+                authenticated_subject_header=None,
                 authenticated_identity_header=None,
                 authenticated_role_header=None,
                 allowed_roles=("platform_admin",),
@@ -235,6 +290,8 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
             forwarded_proto=None,
             reverse_proxy_secret_header=None,
             proxy_service_account_header=None,
+            authenticated_identity_provider_header=None,
+            authenticated_subject_header=None,
             authenticated_identity_header=None,
             authenticated_role_header=None,
             allowed_roles=("loopback_local",),

--- a/control-plane/tests/test_phase21_runtime_auth_validation.py
+++ b/control-plane/tests/test_phase21_runtime_auth_validation.py
@@ -154,6 +154,42 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
         )
         self.assertEqual(readiness.status, "ready")
 
+    def test_startup_status_reports_missing_reviewed_identity_provider_binding(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host=TEST_NON_LOOPBACK_HOST,
+                port=8080,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_WAZUH_PROXY_SECRET,
+                wazuh_ingest_trusted_proxy_cidrs=("10.10.0.5/32",),
+                protected_surface_reverse_proxy_secret=REVIEWED_SURFACE_PROXY_SECRET,
+                protected_surface_trusted_proxy_cidrs=("10.10.0.5/32",),
+                protected_surface_proxy_service_account=REVIEWED_PROXY_SERVICE_ACCOUNT,
+                admin_bootstrap_token=REVIEWED_ADMIN_BOOTSTRAP_TOKEN,
+            ),
+            store=store,
+        )
+
+        startup = service.describe_startup_status()
+        readiness = service.inspect_readiness_diagnostics()
+
+        self.assertFalse(startup.startup_ready)
+        self.assertIn(
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER",
+            startup.required_bindings,
+        )
+        self.assertIn(
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER",
+            startup.missing_bindings,
+        )
+        self.assertIn(
+            "AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER must be set",
+            startup.blocking_reasons[0],
+        )
+        self.assertEqual(readiness.status, "failing_closed")
+
     def test_protected_surface_runtime_fails_closed_without_trusted_proxy_bindings(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_phase23_approval_surface_validation.py
+++ b/control-plane/tests/test_phase23_approval_surface_validation.py
@@ -430,10 +430,10 @@ class Phase23ApprovalSurfaceValidationTests(unittest.TestCase):
             self.assertEqual(exc_info.exception.code, HTTPStatus.FORBIDDEN)
             error_payload = json.loads(exc_info.exception.read().decode("utf-8"))
             self.assertEqual(error_payload["error"], "forbidden")
-            self.assertIn("approver role authority", error_payload["message"])
+            self.assertIn("expected one of: approver", error_payload["message"])
             self.assertEqual(
                 authenticate_mock.call_args_list[0].kwargs["allowed_roles"],
-                ("analyst", "approver", "platform_admin"),
+                ("approver",),
             )
             stored_request = service.get_record(
                 type(action_request),

--- a/docs/auth-baseline.md
+++ b/docs/auth-baseline.md
@@ -26,6 +26,19 @@ Human access must be attributable to an individual operator identity with an aud
 
 Shared interactive administrator logins, anonymous operator accounts, and mailbox-backed human access are not an approved baseline.
 
+The reviewed runtime boundary for human access must bind operator and approver sessions to one reviewed identity-provider path rather than trusting free-form client identity headers.
+
+For the current SMB operating model, Authentik is the preferred reviewed human IdP boundary when a concrete provider choice is required, provided it remains behind the approved reverse proxy and does not widen AegisOps into broad IAM-program ownership.
+
+At minimum, the reviewed reverse-proxy boundary must inject and protect all of the following before approval-sensitive runtime access is admitted:
+
+- the reviewed identity-provider identifier;
+- an attributable provider subject for the authenticated human session;
+- the reviewed human identity string used inside the control plane; and
+- the reviewed role assertion used for analyst, approver, or platform-administrator separation.
+
+If any of those claims are missing, malformed, or do not match the reviewed provider boundary, the runtime must fail closed rather than inferring identity from partial headers or local naming conventions.
+
 ## 3. Authorization and Separation-of-Duties Baseline
 
 Authorization must align to the platform boundary being crossed, not merely to which UI or workflow engine happens to expose the action.


### PR DESCRIPTION
## Summary
- require a reviewed protected-surface identity-provider binding plus IdP and subject claims on reverse-proxy traffic
- split mutable operator POST surfaces into analyst-only and approver-only role admission paths
- add focused regressions for missing or unreviewed IdP claims and for platform-admin rejection on reviewed action-request creation

## Testing
- python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation control-plane.tests.test_phase19_operator_workflow_validation control-plane.tests.test_phase23_approval_surface_validation
- bash scripts/verify-auth-baseline-doc.sh

Closes #564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-based access enforced per operator endpoint (separate analyst vs approver requirements).
  * Reviewed reverse-proxy requests must present validated identity-provider and subject headers; successful requests surface identity info to the runtime principal.
  * Startup will report missing reviewed identity-provider binding and fail readiness when required.

* **Bug Fixes**
  * POST to certain operator endpoints now returns 403 for disallowed identities (e.g., platform-admin) instead of permitting them.

* **Documentation**
  * Authentication baseline updated with reviewed IdP and required identity claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->