### PR TITLE
validation: add disaster, degraded-mode, and identity/secret boundary drills (#566)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,14 @@ jobs:
       - name: Run Phase 26 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-26-workflow-coverage.sh
 
+      - name: Run Phase 27 day-2 hardening validation
+        run: |
+          bash scripts/verify-phase-27-day-2-hardening-validation.sh
+          python3 -m unittest control-plane.tests.test_phase27_day2_hardening_validation control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_restore_drill_fails_closed_when_runtime_bindings_missing_after_restore control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_surfaces_source_and_automation_health control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_startup_status_reports_missing_reviewed_identity_provider_binding control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_protected_surface_request_rejects_unreviewed_identity_provider_boundary control-plane.tests.test_runtime_secret_boundary.RuntimeSecretBoundaryTests.test_runtime_config_fails_closed_when_openbao_backend_is_unavailable control-plane.tests.test_runtime_secret_boundary.RuntimeSecretBoundaryTests.test_runtime_config_reloads_rotated_openbao_secret_on_fresh_load
+
+      - name: Run Phase 27 workflow coverage guard
+        run: bash scripts/test-verify-ci-phase-27-workflow-coverage.sh
+
       - name: Run control-plane runtime unit tests
         run: python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
 
@@ -257,6 +265,7 @@ jobs:
           bash scripts/test-verify-phase-24-live-assistant-workflow-contract.sh
           bash scripts/test-verify-phase-25-multi-source-case-review-runbook.sh
           bash scripts/test-verify-phase-26-ticket-coordination-validation.sh
+          bash scripts/test-verify-phase-27-day-2-hardening-validation.sh
           bash scripts/test-verify-ci-phase-14-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-15-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-19-workflow-coverage.sh
@@ -267,6 +276,7 @@ jobs:
           bash scripts/test-verify-ci-phase-24-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-25-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-26-workflow-coverage.sh
+          bash scripts/test-verify-ci-phase-27-workflow-coverage.sh
           bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
           bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
           bash scripts/test-verify-phase-6-replay-to-notify-validation.sh

--- a/control-plane/tests/test_phase27_day2_hardening_validation.py
+++ b/control-plane/tests/test_phase27_day2_hardening_validation.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase27Day2HardeningValidationTests(unittest.TestCase):
+    @staticmethod
+    def _validation_doc() -> pathlib.Path:
+        return REPO_ROOT / "docs" / "phase-27-day-2-hardening-validation.md"
+
+    def test_phase27_validation_doc_exists_and_covers_reviewed_drills(self) -> None:
+        validation_doc = self._validation_doc()
+        self.assertTrue(
+            validation_doc.exists(),
+            f"expected Phase 27 validation doc at {validation_doc}",
+        )
+
+        validation_text = validation_doc.read_text(encoding="utf-8")
+
+        for term in (
+            "Validation status: PASS",
+            "docs/runbook.md",
+            "docs/auth-baseline.md",
+            "docs/smb-footprint-and-deployment-profile-baseline.md",
+            "control-plane/tests/test_service_persistence_restore_readiness.py",
+            "control-plane/tests/test_runtime_secret_boundary.py",
+            "restore",
+            "degraded-mode",
+            "identity-boundary",
+            "secret rotation",
+            "secret-backend unavailability",
+            "IdP outage",
+            "delegation outage",
+            "source-health",
+            "repo-owned verification path",
+            "bash scripts/verify-phase-27-day-2-hardening-validation.sh",
+        ):
+            self.assertIn(term, validation_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-27-day-2-hardening-validation.md
+++ b/docs/phase-27-day-2-hardening-validation.md
@@ -1,0 +1,39 @@
+# Phase 27 Day-2 Hardening Validation
+
+- Validation status: PASS
+- Reviewed on: 2026-04-19
+- Scope: confirm the reviewed Phase 27 day-2 hardening drills stay narrow, fail closed, and remain wired into the repo-owned verification path for restore, degraded-mode visibility, identity-boundary failure, and secret-boundary handling.
+- Reviewed sources: `docs/runbook.md`, `docs/auth-baseline.md`, `docs/smb-footprint-and-deployment-profile-baseline.md`, `control-plane/tests/test_service_persistence_restore_readiness.py`, `control-plane/tests/test_phase21_runtime_auth_validation.py`, `control-plane/tests/test_runtime_secret_boundary.py`
+
+## Validation Summary
+
+The reviewed restore drill remains specific to the authoritative record chain and continues to prove that restore preserves approval, evidence, action-execution, and reconciliation truth without silently accepting broken runtime bindings.
+
+The degraded-mode validation remains operator-visible instead of permissive. Source-health and delegation outage conditions stay surfaced through readiness diagnostics so operators do not infer healthy ingest or healthy automation from silence.
+
+The identity-boundary validation continues to fail closed for IdP outage and reviewed provider mismatch conditions. Protected surfaces still block when the reviewed identity-provider binding is missing or when an unreviewed provider boundary is presented.
+
+The secret-boundary validation continues to fail closed when the managed backend is unavailable and proves secret rotation is only accepted through a fresh reload of the reviewed OpenBao reference.
+
+## Drill Coverage
+
+- `restore`: `test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain` keeps the approved disaster-recovery path anchored to the authoritative record chain.
+- `restore`: `test_service_phase21_restore_drill_fails_closed_when_runtime_bindings_missing_after_restore` proves restore verification blocks when the recovered runtime boundary is incomplete.
+- `degraded-mode`: `test_service_phase21_readiness_surfaces_source_and_automation_health` keeps source-health and delegation outage visibility explicit during degraded-mode handling.
+- `identity-boundary`: `test_startup_status_reports_missing_reviewed_identity_provider_binding` treats IdP outage or missing reviewed provider binding as a fail-closed startup condition.
+- `identity-boundary`: `test_protected_surface_request_rejects_unreviewed_identity_provider_boundary` rejects requests that cross the identity boundary through an unreviewed provider path.
+- `secret rotation`: `test_runtime_config_reloads_rotated_openbao_secret_on_fresh_load` proves rotation requires a fresh trusted read instead of cached or guessed secret state.
+- `secret-backend unavailability`: `test_runtime_config_fails_closed_when_openbao_backend_is_unavailable` keeps the control plane blocked when the reviewed secret backend cannot be read.
+
+These drills stay intentionally narrow. They do not expand into generic chaos engineering, broad performance benchmarking, or new platform-scope reliability experiments.
+
+## Verification
+
+- `bash scripts/verify-phase-27-day-2-hardening-validation.sh`
+- `python3 -m unittest control-plane.tests.test_phase27_day2_hardening_validation control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_restore_drill_fails_closed_when_runtime_bindings_missing_after_restore control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_surfaces_source_and_automation_health control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_startup_status_reports_missing_reviewed_identity_provider_binding control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_protected_surface_request_rejects_unreviewed_identity_provider_boundary control-plane.tests.test_runtime_secret_boundary.RuntimeSecretBoundaryTests.test_runtime_config_fails_closed_when_openbao_backend_is_unavailable control-plane.tests.test_runtime_secret_boundary.RuntimeSecretBoundaryTests.test_runtime_config_reloads_rotated_openbao_secret_on_fresh_load`
+- `bash scripts/test-verify-phase-27-day-2-hardening-validation.sh`
+- `bash scripts/test-verify-ci-phase-27-workflow-coverage.sh`
+
+## Result
+
+The reviewed Phase 27 day-2 hardening slice now has a repo-owned verification path that covers restore, degraded-mode, identity-boundary, and secret-boundary drills without widening the product thesis or weakening fail-closed behavior.

--- a/scripts/test-verify-ci-phase-27-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-27-workflow-coverage.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+required_verifiers=(
+  "bash scripts/verify-phase-27-day-2-hardening-validation.sh"
+)
+
+required_tests=(
+  "bash scripts/test-verify-phase-27-day-2-hardening-validation.sh"
+)
+
+required_runtime_commands=(
+  "python3 -m unittest control-plane.tests.test_phase27_day2_hardening_validation control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_restore_drill_fails_closed_when_runtime_bindings_missing_after_restore control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_surfaces_source_and_automation_health control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_startup_status_reports_missing_reviewed_identity_provider_binding control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_protected_surface_request_rejects_unreviewed_identity_provider_boundary control-plane.tests.test_runtime_secret_boundary.RuntimeSecretBoundaryTests.test_runtime_config_fails_closed_when_openbao_backend_is_unavailable control-plane.tests.test_runtime_secret_boundary.RuntimeSecretBoundaryTests.test_runtime_config_reloads_rotated_openbao_secret_on_fresh_load"
+)
+
+self_guard_step_name="Run Phase 27 workflow coverage guard"
+self_guard_command="bash scripts/test-verify-ci-phase-27-workflow-coverage.sh"
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+collect_active_run_commands() {
+  awk '
+    {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent > block_indent) {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          if (line != "" && line !~ /^#/) {
+            print line
+          }
+          next
+        }
+
+        in_block = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+        block_indent = match($0, /[^ ]/) - 1
+        in_block = 1
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[^|>]/) {
+        line = $0
+        sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+        if (line != "" && line !~ /^#/) {
+          print line
+        }
+      }
+    }
+  ' "${workflow_path}"
+}
+
+extract_self_guard_step_run_command() {
+  awk -v step_name="${self_guard_step_name}" '
+    function line_indent(line) {
+      return match(line, /[^ ]/) - 1
+    }
+
+    BEGIN {
+      in_step = 0
+      step_indent = -1
+    }
+
+    {
+      if (in_step) {
+        if ($0 ~ /^[[:space:]]*-[[:space:]]name:[[:space:]]+/ && line_indent($0) <= step_indent) {
+          exit 0
+        }
+
+        if ($0 ~ /^[[:space:]]*run:[[:space:]]*/) {
+          line = $0
+          sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+          print line
+          exit 0
+        }
+      }
+
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line == "- name: " step_name) {
+        in_step = 1
+        step_indent = line_indent($0)
+      }
+    }
+  ' "${workflow_path}"
+}
+
+active_run_commands="$(collect_active_run_commands)"
+
+for command in "${required_verifiers[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 27 verifier command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_tests[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 27 focused shell test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_runtime_commands[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 27 focused runtime command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+self_guard_step_run_command="$(extract_self_guard_step_run_command)"
+if [[ -z "${self_guard_step_run_command}" ]]; then
+  echo "Missing dedicated Phase 27 workflow coverage guard step in CI workflow: ${self_guard_step_name}" >&2
+  exit 1
+fi
+
+if [[ "${self_guard_step_run_command}" != "${self_guard_command}" ]]; then
+  echo "Dedicated Phase 27 workflow coverage guard step must run exactly: ${self_guard_command}" >&2
+  echo "Found: ${self_guard_step_run_command}" >&2
+  exit 1
+fi
+
+self_guard_count="$(grep -Fxc -- "${self_guard_command}" <<<"${active_run_commands}" || true)"
+if [[ "${self_guard_count}" -lt 2 ]]; then
+  echo "Phase 27 workflow coverage checker must run both as a dedicated guard and within focused shell tests." >&2
+  exit 1
+fi
+
+echo "CI workflow includes the required Phase 27 verifier, focused shell test, and focused runtime command."

--- a/scripts/test-verify-ci-phase-27-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-27-workflow-coverage.sh
@@ -46,7 +46,7 @@ collect_active_run_commands() {
         in_block = 0
       }
 
-      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*\|[-]?[[:space:]]*$/) {
         block_indent = match($0, /[^ ]/) - 1
         in_block = 1
         next

--- a/scripts/test-verify-ci-phase-27-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-27-workflow-coverage.sh
@@ -76,11 +76,11 @@ extract_self_guard_step_run_command() {
 
     {
       if (in_step) {
-        if ($0 ~ /^[[:space:]]*-[[:space:]]name:[[:space:]]+/ && line_indent($0) <= step_indent) {
+        if ($0 ~ /^[[:space:]]*-[[:space:]]/ && line_indent($0) <= step_indent) {
           exit 0
         }
 
-        if ($0 ~ /^[[:space:]]*run:[[:space:]]*/) {
+        if ($0 ~ /^[[:space:]]*run:[[:space:]]*/ && line_indent($0) > step_indent) {
           line = $0
           sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
           print line

--- a/scripts/test-verify-phase-27-day-2-hardening-validation.sh
+++ b/scripts/test-verify-phase-27-day-2-hardening-validation.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 verifier="${repo_root}/scripts/verify-phase-27-day-2-hardening-validation.sh"
+workflow_guard="${repo_root}/scripts/test-verify-ci-phase-27-workflow-coverage.sh"
 
 workdir="$(mktemp -d)"
 trap 'rm -rf "${workdir}"' EXIT
@@ -12,6 +13,8 @@ pass_stdout="${workdir}/pass.out"
 pass_stderr="${workdir}/pass.err"
 fail_stdout="${workdir}/fail.out"
 fail_stderr="${workdir}/fail.err"
+guard_stdout="${workdir}/guard.out"
+guard_stderr="${workdir}/guard.err"
 
 required_artifacts=(
   "docs/phase-27-day-2-hardening-validation.md"
@@ -54,6 +57,16 @@ remove_text_from_file() {
   git -C "${target}" add "${path}"
 }
 
+replace_text_in_file() {
+  local target="$1"
+  local path="$2"
+  local expected_text="$3"
+  local replacement_text="$4"
+
+  EXPECTED_TEXT="${expected_text}" REPLACEMENT_TEXT="${replacement_text}" perl -0pi -e 's/\Q$ENV{EXPECTED_TEXT}\E/$ENV{REPLACEMENT_TEXT}/g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
 commit_fixture() {
   local target="$1"
 
@@ -66,6 +79,16 @@ assert_passes() {
   if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
     echo "Expected verifier to pass for ${target}" >&2
     cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_guard_passes() {
+  local target="$1"
+
+  if ! bash "${workflow_guard}" "${target}" >"${guard_stdout}" 2>"${guard_stderr}"; then
+    echo "Expected workflow guard to pass for ${target}" >&2
+    cat "${guard_stderr}" >&2
     exit 1
   fi
 }
@@ -86,11 +109,28 @@ assert_fails_with() {
   fi
 }
 
+assert_guard_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${workflow_guard}" "${target}" >"${guard_stdout}" 2>"${guard_stderr}"; then
+    echo "Expected workflow guard to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${guard_stderr}" >/dev/null; then
+    echo "Expected workflow guard failure output to contain: ${expected}" >&2
+    cat "${guard_stderr}" >&2
+    exit 1
+  fi
+}
+
 valid_repo="${workdir}/valid"
 create_repo "${valid_repo}"
 write_required_artifacts "${valid_repo}"
 commit_fixture "${valid_repo}"
 assert_passes "${valid_repo}"
+assert_guard_passes "${valid_repo}"
 
 missing_doc_repo="${workdir}/missing-doc"
 create_repo "${missing_doc_repo}"
@@ -119,5 +159,16 @@ remove_text_from_file \
   "      - name: Run Phase 27 workflow coverage guard"
 commit_fixture "${missing_ci_repo}"
 assert_fails_with "${missing_ci_repo}" "Missing required line in ${missing_ci_repo}/.github/workflows/ci.yml:       - name: Run Phase 27 workflow coverage guard"
+
+unnamed_step_repo="${workdir}/unnamed-step-boundary"
+create_repo "${unnamed_step_repo}"
+write_required_artifacts "${unnamed_step_repo}"
+replace_text_in_file \
+  "${unnamed_step_repo}" \
+  ".github/workflows/ci.yml" \
+  $'      - name: Run Phase 27 workflow coverage guard\n        run: bash scripts/test-verify-ci-phase-27-workflow-coverage.sh\n' \
+  $'      - name: Run Phase 27 workflow coverage guard\n        if: ${{ always() }}\n\n      - run: bash scripts/test-verify-ci-phase-27-workflow-coverage.sh\n'
+commit_fixture "${unnamed_step_repo}"
+assert_guard_fails_with "${unnamed_step_repo}" "Missing dedicated Phase 27 workflow coverage guard step in CI workflow: Run Phase 27 workflow coverage guard"
 
 echo "Phase 27 day-2 hardening verifier fails closed for missing drills and CI wiring."

--- a/scripts/test-verify-phase-27-day-2-hardening-validation.sh
+++ b/scripts/test-verify-phase-27-day-2-hardening-validation.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-27-day-2-hardening-validation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+required_artifacts=(
+  "docs/phase-27-day-2-hardening-validation.md"
+  "control-plane/tests/test_service_persistence_restore_readiness.py"
+  "control-plane/tests/test_phase21_runtime_auth_validation.py"
+  "control-plane/tests/test_runtime_secret_boundary.py"
+  "control-plane/tests/test_phase27_day2_hardening_validation.py"
+  "scripts/verify-phase-27-day-2-hardening-validation.sh"
+  "scripts/test-verify-phase-27-day-2-hardening-validation.sh"
+  "scripts/test-verify-ci-phase-27-workflow-coverage.sh"
+  ".github/workflows/ci.yml"
+)
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs" "${target}/control-plane/tests" "${target}/scripts" "${target}/.github/workflows"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_required_artifacts() {
+  local target="$1"
+  local artifact=""
+
+  for artifact in "${required_artifacts[@]}"; do
+    mkdir -p "${target}/$(dirname "${artifact}")"
+    cp "${repo_root}/${artifact}" "${target}/${artifact}"
+    git -C "${target}" add "${artifact}"
+  done
+}
+
+remove_text_from_file() {
+  local target="$1"
+  local path="$2"
+  local expected_text="$3"
+
+  REMOVE_TEXT="${expected_text}" perl -0pi -e 's/\Q$ENV{REMOVE_TEXT}\E\n?//g' "${target}/${path}"
+  git -C "${target}" add "${path}"
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_required_artifacts "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+write_required_artifacts "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-27-day-2-hardening-validation.md"
+git -C "${missing_doc_repo}" add -u docs/phase-27-day-2-hardening-validation.md
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing Phase 27 validation document:"
+
+missing_drill_repo="${workdir}/missing-drill"
+create_repo "${missing_drill_repo}"
+write_required_artifacts "${missing_drill_repo}"
+remove_text_from_file \
+  "${missing_drill_repo}" \
+  "docs/phase-27-day-2-hardening-validation.md" \
+  "- \`degraded-mode\`: \`test_service_phase21_readiness_surfaces_source_and_automation_health\` keeps source-health and delegation outage visibility explicit during degraded-mode handling."
+commit_fixture "${missing_drill_repo}"
+assert_fails_with "${missing_drill_repo}" "Missing required line in ${missing_drill_repo}/docs/phase-27-day-2-hardening-validation.md: - \`degraded-mode\`: \`test_service_phase21_readiness_surfaces_source_and_automation_health\` keeps source-health and delegation outage visibility explicit during degraded-mode handling."
+
+missing_ci_repo="${workdir}/missing-ci"
+create_repo "${missing_ci_repo}"
+write_required_artifacts "${missing_ci_repo}"
+remove_text_from_file \
+  "${missing_ci_repo}" \
+  ".github/workflows/ci.yml" \
+  "      - name: Run Phase 27 workflow coverage guard"
+commit_fixture "${missing_ci_repo}"
+assert_fails_with "${missing_ci_repo}" "Missing required line in ${missing_ci_repo}/.github/workflows/ci.yml:       - name: Run Phase 27 workflow coverage guard"
+
+echo "Phase 27 day-2 hardening verifier fails closed for missing drills and CI wiring."

--- a/scripts/verify-phase-27-day-2-hardening-validation.sh
+++ b/scripts/verify-phase-27-day-2-hardening-validation.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+validation_doc="${repo_root}/docs/phase-27-day-2-hardening-validation.md"
+restore_readiness_test="${repo_root}/control-plane/tests/test_service_persistence_restore_readiness.py"
+runtime_auth_test="${repo_root}/control-plane/tests/test_phase21_runtime_auth_validation.py"
+runtime_secret_test="${repo_root}/control-plane/tests/test_runtime_secret_boundary.py"
+validation_doc_test="${repo_root}/control-plane/tests/test_phase27_day2_hardening_validation.py"
+workflow_guard="${repo_root}/scripts/test-verify-ci-phase-27-workflow-coverage.sh"
+shell_test="${repo_root}/scripts/test-verify-phase-27-day-2-hardening-validation.sh"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_line() {
+  local path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${path}" >/dev/null; then
+    echo "Missing required line in ${path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${validation_doc}" "Missing Phase 27 validation document"
+require_file "${restore_readiness_test}" "Missing restore readiness unittest"
+require_file "${runtime_auth_test}" "Missing runtime auth unittest"
+require_file "${runtime_secret_test}" "Missing runtime secret unittest"
+require_file "${validation_doc_test}" "Missing Phase 27 validation doc unittest"
+require_file "${workflow_guard}" "Missing Phase 27 workflow coverage guard"
+require_file "${shell_test}" "Missing Phase 27 shell verifier test"
+require_file "${workflow_path}" "Missing CI workflow"
+
+require_fixed_line "${validation_doc}" "# Phase 27 Day-2 Hardening Validation"
+require_fixed_line "${validation_doc}" "- Validation status: PASS"
+require_fixed_line "${validation_doc}" "- Reviewed sources: \`docs/runbook.md\`, \`docs/auth-baseline.md\`, \`docs/smb-footprint-and-deployment-profile-baseline.md\`, \`control-plane/tests/test_service_persistence_restore_readiness.py\`, \`control-plane/tests/test_phase21_runtime_auth_validation.py\`, \`control-plane/tests/test_runtime_secret_boundary.py\`"
+require_fixed_line "${validation_doc}" "- \`restore\`: \`test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain\` keeps the approved disaster-recovery path anchored to the authoritative record chain."
+require_fixed_line "${validation_doc}" "- \`restore\`: \`test_service_phase21_restore_drill_fails_closed_when_runtime_bindings_missing_after_restore\` proves restore verification blocks when the recovered runtime boundary is incomplete."
+require_fixed_line "${validation_doc}" "- \`degraded-mode\`: \`test_service_phase21_readiness_surfaces_source_and_automation_health\` keeps source-health and delegation outage visibility explicit during degraded-mode handling."
+require_fixed_line "${validation_doc}" "- \`identity-boundary\`: \`test_startup_status_reports_missing_reviewed_identity_provider_binding\` treats IdP outage or missing reviewed provider binding as a fail-closed startup condition."
+require_fixed_line "${validation_doc}" "- \`identity-boundary\`: \`test_protected_surface_request_rejects_unreviewed_identity_provider_boundary\` rejects requests that cross the identity boundary through an unreviewed provider path."
+require_fixed_line "${validation_doc}" "- \`secret rotation\`: \`test_runtime_config_reloads_rotated_openbao_secret_on_fresh_load\` proves rotation requires a fresh trusted read instead of cached or guessed secret state."
+require_fixed_line "${validation_doc}" "- \`secret-backend unavailability\`: \`test_runtime_config_fails_closed_when_openbao_backend_is_unavailable\` keeps the control plane blocked when the reviewed secret backend cannot be read."
+require_fixed_line "${validation_doc}" "- \`bash scripts/verify-phase-27-day-2-hardening-validation.sh\`"
+require_fixed_line "${validation_doc}" "- \`bash scripts/test-verify-phase-27-day-2-hardening-validation.sh\`"
+require_fixed_line "${validation_doc}" "- \`bash scripts/test-verify-ci-phase-27-workflow-coverage.sh\`"
+
+require_fixed_line "${restore_readiness_test}" "class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):"
+require_fixed_line "${restore_readiness_test}" "    def test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain("
+require_fixed_line "${restore_readiness_test}" "    def test_service_phase21_restore_drill_fails_closed_when_runtime_bindings_missing_after_restore("
+require_fixed_line "${restore_readiness_test}" "    def test_service_phase21_readiness_surfaces_source_and_automation_health("
+require_fixed_line "${runtime_auth_test}" "class Phase21RuntimeAuthValidationTests(unittest.TestCase):"
+require_fixed_line "${runtime_auth_test}" "    def test_startup_status_reports_missing_reviewed_identity_provider_binding(self) -> None:"
+require_fixed_line "${runtime_auth_test}" "    def test_protected_surface_request_rejects_unreviewed_identity_provider_boundary("
+require_fixed_line "${runtime_secret_test}" "class RuntimeSecretBoundaryTests(unittest.TestCase):"
+require_fixed_line "${runtime_secret_test}" "    def test_runtime_config_fails_closed_when_openbao_backend_is_unavailable(self) -> None:"
+require_fixed_line "${runtime_secret_test}" "    def test_runtime_config_reloads_rotated_openbao_secret_on_fresh_load(self) -> None:"
+require_fixed_line "${validation_doc_test}" "class Phase27Day2HardeningValidationTests(unittest.TestCase):"
+
+require_fixed_line "${workflow_path}" "      - name: Run Phase 27 day-2 hardening validation"
+require_fixed_line "${workflow_path}" "          bash scripts/verify-phase-27-day-2-hardening-validation.sh"
+require_fixed_line "${workflow_path}" "          python3 -m unittest control-plane.tests.test_phase27_day2_hardening_validation control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_backup_restore_and_restore_drill_preserve_record_chain control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_restore_drill_fails_closed_when_runtime_bindings_missing_after_restore control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_surfaces_source_and_automation_health control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_startup_status_reports_missing_reviewed_identity_provider_binding control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_protected_surface_request_rejects_unreviewed_identity_provider_boundary control-plane.tests.test_runtime_secret_boundary.RuntimeSecretBoundaryTests.test_runtime_config_fails_closed_when_openbao_backend_is_unavailable control-plane.tests.test_runtime_secret_boundary.RuntimeSecretBoundaryTests.test_runtime_config_reloads_rotated_openbao_secret_on_fresh_load"
+require_fixed_line "${workflow_path}" "      - name: Run Phase 27 workflow coverage guard"
+require_fixed_line "${workflow_path}" "        run: bash scripts/test-verify-ci-phase-27-workflow-coverage.sh"
+require_fixed_line "${workflow_path}" "          bash scripts/test-verify-phase-27-day-2-hardening-validation.sh"
+
+echo "Phase 27 day-2 hardening validation artifacts and CI wiring are present and aligned."


### PR DESCRIPTION
Closes #566
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a repo-owned Phase 27 validation slice and wired it into CI. The change is additive only: a new validation record at [docs/phase-27-day-2-hardening-validation.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-566/docs/phase-27-day-2-hardening-validation.md), a focused verifier plus self-tests in [scripts/verify-phase-27-day-2-hardening-validation.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-566/scripts/verify-phase-27-day-2-hardening-validation.sh) and [scripts/test-verify-phase-27-day-2-hardening-validation.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-566/scripts/test-verify-phase-27-day-2-hardening-validation.sh), a CI workflow guard in [scripts/test-verify-ci-phase-27-workflow-coverage.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-566/scripts/test-verify-ci-phase-27-workflow-coverage.sh), a doc-level unittest in [control-plane/tests/test_phase27_day2_hardening_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-566/control-plane/tests/test_phase27_day2_hardening_validation.py), and the matching CI wiring in [.github/workflows/ci.yml](/Users/jp.infra/Dev/AegisOps-worktrees/issue-566/.github/workflows/ci.yml). The focused runtime command reuses existing narrow drills for restore preservation, fail-closed restore after broken bindings, degraded source/delegation visibility, IdP boundary failure, OpenBao backend unavailability, and secret rotation reload.

I reproduced the gap first with the new checks: the doc test failed because `docs/phase-27-day-...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Phase 27 day-2 hardening validation test suite covering restore integrity, readiness diagnostics, identity-boundary handling, and secret/rotation failure scenarios.

* **Documentation**
  * Added Phase 27 Day-2 hardening validation doc summarizing scope, PASS result, reviewed drills, and referenced test coverage.

* **Chores**
  * Enhanced CI with Phase 27 validation and workflow-coverage guard steps.
  * Added repository verification and test-harness scripts that enforce expected coverage and fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->