### PR TITLE
docs: define the Phase 28 endpoint evidence-pack boundary

### DIFF
--- a/control-plane/tests/test_phase28_endpoint_evidence_pack_boundary_docs.py
+++ b/control-plane/tests/test_phase28_endpoint_evidence_pack_boundary_docs.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase28EndpointEvidencePackBoundaryDocsTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected document at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_phase28_design_doc_exists_and_keeps_endpoint_evidence_subordinate(
+        self,
+    ) -> None:
+        text = self._read("docs/phase-28-optional-endpoint-evidence-pack-boundary.md")
+
+        for term in (
+            "# AegisOps Phase 28 Optional Endpoint Evidence-Pack Boundary",
+            "This document defines the reviewed optional endpoint evidence-pack boundary for Phase 28.",
+            "Velociraptor is approved only as a subordinate read and evidence-collection substrate for this slice.",
+            "YARA and capa are approved only as subordinate evidence-pack analysis tools for collected files or binaries inside this same boundary.",
+            "Endpoint evidence packs are optional augmentation, not a mandatory platform dependency or case-truth authority surface.",
+            "A reviewed endpoint evidence pack may be used only when an existing operating need or explicit evidence gap is already present on the reviewed case chain.",
+            "Endpoint evidence collection must start from an existing AegisOps-owned case, evidence record, or reviewed follow-up decision rather than from free-form endpoint hunting.",
+            "The approved artifact classes for this boundary are:",
+            "`collection_manifest`",
+            "`triage_bundle`",
+            "`file_sample`",
+            "`binary_analysis`",
+            "`tool_output_receipt`",
+            "Every collected or derived artifact must preserve provenance that identifies the source host binding, collector or tool identity, collection or analysis time, reviewed operator attribution, and the AegisOps evidence record that admitted it.",
+            "Collected endpoint artifacts and derived YARA or capa outputs must be cited as subordinate evidence linked to an AegisOps-owned evidence record.",
+            "Endpoint evidence packs must not replace AegisOps-owned case truth, actor truth, approval truth, or reconciliation truth.",
+            "This boundary does not approve mandatory agent rollout, endpoint-first product repositioning, background fleet sweeps, autonomous collection, or endpoint-tool authority expansion.",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase28_validation_doc_records_roadmap_and_baseline_review(self) -> None:
+        text = self._read(
+            "docs/phase-28-optional-endpoint-evidence-pack-boundary-validation.md"
+        )
+
+        for term in (
+            "# Phase 28 Optional Endpoint Evidence-Pack Boundary Validation",
+            "Validation status: PASS",
+            "ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md",
+            "docs/requirements-baseline.md",
+            "docs/architecture.md",
+            "docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md",
+            "docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md",
+            "Velociraptor remains subordinate to the AegisOps control-plane authority model.",
+            "YARA and capa remain subordinate evidence-analysis tools rather than authority surfaces.",
+            "Endpoint evidence packs remain optional, provenance-preserving, and fail closed when prerequisite case-chain linkage or provenance is incomplete.",
+            'python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs',
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase28_endpoint_evidence_pack_boundary_docs.py
+++ b/control-plane/tests/test_phase28_endpoint_evidence_pack_boundary_docs.py
@@ -49,7 +49,7 @@ class Phase28EndpointEvidencePackBoundaryDocsTests(unittest.TestCase):
         for term in (
             "# Phase 28 Optional Endpoint Evidence-Pack Boundary Validation",
             "Validation status: PASS",
-            "ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md",
+            "docs/Revised Phase23-20 Epic Roadmap.md",
             "docs/requirements-baseline.md",
             "docs/architecture.md",
             "docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md",

--- a/docs/phase-28-optional-endpoint-evidence-pack-boundary-validation.md
+++ b/docs/phase-28-optional-endpoint-evidence-pack-boundary-validation.md
@@ -3,7 +3,7 @@
 - Validation status: PASS
 - Reviewed on: 2026-04-19
 - Scope: confirm the reviewed Phase 28 endpoint evidence-pack boundary keeps Velociraptor, YARA, and capa subordinate to the AegisOps authority model while making optional endpoint evidence-pack use specific enough for later implementation and validation work.
-- Reviewed sources: `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md`, `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`
+- Reviewed sources: `docs/Revised Phase23-20 Epic Roadmap.md` (repository-published roadmap anchor for the reviewed AegisOps thesis, SMB deployment target, and later source-expansion guardrails), `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`
 
 ## Validation Summary
 
@@ -15,7 +15,7 @@ Endpoint evidence packs remain optional, provenance-preserving, and fail closed 
 
 ## Roadmap and Thesis Review
 
-The reviewed roadmap keeps later source and evidence expansion narrow and subordinate to the approved AegisOps thesis for approval, evidence, and reconciliation governance.
+`docs/Revised Phase23-20 Epic Roadmap.md` keeps later source and evidence expansion narrow and subordinate to the approved AegisOps thesis for approval, evidence, and reconciliation governance.
 
 `docs/requirements-baseline.md` remains aligned because AegisOps continues to own authoritative truth for alert, case, evidence, approval, action-execution, and reconciliation records, while upstream and subordinate tooling remain optional substrates rather than co-equal product cores.
 

--- a/docs/phase-28-optional-endpoint-evidence-pack-boundary-validation.md
+++ b/docs/phase-28-optional-endpoint-evidence-pack-boundary-validation.md
@@ -1,0 +1,39 @@
+# Phase 28 Optional Endpoint Evidence-Pack Boundary Validation
+
+- Validation status: PASS
+- Reviewed on: 2026-04-19
+- Scope: confirm the reviewed Phase 28 endpoint evidence-pack boundary keeps Velociraptor, YARA, and capa subordinate to the AegisOps authority model while making optional endpoint evidence-pack use specific enough for later implementation and validation work.
+- Reviewed sources: `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md`, `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`
+
+## Validation Summary
+
+Velociraptor remains subordinate to the AegisOps control-plane authority model.
+
+YARA and capa remain subordinate evidence-analysis tools rather than authority surfaces.
+
+Endpoint evidence packs remain optional, provenance-preserving, and fail closed when prerequisite case-chain linkage or provenance is incomplete.
+
+## Roadmap and Thesis Review
+
+The reviewed roadmap keeps later source and evidence expansion narrow and subordinate to the approved AegisOps thesis for approval, evidence, and reconciliation governance.
+
+`docs/requirements-baseline.md` remains aligned because AegisOps continues to own authoritative truth for alert, case, evidence, approval, action-execution, and reconciliation records, while upstream and subordinate tooling remain optional substrates rather than co-equal product cores.
+
+`docs/architecture.md` remains aligned because the control plane continues to own policy-sensitive workflow truth while subordinate detection, augmentation, and execution tooling stay outside case-truth and approval-truth ownership.
+
+## Endpoint Evidence Boundary Review
+
+`docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md` already established that osquery-backed host evidence is augmenting evidence only. The new Phase 28 boundary extends that same subordinate-evidence posture to optional endpoint evidence packs rather than inventing a new authority model.
+
+`docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md` already requires explicit host binding, explicit provenance, and escalation when linkage is incomplete. The Phase 28 boundary stays consistent with that pattern by requiring an existing operating need or explicit evidence gap before endpoint collection may begin.
+
+`docs/phase-28-optional-endpoint-evidence-pack-boundary.md` now defines a bounded slice for optional endpoint evidence packs, names the approved artifact classes, preserves provenance and citation requirements, and keeps Velociraptor, YARA, and capa subordinate to AegisOps-owned case truth and approval authority.
+
+## Review Outcome
+
+The reviewed boundary is specific enough for later Phase 28 implementation and validation work to build bounded collection, artifact admission, and citation checks without silently widening endpoint tooling into mandatory infrastructure or authority surfaces.
+
+## Verification
+
+- `python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs`
+- `bash scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh`

--- a/docs/phase-28-optional-endpoint-evidence-pack-boundary.md
+++ b/docs/phase-28-optional-endpoint-evidence-pack-boundary.md
@@ -1,0 +1,105 @@
+# AegisOps Phase 28 Optional Endpoint Evidence-Pack Boundary
+
+## 1. Purpose
+
+This document defines the reviewed optional endpoint evidence-pack boundary for Phase 28.
+
+It supplements `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, and `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md` by defining when endpoint-collected artifacts may augment case evidence without turning endpoint tooling into mainline case truth, approval authority, or mandatory infrastructure.
+
+This document defines reviewed design scope only. It does not approve mandatory endpoint-agent rollout, broad endpoint-first product positioning, autonomous collection, free-form hunting, or any expansion of endpoint-tool authority beyond a subordinate evidence-pack role.
+
+## 2. Reviewed Optional Endpoint Evidence-Pack Role
+
+Endpoint evidence packs are optional augmentation, not a mandatory platform dependency or case-truth authority surface.
+
+Velociraptor is approved only as a subordinate read and evidence-collection substrate for this slice.
+
+YARA and capa are approved only as subordinate evidence-pack analysis tools for collected files or binaries inside this same boundary.
+
+The reviewed role of this boundary is to let operators collect bounded endpoint artifacts when an existing case already needs additional host, file, or binary context that upstream analytic signals and already-admitted evidence do not provide.
+
+Endpoint evidence tooling must remain subordinate to the AegisOps-owned case chain.
+
+Endpoint evidence packs must not replace AegisOps-owned case truth, actor truth, approval truth, or reconciliation truth.
+
+## 3. Enablement Conditions
+
+A reviewed endpoint evidence pack may be used only when an existing operating need or explicit evidence gap is already present on the reviewed case chain.
+
+Endpoint evidence collection must start from an existing AegisOps-owned case, evidence record, or reviewed follow-up decision rather than from free-form endpoint hunting.
+
+Approved triggering conditions for this reviewed path are intentionally narrow:
+
+- a case already has an explicit host binding and needs additional endpoint-local state to resolve an evidence gap;
+- a reviewed file, process, or binary artifact already on the case chain requires bounded collection for preservation or deeper inspection; or
+- a reviewed operator decision records why upstream analytic signals or already-admitted augmenting evidence are insufficient for the next case-review step.
+
+The path must fail closed when the host binding is missing, the evidence gap is only implied, the collection target is inferred from weak hints, or the requested collection would widen beyond the reviewed case scope.
+
+## 4. Approved Artifact Classes
+
+The approved artifact classes for this boundary are:
+
+- `collection_manifest` for the reviewed description of what was requested, from which explicitly bound host, by which reviewed operator, and under which case or evidence anchor;
+- `triage_bundle` for bounded read-only host-state output such as reviewed process, service, autorun, user, scheduled-task, or network-observation snapshots tied to the scoped host;
+- `file_sample` for a reviewed collected file or bounded file subset taken from the scoped host or evidence path;
+- `binary_analysis` for derived YARA or capa findings over a reviewed collected file or binary sample; and
+- `tool_output_receipt` for the subordinate receipt that records which reviewed collector or analysis tool produced which artifact and when.
+
+These artifact classes are evidence-pack artifacts only.
+
+They are subordinate evidence that may support reviewed observations, operator notes, or later recommendations, but they do not become authoritative control-plane lifecycle records on their own.
+
+## 5. Provenance and Citation Requirements
+
+Every collected or derived artifact must preserve provenance that identifies the source host binding, collector or tool identity, collection or analysis time, reviewed operator attribution, and the AegisOps evidence record that admitted it.
+
+Minimum reviewed provenance for this boundary includes:
+
+- the explicitly bound host identifier or reviewed binary source reference;
+- the reviewed case identifier and admitting evidence identifier;
+- the reviewed collection or analysis tool name and version when available;
+- the collection or analysis timestamp;
+- the reviewed operator or reviewed automation attribution that initiated the step; and
+- the reviewed path or query description needed to explain what was collected or analyzed.
+
+Collected endpoint artifacts and derived YARA or capa outputs must be cited as subordinate evidence linked to an AegisOps-owned evidence record.
+
+Citation must preserve whether the cited material is raw collected output, a bounded derivative, or an operator-authored interpretation.
+
+The case chain must not cite Velociraptor, YARA, or capa output as if those tools decided case scope, actor identity, approval state, or remediation success.
+
+## 6. Tool-Specific Boundary Notes
+
+Velociraptor remains a read and evidence substrate only for this reviewed slice.
+
+Its reviewed role is bounded collection and preservation of subordinate endpoint evidence packs tied to an already-scoped case or evidence anchor.
+
+Velociraptor is not approved here as a case-led investigation console, fleet-wide hunting authority, approval surface, or workflow owner.
+
+YARA and capa remain subordinate evidence-analysis tools rather than authority surfaces.
+
+They may analyze a reviewed collected file or binary sample and produce derivative findings that stay attached to the admitting evidence record.
+
+YARA or capa findings may support a reviewed observation or operator explanation, but they must not silently promote a file, host, or actor into stronger case truth without an explicit reviewed control-plane link.
+
+## 7. Non-Goals and Fail-Closed Rules
+
+This boundary does not approve mandatory agent rollout, endpoint-first product repositioning, background fleet sweeps, autonomous collection, or endpoint-tool authority expansion.
+
+This boundary also does not approve:
+
+- making Velociraptor, YARA, or capa a required mainline dependency for first boot or routine case handling;
+- treating endpoint evidence packs as a substitute for upstream analytic-signal intake or reviewed case admission;
+- broad collection from hosts that are not already bound explicitly on the reviewed case chain;
+- allowing endpoint-tool UI state, tags, labels, or collection history to become case truth by convenience; or
+- using derived endpoint findings to bypass approval, execution, or reconciliation controls.
+
+The path must fail closed when provenance is partial, the host or binary scope is only inferred, a requested artifact class falls outside this reviewed slice, or a citation would overstate what the subordinate tool output actually proved.
+
+## 8. Repository-Local Verification Commands
+
+The repository-local verification commands for this boundary are:
+
+- `python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs`
+- `bash scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh`

--- a/scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh
+++ b/scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+design_doc="${repo_root}/docs/phase-28-optional-endpoint-evidence-pack-boundary.md"
+validation_doc="${repo_root}/docs/phase-28-optional-endpoint-evidence-pack-boundary-validation.md"
+docs_test="${repo_root}/control-plane/tests/test_phase28_endpoint_evidence_pack_boundary_docs.py"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_line() {
+  local path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${path}" >/dev/null; then
+    echo "Missing required line in ${path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${design_doc}" "Missing Phase 28 endpoint evidence-pack boundary doc"
+require_file "${validation_doc}" "Missing Phase 28 endpoint evidence-pack boundary validation doc"
+require_file "${docs_test}" "Missing Phase 28 endpoint evidence-pack doc unittest"
+
+design_required_lines=(
+  '# AegisOps Phase 28 Optional Endpoint Evidence-Pack Boundary'
+  '## 1. Purpose'
+  '## 2. Reviewed Optional Endpoint Evidence-Pack Role'
+  '## 3. Enablement Conditions'
+  '## 4. Approved Artifact Classes'
+  '## 5. Provenance and Citation Requirements'
+  '## 6. Tool-Specific Boundary Notes'
+  '## 7. Non-Goals and Fail-Closed Rules'
+  '## 8. Repository-Local Verification Commands'
+  'This document defines the reviewed optional endpoint evidence-pack boundary for Phase 28.'
+  'Velociraptor is approved only as a subordinate read and evidence-collection substrate for this slice.'
+  'YARA and capa are approved only as subordinate evidence-pack analysis tools for collected files or binaries inside this same boundary.'
+  'Endpoint evidence packs are optional augmentation, not a mandatory platform dependency or case-truth authority surface.'
+  'A reviewed endpoint evidence pack may be used only when an existing operating need or explicit evidence gap is already present on the reviewed case chain.'
+  'Endpoint evidence collection must start from an existing AegisOps-owned case, evidence record, or reviewed follow-up decision rather than from free-form endpoint hunting.'
+  'The approved artifact classes for this boundary are:'
+  '- `collection_manifest` for the reviewed description of what was requested, from which explicitly bound host, by which reviewed operator, and under which case or evidence anchor;'
+  '- `triage_bundle` for bounded read-only host-state output such as reviewed process, service, autorun, user, scheduled-task, or network-observation snapshots tied to the scoped host;'
+  '- `file_sample` for a reviewed collected file or bounded file subset taken from the scoped host or evidence path;'
+  '- `binary_analysis` for derived YARA or capa findings over a reviewed collected file or binary sample; and'
+  '- `tool_output_receipt` for the subordinate receipt that records which reviewed collector or analysis tool produced which artifact and when.'
+  'Every collected or derived artifact must preserve provenance that identifies the source host binding, collector or tool identity, collection or analysis time, reviewed operator attribution, and the AegisOps evidence record that admitted it.'
+  'Collected endpoint artifacts and derived YARA or capa outputs must be cited as subordinate evidence linked to an AegisOps-owned evidence record.'
+  'Endpoint evidence packs must not replace AegisOps-owned case truth, actor truth, approval truth, or reconciliation truth.'
+  'This boundary does not approve mandatory agent rollout, endpoint-first product repositioning, background fleet sweeps, autonomous collection, or endpoint-tool authority expansion.'
+)
+
+for line in "${design_required_lines[@]}"; do
+  require_fixed_line "${design_doc}" "${line}"
+done
+
+validation_required_lines=(
+  '# Phase 28 Optional Endpoint Evidence-Pack Boundary Validation'
+  '- Validation status: PASS'
+  '- Reviewed on: 2026-04-19'
+  '## Validation Summary'
+  '## Roadmap and Thesis Review'
+  '## Endpoint Evidence Boundary Review'
+  '## Review Outcome'
+  '## Verification'
+  'Velociraptor remains subordinate to the AegisOps control-plane authority model.'
+  'YARA and capa remain subordinate evidence-analysis tools rather than authority surfaces.'
+  'Endpoint evidence packs remain optional, provenance-preserving, and fail closed when prerequisite case-chain linkage or provenance is incomplete.'
+  '- Reviewed sources: `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md`, `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`'
+  '- `python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs`'
+  '- `bash scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh`'
+)
+
+for line in "${validation_required_lines[@]}"; do
+  require_fixed_line "${validation_doc}" "${line}"
+done
+
+require_fixed_line "${docs_test}" 'class Phase28EndpointEvidencePackBoundaryDocsTests(unittest.TestCase):'
+require_fixed_line "${docs_test}" '    def test_phase28_design_doc_exists_and_keeps_endpoint_evidence_subordinate('
+require_fixed_line "${docs_test}" '    def test_phase28_validation_doc_records_roadmap_and_baseline_review(self) -> None:'
+
+echo "Phase 28 endpoint evidence-pack boundary documents are present and aligned."

--- a/scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh
+++ b/scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh
@@ -75,7 +75,7 @@ validation_required_lines=(
   'Velociraptor remains subordinate to the AegisOps control-plane authority model.'
   'YARA and capa remain subordinate evidence-analysis tools rather than authority surfaces.'
   'Endpoint evidence packs remain optional, provenance-preserving, and fail closed when prerequisite case-chain linkage or provenance is incomplete.'
-  '- Reviewed sources: `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md`, `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`'
+  '- Reviewed sources: `docs/Revised Phase23-20 Epic Roadmap.md` (repository-published roadmap anchor for the reviewed AegisOps thesis, SMB deployment target, and later source-expansion guardrails), `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`'
   '- `python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs`'
   '- `bash scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh`'
 )


### PR DESCRIPTION
## Summary
- add the reviewed Phase 28 endpoint evidence-pack boundary for optional Velociraptor and YARA/capa use
- define narrow enablement conditions, approved artifact classes, and provenance/citation requirements
- add focused repo-local verification for the new documentation boundary

## Verification
- python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs
- bash scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 576 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 28 endpoint evidence-pack boundary spec: scope, approved tooling, enablement rules, provenance/citation requirements, non-goals, and verification instructions.
  * Added Phase 28 validation record noting a PASS review and cross-references to roadmap/architecture/baseline materials.

* **Tests**
  * Added unit tests to assert the presence and exact content of the Phase 28 docs.

* **Chores**
  * Added a verification script to enforce documentation presence and exact textual compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->