### PR TITLE
implementation: add optional MISP IOC/taxonomy attachment behind a subordinate boundary (#580)

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/misp.py
+++ b/control-plane/aegisops_control_plane/adapters/misp.py
@@ -42,7 +42,7 @@ def _normalize_mapping_sequence(
 
 def _normalize_indicator_value(object_type: str, value: object, field_name: str) -> str:
     normalized_value = _require_non_empty_string(value, field_name)
-    if object_type in {"domain", "url", "ip", "sha1", "sha256", "md5"}:
+    if object_type in {"domain", "ip", "sha1", "sha256", "md5"}:
         return normalized_value.lower()
     return normalized_value
 

--- a/control-plane/aegisops_control_plane/adapters/misp.py
+++ b/control-plane/aegisops_control_plane/adapters/misp.py
@@ -92,7 +92,7 @@ class MispContextAdapter:
         warninglists: object | None = None,
         galaxies: object | None = None,
         sightings: object | None = None,
-        citation_url: object | None = None,
+        citation_url: object,
         staleness_marker: object | None = None,
         conflict_marker: object | None = None,
     ) -> MispContextAttachment:

--- a/control-plane/aegisops_control_plane/adapters/misp.py
+++ b/control-plane/aegisops_control_plane/adapters/misp.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping, Sequence
+from urllib.parse import quote
+
+
+def _require_non_empty_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+def _require_aware_datetime(value: object, field_name: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise ValueError(f"{field_name} must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    return value
+
+
+def _normalize_mapping(value: object, field_name: str) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field_name} must be a mapping")
+    return {str(key): item for key, item in value.items()}
+
+
+def _normalize_mapping_sequence(
+    value: object,
+    field_name: str,
+) -> tuple[dict[str, object], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{field_name} must be a sequence of mappings")
+    normalized: list[dict[str, object]] = []
+    for index, item in enumerate(value):
+        normalized.append(_normalize_mapping(item, f"{field_name}[{index}]"))
+    return tuple(normalized)
+
+
+def _normalize_indicator_value(object_type: str, value: object, field_name: str) -> str:
+    normalized_value = _require_non_empty_string(value, field_name)
+    if object_type in {"domain", "url", "ip", "sha1", "sha256", "md5"}:
+        return normalized_value.lower()
+    return normalized_value
+
+
+@dataclass(frozen=True)
+class MispContextAttachment:
+    source_record_id: str
+    collector_identity: str
+    acquired_at: datetime
+    provenance: Mapping[str, object]
+    content: Mapping[str, object]
+    observation_provenance: Mapping[str, object]
+    observation_content: Mapping[str, object]
+    source_system: str = "misp"
+    derivation_relationship: str = "misp_context_attachment"
+
+
+@dataclass(frozen=True)
+class MispContextAdapter:
+    enabled: bool = False
+    source_system: str = "misp"
+    collector_identity: str = "misp-reviewed-context-adapter"
+    allowed_object_types: tuple[str, ...] = (
+        "domain",
+        "url",
+        "ip",
+        "sha1",
+        "sha256",
+        "md5",
+    )
+
+    def build_attachment(
+        self,
+        *,
+        case_id: str,
+        alert_id: str | None,
+        admitting_evidence_id: object,
+        queried_object_type: object,
+        queried_object_value: object,
+        looked_up_at: object,
+        reviewed_by: object,
+        event_id: object,
+        event_info: object,
+        event_published_at: object | None,
+        iocs: object | None = None,
+        taxonomies: object | None = None,
+        warninglists: object | None = None,
+        galaxies: object | None = None,
+        sightings: object | None = None,
+        citation_url: object | None = None,
+        staleness_marker: object | None = None,
+        conflict_marker: object | None = None,
+    ) -> MispContextAttachment:
+        if not self.enabled:
+            raise ValueError("MISP subordinate enrichment is disabled")
+
+        case_id = _require_non_empty_string(case_id, "case_id")
+        admitting_evidence_id = _require_non_empty_string(
+            admitting_evidence_id,
+            "admitting_evidence_id",
+        )
+        queried_object_type = _require_non_empty_string(
+            queried_object_type,
+            "queried_object_type",
+        ).lower()
+        if queried_object_type not in self.allowed_object_types:
+            raise ValueError(
+                f"queried_object_type must be one of {self.allowed_object_types!r}"
+            )
+        queried_object_value = _normalize_indicator_value(
+            queried_object_type,
+            queried_object_value,
+            "queried_object_value",
+        )
+        looked_up_at = _require_aware_datetime(looked_up_at, "looked_up_at")
+        reviewed_by = _require_non_empty_string(reviewed_by, "reviewed_by")
+        event_id = _require_non_empty_string(event_id, "event_id")
+        event_info = _require_non_empty_string(event_info, "event_info")
+        citation_url = _require_non_empty_string(citation_url, "citation_url")
+        staleness_marker = _normalize_mapping(staleness_marker, "staleness_marker")
+        staleness_state = _require_non_empty_string(
+            staleness_marker.get("state"),
+            "staleness_marker.state",
+        )
+        _require_non_empty_string(
+            staleness_marker.get("evaluated_at"),
+            "staleness_marker.evaluated_at",
+        )
+        event_published_iso: str | None = None
+        if event_published_at is not None:
+            event_published_iso = _require_aware_datetime(
+                event_published_at,
+                "event_published_at",
+            ).isoformat()
+
+        normalized_iocs = _normalize_mapping_sequence(iocs, "iocs")
+        normalized_taxonomies = _normalize_mapping_sequence(taxonomies, "taxonomies")
+        normalized_warninglists = _normalize_mapping_sequence(
+            warninglists,
+            "warninglists",
+        )
+        normalized_galaxies = _normalize_mapping_sequence(galaxies, "galaxies")
+        normalized_sightings = _normalize_mapping_sequence(sightings, "sightings")
+        if not any(
+            (
+                normalized_iocs,
+                normalized_taxonomies,
+                normalized_warninglists,
+                normalized_galaxies,
+                normalized_sightings,
+            )
+        ):
+            raise ValueError(
+                "MISP attachment requires at least one IOC, taxonomy, warninglist, galaxy, or sighting entry"
+            )
+
+        normalized_conflict_marker: dict[str, object] | None = None
+        if conflict_marker is not None:
+            normalized_conflict_marker = _normalize_mapping(
+                conflict_marker,
+                "conflict_marker",
+            )
+
+        source_record_id = "misp://event/{}/object/{}/value/{}".format(
+            quote(event_id, safe=""),
+            quote(queried_object_type, safe=""),
+            quote(queried_object_value, safe=""),
+        )
+        provenance = {
+            "classification": "augmenting-evidence",
+            "source_id": event_id,
+            "timestamp": looked_up_at.isoformat(),
+            "reviewed_by": reviewed_by,
+            "adapter": "misp_context",
+            "source_system": self.source_system,
+            "queried_object_type": queried_object_type,
+            "queried_object_value": queried_object_value,
+            "admitting_evidence_id": admitting_evidence_id,
+            "citation_url": citation_url,
+            "staleness_state": staleness_state,
+            "ambiguity_badge": (
+                "unresolved" if normalized_conflict_marker is not None else "related-entity"
+            ),
+        }
+        content = {
+            "lookup_receipt": {
+                "adapter": "misp_context",
+                "service": self.source_system,
+                "queried_object": {
+                    "type": queried_object_type,
+                    "value": queried_object_value,
+                },
+                "looked_up_at": looked_up_at.isoformat(),
+                "admitting_case_id": case_id,
+                "admitting_evidence_id": admitting_evidence_id,
+            },
+            "source_observation": {
+                "event_id": event_id,
+                "event_info": event_info,
+                "event_published_at": event_published_iso,
+                "iocs": normalized_iocs,
+                "taxonomies": normalized_taxonomies,
+                "warninglists": normalized_warninglists,
+                "galaxies": normalized_galaxies,
+                "sightings": normalized_sightings,
+            },
+            "citation_attachment": {
+                "service": self.source_system,
+                "url": citation_url,
+                "queried_object": {
+                    "type": queried_object_type,
+                    "value": queried_object_value,
+                },
+                "lookup_timestamp": looked_up_at.isoformat(),
+                "event_id": event_id,
+            },
+            "staleness_marker": staleness_marker,
+            "scope": {
+                "case_id": case_id,
+                "alert_id": alert_id,
+                "admitting_evidence_id": admitting_evidence_id,
+            },
+        }
+        if normalized_conflict_marker is not None:
+            content["conflict_marker"] = normalized_conflict_marker
+            provenance["conflict_present"] = True
+
+        observation_provenance = {
+            "classification": "reviewed-derived",
+            "source_id": event_id,
+            "timestamp": looked_up_at.isoformat(),
+            "reviewed_by": reviewed_by,
+            "adapter": "misp_context",
+            "source_system": self.source_system,
+            "derived_from_source_id": event_id,
+            "admitting_evidence_id": admitting_evidence_id,
+            "queried_object_type": queried_object_type,
+            "queried_object_value": queried_object_value,
+            "ambiguity_badge": provenance["ambiguity_badge"],
+        }
+        observation_content = {
+            "adapter": "misp_context",
+            "event_id": event_id,
+            "queried_object_type": queried_object_type,
+            "queried_object_value": queried_object_value,
+            "staleness_state": staleness_state,
+            "conflict_present": normalized_conflict_marker is not None,
+        }
+        return MispContextAttachment(
+            source_record_id=source_record_id,
+            collector_identity=self.collector_identity,
+            acquired_at=looked_up_at,
+            provenance=provenance,
+            content=content,
+            observation_provenance=observation_provenance,
+            observation_content=observation_content,
+        )

--- a/control-plane/aegisops_control_plane/config.py
+++ b/control-plane/aegisops_control_plane/config.py
@@ -171,6 +171,19 @@ def _load_bound_string(
     return default
 
 
+def _load_bool(source: Mapping[str, str], env_name: str, default: bool) -> bool:
+    raw_value = source.get(env_name, "").strip().lower()
+    if raw_value == "":
+        return default
+    if raw_value in {"1", "true", "yes", "on"}:
+        return True
+    if raw_value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(
+        f"{env_name} must be a boolean string, got: {source.get(env_name)!r}"
+    )
+
+
 @dataclass(frozen=True)
 class RuntimeConfig:
     host: str = "127.0.0.1"
@@ -189,6 +202,7 @@ class RuntimeConfig:
     protected_surface_reviewed_identity_provider: str = ""
     admin_bootstrap_token: str = field(default="", repr=False)
     break_glass_token: str = field(default="", repr=False)
+    misp_enrichment_enabled: bool = False
 
     @classmethod
     def from_env(
@@ -288,5 +302,10 @@ class RuntimeConfig:
                 "AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN",
                 cls.break_glass_token,
                 secret_backend_transport=secret_backend_transport,
+            ),
+            misp_enrichment_enabled=_load_bool(
+                source,
+                "AEGISOPS_CONTROL_PLANE_MISP_ENRICHMENT_ENABLED",
+                cls.misp_enrichment_enabled,
             ),
         )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -17,6 +17,7 @@ _DATETIME_TYPE = datetime
 
 from .adapters.executor import IsolatedExecutorAdapter
 from .adapters.endpoint_evidence import EndpointEvidencePackAdapter
+from .adapters.misp import MispContextAdapter
 from .adapters.n8n import N8NReconciliationAdapter
 from .adapters.osquery import OsqueryHostContextAdapter
 from .adapters.postgres import (
@@ -1360,6 +1361,9 @@ class AegisOpsControlPlaneService:
         )
         self._execution_coordinator = ExecutionCoordinator(self)
         self._endpoint_evidence_pack_adapter = EndpointEvidencePackAdapter()
+        self._misp_context_adapter = MispContextAdapter(
+            enabled=config.misp_enrichment_enabled
+        )
         self._osquery_host_context_adapter = OsqueryHostContextAdapter()
         self._runtime_boundary_service = RuntimeBoundaryService(
             config=self._config,
@@ -5387,6 +5391,147 @@ class AegisOpsControlPlaneService:
                 )
             return evidence, observation
 
+    def attach_misp_context(
+        self,
+        *,
+        case_id: str,
+        admitting_evidence_id: str,
+        queried_object_type: str,
+        queried_object_value: str,
+        looked_up_at: datetime,
+        reviewed_by: str,
+        event_id: str,
+        event_info: str,
+        event_published_at: datetime | None = None,
+        iocs: tuple[Mapping[str, object], ...] = (),
+        taxonomies: tuple[Mapping[str, object], ...] = (),
+        warninglists: tuple[Mapping[str, object], ...] = (),
+        galaxies: tuple[Mapping[str, object], ...] = (),
+        sightings: tuple[Mapping[str, object], ...] = (),
+        citation_url: str = "",
+        staleness_marker: Mapping[str, object] | None = None,
+        conflict_marker: Mapping[str, object] | None = None,
+        evidence_id: str | None = None,
+        observation_scope_statement: str | None = None,
+        observation_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ObservationRecord | None]:
+        case_id = self._require_non_empty_string(case_id, "case_id")
+        admitting_evidence_id = self._require_non_empty_string(
+            admitting_evidence_id,
+            "admitting_evidence_id",
+        )
+        normalized_scope_statement = self._normalize_optional_string(
+            observation_scope_statement,
+            "observation_scope_statement",
+        )
+        if normalized_scope_statement is None and observation_id is not None:
+            raise ValueError(
+                "observation_id requires observation_scope_statement for MISP attachment"
+            )
+        if not self._misp_context_adapter.enabled:
+            raise ValueError("MISP subordinate enrichment is disabled")
+        with self._store.transaction(isolation_level="SERIALIZABLE"):
+            case = self._require_reviewed_operator_case(case_id)
+            self._validate_case_evidence_linkage(
+                case=case,
+                evidence_ids=(admitting_evidence_id,),
+                field_name="admitting_evidence_id",
+            )
+            admitting_evidence = self._store.get(EvidenceRecord, admitting_evidence_id)
+            if admitting_evidence is None:
+                raise LookupError(f"Missing evidence {admitting_evidence_id!r}")
+            self._require_explicit_misp_anchor_binding(
+                case=case,
+                admitting_evidence=admitting_evidence,
+                queried_object_type=queried_object_type,
+                queried_object_value=queried_object_value,
+            )
+            attachment = self._misp_context_adapter.build_attachment(
+                case_id=case.case_id,
+                alert_id=case.alert_id,
+                admitting_evidence_id=admitting_evidence_id,
+                queried_object_type=queried_object_type,
+                queried_object_value=queried_object_value,
+                looked_up_at=looked_up_at,
+                reviewed_by=reviewed_by,
+                event_id=event_id,
+                event_info=event_info,
+                event_published_at=event_published_at,
+                iocs=iocs,
+                taxonomies=taxonomies,
+                warninglists=warninglists,
+                galaxies=galaxies,
+                sightings=sightings,
+                citation_url=citation_url,
+                staleness_marker=staleness_marker,
+                conflict_marker=conflict_marker,
+            )
+            resolved_evidence_id = self._resolve_new_record_identifier(
+                EvidenceRecord,
+                evidence_id,
+                "evidence_id",
+                "evidence",
+            )
+            evidence = self.persist_record(
+                EvidenceRecord(
+                    evidence_id=resolved_evidence_id,
+                    source_record_id=attachment.source_record_id,
+                    alert_id=case.alert_id,
+                    case_id=case.case_id,
+                    source_system=attachment.source_system,
+                    collector_identity=attachment.collector_identity,
+                    acquired_at=attachment.acquired_at,
+                    derivation_relationship=attachment.derivation_relationship,
+                    lifecycle_state="linked",
+                    provenance=attachment.provenance,
+                    content=attachment.content,
+                )
+            )
+            current_case = self._require_reviewed_operator_case(case.case_id)
+            merged_case_evidence_ids = self._merge_linked_ids(
+                current_case.evidence_ids,
+                evidence.evidence_id,
+            )
+            if merged_case_evidence_ids != current_case.evidence_ids:
+                self.persist_record(
+                    replace(current_case, evidence_ids=merged_case_evidence_ids)
+                )
+
+            observation: ObservationRecord | None = None
+            if normalized_scope_statement is not None:
+                resolved_observation_id = self._resolve_new_record_identifier(
+                    ObservationRecord,
+                    observation_id,
+                    "observation_id",
+                    "observation",
+                )
+                observation = self.persist_record(
+                    ObservationRecord(
+                        observation_id=resolved_observation_id,
+                        hunt_id=None,
+                        hunt_run_id=None,
+                        alert_id=current_case.alert_id,
+                        case_id=current_case.case_id,
+                        supporting_evidence_ids=(evidence.evidence_id,),
+                        author_identity=self._require_non_empty_string(
+                            reviewed_by,
+                            "reviewed_by",
+                        ),
+                        observed_at=self._require_aware_datetime(
+                            looked_up_at,
+                            "looked_up_at",
+                        ),
+                        scope_statement=normalized_scope_statement,
+                        lifecycle_state="confirmed",
+                        provenance=attachment.observation_provenance,
+                        content={
+                            **attachment.observation_content,
+                            "misp_context_evidence_id": evidence.evidence_id,
+                        },
+                    )
+                )
+            return evidence, observation
+
     def record_case_observation(
         self,
         *,
@@ -7415,6 +7560,120 @@ class AegisOpsControlPlaneService:
         if self._store.get(record_type, normalized_id) is not None:
             raise ValueError(f"{field_name} {normalized_id!r} already exists")
         return normalized_id
+
+    @staticmethod
+    def _normalize_misp_indicator_value(object_type: str, value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        if normalized == "":
+            return None
+        if object_type in {"domain", "url", "ip", "sha1", "sha256", "md5"}:
+            return normalized.lower()
+        return normalized
+
+    def _mapping_matches_misp_indicator(
+        self,
+        mapping: Mapping[str, object],
+        *,
+        queried_object_type: str,
+        queried_object_value: str,
+    ) -> bool:
+        direct_type = self._normalize_misp_indicator_value(
+            queried_object_type,
+            mapping.get("type"),
+        )
+        direct_value = self._normalize_misp_indicator_value(
+            queried_object_type,
+            mapping.get("value"),
+        )
+        if direct_type == queried_object_type and direct_value == queried_object_value:
+            return True
+
+        indicator_type = self._normalize_misp_indicator_value(
+            queried_object_type,
+            mapping.get("indicator_type"),
+        )
+        indicator_value = self._normalize_misp_indicator_value(
+            queried_object_type,
+            mapping.get("indicator_value"),
+        )
+        return (
+            indicator_type == queried_object_type
+            and indicator_value == queried_object_value
+        )
+
+    def _container_explicitly_cites_misp_indicator(
+        self,
+        value: object,
+        *,
+        queried_object_type: str,
+        queried_object_value: str,
+    ) -> bool:
+        if isinstance(value, Mapping):
+            if self._mapping_matches_misp_indicator(
+                value,
+                queried_object_type=queried_object_type,
+                queried_object_value=queried_object_value,
+            ):
+                return True
+            return any(
+                self._container_explicitly_cites_misp_indicator(
+                    child,
+                    queried_object_type=queried_object_type,
+                    queried_object_value=queried_object_value,
+                )
+                for child in value.values()
+            )
+        if isinstance(value, (list, tuple)):
+            return any(
+                self._container_explicitly_cites_misp_indicator(
+                    item,
+                    queried_object_type=queried_object_type,
+                    queried_object_value=queried_object_value,
+                )
+                for item in value
+            )
+        return False
+
+    def _require_explicit_misp_anchor_binding(
+        self,
+        *,
+        case: CaseRecord,
+        admitting_evidence: EvidenceRecord,
+        queried_object_type: object,
+        queried_object_value: object,
+    ) -> None:
+        if not isinstance(queried_object_type, str) or not queried_object_type.strip():
+            raise ValueError("queried_object_type must be a non-empty string")
+        normalized_type = queried_object_type.strip().lower()
+        normalized_value = self._normalize_misp_indicator_value(
+            normalized_type,
+            queried_object_value,
+        )
+        if normalized_value is None:
+            raise ValueError("queried_object_value must be a non-empty string")
+        if self._container_explicitly_cites_misp_indicator(
+            admitting_evidence.content,
+            queried_object_type=normalized_type,
+            queried_object_value=normalized_value,
+        ):
+            return
+        if self._container_explicitly_cites_misp_indicator(
+            admitting_evidence.provenance,
+            queried_object_type=normalized_type,
+            queried_object_value=normalized_value,
+        ):
+            return
+        if self._container_explicitly_cites_misp_indicator(
+            case.reviewed_context,
+            queried_object_type=normalized_type,
+            queried_object_value=normalized_value,
+        ):
+            return
+        raise ValueError(
+            "queried_object must be explicitly cited by the reviewed case or admitting evidence anchor"
+        )
 
     def _require_case_host_identifier(self, case: CaseRecord) -> str:
         asset = case.reviewed_context.get("asset")

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -5440,6 +5440,10 @@ class AegisOpsControlPlaneService:
             admitting_evidence = self._store.get(EvidenceRecord, admitting_evidence_id)
             if admitting_evidence is None:
                 raise LookupError(f"Missing evidence {admitting_evidence_id!r}")
+            if admitting_evidence.derivation_relationship == "misp_context_attachment":
+                raise ValueError(
+                    "admitting_evidence_id must reference reviewed evidence, not previously attached MISP context"
+                )
             self._require_explicit_misp_anchor_binding(
                 case=case,
                 admitting_evidence=admitting_evidence,
@@ -7562,13 +7566,22 @@ class AegisOpsControlPlaneService:
         return normalized_id
 
     @staticmethod
+    def _normalize_misp_indicator_type(value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        if normalized == "":
+            return None
+        return normalized.lower()
+
+    @staticmethod
     def _normalize_misp_indicator_value(object_type: str, value: object) -> str | None:
         if not isinstance(value, str):
             return None
         normalized = value.strip()
         if normalized == "":
             return None
-        if object_type in {"domain", "url", "ip", "sha1", "sha256", "md5"}:
+        if object_type in {"domain", "ip", "sha1", "sha256", "md5"}:
             return normalized.lower()
         return normalized
 
@@ -7579,10 +7592,7 @@ class AegisOpsControlPlaneService:
         queried_object_type: str,
         queried_object_value: str,
     ) -> bool:
-        direct_type = self._normalize_misp_indicator_value(
-            queried_object_type,
-            mapping.get("type"),
-        )
+        direct_type = self._normalize_misp_indicator_type(mapping.get("type"))
         direct_value = self._normalize_misp_indicator_value(
             queried_object_type,
             mapping.get("value"),
@@ -7590,9 +7600,8 @@ class AegisOpsControlPlaneService:
         if direct_type == queried_object_type and direct_value == queried_object_value:
             return True
 
-        indicator_type = self._normalize_misp_indicator_value(
-            queried_object_type,
-            mapping.get("indicator_type"),
+        indicator_type = self._normalize_misp_indicator_type(
+            mapping.get("indicator_type")
         )
         indicator_value = self._normalize_misp_indicator_value(
             queried_object_type,

--- a/control-plane/tests/test_phase28_misp_enrichment_validation.py
+++ b/control-plane/tests/test_phase28_misp_enrichment_validation.py
@@ -98,7 +98,7 @@ class Phase28MispEnrichmentValidationTests(ServicePersistenceTestBase):
     def test_attach_misp_context_persists_subordinate_attachment_with_provenance(
         self,
     ) -> None:
-        store, service, promoted_case, _, reviewed_at = self._build_in_scope_case(
+        _store, service, promoted_case, _, reviewed_at = self._build_in_scope_case(
             misp_enrichment_enabled=True
         )
         anchor_evidence = self._attach_anchor_evidence(

--- a/control-plane/tests/test_phase28_misp_enrichment_validation.py
+++ b/control-plane/tests/test_phase28_misp_enrichment_validation.py
@@ -292,3 +292,105 @@ class Phase28MispEnrichmentValidationTests(ServicePersistenceTestBase):
             )
 
         self.assertEqual(store.list(EvidenceRecord), evidence_before)
+
+    def test_attach_misp_context_rejects_misp_derived_anchor_without_writes(self) -> None:
+        store, service, promoted_case, _, reviewed_at = self._build_in_scope_case(
+            misp_enrichment_enabled=True
+        )
+        anchor_evidence = self._attach_anchor_evidence(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            indicator_value="pivot.example",
+        )
+        misp_evidence, _observation = service.attach_misp_context(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence.evidence_id,
+            queried_object_type="domain",
+            queried_object_value="pivot.example",
+            looked_up_at=reviewed_at,
+            reviewed_by="analyst-001",
+            event_id="misp-event-003",
+            event_info="Initial bounded MISP attachment",
+            iocs=(
+                {
+                    "type": "domain",
+                    "value": "pivot.example",
+                },
+            ),
+            citation_url="https://misp.example/events/view/3",
+            staleness_marker={
+                "state": "fresh",
+                "evaluated_at": reviewed_at.isoformat(),
+            },
+        )
+        evidence_before = store.list(EvidenceRecord)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "admitting_evidence_id must reference reviewed evidence",
+        ):
+            service.attach_misp_context(
+                case_id=promoted_case.case_id,
+                admitting_evidence_id=misp_evidence.evidence_id,
+                queried_object_type="domain",
+                queried_object_value="pivot.example",
+                looked_up_at=reviewed_at,
+                reviewed_by="analyst-001",
+                event_id="misp-event-004",
+                event_info="Attempted MISP-on-MISP pivot",
+                iocs=(
+                    {
+                        "type": "domain",
+                        "value": "pivot.example",
+                    },
+                ),
+                citation_url="https://misp.example/events/view/4",
+                staleness_marker={
+                    "state": "fresh",
+                    "evaluated_at": reviewed_at.isoformat(),
+                },
+            )
+
+        self.assertEqual(store.list(EvidenceRecord), evidence_before)
+
+    def test_attach_misp_context_treats_url_values_as_case_sensitive(self) -> None:
+        store, service, promoted_case, _, reviewed_at = self._build_in_scope_case(
+            misp_enrichment_enabled=True
+        )
+        anchor_evidence = self._attach_anchor_evidence(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            indicator_type="URL",
+            indicator_value="https://Example.test/Path?Token=AbC",
+        )
+        evidence_before = store.list(EvidenceRecord)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "queried_object must be explicitly cited",
+        ):
+            service.attach_misp_context(
+                case_id=promoted_case.case_id,
+                admitting_evidence_id=anchor_evidence.evidence_id,
+                queried_object_type="url",
+                queried_object_value="https://Example.test/path?token=abc",
+                looked_up_at=reviewed_at,
+                reviewed_by="analyst-001",
+                event_id="misp-event-url-001",
+                event_info="URL mismatch should fail closed",
+                iocs=(
+                    {
+                        "type": "url",
+                        "value": "https://Example.test/path?token=abc",
+                    },
+                ),
+                citation_url="https://misp.example/events/view/5",
+                staleness_marker={
+                    "state": "fresh",
+                    "evaluated_at": reviewed_at.isoformat(),
+                },
+            )
+
+        self.assertEqual(store.list(EvidenceRecord), evidence_before)

--- a/control-plane/tests/test_phase28_misp_enrichment_validation.py
+++ b/control-plane/tests/test_phase28_misp_enrichment_validation.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import pathlib
+import secrets
+import sys
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.models import EvidenceRecord
+from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
+from tests.test_service_persistence import ServicePersistenceTestBase
+from tests.support.fixtures import load_wazuh_fixture
+
+
+class Phase28MispEnrichmentValidationTests(ServicePersistenceTestBase):
+    def _build_in_scope_case(
+        self,
+        *,
+        misp_enrichment_enabled: bool,
+    ) -> tuple[object, AegisOpsControlPlaneService, object, str, datetime]:
+        store, _ = make_store()
+        shared_secret = secrets.token_urlsafe(24)
+        reverse_proxy_secret = secrets.token_urlsafe(24)
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=shared_secret,
+                wazuh_ingest_reverse_proxy_secret=reverse_proxy_secret,
+                misp_enrichment_enabled=misp_enrichment_enabled,
+            ),
+            store=store,
+        )
+        admitted = service.ingest_wazuh_alert(
+            raw_alert=load_wazuh_fixture("github-audit-alert.json"),
+            authorization_header=f"Bearer {shared_secret}",
+            forwarded_proto="https",
+            reverse_proxy_secret_header=reverse_proxy_secret,
+            peer_addr="127.0.0.1",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        reviewed_at = service.list_lifecycle_transitions("case", promoted_case.case_id)[
+            -1
+        ].transitioned_at
+        return store, service, promoted_case, promoted_case.evidence_ids[0], reviewed_at
+
+    def _attach_anchor_evidence(
+        self,
+        *,
+        service: AegisOpsControlPlaneService,
+        promoted_case: object,
+        reviewed_at: datetime,
+        indicator_type: str = "domain",
+        indicator_value: str = "malicious.example",
+    ) -> EvidenceRecord:
+        anchor_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-misp-anchor-001",
+                source_record_id="reviewed-fixture-anchor-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="reviewed_fixture",
+                collector_identity="fixture://reviewed/anchor",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_context_anchor",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "reviewed-derived",
+                    "source_id": "reviewed-anchor-001",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "indicator_type": indicator_type,
+                    "indicator_value": indicator_value,
+                },
+                content={
+                    "indicator": {
+                        "type": indicator_type,
+                        "value": indicator_value,
+                    }
+                },
+            )
+        )
+        service.persist_record(
+            replace(
+                promoted_case,
+                evidence_ids=(*promoted_case.evidence_ids, anchor_evidence.evidence_id),
+            )
+        )
+        return anchor_evidence
+
+    def test_attach_misp_context_persists_subordinate_attachment_with_provenance(
+        self,
+    ) -> None:
+        store, service, promoted_case, _, reviewed_at = self._build_in_scope_case(
+            misp_enrichment_enabled=True
+        )
+        anchor_evidence = self._attach_anchor_evidence(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+        )
+
+        evidence, observation = service.attach_misp_context(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence.evidence_id,
+            queried_object_type="domain",
+            queried_object_value="malicious.example",
+            looked_up_at=reviewed_at,
+            reviewed_by="analyst-001",
+            event_id="misp-event-001",
+            event_info="Known phishing infrastructure",
+            event_published_at=reviewed_at - timedelta(hours=1),
+            iocs=(
+                {
+                    "type": "domain",
+                    "value": "malicious.example",
+                    "category": "Network activity",
+                    "to_ids": True,
+                },
+            ),
+            taxonomies=(
+                {
+                    "namespace": "tlp",
+                    "predicate": "color",
+                    "value": "amber",
+                },
+            ),
+            warninglists=(
+                {
+                    "name": "Known phishing domains",
+                    "match": "malicious.example",
+                },
+            ),
+            galaxies=(
+                {
+                    "name": "Threat Actor",
+                    "cluster": "Example Actor",
+                },
+            ),
+            sightings=(
+                {
+                    "source": "partner-feed",
+                    "count": 2,
+                    "timestamp": reviewed_at.isoformat(),
+                },
+            ),
+            citation_url="https://misp.example/events/view/1",
+            staleness_marker={
+                "state": "fresh",
+                "evaluated_at": reviewed_at.isoformat(),
+            },
+            observation_scope_statement=(
+                "Attached bounded MISP context to the reviewed domain indicator."
+            ),
+        )
+
+        self.assertEqual(evidence.case_id, promoted_case.case_id)
+        self.assertEqual(evidence.source_system, "misp")
+        self.assertEqual(
+            evidence.provenance["classification"],
+            "augmenting-evidence",
+        )
+        self.assertEqual(evidence.provenance["adapter"], "misp_context")
+        self.assertEqual(evidence.provenance["queried_object_type"], "domain")
+        self.assertEqual(
+            evidence.provenance["queried_object_value"],
+            "malicious.example",
+        )
+        self.assertEqual(
+            evidence.content["citation_attachment"]["url"],
+            "https://misp.example/events/view/1",
+        )
+        self.assertEqual(evidence.content["source_observation"]["event_id"], "misp-event-001")
+        self.assertEqual(
+            evidence.content["source_observation"]["iocs"][0]["value"],
+            "malicious.example",
+        )
+        self.assertEqual(
+            evidence.content["staleness_marker"]["state"],
+            "fresh",
+        )
+        self.assertIsNotNone(observation)
+        assert observation is not None
+        self.assertEqual(observation.case_id, promoted_case.case_id)
+        self.assertEqual(observation.supporting_evidence_ids, (evidence.evidence_id,))
+
+        current_case = service.inspect_case_detail(promoted_case.case_id)
+        linked_evidence_ids = {
+            record["evidence_id"] for record in current_case.linked_evidence_records
+        }
+        self.assertIn(evidence.evidence_id, linked_evidence_ids)
+        self.assertIn(anchor_evidence.evidence_id, linked_evidence_ids)
+
+    def test_attach_misp_context_preserves_stale_and_conflicting_markers(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _, reviewed_at = self._build_in_scope_case(
+            misp_enrichment_enabled=True
+        )
+        anchor_evidence = self._attach_anchor_evidence(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            indicator_value="stale.example",
+        )
+
+        evidence, observation = service.attach_misp_context(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence.evidence_id,
+            queried_object_type="domain",
+            queried_object_value="stale.example",
+            looked_up_at=reviewed_at,
+            reviewed_by="analyst-001",
+            event_id="misp-event-002",
+            event_info="Conflicting stale context",
+            event_published_at=reviewed_at - timedelta(days=10),
+            iocs=(
+                {
+                    "type": "domain",
+                    "value": "stale.example",
+                    "category": "Network activity",
+                },
+            ),
+            taxonomies=(
+                {
+                    "namespace": "admiralty-scale",
+                    "predicate": "source-reliability",
+                    "value": "c",
+                },
+            ),
+            citation_url="https://misp.example/events/view/2",
+            staleness_marker={
+                "state": "stale",
+                "evaluated_at": reviewed_at.isoformat(),
+                "reason": "event older than review threshold",
+            },
+            conflict_marker={
+                "state": "conflict",
+                "reason": "MISP taxonomy confidence disagrees with reviewed case context",
+            },
+        )
+
+        self.assertIsNone(observation)
+        self.assertEqual(evidence.content["staleness_marker"]["state"], "stale")
+        self.assertEqual(evidence.content["conflict_marker"]["state"], "conflict")
+        self.assertTrue(evidence.provenance["conflict_present"])
+        self.assertEqual(evidence.provenance["ambiguity_badge"], "unresolved")
+
+    def test_attach_misp_context_rejects_disabled_mode_without_writes(self) -> None:
+        store, service, promoted_case, _, reviewed_at = self._build_in_scope_case(
+            misp_enrichment_enabled=False
+        )
+        anchor_evidence = self._attach_anchor_evidence(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            indicator_value="disabled.example",
+        )
+        evidence_before = store.list(EvidenceRecord)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "MISP subordinate enrichment is disabled",
+        ):
+            service.attach_misp_context(
+                case_id=promoted_case.case_id,
+                admitting_evidence_id=anchor_evidence.evidence_id,
+                queried_object_type="domain",
+                queried_object_value="disabled.example",
+                looked_up_at=reviewed_at,
+                reviewed_by="analyst-001",
+                event_id="misp-event-disabled-001",
+                event_info="Disabled mode should fail closed",
+                iocs=(
+                    {
+                        "type": "domain",
+                        "value": "disabled.example",
+                    },
+                ),
+                citation_url="https://misp.example/events/view/3",
+                staleness_marker={
+                    "state": "fresh",
+                    "evaluated_at": reviewed_at.isoformat(),
+                },
+            )
+
+        self.assertEqual(store.list(EvidenceRecord), evidence_before)


### PR DESCRIPTION
Closes #580
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a bounded MISP attachment path and committed it as `dc02e16` (`Add bounded MISP context attachment`). The new path adds a dedicated `MispContextAdapter`, a reviewed `attach_misp_context` service boundary, and a runtime flag `misp_enrichment_enabled` that defaults to disabled. The service now fails closed unless the queried IOC is explicitly cited by the reviewed case or admitting evidence anchor, and it persists MISP context as subordinate evidence with preserved lookup receipt, citation, staleness marker, and optional conflict marker.

Focused coverage is in `control-plane.tests.test_phase28_misp_enrichment_validation`: subordinate persistence with provenance, stale/conflicting marker preservation, and disabled-mode no-write behavior. I also ran `test_runtime_skeleton` after adding the new config flag, and `issue-lint 580 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json` passed. The issue journal was updated with the current hypothesis, commands, and next step.

Summary: Added a fail-closed optional MISP subordinate enrichment boundary with focused tests and committed it as `dc02e16`
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase28_misp_enrichment_validation`; `python3 -m unittest control-plane.tests.test_runtime_skeleton`; `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 580 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegiso...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MISP subordinate enrichment: create and attach MISP-derived evidence and optional observations with provenance, citation, conflict and staleness handling.
  * New service API to attach MISP context to cases and enforce explicit anchor-binding.
  * New runtime toggle to enable/disable MISP enrichment.

* **Tests**
  * Added comprehensive tests covering enrichment flows, conflict/staleness behavior, anchor-binding validation, and disabled-mode rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->