### PR TITLE
validation: prove optional evidence/intel packs stay subordinate and can be disabled cleanly (#581)

### DIFF
--- a/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
+++ b/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
@@ -743,6 +743,7 @@ class Phase28EndpointEvidencePackValidationTests(unittest.TestCase):
             expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
         )
         before_ids = {record.evidence_id for record in store.list(EvidenceRecord)}
+        case_detail_before = service.inspect_case_detail(promoted_case.case_id).to_dict()
 
         with self.assertRaisesRegex(
             ValueError,
@@ -770,6 +771,10 @@ class Phase28EndpointEvidencePackValidationTests(unittest.TestCase):
         self.assertEqual(
             {record.evidence_id for record in store.list(EvidenceRecord)},
             before_ids,
+        )
+        self.assertEqual(
+            service.inspect_case_detail(promoted_case.case_id).to_dict(),
+            case_detail_before,
         )
 
     def test_ingest_endpoint_evidence_artifacts_rejects_expired_requests_without_writes(
@@ -893,6 +898,113 @@ class Phase28EndpointEvidencePackValidationTests(unittest.TestCase):
                 promoted_case.evidence_ids[0],
                 first_ingest[0].evidence_id,
             },
+        )
+
+    def test_ingest_endpoint_evidence_artifacts_remain_subordinate_in_case_detail(
+        self,
+    ) -> None:
+        _store, service, promoted_case, anchor_evidence_id, reviewed_at = (
+            self._build_host_bound_case()
+        )
+        action_request = service.create_endpoint_evidence_collection_request(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence_id,
+            requester_identity="analyst-001",
+            host_identifier="host-001",
+            evidence_gap="Need endpoint evidence to resolve the reviewed host-state gap.",
+            artifact_classes=("collection_manifest", "file_sample", "binary_analysis"),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+        )
+        self._approve_action_request(
+            service,
+            action_request.action_request_id,
+            decided_at=action_request.requested_at + timedelta(minutes=5),
+        )
+
+        ingested = service.ingest_endpoint_evidence_artifacts(
+            action_request_id=action_request.action_request_id,
+            artifacts=(
+                {
+                    "artifact_class": "collection_manifest",
+                    "artifact_id": "manifest-subordinate-001",
+                    "source_artifact_id": "collector-manifest-subordinate-001",
+                    "collected_at": reviewed_at,
+                    "collector_identity": "velociraptor",
+                    "tool_name": "Velociraptor",
+                    "source_boundary": "endpoint_evidence_pack",
+                    "citation_kind": "raw_collected_output",
+                    "description": "Reviewed collection manifest.",
+                    "content": {"requested_paths": ("/opt/suspicious",)},
+                },
+                {
+                    "artifact_class": "file_sample",
+                    "artifact_id": "sample-subordinate-001",
+                    "source_artifact_id": "collector-sample-subordinate-001",
+                    "collected_at": reviewed_at + timedelta(minutes=1),
+                    "collector_identity": "velociraptor",
+                    "tool_name": "Velociraptor",
+                    "source_boundary": "endpoint_evidence_pack",
+                    "citation_kind": "raw_collected_output",
+                    "description": "Collected reviewed file sample.",
+                    "content": {
+                        "path": "/opt/suspicious/sample.bin",
+                        "sha256": "c" * 64,
+                    },
+                },
+                {
+                    "artifact_class": "binary_analysis",
+                    "artifact_id": "analysis-subordinate-001",
+                    "source_artifact_id": "analysis-subordinate-001",
+                    "derived_from_artifact_id": "sample-subordinate-001",
+                    "collected_at": reviewed_at + timedelta(minutes=2),
+                    "collector_identity": "yara",
+                    "tool_name": "YARA",
+                    "source_boundary": "endpoint_evidence_pack",
+                    "citation_kind": "bounded_derivative",
+                    "description": "Bounded derivative analysis over the reviewed file sample.",
+                    "content": {
+                        "matches": (
+                            {
+                                "rule_name": "Subordinate.Sample.Match",
+                            },
+                        ),
+                    },
+                },
+            ),
+            admitted_by="analyst-001",
+        )
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+        attached_records = {
+            record["record_id"]: record
+            for record in case_detail.provenance_summary["attached_records"]
+        }
+
+        self.assertEqual(
+            case_detail.provenance_summary["authoritative_anchor"]["record_id"],
+            promoted_case.alert_id,
+        )
+        self.assertEqual(
+            case_detail.provenance_summary["authoritative_anchor"][
+                "provenance_classification"
+            ],
+            "authoritative-anchor",
+        )
+        self.assertEqual(case_detail.advisory_output["status"], "ready")
+        self.assertEqual(
+            tuple(record["source_family"] for record in case_detail.cross_source_timeline[1:]),
+            ("wazuh", "endpoint_evidence_pack", "endpoint_evidence_pack", "endpoint_evidence_pack"),
+        )
+        self.assertEqual(
+            tuple(
+                attached_records[record.evidence_id]["provenance_classification"]
+                for record in ingested
+            ),
+            ("augmenting-evidence", "augmenting-evidence", "reviewed-derived"),
+        )
+        self.assertEqual(
+            tuple(attached_records[record.evidence_id]["source_family"] for record in ingested),
+            ("endpoint_evidence_pack", "endpoint_evidence_pack", "endpoint_evidence_pack"),
         )
 
     def test_ingest_endpoint_evidence_artifacts_rejects_conflicting_replay_without_writes(

--- a/control-plane/tests/test_phase28_misp_enrichment_validation.py
+++ b/control-plane/tests/test_phase28_misp_enrichment_validation.py
@@ -264,6 +264,7 @@ class Phase28MispEnrichmentValidationTests(ServicePersistenceTestBase):
             indicator_value="disabled.example",
         )
         evidence_before = store.list(EvidenceRecord)
+        case_detail_before = service.inspect_case_detail(promoted_case.case_id).to_dict()
 
         with self.assertRaisesRegex(
             ValueError,
@@ -292,6 +293,90 @@ class Phase28MispEnrichmentValidationTests(ServicePersistenceTestBase):
             )
 
         self.assertEqual(store.list(EvidenceRecord), evidence_before)
+        self.assertEqual(
+            service.inspect_case_detail(promoted_case.case_id).to_dict(),
+            case_detail_before,
+        )
+
+    def test_attach_misp_context_keeps_stale_conflicting_attachment_subordinate_in_case_detail(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _, reviewed_at = self._build_in_scope_case(
+            misp_enrichment_enabled=True
+        )
+        anchor_evidence = self._attach_anchor_evidence(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            indicator_value="stale.example",
+        )
+
+        evidence, observation = service.attach_misp_context(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence.evidence_id,
+            queried_object_type="domain",
+            queried_object_value="stale.example",
+            looked_up_at=reviewed_at,
+            reviewed_by="analyst-001",
+            event_id="misp-event-case-detail-001",
+            event_info="Conflicting stale context",
+            event_published_at=reviewed_at - timedelta(days=10),
+            iocs=(
+                {
+                    "type": "domain",
+                    "value": "stale.example",
+                    "category": "Network activity",
+                },
+            ),
+            citation_url="https://misp.example/events/view/6",
+            staleness_marker={
+                "state": "stale",
+                "evaluated_at": reviewed_at.isoformat(),
+                "reason": "event older than review threshold",
+            },
+            conflict_marker={
+                "state": "conflict",
+                "reason": "MISP taxonomy confidence disagrees with reviewed case context",
+            },
+            observation_scope_statement=(
+                "Reviewed the subordinate MISP context without promoting it to case truth."
+            ),
+        )
+        assert observation is not None
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id)
+        attached_records = {
+            record["record_id"]: record
+            for record in case_detail.provenance_summary["attached_records"]
+        }
+
+        self.assertEqual(
+            case_detail.provenance_summary["authoritative_anchor"]["record_id"],
+            promoted_case.alert_id,
+        )
+        self.assertEqual(
+            case_detail.provenance_summary["authoritative_anchor"][
+                "provenance_classification"
+            ],
+            "authoritative-anchor",
+        )
+        self.assertEqual(
+            attached_records[evidence.evidence_id]["provenance_classification"],
+            "augmenting-evidence",
+        )
+        self.assertEqual(
+            attached_records[evidence.evidence_id]["source_family"],
+            "misp",
+        )
+        self.assertEqual(
+            attached_records[evidence.evidence_id]["ambiguity_badge"],
+            "unresolved",
+        )
+        self.assertEqual(
+            attached_records[observation.observation_id]["provenance_classification"],
+            "reviewed-derived",
+        )
+        self.assertEqual(case_detail.advisory_output["status"], "ready")
 
     def test_attach_misp_context_rejects_misp_derived_anchor_without_writes(self) -> None:
         store, service, promoted_case, _, reviewed_at = self._build_in_scope_case(


### PR DESCRIPTION
Closes #581
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused Phase 28 validation checkpoint and committed it as `bee090b` (`test: tighten phase28 subordinate optional validation`).

The new coverage is at the authoritative read boundary, not just adapter input validation. In `control-plane/tests/test_phase28_misp_enrichment_validation.py` I added assertions that disabled MISP enrichment leaves `inspect_case_detail()` unchanged and that stale/conflicting MISP attachments remain subordinate while the alert anchor stays authoritative. In `control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py` I added the same kind of clean fail-closed case-detail check for blocked endpoint-evidence ingestion and a new assertion set proving admitted endpoint artifacts stay subordinate in case detail instead of becoming case truth.

Focused verification passed locally:
- `python3 -m unittest control-plane.tests.test_phase28_misp_enrichment_validation`
- `python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_validation`
- `python3 -m unittest control-plane.tests.test_phase24_live_assistant_fallback_validation`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 581 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`

I also updated `.codex-supervisor/issues/581/issue-journal.md` in the worktree with the current hypothesis, commands, and outcome.

Summary: Added and committed focused Phase 28 regression tests proving disabled optional enrichment le...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation testing for endpoint evidence pack handling, including idempotency checks and provenance invariants for multi-artifact chains.
  * Expanded MISP enrichment testing to verify case detail consistency and subordinate evidence classification remain correct across various attachment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->