### PR TITLE
Fix Phase 28 endpoint evidence validation contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,14 @@ jobs:
       - name: Run Phase 27 workflow coverage guard
         run: bash scripts/test-verify-ci-phase-27-workflow-coverage.sh
 
+      - name: Run Phase 28 endpoint evidence-pack boundary validation
+        run: |
+          bash scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh
+          python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs
+
+      - name: Run Phase 28 workflow coverage guard
+        run: bash scripts/test-verify-ci-phase-28-workflow-coverage.sh
+
       - name: Run control-plane runtime unit tests
         run: python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
 
@@ -266,6 +274,7 @@ jobs:
           bash scripts/test-verify-phase-25-multi-source-case-review-runbook.sh
           bash scripts/test-verify-phase-26-ticket-coordination-validation.sh
           bash scripts/test-verify-phase-27-day-2-hardening-validation.sh
+          bash scripts/test-verify-ci-phase-28-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-14-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-15-workflow-coverage.sh
           bash scripts/test-verify-ci-phase-19-workflow-coverage.sh

--- a/control-plane/tests/test_phase28_endpoint_evidence_pack_boundary_docs.py
+++ b/control-plane/tests/test_phase28_endpoint_evidence_pack_boundary_docs.py
@@ -49,7 +49,7 @@ class Phase28EndpointEvidencePackBoundaryDocsTests(unittest.TestCase):
         for term in (
             "# Phase 28 Optional Endpoint Evidence-Pack Boundary Validation",
             "Validation status: PASS",
-            "docs/Revised Phase23-20 Epic Roadmap.md",
+            "ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md",
             "docs/requirements-baseline.md",
             "docs/architecture.md",
             "docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md",
@@ -60,6 +60,8 @@ class Phase28EndpointEvidencePackBoundaryDocsTests(unittest.TestCase):
             'python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs',
         ):
             self.assertIn(term, text)
+
+        self.assertNotIn("docs/Revised Phase23-20 Epic Roadmap.md", text)
 
 
 if __name__ == "__main__":

--- a/docs/phase-28-optional-endpoint-evidence-pack-boundary-validation.md
+++ b/docs/phase-28-optional-endpoint-evidence-pack-boundary-validation.md
@@ -3,7 +3,7 @@
 - Validation status: PASS
 - Reviewed on: 2026-04-19
 - Scope: confirm the reviewed Phase 28 endpoint evidence-pack boundary keeps Velociraptor, YARA, and capa subordinate to the AegisOps authority model while making optional endpoint evidence-pack use specific enough for later implementation and validation work.
-- Reviewed sources: `docs/Revised Phase23-20 Epic Roadmap.md` (repository-published roadmap anchor for the reviewed AegisOps thesis, SMB deployment target, and later source-expansion guardrails), `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`
+- Reviewed sources: `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` (vault-relative path for the reviewed roadmap note that defines the accepted Phase 28 optional endpoint evidence-pack and bounded intel-enrichment slice while keeping those extensions subordinate to the AegisOps authority model), `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`
 
 ## Validation Summary
 
@@ -15,7 +15,7 @@ Endpoint evidence packs remain optional, provenance-preserving, and fail closed 
 
 ## Roadmap and Thesis Review
 
-`docs/Revised Phase23-20 Epic Roadmap.md` keeps later source and evidence expansion narrow and subordinate to the approved AegisOps thesis for approval, evidence, and reconciliation governance.
+`ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` keeps Phase 28 endpoint evidence and bounded enrichment narrow, optional, and subordinate to the approved AegisOps thesis for approval, evidence, and reconciliation governance rather than allowing endpoint tooling to become mandatory infrastructure or authority.
 
 `docs/requirements-baseline.md` remains aligned because AegisOps continues to own authoritative truth for alert, case, evidence, approval, action-execution, and reconciliation records, while upstream and subordinate tooling remain optional substrates rather than co-equal product cores.
 

--- a/scripts/test-verify-ci-phase-28-workflow-coverage.sh
+++ b/scripts/test-verify-ci-phase-28-workflow-coverage.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+required_verifiers=(
+  "bash scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh"
+)
+
+required_tests=(
+  "bash scripts/test-verify-ci-phase-28-workflow-coverage.sh"
+)
+
+required_runtime_commands=(
+  "python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs"
+)
+
+self_guard_step_name="Run Phase 28 workflow coverage guard"
+self_guard_command="bash scripts/test-verify-ci-phase-28-workflow-coverage.sh"
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+collect_active_run_commands() {
+  awk '
+    {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]*$/) {
+          next
+        }
+
+        current_indent = match($0, /[^ ]/) - 1
+        if (current_indent > block_indent) {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          if (line != "" && line !~ /^#/) {
+            print line
+          }
+          next
+        }
+
+        in_block = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[|>]-?[[:space:]]*$/) {
+        block_indent = match($0, /[^ ]/) - 1
+        in_block = 1
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*run:[[:space:]]*[^|>]/) {
+        line = $0
+        sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+        if (line != "" && line !~ /^#/) {
+          print line
+        }
+      }
+    }
+  ' "${workflow_path}"
+}
+
+extract_self_guard_step_run_command() {
+  awk -v step_name="${self_guard_step_name}" '
+    function line_indent(line) {
+      return match(line, /[^ ]/) - 1
+    }
+
+    BEGIN {
+      in_step = 0
+      step_indent = -1
+    }
+
+    {
+      if (in_step) {
+        if ($0 ~ /^[[:space:]]*-[[:space:]]name:[[:space:]]+/ && line_indent($0) <= step_indent) {
+          exit 0
+        }
+
+        if ($0 ~ /^[[:space:]]*run:[[:space:]]*/) {
+          line = $0
+          sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+          print line
+          exit 0
+        }
+      }
+
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line == "- name: " step_name) {
+        in_step = 1
+        step_indent = line_indent($0)
+      }
+    }
+  ' "${workflow_path}"
+}
+
+active_run_commands="$(collect_active_run_commands)"
+
+for command in "${required_verifiers[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 28 verifier command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_tests[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 28 focused shell test command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+for command in "${required_runtime_commands[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${active_run_commands}" >/dev/null; then
+    echo "Missing Phase 28 focused runtime command in CI workflow: ${command}" >&2
+    exit 1
+  fi
+done
+
+self_guard_step_run_command="$(extract_self_guard_step_run_command)"
+if [[ -z "${self_guard_step_run_command}" ]]; then
+  echo "Missing dedicated Phase 28 workflow coverage guard step in CI workflow: ${self_guard_step_name}" >&2
+  exit 1
+fi
+
+if [[ "${self_guard_step_run_command}" != "${self_guard_command}" ]]; then
+  echo "Dedicated Phase 28 workflow coverage guard step must run exactly: ${self_guard_command}" >&2
+  echo "Found: ${self_guard_step_run_command}" >&2
+  exit 1
+fi
+
+self_guard_count="$(grep -Fxc -- "${self_guard_command}" <<<"${active_run_commands}" || true)"
+if [[ "${self_guard_count}" -lt 2 ]]; then
+  echo "Phase 28 workflow coverage checker must run both as a dedicated guard and within focused shell tests." >&2
+  exit 1
+fi
+
+echo "CI workflow includes the required Phase 28 verifier, focused shell test, and focused runtime command."

--- a/scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh
+++ b/scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh
@@ -75,7 +75,7 @@ validation_required_lines=(
   'Velociraptor remains subordinate to the AegisOps control-plane authority model.'
   'YARA and capa remain subordinate evidence-analysis tools rather than authority surfaces.'
   'Endpoint evidence packs remain optional, provenance-preserving, and fail closed when prerequisite case-chain linkage or provenance is incomplete.'
-  '- Reviewed sources: `docs/Revised Phase23-20 Epic Roadmap.md` (repository-published roadmap anchor for the reviewed AegisOps thesis, SMB deployment target, and later source-expansion guardrails), `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`'
+  '- Reviewed sources: `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` (vault-relative path for the reviewed roadmap note that defines the accepted Phase 28 optional endpoint evidence-pack and bounded intel-enrichment slice while keeping those extensions subordinate to the AegisOps authority model), `docs/requirements-baseline.md`, `docs/architecture.md`, `docs/phase-25-reviewed-multi-source-case-admission-and-ambiguity-taxonomy.md`, `docs/phase-25-multi-source-case-review-and-osquery-evidence-runbook.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`'
   '- `python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs`'
   '- `bash scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh`'
 )
@@ -83,6 +83,11 @@ validation_required_lines=(
 for line in "${validation_required_lines[@]}"; do
   require_fixed_line "${validation_doc}" "${line}"
 done
+
+if grep -Fq -- 'docs/Revised Phase23-20 Epic Roadmap.md' "${validation_doc}"; then
+  echo "Phase 28 validation doc must not reference the stale Phase23-20 roadmap anchor." >&2
+  exit 1
+fi
 
 require_fixed_line "${docs_test}" 'class Phase28EndpointEvidencePackBoundaryDocsTests(unittest.TestCase):'
 require_fixed_line "${docs_test}" '    def test_phase28_design_doc_exists_and_keeps_endpoint_evidence_subordinate('


### PR DESCRIPTION
## Summary
- refresh the Phase 28 endpoint-evidence validation chain to the current reviewed roadmap anchor
- add a dedicated Phase 28 CI workflow coverage guard and explicit validation step
- keep the accepted Phase 28 subordinate-evidence boundary intact while tightening drift detection

## Testing
- python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_boundary_docs
- bash scripts/verify-phase-28-endpoint-evidence-pack-boundary.sh
- bash scripts/test-verify-ci-phase-28-workflow-coverage.sh

Closes #589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow with Phase 28 validation coverage and boundary verification checks
  * Added automated verification script for workflow coverage validation

* **Tests**
  * Updated validation tests with corrected roadmap reference paths

* **Documentation**
  * Updated roadmap references to reflect current documentation structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->