### PR TITLE
refactor: extract action-review projection surface

### DIFF
--- a/control-plane/aegisops_control_plane/action_review_projection.py
+++ b/control-plane/aegisops_control_plane/action_review_projection.py
@@ -1,0 +1,905 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Mapping
+
+from .models import (
+    ActionExecutionRecord,
+    ActionRequestRecord,
+    AlertRecord,
+    ApprovalDecisionRecord,
+    CaseRecord,
+    ReconciliationRecord,
+)
+
+if TYPE_CHECKING:
+    from .service import AegisOpsControlPlaneService
+
+
+@dataclass(frozen=True)
+class _ActionReviewRecordIndex:
+    requests_by_case_id: dict[str, tuple[ActionRequestRecord, ...]]
+    requests_by_alert_id: dict[str, tuple[ActionRequestRecord, ...]]
+    requests_by_scope: dict[tuple[str | None, str | None], tuple[ActionRequestRecord, ...]]
+    approvals_by_id: dict[str, ApprovalDecisionRecord]
+    approvals_by_action_request_id: dict[str, tuple[ApprovalDecisionRecord, ...]]
+    executions_by_action_request_id: dict[str, tuple[ActionExecutionRecord, ...]]
+    reconciliations_by_action_request_id: dict[str, tuple[ReconciliationRecord, ...]]
+    reconciliations_by_approval_decision_id: dict[str, tuple[ReconciliationRecord, ...]]
+    reconciliations_by_action_execution_id: dict[str, tuple[ReconciliationRecord, ...]]
+    reconciliations_by_delegation_id: dict[str, tuple[ReconciliationRecord, ...]]
+
+    def matching_requests(
+        self,
+        *,
+        case_id: str | None,
+        alert_id: str | None,
+    ) -> tuple[ActionRequestRecord, ...]:
+        matching_by_id: dict[str, ActionRequestRecord] = {}
+        if case_id is not None:
+            for record in self.requests_by_case_id.get(case_id, ()):
+                matching_by_id[record.action_request_id] = record
+        if alert_id is not None:
+            for record in self.requests_by_alert_id.get(alert_id, ()):
+                matching_by_id[record.action_request_id] = record
+        return tuple(matching_by_id.values())
+
+    def scoped_requests(
+        self,
+        *,
+        case_id: str | None,
+        alert_id: str | None,
+    ) -> tuple[ActionRequestRecord, ...]:
+        return self.requests_by_scope.get((case_id, alert_id), ())
+
+
+def build_action_review_record_index(
+    service: AegisOpsControlPlaneService,
+) -> _ActionReviewRecordIndex:
+    def _freeze_grouped_records(
+        grouped_records: defaultdict[object, list[object]],
+    ) -> dict[object, tuple[object, ...]]:
+        return {
+            key: tuple(records)
+            for key, records in grouped_records.items()
+        }
+
+    action_requests = service._store.list(ActionRequestRecord)
+    if not action_requests:
+        return _ActionReviewRecordIndex(
+            requests_by_case_id={},
+            requests_by_alert_id={},
+            requests_by_scope={},
+            approvals_by_id={},
+            approvals_by_action_request_id={},
+            executions_by_action_request_id={},
+            reconciliations_by_action_request_id={},
+            reconciliations_by_approval_decision_id={},
+            reconciliations_by_action_execution_id={},
+            reconciliations_by_delegation_id={},
+        )
+    approvals = service._store.list(ApprovalDecisionRecord)
+    action_executions = service._store.list(ActionExecutionRecord)
+    reconciliations = service._store.list(ReconciliationRecord)
+
+    requests_by_case_id: defaultdict[str, list[ActionRequestRecord]] = defaultdict(list)
+    requests_by_alert_id: defaultdict[str, list[ActionRequestRecord]] = defaultdict(list)
+    requests_by_scope: defaultdict[
+        tuple[str | None, str | None],
+        list[ActionRequestRecord],
+    ] = defaultdict(list)
+    for action_request in action_requests:
+        requests_by_scope[
+            (action_request.case_id, action_request.alert_id)
+        ].append(action_request)
+        if action_request.case_id is not None:
+            requests_by_case_id[action_request.case_id].append(action_request)
+        if action_request.alert_id is not None:
+            requests_by_alert_id[action_request.alert_id].append(action_request)
+
+    approvals_by_action_request_id: defaultdict[
+        str,
+        list[ApprovalDecisionRecord],
+    ] = defaultdict(list)
+    approvals_by_id = {
+        approval.approval_decision_id: approval for approval in approvals
+    }
+    for approval in approvals:
+        approvals_by_action_request_id[approval.action_request_id].append(approval)
+
+    executions_by_action_request_id: defaultdict[
+        str,
+        list[ActionExecutionRecord],
+    ] = defaultdict(list)
+    for action_execution in action_executions:
+        executions_by_action_request_id[action_execution.action_request_id].append(
+            action_execution
+        )
+
+    reconciliations_by_action_request_id: defaultdict[
+        str,
+        list[ReconciliationRecord],
+    ] = defaultdict(list)
+    reconciliations_by_approval_decision_id: defaultdict[
+        str,
+        list[ReconciliationRecord],
+    ] = defaultdict(list)
+    reconciliations_by_action_execution_id: defaultdict[
+        str,
+        list[ReconciliationRecord],
+    ] = defaultdict(list)
+    reconciliations_by_delegation_id: defaultdict[
+        str,
+        list[ReconciliationRecord],
+    ] = defaultdict(list)
+    for reconciliation in reconciliations:
+        for action_request_id in service._assistant_ids_from_mapping(
+            reconciliation.subject_linkage,
+            "action_request_ids",
+        ):
+            reconciliations_by_action_request_id[action_request_id].append(
+                reconciliation
+            )
+        for approval_decision_id in service._assistant_ids_from_mapping(
+            reconciliation.subject_linkage,
+            "approval_decision_ids",
+        ):
+            reconciliations_by_approval_decision_id[approval_decision_id].append(
+                reconciliation
+            )
+        for action_execution_id in service._assistant_ids_from_mapping(
+            reconciliation.subject_linkage,
+            "action_execution_ids",
+        ):
+            reconciliations_by_action_execution_id[action_execution_id].append(
+                reconciliation
+            )
+        for delegation_id in service._assistant_ids_from_mapping(
+            reconciliation.subject_linkage,
+            "delegation_ids",
+        ):
+            reconciliations_by_delegation_id[delegation_id].append(reconciliation)
+
+    return _ActionReviewRecordIndex(
+        requests_by_case_id=_freeze_grouped_records(requests_by_case_id),
+        requests_by_alert_id=_freeze_grouped_records(requests_by_alert_id),
+        requests_by_scope=_freeze_grouped_records(requests_by_scope),
+        approvals_by_id=approvals_by_id,
+        approvals_by_action_request_id=_freeze_grouped_records(
+            approvals_by_action_request_id
+        ),
+        executions_by_action_request_id=_freeze_grouped_records(
+            executions_by_action_request_id
+        ),
+        reconciliations_by_action_request_id=_freeze_grouped_records(
+            reconciliations_by_action_request_id
+        ),
+        reconciliations_by_approval_decision_id=_freeze_grouped_records(
+            reconciliations_by_approval_decision_id
+        ),
+        reconciliations_by_action_execution_id=_freeze_grouped_records(
+            reconciliations_by_action_execution_id
+        ),
+        reconciliations_by_delegation_id=_freeze_grouped_records(
+            reconciliations_by_delegation_id
+        ),
+    )
+
+
+def action_review_chains_for_scope(
+    service: AegisOpsControlPlaneService,
+    *,
+    case_id: str | None,
+    alert_id: str | None,
+    record_index: _ActionReviewRecordIndex | None = None,
+) -> tuple[dict[str, object], ...]:
+    if record_index is not None:
+        matching_requests = list(
+            record_index.matching_requests(case_id=case_id, alert_id=alert_id)
+        )
+    else:
+        matching_requests = [
+            record
+            for record in service._store.list(ActionRequestRecord)
+            if (
+                (case_id is not None and record.case_id == case_id)
+                or (alert_id is not None and record.alert_id == alert_id)
+            )
+        ]
+    matching_requests = [
+        record
+        for record in matching_requests
+        if service._action_request_is_review_bound(record)
+    ]
+    chains = [
+        build_action_review_chain_snapshot(
+            service,
+            action_request,
+            record_index=record_index,
+        )
+        for action_request in matching_requests
+    ]
+    chains.sort(
+        key=lambda chain: (
+            chain.get("requested_at") or datetime.min.replace(tzinfo=timezone.utc),
+            action_review_priority(chain),
+            chain.get("action_request_id") or "",
+        ),
+        reverse=True,
+    )
+    return tuple(chains)
+
+
+def action_review_priority(chain: Mapping[str, object]) -> int:
+    review_state = chain.get("review_state")
+    if review_state == "pending":
+        return 5
+    if review_state in {"approved", "executing"}:
+        return 4
+    if review_state in {"expired", "rejected"}:
+        return 3
+    if review_state == "superseded":
+        return 2
+    return 1
+
+
+def build_action_review_chain_snapshot(
+    service: AegisOpsControlPlaneService,
+    action_request: ActionRequestRecord,
+    *,
+    record_index: _ActionReviewRecordIndex | None = None,
+) -> dict[str, object]:
+    approval_decision = service._action_review_approval_decision(
+        action_request,
+        record_index=record_index,
+    )
+    action_execution = service._action_review_execution(
+        action_request,
+        record_index=record_index,
+    )
+    reconciliation = service._latest_action_review_reconciliation(
+        action_request=action_request,
+        approval_decision=approval_decision,
+        action_execution=action_execution,
+        record_index=record_index,
+    )
+    approval_state = service._action_review_approval_state(
+        action_request=action_request,
+        approval_decision=approval_decision,
+    )
+    review_state = service._action_review_state(
+        action_request=action_request,
+        approval_state=approval_state,
+        action_execution=action_execution,
+    )
+    timeline = action_review_timeline(
+        service,
+        action_request=action_request,
+        approval_state=approval_state,
+        approval_decision=approval_decision,
+        action_execution=action_execution,
+        reconciliation=reconciliation,
+    )
+    mismatch_inspection = action_review_mismatch_inspection(reconciliation)
+    replacement_action_request = service._replacement_action_request(
+        action_request,
+        record_index=record_index,
+    )
+    requested_payload = dict(action_request.requested_payload)
+    runtime_visibility = action_review_runtime_visibility(
+        service,
+        action_request=action_request,
+        approval_decision=approval_decision,
+        review_state=review_state,
+        record_index=record_index,
+    )
+    path_health_as_of = datetime.now(timezone.utc)
+    path_health = action_review_path_health(
+        service,
+        action_request=action_request,
+        approval_decision=approval_decision,
+        action_execution=action_execution,
+        reconciliation=reconciliation,
+        review_state=review_state,
+        as_of=path_health_as_of,
+    )
+    coordination_ticket_outcome = action_review_coordination_ticket_outcome(
+        service,
+        action_request=action_request,
+        approval_decision=approval_decision,
+        action_execution=action_execution,
+        reconciliation=reconciliation,
+        runtime_visibility=runtime_visibility,
+        path_health=path_health,
+        review_state=review_state,
+    )
+
+    return {
+        "review_state": review_state,
+        "next_expected_action": service._next_expected_action_for_review_state(
+            review_state
+        ),
+        "action_request_id": action_request.action_request_id,
+        "action_request_state": action_request.lifecycle_state,
+        "approval_decision_id": (
+            approval_decision.approval_decision_id if approval_decision is not None else None
+        ),
+        "approval_state": approval_state,
+        "requester_identity": action_request.requester_identity,
+        "approver_identities": (
+            approval_decision.approver_identities if approval_decision is not None else ()
+        ),
+        "decision_rationale": (
+            approval_decision.decision_rationale
+            if approval_decision is not None
+            else None
+        ),
+        "requested_at": action_request.requested_at,
+        "expires_at": action_request.expires_at,
+        "target_scope": dict(action_request.target_scope),
+        "requested_payload": requested_payload,
+        "recommendation_id": requested_payload.get("recommendation_id"),
+        "recipient_identity": requested_payload.get("recipient_identity"),
+        "message_intent": requested_payload.get("message_intent"),
+        "escalation_reason": requested_payload.get("escalation_reason"),
+        "runtime_visibility": runtime_visibility,
+        "path_health": path_health,
+        "coordination_ticket_outcome": coordination_ticket_outcome,
+        "execution_surface_type": (
+            action_execution.execution_surface_type
+            if action_execution is not None
+            else action_request.policy_evaluation.get("execution_surface_type")
+        ),
+        "execution_surface_id": (
+            action_execution.execution_surface_id
+            if action_execution is not None
+            else action_request.policy_evaluation.get("execution_surface_id")
+        ),
+        "timeline": timeline,
+        "mismatch_inspection": mismatch_inspection,
+        "action_execution_id": (
+            action_execution.action_execution_id if action_execution is not None else None
+        ),
+        "action_execution_state": (
+            action_execution.lifecycle_state if action_execution is not None else None
+        ),
+        "delegation_id": (
+            action_execution.delegation_id if action_execution is not None else None
+        ),
+        "execution_run_id": (
+            action_execution.execution_run_id if action_execution is not None else None
+        ),
+        "reconciliation_id": (
+            reconciliation.reconciliation_id if reconciliation is not None else None
+        ),
+        "reconciliation_state": (
+            reconciliation.lifecycle_state if reconciliation is not None else None
+        ),
+        "replacement_action_request_id": (
+            replacement_action_request.action_request_id
+            if replacement_action_request is not None
+            else None
+        ),
+        "replacement_approval_decision_id": (
+            replacement_action_request.approval_decision_id
+            if replacement_action_request is not None
+            else None
+        ),
+    }
+
+
+def action_review_path_health(
+    service: AegisOpsControlPlaneService,
+    *,
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+    action_execution: ActionExecutionRecord | None,
+    reconciliation: ReconciliationRecord | None,
+    review_state: str,
+    as_of: datetime,
+) -> dict[str, object]:
+    if action_execution is None and reconciliation is None:
+        if review_state in {"rejected", "expired", "superseded", "canceled"}:
+            paths = service._action_review_terminal_non_delegated_path_health()
+        elif (
+            review_state == "unresolved"
+            and approval_decision is not None
+            and approval_decision.lifecycle_state == "approved"
+        ):
+            paths = service._action_review_unresolved_without_execution_path_health()
+        else:
+            paths = {
+                "ingest": service._action_review_ingest_path_health(reconciliation),
+                "delegation": service._action_review_delegation_path_health(
+                    action_request=action_request,
+                    approval_decision=approval_decision,
+                    action_execution=action_execution,
+                    review_state=review_state,
+                ),
+                "provider": service._action_review_provider_path_health(action_execution),
+                "persistence": service._action_review_persistence_path_health(
+                    reconciliation
+                ),
+            }
+    elif action_execution is None:
+        paths = service._action_review_reconciliation_without_execution_path_health(
+            action_request=action_request,
+            approval_decision=approval_decision,
+            reconciliation=reconciliation,
+            review_state=review_state,
+        )
+    else:
+        paths = {
+            "ingest": service._action_review_ingest_path_health(reconciliation),
+            "delegation": service._action_review_delegation_path_health(
+                action_request=action_request,
+                approval_decision=approval_decision,
+                action_execution=action_execution,
+                review_state=review_state,
+            ),
+            "provider": service._action_review_provider_path_health(action_execution),
+            "persistence": service._action_review_persistence_path_health(reconciliation),
+        }
+    deadline = service._action_review_visibility_deadline(
+        action_request=action_request,
+        approval_decision=approval_decision,
+        action_execution=action_execution,
+    )
+    if deadline is not None and deadline <= as_of:
+        paths = service._action_review_overdue_path_health(
+            review_state=review_state,
+            action_execution=action_execution,
+            paths=paths,
+        )
+    overall_state = service._action_review_overall_path_state(paths.values())
+    return {
+        "overall_state": overall_state,
+        "summary": service._action_review_path_health_summary(
+            overall_state=overall_state,
+            paths=paths,
+        ),
+        "paths": paths,
+    }
+
+
+def action_review_runtime_visibility(
+    service: AegisOpsControlPlaneService,
+    *,
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+    review_state: str,
+    record_index: _ActionReviewRecordIndex | None = None,
+) -> dict[str, object] | None:
+    reviewed_context = service._action_review_visibility_context(action_request)
+    if reviewed_context is None:
+        return None
+
+    allow_unscoped_action_visibility = service._case_has_single_review_bound_action_request(
+        action_request.case_id,
+        record_index=record_index,
+    )
+    visibility: dict[str, object] = {}
+    after_hours_handoff = service._action_review_after_hours_handoff_visibility(
+        reviewed_context=reviewed_context,
+        review_state=review_state,
+    )
+    if after_hours_handoff is not None:
+        visibility["after_hours_handoff"] = after_hours_handoff
+
+    manual_fallback = service._action_review_manual_fallback_visibility(
+        reviewed_context=reviewed_context,
+        action_request=action_request,
+        approval_decision=approval_decision,
+        review_state=review_state,
+        allow_unscoped_context=allow_unscoped_action_visibility,
+    )
+    if manual_fallback is not None:
+        visibility["manual_fallback"] = manual_fallback
+
+    escalation_notes = service._action_review_escalation_visibility(
+        reviewed_context=reviewed_context,
+        action_request=action_request,
+        approval_decision=approval_decision,
+        review_state=review_state,
+        allow_unscoped_context=allow_unscoped_action_visibility,
+    )
+    if escalation_notes is not None:
+        visibility["escalation_notes"] = escalation_notes
+
+    return visibility or None
+
+
+def action_review_timeline(
+    service: AegisOpsControlPlaneService,
+    *,
+    action_request: ActionRequestRecord,
+    approval_state: str | None,
+    approval_decision: ApprovalDecisionRecord | None,
+    action_execution: ActionExecutionRecord | None,
+    reconciliation: ReconciliationRecord | None,
+) -> tuple[dict[str, object], ...]:
+    delegation_details: dict[str, object] = {}
+    action_execution_details: dict[str, object] = {}
+    execution_actor_identities: tuple[str, ...] = ()
+    action_execution_occurred_at: datetime | None = None
+    if action_execution is not None:
+        delegation_details["delegation_id"] = action_execution.delegation_id
+        execution_actor_identities = service._assistant_merge_ids(
+            action_execution.provenance.get("initiated_by"),
+            action_execution.provenance.get("delegation_issuer"),
+        )
+        downstream_binding = action_execution.provenance.get("downstream_binding")
+        if isinstance(downstream_binding, Mapping):
+            delegation_details["downstream_binding"] = dict(downstream_binding)
+        adapter = action_execution.provenance.get("adapter")
+        if isinstance(adapter, str) and adapter.strip():
+            action_execution_details["adapter"] = adapter
+        adapter_base_url = action_execution.provenance.get("adapter_base_url")
+        if isinstance(adapter_base_url, str) and adapter_base_url.strip():
+            action_execution_details["adapter_base_url"] = adapter_base_url
+    timeline = (
+        service._action_review_stage_snapshot(
+            stage="action_request",
+            record_family="action_request",
+            record_id=action_request.action_request_id,
+            state=action_request.lifecycle_state,
+            occurred_at=action_request.requested_at,
+            actor_identities=(
+                ()
+                if action_request.requester_identity is None
+                else (action_request.requester_identity,)
+            ),
+            details={
+                "recipient_identity": action_request.requested_payload.get(
+                    "recipient_identity"
+                ),
+                "execution_surface_type": action_request.policy_evaluation.get(
+                    "execution_surface_type"
+                ),
+                "execution_surface_id": action_request.policy_evaluation.get(
+                    "execution_surface_id"
+                ),
+            },
+        ),
+        service._action_review_stage_snapshot(
+            stage="approval_decision",
+            record_family="approval_decision",
+            record_id=(
+                None
+                if approval_decision is None
+                else approval_decision.approval_decision_id
+            ),
+            state=(
+                approval_decision.lifecycle_state
+                if approval_decision is not None
+                else (approval_state or "pending")
+            ),
+            occurred_at=(
+                None if approval_decision is None else approval_decision.decided_at
+            ),
+            actor_identities=(
+                ()
+                if approval_decision is None
+                else approval_decision.approver_identities
+            ),
+            details=(
+                {}
+                if approval_decision is None
+                or approval_decision.decision_rationale is None
+                else {
+                    "decision_rationale": approval_decision.decision_rationale,
+                }
+            ),
+        ),
+        service._action_review_stage_snapshot(
+            stage="delegation",
+            record_family="action_execution",
+            record_id=(
+                None
+                if action_execution is None
+                else action_execution.action_execution_id
+            ),
+            state=(
+                "awaiting_delegation"
+                if action_execution is None
+                else "delegated"
+            ),
+            occurred_at=(
+                None if action_execution is None else action_execution.delegated_at
+            ),
+            actor_identities=(
+                ()
+                if action_execution is None
+                else service._assistant_ids_from_mapping(
+                    action_execution.provenance,
+                    "delegation_issuer",
+                )
+            ),
+            details=delegation_details,
+        ),
+        service._action_review_stage_snapshot(
+            stage="action_execution",
+            record_family="action_execution",
+            record_id=(
+                None
+                if action_execution is None
+                else action_execution.action_execution_id
+            ),
+            state=(
+                "awaiting_execution"
+                if action_execution is None
+                else action_execution.lifecycle_state
+            ),
+            occurred_at=action_execution_occurred_at,
+            actor_identities=execution_actor_identities,
+            details=(
+                {}
+                if action_execution is None
+                else {
+                    "execution_run_id": action_execution.execution_run_id,
+                    "execution_surface_type": action_execution.execution_surface_type,
+                    "execution_surface_id": action_execution.execution_surface_id,
+                    **action_execution_details,
+                }
+            ),
+        ),
+        service._action_review_stage_snapshot(
+            stage="reconciliation",
+            record_family="reconciliation",
+            record_id=(
+                None if reconciliation is None else reconciliation.reconciliation_id
+            ),
+            state=(
+                "awaiting_reconciliation"
+                if reconciliation is None
+                else reconciliation.lifecycle_state
+            ),
+            occurred_at=(
+                None if reconciliation is None else reconciliation.compared_at
+            ),
+            details=(
+                {}
+                if reconciliation is None
+                else {
+                    "ingest_disposition": reconciliation.ingest_disposition,
+                    "execution_run_id": reconciliation.execution_run_id,
+                }
+            ),
+        ),
+    )
+    return timeline
+
+
+def action_review_mismatch_inspection(
+    reconciliation: ReconciliationRecord | None,
+) -> dict[str, object] | None:
+    if reconciliation is None:
+        return None
+    if reconciliation.lifecycle_state not in {"pending", "mismatched", "stale"}:
+        return None
+    return {
+        "reconciliation_id": reconciliation.reconciliation_id,
+        "lifecycle_state": reconciliation.lifecycle_state,
+        "ingest_disposition": reconciliation.ingest_disposition,
+        "mismatch_summary": reconciliation.mismatch_summary,
+        "correlation_key": reconciliation.correlation_key,
+        "execution_run_id": reconciliation.execution_run_id,
+        "linked_execution_run_ids": reconciliation.linked_execution_run_ids,
+        "subject_linkage": dict(reconciliation.subject_linkage),
+        "first_seen_at": reconciliation.first_seen_at,
+        "last_seen_at": reconciliation.last_seen_at,
+        "compared_at": reconciliation.compared_at,
+    }
+
+
+def action_review_coordination_ticket_outcome(
+    service: AegisOpsControlPlaneService,
+    *,
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+    action_execution: ActionExecutionRecord | None,
+    reconciliation: ReconciliationRecord | None,
+    runtime_visibility: Mapping[str, object] | None,
+    path_health: Mapping[str, object],
+    review_state: str,
+) -> dict[str, object] | None:
+    requested_payload = action_request.requested_payload
+    if requested_payload.get("action_type") != "create_tracking_ticket":
+        return None
+    if (
+        action_execution is None
+        and reconciliation is None
+        and review_state in {"rejected", "expired", "superseded", "canceled"}
+    ):
+        return None
+
+    downstream_binding = action_review_downstream_binding(action_execution)
+    mismatch = action_review_coordination_ticket_mismatch(reconciliation)
+    terminal_issue = action_review_coordination_ticket_terminal_issue(
+        action_execution=action_execution,
+        path_health=path_health,
+    )
+    manual_fallback = None
+    if isinstance(runtime_visibility, Mapping):
+        manual_fallback_entry = runtime_visibility.get("manual_fallback")
+        if isinstance(manual_fallback_entry, Mapping):
+            manual_fallback = dict(manual_fallback_entry)
+
+    if (
+        reconciliation is not None
+        and reconciliation.lifecycle_state == "matched"
+        and action_execution is not None
+        and action_execution.lifecycle_state == "succeeded"
+    ):
+        status = "created"
+        summary = (
+            "reviewed create-ticket outcome recorded from authoritative "
+            "execution and reconciliation"
+        )
+    elif manual_fallback is not None:
+        status = "manual_fallback"
+        summary = str(
+            manual_fallback.get("action_taken")
+            or manual_fallback.get("reason")
+            or "reviewed create-ticket outcome recorded as manual fallback"
+        )
+    elif mismatch is not None:
+        status = "mismatch"
+        summary = str(mismatch["mismatch_summary"])
+    elif terminal_issue is not None and terminal_issue["category"] == "timeout":
+        status = "timeout"
+        summary = str(terminal_issue["reason"]).replace("_", " ")
+    elif terminal_issue is not None:
+        status = "timeout"
+        summary = str(terminal_issue["reason"]).replace("_", " ")
+    else:
+        status = "pending"
+        summary = "reviewed create-ticket outcome still awaiting authoritative result"
+
+    outcome = {
+        "authority": "authoritative_aegisops_review",
+        "status": status,
+        "summary": summary,
+        "action_request_id": action_request.action_request_id,
+        "approval_decision_id": (
+            None if approval_decision is None else approval_decision.approval_decision_id
+        ),
+        "action_execution_id": (
+            None if action_execution is None else action_execution.action_execution_id
+        ),
+        "execution_run_id": (
+            None if action_execution is None else action_execution.execution_run_id
+        ),
+        "reconciliation_id": (
+            None if reconciliation is None else reconciliation.reconciliation_id
+        ),
+        "coordination_reference_id": (
+            action_request.target_scope.get("coordination_reference_id")
+            if isinstance(action_request.target_scope.get("coordination_reference_id"), str)
+            else requested_payload.get("coordination_reference_id")
+        ),
+        "coordination_target_type": (
+            action_request.target_scope.get("coordination_target_type")
+            if isinstance(action_request.target_scope.get("coordination_target_type"), str)
+            else requested_payload.get("coordination_target_type")
+        ),
+        "coordination_target_id": (
+            None
+            if downstream_binding is None
+            else downstream_binding.get("coordination_target_id")
+        ),
+        "external_receipt_id": (
+            None
+            if downstream_binding is None
+            else downstream_binding.get("external_receipt_id")
+        ),
+        "ticket_reference_url": (
+            None
+            if downstream_binding is None
+            else downstream_binding.get("ticket_reference_url")
+        ),
+    }
+    if terminal_issue is not None:
+        outcome["timeout"] = {
+            key: value
+            for key, value in terminal_issue.items()
+            if key != "category"
+        }
+    if mismatch is not None:
+        outcome["mismatch"] = mismatch
+    if manual_fallback is not None:
+        outcome["manual_fallback"] = manual_fallback
+    return outcome
+
+
+def action_review_downstream_binding(
+    action_execution: ActionExecutionRecord | None,
+) -> Mapping[str, object] | None:
+    if action_execution is None or not isinstance(action_execution.provenance, Mapping):
+        return None
+    downstream_binding = action_execution.provenance.get("downstream_binding")
+    if not isinstance(downstream_binding, Mapping):
+        return None
+    return downstream_binding
+
+
+def action_review_coordination_ticket_mismatch(
+    reconciliation: ReconciliationRecord | None,
+) -> dict[str, object] | None:
+    mismatch = action_review_mismatch_inspection(reconciliation)
+    if mismatch is None:
+        return None
+    if (
+        mismatch["lifecycle_state"] != "mismatched"
+        and mismatch["ingest_disposition"] != "mismatch"
+    ):
+        return None
+    return mismatch
+
+
+def action_review_coordination_ticket_terminal_issue(
+    *,
+    action_execution: ActionExecutionRecord | None,
+    path_health: Mapping[str, object],
+) -> dict[str, object] | None:
+    if (
+        action_execution is not None
+        and isinstance(action_execution.provenance, Mapping)
+        and isinstance(action_execution.provenance.get("dispatch_failure"), Mapping)
+    ):
+        dispatch_failure = action_execution.provenance["dispatch_failure"]
+        if dispatch_failure.get("error_type") == "TimeoutError":
+            timeout = {
+                "category": "timeout",
+                "path": "provider",
+                "reason": "dispatch_timeout",
+            }
+            error = dispatch_failure.get("error")
+            if isinstance(error, str) and error:
+                timeout["error"] = error
+            return timeout
+
+    paths = path_health.get("paths")
+    if not isinstance(paths, Mapping):
+        return None
+    timeout_reasons = {
+        "ingest_signal_timeout",
+        "delegation_receipt_timeout",
+        "provider_receipt_timeout",
+        "authoritative_outcome_timeout",
+        "reconciliation_timeout",
+    }
+    terminal_failure_reasons = {
+        "execution_failed",
+        "execution_canceled",
+        "execution_expired",
+        "execution_rejected",
+    }
+    provider_path = paths.get("provider")
+    if isinstance(provider_path, Mapping):
+        provider_reason = provider_path.get("reason")
+        if (
+            isinstance(provider_reason, str)
+            and provider_reason in terminal_failure_reasons
+        ):
+            return {
+                "category": "failed",
+                "path": "provider",
+                "reason": provider_reason,
+            }
+    for path_name in ("ingest", "delegation", "provider", "persistence"):
+        path = paths.get(path_name)
+        if not isinstance(path, Mapping):
+            continue
+        reason = path.get("reason")
+        if not isinstance(reason, str):
+            continue
+        if reason in timeout_reasons:
+            return {
+                "category": "timeout",
+                "path": path_name,
+                "reason": reason,
+            }
+    return None

--- a/control-plane/aegisops_control_plane/action_review_projection.py
+++ b/control-plane/aegisops_control_plane/action_review_projection.py
@@ -196,16 +196,52 @@ def action_review_chains_for_scope(
     record_index: _ActionReviewRecordIndex | None = None,
 ) -> tuple[dict[str, object], ...]:
     if record_index is not None:
-        matching_requests = list(
-            record_index.matching_requests(case_id=case_id, alert_id=alert_id)
-        )
+        if case_id is not None and alert_id is not None:
+            matching_by_id: dict[str, ActionRequestRecord] = {}
+            for scoped_request in (
+                *record_index.scoped_requests(case_id=case_id, alert_id=alert_id),
+                *record_index.scoped_requests(case_id=case_id, alert_id=None),
+                *record_index.scoped_requests(case_id=None, alert_id=alert_id),
+            ):
+                matching_by_id[scoped_request.action_request_id] = scoped_request
+            matching_requests = list(matching_by_id.values())
+        else:
+            matching_requests = list(
+                record_index.matching_requests(case_id=case_id, alert_id=alert_id)
+            )
     else:
         matching_requests = [
             record
             for record in service._store.list(ActionRequestRecord)
             if (
-                (case_id is not None and record.case_id == case_id)
-                or (alert_id is not None and record.alert_id == alert_id)
+                (
+                    case_id is not None
+                    and alert_id is not None
+                    and (
+                        (
+                            record.case_id == case_id
+                            and record.alert_id == alert_id
+                        )
+                        or (
+                            record.case_id == case_id
+                            and record.alert_id is None
+                        )
+                        or (
+                            record.case_id is None
+                            and record.alert_id == alert_id
+                        )
+                    )
+                )
+                or (
+                    alert_id is None
+                    and case_id is not None
+                    and record.case_id == case_id
+                )
+                or (
+                    case_id is None
+                    and alert_id is not None
+                    and record.alert_id == alert_id
+                )
             )
         ]
     matching_requests = [
@@ -801,11 +837,15 @@ def action_review_coordination_ticket_outcome(
         ),
     }
     if terminal_issue is not None:
-        outcome["timeout"] = {
+        issue_payload = {
             key: value
             for key, value in terminal_issue.items()
             if key != "category"
         }
+        if terminal_issue["category"] == "timeout":
+            outcome["timeout"] = issue_payload
+        else:
+            outcome["terminal_issue"] = issue_payload
     if mismatch is not None:
         outcome["mismatch"] = mismatch
     if manual_fallback is not None:

--- a/control-plane/aegisops_control_plane/action_review_projection.py
+++ b/control-plane/aegisops_control_plane/action_review_projection.py
@@ -523,7 +523,6 @@ def action_review_timeline(
     delegation_details: dict[str, object] = {}
     action_execution_details: dict[str, object] = {}
     execution_actor_identities: tuple[str, ...] = ()
-    action_execution_occurred_at: datetime | None = None
     if action_execution is not None:
         delegation_details["delegation_id"] = action_execution.delegation_id
         execution_actor_identities = service._assistant_merge_ids(
@@ -632,7 +631,7 @@ def action_review_timeline(
                 if action_execution is None
                 else action_execution.lifecycle_state
             ),
-            occurred_at=action_execution_occurred_at,
+            occurred_at=None,
             actor_identities=execution_actor_identities,
             details=(
                 {}
@@ -752,7 +751,7 @@ def action_review_coordination_ticket_outcome(
         status = "timeout"
         summary = str(terminal_issue["reason"]).replace("_", " ")
     elif terminal_issue is not None:
-        status = "timeout"
+        status = "failed"
         summary = str(terminal_issue["reason"]).replace("_", " ")
     else:
         status = "pending"

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -15,6 +15,7 @@ from typing import Iterable, Iterator, Mapping, Protocol, Type, TypeVar
 
 _DATETIME_TYPE = datetime
 
+from . import action_review_projection as _action_review_projection
 from .adapters.executor import IsolatedExecutorAdapter
 from .adapters.endpoint_evidence import EndpointEvidencePackAdapter
 from .adapters.misp import MispContextAdapter
@@ -70,6 +71,7 @@ from .reviewed_slice_policy import (
     REVIEWED_LIVE_SOURCE_FAMILIES,
     ReviewedSlicePolicy,
 )
+from .action_review_projection import _ActionReviewRecordIndex
 
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
@@ -610,43 +612,6 @@ class ReadinessDiagnosticsSnapshot:
                 "latest_reconciliation": self.latest_reconciliation,
             }
         )
-
-
-@dataclass(frozen=True)
-class _ActionReviewRecordIndex:
-    requests_by_case_id: dict[str, tuple[ActionRequestRecord, ...]]
-    requests_by_alert_id: dict[str, tuple[ActionRequestRecord, ...]]
-    requests_by_scope: dict[tuple[str | None, str | None], tuple[ActionRequestRecord, ...]]
-    approvals_by_id: dict[str, ApprovalDecisionRecord]
-    approvals_by_action_request_id: dict[str, tuple[ApprovalDecisionRecord, ...]]
-    executions_by_action_request_id: dict[str, tuple[ActionExecutionRecord, ...]]
-    reconciliations_by_action_request_id: dict[str, tuple[ReconciliationRecord, ...]]
-    reconciliations_by_approval_decision_id: dict[str, tuple[ReconciliationRecord, ...]]
-    reconciliations_by_action_execution_id: dict[str, tuple[ReconciliationRecord, ...]]
-    reconciliations_by_delegation_id: dict[str, tuple[ReconciliationRecord, ...]]
-
-    def matching_requests(
-        self,
-        *,
-        case_id: str | None,
-        alert_id: str | None,
-    ) -> tuple[ActionRequestRecord, ...]:
-        matching_by_id: dict[str, ActionRequestRecord] = {}
-        if case_id is not None:
-            for record in self.requests_by_case_id.get(case_id, ()):
-                matching_by_id[record.action_request_id] = record
-        if alert_id is not None:
-            for record in self.requests_by_alert_id.get(alert_id, ()):
-                matching_by_id[record.action_request_id] = record
-        return tuple(matching_by_id.values())
-
-    def scoped_requests(
-        self,
-        *,
-        case_id: str | None,
-        alert_id: str | None,
-    ) -> tuple[ActionRequestRecord, ...]:
-        return self.requests_by_scope.get((case_id, alert_id), ())
 
 
 def _derive_readiness_status(
@@ -2171,134 +2136,7 @@ class AegisOpsControlPlaneService:
         return self._restore_readiness_service.run_authoritative_restore_drill_snapshot()
 
     def _build_action_review_record_index(self) -> _ActionReviewRecordIndex:
-        def _freeze_grouped_records(
-            grouped_records: defaultdict[object, list[object]],
-        ) -> dict[object, tuple[object, ...]]:
-            return {
-                key: tuple(records)
-                for key, records in grouped_records.items()
-            }
-
-        action_requests = self._store.list(ActionRequestRecord)
-        if not action_requests:
-            return _ActionReviewRecordIndex(
-                requests_by_case_id={},
-                requests_by_alert_id={},
-                requests_by_scope={},
-                approvals_by_id={},
-                approvals_by_action_request_id={},
-                executions_by_action_request_id={},
-                reconciliations_by_action_request_id={},
-                reconciliations_by_approval_decision_id={},
-                reconciliations_by_action_execution_id={},
-                reconciliations_by_delegation_id={},
-            )
-        approvals = self._store.list(ApprovalDecisionRecord)
-        action_executions = self._store.list(ActionExecutionRecord)
-        reconciliations = self._store.list(ReconciliationRecord)
-
-        requests_by_case_id: defaultdict[str, list[ActionRequestRecord]] = defaultdict(list)
-        requests_by_alert_id: defaultdict[str, list[ActionRequestRecord]] = defaultdict(list)
-        requests_by_scope: defaultdict[
-            tuple[str | None, str | None],
-            list[ActionRequestRecord],
-        ] = defaultdict(list)
-        for action_request in action_requests:
-            requests_by_scope[
-                (action_request.case_id, action_request.alert_id)
-            ].append(action_request)
-            if action_request.case_id is not None:
-                requests_by_case_id[action_request.case_id].append(action_request)
-            if action_request.alert_id is not None:
-                requests_by_alert_id[action_request.alert_id].append(action_request)
-
-        approvals_by_action_request_id: defaultdict[
-            str,
-            list[ApprovalDecisionRecord],
-        ] = defaultdict(list)
-        approvals_by_id = {
-            approval.approval_decision_id: approval for approval in approvals
-        }
-        for approval in approvals:
-            approvals_by_action_request_id[approval.action_request_id].append(approval)
-
-        executions_by_action_request_id: defaultdict[
-            str,
-            list[ActionExecutionRecord],
-        ] = defaultdict(list)
-        for action_execution in action_executions:
-            executions_by_action_request_id[action_execution.action_request_id].append(
-                action_execution
-            )
-
-        reconciliations_by_action_request_id: defaultdict[
-            str,
-            list[ReconciliationRecord],
-        ] = defaultdict(list)
-        reconciliations_by_approval_decision_id: defaultdict[
-            str,
-            list[ReconciliationRecord],
-        ] = defaultdict(list)
-        reconciliations_by_action_execution_id: defaultdict[
-            str,
-            list[ReconciliationRecord],
-        ] = defaultdict(list)
-        reconciliations_by_delegation_id: defaultdict[
-            str,
-            list[ReconciliationRecord],
-        ] = defaultdict(list)
-        for reconciliation in reconciliations:
-            for action_request_id in self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "action_request_ids",
-            ):
-                reconciliations_by_action_request_id[action_request_id].append(
-                    reconciliation
-                )
-            for approval_decision_id in self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "approval_decision_ids",
-            ):
-                reconciliations_by_approval_decision_id[approval_decision_id].append(
-                    reconciliation
-                )
-            for action_execution_id in self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "action_execution_ids",
-            ):
-                reconciliations_by_action_execution_id[action_execution_id].append(
-                    reconciliation
-                )
-            for delegation_id in self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "delegation_ids",
-            ):
-                reconciliations_by_delegation_id[delegation_id].append(reconciliation)
-
-        return _ActionReviewRecordIndex(
-            requests_by_case_id=_freeze_grouped_records(requests_by_case_id),
-            requests_by_alert_id=_freeze_grouped_records(requests_by_alert_id),
-            requests_by_scope=_freeze_grouped_records(requests_by_scope),
-            approvals_by_id=approvals_by_id,
-            approvals_by_action_request_id=_freeze_grouped_records(
-                approvals_by_action_request_id
-            ),
-            executions_by_action_request_id=_freeze_grouped_records(
-                executions_by_action_request_id
-            ),
-            reconciliations_by_action_request_id=_freeze_grouped_records(
-                reconciliations_by_action_request_id
-            ),
-            reconciliations_by_approval_decision_id=_freeze_grouped_records(
-                reconciliations_by_approval_decision_id
-            ),
-            reconciliations_by_action_execution_id=_freeze_grouped_records(
-                reconciliations_by_action_execution_id
-            ),
-            reconciliations_by_delegation_id=_freeze_grouped_records(
-                reconciliations_by_delegation_id
-            ),
-        )
+        return _action_review_projection.build_action_review_record_index(self)
 
     def _action_review_chains_for_scope(
         self,
@@ -2307,53 +2145,16 @@ class AegisOpsControlPlaneService:
         alert_id: str | None,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> tuple[dict[str, object], ...]:
-        if record_index is not None:
-            matching_requests = list(
-                record_index.matching_requests(case_id=case_id, alert_id=alert_id)
-            )
-        else:
-            matching_requests = [
-                record
-                for record in self._store.list(ActionRequestRecord)
-                if (
-                    (case_id is not None and record.case_id == case_id)
-                    or (alert_id is not None and record.alert_id == alert_id)
-                )
-            ]
-        matching_requests = [
-            record
-            for record in matching_requests
-            if self._action_request_is_review_bound(record)
-        ]
-        chains = [
-            self._build_action_review_chain_snapshot(
-                action_request,
-                record_index=record_index,
-            )
-            for action_request in matching_requests
-        ]
-        chains.sort(
-            key=lambda chain: (
-                chain.get("requested_at") or datetime.min.replace(tzinfo=timezone.utc),
-                self._action_review_priority(chain),
-                chain.get("action_request_id") or "",
-            ),
-            reverse=True,
+        return _action_review_projection.action_review_chains_for_scope(
+            self,
+            case_id=case_id,
+            alert_id=alert_id,
+            record_index=record_index,
         )
-        return tuple(chains)
 
     @staticmethod
     def _action_review_priority(chain: Mapping[str, object]) -> int:
-        review_state = chain.get("review_state")
-        if review_state == "pending":
-            return 5
-        if review_state in {"approved", "executing"}:
-            return 4
-        if review_state in {"expired", "rejected"}:
-            return 3
-        if review_state == "superseded":
-            return 2
-        return 1
+        return _action_review_projection.action_review_priority(chain)
 
     def _build_action_review_chain_snapshot(
         self,
@@ -2361,139 +2162,11 @@ class AegisOpsControlPlaneService:
         *,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> dict[str, object]:
-        approval_decision = self._action_review_approval_decision(
+        return _action_review_projection.build_action_review_chain_snapshot(
+            self,
             action_request,
             record_index=record_index,
         )
-        action_execution = self._action_review_execution(
-            action_request,
-            record_index=record_index,
-        )
-        reconciliation = self._latest_action_review_reconciliation(
-            action_request=action_request,
-            approval_decision=approval_decision,
-            action_execution=action_execution,
-            record_index=record_index,
-        )
-        approval_state = self._action_review_approval_state(
-            action_request=action_request,
-            approval_decision=approval_decision,
-        )
-        review_state = self._action_review_state(
-            action_request=action_request,
-            approval_state=approval_state,
-            action_execution=action_execution,
-        )
-        timeline = self._action_review_timeline(
-            action_request=action_request,
-            approval_state=approval_state,
-            approval_decision=approval_decision,
-            action_execution=action_execution,
-            reconciliation=reconciliation,
-        )
-        mismatch_inspection = self._action_review_mismatch_inspection(reconciliation)
-        replacement_action_request = self._replacement_action_request(
-            action_request,
-            record_index=record_index,
-        )
-        requested_payload = dict(action_request.requested_payload)
-        runtime_visibility = self._action_review_runtime_visibility(
-            action_request=action_request,
-            approval_decision=approval_decision,
-            review_state=review_state,
-            record_index=record_index,
-        )
-        path_health_as_of = datetime.now(timezone.utc)
-        path_health = self._action_review_path_health(
-            action_request=action_request,
-            approval_decision=approval_decision,
-            action_execution=action_execution,
-            reconciliation=reconciliation,
-            review_state=review_state,
-            as_of=path_health_as_of,
-        )
-        coordination_ticket_outcome = self._action_review_coordination_ticket_outcome(
-            action_request=action_request,
-            approval_decision=approval_decision,
-            action_execution=action_execution,
-            reconciliation=reconciliation,
-            runtime_visibility=runtime_visibility,
-            path_health=path_health,
-            review_state=review_state,
-        )
-
-        return {
-            "review_state": review_state,
-            "next_expected_action": self._next_expected_action_for_review_state(
-                review_state
-            ),
-            "action_request_id": action_request.action_request_id,
-            "action_request_state": action_request.lifecycle_state,
-            "approval_decision_id": (
-                approval_decision.approval_decision_id if approval_decision is not None else None
-            ),
-            "approval_state": approval_state,
-            "requester_identity": action_request.requester_identity,
-            "approver_identities": (
-                approval_decision.approver_identities if approval_decision is not None else ()
-            ),
-            "decision_rationale": (
-                approval_decision.decision_rationale
-                if approval_decision is not None
-                else None
-            ),
-            "requested_at": action_request.requested_at,
-            "expires_at": action_request.expires_at,
-            "target_scope": dict(action_request.target_scope),
-            "requested_payload": requested_payload,
-            "recommendation_id": requested_payload.get("recommendation_id"),
-            "recipient_identity": requested_payload.get("recipient_identity"),
-            "message_intent": requested_payload.get("message_intent"),
-            "escalation_reason": requested_payload.get("escalation_reason"),
-            "runtime_visibility": runtime_visibility,
-            "path_health": path_health,
-            "coordination_ticket_outcome": coordination_ticket_outcome,
-            "execution_surface_type": (
-                action_execution.execution_surface_type
-                if action_execution is not None
-                else action_request.policy_evaluation.get("execution_surface_type")
-            ),
-            "execution_surface_id": (
-                action_execution.execution_surface_id
-                if action_execution is not None
-                else action_request.policy_evaluation.get("execution_surface_id")
-            ),
-            "timeline": timeline,
-            "mismatch_inspection": mismatch_inspection,
-            "action_execution_id": (
-                action_execution.action_execution_id if action_execution is not None else None
-            ),
-            "action_execution_state": (
-                action_execution.lifecycle_state if action_execution is not None else None
-            ),
-            "delegation_id": (
-                action_execution.delegation_id if action_execution is not None else None
-            ),
-            "execution_run_id": (
-                action_execution.execution_run_id if action_execution is not None else None
-            ),
-            "reconciliation_id": (
-                reconciliation.reconciliation_id if reconciliation is not None else None
-            ),
-            "reconciliation_state": (
-                reconciliation.lifecycle_state if reconciliation is not None else None
-            ),
-            "replacement_action_request_id": (
-                replacement_action_request.action_request_id
-                if replacement_action_request is not None
-                else None
-            ),
-            "replacement_approval_decision_id": (
-                replacement_action_request.approval_decision_id
-                if replacement_action_request is not None
-                else None
-            ),
-        }
 
     def _action_review_path_health(
         self,
@@ -2505,68 +2178,15 @@ class AegisOpsControlPlaneService:
         review_state: str,
         as_of: datetime,
     ) -> dict[str, object]:
-        if action_execution is None and reconciliation is None:
-            if review_state in {"rejected", "expired", "superseded", "canceled"}:
-                paths = self._action_review_terminal_non_delegated_path_health()
-            elif (
-                review_state == "unresolved"
-                and approval_decision is not None
-                and approval_decision.lifecycle_state == "approved"
-            ):
-                paths = self._action_review_unresolved_without_execution_path_health()
-            else:
-                paths = {
-                    "ingest": self._action_review_ingest_path_health(reconciliation),
-                    "delegation": self._action_review_delegation_path_health(
-                        action_request=action_request,
-                        approval_decision=approval_decision,
-                        action_execution=action_execution,
-                        review_state=review_state,
-                    ),
-                    "provider": self._action_review_provider_path_health(action_execution),
-                    "persistence": self._action_review_persistence_path_health(
-                        reconciliation
-                    ),
-                }
-        elif action_execution is None:
-            paths = self._action_review_reconciliation_without_execution_path_health(
-                action_request=action_request,
-                approval_decision=approval_decision,
-                reconciliation=reconciliation,
-                review_state=review_state,
-            )
-        else:
-            paths = {
-                "ingest": self._action_review_ingest_path_health(reconciliation),
-                "delegation": self._action_review_delegation_path_health(
-                    action_request=action_request,
-                    approval_decision=approval_decision,
-                    action_execution=action_execution,
-                    review_state=review_state,
-                ),
-                "provider": self._action_review_provider_path_health(action_execution),
-                "persistence": self._action_review_persistence_path_health(reconciliation),
-            }
-        deadline = self._action_review_visibility_deadline(
+        return _action_review_projection.action_review_path_health(
+            self,
             action_request=action_request,
             approval_decision=approval_decision,
             action_execution=action_execution,
+            reconciliation=reconciliation,
+            review_state=review_state,
+            as_of=as_of,
         )
-        if deadline is not None and deadline <= as_of:
-            paths = self._action_review_overdue_path_health(
-                review_state=review_state,
-                action_execution=action_execution,
-                paths=paths,
-            )
-        overall_state = self._action_review_overall_path_state(paths.values())
-        return {
-            "overall_state": overall_state,
-            "summary": self._action_review_path_health_summary(
-                overall_state=overall_state,
-                paths=paths,
-            ),
-            "paths": paths,
-        }
 
     @staticmethod
     def _action_review_terminal_non_delegated_path_health() -> dict[str, dict[str, str]]:
@@ -3612,43 +3232,13 @@ class AegisOpsControlPlaneService:
         review_state: str,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> dict[str, object] | None:
-        reviewed_context = self._action_review_visibility_context(action_request)
-        if reviewed_context is None:
-            return None
-
-        allow_unscoped_action_visibility = self._case_has_single_review_bound_action_request(
-            action_request.case_id,
+        return _action_review_projection.action_review_runtime_visibility(
+            self,
+            action_request=action_request,
+            approval_decision=approval_decision,
+            review_state=review_state,
             record_index=record_index,
         )
-        visibility: dict[str, object] = {}
-        after_hours_handoff = self._action_review_after_hours_handoff_visibility(
-            reviewed_context=reviewed_context,
-            review_state=review_state,
-        )
-        if after_hours_handoff is not None:
-            visibility["after_hours_handoff"] = after_hours_handoff
-
-        manual_fallback = self._action_review_manual_fallback_visibility(
-            reviewed_context=reviewed_context,
-            action_request=action_request,
-            approval_decision=approval_decision,
-            review_state=review_state,
-            allow_unscoped_context=allow_unscoped_action_visibility,
-        )
-        if manual_fallback is not None:
-            visibility["manual_fallback"] = manual_fallback
-
-        escalation_notes = self._action_review_escalation_visibility(
-            reviewed_context=reviewed_context,
-            action_request=action_request,
-            approval_decision=approval_decision,
-            review_state=review_state,
-            allow_unscoped_context=allow_unscoped_action_visibility,
-        )
-        if escalation_notes is not None:
-            visibility["escalation_notes"] = escalation_notes
-
-        return visibility or None
 
     @staticmethod
     def _action_review_after_hours_handoff_visibility(
@@ -4253,178 +3843,22 @@ class AegisOpsControlPlaneService:
         action_execution: ActionExecutionRecord | None,
         reconciliation: ReconciliationRecord | None,
     ) -> tuple[dict[str, object], ...]:
-        delegation_details: dict[str, object] = {}
-        action_execution_details: dict[str, object] = {}
-        execution_actor_identities: tuple[str, ...] = ()
-        action_execution_occurred_at: datetime | None = None
-        if action_execution is not None:
-            delegation_details["delegation_id"] = action_execution.delegation_id
-            execution_actor_identities = self._assistant_merge_ids(
-                action_execution.provenance.get("initiated_by"),
-                action_execution.provenance.get("delegation_issuer"),
-            )
-            downstream_binding = action_execution.provenance.get("downstream_binding")
-            if isinstance(downstream_binding, Mapping):
-                delegation_details["downstream_binding"] = dict(downstream_binding)
-            adapter = action_execution.provenance.get("adapter")
-            if isinstance(adapter, str) and adapter.strip():
-                action_execution_details["adapter"] = adapter
-            adapter_base_url = action_execution.provenance.get("adapter_base_url")
-            if isinstance(adapter_base_url, str) and adapter_base_url.strip():
-                action_execution_details["adapter_base_url"] = adapter_base_url
-        timeline = (
-            self._action_review_stage_snapshot(
-                stage="action_request",
-                record_family="action_request",
-                record_id=action_request.action_request_id,
-                state=action_request.lifecycle_state,
-                occurred_at=action_request.requested_at,
-                actor_identities=(
-                    ()
-                    if action_request.requester_identity is None
-                    else (action_request.requester_identity,)
-                ),
-                details={
-                    "recipient_identity": action_request.requested_payload.get(
-                        "recipient_identity"
-                    ),
-                    "execution_surface_type": action_request.policy_evaluation.get(
-                        "execution_surface_type"
-                    ),
-                    "execution_surface_id": action_request.policy_evaluation.get(
-                        "execution_surface_id"
-                    ),
-                },
-            ),
-            self._action_review_stage_snapshot(
-                stage="approval_decision",
-                record_family="approval_decision",
-                record_id=(
-                    None
-                    if approval_decision is None
-                    else approval_decision.approval_decision_id
-                ),
-                state=(
-                    approval_decision.lifecycle_state
-                    if approval_decision is not None
-                    else (approval_state or "pending")
-                ),
-                occurred_at=(
-                    None if approval_decision is None else approval_decision.decided_at
-                ),
-                actor_identities=(
-                    ()
-                    if approval_decision is None
-                    else approval_decision.approver_identities
-                ),
-                details=(
-                    {}
-                    if approval_decision is None
-                    or approval_decision.decision_rationale is None
-                    else {
-                        "decision_rationale": approval_decision.decision_rationale,
-                    }
-                ),
-            ),
-            self._action_review_stage_snapshot(
-                stage="delegation",
-                record_family="action_execution",
-                record_id=(
-                    None
-                    if action_execution is None
-                    else action_execution.action_execution_id
-                ),
-                state=(
-                    "awaiting_delegation"
-                    if action_execution is None
-                    else "delegated"
-                ),
-                occurred_at=(
-                    None if action_execution is None else action_execution.delegated_at
-                ),
-                actor_identities=(
-                    ()
-                    if action_execution is None
-                    else self._assistant_ids_from_mapping(
-                        action_execution.provenance,
-                        "delegation_issuer",
-                    )
-                ),
-                details=delegation_details,
-            ),
-            self._action_review_stage_snapshot(
-                stage="action_execution",
-                record_family="action_execution",
-                record_id=(
-                    None
-                    if action_execution is None
-                    else action_execution.action_execution_id
-                ),
-                state=(
-                    "awaiting_execution"
-                    if action_execution is None
-                    else action_execution.lifecycle_state
-                ),
-                occurred_at=action_execution_occurred_at,
-                actor_identities=execution_actor_identities,
-                details=(
-                    {}
-                    if action_execution is None
-                    else {
-                        "execution_run_id": action_execution.execution_run_id,
-                        "execution_surface_type": action_execution.execution_surface_type,
-                        "execution_surface_id": action_execution.execution_surface_id,
-                        **action_execution_details,
-                    }
-                ),
-            ),
-            self._action_review_stage_snapshot(
-                stage="reconciliation",
-                record_family="reconciliation",
-                record_id=(
-                    None if reconciliation is None else reconciliation.reconciliation_id
-                ),
-                state=(
-                    "awaiting_reconciliation"
-                    if reconciliation is None
-                    else reconciliation.lifecycle_state
-                ),
-                occurred_at=(
-                    None if reconciliation is None else reconciliation.compared_at
-                ),
-                details=(
-                    {}
-                    if reconciliation is None
-                    else {
-                        "ingest_disposition": reconciliation.ingest_disposition,
-                        "execution_run_id": reconciliation.execution_run_id,
-                    }
-                ),
-            ),
+        return _action_review_projection.action_review_timeline(
+            self,
+            action_request=action_request,
+            approval_state=approval_state,
+            approval_decision=approval_decision,
+            action_execution=action_execution,
+            reconciliation=reconciliation,
         )
-        return timeline
 
     @staticmethod
     def _action_review_mismatch_inspection(
         reconciliation: ReconciliationRecord | None,
     ) -> dict[str, object] | None:
-        if reconciliation is None:
-            return None
-        if reconciliation.lifecycle_state not in {"pending", "mismatched", "stale"}:
-            return None
-        return {
-            "reconciliation_id": reconciliation.reconciliation_id,
-            "lifecycle_state": reconciliation.lifecycle_state,
-            "ingest_disposition": reconciliation.ingest_disposition,
-            "mismatch_summary": reconciliation.mismatch_summary,
-            "correlation_key": reconciliation.correlation_key,
-            "execution_run_id": reconciliation.execution_run_id,
-            "linked_execution_run_ids": reconciliation.linked_execution_run_ids,
-            "subject_linkage": dict(reconciliation.subject_linkage),
-            "first_seen_at": reconciliation.first_seen_at,
-            "last_seen_at": reconciliation.last_seen_at,
-            "compared_at": reconciliation.compared_at,
-        }
+        return _action_review_projection.action_review_mismatch_inspection(
+            reconciliation
+        )
 
     def _action_review_coordination_ticket_outcome(
         self,
@@ -4437,148 +3871,32 @@ class AegisOpsControlPlaneService:
         path_health: Mapping[str, object],
         review_state: str,
     ) -> dict[str, object] | None:
-        requested_payload = action_request.requested_payload
-        if requested_payload.get("action_type") != "create_tracking_ticket":
-            return None
-        if (
-            action_execution is None
-            and reconciliation is None
-            and review_state in {"rejected", "expired", "superseded", "canceled"}
-        ):
-            return None
-
-        downstream_binding = self._action_review_downstream_binding(action_execution)
-        mismatch = self._action_review_coordination_ticket_mismatch(reconciliation)
-        terminal_issue = self._action_review_coordination_ticket_terminal_issue(
+        return _action_review_projection.action_review_coordination_ticket_outcome(
+            self,
+            action_request=action_request,
+            approval_decision=approval_decision,
             action_execution=action_execution,
+            reconciliation=reconciliation,
+            runtime_visibility=runtime_visibility,
             path_health=path_health,
+            review_state=review_state,
         )
-        manual_fallback = None
-        if isinstance(runtime_visibility, Mapping):
-            manual_fallback_entry = runtime_visibility.get("manual_fallback")
-            if isinstance(manual_fallback_entry, Mapping):
-                manual_fallback = dict(manual_fallback_entry)
-
-        if (
-            reconciliation is not None
-            and reconciliation.lifecycle_state == "matched"
-            and action_execution is not None
-            and action_execution.lifecycle_state == "succeeded"
-        ):
-            status = "created"
-            summary = (
-                "reviewed create-ticket outcome recorded from authoritative "
-                "execution and reconciliation"
-            )
-        elif manual_fallback is not None:
-            status = "manual_fallback"
-            summary = str(
-                manual_fallback.get("action_taken")
-                or manual_fallback.get("reason")
-                or "reviewed create-ticket outcome recorded as manual fallback"
-            )
-        elif mismatch is not None:
-            status = "mismatch"
-            summary = str(mismatch["mismatch_summary"])
-        elif terminal_issue is not None and terminal_issue["category"] == "timeout":
-            status = "timeout"
-            summary = str(terminal_issue["reason"]).replace("_", " ")
-        elif terminal_issue is not None:
-            status = "timeout"
-            summary = str(terminal_issue["reason"]).replace("_", " ")
-        else:
-            status = "pending"
-            summary = "reviewed create-ticket outcome still awaiting authoritative result"
-
-        outcome = {
-            "authority": "authoritative_aegisops_review",
-            "status": status,
-            "summary": summary,
-            "action_request_id": action_request.action_request_id,
-            "approval_decision_id": (
-                None if approval_decision is None else approval_decision.approval_decision_id
-            ),
-            "action_execution_id": (
-                None if action_execution is None else action_execution.action_execution_id
-            ),
-            "execution_run_id": (
-                None if action_execution is None else action_execution.execution_run_id
-            ),
-            "reconciliation_id": (
-                None if reconciliation is None else reconciliation.reconciliation_id
-            ),
-            "coordination_reference_id": (
-                action_request.target_scope.get("coordination_reference_id")
-                if isinstance(action_request.target_scope.get("coordination_reference_id"), str)
-                else requested_payload.get("coordination_reference_id")
-            ),
-            "coordination_target_type": (
-                action_request.target_scope.get("coordination_target_type")
-                if isinstance(action_request.target_scope.get("coordination_target_type"), str)
-                else requested_payload.get("coordination_target_type")
-            ),
-            "coordination_target_id": (
-                None
-                if downstream_binding is None
-                else downstream_binding.get("coordination_target_id")
-            ),
-            "external_receipt_id": (
-                None
-                if downstream_binding is None
-                else downstream_binding.get("external_receipt_id")
-            ),
-            "ticket_reference_url": (
-                None
-                if downstream_binding is None
-                else downstream_binding.get("ticket_reference_url")
-            ),
-        }
-        if terminal_issue is not None and terminal_issue["category"] == "timeout":
-            timeout = {
-                key: value
-                for key, value in terminal_issue.items()
-                if key != "category"
-            }
-            outcome["timeout"] = timeout
-        elif terminal_issue is not None:
-            timeout = {
-                key: value
-                for key, value in terminal_issue.items()
-                if key != "category"
-            }
-            outcome["timeout"] = timeout
-        if mismatch is not None:
-            outcome["mismatch"] = mismatch
-        if manual_fallback is not None:
-            outcome["manual_fallback"] = manual_fallback
-        return outcome
 
     @staticmethod
     def _action_review_downstream_binding(
         action_execution: ActionExecutionRecord | None,
     ) -> Mapping[str, object] | None:
-        if action_execution is None or not isinstance(action_execution.provenance, Mapping):
-            return None
-        downstream_binding = action_execution.provenance.get("downstream_binding")
-        if not isinstance(downstream_binding, Mapping):
-            return None
-        return downstream_binding
+        return _action_review_projection.action_review_downstream_binding(
+            action_execution
+        )
 
     @staticmethod
     def _action_review_coordination_ticket_mismatch(
         reconciliation: ReconciliationRecord | None,
     ) -> dict[str, object] | None:
-        mismatch = AegisOpsControlPlaneService._action_review_mismatch_inspection(
+        return _action_review_projection.action_review_coordination_ticket_mismatch(
             reconciliation
         )
-        if mismatch is None:
-            return None
-        if (
-            mismatch["lifecycle_state"] != "mismatched"
-            and mismatch["ingest_disposition"] != "mismatch"
-        ):
-            return None
-        return mismatch
 
     @staticmethod
     def _action_review_coordination_ticket_terminal_issue(
@@ -4586,65 +3904,10 @@ class AegisOpsControlPlaneService:
         action_execution: ActionExecutionRecord | None,
         path_health: Mapping[str, object],
     ) -> dict[str, object] | None:
-        if (
-            action_execution is not None
-            and isinstance(action_execution.provenance, Mapping)
-            and isinstance(action_execution.provenance.get("dispatch_failure"), Mapping)
-        ):
-            dispatch_failure = action_execution.provenance["dispatch_failure"]
-            if dispatch_failure.get("error_type") == "TimeoutError":
-                timeout = {
-                    "category": "timeout",
-                    "path": "provider",
-                    "reason": "dispatch_timeout",
-                }
-                error = dispatch_failure.get("error")
-                if isinstance(error, str) and error:
-                    timeout["error"] = error
-                return timeout
-
-        paths = path_health.get("paths")
-        if not isinstance(paths, Mapping):
-            return None
-        timeout_reasons = {
-            "ingest_signal_timeout",
-            "delegation_receipt_timeout",
-            "provider_receipt_timeout",
-            "authoritative_outcome_timeout",
-            "reconciliation_timeout",
-        }
-        terminal_failure_reasons = {
-            "execution_failed",
-            "execution_canceled",
-            "execution_expired",
-            "execution_rejected",
-        }
-        provider_path = paths.get("provider")
-        if isinstance(provider_path, Mapping):
-            provider_reason = provider_path.get("reason")
-            if (
-                isinstance(provider_reason, str)
-                and provider_reason in terminal_failure_reasons
-            ):
-                return {
-                    "category": "failed",
-                    "path": "provider",
-                    "reason": provider_reason,
-                }
-        for path_name in ("ingest", "delegation", "provider", "persistence"):
-            path = paths.get(path_name)
-            if not isinstance(path, Mapping):
-                continue
-            reason = path.get("reason")
-            if not isinstance(reason, str):
-                continue
-            if reason in timeout_reasons:
-                return {
-                    "category": "timeout",
-                    "path": path_name,
-                    "reason": reason,
-                }
-        return None
+        return _action_review_projection.action_review_coordination_ticket_terminal_issue(
+            action_execution=action_execution,
+            path_health=path_health,
+        )
 
     def inspect_analyst_queue(self) -> AnalystQueueSnapshot:
         active_alert_states = {

--- a/control-plane/tests/test_cli_inspection_action_reviews.py
+++ b/control-plane/tests/test_cli_inspection_action_reviews.py
@@ -1296,7 +1296,7 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
 
         payload = json.loads(stdout.getvalue())
         review = payload["current_action_review"]
-        self.assertEqual(review["coordination_ticket_outcome"]["status"], "timeout")
+        self.assertEqual(review["coordination_ticket_outcome"]["status"], "failed")
         self.assertEqual(
             review["coordination_ticket_outcome"]["timeout"]["reason"],
             "execution_failed",
@@ -1370,7 +1370,7 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
             review["path_health"]["paths"]["persistence"]["reason"],
             "reconciliation_timeout",
         )
-        self.assertEqual(review["coordination_ticket_outcome"]["status"], "timeout")
+        self.assertEqual(review["coordination_ticket_outcome"]["status"], "failed")
         self.assertEqual(
             review["coordination_ticket_outcome"]["timeout"]["reason"],
             "execution_failed",

--- a/control-plane/tests/test_cli_inspection_action_reviews.py
+++ b/control-plane/tests/test_cli_inspection_action_reviews.py
@@ -1266,7 +1266,7 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
             "provider",
         )
 
-    def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_provider_failure_as_timeout(
+    def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_provider_failure(
         self,
     ) -> None:
         _, service, promoted_case, _evidence_id, reviewed_at = self._build_phase19_in_scope_case()
@@ -1298,13 +1298,14 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
         review = payload["current_action_review"]
         self.assertEqual(review["coordination_ticket_outcome"]["status"], "failed")
         self.assertEqual(
-            review["coordination_ticket_outcome"]["timeout"]["reason"],
+            review["coordination_ticket_outcome"]["terminal_issue"]["reason"],
             "execution_failed",
         )
         self.assertEqual(
-            review["coordination_ticket_outcome"]["timeout"]["path"],
+            review["coordination_ticket_outcome"]["terminal_issue"]["path"],
             "provider",
         )
+        self.assertNotIn("timeout", review["coordination_ticket_outcome"])
 
     def test_cli_inspect_case_detail_prefers_provider_failure_over_derived_timeouts(
         self,
@@ -1372,13 +1373,14 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
         )
         self.assertEqual(review["coordination_ticket_outcome"]["status"], "failed")
         self.assertEqual(
-            review["coordination_ticket_outcome"]["timeout"]["reason"],
+            review["coordination_ticket_outcome"]["terminal_issue"]["reason"],
             "execution_failed",
         )
         self.assertEqual(
-            review["coordination_ticket_outcome"]["timeout"]["path"],
+            review["coordination_ticket_outcome"]["terminal_issue"]["path"],
             "provider",
         )
+        self.assertNotIn("timeout", review["coordination_ticket_outcome"])
 
     def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_manual_fallback(
         self,

--- a/control-plane/tests/test_phase26_end_to_end_validation.py
+++ b/control-plane/tests/test_phase26_end_to_end_validation.py
@@ -211,7 +211,7 @@ class Phase26EndToEndValidationTests(unittest.TestCase):
         outcome = review["coordination_ticket_outcome"]
 
         self.assertEqual(review["action_execution_state"], "failed")
-        self.assertEqual(outcome["status"], "timeout")
+        self.assertEqual(outcome["status"], "failed")
         self.assertEqual(outcome["timeout"]["path"], "provider")
         self.assertEqual(outcome["timeout"]["reason"], "execution_failed")
         self.assertEqual(

--- a/control-plane/tests/test_phase26_end_to_end_validation.py
+++ b/control-plane/tests/test_phase26_end_to_end_validation.py
@@ -212,8 +212,9 @@ class Phase26EndToEndValidationTests(unittest.TestCase):
 
         self.assertEqual(review["action_execution_state"], "failed")
         self.assertEqual(outcome["status"], "failed")
-        self.assertEqual(outcome["timeout"]["path"], "provider")
-        self.assertEqual(outcome["timeout"]["reason"], "execution_failed")
+        self.assertEqual(outcome["terminal_issue"]["path"], "provider")
+        self.assertEqual(outcome["terminal_issue"]["reason"], "execution_failed")
+        self.assertNotIn("timeout", outcome)
         self.assertEqual(
             store.list(cli_inspection_tests.ActionExecutionRecord)[0].provenance[
                 "dispatch_failure"

--- a/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
@@ -1123,6 +1123,72 @@ class ActionReviewSurfacePersistenceTests(ServicePersistenceTestBase):
             ],
             replacement_request.action_request_id,
         )
+
+    def test_service_action_review_surfaces_require_exact_case_and_alert_scope_match(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep case detail scoped to the authoritative case and alert pair.",
+            lead_id=lead.lead_id,
+        )
+        matching_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-exact-scope-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-surface-exact-scope-001",
+        )
+        service.persist_record(
+            replace(
+                matching_request,
+                action_request_id="action-request-surface-exact-scope-sibling-001",
+                alert_id="alert-surface-exact-scope-sibling-001",
+                idempotency_key="idempotency-surface-exact-scope-sibling-001",
+                requested_at=matching_request.requested_at + timedelta(minutes=15),
+            )
+        )
+        service.persist_record(
+            replace(
+                matching_request,
+                action_request_id="action-request-surface-exact-scope-sibling-002",
+                case_id="case-surface-exact-scope-sibling-001",
+                idempotency_key="idempotency-surface-exact-scope-sibling-002",
+                requested_at=matching_request.requested_at + timedelta(minutes=30),
+            )
+        )
+
+        case_snapshot = service.inspect_case_detail(promoted_case.case_id).to_dict()
+
+        self.assertEqual(
+            case_snapshot["current_action_review"]["action_request_id"],
+            matching_request.action_request_id,
+        )
+        self.assertEqual(
+            [record["action_request_id"] for record in case_snapshot["action_reviews"]],
+            [matching_request.action_request_id],
+        )
+
     def test_approved_payload_binding_hash_normalizes_equivalent_datetime_offsets(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
@@ -10,6 +10,7 @@ if str(TESTS_ROOT) not in sys.path:
     sys.path.insert(0, str(TESTS_ROOT))
 
 import _service_persistence_support as support
+from aegisops_control_plane import action_review_projection
 from _service_persistence_support import (
     ActionExecutionRecord,
     ActionRequestRecord,
@@ -29,6 +30,62 @@ from _service_persistence_support import (
 )
 
 class ActionReviewSurfacePersistenceTests(ServicePersistenceTestBase):
+    def test_service_delegates_action_review_chain_snapshot_to_projection_module(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-projection-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-projection-delegation-001",
+        )
+        record_index = service._build_action_review_record_index()
+        sentinel = {"review_state": "delegated-to-module"}
+
+        with support.mock.patch.object(
+            action_review_projection,
+            "build_action_review_chain_snapshot",
+            autospec=True,
+            return_value=sentinel,
+        ) as build_snapshot:
+            result = service._build_action_review_chain_snapshot(
+                action_request,
+                record_index=record_index,
+            )
+
+        self.assertIs(result, sentinel)
+        build_snapshot.assert_called_once_with(
+            service,
+            action_request,
+            record_index=record_index,
+        )
+
     def test_service_inspects_action_review_states_on_queue_alert_and_case_surfaces(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- extract action-review projection and visibility assembly into a dedicated internal module
- keep AegisOpsControlPlaneService as the stable orchestration entrypoint via thin wrappers
- add a regression test proving chain snapshot assembly delegates through the projection module

## Testing
- python3 -m unittest control-plane.tests.test_cli_inspection_action_reviews
- python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_review_surfaces
- python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests
- python3 -m unittest control-plane.tests.test_cli_inspection_action_reviews control-plane.tests.test_service_persistence_action_reconciliation_review_surfaces control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests

Refs #605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Action-review logic moved into a dedicated projection component; service now delegates chain/index construction to that component.

* **Bug Fixes**
  * Coordination outcome classification: create-tracking-ticket provider/dispatch failures are reported as "failed" (with terminal_issue details) instead of "timeout".

* **Tests**
  * Added/updated tests to verify delegation to the projection component and the revised coordination outcome shape and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->