### PR TITLE
refactor: extract detection admission and alert-case lifecycle out of control-plane service.py (#607)

### DIFF
--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -1026,12 +1026,13 @@ class PostgresControlPlaneStore:
             try:
                 cursor.execute(query, params)
                 row = cursor.fetchone()
+                mapping = None if row is None else _row_to_mapping(cursor, row)
             finally:
                 cursor.close()
 
-        if row is None:
+        if mapping is None:
             return None
-        return self._row_to_record(ReconciliationRecord, _row_to_mapping(cursor, row))
+        return self._row_to_record(ReconciliationRecord, mapping)
 
     def latest_lifecycle_transition(
         self,

--- a/control-plane/aegisops_control_plane/adapters/postgres.py
+++ b/control-plane/aegisops_control_plane/adapters/postgres.py
@@ -1004,6 +1004,35 @@ class PostgresControlPlaneStore:
             for row in rows
         )
 
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> ReconciliationRecord | None:
+        table = self._table_config(ReconciliationRecord)
+        query = (
+            f"select {', '.join(table.record_fields)} "
+            f"from aegisops_control.{table.table_name} "
+            "where correlation_key = %s"
+        )
+        params: tuple[object, ...] = (correlation_key,)
+        if require_alert_id:
+            query += " and alert_id is not null"
+        query += " order by compared_at desc, reconciliation_id desc limit 1"
+
+        with self._borrow_connection() as connection:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(query, params)
+                row = cursor.fetchone()
+            finally:
+                cursor.close()
+
+        if row is None:
+            return None
+        return self._row_to_record(ReconciliationRecord, _row_to_mapping(cursor, row))
+
     def latest_lifecycle_transition(
         self,
         record_family: str,

--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -558,33 +558,41 @@ class DetectionLifecycleService:
         substrate_detection_record_id: str,
     ) -> FindingAlertIngestResult:
         service = self._service
-        source_system = service._normalize_optional_string(
-            record.metadata.get("source_system"),
-            "metadata.source_system",
-        ) or record.substrate_key
-        evidence_id = f"evidence-{uuid.uuid5(uuid.NAMESPACE_URL, substrate_detection_record_id)}"
-        case_id = ingest_result.alert.case_id
-        evidence = service.persist_record(
-            EvidenceRecord(
-                evidence_id=evidence_id,
-                source_record_id=substrate_detection_record_id,
-                alert_id=ingest_result.alert.alert_id,
-                case_id=case_id,
-                source_system=source_system,
-                collector_identity=f"{record.substrate_key}-native-detection-adapter",
-                acquired_at=service._require_aware_datetime(
-                    record.first_seen_at,
-                    "record.first_seen_at",
-                ),
-                derivation_relationship="native_detection_record",
-                lifecycle_state="linked" if case_id is not None else "collected",
-                provenance={},
-                content={},
+        with service._store.transaction():
+            source_system = service._normalize_optional_string(
+                record.metadata.get("source_system"),
+                "metadata.source_system",
+            ) or record.substrate_key
+            evidence_id = (
+                f"evidence-{uuid.uuid5(uuid.NAMESPACE_URL, substrate_detection_record_id)}"
             )
-        )
+            case_id = ingest_result.alert.case_id
+            existing_case = None
+            if case_id is not None:
+                existing_case = service._store.get(CaseRecord, case_id)
+                if existing_case is None:
+                    raise LookupError(
+                        f"Alert {ingest_result.alert.alert_id!r} references missing case {case_id!r}"
+                    )
+            evidence = service.persist_record(
+                EvidenceRecord(
+                    evidence_id=evidence_id,
+                    source_record_id=substrate_detection_record_id,
+                    alert_id=ingest_result.alert.alert_id,
+                    case_id=case_id,
+                    source_system=source_system,
+                    collector_identity=f"{record.substrate_key}-native-detection-adapter",
+                    acquired_at=service._require_aware_datetime(
+                        record.first_seen_at,
+                        "record.first_seen_at",
+                    ),
+                    derivation_relationship="native_detection_record",
+                    lifecycle_state="linked" if case_id is not None else "collected",
+                    provenance={},
+                    content={},
+                )
+            )
 
-        if case_id is not None:
-            existing_case = service._store.get(CaseRecord, case_id)
             if existing_case is not None:
                 merged_case_evidence_ids = service._merge_linked_ids(
                     existing_case.evidence_ids,
@@ -606,91 +614,95 @@ class DetectionLifecycleService:
                         )
                     )
 
-        subject_linkage = dict(ingest_result.reconciliation.subject_linkage)
-        subject_linkage["evidence_ids"] = service._merge_linked_ids(
-            subject_linkage.get("evidence_ids"),
-            evidence.evidence_id,
-        )
-        subject_linkage["source_systems"] = service._merge_linked_ids(
-            subject_linkage.get("source_systems"),
-            source_system,
-        )
-
-        source_provenance = record.metadata.get("source_provenance")
-        if isinstance(source_provenance, Mapping):
-            accountable_source_identity = service._normalize_optional_string(
-                source_provenance.get("accountable_source_identity"),
-                "metadata.source_provenance.accountable_source_identity",
+            subject_linkage = dict(ingest_result.reconciliation.subject_linkage)
+            subject_linkage["evidence_ids"] = service._merge_linked_ids(
+                subject_linkage.get("evidence_ids"),
+                evidence.evidence_id,
             )
-            if accountable_source_identity is not None:
-                subject_linkage["accountable_source_identities"] = (
-                    service._merge_linked_ids(
-                        subject_linkage.get("accountable_source_identities"),
-                        accountable_source_identity,
+            subject_linkage["source_systems"] = service._merge_linked_ids(
+                subject_linkage.get("source_systems"),
+                source_system,
+            )
+
+            source_provenance = record.metadata.get("source_provenance")
+            if isinstance(source_provenance, Mapping):
+                accountable_source_identity = service._normalize_optional_string(
+                    source_provenance.get("accountable_source_identity"),
+                    "metadata.source_provenance.accountable_source_identity",
+                )
+                if accountable_source_identity is not None:
+                    subject_linkage["accountable_source_identities"] = (
+                        service._merge_linked_ids(
+                            subject_linkage.get("accountable_source_identities"),
+                            accountable_source_identity,
+                        )
                     )
+
+            native_rule = record.metadata.get("native_rule")
+            if isinstance(native_rule, Mapping):
+                native_rule_id = service._normalize_optional_string(
+                    native_rule.get("id"),
+                    "metadata.native_rule.id",
+                )
+                native_rule_description = service._normalize_optional_string(
+                    native_rule.get("description"),
+                    "metadata.native_rule.description",
+                )
+                rule_level = native_rule.get("level")
+                subject_linkage["latest_native_rule"] = {
+                    "id": native_rule_id,
+                    "level": rule_level if isinstance(rule_level, int) else None,
+                    "description": native_rule_description,
+                }
+
+            reviewed_correlation_context = record.metadata.get(
+                "reviewed_correlation_context"
+            )
+            if isinstance(reviewed_correlation_context, Mapping):
+                subject_linkage["reviewed_correlation_context"] = {
+                    str(field_name): field_value
+                    for field_name, field_value in reviewed_correlation_context.items()
+                    if isinstance(field_value, str) and field_value.strip()
+                }
+
+            reviewed_source_profile = record.metadata.get("reviewed_source_profile")
+            if isinstance(reviewed_source_profile, Mapping):
+                subject_linkage["reviewed_source_profile"] = dict(
+                    reviewed_source_profile
                 )
 
-        native_rule = record.metadata.get("native_rule")
-        if isinstance(native_rule, Mapping):
-            native_rule_id = service._normalize_optional_string(
-                native_rule.get("id"),
-                "metadata.native_rule.id",
+            raw_alert = record.metadata.get("raw_alert")
+            if isinstance(raw_alert, Mapping):
+                subject_linkage["latest_native_payload"] = dict(raw_alert)
+
+            admission_provenance = self._normalize_admission_provenance(
+                record.metadata.get("admission_provenance")
             )
-            native_rule_description = service._normalize_optional_string(
-                native_rule.get("description"),
-                "metadata.native_rule.description",
+            if admission_provenance is not None:
+                subject_linkage["admission_provenance"] = admission_provenance
+
+            reconciliation = service.persist_record(
+                ReconciliationRecord(
+                    reconciliation_id=ingest_result.reconciliation.reconciliation_id,
+                    subject_linkage=subject_linkage,
+                    alert_id=ingest_result.reconciliation.alert_id,
+                    finding_id=ingest_result.reconciliation.finding_id,
+                    analytic_signal_id=ingest_result.reconciliation.analytic_signal_id,
+                    execution_run_id=ingest_result.reconciliation.execution_run_id,
+                    linked_execution_run_ids=(
+                        ingest_result.reconciliation.linked_execution_run_ids
+                    ),
+                    correlation_key=ingest_result.reconciliation.correlation_key,
+                    first_seen_at=ingest_result.reconciliation.first_seen_at,
+                    last_seen_at=ingest_result.reconciliation.last_seen_at,
+                    ingest_disposition=ingest_result.reconciliation.ingest_disposition,
+                    mismatch_summary=ingest_result.reconciliation.mismatch_summary,
+                    compared_at=ingest_result.reconciliation.compared_at,
+                    lifecycle_state=ingest_result.reconciliation.lifecycle_state,
+                )
             )
-            rule_level = native_rule.get("level")
-            subject_linkage["latest_native_rule"] = {
-                "id": native_rule_id,
-                "level": rule_level if isinstance(rule_level, int) else None,
-                "description": native_rule_description,
-            }
-
-        reviewed_correlation_context = record.metadata.get("reviewed_correlation_context")
-        if isinstance(reviewed_correlation_context, Mapping):
-            subject_linkage["reviewed_correlation_context"] = {
-                str(field_name): field_value
-                for field_name, field_value in reviewed_correlation_context.items()
-                if isinstance(field_value, str) and field_value.strip()
-            }
-
-        reviewed_source_profile = record.metadata.get("reviewed_source_profile")
-        if isinstance(reviewed_source_profile, Mapping):
-            subject_linkage["reviewed_source_profile"] = dict(reviewed_source_profile)
-
-        raw_alert = record.metadata.get("raw_alert")
-        if isinstance(raw_alert, Mapping):
-            subject_linkage["latest_native_payload"] = dict(raw_alert)
-
-        admission_provenance = self._normalize_admission_provenance(
-            record.metadata.get("admission_provenance")
-        )
-        if admission_provenance is not None:
-            subject_linkage["admission_provenance"] = admission_provenance
-
-        reconciliation = service.persist_record(
-            ReconciliationRecord(
-                reconciliation_id=ingest_result.reconciliation.reconciliation_id,
-                subject_linkage=subject_linkage,
-                alert_id=ingest_result.reconciliation.alert_id,
-                finding_id=ingest_result.reconciliation.finding_id,
-                analytic_signal_id=ingest_result.reconciliation.analytic_signal_id,
-                execution_run_id=ingest_result.reconciliation.execution_run_id,
-                linked_execution_run_ids=(
-                    ingest_result.reconciliation.linked_execution_run_ids
-                ),
-                correlation_key=ingest_result.reconciliation.correlation_key,
-                first_seen_at=ingest_result.reconciliation.first_seen_at,
-                last_seen_at=ingest_result.reconciliation.last_seen_at,
-                ingest_disposition=ingest_result.reconciliation.ingest_disposition,
-                mismatch_summary=ingest_result.reconciliation.mismatch_summary,
-                compared_at=ingest_result.reconciliation.compared_at,
-                lifecycle_state=ingest_result.reconciliation.lifecycle_state,
+            return FindingAlertIngestResult(
+                alert=ingest_result.alert,
+                reconciliation=reconciliation,
+                disposition=ingest_result.disposition,
             )
-        )
-        return FindingAlertIngestResult(
-            alert=ingest_result.alert,
-            reconciliation=reconciliation,
-            disposition=ingest_result.disposition,
-        )

--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -445,10 +445,14 @@ class DetectionLifecycleService:
                         existing_case.reviewed_context,
                         alert.reviewed_context,
                     )
-                    if merged_case_reviewed_context != existing_case.reviewed_context:
+                    if (
+                        existing_case.finding_id != alert.finding_id
+                        or merged_case_reviewed_context != existing_case.reviewed_context
+                    ):
                         service.persist_record(
                             replace(
                                 existing_case,
+                                finding_id=alert.finding_id,
                                 reviewed_context=merged_case_reviewed_context,
                             )
                         )
@@ -458,6 +462,12 @@ class DetectionLifecycleService:
                     AnalyticSignalRecord,
                     analytic_signal_id,
                 )
+                if existing_signal is not None:
+                    if existing_signal.correlation_key != correlation_key:
+                        raise ValueError(
+                            f"Analytic signal {analytic_signal_id!r} already belongs to "
+                            f"correlation key {existing_signal.correlation_key!r}"
+                        )
                 signal_reviewed_context = self._merge_reviewed_context(
                     alert.reviewed_context,
                     admission.reviewed_context,
@@ -501,16 +511,24 @@ class DetectionLifecycleService:
 
             service._link_case_to_analytic_signals(linked_signal_ids, alert.case_id)
 
+            subject_linkage = (
+                dict(latest_reconciliation.subject_linkage)
+                if latest_reconciliation is not None
+                else {}
+            )
+            subject_linkage.update(
+                {
+                    "alert_ids": (alert.alert_id,),
+                    "case_ids": linked_case_ids,
+                    "substrate_detection_record_ids": linked_substrate_detection_ids,
+                    "finding_ids": linked_finding_ids,
+                    "analytic_signal_ids": linked_signal_ids,
+                }
+            )
             reconciliation = service.persist_record(
                 ReconciliationRecord(
                     reconciliation_id=service._next_identifier("reconciliation"),
-                    subject_linkage={
-                        "alert_ids": (alert.alert_id,),
-                        "case_ids": linked_case_ids,
-                        "substrate_detection_record_ids": linked_substrate_detection_ids,
-                        "finding_ids": linked_finding_ids,
-                        "analytic_signal_ids": linked_signal_ids,
-                    },
+                    subject_linkage=subject_linkage,
                     alert_id=alert.alert_id,
                     finding_id=finding_id,
                     analytic_signal_id=analytic_signal_id,

--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -310,15 +310,9 @@ class DetectionLifecycleService:
         materially_new_work = admission.materially_new_work
         reviewed_context = self._merge_reviewed_context({}, admission.reviewed_context)
         with service._store.transaction():
-            existing_reconciliations = [
-                record
-                for record in service._store.list(ReconciliationRecord)
-                if record.correlation_key == correlation_key and record.alert_id is not None
-            ]
-            latest_reconciliation = max(
-                existing_reconciliations,
-                key=lambda record: record.compared_at,
-                default=None,
+            latest_reconciliation = service._store.latest_reconciliation_for_correlation_key(
+                correlation_key,
+                require_alert_id=True,
             )
             analytic_signal_id = service._resolve_analytic_signal_id(
                 analytic_signal_id=analytic_signal_id,

--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -94,6 +94,12 @@ class DetectionLifecycleService:
             else:
                 resolved_case_id = requested_case_id or service._next_identifier("case")
 
+            existing_case = service._store.get(CaseRecord, resolved_case_id)
+            if alert.case_id is not None and existing_case is None:
+                raise LookupError(
+                    f"Alert {alert_id!r} references missing case {resolved_case_id!r}"
+                )
+
             evidence_records = service._list_alert_evidence_records(
                 alert_id=alert.alert_id,
                 case_id=resolved_case_id,
@@ -135,7 +141,6 @@ class DetectionLifecycleService:
                     )
                 )
 
-            existing_case = service._store.get(CaseRecord, resolved_case_id)
             if existing_case is not None:
                 if (
                     existing_case.alert_id is not None
@@ -304,130 +309,144 @@ class DetectionLifecycleService:
             )
         materially_new_work = admission.materially_new_work
         reviewed_context = self._merge_reviewed_context({}, admission.reviewed_context)
+        with service._store.transaction():
+            existing_reconciliations = [
+                record
+                for record in service._store.list(ReconciliationRecord)
+                if record.correlation_key == correlation_key and record.alert_id is not None
+            ]
+            latest_reconciliation = max(
+                existing_reconciliations,
+                key=lambda record: record.compared_at,
+                default=None,
+            )
+            analytic_signal_id = service._resolve_analytic_signal_id(
+                analytic_signal_id=analytic_signal_id,
+                finding_id=finding_id,
+                correlation_key=correlation_key,
+                substrate_detection_record_id=substrate_detection_record_id,
+                latest_reconciliation=latest_reconciliation,
+            )
 
-        existing_reconciliations = [
-            record
-            for record in service._store.list(ReconciliationRecord)
-            if record.correlation_key == correlation_key and record.alert_id is not None
-        ]
-        latest_reconciliation = max(
-            existing_reconciliations,
-            key=lambda record: record.compared_at,
-            default=None,
-        )
-        analytic_signal_id = service._resolve_analytic_signal_id(
-            analytic_signal_id=analytic_signal_id,
-            finding_id=finding_id,
-            correlation_key=correlation_key,
-            substrate_detection_record_id=substrate_detection_record_id,
-            latest_reconciliation=latest_reconciliation,
-        )
-
-        if latest_reconciliation is None:
-            alert = service.persist_record(
-                AlertRecord(
-                    alert_id=service._next_identifier("alert"),
-                    finding_id=finding_id,
-                    analytic_signal_id=analytic_signal_id,
-                    case_id=None,
-                    lifecycle_state="new",
-                    reviewed_context=reviewed_context,
-                )
-            )
-            disposition = "created"
-            linked_finding_ids = (finding_id,)
-            linked_signal_ids = (
-                (analytic_signal_id,) if analytic_signal_id is not None else tuple()
-            )
-            linked_substrate_detection_ids = service._merge_linked_ids(
-                (),
-                substrate_detection_record_id,
-            )
-            linked_case_ids = service._merge_linked_ids((), alert.case_id)
-            persisted_first_seen = first_seen_at
-            persisted_last_seen = last_seen_at
-        else:
-            alert = service._store.get(AlertRecord, latest_reconciliation.alert_id)
-            if alert is None:
-                raise LookupError(
-                    f"Missing alert {latest_reconciliation.alert_id!r} for correlation key {correlation_key!r}"
-                )
-            merged_reviewed_context = self._merge_reviewed_context(
-                alert.reviewed_context,
-                admission.reviewed_context,
-            )
-            existing_finding_ids = latest_reconciliation.subject_linkage.get("finding_ids")
-            existing_signal_ids = latest_reconciliation.subject_linkage.get(
-                "analytic_signal_ids"
-            )
-            existing_substrate_detection_ids = latest_reconciliation.subject_linkage.get(
-                "substrate_detection_record_ids"
-            )
-            existing_case_ids = latest_reconciliation.subject_linkage.get("case_ids")
-            linked_finding_ids = service._merge_linked_ids(
-                existing_finding_ids,
-                finding_id,
-            )
-            linked_signal_ids = service._merge_linked_ids(
-                existing_signal_ids,
-                analytic_signal_id,
-            )
-            linked_substrate_detection_ids = service._merge_linked_ids(
-                existing_substrate_detection_ids,
-                substrate_detection_record_id,
-            )
-            linked_case_ids = service._merge_linked_ids(
-                existing_case_ids,
-                alert.case_id,
-            )
-            persisted_first_seen = min(
-                latest_reconciliation.first_seen_at or first_seen_at,
-                first_seen_at,
-            )
-            persisted_last_seen = max(
-                latest_reconciliation.last_seen_at or last_seen_at,
-                last_seen_at,
-            )
-            already_linked = (
-                service._linked_id_exists(existing_finding_ids, finding_id)
-                and (
-                    analytic_signal_id is None
-                    or service._linked_id_exists(existing_signal_ids, analytic_signal_id)
-                )
-                and (
-                    substrate_detection_record_id is None
-                    or service._linked_id_exists(
-                        existing_substrate_detection_ids,
-                        substrate_detection_record_id,
-                    )
-                )
-            )
-            if materially_new_work:
+            if latest_reconciliation is None:
                 alert = service.persist_record(
-                    replace(
-                        alert,
+                    AlertRecord(
+                        alert_id=service._next_identifier("alert"),
                         finding_id=finding_id,
                         analytic_signal_id=analytic_signal_id,
-                        reviewed_context=merged_reviewed_context,
+                        case_id=None,
+                        lifecycle_state="new",
+                        reviewed_context=reviewed_context,
                     )
                 )
-                disposition = "updated"
-            elif merged_reviewed_context != alert.reviewed_context:
-                alert = service.persist_record(
-                    replace(
-                        alert,
-                        reviewed_context=merged_reviewed_context,
-                    )
+                disposition = "created"
+                linked_finding_ids = (finding_id,)
+                linked_signal_ids = (
+                    (analytic_signal_id,) if analytic_signal_id is not None else tuple()
                 )
-                disposition = "updated"
-            elif already_linked:
-                disposition = "deduplicated"
+                linked_substrate_detection_ids = service._merge_linked_ids(
+                    (),
+                    substrate_detection_record_id,
+                )
+                linked_case_ids = service._merge_linked_ids((), alert.case_id)
+                persisted_first_seen = first_seen_at
+                persisted_last_seen = last_seen_at
             else:
-                disposition = "restated"
+                alert = service._store.get(AlertRecord, latest_reconciliation.alert_id)
+                if alert is None:
+                    raise LookupError(
+                        f"Missing alert {latest_reconciliation.alert_id!r} for correlation key {correlation_key!r}"
+                    )
+                merged_reviewed_context = self._merge_reviewed_context(
+                    alert.reviewed_context,
+                    admission.reviewed_context,
+                )
+                existing_finding_ids = latest_reconciliation.subject_linkage.get("finding_ids")
+                existing_signal_ids = latest_reconciliation.subject_linkage.get(
+                    "analytic_signal_ids"
+                )
+                existing_substrate_detection_ids = latest_reconciliation.subject_linkage.get(
+                    "substrate_detection_record_ids"
+                )
+                existing_case_ids = latest_reconciliation.subject_linkage.get("case_ids")
+                linked_finding_ids = service._merge_linked_ids(
+                    existing_finding_ids,
+                    finding_id,
+                )
+                linked_signal_ids = service._merge_linked_ids(
+                    existing_signal_ids,
+                    analytic_signal_id,
+                )
+                linked_substrate_detection_ids = service._merge_linked_ids(
+                    existing_substrate_detection_ids,
+                    substrate_detection_record_id,
+                )
+                linked_case_ids = service._merge_linked_ids(
+                    existing_case_ids,
+                    alert.case_id,
+                )
+                persisted_first_seen = min(
+                    latest_reconciliation.first_seen_at or first_seen_at,
+                    first_seen_at,
+                )
+                persisted_last_seen = max(
+                    latest_reconciliation.last_seen_at or last_seen_at,
+                    last_seen_at,
+                )
+                already_linked = (
+                    service._linked_id_exists(existing_finding_ids, finding_id)
+                    and (
+                        analytic_signal_id is None
+                        or service._linked_id_exists(
+                            existing_signal_ids,
+                            analytic_signal_id,
+                        )
+                    )
+                    and (
+                        substrate_detection_record_id is None
+                        or service._linked_id_exists(
+                            existing_substrate_detection_ids,
+                            substrate_detection_record_id,
+                        )
+                    )
+                )
+                if materially_new_work:
+                    alert = service.persist_record(
+                        replace(
+                            alert,
+                            finding_id=finding_id,
+                            analytic_signal_id=analytic_signal_id,
+                            reviewed_context=merged_reviewed_context,
+                        )
+                    )
+                    disposition = "updated"
+                elif merged_reviewed_context != alert.reviewed_context:
+                    alert = service.persist_record(
+                        replace(
+                            alert,
+                            reviewed_context=merged_reviewed_context,
+                        )
+                    )
+                    disposition = "updated"
+                elif analytic_signal_id != alert.analytic_signal_id:
+                    alert = service.persist_record(
+                        replace(
+                            alert,
+                            analytic_signal_id=analytic_signal_id,
+                        )
+                    )
+                    disposition = "restated"
+                elif already_linked:
+                    disposition = "deduplicated"
+                else:
+                    disposition = "restated"
 
-            if alert.case_id is not None:
-                existing_case = service._store.get(CaseRecord, alert.case_id)
-                if existing_case is not None:
+                if alert.case_id is not None:
+                    existing_case = service._store.get(CaseRecord, alert.case_id)
+                    if existing_case is None:
+                        raise LookupError(
+                            f"Alert {alert.alert_id!r} references missing case {alert.case_id!r}"
+                        )
                     merged_case_reviewed_context = self._merge_reviewed_context(
                         existing_case.reviewed_context,
                         alert.reviewed_context,
@@ -440,81 +459,84 @@ class DetectionLifecycleService:
                             )
                         )
 
-        if analytic_signal_id is not None:
-            existing_signal = service._store.get(AnalyticSignalRecord, analytic_signal_id)
-            signal_reviewed_context = self._merge_reviewed_context(
-                alert.reviewed_context,
-                admission.reviewed_context,
-            )
-            signal_alert_ids = service._merge_linked_ids(
-                existing_signal.alert_ids if existing_signal is not None else (),
-                alert.alert_id,
-            )
-            signal_case_ids = service._merge_linked_ids(
-                existing_signal.case_ids if existing_signal is not None else (),
-                alert.case_id,
-            )
-            signal_first_seen = first_seen_at
-            if existing_signal is not None and existing_signal.first_seen_at is not None:
-                signal_first_seen = min(existing_signal.first_seen_at, first_seen_at)
-            signal_last_seen = last_seen_at
-            if existing_signal is not None and existing_signal.last_seen_at is not None:
-                signal_last_seen = max(existing_signal.last_seen_at, last_seen_at)
-            service.persist_record(
-                AnalyticSignalRecord(
-                    analytic_signal_id=analytic_signal_id,
-                    substrate_detection_record_id=(
-                        substrate_detection_record_id
-                        if substrate_detection_record_id is not None
-                        else (
-                            existing_signal.substrate_detection_record_id
-                            if existing_signal is not None
-                            else None
-                        )
-                    ),
+            if analytic_signal_id is not None:
+                existing_signal = service._store.get(
+                    AnalyticSignalRecord,
+                    analytic_signal_id,
+                )
+                signal_reviewed_context = self._merge_reviewed_context(
+                    alert.reviewed_context,
+                    admission.reviewed_context,
+                )
+                signal_alert_ids = service._merge_linked_ids(
+                    existing_signal.alert_ids if existing_signal is not None else (),
+                    alert.alert_id,
+                )
+                signal_case_ids = service._merge_linked_ids(
+                    existing_signal.case_ids if existing_signal is not None else (),
+                    alert.case_id,
+                )
+                signal_first_seen = first_seen_at
+                if existing_signal is not None and existing_signal.first_seen_at is not None:
+                    signal_first_seen = min(existing_signal.first_seen_at, first_seen_at)
+                signal_last_seen = last_seen_at
+                if existing_signal is not None and existing_signal.last_seen_at is not None:
+                    signal_last_seen = max(existing_signal.last_seen_at, last_seen_at)
+                service.persist_record(
+                    AnalyticSignalRecord(
+                        analytic_signal_id=analytic_signal_id,
+                        substrate_detection_record_id=(
+                            substrate_detection_record_id
+                            if substrate_detection_record_id is not None
+                            else (
+                                existing_signal.substrate_detection_record_id
+                                if existing_signal is not None
+                                else None
+                            )
+                        ),
+                        finding_id=finding_id,
+                        alert_ids=signal_alert_ids,
+                        case_ids=signal_case_ids,
+                        correlation_key=correlation_key,
+                        first_seen_at=signal_first_seen,
+                        last_seen_at=signal_last_seen,
+                        lifecycle_state="active",
+                        reviewed_context=signal_reviewed_context,
+                    )
+                )
+
+            service._link_case_to_analytic_signals(linked_signal_ids, alert.case_id)
+
+            reconciliation = service.persist_record(
+                ReconciliationRecord(
+                    reconciliation_id=service._next_identifier("reconciliation"),
+                    subject_linkage={
+                        "alert_ids": (alert.alert_id,),
+                        "case_ids": linked_case_ids,
+                        "substrate_detection_record_ids": linked_substrate_detection_ids,
+                        "finding_ids": linked_finding_ids,
+                        "analytic_signal_ids": linked_signal_ids,
+                    },
+                    alert_id=alert.alert_id,
                     finding_id=finding_id,
-                    alert_ids=signal_alert_ids,
-                    case_ids=signal_case_ids,
+                    analytic_signal_id=analytic_signal_id,
+                    execution_run_id=None,
+                    linked_execution_run_ids=(),
                     correlation_key=correlation_key,
-                    first_seen_at=signal_first_seen,
-                    last_seen_at=signal_last_seen,
-                    lifecycle_state="active",
-                    reviewed_context=signal_reviewed_context,
+                    first_seen_at=persisted_first_seen,
+                    last_seen_at=persisted_last_seen,
+                    ingest_disposition=disposition,
+                    mismatch_summary=f"{disposition} upstream analytic signal into alert lifecycle",
+                    compared_at=datetime.now(timezone.utc),
+                    lifecycle_state="matched",
                 )
             )
 
-        service._link_case_to_analytic_signals(linked_signal_ids, alert.case_id)
-
-        reconciliation = service.persist_record(
-            ReconciliationRecord(
-                reconciliation_id=service._next_identifier("reconciliation"),
-                subject_linkage={
-                    "alert_ids": (alert.alert_id,),
-                    "case_ids": linked_case_ids,
-                    "substrate_detection_record_ids": linked_substrate_detection_ids,
-                    "finding_ids": linked_finding_ids,
-                    "analytic_signal_ids": linked_signal_ids,
-                },
-                alert_id=alert.alert_id,
-                finding_id=finding_id,
-                analytic_signal_id=analytic_signal_id,
-                execution_run_id=None,
-                linked_execution_run_ids=(),
-                correlation_key=correlation_key,
-                first_seen_at=persisted_first_seen,
-                last_seen_at=persisted_last_seen,
-                ingest_disposition=disposition,
-                mismatch_summary=f"{disposition} upstream analytic signal into alert lifecycle",
-                compared_at=datetime.now(timezone.utc),
-                lifecycle_state="matched",
+            return FindingAlertIngestResult(
+                alert=alert,
+                reconciliation=reconciliation,
+                disposition=disposition,
             )
-        )
-
-        return FindingAlertIngestResult(
-            alert=alert,
-            reconciliation=reconciliation,
-            disposition=disposition,
-        )
 
     def attach_native_detection_context(
         self,

--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -1,0 +1,662 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Callable, Mapping
+import uuid
+
+from .models import (
+    AnalyticSignalAdmission,
+    AnalyticSignalRecord,
+    AlertRecord,
+    CaseRecord,
+    EvidenceRecord,
+    FindingAlertIngestResult,
+    NativeDetectionRecord,
+    ReconciliationRecord,
+)
+
+if TYPE_CHECKING:
+    from .service import AegisOpsControlPlaneService, NativeDetectionRecordAdapter
+
+
+class DetectionLifecycleService:
+    def __init__(
+        self,
+        service: AegisOpsControlPlaneService,
+        *,
+        merge_reviewed_context: Callable[
+            [Mapping[str, object], Mapping[str, object]],
+            dict[str, object],
+        ],
+        normalize_admission_provenance: Callable[
+            [object],
+            dict[str, str] | None,
+        ],
+    ) -> None:
+        self._service = service
+        self._merge_reviewed_context = merge_reviewed_context
+        self._normalize_admission_provenance = normalize_admission_provenance
+
+    def ingest_finding_alert(
+        self,
+        *,
+        finding_id: str,
+        analytic_signal_id: str | None,
+        substrate_detection_record_id: str | None = None,
+        correlation_key: str,
+        first_seen_at: datetime,
+        last_seen_at: datetime,
+        materially_new_work: bool = False,
+        reviewed_context: Mapping[str, object] | None = None,
+    ) -> FindingAlertIngestResult:
+        return self.ingest_analytic_signal_admission(
+            AnalyticSignalAdmission(
+                finding_id=finding_id,
+                analytic_signal_id=analytic_signal_id,
+                substrate_detection_record_id=substrate_detection_record_id,
+                correlation_key=correlation_key,
+                first_seen_at=first_seen_at,
+                last_seen_at=last_seen_at,
+                materially_new_work=materially_new_work,
+                reviewed_context=reviewed_context or {},
+            )
+        )
+
+    def promote_alert_to_case(
+        self,
+        alert_id: str,
+        *,
+        case_id: str | None = None,
+        case_lifecycle_state: str = "open",
+    ) -> CaseRecord:
+        service = self._service
+        alert_id = service._require_non_empty_string(alert_id, "alert_id")
+        requested_case_id = service._normalize_optional_string(case_id, "case_id")
+        case_lifecycle_state = service._require_non_empty_string(
+            case_lifecycle_state,
+            "case_lifecycle_state",
+        )
+        with service._store.transaction():
+            alert = service._store.get(AlertRecord, alert_id)
+            if alert is None:
+                raise LookupError(f"Missing alert {alert_id!r}")
+
+            if alert.case_id is not None:
+                resolved_case_id = alert.case_id
+                if (
+                    requested_case_id is not None
+                    and requested_case_id != resolved_case_id
+                ):
+                    raise ValueError(
+                        f"Alert {alert_id!r} is already linked to case {resolved_case_id!r}"
+                    )
+            else:
+                resolved_case_id = requested_case_id or service._next_identifier("case")
+
+            evidence_records = service._list_alert_evidence_records(
+                alert_id=alert.alert_id,
+                case_id=resolved_case_id,
+            )
+            if not evidence_records:
+                raise ValueError(
+                    f"Alert {alert_id!r} has no linked evidence to promote into a case"
+                )
+
+            merged_evidence_ids: tuple[str, ...] = ()
+            for evidence in evidence_records:
+                merged_evidence_ids = service._merge_linked_ids(
+                    merged_evidence_ids,
+                    evidence.evidence_id,
+                )
+                updated_lifecycle_state = (
+                    "linked"
+                    if evidence.lifecycle_state == "collected"
+                    else evidence.lifecycle_state
+                )
+                if (
+                    evidence.case_id == resolved_case_id
+                    and updated_lifecycle_state == evidence.lifecycle_state
+                ):
+                    continue
+                service.persist_record(
+                    EvidenceRecord(
+                        evidence_id=evidence.evidence_id,
+                        source_record_id=evidence.source_record_id,
+                        alert_id=evidence.alert_id,
+                        case_id=resolved_case_id,
+                        source_system=evidence.source_system,
+                        collector_identity=evidence.collector_identity,
+                        acquired_at=evidence.acquired_at,
+                        derivation_relationship=evidence.derivation_relationship,
+                        lifecycle_state=updated_lifecycle_state,
+                        provenance=evidence.provenance,
+                        content=evidence.content,
+                    )
+                )
+
+            existing_case = service._store.get(CaseRecord, resolved_case_id)
+            if existing_case is not None:
+                if (
+                    existing_case.alert_id is not None
+                    and existing_case.alert_id != alert.alert_id
+                ):
+                    raise ValueError(
+                        f"Case {resolved_case_id!r} is already linked to alert {existing_case.alert_id!r}"
+                    )
+                if (
+                    existing_case.finding_id is not None
+                    and existing_case.finding_id != alert.finding_id
+                ):
+                    raise ValueError(
+                        f"Case {resolved_case_id!r} is already linked to finding {existing_case.finding_id!r}"
+                    )
+            merged_case_evidence_ids = service._merge_linked_ids(
+                existing_case.evidence_ids if existing_case is not None else (),
+                None,
+            )
+            for evidence_id in merged_evidence_ids:
+                merged_case_evidence_ids = service._merge_linked_ids(
+                    merged_case_evidence_ids,
+                    evidence_id,
+                )
+
+            promoted_case = service.persist_record(
+                replace(
+                    existing_case,
+                    alert_id=alert.alert_id,
+                    finding_id=alert.finding_id,
+                    evidence_ids=merged_case_evidence_ids,
+                    reviewed_context=self._merge_reviewed_context(
+                        existing_case.reviewed_context,
+                        alert.reviewed_context,
+                    ),
+                )
+                if existing_case is not None
+                else CaseRecord(
+                    case_id=resolved_case_id,
+                    alert_id=alert.alert_id,
+                    finding_id=alert.finding_id,
+                    evidence_ids=merged_case_evidence_ids,
+                    lifecycle_state=case_lifecycle_state,
+                    reviewed_context=alert.reviewed_context,
+                )
+            )
+            promoted_alert = service.persist_record(
+                replace(
+                    alert,
+                    case_id=promoted_case.case_id,
+                    lifecycle_state="escalated_to_case",
+                )
+            )
+            if promoted_alert.analytic_signal_id is not None:
+                service._link_case_to_analytic_signals(
+                    (promoted_alert.analytic_signal_id,),
+                    promoted_case.case_id,
+                )
+            service._link_case_to_alert_reconciliations(
+                alert_id=promoted_alert.alert_id,
+                case_id=promoted_case.case_id,
+                evidence_ids=merged_evidence_ids,
+            )
+            return promoted_case
+
+    def ingest_native_detection_record(
+        self,
+        adapter: NativeDetectionRecordAdapter,
+        record: NativeDetectionRecord,
+    ) -> FindingAlertIngestResult:
+        service = self._service
+        record = service._with_native_detection_admission_provenance(
+            record,
+            admission_kind="replay",
+            admission_channel="fixture_replay",
+        )
+        adapter_substrate_key = service._require_non_empty_string(
+            adapter.substrate_key,
+            "adapter.substrate_key",
+        )
+        record_substrate_key = service._require_non_empty_string(
+            record.substrate_key,
+            "record.substrate_key",
+        )
+        if record_substrate_key != adapter_substrate_key:
+            raise ValueError(
+                "native detection record substrate does not match adapter boundary "
+                f"({record_substrate_key!r} != {adapter_substrate_key!r})"
+            )
+        admission = adapter.build_analytic_signal_admission(record)
+        admission_provenance = self._normalize_admission_provenance(
+            record.metadata.get("admission_provenance")
+        )
+        if admission_provenance is not None:
+            admission = AnalyticSignalAdmission(
+                finding_id=admission.finding_id,
+                analytic_signal_id=admission.analytic_signal_id,
+                substrate_detection_record_id=admission.substrate_detection_record_id,
+                correlation_key=admission.correlation_key,
+                first_seen_at=admission.first_seen_at,
+                last_seen_at=admission.last_seen_at,
+                materially_new_work=admission.materially_new_work,
+                reviewed_context=self._merge_reviewed_context(
+                    admission.reviewed_context,
+                    {"provenance": admission_provenance},
+                ),
+            )
+        raw_substrate_detection_record_id = service._require_non_empty_string(
+            admission.substrate_detection_record_id or record.native_record_id,
+            "substrate_detection_record_id/native_record_id",
+        )
+        substrate_detection_record_id = service._normalize_substrate_detection_record_id(
+            record_substrate_key,
+            raw_substrate_detection_record_id,
+        )
+        admission = AnalyticSignalAdmission(
+            finding_id=admission.finding_id,
+            analytic_signal_id=admission.analytic_signal_id,
+            substrate_detection_record_id=substrate_detection_record_id,
+            correlation_key=admission.correlation_key,
+            first_seen_at=admission.first_seen_at,
+            last_seen_at=admission.last_seen_at,
+            materially_new_work=admission.materially_new_work,
+            reviewed_context=admission.reviewed_context,
+        )
+        with service._store.transaction():
+            result = self.ingest_analytic_signal_admission(admission)
+            return self.attach_native_detection_context(
+                record=record,
+                ingest_result=result,
+                substrate_detection_record_id=substrate_detection_record_id,
+            )
+
+    def ingest_analytic_signal_admission(
+        self,
+        admission: AnalyticSignalAdmission,
+    ) -> FindingAlertIngestResult:
+        service = self._service
+        finding_id = service._require_non_empty_string(
+            admission.finding_id,
+            "finding_id",
+        )
+        analytic_signal_id = service._normalize_optional_string(
+            admission.analytic_signal_id,
+            "analytic_signal_id",
+        )
+        substrate_detection_record_id = service._normalize_optional_string(
+            admission.substrate_detection_record_id,
+            "substrate_detection_record_id",
+        )
+        correlation_key = service._require_non_empty_string(
+            admission.correlation_key,
+            "correlation_key",
+        )
+        first_seen_at = service._require_aware_datetime(
+            admission.first_seen_at,
+            "first_seen_at",
+        )
+        last_seen_at = service._require_aware_datetime(
+            admission.last_seen_at,
+            "last_seen_at",
+        )
+        if last_seen_at < first_seen_at:
+            raise ValueError(
+                "last_seen_at must be greater than or equal to first_seen_at"
+            )
+        materially_new_work = admission.materially_new_work
+        reviewed_context = self._merge_reviewed_context({}, admission.reviewed_context)
+
+        existing_reconciliations = [
+            record
+            for record in service._store.list(ReconciliationRecord)
+            if record.correlation_key == correlation_key and record.alert_id is not None
+        ]
+        latest_reconciliation = max(
+            existing_reconciliations,
+            key=lambda record: record.compared_at,
+            default=None,
+        )
+        analytic_signal_id = service._resolve_analytic_signal_id(
+            analytic_signal_id=analytic_signal_id,
+            finding_id=finding_id,
+            correlation_key=correlation_key,
+            substrate_detection_record_id=substrate_detection_record_id,
+            latest_reconciliation=latest_reconciliation,
+        )
+
+        if latest_reconciliation is None:
+            alert = service.persist_record(
+                AlertRecord(
+                    alert_id=service._next_identifier("alert"),
+                    finding_id=finding_id,
+                    analytic_signal_id=analytic_signal_id,
+                    case_id=None,
+                    lifecycle_state="new",
+                    reviewed_context=reviewed_context,
+                )
+            )
+            disposition = "created"
+            linked_finding_ids = (finding_id,)
+            linked_signal_ids = (
+                (analytic_signal_id,) if analytic_signal_id is not None else tuple()
+            )
+            linked_substrate_detection_ids = service._merge_linked_ids(
+                (),
+                substrate_detection_record_id,
+            )
+            linked_case_ids = service._merge_linked_ids((), alert.case_id)
+            persisted_first_seen = first_seen_at
+            persisted_last_seen = last_seen_at
+        else:
+            alert = service._store.get(AlertRecord, latest_reconciliation.alert_id)
+            if alert is None:
+                raise LookupError(
+                    f"Missing alert {latest_reconciliation.alert_id!r} for correlation key {correlation_key!r}"
+                )
+            merged_reviewed_context = self._merge_reviewed_context(
+                alert.reviewed_context,
+                admission.reviewed_context,
+            )
+            existing_finding_ids = latest_reconciliation.subject_linkage.get("finding_ids")
+            existing_signal_ids = latest_reconciliation.subject_linkage.get(
+                "analytic_signal_ids"
+            )
+            existing_substrate_detection_ids = latest_reconciliation.subject_linkage.get(
+                "substrate_detection_record_ids"
+            )
+            existing_case_ids = latest_reconciliation.subject_linkage.get("case_ids")
+            linked_finding_ids = service._merge_linked_ids(
+                existing_finding_ids,
+                finding_id,
+            )
+            linked_signal_ids = service._merge_linked_ids(
+                existing_signal_ids,
+                analytic_signal_id,
+            )
+            linked_substrate_detection_ids = service._merge_linked_ids(
+                existing_substrate_detection_ids,
+                substrate_detection_record_id,
+            )
+            linked_case_ids = service._merge_linked_ids(
+                existing_case_ids,
+                alert.case_id,
+            )
+            persisted_first_seen = min(
+                latest_reconciliation.first_seen_at or first_seen_at,
+                first_seen_at,
+            )
+            persisted_last_seen = max(
+                latest_reconciliation.last_seen_at or last_seen_at,
+                last_seen_at,
+            )
+            already_linked = (
+                service._linked_id_exists(existing_finding_ids, finding_id)
+                and (
+                    analytic_signal_id is None
+                    or service._linked_id_exists(existing_signal_ids, analytic_signal_id)
+                )
+                and (
+                    substrate_detection_record_id is None
+                    or service._linked_id_exists(
+                        existing_substrate_detection_ids,
+                        substrate_detection_record_id,
+                    )
+                )
+            )
+            if materially_new_work:
+                alert = service.persist_record(
+                    replace(
+                        alert,
+                        finding_id=finding_id,
+                        analytic_signal_id=analytic_signal_id,
+                        reviewed_context=merged_reviewed_context,
+                    )
+                )
+                disposition = "updated"
+            elif merged_reviewed_context != alert.reviewed_context:
+                alert = service.persist_record(
+                    replace(
+                        alert,
+                        reviewed_context=merged_reviewed_context,
+                    )
+                )
+                disposition = "updated"
+            elif already_linked:
+                disposition = "deduplicated"
+            else:
+                disposition = "restated"
+
+            if alert.case_id is not None:
+                existing_case = service._store.get(CaseRecord, alert.case_id)
+                if existing_case is not None:
+                    merged_case_reviewed_context = self._merge_reviewed_context(
+                        existing_case.reviewed_context,
+                        alert.reviewed_context,
+                    )
+                    if merged_case_reviewed_context != existing_case.reviewed_context:
+                        service.persist_record(
+                            replace(
+                                existing_case,
+                                reviewed_context=merged_case_reviewed_context,
+                            )
+                        )
+
+        if analytic_signal_id is not None:
+            existing_signal = service._store.get(AnalyticSignalRecord, analytic_signal_id)
+            signal_reviewed_context = self._merge_reviewed_context(
+                alert.reviewed_context,
+                admission.reviewed_context,
+            )
+            signal_alert_ids = service._merge_linked_ids(
+                existing_signal.alert_ids if existing_signal is not None else (),
+                alert.alert_id,
+            )
+            signal_case_ids = service._merge_linked_ids(
+                existing_signal.case_ids if existing_signal is not None else (),
+                alert.case_id,
+            )
+            signal_first_seen = first_seen_at
+            if existing_signal is not None and existing_signal.first_seen_at is not None:
+                signal_first_seen = min(existing_signal.first_seen_at, first_seen_at)
+            signal_last_seen = last_seen_at
+            if existing_signal is not None and existing_signal.last_seen_at is not None:
+                signal_last_seen = max(existing_signal.last_seen_at, last_seen_at)
+            service.persist_record(
+                AnalyticSignalRecord(
+                    analytic_signal_id=analytic_signal_id,
+                    substrate_detection_record_id=(
+                        substrate_detection_record_id
+                        if substrate_detection_record_id is not None
+                        else (
+                            existing_signal.substrate_detection_record_id
+                            if existing_signal is not None
+                            else None
+                        )
+                    ),
+                    finding_id=finding_id,
+                    alert_ids=signal_alert_ids,
+                    case_ids=signal_case_ids,
+                    correlation_key=correlation_key,
+                    first_seen_at=signal_first_seen,
+                    last_seen_at=signal_last_seen,
+                    lifecycle_state="active",
+                    reviewed_context=signal_reviewed_context,
+                )
+            )
+
+        service._link_case_to_analytic_signals(linked_signal_ids, alert.case_id)
+
+        reconciliation = service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id=service._next_identifier("reconciliation"),
+                subject_linkage={
+                    "alert_ids": (alert.alert_id,),
+                    "case_ids": linked_case_ids,
+                    "substrate_detection_record_ids": linked_substrate_detection_ids,
+                    "finding_ids": linked_finding_ids,
+                    "analytic_signal_ids": linked_signal_ids,
+                },
+                alert_id=alert.alert_id,
+                finding_id=finding_id,
+                analytic_signal_id=analytic_signal_id,
+                execution_run_id=None,
+                linked_execution_run_ids=(),
+                correlation_key=correlation_key,
+                first_seen_at=persisted_first_seen,
+                last_seen_at=persisted_last_seen,
+                ingest_disposition=disposition,
+                mismatch_summary=f"{disposition} upstream analytic signal into alert lifecycle",
+                compared_at=datetime.now(timezone.utc),
+                lifecycle_state="matched",
+            )
+        )
+
+        return FindingAlertIngestResult(
+            alert=alert,
+            reconciliation=reconciliation,
+            disposition=disposition,
+        )
+
+    def attach_native_detection_context(
+        self,
+        *,
+        record: NativeDetectionRecord,
+        ingest_result: FindingAlertIngestResult,
+        substrate_detection_record_id: str,
+    ) -> FindingAlertIngestResult:
+        service = self._service
+        source_system = service._normalize_optional_string(
+            record.metadata.get("source_system"),
+            "metadata.source_system",
+        ) or record.substrate_key
+        evidence_id = f"evidence-{uuid.uuid5(uuid.NAMESPACE_URL, substrate_detection_record_id)}"
+        case_id = ingest_result.alert.case_id
+        evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id=evidence_id,
+                source_record_id=substrate_detection_record_id,
+                alert_id=ingest_result.alert.alert_id,
+                case_id=case_id,
+                source_system=source_system,
+                collector_identity=f"{record.substrate_key}-native-detection-adapter",
+                acquired_at=service._require_aware_datetime(
+                    record.first_seen_at,
+                    "record.first_seen_at",
+                ),
+                derivation_relationship="native_detection_record",
+                lifecycle_state="linked" if case_id is not None else "collected",
+                provenance={},
+                content={},
+            )
+        )
+
+        if case_id is not None:
+            existing_case = service._store.get(CaseRecord, case_id)
+            if existing_case is not None:
+                merged_case_evidence_ids = service._merge_linked_ids(
+                    existing_case.evidence_ids,
+                    evidence.evidence_id,
+                )
+                merged_case_reviewed_context = self._merge_reviewed_context(
+                    existing_case.reviewed_context,
+                    ingest_result.alert.reviewed_context,
+                )
+                if (
+                    merged_case_evidence_ids != existing_case.evidence_ids
+                    or merged_case_reviewed_context != existing_case.reviewed_context
+                ):
+                    service.persist_record(
+                        replace(
+                            existing_case,
+                            evidence_ids=merged_case_evidence_ids,
+                            reviewed_context=merged_case_reviewed_context,
+                        )
+                    )
+
+        subject_linkage = dict(ingest_result.reconciliation.subject_linkage)
+        subject_linkage["evidence_ids"] = service._merge_linked_ids(
+            subject_linkage.get("evidence_ids"),
+            evidence.evidence_id,
+        )
+        subject_linkage["source_systems"] = service._merge_linked_ids(
+            subject_linkage.get("source_systems"),
+            source_system,
+        )
+
+        source_provenance = record.metadata.get("source_provenance")
+        if isinstance(source_provenance, Mapping):
+            accountable_source_identity = service._normalize_optional_string(
+                source_provenance.get("accountable_source_identity"),
+                "metadata.source_provenance.accountable_source_identity",
+            )
+            if accountable_source_identity is not None:
+                subject_linkage["accountable_source_identities"] = (
+                    service._merge_linked_ids(
+                        subject_linkage.get("accountable_source_identities"),
+                        accountable_source_identity,
+                    )
+                )
+
+        native_rule = record.metadata.get("native_rule")
+        if isinstance(native_rule, Mapping):
+            native_rule_id = service._normalize_optional_string(
+                native_rule.get("id"),
+                "metadata.native_rule.id",
+            )
+            native_rule_description = service._normalize_optional_string(
+                native_rule.get("description"),
+                "metadata.native_rule.description",
+            )
+            rule_level = native_rule.get("level")
+            subject_linkage["latest_native_rule"] = {
+                "id": native_rule_id,
+                "level": rule_level if isinstance(rule_level, int) else None,
+                "description": native_rule_description,
+            }
+
+        reviewed_correlation_context = record.metadata.get("reviewed_correlation_context")
+        if isinstance(reviewed_correlation_context, Mapping):
+            subject_linkage["reviewed_correlation_context"] = {
+                str(field_name): field_value
+                for field_name, field_value in reviewed_correlation_context.items()
+                if isinstance(field_value, str) and field_value.strip()
+            }
+
+        reviewed_source_profile = record.metadata.get("reviewed_source_profile")
+        if isinstance(reviewed_source_profile, Mapping):
+            subject_linkage["reviewed_source_profile"] = dict(reviewed_source_profile)
+
+        raw_alert = record.metadata.get("raw_alert")
+        if isinstance(raw_alert, Mapping):
+            subject_linkage["latest_native_payload"] = dict(raw_alert)
+
+        admission_provenance = self._normalize_admission_provenance(
+            record.metadata.get("admission_provenance")
+        )
+        if admission_provenance is not None:
+            subject_linkage["admission_provenance"] = admission_provenance
+
+        reconciliation = service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id=ingest_result.reconciliation.reconciliation_id,
+                subject_linkage=subject_linkage,
+                alert_id=ingest_result.reconciliation.alert_id,
+                finding_id=ingest_result.reconciliation.finding_id,
+                analytic_signal_id=ingest_result.reconciliation.analytic_signal_id,
+                execution_run_id=ingest_result.reconciliation.execution_run_id,
+                linked_execution_run_ids=(
+                    ingest_result.reconciliation.linked_execution_run_ids
+                ),
+                correlation_key=ingest_result.reconciliation.correlation_key,
+                first_seen_at=ingest_result.reconciliation.first_seen_at,
+                last_seen_at=ingest_result.reconciliation.last_seen_at,
+                ingest_disposition=ingest_result.reconciliation.ingest_disposition,
+                mismatch_summary=ingest_result.reconciliation.mismatch_summary,
+                compared_at=ingest_result.reconciliation.compared_at,
+                lifecycle_state=ingest_result.reconciliation.lifecycle_state,
+            )
+        )
+        return FindingAlertIngestResult(
+            alert=ingest_result.alert,
+            reconciliation=reconciliation,
+            disposition=ingest_result.disposition,
+        )

--- a/control-plane/aegisops_control_plane/models.py
+++ b/control-plane/aegisops_control_plane/models.py
@@ -102,6 +102,13 @@ class AnalyticSignalAdmission:
 
 
 @dataclass(frozen=True)
+class FindingAlertIngestResult:
+    alert: AlertRecord
+    reconciliation: ReconciliationRecord
+    disposition: str
+
+
+@dataclass(frozen=True)
 class CaseRecord(ControlPlaneRecord):
     record_family: ClassVar[str] = "case"
     identifier_field: ClassVar[str] = "case_id"

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -51,6 +51,7 @@ from .models import (
     CaseRecord,
     ControlPlaneRecord,
     EvidenceRecord,
+    FindingAlertIngestResult,
     HuntRecord,
     HuntRunRecord,
     LeadRecord,
@@ -67,6 +68,7 @@ from .assistant_context import (
     AssistantContextAssembler,
     _advisory_text_claims_authority_or_scope_expansion,
 )
+from .detection_lifecycle import DetectionLifecycleService
 from .reviewed_slice_policy import (
     REVIEWED_LIVE_SLICE_LABEL,
     REVIEWED_LIVE_SOURCE_FAMILIES,
@@ -213,14 +215,6 @@ class RuntimeSnapshot:
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
-
-
-@dataclass(frozen=True)
-class FindingAlertIngestResult:
-    alert: AlertRecord
-    reconciliation: ReconciliationRecord
-    disposition: str
-
 
 @dataclass(frozen=True)
 class AuthenticatedRuntimePrincipal:
@@ -1338,6 +1332,11 @@ class AegisOpsControlPlaneService:
             coordination_reference_payload=_coordination_reference_payload,
             coordination_reference_signature=_coordination_reference_signature,
             dedupe_strings=_dedupe_strings,
+        )
+        self._detection_lifecycle_service = DetectionLifecycleService(
+            self,
+            merge_reviewed_context=_merge_reviewed_context,
+            normalize_admission_provenance=_normalize_admission_provenance,
         )
         self._execution_coordinator = ExecutionCoordinator(self)
         self._endpoint_evidence_pack_adapter = EndpointEvidencePackAdapter()
@@ -5920,17 +5919,15 @@ class AegisOpsControlPlaneService:
         materially_new_work: bool = False,
         reviewed_context: Mapping[str, object] | None = None,
     ) -> FindingAlertIngestResult:
-        return self._ingest_analytic_signal_admission(
-            AnalyticSignalAdmission(
-                finding_id=finding_id,
-                analytic_signal_id=analytic_signal_id,
-                substrate_detection_record_id=substrate_detection_record_id,
-                correlation_key=correlation_key,
-                first_seen_at=first_seen_at,
-                last_seen_at=last_seen_at,
-                materially_new_work=materially_new_work,
-                reviewed_context=reviewed_context or {},
-            )
+        return self._detection_lifecycle_service.ingest_finding_alert(
+            finding_id=finding_id,
+            analytic_signal_id=analytic_signal_id,
+            substrate_detection_record_id=substrate_detection_record_id,
+            correlation_key=correlation_key,
+            first_seen_at=first_seen_at,
+            last_seen_at=last_seen_at,
+            materially_new_work=materially_new_work,
+            reviewed_context=reviewed_context,
         )
 
     def promote_alert_to_case(
@@ -5940,447 +5937,28 @@ class AegisOpsControlPlaneService:
         case_id: str | None = None,
         case_lifecycle_state: str = "open",
     ) -> CaseRecord:
-        alert_id = self._require_non_empty_string(alert_id, "alert_id")
-        requested_case_id = self._normalize_optional_string(case_id, "case_id")
-        case_lifecycle_state = self._require_non_empty_string(
-            case_lifecycle_state,
-            "case_lifecycle_state",
+        return self._detection_lifecycle_service.promote_alert_to_case(
+            alert_id,
+            case_id=case_id,
+            case_lifecycle_state=case_lifecycle_state,
         )
-        with self._store.transaction():
-            alert = self._store.get(AlertRecord, alert_id)
-            if alert is None:
-                raise LookupError(f"Missing alert {alert_id!r}")
-
-            if alert.case_id is not None:
-                resolved_case_id = alert.case_id
-                if (
-                    requested_case_id is not None
-                    and requested_case_id != resolved_case_id
-                ):
-                    raise ValueError(
-                        f"Alert {alert_id!r} is already linked to case {resolved_case_id!r}"
-                    )
-            else:
-                resolved_case_id = requested_case_id or self._next_identifier("case")
-
-            evidence_records = self._list_alert_evidence_records(
-                alert_id=alert.alert_id,
-                case_id=resolved_case_id,
-            )
-            if not evidence_records:
-                raise ValueError(
-                    f"Alert {alert_id!r} has no linked evidence to promote into a case"
-                )
-
-            merged_evidence_ids: tuple[str, ...] = ()
-            for evidence in evidence_records:
-                merged_evidence_ids = self._merge_linked_ids(
-                    merged_evidence_ids,
-                    evidence.evidence_id,
-                )
-                updated_lifecycle_state = (
-                    "linked"
-                    if evidence.lifecycle_state == "collected"
-                    else evidence.lifecycle_state
-                )
-                if (
-                    evidence.case_id == resolved_case_id
-                    and updated_lifecycle_state == evidence.lifecycle_state
-                ):
-                    continue
-                self.persist_record(
-                    EvidenceRecord(
-                        evidence_id=evidence.evidence_id,
-                        source_record_id=evidence.source_record_id,
-                        alert_id=evidence.alert_id,
-                        case_id=resolved_case_id,
-                        source_system=evidence.source_system,
-                        collector_identity=evidence.collector_identity,
-                        acquired_at=evidence.acquired_at,
-                        derivation_relationship=evidence.derivation_relationship,
-                        lifecycle_state=updated_lifecycle_state,
-                        provenance=evidence.provenance,
-                        content=evidence.content,
-                    )
-                )
-
-            existing_case = self._store.get(CaseRecord, resolved_case_id)
-            if existing_case is not None:
-                if (
-                    existing_case.alert_id is not None
-                    and existing_case.alert_id != alert.alert_id
-                ):
-                    raise ValueError(
-                        f"Case {resolved_case_id!r} is already linked to alert {existing_case.alert_id!r}"
-                    )
-                if (
-                    existing_case.finding_id is not None
-                    and existing_case.finding_id != alert.finding_id
-                ):
-                    raise ValueError(
-                        f"Case {resolved_case_id!r} is already linked to finding {existing_case.finding_id!r}"
-                    )
-            merged_case_evidence_ids = self._merge_linked_ids(
-                existing_case.evidence_ids if existing_case is not None else (),
-                None,
-            )
-            for evidence_id in merged_evidence_ids:
-                merged_case_evidence_ids = self._merge_linked_ids(
-                    merged_case_evidence_ids,
-                    evidence_id,
-                )
-
-            promoted_case = self.persist_record(
-                replace(
-                    existing_case,
-                    alert_id=alert.alert_id,
-                    finding_id=alert.finding_id,
-                    evidence_ids=merged_case_evidence_ids,
-                    reviewed_context=_merge_reviewed_context(
-                        existing_case.reviewed_context,
-                        alert.reviewed_context,
-                    ),
-                )
-                if existing_case is not None
-                else CaseRecord(
-                    case_id=resolved_case_id,
-                    alert_id=alert.alert_id,
-                    finding_id=alert.finding_id,
-                    evidence_ids=merged_case_evidence_ids,
-                    lifecycle_state=case_lifecycle_state,
-                    reviewed_context=alert.reviewed_context,
-                )
-            )
-            promoted_alert = self.persist_record(
-                replace(
-                    alert,
-                    case_id=promoted_case.case_id,
-                    lifecycle_state="escalated_to_case",
-                )
-            )
-            if promoted_alert.analytic_signal_id is not None:
-                self._link_case_to_analytic_signals(
-                    (promoted_alert.analytic_signal_id,),
-                    promoted_case.case_id,
-                )
-            self._link_case_to_alert_reconciliations(
-                alert_id=promoted_alert.alert_id,
-                case_id=promoted_case.case_id,
-                evidence_ids=merged_evidence_ids,
-            )
-            return promoted_case
 
     def ingest_native_detection_record(
         self,
         adapter: NativeDetectionRecordAdapter,
         record: NativeDetectionRecord,
     ) -> FindingAlertIngestResult:
-        record = self._with_native_detection_admission_provenance(
+        return self._detection_lifecycle_service.ingest_native_detection_record(
+            adapter,
             record,
-            admission_kind="replay",
-            admission_channel="fixture_replay",
         )
-        adapter_substrate_key = self._require_non_empty_string(
-            adapter.substrate_key,
-            "adapter.substrate_key",
-        )
-        record_substrate_key = self._require_non_empty_string(
-            record.substrate_key,
-            "record.substrate_key",
-        )
-        if record_substrate_key != adapter_substrate_key:
-            raise ValueError(
-                "native detection record substrate does not match adapter boundary "
-                f"({record_substrate_key!r} != {adapter_substrate_key!r})"
-            )
-        admission = adapter.build_analytic_signal_admission(record)
-        admission_provenance = _normalize_admission_provenance(
-            record.metadata.get("admission_provenance")
-        )
-        if admission_provenance is not None:
-            admission = AnalyticSignalAdmission(
-                finding_id=admission.finding_id,
-                analytic_signal_id=admission.analytic_signal_id,
-                substrate_detection_record_id=admission.substrate_detection_record_id,
-                correlation_key=admission.correlation_key,
-                first_seen_at=admission.first_seen_at,
-                last_seen_at=admission.last_seen_at,
-                materially_new_work=admission.materially_new_work,
-                reviewed_context=_merge_reviewed_context(
-                    admission.reviewed_context,
-                    {"provenance": admission_provenance},
-                ),
-            )
-        raw_substrate_detection_record_id = self._require_non_empty_string(
-            admission.substrate_detection_record_id or record.native_record_id,
-            "substrate_detection_record_id/native_record_id",
-        )
-        substrate_detection_record_id = self._normalize_substrate_detection_record_id(
-            record_substrate_key,
-            raw_substrate_detection_record_id,
-        )
-        admission = AnalyticSignalAdmission(
-            finding_id=admission.finding_id,
-            analytic_signal_id=admission.analytic_signal_id,
-            substrate_detection_record_id=substrate_detection_record_id,
-            correlation_key=admission.correlation_key,
-            first_seen_at=admission.first_seen_at,
-            last_seen_at=admission.last_seen_at,
-            materially_new_work=admission.materially_new_work,
-            reviewed_context=admission.reviewed_context,
-        )
-        with self._store.transaction():
-            result = self._ingest_analytic_signal_admission(admission)
-            return self._attach_native_detection_context(
-                record=record,
-                ingest_result=result,
-                substrate_detection_record_id=substrate_detection_record_id,
-            )
 
     def _ingest_analytic_signal_admission(
         self,
         admission: AnalyticSignalAdmission,
     ) -> FindingAlertIngestResult:
-        finding_id = self._require_non_empty_string(
-            admission.finding_id,
-            "finding_id",
-        )
-        analytic_signal_id = self._normalize_optional_string(
-            admission.analytic_signal_id,
-            "analytic_signal_id",
-        )
-        substrate_detection_record_id = self._normalize_optional_string(
-            admission.substrate_detection_record_id,
-            "substrate_detection_record_id",
-        )
-        correlation_key = self._require_non_empty_string(
-            admission.correlation_key,
-            "correlation_key",
-        )
-        first_seen_at = self._require_aware_datetime(
-            admission.first_seen_at,
-            "first_seen_at",
-        )
-        last_seen_at = self._require_aware_datetime(
-            admission.last_seen_at,
-            "last_seen_at",
-        )
-        if last_seen_at < first_seen_at:
-            raise ValueError(
-                "last_seen_at must be greater than or equal to first_seen_at"
-            )
-        materially_new_work = admission.materially_new_work
-        reviewed_context = _merge_reviewed_context({}, admission.reviewed_context)
-
-        existing_reconciliations = [
-            record
-            for record in self._store.list(ReconciliationRecord)
-            if record.correlation_key == correlation_key and record.alert_id is not None
-        ]
-        latest_reconciliation = max(
-            existing_reconciliations,
-            key=lambda record: record.compared_at,
-            default=None,
-        )
-        analytic_signal_id = self._resolve_analytic_signal_id(
-            analytic_signal_id=analytic_signal_id,
-            finding_id=finding_id,
-            correlation_key=correlation_key,
-            substrate_detection_record_id=substrate_detection_record_id,
-            latest_reconciliation=latest_reconciliation,
-        )
-
-        if latest_reconciliation is None:
-            alert = self.persist_record(
-                AlertRecord(
-                    alert_id=self._next_identifier("alert"),
-                    finding_id=finding_id,
-                    analytic_signal_id=analytic_signal_id,
-                    case_id=None,
-                    lifecycle_state="new",
-                    reviewed_context=reviewed_context,
-                )
-            )
-            disposition = "created"
-            linked_finding_ids = (finding_id,)
-            linked_signal_ids = (
-                (analytic_signal_id,) if analytic_signal_id is not None else tuple()
-            )
-            linked_substrate_detection_ids = self._merge_linked_ids(
-                (),
-                substrate_detection_record_id,
-            )
-            linked_case_ids = self._merge_linked_ids((), alert.case_id)
-            persisted_first_seen = first_seen_at
-            persisted_last_seen = last_seen_at
-        else:
-            alert = self._store.get(AlertRecord, latest_reconciliation.alert_id)
-            if alert is None:
-                raise LookupError(
-                    f"Missing alert {latest_reconciliation.alert_id!r} for correlation key {correlation_key!r}"
-                )
-            merged_reviewed_context = _merge_reviewed_context(
-                alert.reviewed_context,
-                admission.reviewed_context,
-            )
-            existing_finding_ids = latest_reconciliation.subject_linkage.get("finding_ids")
-            existing_signal_ids = latest_reconciliation.subject_linkage.get(
-                "analytic_signal_ids"
-            )
-            existing_substrate_detection_ids = latest_reconciliation.subject_linkage.get(
-                "substrate_detection_record_ids"
-            )
-            existing_case_ids = latest_reconciliation.subject_linkage.get("case_ids")
-            linked_finding_ids = self._merge_linked_ids(
-                existing_finding_ids,
-                finding_id,
-            )
-            linked_signal_ids = self._merge_linked_ids(
-                existing_signal_ids,
-                analytic_signal_id,
-            )
-            linked_substrate_detection_ids = self._merge_linked_ids(
-                existing_substrate_detection_ids,
-                substrate_detection_record_id,
-            )
-            linked_case_ids = self._merge_linked_ids(
-                existing_case_ids,
-                alert.case_id,
-            )
-            persisted_first_seen = min(
-                latest_reconciliation.first_seen_at or first_seen_at,
-                first_seen_at,
-            )
-            persisted_last_seen = max(
-                latest_reconciliation.last_seen_at or last_seen_at,
-                last_seen_at,
-            )
-            already_linked = (
-                self._linked_id_exists(existing_finding_ids, finding_id)
-                and (
-                    analytic_signal_id is None
-                    or self._linked_id_exists(existing_signal_ids, analytic_signal_id)
-                )
-                and (
-                    substrate_detection_record_id is None
-                    or self._linked_id_exists(
-                        existing_substrate_detection_ids,
-                        substrate_detection_record_id,
-                    )
-                )
-            )
-            if materially_new_work:
-                alert = self.persist_record(
-                    replace(
-                        alert,
-                        finding_id=finding_id,
-                        analytic_signal_id=analytic_signal_id,
-                        reviewed_context=merged_reviewed_context,
-                    )
-                )
-                disposition = "updated"
-            elif merged_reviewed_context != alert.reviewed_context:
-                alert = self.persist_record(
-                    replace(
-                        alert,
-                        reviewed_context=merged_reviewed_context,
-                    )
-                )
-                disposition = "updated"
-            elif already_linked:
-                disposition = "deduplicated"
-            else:
-                disposition = "restated"
-
-            if alert.case_id is not None:
-                existing_case = self._store.get(CaseRecord, alert.case_id)
-                if existing_case is not None:
-                    merged_case_reviewed_context = _merge_reviewed_context(
-                        existing_case.reviewed_context,
-                        alert.reviewed_context,
-                    )
-                    if merged_case_reviewed_context != existing_case.reviewed_context:
-                        self.persist_record(
-                            replace(
-                                existing_case,
-                                reviewed_context=merged_case_reviewed_context,
-                            )
-                        )
-
-        if analytic_signal_id is not None:
-            existing_signal = self._store.get(AnalyticSignalRecord, analytic_signal_id)
-            signal_reviewed_context = _merge_reviewed_context(
-                alert.reviewed_context,
-                admission.reviewed_context,
-            )
-            signal_alert_ids = self._merge_linked_ids(
-                existing_signal.alert_ids if existing_signal is not None else (),
-                alert.alert_id,
-            )
-            signal_case_ids = self._merge_linked_ids(
-                existing_signal.case_ids if existing_signal is not None else (),
-                alert.case_id,
-            )
-            signal_first_seen = first_seen_at
-            if existing_signal is not None and existing_signal.first_seen_at is not None:
-                signal_first_seen = min(existing_signal.first_seen_at, first_seen_at)
-            signal_last_seen = last_seen_at
-            if existing_signal is not None and existing_signal.last_seen_at is not None:
-                signal_last_seen = max(existing_signal.last_seen_at, last_seen_at)
-            self.persist_record(
-                AnalyticSignalRecord(
-                    analytic_signal_id=analytic_signal_id,
-                    substrate_detection_record_id=(
-                        substrate_detection_record_id
-                        if substrate_detection_record_id is not None
-                        else (
-                            existing_signal.substrate_detection_record_id
-                            if existing_signal is not None
-                            else None
-                        )
-                    ),
-                    finding_id=finding_id,
-                    alert_ids=signal_alert_ids,
-                    case_ids=signal_case_ids,
-                    correlation_key=correlation_key,
-                    first_seen_at=signal_first_seen,
-                    last_seen_at=signal_last_seen,
-                    lifecycle_state="active",
-                    reviewed_context=signal_reviewed_context,
-                )
-            )
-
-        self._link_case_to_analytic_signals(linked_signal_ids, alert.case_id)
-
-        reconciliation = self.persist_record(
-            ReconciliationRecord(
-                reconciliation_id=self._next_identifier("reconciliation"),
-                subject_linkage={
-                    "alert_ids": (alert.alert_id,),
-                    "case_ids": linked_case_ids,
-                    "substrate_detection_record_ids": linked_substrate_detection_ids,
-                    "finding_ids": linked_finding_ids,
-                    "analytic_signal_ids": linked_signal_ids,
-                },
-                alert_id=alert.alert_id,
-                finding_id=finding_id,
-                analytic_signal_id=analytic_signal_id,
-                execution_run_id=None,
-                linked_execution_run_ids=(),
-                correlation_key=correlation_key,
-                first_seen_at=persisted_first_seen,
-                last_seen_at=persisted_last_seen,
-                ingest_disposition=disposition,
-                mismatch_summary=f"{disposition} upstream analytic signal into alert lifecycle",
-                compared_at=datetime.now(timezone.utc),
-                lifecycle_state="matched",
-            )
-        )
-
-        return FindingAlertIngestResult(
-            alert=alert,
-            reconciliation=reconciliation,
-            disposition=disposition,
+        return self._detection_lifecycle_service.ingest_analytic_signal_admission(
+            admission
         )
 
     def _attach_native_detection_context(
@@ -6390,141 +5968,10 @@ class AegisOpsControlPlaneService:
         ingest_result: FindingAlertIngestResult,
         substrate_detection_record_id: str,
     ) -> FindingAlertIngestResult:
-        source_system = self._normalize_optional_string(
-            record.metadata.get("source_system"),
-            "metadata.source_system",
-        ) or record.substrate_key
-        evidence_id = f"evidence-{uuid.uuid5(uuid.NAMESPACE_URL, substrate_detection_record_id)}"
-        case_id = ingest_result.alert.case_id
-        evidence = self.persist_record(
-            EvidenceRecord(
-                evidence_id=evidence_id,
-                source_record_id=substrate_detection_record_id,
-                alert_id=ingest_result.alert.alert_id,
-                case_id=case_id,
-                source_system=source_system,
-                collector_identity=f"{record.substrate_key}-native-detection-adapter",
-                acquired_at=self._require_aware_datetime(
-                    record.first_seen_at,
-                    "record.first_seen_at",
-                ),
-                derivation_relationship="native_detection_record",
-                lifecycle_state="linked" if case_id is not None else "collected",
-                provenance={},
-                content={},
-            )
-        )
-
-        if case_id is not None:
-            existing_case = self._store.get(CaseRecord, case_id)
-            if existing_case is not None:
-                merged_case_evidence_ids = self._merge_linked_ids(
-                    existing_case.evidence_ids,
-                    evidence.evidence_id,
-                )
-                merged_case_reviewed_context = _merge_reviewed_context(
-                    existing_case.reviewed_context,
-                    ingest_result.alert.reviewed_context,
-                )
-                if (
-                    merged_case_evidence_ids != existing_case.evidence_ids
-                    or merged_case_reviewed_context != existing_case.reviewed_context
-                ):
-                    self.persist_record(
-                        replace(
-                            existing_case,
-                            evidence_ids=merged_case_evidence_ids,
-                            reviewed_context=merged_case_reviewed_context,
-                        )
-                    )
-
-        subject_linkage = dict(ingest_result.reconciliation.subject_linkage)
-        subject_linkage["evidence_ids"] = self._merge_linked_ids(
-            subject_linkage.get("evidence_ids"),
-            evidence.evidence_id,
-        )
-        subject_linkage["source_systems"] = self._merge_linked_ids(
-            subject_linkage.get("source_systems"),
-            source_system,
-        )
-
-        source_provenance = record.metadata.get("source_provenance")
-        if isinstance(source_provenance, Mapping):
-            accountable_source_identity = self._normalize_optional_string(
-                source_provenance.get("accountable_source_identity"),
-                "metadata.source_provenance.accountable_source_identity",
-            )
-            if accountable_source_identity is not None:
-                subject_linkage["accountable_source_identities"] = (
-                    self._merge_linked_ids(
-                        subject_linkage.get("accountable_source_identities"),
-                        accountable_source_identity,
-                    )
-                )
-
-        native_rule = record.metadata.get("native_rule")
-        if isinstance(native_rule, Mapping):
-            native_rule_id = self._normalize_optional_string(
-                native_rule.get("id"),
-                "metadata.native_rule.id",
-            )
-            native_rule_description = self._normalize_optional_string(
-                native_rule.get("description"),
-                "metadata.native_rule.description",
-            )
-            rule_level = native_rule.get("level")
-            subject_linkage["latest_native_rule"] = {
-                "id": native_rule_id,
-                "level": rule_level if isinstance(rule_level, int) else None,
-                "description": native_rule_description,
-            }
-
-        reviewed_correlation_context = record.metadata.get("reviewed_correlation_context")
-        if isinstance(reviewed_correlation_context, Mapping):
-            subject_linkage["reviewed_correlation_context"] = {
-                str(field_name): field_value
-                for field_name, field_value in reviewed_correlation_context.items()
-                if isinstance(field_value, str) and field_value.strip()
-            }
-
-        reviewed_source_profile = record.metadata.get("reviewed_source_profile")
-        if isinstance(reviewed_source_profile, Mapping):
-            subject_linkage["reviewed_source_profile"] = dict(reviewed_source_profile)
-
-        raw_alert = record.metadata.get("raw_alert")
-        if isinstance(raw_alert, Mapping):
-            subject_linkage["latest_native_payload"] = dict(raw_alert)
-
-        admission_provenance = _normalize_admission_provenance(
-            record.metadata.get("admission_provenance")
-        )
-        if admission_provenance is not None:
-            subject_linkage["admission_provenance"] = admission_provenance
-
-        reconciliation = self.persist_record(
-            ReconciliationRecord(
-                reconciliation_id=ingest_result.reconciliation.reconciliation_id,
-                subject_linkage=subject_linkage,
-                alert_id=ingest_result.reconciliation.alert_id,
-                finding_id=ingest_result.reconciliation.finding_id,
-                analytic_signal_id=ingest_result.reconciliation.analytic_signal_id,
-                execution_run_id=ingest_result.reconciliation.execution_run_id,
-                linked_execution_run_ids=(
-                    ingest_result.reconciliation.linked_execution_run_ids
-                ),
-                correlation_key=ingest_result.reconciliation.correlation_key,
-                first_seen_at=ingest_result.reconciliation.first_seen_at,
-                last_seen_at=ingest_result.reconciliation.last_seen_at,
-                ingest_disposition=ingest_result.reconciliation.ingest_disposition,
-                mismatch_summary=ingest_result.reconciliation.mismatch_summary,
-                compared_at=ingest_result.reconciliation.compared_at,
-                lifecycle_state=ingest_result.reconciliation.lifecycle_state,
-            )
-        )
-        return FindingAlertIngestResult(
-            alert=ingest_result.alert,
-            reconciliation=reconciliation,
-            disposition=ingest_result.disposition,
+        return self._detection_lifecycle_service.attach_native_detection_context(
+            record=record,
+            ingest_result=ingest_result,
+            substrate_detection_record_id=substrate_detection_record_id,
         )
 
     def _with_native_detection_admission_provenance(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -165,6 +165,14 @@ class ControlPlaneStore(Protocol):
     def list(self, record_type: Type[RecordT]) -> tuple[RecordT, ...]:
         ...
 
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> ReconciliationRecord | None:
+        ...
+
     def latest_lifecycle_transition(
         self,
         record_family: str,

--- a/control-plane/postgres_test_support.py
+++ b/control-plane/postgres_test_support.py
@@ -87,6 +87,12 @@ _SELECT_LATEST_RECONCILIATION_RE = re.compile(
     r"order by compared_at desc, reconciliation_id desc limit 1",
     re.IGNORECASE,
 )
+_SELECT_LATEST_RECONCILIATION_BY_CORRELATION_KEY_RE = re.compile(
+    r"select (?P<columns>.+) from aegisops_control\.reconciliation_records "
+    r"where correlation_key = %s(?P<require_alert_id> and alert_id is not null)? "
+    r"order by compared_at desc, reconciliation_id desc limit 1",
+    re.IGNORECASE,
+)
 _SELECT_EXECUTIONS_BY_ACTION_REQUEST_IDS_RE = re.compile(
     r"select (?P<columns>.+) from aegisops_control\.action_execution_records "
     r"where action_request_id in \((?P<placeholders>.+)\) "
@@ -280,6 +286,21 @@ class FakePostgresCursor:
         if select_latest_reconciliation_match is not None:
             self._execute_select_latest_reconciliation(
                 select_latest_reconciliation_match.group("columns")
+            )
+            return
+        select_latest_reconciliation_by_correlation_key_match = (
+            _SELECT_LATEST_RECONCILIATION_BY_CORRELATION_KEY_RE.fullmatch(normalized)
+        )
+        if select_latest_reconciliation_by_correlation_key_match is not None:
+            self._execute_select_latest_reconciliation_by_correlation_key(
+                select_latest_reconciliation_by_correlation_key_match.group("columns"),
+                params,
+                require_alert_id=(
+                    select_latest_reconciliation_by_correlation_key_match.group(
+                        "require_alert_id"
+                    )
+                    is not None
+                ),
             )
             return
 
@@ -519,6 +540,31 @@ class FakePostgresCursor:
     def _execute_select_latest_reconciliation(self, columns: str) -> None:
         column_names = [column.strip() for column in columns.split(",")]
         rows = list(self.tables.get("reconciliation_records", {}).values())
+        rows.sort(
+            key=lambda row: (row["compared_at"], row["reconciliation_id"]),
+            reverse=True,
+        )
+        self.description = tuple((name,) for name in column_names)
+        if not rows:
+            self._rows = []
+            return
+        self._rows = [self._project_row(rows[0], column_names)]
+
+    def _execute_select_latest_reconciliation_by_correlation_key(
+        self,
+        columns: str,
+        params: tuple[object, ...] | None,
+        *,
+        require_alert_id: bool,
+    ) -> None:
+        column_names = [column.strip() for column in columns.split(",")]
+        correlation_key = str((params or ("",))[0])
+        rows = [
+            row
+            for row in self.tables.get("reconciliation_records", {}).values()
+            if str(row.get("correlation_key")) == correlation_key
+            and (not require_alert_id or row.get("alert_id") is not None)
+        ]
         rows.sort(
             key=lambda row: (row["compared_at"], row["reconciliation_id"]),
             reverse=True,

--- a/control-plane/tests/support/fake_store.py
+++ b/control-plane/tests/support/fake_store.py
@@ -53,6 +53,17 @@ class TransactionMutationStore:
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
 
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> ReconciliationRecord | None:
+        return self.inner.latest_reconciliation_for_correlation_key(
+            correlation_key,
+            require_alert_id=require_alert_id,
+        )
+
     def latest_lifecycle_transition(
         self,
         record_family: str,
@@ -146,6 +157,20 @@ class ConcurrentListMutationStore:
             self.mutate_once()
         return records
 
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> ReconciliationRecord | None:
+        reconciliation = self.inner.latest_reconciliation_for_correlation_key(
+            correlation_key,
+            require_alert_id=require_alert_id,
+        )
+        if self._consume_mutation_token():
+            self.mutate_once()
+        return reconciliation
+
     def latest_lifecycle_transition(
         self,
         record_family: str,
@@ -225,6 +250,17 @@ class CommitFailingStore:
 
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
+
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> ReconciliationRecord | None:
+        return self.inner.latest_reconciliation_for_correlation_key(
+            correlation_key,
+            require_alert_id=require_alert_id,
+        )
 
     def latest_lifecycle_transition(
         self,
@@ -316,6 +352,17 @@ class RecordTypeSaveFailingStore:
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
 
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> ReconciliationRecord | None:
+        return self.inner.latest_reconciliation_for_correlation_key(
+            correlation_key,
+            require_alert_id=require_alert_id,
+        )
+
     def latest_lifecycle_transition(
         self,
         record_family: str,
@@ -379,6 +426,7 @@ class ListCountingStore:
     inner: object
     list_calls: int = 0
     reconciliation_list_calls: int = 0
+    latest_reconciliation_for_correlation_key_calls: int = 0
     lifecycle_transition_record_list_calls: int = 0
     latest_lifecycle_transition_calls: int = 0
     lifecycle_transition_history_calls: int = 0
@@ -410,6 +458,18 @@ class ListCountingStore:
         if record_type is LifecycleTransitionRecord:
             self.lifecycle_transition_record_list_calls += 1
         return self.inner.list(record_type)
+
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> ReconciliationRecord | None:
+        self.latest_reconciliation_for_correlation_key_calls += 1
+        return self.inner.latest_reconciliation_for_correlation_key(
+            correlation_key,
+            require_alert_id=require_alert_id,
+        )
 
     def latest_lifecycle_transition(
         self,
@@ -486,6 +546,17 @@ class OutOfBandMutationStore:
 
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
+
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> ReconciliationRecord | None:
+        return self.inner.latest_reconciliation_for_correlation_key(
+            correlation_key,
+            require_alert_id=require_alert_id,
+        )
 
     def latest_lifecycle_transition(
         self,

--- a/control-plane/tests/test_phase25_osquery_host_context_validation.py
+++ b/control-plane/tests/test_phase25_osquery_host_context_validation.py
@@ -62,6 +62,17 @@ class _EvidenceSaveMutationStore:
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
 
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> object | None:
+        return self.inner.latest_reconciliation_for_correlation_key(
+            correlation_key,
+            require_alert_id=require_alert_id,
+        )
+
     def latest_lifecycle_transition(
         self,
         record_family: str,

--- a/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
+++ b/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
@@ -64,6 +64,17 @@ class _EvidenceSaveMutationStore:
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
 
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> object | None:
+        return self.inner.latest_reconciliation_for_correlation_key(
+            correlation_key,
+            require_alert_id=require_alert_id,
+        )
+
     def latest_lifecycle_transition(
         self,
         record_family: str,
@@ -108,6 +119,17 @@ class _ActionRequestMutationStore:
 
     def list(self, record_type: object) -> tuple[object, ...]:
         return self.inner.list(record_type)
+
+    def latest_reconciliation_for_correlation_key(
+        self,
+        correlation_key: str,
+        *,
+        require_alert_id: bool = False,
+    ) -> object | None:
+        return self.inner.latest_reconciliation_for_correlation_key(
+            correlation_key,
+            require_alert_id=require_alert_id,
+        )
 
     def latest_lifecycle_transition(
         self,

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -1177,6 +1177,51 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
             "select reconciliation_id, subject_linkage, alert_id, finding_id, analytic_signal_id, execution_run_id, linked_execution_run_ids, correlation_key, first_seen_at, last_seen_at, ingest_disposition, mismatch_summary, compared_at, lifecycle_state from aegisops_control.reconciliation_records where correlation_key = %s and alert_id is not null order by compared_at desc, reconciliation_id desc limit 1",
         )
 
+    def test_reconciliation_lookup_maps_tuple_rows_before_cursor_close(self) -> None:
+        store, _ = make_store(_TupleRowClosingBackend())
+        older = ReconciliationRecord(
+            reconciliation_id="reconciliation-tuple-001",
+            subject_linkage={"finding_ids": ["finding-tuple-001"]},
+            alert_id="alert-tuple-001",
+            finding_id="finding-tuple-001",
+            analytic_signal_id="signal-tuple-001",
+            execution_run_id=None,
+            linked_execution_run_ids=(),
+            correlation_key="claim:host-001:tuple-lookup",
+            first_seen_at=datetime(2026, 4, 16, 8, 0, tzinfo=timezone.utc),
+            last_seen_at=datetime(2026, 4, 16, 8, 1, tzinfo=timezone.utc),
+            ingest_disposition="created",
+            mismatch_summary="",
+            compared_at=datetime(2026, 4, 16, 8, 2, tzinfo=timezone.utc),
+            lifecycle_state="matched",
+        )
+        latest = ReconciliationRecord(
+            reconciliation_id="reconciliation-tuple-002",
+            subject_linkage={"finding_ids": ["finding-tuple-001", "finding-tuple-002"]},
+            alert_id="alert-tuple-001",
+            finding_id="finding-tuple-002",
+            analytic_signal_id="signal-tuple-002",
+            execution_run_id=None,
+            linked_execution_run_ids=(),
+            correlation_key="claim:host-001:tuple-lookup",
+            first_seen_at=datetime(2026, 4, 16, 8, 0, tzinfo=timezone.utc),
+            last_seen_at=datetime(2026, 4, 16, 8, 3, tzinfo=timezone.utc),
+            ingest_disposition="restated",
+            mismatch_summary="",
+            compared_at=datetime(2026, 4, 16, 8, 4, tzinfo=timezone.utc),
+            lifecycle_state="matched",
+        )
+
+        for record in (older, latest):
+            store.save(record)
+
+        self.assertEqual(
+            store.latest_reconciliation_for_correlation_key(
+                "claim:host-001:tuple-lookup"
+            ),
+            latest,
+        )
+
     def test_store_lists_lifecycle_transitions_by_subject(self) -> None:
         store, _ = make_store()
         first_transition = LifecycleTransitionRecord(

--- a/control-plane/tests/test_postgres_store.py
+++ b/control-plane/tests/test_postgres_store.py
@@ -337,6 +337,40 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
             schema_sql,
         )
 
+    def test_phase28_reconciliation_correlation_lookup_index_migration_asset_exists(
+        self,
+    ) -> None:
+        migration_path = (
+            CONTROL_PLANE_ROOT.parent
+            / "postgres"
+            / "control-plane"
+            / "migrations"
+            / "0011_phase_28_reconciliation_correlation_lookup_index.sql"
+        )
+
+        self.assertTrue(
+            migration_path.exists(),
+            f"Missing Phase 28 forward migration asset: {migration_path}",
+        )
+
+        migration_sql = migration_path.read_text(encoding="utf-8").lower()
+        schema_sql = (
+            CONTROL_PLANE_ROOT.parent / "postgres" / "control-plane" / "schema.sql"
+        ).read_text(encoding="utf-8").lower()
+
+        self.assertIn("begin;", migration_sql)
+        self.assertIn("commit;", migration_sql)
+        self.assertIn(
+            "create index if not exists reconciliation_records_correlation_alert_latest_idx",
+            migration_sql,
+        )
+        self.assertIn("where alert_id is not null", migration_sql)
+        self.assertIn(
+            "create index if not exists reconciliation_records_correlation_alert_latest_idx",
+            schema_sql,
+        )
+        self.assertIn("where alert_id is not null", schema_sql)
+
     def test_phase23_lifecycle_transition_forward_migration_asset_exists(self) -> None:
         migration_path = (
             CONTROL_PLANE_ROOT.parent
@@ -1051,6 +1085,96 @@ class PostgresControlPlaneStoreTests(unittest.TestCase):
         )
         self.assertIsNone(
             store.latest_lifecycle_transition("alert", "alert-missing-001")
+        )
+
+    def test_store_lists_latest_reconciliation_by_correlation_key(self) -> None:
+        store, backend = make_store()
+        older = ReconciliationRecord(
+            reconciliation_id="reconciliation-correlation-older",
+            subject_linkage={"finding_ids": ["finding-correlation-001"]},
+            alert_id="alert-correlation-001",
+            finding_id="finding-correlation-001",
+            analytic_signal_id="signal-correlation-001",
+            execution_run_id=None,
+            linked_execution_run_ids=(),
+            correlation_key="claim:host-001:correlation-lookup",
+            first_seen_at=datetime(2026, 4, 16, 8, 0, tzinfo=timezone.utc),
+            last_seen_at=datetime(2026, 4, 16, 8, 1, tzinfo=timezone.utc),
+            ingest_disposition="created",
+            mismatch_summary="",
+            compared_at=datetime(2026, 4, 16, 8, 2, tzinfo=timezone.utc),
+            lifecycle_state="matched",
+        )
+        latest_without_alert = ReconciliationRecord(
+            reconciliation_id="reconciliation-correlation-latest-without-alert",
+            subject_linkage={"finding_ids": ["finding-correlation-002"]},
+            alert_id=None,
+            finding_id="finding-correlation-002",
+            analytic_signal_id="signal-correlation-002",
+            execution_run_id=None,
+            linked_execution_run_ids=(),
+            correlation_key="claim:host-001:correlation-lookup",
+            first_seen_at=datetime(2026, 4, 16, 8, 3, tzinfo=timezone.utc),
+            last_seen_at=datetime(2026, 4, 16, 8, 4, tzinfo=timezone.utc),
+            ingest_disposition="matched",
+            mismatch_summary="",
+            compared_at=datetime(2026, 4, 16, 8, 9, tzinfo=timezone.utc),
+            lifecycle_state="matched",
+        )
+        latest_with_alert = ReconciliationRecord(
+            reconciliation_id="reconciliation-correlation-latest-with-alert",
+            subject_linkage={"finding_ids": ["finding-correlation-003"]},
+            alert_id="alert-correlation-003",
+            finding_id="finding-correlation-003",
+            analytic_signal_id="signal-correlation-003",
+            execution_run_id=None,
+            linked_execution_run_ids=(),
+            correlation_key="claim:host-001:correlation-lookup",
+            first_seen_at=datetime(2026, 4, 16, 8, 6, tzinfo=timezone.utc),
+            last_seen_at=datetime(2026, 4, 16, 8, 7, tzinfo=timezone.utc),
+            ingest_disposition="restated",
+            mismatch_summary="",
+            compared_at=datetime(2026, 4, 16, 8, 8, tzinfo=timezone.utc),
+            lifecycle_state="matched",
+        )
+        unrelated = ReconciliationRecord(
+            reconciliation_id="reconciliation-correlation-unrelated",
+            subject_linkage={"finding_ids": ["finding-correlation-004"]},
+            alert_id="alert-correlation-004",
+            finding_id="finding-correlation-004",
+            analytic_signal_id="signal-correlation-004",
+            execution_run_id=None,
+            linked_execution_run_ids=(),
+            correlation_key="claim:host-001:other",
+            first_seen_at=datetime(2026, 4, 16, 8, 10, tzinfo=timezone.utc),
+            last_seen_at=datetime(2026, 4, 16, 8, 11, tzinfo=timezone.utc),
+            ingest_disposition="matched",
+            mismatch_summary="",
+            compared_at=datetime(2026, 4, 16, 8, 12, tzinfo=timezone.utc),
+            lifecycle_state="matched",
+        )
+
+        for record in (older, latest_without_alert, latest_with_alert, unrelated):
+            store.save(record)
+
+        statement_count_before = len(backend.statements)
+        latest = store.latest_reconciliation_for_correlation_key(
+            "claim:host-001:correlation-lookup"
+        )
+        latest_with_required_alert = store.latest_reconciliation_for_correlation_key(
+            "claim:host-001:correlation-lookup",
+            require_alert_id=True,
+        )
+
+        self.assertEqual(latest, latest_without_alert)
+        self.assertEqual(latest_with_required_alert, latest_with_alert)
+        self.assertEqual(
+            backend.statements[statement_count_before][0],
+            "select reconciliation_id, subject_linkage, alert_id, finding_id, analytic_signal_id, execution_run_id, linked_execution_run_ids, correlation_key, first_seen_at, last_seen_at, ingest_disposition, mismatch_summary, compared_at, lifecycle_state from aegisops_control.reconciliation_records where correlation_key = %s order by compared_at desc, reconciliation_id desc limit 1",
+        )
+        self.assertEqual(
+            backend.statements[statement_count_before + 1][0],
+            "select reconciliation_id, subject_linkage, alert_id, finding_id, analytic_signal_id, execution_run_id, linked_execution_run_ids, correlation_key, first_seen_at, last_seen_at, ingest_disposition, mismatch_summary, compared_at, lifecycle_state from aegisops_control.reconciliation_records where correlation_key = %s and alert_id is not null order by compared_at desc, reconciliation_id desc limit 1",
         )
 
     def test_store_lists_lifecycle_transitions_by_subject(self) -> None:

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -3785,6 +3785,147 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(store.list(support.AnalyticSignalRecord), ())
         self.assertEqual(store.list(support.ReconciliationRecord), ())
 
+    def test_service_rolls_back_failed_direct_native_context_attachment(self) -> None:
+        inner_store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=inner_store,
+        )
+        first_seen_at = support.datetime(2026, 4, 5, 12, 0, tzinfo=support.timezone.utc)
+        reviewed_context = {"source": {"source_family": "reviewed-source"}}
+        created = service.ingest_finding_alert(
+            finding_id="finding-native-context-rollback-001",
+            analytic_signal_id="signal-native-context-rollback-001",
+            substrate_detection_record_id="substrate-detection-native-context-rollback-001",
+            correlation_key="claim:host-001:native-context-rollback",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+            reviewed_context=reviewed_context,
+        )
+        seed_evidence = service.persist_record(
+            support.EvidenceRecord(
+                evidence_id="evidence-native-context-seed-001",
+                source_record_id="substrate-detection-native-context-rollback-001",
+                alert_id=created.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="control-plane-test",
+                acquired_at=first_seen_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = service.promote_alert_to_case(created.alert.alert_id)
+        persisted_alert = service.get_record(support.AlertRecord, created.alert.alert_id)
+        persisted_reconciliation = service.get_record(
+            support.ReconciliationRecord,
+            created.reconciliation.reconciliation_id,
+        )
+        self.assertIsNotNone(persisted_alert)
+        self.assertIsNotNone(persisted_reconciliation)
+
+        failing_store = support.RecordTypeSaveFailingStore(
+            inner=inner_store,
+            record_type=support.ReconciliationRecord,
+            message="synthetic native-context reconciliation failure",
+        )
+        failing_service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=failing_store,
+        )
+        native_record = support.NativeDetectionRecord(
+            substrate_key="wazuh",
+            native_record_id="native-context-rollback-001",
+            record_kind="alert",
+            correlation_key="claim:host-001:native-context-rollback",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+            metadata={},
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "synthetic native-context reconciliation failure",
+        ):
+            failing_service._attach_native_detection_context(
+                record=native_record,
+                ingest_result=replace(
+                    created,
+                    alert=persisted_alert,
+                    reconciliation=persisted_reconciliation,
+                ),
+                substrate_detection_record_id="substrate-detection-native-context-rollback-native-001",
+            )
+
+        persisted_case = service.get_record(support.CaseRecord, promoted_case.case_id)
+        persisted_reconciliation = service.get_record(
+            support.ReconciliationRecord,
+            created.reconciliation.reconciliation_id,
+        )
+        evidence_records = tuple(
+            evidence
+            for evidence in inner_store.list(support.EvidenceRecord)
+            if evidence.alert_id == created.alert.alert_id
+        )
+        self.assertEqual(len(evidence_records), 1)
+        self.assertEqual(evidence_records[0].evidence_id, seed_evidence.evidence_id)
+        self.assertEqual(evidence_records[0].case_id, promoted_case.case_id)
+        self.assertEqual(persisted_case.evidence_ids, (seed_evidence.evidence_id,))
+        self.assertEqual(
+            persisted_reconciliation.subject_linkage.get("evidence_ids"),
+            (seed_evidence.evidence_id,),
+        )
+
+    def test_service_rejects_direct_native_context_attach_when_alert_links_missing_case(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        first_seen_at = support.datetime(2026, 4, 5, 12, 0, tzinfo=support.timezone.utc)
+        created = service.ingest_finding_alert(
+            finding_id="finding-missing-direct-native-case-001",
+            analytic_signal_id="signal-missing-direct-native-case-001",
+            substrate_detection_record_id="substrate-detection-missing-direct-native-case-001",
+            correlation_key="claim:host-001:missing-direct-native-case",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+        )
+        broken_alert = replace(
+            created.alert,
+            case_id="case-missing-direct-native-001",
+            lifecycle_state="escalated_to_case",
+        )
+        service.persist_record(broken_alert)
+        native_record = support.NativeDetectionRecord(
+            substrate_key="wazuh",
+            native_record_id="native-missing-direct-case-001",
+            record_kind="alert",
+            correlation_key="claim:host-001:missing-direct-native-case",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+            metadata={},
+        )
+
+        with self.assertRaisesRegex(
+            LookupError,
+            "Alert 'alert-[^']+' references missing case 'case-missing-direct-native-001'",
+        ):
+            service._attach_native_detection_context(
+                record=native_record,
+                ingest_result=replace(created, alert=broken_alert),
+                substrate_detection_record_id="substrate-detection-missing-direct-native-002",
+            )
+
+        self.assertEqual(store.list(support.EvidenceRecord), ())
+        self.assertEqual(
+            service.get_record(support.AlertRecord, created.alert.alert_id).case_id,
+            "case-missing-direct-native-001",
+        )
+        self.assertEqual(len(store.list(support.ReconciliationRecord)), 1)
+
     def test_service_rejects_restated_admission_when_alert_links_missing_case(self) -> None:
         store, _ = support.make_store()
         service = support.AegisOpsControlPlaneService(

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -20,18 +20,18 @@ for name, value in vars(support).items():
 
 class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
     def test_service_delegates_detection_lifecycle_operations(self) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,
         )
-        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
-        ingest_result = SimpleNamespace(name="ingest-result")
-        native_result = SimpleNamespace(name="native-result")
-        attach_result = SimpleNamespace(name="attach-result")
-        promoted_case = SimpleNamespace(case_id="case-delegated-001")
-        adapter = SimpleNamespace(substrate_key="wazuh")
-        native_record = NativeDetectionRecord(
+        first_seen_at = support.datetime(2026, 4, 5, 12, 0, tzinfo=support.timezone.utc)
+        ingest_result = support.SimpleNamespace(name="ingest-result")
+        native_result = support.SimpleNamespace(name="native-result")
+        attach_result = support.SimpleNamespace(name="attach-result")
+        promoted_case = support.SimpleNamespace(case_id="case-delegated-001")
+        adapter = support.SimpleNamespace(substrate_key="wazuh")
+        native_record = support.NativeDetectionRecord(
             substrate_key="wazuh",
             native_record_id="native-delegated-001",
             record_kind="alert",
@@ -40,7 +40,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             last_seen_at=first_seen_at,
             metadata={},
         )
-        admission = AnalyticSignalAdmission(
+        admission = support.AnalyticSignalAdmission(
             finding_id="finding-delegated-001",
             analytic_signal_id="signal-delegated-001",
             substrate_detection_record_id="substrate-delegated-001",
@@ -49,7 +49,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             last_seen_at=first_seen_at,
             reviewed_context={"source": {"source_family": "delegated"}},
         )
-        lifecycle_delegate = mock.Mock()
+        lifecycle_delegate = support.mock.Mock()
         lifecycle_delegate.ingest_finding_alert.return_value = ingest_result
         lifecycle_delegate.promote_alert_to_case.return_value = promoted_case
         lifecycle_delegate.ingest_native_detection_record.return_value = native_result
@@ -122,6 +122,58 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             ingest_result=ingest_result,
             substrate_detection_record_id="substrate-delegated-001",
         )
+
+    def test_service_rejects_promoting_alert_with_missing_linked_case(self) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        first_seen_at = support.datetime(2026, 4, 5, 12, 0, tzinfo=support.timezone.utc)
+
+        created = service.ingest_finding_alert(
+            finding_id="finding-missing-case-001",
+            analytic_signal_id="signal-missing-case-001",
+            substrate_detection_record_id="substrate-detection-missing-case-001",
+            correlation_key="claim:host-001:missing-case",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+        )
+        service.persist_record(
+            support.EvidenceRecord(
+                evidence_id="evidence-missing-case-001",
+                source_record_id="substrate-detection-missing-case-001",
+                alert_id=created.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="control-plane-test",
+                acquired_at=first_seen_at,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        service.persist_record(
+            replace(
+                created.alert,
+                case_id="case-missing-001",
+                lifecycle_state="escalated_to_case",
+            )
+        )
+
+        with self.assertRaisesRegex(
+            LookupError,
+            "Alert 'alert-[^']+' references missing case 'case-missing-001'",
+        ):
+            service.promote_alert_to_case(created.alert.alert_id)
+
+        stored_alert = service.get_record(support.AlertRecord, created.alert.alert_id)
+        stored_evidence = service.get_record(
+            support.EvidenceRecord,
+            "evidence-missing-case-001",
+        )
+        self.assertEqual(stored_alert.case_id, "case-missing-001")
+        self.assertEqual(stored_evidence.case_id, None)
+        self.assertIsNone(service.get_record(support.CaseRecord, "case-missing-001"))
 
     def test_service_merges_reviewed_context_for_existing_alert_updates(self) -> None:
         store, _ = make_store()
@@ -3437,7 +3489,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(updated.alert.alert_id, created.alert.alert_id)
         self.assertEqual(deduplicated.alert.alert_id, created.alert.alert_id)
         self.assertEqual(restated.alert.finding_id, "finding-001")
-        self.assertEqual(restated.alert.analytic_signal_id, "signal-001")
+        self.assertEqual(restated.alert.analytic_signal_id, "signal-002")
         self.assertEqual(updated.alert.finding_id, "finding-003")
         self.assertEqual(updated.alert.analytic_signal_id, "signal-003")
         self.assertEqual(deduplicated.alert.finding_id, "finding-003")
@@ -3584,6 +3636,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(created.disposition, "created")
         self.assertEqual(restated.disposition, "restated")
         self.assertEqual(restated.alert.alert_id, created.alert.alert_id)
+        self.assertEqual(restated.alert.analytic_signal_id, "signal-002")
 
         reconciliation = service.get_record(
             ReconciliationRecord, restated.reconciliation.reconciliation_id
@@ -3601,6 +3654,83 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             reconciliation.subject_linkage["substrate_detection_record_ids"],
             ("substrate-detection-001", "substrate-detection-002"),
         )
+
+    def test_service_rolls_back_failed_analytic_signal_admission(self) -> None:
+        store, _ = support.make_store()
+        store = support.RecordTypeSaveFailingStore(
+            inner=store,
+            record_type=support.ReconciliationRecord,
+            message="synthetic reconciliation failure",
+        )
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        first_seen_at = support.datetime(2026, 4, 5, 12, 0, tzinfo=support.timezone.utc)
+
+        with self.assertRaisesRegex(RuntimeError, "synthetic reconciliation failure"):
+            service.ingest_finding_alert(
+                finding_id="finding-rollback-001",
+                analytic_signal_id="signal-rollback-001",
+                substrate_detection_record_id="substrate-detection-rollback-001",
+                correlation_key="claim:host-001:rollback",
+                first_seen_at=first_seen_at,
+                last_seen_at=first_seen_at,
+            )
+
+        self.assertEqual(store.list(support.AlertRecord), ())
+        self.assertEqual(store.list(support.AnalyticSignalRecord), ())
+        self.assertEqual(store.list(support.ReconciliationRecord), ())
+
+    def test_service_rejects_restated_admission_when_alert_links_missing_case(self) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        first_seen_at = support.datetime(2026, 4, 5, 12, 0, tzinfo=support.timezone.utc)
+        second_seen_at = support.datetime(2026, 4, 5, 12, 15, tzinfo=support.timezone.utc)
+
+        created = service.ingest_finding_alert(
+            finding_id="finding-missing-case-restated-001",
+            analytic_signal_id="signal-missing-case-restated-001",
+            substrate_detection_record_id="substrate-detection-missing-case-restated-001",
+            correlation_key="claim:host-001:missing-linked-case",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+        )
+        service.persist_record(
+            replace(
+                created.alert,
+                case_id="case-missing-restated-001",
+                lifecycle_state="escalated_to_case",
+            )
+        )
+
+        with self.assertRaisesRegex(
+            LookupError,
+            "Alert 'alert-[^']+' references missing case 'case-missing-restated-001'",
+        ):
+            service.ingest_finding_alert(
+                finding_id="finding-missing-case-restated-001",
+                analytic_signal_id="signal-missing-case-restated-002",
+                substrate_detection_record_id="substrate-detection-missing-case-restated-002",
+                correlation_key="claim:host-001:missing-linked-case",
+                first_seen_at=first_seen_at,
+                last_seen_at=second_seen_at,
+            )
+
+        self.assertEqual(
+            service.get_record(support.AlertRecord, created.alert.alert_id).case_id,
+            "case-missing-restated-001",
+        )
+        self.assertIsNone(
+            service.get_record(
+                support.AnalyticSignalRecord,
+                "signal-missing-case-restated-002",
+            )
+        )
+        self.assertEqual(len(store.list(support.ReconciliationRecord)), 1)
 
     def test_service_rejects_naive_intake_timestamps(self) -> None:
         store, _ = make_store()

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -3655,6 +3655,39 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             ("substrate-detection-001", "substrate-detection-002"),
         )
 
+    def test_service_ingest_uses_targeted_reconciliation_lookup(self) -> None:
+        inner_store, _ = make_store()
+        store = _ListCountingStore(inner=inner_store)
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        first_seen = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        second_seen = datetime(2026, 4, 5, 12, 15, tzinfo=timezone.utc)
+
+        service.ingest_finding_alert(
+            finding_id="finding-lookup-001",
+            analytic_signal_id="signal-lookup-001",
+            substrate_detection_record_id="substrate-detection-lookup-001",
+            correlation_key="claim:host-001:lookup",
+            first_seen_at=first_seen,
+            last_seen_at=first_seen,
+        )
+        store.reconciliation_list_calls = 0
+        store.latest_reconciliation_for_correlation_key_calls = 0
+
+        service.ingest_finding_alert(
+            finding_id="finding-lookup-002",
+            analytic_signal_id="signal-lookup-002",
+            substrate_detection_record_id="substrate-detection-lookup-002",
+            correlation_key="claim:host-001:lookup",
+            first_seen_at=first_seen,
+            last_seen_at=second_seen,
+        )
+
+        self.assertEqual(store.reconciliation_list_calls, 0)
+        self.assertEqual(store.latest_reconciliation_for_correlation_key_calls, 1)
+
     def test_service_rolls_back_failed_analytic_signal_admission(self) -> None:
         store, _ = support.make_store()
         store = support.RecordTypeSaveFailingStore(

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -19,6 +19,110 @@ for name, value in vars(support).items():
 
 
 class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
+    def test_service_delegates_detection_lifecycle_operations(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        ingest_result = SimpleNamespace(name="ingest-result")
+        native_result = SimpleNamespace(name="native-result")
+        attach_result = SimpleNamespace(name="attach-result")
+        promoted_case = SimpleNamespace(case_id="case-delegated-001")
+        adapter = SimpleNamespace(substrate_key="wazuh")
+        native_record = NativeDetectionRecord(
+            substrate_key="wazuh",
+            native_record_id="native-delegated-001",
+            record_kind="alert",
+            correlation_key="claim:delegated",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+            metadata={},
+        )
+        admission = AnalyticSignalAdmission(
+            finding_id="finding-delegated-001",
+            analytic_signal_id="signal-delegated-001",
+            substrate_detection_record_id="substrate-delegated-001",
+            correlation_key="claim:delegated",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+            reviewed_context={"source": {"source_family": "delegated"}},
+        )
+        lifecycle_delegate = mock.Mock()
+        lifecycle_delegate.ingest_finding_alert.return_value = ingest_result
+        lifecycle_delegate.promote_alert_to_case.return_value = promoted_case
+        lifecycle_delegate.ingest_native_detection_record.return_value = native_result
+        lifecycle_delegate.ingest_analytic_signal_admission.return_value = ingest_result
+        lifecycle_delegate.attach_native_detection_context.return_value = attach_result
+        service._detection_lifecycle_service = lifecycle_delegate
+
+        self.assertIs(
+            service.ingest_finding_alert(
+                finding_id="finding-delegated-001",
+                analytic_signal_id="signal-delegated-001",
+                substrate_detection_record_id="substrate-delegated-001",
+                correlation_key="claim:delegated",
+                first_seen_at=first_seen_at,
+                last_seen_at=first_seen_at,
+                materially_new_work=True,
+                reviewed_context={"source": {"source_family": "delegated"}},
+            ),
+            ingest_result,
+        )
+        self.assertIs(
+            service.promote_alert_to_case(
+                "alert-delegated-001",
+                case_id="case-delegated-001",
+                case_lifecycle_state="investigating",
+            ),
+            promoted_case,
+        )
+        self.assertIs(
+            service.ingest_native_detection_record(adapter, native_record),
+            native_result,
+        )
+        self.assertIs(
+            service._ingest_analytic_signal_admission(admission),
+            ingest_result,
+        )
+        self.assertIs(
+            service._attach_native_detection_context(
+                record=native_record,
+                ingest_result=ingest_result,
+                substrate_detection_record_id="substrate-delegated-001",
+            ),
+            attach_result,
+        )
+
+        lifecycle_delegate.ingest_finding_alert.assert_called_once_with(
+            finding_id="finding-delegated-001",
+            analytic_signal_id="signal-delegated-001",
+            substrate_detection_record_id="substrate-delegated-001",
+            correlation_key="claim:delegated",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+            materially_new_work=True,
+            reviewed_context={"source": {"source_family": "delegated"}},
+        )
+        lifecycle_delegate.promote_alert_to_case.assert_called_once_with(
+            "alert-delegated-001",
+            case_id="case-delegated-001",
+            case_lifecycle_state="investigating",
+        )
+        lifecycle_delegate.ingest_native_detection_record.assert_called_once_with(
+            adapter,
+            native_record,
+        )
+        lifecycle_delegate.ingest_analytic_signal_admission.assert_called_once_with(
+            admission
+        )
+        lifecycle_delegate.attach_native_detection_context.assert_called_once_with(
+            record=native_record,
+            ingest_result=ingest_result,
+            substrate_detection_record_id="substrate-delegated-001",
+        )
+
     def test_service_merges_reviewed_context_for_existing_alert_updates(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -959,6 +959,19 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
                 "admission_kind": "live",
             },
         )
+        expected_evidence_ids = tuple(
+            evidence.evidence_id
+            for evidence in store.list(EvidenceRecord)
+            if evidence.alert_id == created.alert.alert_id
+        )
+        self.assertCountEqual(
+            restated_reconciliation.subject_linkage["evidence_ids"],
+            expected_evidence_ids,
+        )
+        self.assertCountEqual(
+            deduplicated_reconciliation.subject_linkage["evidence_ids"],
+            expected_evidence_ids,
+        )
 
         persisted_case = service.get_record(CaseRecord, promoted_case.case_id)
         self.assertIsNotNone(persisted_case)
@@ -3607,6 +3620,63 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(signal_three.first_seen_at, updated_seen)
         self.assertEqual(signal_three.last_seen_at, duplicate_seen)
 
+    def test_service_keeps_promoted_case_finding_aligned_with_materially_new_alert_work(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        first_seen = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        updated_seen = datetime(2026, 4, 5, 12, 30, tzinfo=timezone.utc)
+
+        created = service.ingest_finding_alert(
+            finding_id="finding-case-alignment-001",
+            analytic_signal_id="signal-case-alignment-001",
+            substrate_detection_record_id="substrate-detection-case-alignment-001",
+            correlation_key="claim:host-001:case-alignment",
+            first_seen_at=first_seen,
+            last_seen_at=first_seen,
+            reviewed_context={"source": {"family": "seed"}},
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-case-alignment-001",
+                source_record_id="substrate-detection-case-alignment-001",
+                alert_id=created.alert.alert_id,
+                case_id=None,
+                source_system="reviewed-source",
+                collector_identity="control-plane-test",
+                acquired_at=first_seen,
+                derivation_relationship="admitted_analytic_signal",
+                lifecycle_state="collected",
+            )
+        )
+        promoted_case = service.promote_alert_to_case(created.alert.alert_id)
+
+        updated = service.ingest_finding_alert(
+            finding_id="finding-case-alignment-002",
+            analytic_signal_id="signal-case-alignment-002",
+            substrate_detection_record_id="substrate-detection-case-alignment-002",
+            correlation_key="claim:host-001:case-alignment",
+            first_seen_at=updated_seen,
+            last_seen_at=updated_seen,
+            materially_new_work=True,
+            reviewed_context={"source": {"family": "updated"}},
+        )
+
+        persisted_case = service.get_record(CaseRecord, promoted_case.case_id)
+
+        self.assertEqual(updated.disposition, "updated")
+        self.assertEqual(updated.alert.case_id, promoted_case.case_id)
+        self.assertIsNotNone(persisted_case)
+        self.assertEqual(persisted_case.finding_id, "finding-case-alignment-002")
+        self.assertEqual(
+            persisted_case.reviewed_context["source"]["family"],
+            "updated",
+        )
+
     def test_service_restates_when_repeated_finding_adds_new_signal_identity(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -3884,6 +3954,52 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(
             reconciliation.subject_linkage["substrate_detection_record_ids"],
             (),
+        )
+
+    def test_service_rejects_supplied_analytic_signal_id_from_other_correlation_key(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        first_seen_at = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+
+        created = service.ingest_finding_alert(
+            finding_id="finding-signal-collision-001",
+            analytic_signal_id="signal-collision-001",
+            substrate_detection_record_id="substrate-detection-collision-001",
+            correlation_key="claim:host-001:signal-collision-a",
+            first_seen_at=first_seen_at,
+            last_seen_at=first_seen_at,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            (
+                "Analytic signal 'signal-collision-001' already belongs to "
+                "correlation key 'claim:host-001:signal-collision-a'"
+            ),
+        ):
+            service.ingest_finding_alert(
+                finding_id="finding-signal-collision-002",
+                analytic_signal_id="signal-collision-001",
+                substrate_detection_record_id="substrate-detection-collision-002",
+                correlation_key="claim:host-001:signal-collision-b",
+                first_seen_at=first_seen_at,
+                last_seen_at=first_seen_at + timedelta(minutes=15),
+            )
+
+        self.assertEqual(len(store.list(AlertRecord)), 1)
+        self.assertEqual(len(store.list(AnalyticSignalRecord)), 1)
+        self.assertEqual(len(store.list(ReconciliationRecord)), 1)
+        self.assertEqual(
+            service.get_record(
+                AnalyticSignalRecord,
+                "signal-collision-001",
+            ).correlation_key,
+            created.reconciliation.correlation_key,
         )
 
     def test_service_inspects_analytic_signal_records_as_first_class_records(self) -> None:

--- a/postgres/control-plane/migrations/0011_phase_28_reconciliation_correlation_lookup_index.sql
+++ b/postgres/control-plane/migrations/0011_phase_28_reconciliation_correlation_lookup_index.sql
@@ -1,0 +1,11 @@
+begin;
+
+create index if not exists reconciliation_records_correlation_alert_latest_idx
+  on aegisops_control.reconciliation_records (
+    correlation_key,
+    compared_at desc,
+    reconciliation_id desc
+  )
+  where alert_id is not null;
+
+commit;

--- a/postgres/control-plane/schema.sql
+++ b/postgres/control-plane/schema.sql
@@ -740,3 +740,11 @@ create index if not exists lifecycle_transition_records_subject_latest_idx
     transitioned_at desc,
     transition_id desc
   );
+
+create index if not exists reconciliation_records_correlation_alert_latest_idx
+  on aegisops_control.reconciliation_records (
+    correlation_key,
+    compared_at desc,
+    reconciliation_id desc
+  )
+  where alert_id is not null;


### PR DESCRIPTION
Closes #607
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the admission/promotion cluster out of `control-plane/aegisops_control_plane/service.py` into [detection_lifecycle.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-607/control-plane/aegisops_control_plane/detection_lifecycle.py). `service.py` now keeps the public API stable and delegates `ingest_finding_alert`, `ingest_native_detection_record`, `_ingest_analytic_signal_admission`, `_attach_native_detection_context`, and `promote_alert_to_case` through that helper. I also moved `FindingAlertIngestResult` into [models.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-607/control-plane/aegisops_control_plane/models.py) to avoid a helper/service import cycle.

I added a focused delegation regression in [test_service_persistence_ingest_case_lifecycle.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-607/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py) so this boundary stays extracted. Behavior-focused persistence coverage remained green. The issue journal was updated locally, but `.codex-supervisor/issues` is gitignored here, so that update was not part of the commit. Checkpoint commit: `0ddafd95ad7b14886b6dba61a7c8767834c11dfc` (`refactor control-plane detection lifecycle boundary`).

Summary: Extracted detection admission and alert-case lifecycle logic into a dedicated internal lifecycle module, kept the service API stable via delegation, and added a narrow delegation regression.
State hint: implementing
Blocked reason: none
Tests: `python3 -m un...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New detection lifecycle service to handle ingestion, alert→case promotion, evidence linking, and reconciliation; added a typed ingest result container.

* **Refactor**
  * Core ingestion/promotion flows delegated to the new lifecycle service for clearer responsibilities.

* **Performance**
  * Added a partial DB index to speed latest-reconciliation lookups by correlation key.

* **Tests**
  * Expanded tests for delegation, rollback, promotion edge-cases, reconciliation lookup semantics, and store/backing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->