### PR TITLE
implementation: add offline feature extraction and shadow dataset generation from reviewed records (#618)

### DIFF
--- a/control-plane/aegisops_control_plane/phase29_shadow_dataset.py
+++ b/control-plane/aegisops_control_plane/phase29_shadow_dataset.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import hashlib
 import json
-from typing import Mapping
+from typing import Mapping, Sequence
 
 from .models import (
     AlertRecord,
@@ -79,22 +79,34 @@ def generate_reviewed_shadow_dataset(
         key=lambda record: record.recommendation_id,
     )
 
-    examples = tuple(
-        _build_recommendation_example(
-            service=service,
-            store=store,
-            recommendation=recommendation,
-            extraction_spec_version=extraction_spec_version,
-            snapshot_timestamp=snapshot_timestamp,
+    examples: list[dict[str, object]] = []
+    for recommendation in recommendations:
+        label_transition = _latest_lifecycle_transition_as_of(
+            service,
+            "recommendation",
+            recommendation.recommendation_id,
+            snapshot_timestamp,
         )
-        for recommendation in recommendations
-        if recommendation.lifecycle_state in _ALLOWED_RECOMMENDATION_LABEL_STATES
-    )
+        if (
+            label_transition is None
+            or label_transition.lifecycle_state not in _ALLOWED_RECOMMENDATION_LABEL_STATES
+        ):
+            continue
+        examples.append(
+            _build_recommendation_example(
+                service=service,
+                store=store,
+                recommendation=recommendation,
+                label_transition=label_transition,
+                extraction_spec_version=extraction_spec_version,
+                snapshot_timestamp=snapshot_timestamp,
+            )
+        )
 
     snapshot_payload = {
         "extraction_spec_version": extraction_spec_version,
         "snapshot_timestamp": snapshot_timestamp.isoformat(),
-        "examples": examples,
+        "examples": tuple(examples),
     }
     snapshot_id = hashlib.sha256(
         _canonical_json(snapshot_payload).encode("utf-8")
@@ -104,7 +116,7 @@ def generate_reviewed_shadow_dataset(
         extraction_spec_version=extraction_spec_version,
         snapshot_timestamp=snapshot_timestamp.isoformat(),
         example_count=len(examples),
-        examples=examples,
+        examples=tuple(examples),
     )
 
 
@@ -113,6 +125,7 @@ def _build_recommendation_example(
     service: object,
     store: object,
     recommendation: RecommendationRecord,
+    label_transition: LifecycleTransitionRecord,
     extraction_spec_version: str,
     snapshot_timestamp: datetime,
 ) -> dict[str, object]:
@@ -133,6 +146,17 @@ def _build_recommendation_example(
             f"recommendation {recommendation.recommendation_id} references missing alert "
             f"{recommendation.alert_id}"
         )
+    alert_transition = _latest_lifecycle_transition_as_of(
+        service,
+        "alert",
+        alert_record.alert_id,
+        snapshot_timestamp,
+    )
+    if alert_transition is None:
+        raise Phase29ShadowDatasetGenerationError(
+            f"recommendation {recommendation.recommendation_id} references alert "
+            f"{alert_record.alert_id} without authoritative state at requested snapshot"
+        )
 
     source_family = _nested_string(
         alert_record.reviewed_context,
@@ -145,40 +169,34 @@ def _build_recommendation_example(
 
     linked_evidence = _linked_evidence_records(
         store=store,
-        case_id=case_record.case_id,
-        alert_id=alert_record.alert_id,
+        evidence_ids=case_record.evidence_ids,
+        snapshot_timestamp=snapshot_timestamp,
     )
     anchor_evidence = _select_anchor_evidence(
         recommendation_id=recommendation.recommendation_id,
         linked_evidence=linked_evidence,
     )
-
-    label_transition = _latest_lifecycle_transition(
-        service,
-        "recommendation",
-        recommendation.recommendation_id,
-    )
-    if label_transition is None:
-        raise Phase29ShadowDatasetGenerationError(
-            "missing required reviewed label transition for recommendation "
-            f"{recommendation.recommendation_id}"
-        )
-
-    ambiguity_badges = sorted(
-        {
-            ambiguity_badge
-            for evidence in linked_evidence
-            for ambiguity_badge in (_optional_string(evidence.provenance.get("ambiguity_badge")),)
-            if ambiguity_badge is not None
-        }
+    ambiguity_badges, ambiguity_contributors = _ambiguity_badge_provenance(
+        linked_evidence=linked_evidence
     )
     latest_reconciliation = _latest_reconciliation(
         store=store,
         alert_id=alert_record.alert_id,
         case_id=case_record.case_id,
+        snapshot_timestamp=snapshot_timestamp,
     )
 
-    case_transition = _latest_lifecycle_transition(service, "case", case_record.case_id)
+    case_transition = _latest_lifecycle_transition_as_of(
+        service,
+        "case",
+        case_record.case_id,
+        snapshot_timestamp,
+    )
+    if case_transition is None:
+        raise Phase29ShadowDatasetGenerationError(
+            f"recommendation {recommendation.recommendation_id} references case "
+            f"{case_record.case_id} without authoritative state at requested snapshot"
+        )
 
     features: dict[str, object] = {
         "source_family": _feature_entry(
@@ -189,11 +207,11 @@ def _build_recommendation_example(
             extraction_spec_version=extraction_spec_version,
             snapshot_timestamp=snapshot_timestamp,
             classification=None,
-            reviewed_by=_first_actor_identity(case_transition),
+            reviewed_by=_first_actor_identity(alert_transition),
             reviewed_linkage="subject-alert-link",
         ),
         "case_lifecycle_state": _feature_entry(
-            value=case_record.lifecycle_state,
+            value=case_transition.lifecycle_state,
             record_family="case",
             record_id=case_record.case_id,
             field_path="lifecycle_state",
@@ -209,7 +227,12 @@ def _build_recommendation_example(
         case_record.reviewed_context,
         ("triage", "disposition"),
     )
-    if case_triage_disposition is not None:
+    case_triage_recorded_at = _reviewed_context_recorded_at(case_record.reviewed_context)
+    if (
+        case_triage_disposition is not None
+        and case_triage_recorded_at is not None
+        and case_triage_recorded_at <= snapshot_timestamp
+    ):
         features["case_triage_disposition"] = _feature_entry(
             value=case_triage_disposition,
             record_family="case",
@@ -232,6 +255,7 @@ def _build_recommendation_example(
         classification=_optional_string(anchor_evidence.provenance.get("classification")),
         reviewed_by=_optional_string(anchor_evidence.provenance.get("reviewed_by")),
         reviewed_linkage="subject-anchor-evidence-link",
+        source_contributors=ambiguity_contributors,
     )
 
     if latest_reconciliation is not None:
@@ -265,7 +289,7 @@ def _build_recommendation_example(
         "linked_alert_id": alert_record.alert_id,
         "features": features,
         "label": {
-            "value": recommendation.lifecycle_state,
+            "value": label_transition.lifecycle_state,
             "provenance": {
                 "label_record_family": _display_record_family("recommendation"),
                 "label_record_id": recommendation.recommendation_id,
@@ -284,19 +308,20 @@ def _build_recommendation_example(
 def _linked_evidence_records(
     *,
     store: object,
-    case_id: str,
-    alert_id: str,
+    evidence_ids: Sequence[str],
+    snapshot_timestamp: datetime,
 ) -> tuple[EvidenceRecord, ...]:
-    return tuple(
-        sorted(
-            (
-                evidence
-                for evidence in store.list(EvidenceRecord)
-                if evidence.case_id == case_id or evidence.alert_id == alert_id
-            ),
-            key=lambda evidence: evidence.evidence_id,
-        )
-    )
+    linked_evidence: list[EvidenceRecord] = []
+    for evidence_id in evidence_ids:
+        evidence = store.get(EvidenceRecord, evidence_id)
+        if evidence is None:
+            raise Phase29ShadowDatasetGenerationError(
+                f"reviewed subject links missing evidence record {evidence_id}"
+            )
+        if _evidence_snapshot_timestamp(evidence) > snapshot_timestamp:
+            continue
+        linked_evidence.append(evidence)
+    return tuple(sorted(linked_evidence, key=lambda evidence: evidence.evidence_id))
 
 
 def _select_anchor_evidence(
@@ -334,12 +359,19 @@ def _latest_reconciliation(
     store: object,
     alert_id: str,
     case_id: str,
+    snapshot_timestamp: datetime,
 ) -> ReconciliationRecord | None:
     matching = [
         reconciliation
         for reconciliation in store.list(ReconciliationRecord)
-        if reconciliation.alert_id == alert_id
-        or case_id in _tuple_of_strings(reconciliation.subject_linkage.get("case_ids"))
+        if (
+            reconciliation.compared_at <= snapshot_timestamp
+            and (
+                reconciliation.alert_id == alert_id
+                or case_id
+                in _tuple_of_strings(reconciliation.subject_linkage.get("case_ids"))
+            )
+        )
     ]
     if not matching:
         return None
@@ -352,15 +384,20 @@ def _latest_reconciliation(
     )[-1]
 
 
-def _latest_lifecycle_transition(
+def _latest_lifecycle_transition_as_of(
     service: object,
     record_family: str,
     record_id: str,
+    as_of: datetime,
 ) -> LifecycleTransitionRecord | None:
     list_transitions = getattr(service, "list_lifecycle_transitions", None)
     if not callable(list_transitions):
         raise TypeError("service must expose list_lifecycle_transitions")
-    transitions = list_transitions(record_family, record_id)
+    transitions = tuple(
+        transition
+        for transition in list_transitions(record_family, record_id)
+        if transition.transitioned_at <= as_of
+    )
     if not transitions:
         return None
     return transitions[-1]
@@ -377,20 +414,86 @@ def _feature_entry(
     classification: str | None,
     reviewed_by: str | None,
     reviewed_linkage: str,
+    source_contributors: Sequence[Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
+    provenance: dict[str, object] = {
+        "feature_source_record_family": _display_record_family(record_family),
+        "feature_source_record_id": record_id,
+        "feature_source_field_path": field_path,
+        "feature_extraction_spec_version": extraction_spec_version,
+        "feature_snapshot_timestamp": snapshot_timestamp.isoformat(),
+        "feature_reviewed_linkage": reviewed_linkage,
+        "feature_source_provenance_classification": classification,
+        "feature_source_reviewed_by": reviewed_by,
+    }
+    if source_contributors:
+        provenance["feature_source_contributors"] = tuple(
+            dict(contributor) for contributor in source_contributors
+        )
     return {
         "value": value,
-        "provenance": {
-            "feature_source_record_family": _display_record_family(record_family),
-            "feature_source_record_id": record_id,
-            "feature_source_field_path": field_path,
-            "feature_extraction_spec_version": extraction_spec_version,
-            "feature_snapshot_timestamp": snapshot_timestamp.isoformat(),
-            "feature_reviewed_linkage": reviewed_linkage,
-            "feature_source_provenance_classification": classification,
-            "feature_source_reviewed_by": reviewed_by,
-        },
+        "provenance": provenance,
     }
+
+
+def _ambiguity_badge_provenance(
+    *,
+    linked_evidence: Sequence[EvidenceRecord],
+) -> tuple[list[str], tuple[dict[str, object], ...]]:
+    badges = sorted(
+        {
+            ambiguity_badge
+            for evidence in linked_evidence
+            for ambiguity_badge in (_optional_string(evidence.provenance.get("ambiguity_badge")),)
+            if ambiguity_badge is not None
+        }
+    )
+    contributors = tuple(
+        {
+            "feature_source_record_family": _display_record_family("evidence"),
+            "feature_source_record_id": evidence.evidence_id,
+            "feature_source_field_path": "provenance.ambiguity_badge",
+            "feature_source_badge_value": ambiguity_badge,
+            "feature_source_provenance_classification": _optional_string(
+                evidence.provenance.get("classification")
+            ),
+            "feature_source_reviewed_by": _optional_string(
+                evidence.provenance.get("reviewed_by")
+            ),
+        }
+        for evidence in linked_evidence
+        for ambiguity_badge in (_optional_string(evidence.provenance.get("ambiguity_badge")),)
+        if ambiguity_badge is not None
+    )
+    return badges, contributors
+
+
+def _evidence_snapshot_timestamp(evidence: EvidenceRecord) -> datetime:
+    provenance_timestamp = _parse_optional_aware_datetime(
+        evidence.provenance.get("timestamp")
+    )
+    if provenance_timestamp is None:
+        return evidence.acquired_at
+    return max(evidence.acquired_at, provenance_timestamp)
+
+
+def _reviewed_context_recorded_at(reviewed_context: Mapping[str, object]) -> datetime | None:
+    triage = reviewed_context.get("triage")
+    if not isinstance(triage, Mapping):
+        return None
+    return _parse_optional_aware_datetime(triage.get("recorded_at"))
+
+
+def _parse_optional_aware_datetime(value: object) -> datetime | None:
+    raw_value = _optional_string(value)
+    if raw_value is None:
+        return None
+    parsed = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise Phase29ShadowDatasetGenerationError(
+            f"expected timezone-aware ISO timestamp, got {raw_value!r}"
+        )
+    return parsed
 
 
 def _display_record_family(record_family: str) -> str:

--- a/control-plane/aegisops_control_plane/phase29_shadow_dataset.py
+++ b/control-plane/aegisops_control_plane/phase29_shadow_dataset.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+from typing import Mapping
+
+from .models import (
+    AlertRecord,
+    CaseRecord,
+    EvidenceRecord,
+    LifecycleTransitionRecord,
+    RecommendationRecord,
+    ReconciliationRecord,
+)
+
+
+_ALLOWED_RECOMMENDATION_LABEL_STATES = frozenset(
+    {"accepted", "rejected", "superseded", "withdrawn"}
+)
+_RECORD_FAMILY_DISPLAY_NAMES = {
+    "alert": "Alert",
+    "case": "Case",
+    "evidence": "Evidence",
+    "recommendation": "Recommendation",
+    "reconciliation": "Reconciliation",
+}
+_REQUIRED_ANCHOR_PROVENANCE_FIELDS = (
+    "classification",
+    "source_id",
+    "timestamp",
+)
+
+
+class Phase29ShadowDatasetGenerationError(ValueError):
+    """Raised when reviewed shadow dataset generation cannot stay within bounds."""
+
+
+@dataclass(frozen=True)
+class Phase29ShadowDatasetSnapshot:
+    snapshot_id: str
+    extraction_spec_version: str
+    snapshot_timestamp: str
+    example_count: int
+    examples: tuple[dict[str, object], ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "snapshot_id": self.snapshot_id,
+            "extraction_spec_version": self.extraction_spec_version,
+            "snapshot_timestamp": self.snapshot_timestamp,
+            "example_count": self.example_count,
+            "examples": self.examples,
+        }
+
+
+def generate_reviewed_shadow_dataset(
+    service: object,
+    *,
+    extraction_spec_version: str,
+    snapshot_timestamp: datetime,
+) -> Phase29ShadowDatasetSnapshot:
+    if (
+        not isinstance(snapshot_timestamp, datetime)
+        or snapshot_timestamp.tzinfo is None
+        or snapshot_timestamp.utcoffset() is None
+    ):
+        raise ValueError("snapshot_timestamp must be a timezone-aware datetime")
+    if not isinstance(extraction_spec_version, str) or not extraction_spec_version.strip():
+        raise ValueError("extraction_spec_version must be a non-empty string")
+
+    store = getattr(service, "_store", None)
+    if store is None:
+        raise TypeError("service must expose the authoritative control-plane store")
+
+    recommendations = sorted(
+        store.list(RecommendationRecord),
+        key=lambda record: record.recommendation_id,
+    )
+
+    examples = tuple(
+        _build_recommendation_example(
+            service=service,
+            store=store,
+            recommendation=recommendation,
+            extraction_spec_version=extraction_spec_version,
+            snapshot_timestamp=snapshot_timestamp,
+        )
+        for recommendation in recommendations
+        if recommendation.lifecycle_state in _ALLOWED_RECOMMENDATION_LABEL_STATES
+    )
+
+    snapshot_payload = {
+        "extraction_spec_version": extraction_spec_version,
+        "snapshot_timestamp": snapshot_timestamp.isoformat(),
+        "examples": examples,
+    }
+    snapshot_id = hashlib.sha256(
+        _canonical_json(snapshot_payload).encode("utf-8")
+    ).hexdigest()
+    return Phase29ShadowDatasetSnapshot(
+        snapshot_id=snapshot_id,
+        extraction_spec_version=extraction_spec_version,
+        snapshot_timestamp=snapshot_timestamp.isoformat(),
+        example_count=len(examples),
+        examples=examples,
+    )
+
+
+def _build_recommendation_example(
+    *,
+    service: object,
+    store: object,
+    recommendation: RecommendationRecord,
+    extraction_spec_version: str,
+    snapshot_timestamp: datetime,
+) -> dict[str, object]:
+    if not recommendation.case_id or not recommendation.alert_id:
+        raise Phase29ShadowDatasetGenerationError(
+            f"recommendation {recommendation.recommendation_id} is missing reviewed subject linkage"
+        )
+
+    case_record = store.get(CaseRecord, recommendation.case_id)
+    if case_record is None:
+        raise Phase29ShadowDatasetGenerationError(
+            f"recommendation {recommendation.recommendation_id} references missing case "
+            f"{recommendation.case_id}"
+        )
+    alert_record = store.get(AlertRecord, recommendation.alert_id)
+    if alert_record is None:
+        raise Phase29ShadowDatasetGenerationError(
+            f"recommendation {recommendation.recommendation_id} references missing alert "
+            f"{recommendation.alert_id}"
+        )
+
+    source_family = _nested_string(
+        alert_record.reviewed_context,
+        ("source", "source_family"),
+    )
+    if source_family is None:
+        raise Phase29ShadowDatasetGenerationError(
+            f"recommendation {recommendation.recommendation_id} is missing reviewed source family linkage"
+        )
+
+    linked_evidence = _linked_evidence_records(
+        store=store,
+        case_id=case_record.case_id,
+        alert_id=alert_record.alert_id,
+    )
+    anchor_evidence = _select_anchor_evidence(
+        recommendation_id=recommendation.recommendation_id,
+        linked_evidence=linked_evidence,
+    )
+
+    label_transition = _latest_lifecycle_transition(
+        service,
+        "recommendation",
+        recommendation.recommendation_id,
+    )
+    if label_transition is None:
+        raise Phase29ShadowDatasetGenerationError(
+            "missing required reviewed label transition for recommendation "
+            f"{recommendation.recommendation_id}"
+        )
+
+    ambiguity_badges = sorted(
+        {
+            ambiguity_badge
+            for evidence in linked_evidence
+            for ambiguity_badge in (_optional_string(evidence.provenance.get("ambiguity_badge")),)
+            if ambiguity_badge is not None
+        }
+    )
+    latest_reconciliation = _latest_reconciliation(
+        store=store,
+        alert_id=alert_record.alert_id,
+        case_id=case_record.case_id,
+    )
+
+    case_transition = _latest_lifecycle_transition(service, "case", case_record.case_id)
+
+    features: dict[str, object] = {
+        "source_family": _feature_entry(
+            value=source_family,
+            record_family="alert",
+            record_id=alert_record.alert_id,
+            field_path="reviewed_context.source.source_family",
+            extraction_spec_version=extraction_spec_version,
+            snapshot_timestamp=snapshot_timestamp,
+            classification=None,
+            reviewed_by=_first_actor_identity(case_transition),
+            reviewed_linkage="subject-alert-link",
+        ),
+        "case_lifecycle_state": _feature_entry(
+            value=case_record.lifecycle_state,
+            record_family="case",
+            record_id=case_record.case_id,
+            field_path="lifecycle_state",
+            extraction_spec_version=extraction_spec_version,
+            snapshot_timestamp=snapshot_timestamp,
+            classification=None,
+            reviewed_by=_first_actor_identity(case_transition),
+            reviewed_linkage="subject-case-link",
+        ),
+    }
+
+    case_triage_disposition = _nested_string(
+        case_record.reviewed_context,
+        ("triage", "disposition"),
+    )
+    if case_triage_disposition is not None:
+        features["case_triage_disposition"] = _feature_entry(
+            value=case_triage_disposition,
+            record_family="case",
+            record_id=case_record.case_id,
+            field_path="reviewed_context.triage.disposition",
+            extraction_spec_version=extraction_spec_version,
+            snapshot_timestamp=snapshot_timestamp,
+            classification=None,
+            reviewed_by=_first_actor_identity(case_transition),
+            reviewed_linkage="subject-case-link",
+        )
+
+    features["ambiguity_badges"] = _feature_entry(
+        value=ambiguity_badges,
+        record_family="evidence",
+        record_id=anchor_evidence.evidence_id,
+        field_path="provenance.ambiguity_badge",
+        extraction_spec_version=extraction_spec_version,
+        snapshot_timestamp=snapshot_timestamp,
+        classification=_optional_string(anchor_evidence.provenance.get("classification")),
+        reviewed_by=_optional_string(anchor_evidence.provenance.get("reviewed_by")),
+        reviewed_linkage="subject-anchor-evidence-link",
+    )
+
+    if latest_reconciliation is not None:
+        features["source_health_state"] = _feature_entry(
+            value=latest_reconciliation.lifecycle_state,
+            record_family="reconciliation",
+            record_id=latest_reconciliation.reconciliation_id,
+            field_path="lifecycle_state",
+            extraction_spec_version=extraction_spec_version,
+            snapshot_timestamp=snapshot_timestamp,
+            classification=None,
+            reviewed_by=None,
+            reviewed_linkage="subject-alert-link",
+        )
+        features["source_health_ingest_disposition"] = _feature_entry(
+            value=latest_reconciliation.ingest_disposition,
+            record_family="reconciliation",
+            record_id=latest_reconciliation.reconciliation_id,
+            field_path="ingest_disposition",
+            extraction_spec_version=extraction_spec_version,
+            snapshot_timestamp=snapshot_timestamp,
+            classification=None,
+            reviewed_by=None,
+            reviewed_linkage="subject-alert-link",
+        )
+
+    return {
+        "subject_record_family": "recommendation",
+        "subject_record_id": recommendation.recommendation_id,
+        "linked_case_id": case_record.case_id,
+        "linked_alert_id": alert_record.alert_id,
+        "features": features,
+        "label": {
+            "value": recommendation.lifecycle_state,
+            "provenance": {
+                "label_record_family": _display_record_family("recommendation"),
+                "label_record_id": recommendation.recommendation_id,
+                "label_field_path": "lifecycle_state",
+                "label_decision_basis": "reviewed recommendation lifecycle_state",
+                "label_decided_at": label_transition.transitioned_at.isoformat(),
+                "label_reviewed_by": (
+                    _first_actor_identity(label_transition) or recommendation.review_owner
+                ),
+                "label_linked_subject_record_id": recommendation.recommendation_id,
+            },
+        },
+    }
+
+
+def _linked_evidence_records(
+    *,
+    store: object,
+    case_id: str,
+    alert_id: str,
+) -> tuple[EvidenceRecord, ...]:
+    return tuple(
+        sorted(
+            (
+                evidence
+                for evidence in store.list(EvidenceRecord)
+                if evidence.case_id == case_id or evidence.alert_id == alert_id
+            ),
+            key=lambda evidence: evidence.evidence_id,
+        )
+    )
+
+
+def _select_anchor_evidence(
+    *,
+    recommendation_id: str,
+    linked_evidence: tuple[EvidenceRecord, ...],
+) -> EvidenceRecord:
+    anchor_evidence = tuple(
+        evidence
+        for evidence in linked_evidence
+        if evidence.derivation_relationship == "reviewed_context_anchor"
+    )
+    if not anchor_evidence:
+        raise Phase29ShadowDatasetGenerationError(
+            f"recommendation {recommendation_id} is missing required reviewed provenance "
+            "anchor evidence"
+        )
+
+    for evidence in anchor_evidence:
+        missing_fields = tuple(
+            field_name
+            for field_name in _REQUIRED_ANCHOR_PROVENANCE_FIELDS
+            if _optional_string(evidence.provenance.get(field_name)) is None
+        )
+        if missing_fields:
+            raise Phase29ShadowDatasetGenerationError(
+                "missing required reviewed provenance on anchor evidence "
+                f"{evidence.evidence_id}: {', '.join(missing_fields)}"
+            )
+    return anchor_evidence[0]
+
+
+def _latest_reconciliation(
+    *,
+    store: object,
+    alert_id: str,
+    case_id: str,
+) -> ReconciliationRecord | None:
+    matching = [
+        reconciliation
+        for reconciliation in store.list(ReconciliationRecord)
+        if reconciliation.alert_id == alert_id
+        or case_id in _tuple_of_strings(reconciliation.subject_linkage.get("case_ids"))
+    ]
+    if not matching:
+        return None
+    return sorted(
+        matching,
+        key=lambda reconciliation: (
+            reconciliation.compared_at,
+            reconciliation.reconciliation_id,
+        ),
+    )[-1]
+
+
+def _latest_lifecycle_transition(
+    service: object,
+    record_family: str,
+    record_id: str,
+) -> LifecycleTransitionRecord | None:
+    list_transitions = getattr(service, "list_lifecycle_transitions", None)
+    if not callable(list_transitions):
+        raise TypeError("service must expose list_lifecycle_transitions")
+    transitions = list_transitions(record_family, record_id)
+    if not transitions:
+        return None
+    return transitions[-1]
+
+
+def _feature_entry(
+    *,
+    value: object,
+    record_family: str,
+    record_id: str,
+    field_path: str,
+    extraction_spec_version: str,
+    snapshot_timestamp: datetime,
+    classification: str | None,
+    reviewed_by: str | None,
+    reviewed_linkage: str,
+) -> dict[str, object]:
+    return {
+        "value": value,
+        "provenance": {
+            "feature_source_record_family": _display_record_family(record_family),
+            "feature_source_record_id": record_id,
+            "feature_source_field_path": field_path,
+            "feature_extraction_spec_version": extraction_spec_version,
+            "feature_snapshot_timestamp": snapshot_timestamp.isoformat(),
+            "feature_reviewed_linkage": reviewed_linkage,
+            "feature_source_provenance_classification": classification,
+            "feature_source_reviewed_by": reviewed_by,
+        },
+    }
+
+
+def _display_record_family(record_family: str) -> str:
+    return _RECORD_FAMILY_DISPLAY_NAMES.get(record_family, record_family)
+
+
+def _nested_string(
+    mapping: Mapping[str, object],
+    path: tuple[str, ...],
+) -> str | None:
+    current: object = mapping
+    for part in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(part)
+    return _optional_string(current)
+
+
+def _optional_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
+def _first_actor_identity(transition: LifecycleTransitionRecord | None) -> str | None:
+    if transition is None:
+        return None
+    attribution = transition.attribution
+    if not isinstance(attribution, Mapping):
+        return None
+    actor_identities = attribution.get("actor_identities")
+    if not isinstance(actor_identities, tuple) or not actor_identities:
+        return None
+    return _optional_string(actor_identities[0])
+
+
+def _tuple_of_strings(value: object) -> tuple[str, ...]:
+    if isinstance(value, tuple):
+        return tuple(
+            item.strip() for item in value if isinstance(item, str) and item.strip()
+        )
+    return ()
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        _json_ready(value),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _json_ready(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    return value

--- a/control-plane/tests/test_phase29_shadow_dataset_generation_validation.py
+++ b/control-plane/tests/test_phase29_shadow_dataset_generation_validation.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+import pathlib
+import sys
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+
+from aegisops_control_plane.models import EvidenceRecord, ReconciliationRecord
+from aegisops_control_plane.phase29_shadow_dataset import (
+    Phase29ShadowDatasetGenerationError,
+    generate_reviewed_shadow_dataset,
+)
+from tests.test_service_persistence import ServicePersistenceTestBase
+
+
+class Phase29ShadowDatasetGenerationValidationTests(ServicePersistenceTestBase):
+    def test_generator_emits_reproducible_shadow_examples_with_lineage(self) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Reviewed feature extraction must stay anchored to the case.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting repository change requires bounded review.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            review_owner="analyst-001",
+            intended_outcome="Confirm the reviewed recommendation remains advisory-only.",
+        )
+        decided_at = reviewed_at + timedelta(minutes=5)
+        accepted_recommendation = service.persist_record(
+            replace(
+                recommendation,
+                lifecycle_state="accepted",
+            ),
+            transitioned_at=decided_at,
+        )
+        disposed_case = service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Preserve the reviewed business-hours handoff as bounded context.",
+            recorded_at=decided_at,
+        )
+        anchored_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase29-shadow-anchor-001",
+                source_record_id="reviewed-source-phase29-001",
+                alert_id=disposed_case.alert_id,
+                case_id=disposed_case.case_id,
+                source_system="github_audit",
+                collector_identity="fixture://reviewed/source-health",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_context_anchor",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "authoritative-anchor",
+                    "source_id": "github-audit-event-001",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "ambiguity_badge": "unresolved",
+                },
+                content={"summary": {"kind": "anchor"}},
+            )
+        )
+        service.persist_record(
+            replace(
+                disposed_case,
+                evidence_ids=(*disposed_case.evidence_ids, anchored_evidence.evidence_id),
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase29-shadow-001",
+                subject_linkage={
+                    "alert_ids": (disposed_case.alert_id,),
+                    "case_ids": (disposed_case.case_id,),
+                    "recommendation_ids": (accepted_recommendation.recommendation_id,),
+                },
+                alert_id=disposed_case.alert_id,
+                finding_id=disposed_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id=None,
+                linked_execution_run_ids=(),
+                correlation_key=f"case:{disposed_case.case_id}:source-health",
+                first_seen_at=reviewed_at,
+                last_seen_at=decided_at,
+                ingest_disposition="stale",
+                mismatch_summary="reviewed source-health context only",
+                compared_at=decided_at,
+                lifecycle_state="stale",
+            )
+        )
+
+        first_snapshot = generate_reviewed_shadow_dataset(
+            service,
+            extraction_spec_version="phase29-shadow-dataset-v1",
+            snapshot_timestamp=decided_at,
+        )
+        second_snapshot = generate_reviewed_shadow_dataset(
+            service,
+            extraction_spec_version="phase29-shadow-dataset-v1",
+            snapshot_timestamp=decided_at,
+        )
+
+        self.assertEqual(first_snapshot.snapshot_id, second_snapshot.snapshot_id)
+        self.assertEqual(first_snapshot.example_count, 1)
+        self.assertEqual(first_snapshot.examples, second_snapshot.examples)
+
+        example = first_snapshot.examples[0]
+        self.assertEqual(example["subject_record_family"], "recommendation")
+        self.assertEqual(
+            example["subject_record_id"],
+            accepted_recommendation.recommendation_id,
+        )
+        self.assertEqual(example["label"]["value"], "accepted")
+        self.assertEqual(example["label"]["provenance"]["label_record_family"], "Recommendation")
+        self.assertEqual(
+            example["label"]["provenance"]["label_record_id"],
+            accepted_recommendation.recommendation_id,
+        )
+        self.assertEqual(
+            example["features"]["case_triage_disposition"]["value"],
+            "business_hours_handoff",
+        )
+        self.assertEqual(
+            example["features"]["source_family"]["value"],
+            "github_audit",
+        )
+        self.assertEqual(
+            example["features"]["source_health_state"]["value"],
+            "stale",
+        )
+        self.assertEqual(
+            example["features"]["ambiguity_badges"]["value"],
+            ["unresolved"],
+        )
+        self.assertEqual(
+            example["features"]["ambiguity_badges"]["provenance"][
+                "feature_source_record_family"
+            ],
+            "Evidence",
+        )
+
+    def test_generator_fails_closed_when_anchor_provenance_is_missing(self) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Missing lineage must block shadow dataset generation.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Fail closed when reviewed provenance is incomplete.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            review_owner="analyst-001",
+            intended_outcome="Do not synthesize training lineage from incomplete records.",
+        )
+        service.persist_record(
+            replace(
+                recommendation,
+                lifecycle_state="accepted",
+            ),
+            transitioned_at=reviewed_at + timedelta(minutes=5),
+        )
+        broken_anchor = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase29-shadow-broken-001",
+                source_record_id="reviewed-source-phase29-broken-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="github_audit",
+                collector_identity="fixture://reviewed/broken",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_context_anchor",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "authoritative-anchor",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                },
+                content={"summary": {"kind": "broken-anchor"}},
+            )
+        )
+        service.persist_record(
+            replace(
+                promoted_case,
+                evidence_ids=(*promoted_case.evidence_ids, broken_anchor.evidence_id),
+            )
+        )
+
+        with self.assertRaisesRegex(
+            Phase29ShadowDatasetGenerationError,
+            "missing required reviewed provenance",
+        ):
+            generate_reviewed_shadow_dataset(
+                service,
+                extraction_spec_version="phase29-shadow-dataset-v1",
+                snapshot_timestamp=reviewed_at + timedelta(minutes=5),
+            )

--- a/control-plane/tests/test_phase29_shadow_dataset_generation_validation.py
+++ b/control-plane/tests/test_phase29_shadow_dataset_generation_validation.py
@@ -222,3 +222,335 @@ class Phase29ShadowDatasetGenerationValidationTests(ServicePersistenceTestBase):
                 extraction_spec_version="phase29-shadow-dataset-v1",
                 snapshot_timestamp=reviewed_at + timedelta(minutes=5),
             )
+
+    def test_generator_uses_snapshot_timestamp_as_authoritative_cutoff(self) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Historical snapshots must not drift after later reviews.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Snapshot generation must honor authoritative review timing.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep offline shadow labels reproducible.",
+        )
+        accepted_at = reviewed_at + timedelta(minutes=5)
+        accepted_recommendation = service.persist_record(
+            replace(recommendation, lifecycle_state="accepted"),
+            transitioned_at=accepted_at,
+        )
+        anchor_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase29-snapshot-anchor-001",
+                source_record_id="reviewed-source-phase29-snapshot-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="github_audit",
+                collector_identity="fixture://reviewed/snapshot-anchor",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_context_anchor",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "authoritative-anchor",
+                    "source_id": "github-audit-event-snapshot-001",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "ambiguity_badge": "unresolved",
+                },
+                content={"summary": {"kind": "snapshot-anchor"}},
+            )
+        )
+        linked_case = service.persist_record(
+            replace(
+                promoted_case,
+                evidence_ids=(*promoted_case.evidence_ids, anchor_evidence.evidence_id),
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase29-snapshot-001",
+                subject_linkage={
+                    "alert_ids": (linked_case.alert_id,),
+                    "case_ids": (linked_case.case_id,),
+                    "recommendation_ids": (accepted_recommendation.recommendation_id,),
+                },
+                alert_id=linked_case.alert_id,
+                finding_id=linked_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id=None,
+                linked_execution_run_ids=(),
+                correlation_key=f"case:{linked_case.case_id}:snapshot-health",
+                first_seen_at=reviewed_at,
+                last_seen_at=accepted_at,
+                ingest_disposition="stale",
+                mismatch_summary="Historical source-health state",
+                compared_at=accepted_at,
+                lifecycle_state="stale",
+            )
+        )
+
+        later_reviewed_at = accepted_at + timedelta(minutes=10)
+        service.persist_record(
+            replace(accepted_recommendation, lifecycle_state="rejected"),
+            transitioned_at=later_reviewed_at,
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase29-snapshot-002",
+                subject_linkage={
+                    "alert_ids": (linked_case.alert_id,),
+                    "case_ids": (linked_case.case_id,),
+                    "recommendation_ids": (accepted_recommendation.recommendation_id,),
+                },
+                alert_id=linked_case.alert_id,
+                finding_id=linked_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id=None,
+                linked_execution_run_ids=(),
+                correlation_key=f"case:{linked_case.case_id}:snapshot-health",
+                first_seen_at=later_reviewed_at,
+                last_seen_at=later_reviewed_at,
+                ingest_disposition="updated",
+                mismatch_summary="Later state that must not leak into the older snapshot",
+                compared_at=later_reviewed_at,
+                lifecycle_state="resolved",
+            )
+        )
+
+        historical_snapshot = generate_reviewed_shadow_dataset(
+            service,
+            extraction_spec_version="phase29-shadow-dataset-v1",
+            snapshot_timestamp=accepted_at,
+        )
+
+        self.assertEqual(historical_snapshot.example_count, 1)
+        example = historical_snapshot.examples[0]
+        self.assertEqual(example["label"]["value"], "accepted")
+        self.assertEqual(
+            example["label"]["provenance"]["label_decided_at"],
+            accepted_at.isoformat(),
+        )
+        self.assertEqual(
+            example["features"]["source_health_state"]["value"],
+            "stale",
+        )
+        self.assertEqual(
+            example["features"]["source_health_ingest_disposition"]["value"],
+            "stale",
+        )
+
+    def test_generator_emits_per_evidence_ambiguity_provenance(self) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Ambiguity features must preserve every contributing record.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Keep aggregate ambiguity lineage reconstructible.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            review_owner="analyst-001",
+            intended_outcome="Preserve per-record badge provenance.",
+        )
+        decided_at = reviewed_at + timedelta(minutes=5)
+        accepted_recommendation = service.persist_record(
+            replace(recommendation, lifecycle_state="accepted"),
+            transitioned_at=decided_at,
+        )
+        anchor_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase29-ambiguity-anchor-001",
+                source_record_id="reviewed-source-phase29-ambiguity-anchor-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="github_audit",
+                collector_identity="fixture://reviewed/ambiguity-anchor",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_context_anchor",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "authoritative-anchor",
+                    "source_id": "github-audit-event-ambiguity-anchor-001",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "ambiguity_badge": "unresolved",
+                },
+                content={"summary": {"kind": "anchor"}},
+            )
+        )
+        secondary_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase29-ambiguity-secondary-001",
+                source_record_id="reviewed-source-phase29-ambiguity-secondary-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="github_audit",
+                collector_identity="fixture://reviewed/ambiguity-secondary",
+                acquired_at=reviewed_at + timedelta(minutes=1),
+                derivation_relationship="reviewed_context_supporting",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "reviewed-supporting",
+                    "source_id": "github-audit-event-ambiguity-secondary-001",
+                    "timestamp": (reviewed_at + timedelta(minutes=1)).isoformat(),
+                    "reviewed_by": "analyst-002",
+                    "ambiguity_badge": "related-entity",
+                },
+                content={"summary": {"kind": "supporting"}},
+            )
+        )
+        service.persist_record(
+            replace(
+                promoted_case,
+                evidence_ids=(
+                    *promoted_case.evidence_ids,
+                    anchor_evidence.evidence_id,
+                    secondary_evidence.evidence_id,
+                ),
+            )
+        )
+
+        snapshot = generate_reviewed_shadow_dataset(
+            service,
+            extraction_spec_version="phase29-shadow-dataset-v1",
+            snapshot_timestamp=decided_at,
+        )
+
+        self.assertEqual(snapshot.example_count, 1)
+        example = snapshot.examples[0]
+        self.assertEqual(example["subject_record_id"], accepted_recommendation.recommendation_id)
+        self.assertEqual(
+            example["features"]["ambiguity_badges"]["value"],
+            ["related-entity", "unresolved"],
+        )
+        contributors = example["features"]["ambiguity_badges"]["provenance"][
+            "feature_source_contributors"
+        ]
+        self.assertEqual(len(contributors), 2)
+        self.assertEqual(
+            {
+                (entry["feature_source_record_id"], entry["feature_source_badge_value"])
+                for entry in contributors
+            },
+            {
+                (anchor_evidence.evidence_id, "unresolved"),
+                (secondary_evidence.evidence_id, "related-entity"),
+            },
+        )
+
+    def test_generator_ignores_unlinked_sibling_evidence(self) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Extraction must stay within explicit reviewed evidence linkage.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Exclude sibling evidence that was never linked on the case.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            review_owner="analyst-001",
+            intended_outcome="Keep Phase 29 extraction on explicit reviewed evidence only.",
+        )
+        decided_at = reviewed_at + timedelta(minutes=5)
+        service.persist_record(
+            replace(recommendation, lifecycle_state="accepted"),
+            transitioned_at=decided_at,
+        )
+        linked_anchor = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase29-linked-anchor-001",
+                source_record_id="reviewed-source-phase29-linked-anchor-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="github_audit",
+                collector_identity="fixture://reviewed/linked-anchor",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_context_anchor",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "authoritative-anchor",
+                    "source_id": "github-audit-event-linked-anchor-001",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "ambiguity_badge": "unresolved",
+                },
+                content={"summary": {"kind": "linked-anchor"}},
+            )
+        )
+        service.persist_record(
+            replace(
+                promoted_case,
+                evidence_ids=(*promoted_case.evidence_ids, linked_anchor.evidence_id),
+            )
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase29-unlinked-sibling-001",
+                source_record_id="reviewed-source-phase29-unlinked-sibling-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="github_audit",
+                collector_identity="fixture://reviewed/unlinked-sibling",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_context_anchor",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "authoritative-anchor",
+                    "source_id": "github-audit-event-unlinked-sibling-001",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-002",
+                    "ambiguity_badge": "related-entity",
+                },
+                content={"summary": {"kind": "unlinked-sibling"}},
+            )
+        )
+
+        snapshot = generate_reviewed_shadow_dataset(
+            service,
+            extraction_spec_version="phase29-shadow-dataset-v1",
+            snapshot_timestamp=decided_at,
+        )
+
+        self.assertEqual(snapshot.example_count, 1)
+        example = snapshot.examples[0]
+        self.assertEqual(example["features"]["ambiguity_badges"]["value"], ["unresolved"])
+        contributors = example["features"]["ambiguity_badges"]["provenance"][
+            "feature_source_contributors"
+        ]
+        self.assertEqual(len(contributors), 1)
+        self.assertEqual(
+            contributors[0]["feature_source_record_id"],
+            linked_anchor.evidence_id,
+        )


### PR DESCRIPTION
Closes #618
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a focused Phase 29 checkpoint on `codex/issue-618` and committed it as `448c345` (`Add Phase 29 shadow dataset extraction`).

The slice adds `control-plane/aegisops_control_plane/phase29_shadow_dataset.py`, which generates deterministic offline shadow-dataset examples from explicitly labeled reviewed recommendations and carries feature/label provenance from linked reviewed records. It fails closed if the recommendation is missing reviewed subject linkage or if the required reviewed anchor evidence provenance is incomplete. I also added `control-plane/tests/test_phase29_shadow_dataset_generation_validation.py`, which proves both the reproducible happy path and the fail-closed missing-provenance path.

Verification completed with:
- `python3 -m unittest control-plane.tests.test_phase29_shadow_dataset_generation_validation`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 618 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`

Summary: Added an offline Phase 29 shadow-dataset extractor plus a narrow validation test for deterministic lineage emission and fail-closed provenance enforcement, then committed the slice as `448c345`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase29_shadow_dataset_generation_validation`; `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 618 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.a...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reviewed shadow dataset snapshot generation with deterministic snapshot IDs for reproducibility.
  * Produces ordered, provenance-rich examples (including reviewed source, evidence anchors, ambiguity badges) and enforces snapshot-time cutoffs for temporal consistency.
  * Fails closed on missing required reviewed provenance or authoritative lifecycle data.

* **Tests**
  * Added end-to-end validation tests for determinism, temporal cutoff behavior, ambiguity provenance, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->