### PR TITLE
Phase 29: add MLflow shadow model tracking

### DIFF
--- a/control-plane/aegisops_control_plane/phase29_mlflow_shadow_model_registry.py
+++ b/control-plane/aegisops_control_plane/phase29_mlflow_shadow_model_registry.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from typing import Mapping, Protocol
+
+from .phase29_shadow_dataset import Phase29ShadowDatasetSnapshot
+
+
+_REQUIRED_FEATURE_PROVENANCE_FIELDS = (
+    "feature_source_record_family",
+    "feature_source_record_id",
+    "feature_source_field_path",
+    "feature_extraction_spec_version",
+    "feature_snapshot_timestamp",
+    "feature_reviewed_linkage",
+)
+_REQUIRED_LABEL_PROVENANCE_FIELDS = (
+    "label_record_family",
+    "label_record_id",
+    "label_field_path",
+    "label_decision_basis",
+    "label_decided_at",
+    "label_linked_subject_record_id",
+)
+
+
+class MlflowRunInfo(Protocol):
+    run_id: str
+
+
+class MlflowRun(Protocol):
+    info: MlflowRunInfo
+
+
+class MlflowExperiment(Protocol):
+    experiment_id: str
+
+
+class MlflowModelVersion(Protocol):
+    version: str
+
+
+class Phase29MlflowClient(Protocol):
+    def get_experiment_by_name(self, name: str) -> MlflowExperiment | None: ...
+
+    def create_experiment(
+        self,
+        name: str,
+        tags: Mapping[str, str] | None = None,
+    ) -> str: ...
+
+    def create_run(
+        self,
+        experiment_id: str,
+        tags: Mapping[str, str] | None = None,
+        run_name: str | None = None,
+    ) -> MlflowRun: ...
+
+    def log_param(self, run_id: str, key: str, value: object) -> None: ...
+
+    def set_tag(self, run_id: str, key: str, value: object) -> None: ...
+
+    def log_metric(
+        self,
+        run_id: str,
+        key: str,
+        value: float,
+        timestamp: int | None = None,
+        step: int = 0,
+    ) -> None: ...
+
+    def get_registered_model(self, name: str) -> object | None: ...
+
+    def create_registered_model(
+        self,
+        name: str,
+        tags: Mapping[str, str] | None = None,
+        description: str | None = None,
+    ) -> object: ...
+
+    def create_model_version(
+        self,
+        name: str,
+        source: str,
+        run_id: str | None = None,
+        tags: Mapping[str, str] | None = None,
+        description: str | None = None,
+    ) -> MlflowModelVersion: ...
+
+
+class Phase29MlflowShadowModelRegistryError(ValueError):
+    """Raised when shadow-model MLflow lineage cannot be justified explicitly."""
+
+
+@dataclass(frozen=True)
+class Phase29MlflowShadowModelTrackingResult:
+    experiment_name: str
+    run_id: str
+    registered_model_name: str
+    registered_model_version: str
+    model_family: str
+    model_version: str
+    dataset_snapshot_id: str
+    registry_posture: str
+
+
+def track_shadow_model_with_mlflow(
+    *,
+    client: Phase29MlflowClient,
+    dataset_snapshot: Phase29ShadowDatasetSnapshot,
+    experiment_name: str,
+    run_name: str,
+    registered_model_name: str,
+    model_source_uri: str,
+    model_family: str,
+    model_version: str,
+    training_spec_version: str,
+    feature_schema_version: str,
+    label_schema_version: str,
+    lineage_review_note_id: str,
+    evaluation_metrics: Mapping[str, float],
+    evaluation_metadata: Mapping[str, object],
+    run_timestamp: datetime,
+) -> Phase29MlflowShadowModelTrackingResult:
+    if not isinstance(dataset_snapshot, Phase29ShadowDatasetSnapshot):
+        raise TypeError("dataset_snapshot must be a Phase29ShadowDatasetSnapshot")
+    if (
+        not isinstance(run_timestamp, datetime)
+        or run_timestamp.tzinfo is None
+        or run_timestamp.utcoffset() is None
+    ):
+        raise ValueError("run_timestamp must be a timezone-aware datetime")
+
+    experiment_name = _require_non_empty_string(experiment_name, "experiment_name")
+    run_name = _require_non_empty_string(run_name, "run_name")
+    registered_model_name = _require_non_empty_string(
+        registered_model_name,
+        "registered_model_name",
+    )
+    model_source_uri = _require_non_empty_string(model_source_uri, "model_source_uri")
+    model_family = _require_non_empty_string(model_family, "model_family")
+    model_version = _require_non_empty_string(model_version, "model_version")
+    training_spec_version = _require_non_empty_string(
+        training_spec_version,
+        "training_spec_version",
+    )
+    feature_schema_version = _require_non_empty_string(
+        feature_schema_version,
+        "feature_schema_version",
+    )
+    label_schema_version = _require_non_empty_string(
+        label_schema_version,
+        "label_schema_version",
+    )
+    lineage_review_note_id = _require_non_empty_string(
+        lineage_review_note_id,
+        "lineage_review_note_id",
+    )
+
+    if dataset_snapshot.example_count <= 0 or not dataset_snapshot.examples:
+        raise Phase29MlflowShadowModelRegistryError(
+            "shadow model tracking requires at least one lineage-backed dataset example"
+        )
+
+    dataset_lineage_summary = _validate_shadow_dataset_lineage(dataset_snapshot)
+    run_tags = {
+        "aegisops.phase": "29",
+        "aegisops.registry_posture": "shadow-only",
+        "aegisops.authority_path": "outside-control-plane",
+        "aegisops.lineage_review_note_id": lineage_review_note_id,
+        "aegisops.model_family": model_family,
+        "aegisops.model_version": model_version,
+        "aegisops.training_data_snapshot_id": dataset_snapshot.snapshot_id,
+    }
+    experiment_id = _resolve_experiment_id(
+        client=client,
+        experiment_name=experiment_name,
+        experiment_tags={
+            "aegisops.phase": "29",
+            "aegisops.registry_posture": "shadow-only",
+            "aegisops.authority_path": "outside-control-plane",
+        },
+    )
+    run = client.create_run(experiment_id, tags=run_tags, run_name=run_name)
+    run_id = run.info.run_id
+
+    run_params = {
+        "training_data_snapshot_id": dataset_snapshot.snapshot_id,
+        "dataset_extraction_spec_version": dataset_snapshot.extraction_spec_version,
+        "training_spec_version": training_spec_version,
+        "feature_schema_version": feature_schema_version,
+        "label_schema_version": label_schema_version,
+        "model_family": model_family,
+        "model_version": model_version,
+        "lineage_review_note_id": lineage_review_note_id,
+        "dataset_example_count": dataset_snapshot.example_count,
+        "tracked_source_families": ",".join(dataset_lineage_summary["source_families"]),
+        "tracked_subject_record_families": ",".join(
+            dataset_lineage_summary["subject_record_families"]
+        ),
+    }
+    run_params.update(_stringify_mapping(evaluation_metadata))
+
+    for key, value in sorted(run_params.items()):
+        client.log_param(run_id, key, value)
+
+    for metric_name, metric_value in sorted(evaluation_metrics.items()):
+        _validate_metric_name(metric_name)
+        client.log_metric(
+            run_id,
+            metric_name,
+            _coerce_float(metric_name, metric_value),
+            timestamp=int(run_timestamp.timestamp() * 1000),
+            step=0,
+        )
+
+    for tag_key, tag_value in sorted(dataset_lineage_summary["tags"].items()):
+        client.set_tag(run_id, tag_key, tag_value)
+
+    _ensure_registered_model(
+        client=client,
+        registered_model_name=registered_model_name,
+    )
+    model_version_payload = client.create_model_version(
+        registered_model_name,
+        model_source_uri,
+        run_id=run_id,
+        tags={
+            "aegisops.registry_posture": "shadow-only",
+            "aegisops.authority_path": "outside-control-plane",
+            "aegisops.training_data_snapshot_id": dataset_snapshot.snapshot_id,
+            "aegisops.dataset_extraction_spec_version": dataset_snapshot.extraction_spec_version,
+            "aegisops.feature_schema_version": feature_schema_version,
+            "aegisops.label_schema_version": label_schema_version,
+            "aegisops.training_spec_version": training_spec_version,
+            "aegisops.model_family": model_family,
+            "aegisops.model_version": model_version,
+            "aegisops.lineage_review_note_id": lineage_review_note_id,
+            **{
+                f"aegisops.{key}": value
+                for key, value in sorted(_stringify_mapping(evaluation_metadata).items())
+            },
+        },
+        description=(
+            "Phase 29 shadow-only candidate model. "
+            "Non-authoritative registry entry outside the control-plane truth chain."
+        ),
+    )
+    return Phase29MlflowShadowModelTrackingResult(
+        experiment_name=experiment_name,
+        run_id=run_id,
+        registered_model_name=registered_model_name,
+        registered_model_version=str(model_version_payload.version),
+        model_family=model_family,
+        model_version=model_version,
+        dataset_snapshot_id=dataset_snapshot.snapshot_id,
+        registry_posture="shadow-only",
+    )
+
+
+def _resolve_experiment_id(
+    *,
+    client: Phase29MlflowClient,
+    experiment_name: str,
+    experiment_tags: Mapping[str, str],
+) -> str:
+    experiment = client.get_experiment_by_name(experiment_name)
+    if experiment is not None:
+        return experiment.experiment_id
+    return client.create_experiment(experiment_name, tags=experiment_tags)
+
+
+def _ensure_registered_model(
+    *,
+    client: Phase29MlflowClient,
+    registered_model_name: str,
+) -> None:
+    try:
+        existing = client.get_registered_model(registered_model_name)
+    except Exception:
+        existing = None
+    if existing is not None:
+        return
+    client.create_registered_model(
+        registered_model_name,
+        tags={
+            "aegisops.registry_posture": "shadow-only",
+            "aegisops.authority_path": "outside-control-plane",
+        },
+        description=(
+            "Shadow-only candidate registry namespace for Phase 29 reviewed ML lineage. "
+            "This registry does not confer control-plane authority."
+        ),
+    )
+
+
+def _validate_shadow_dataset_lineage(
+    dataset_snapshot: Phase29ShadowDatasetSnapshot,
+) -> dict[str, object]:
+    source_families: set[str] = set()
+    subject_record_families: set[str] = set()
+    linked_case_ids: set[str] = set()
+    linked_alert_ids: set[str] = set()
+
+    for example in dataset_snapshot.examples:
+        if not isinstance(example, Mapping):
+            raise Phase29MlflowShadowModelRegistryError(
+                "dataset example must be a mapping with feature and label lineage"
+            )
+        subject_record_family = _require_non_empty_mapping_string(
+            example,
+            "subject_record_family",
+        )
+        _require_non_empty_mapping_string(example, "subject_record_id")
+        linked_case_ids.add(_require_non_empty_mapping_string(example, "linked_case_id"))
+        linked_alert_ids.add(_require_non_empty_mapping_string(example, "linked_alert_id"))
+        subject_record_families.add(subject_record_family)
+
+        features = example.get("features")
+        if not isinstance(features, Mapping) or not features:
+            raise Phase29MlflowShadowModelRegistryError(
+                "dataset example must include at least one tracked feature"
+            )
+        for feature_name, feature_payload in features.items():
+            if not isinstance(feature_payload, Mapping):
+                raise Phase29MlflowShadowModelRegistryError(
+                    f"feature {feature_name!r} must include provenance"
+                )
+            provenance = feature_payload.get("provenance")
+            if not isinstance(provenance, Mapping):
+                raise Phase29MlflowShadowModelRegistryError(
+                    f"feature {feature_name!r} is missing required feature provenance"
+                )
+            _require_mapping_keys(
+                provenance,
+                _REQUIRED_FEATURE_PROVENANCE_FIELDS,
+                "missing required feature provenance",
+            )
+            source_families.add(
+                _require_non_empty_mapping_string(
+                    provenance,
+                    "feature_source_record_family",
+                )
+            )
+
+        label = example.get("label")
+        if not isinstance(label, Mapping):
+            raise Phase29MlflowShadowModelRegistryError(
+                "dataset example must include label lineage"
+            )
+        label_provenance = label.get("provenance")
+        if not isinstance(label_provenance, Mapping):
+            raise Phase29MlflowShadowModelRegistryError(
+                "dataset example is missing required label provenance"
+            )
+        _require_mapping_keys(
+            label_provenance,
+            _REQUIRED_LABEL_PROVENANCE_FIELDS,
+            "missing required label provenance",
+        )
+
+    return {
+        "source_families": tuple(sorted(source_families)),
+        "subject_record_families": tuple(sorted(subject_record_families)),
+        "tags": {
+            "aegisops.dataset_source_families": ",".join(sorted(source_families)),
+            "aegisops.dataset_subject_record_families": ",".join(
+                sorted(subject_record_families)
+            ),
+            "aegisops.linked_case_count": str(len(linked_case_ids)),
+            "aegisops.linked_alert_count": str(len(linked_alert_ids)),
+        },
+    }
+
+
+def _require_mapping_keys(
+    mapping: Mapping[str, object],
+    required_keys: tuple[str, ...],
+    error_prefix: str,
+) -> None:
+    missing = [
+        key
+        for key in required_keys
+        if _optional_string(mapping.get(key)) is None
+    ]
+    if missing:
+        raise Phase29MlflowShadowModelRegistryError(
+            f"{error_prefix}: {', '.join(missing)}"
+        )
+
+
+def _require_non_empty_mapping_string(
+    mapping: Mapping[str, object],
+    key: str,
+) -> str:
+    value = _optional_string(mapping.get(key))
+    if value is None:
+        raise Phase29MlflowShadowModelRegistryError(
+            f"dataset lineage is missing required field {key}"
+        )
+    return value
+
+
+def _require_non_empty_string(value: object, field_name: str) -> str:
+    normalized = _optional_string(value)
+    if normalized is None:
+        raise Phase29MlflowShadowModelRegistryError(
+            f"{field_name} must be a non-empty string"
+        )
+    return normalized
+
+
+def _stringify_mapping(values: Mapping[str, object]) -> dict[str, str]:
+    return {
+        _normalize_param_key(key): _stringify_value(value)
+        for key, value in values.items()
+    }
+
+
+def _normalize_param_key(key: object) -> str:
+    normalized = _optional_string(key)
+    if normalized is None:
+        raise Phase29MlflowShadowModelRegistryError(
+            "evaluation metadata keys must be non-empty strings"
+        )
+    return normalized
+
+
+def _stringify_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise Phase29MlflowShadowModelRegistryError(
+                "datetime metadata must be timezone-aware"
+            )
+        return value.isoformat()
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _validate_metric_name(metric_name: object) -> str:
+    normalized = _optional_string(metric_name)
+    if normalized is None:
+        raise Phase29MlflowShadowModelRegistryError(
+            "evaluation metric names must be non-empty strings"
+        )
+    return normalized
+
+
+def _coerce_float(metric_name: str, metric_value: object) -> float:
+    if isinstance(metric_value, bool):
+        raise Phase29MlflowShadowModelRegistryError(
+            f"evaluation metric {metric_name} must be numeric"
+        )
+    if not isinstance(metric_value, (int, float)):
+        raise Phase29MlflowShadowModelRegistryError(
+            f"evaluation metric {metric_name} must be numeric"
+        )
+    return float(metric_value)
+
+
+def _optional_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None

--- a/control-plane/aegisops_control_plane/phase29_mlflow_shadow_model_registry.py
+++ b/control-plane/aegisops_control_plane/phase29_mlflow_shadow_model_registry.py
@@ -29,6 +29,21 @@ _REQUIRED_LABEL_PROVENANCE_FIELDS = (
     "label_decided_at",
     "label_linked_subject_record_id",
 )
+_RESERVED_EVALUATION_METADATA_KEYS = frozenset(
+    {
+        "training_data_snapshot_id",
+        "dataset_extraction_spec_version",
+        "training_spec_version",
+        "feature_schema_version",
+        "label_schema_version",
+        "model_family",
+        "model_version",
+        "lineage_review_note_id",
+        "dataset_example_count",
+        "tracked_source_families",
+        "tracked_subject_record_families",
+    }
+)
 _MLFLOW_LOOKUP_EXCEPTIONS = tuple(
     exception_class
     for exception_class in (MlflowException,)
@@ -173,6 +188,12 @@ def track_shadow_model_with_mlflow(
         raise Phase29MlflowShadowModelRegistryError(
             "shadow model tracking requires at least one lineage-backed dataset example"
         )
+    actual_example_count = len(dataset_snapshot.examples)
+    if dataset_snapshot.example_count != actual_example_count:
+        raise Phase29MlflowShadowModelRegistryError(
+            "dataset_snapshot.example_count must match examples payload length: "
+            f"declared={dataset_snapshot.example_count}, actual={actual_example_count}"
+        )
 
     dataset_lineage_summary = _validate_shadow_dataset_lineage(dataset_snapshot)
     run_tags = {
@@ -184,18 +205,15 @@ def track_shadow_model_with_mlflow(
         "aegisops.model_version": model_version,
         "aegisops.training_data_snapshot_id": dataset_snapshot.snapshot_id,
     }
-    experiment_id = _resolve_experiment_id(
-        client=client,
-        experiment_name=experiment_name,
-        experiment_tags={
-            "aegisops.phase": "29",
-            "aegisops.registry_posture": "shadow-only",
-            "aegisops.authority_path": "outside-control-plane",
-        },
+    stringified_evaluation_metadata = _stringify_mapping(evaluation_metadata)
+    reserved_metadata_keys = sorted(
+        _RESERVED_EVALUATION_METADATA_KEYS.intersection(stringified_evaluation_metadata)
     )
-    run = client.create_run(experiment_id, tags=run_tags, run_name=run_name)
-    run_id = run.info.run_id
-
+    if reserved_metadata_keys:
+        raise Phase29MlflowShadowModelRegistryError(
+            "evaluation_metadata contains reserved lineage keys: "
+            + ", ".join(reserved_metadata_keys)
+        )
     run_params = {
         "training_data_snapshot_id": dataset_snapshot.snapshot_id,
         "dataset_extraction_spec_version": dataset_snapshot.extraction_spec_version,
@@ -210,19 +228,43 @@ def track_shadow_model_with_mlflow(
         "tracked_subject_record_families": ",".join(
             dataset_lineage_summary["subject_record_families"]
         ),
+        **{
+            f"evaluation_metadata.{key}": value
+            for key, value in sorted(stringified_evaluation_metadata.items())
+        },
     }
-    run_params.update(_stringify_mapping(evaluation_metadata))
+    validated_metrics: list[tuple[str, float]] = []
+    for metric_name, metric_value in sorted(evaluation_metrics.items()):
+        normalized_metric_name = _validate_metric_name(metric_name)
+        validated_metrics.append(
+            (
+                normalized_metric_name,
+                _coerce_float(normalized_metric_name, metric_value),
+            )
+        )
+    metric_timestamp = int(run_timestamp.timestamp() * 1000)
+
+    experiment_id = _resolve_experiment_id(
+        client=client,
+        experiment_name=experiment_name,
+        experiment_tags={
+            "aegisops.phase": "29",
+            "aegisops.registry_posture": "shadow-only",
+            "aegisops.authority_path": "outside-control-plane",
+        },
+    )
+    run = client.create_run(experiment_id, tags=run_tags, run_name=run_name)
+    run_id = run.info.run_id
 
     for key, value in sorted(run_params.items()):
         client.log_param(run_id, key, value)
 
-    for metric_name, metric_value in sorted(evaluation_metrics.items()):
-        _validate_metric_name(metric_name)
+    for metric_name, metric_value in validated_metrics:
         client.log_metric(
             run_id,
             metric_name,
-            _coerce_float(metric_name, metric_value),
-            timestamp=int(run_timestamp.timestamp() * 1000),
+            metric_value,
+            timestamp=metric_timestamp,
             step=0,
         )
 
@@ -249,8 +291,8 @@ def track_shadow_model_with_mlflow(
             "aegisops.model_version": model_version,
             "aegisops.lineage_review_note_id": lineage_review_note_id,
             **{
-                f"aegisops.{key}": value
-                for key, value in sorted(_stringify_mapping(evaluation_metadata).items())
+                f"aegisops.evaluation_metadata.{key}": value
+                for key, value in sorted(stringified_evaluation_metadata.items())
             },
         },
         description=(

--- a/control-plane/aegisops_control_plane/phase29_mlflow_shadow_model_registry.py
+++ b/control-plane/aegisops_control_plane/phase29_mlflow_shadow_model_registry.py
@@ -7,6 +7,11 @@ from typing import Mapping, Protocol
 
 from .phase29_shadow_dataset import Phase29ShadowDatasetSnapshot
 
+try:
+    from mlflow.exceptions import MlflowException
+except ImportError:  # pragma: no cover - mlflow is optional in unit-test environments.
+    MlflowException = None
+
 
 _REQUIRED_FEATURE_PROVENANCE_FIELDS = (
     "feature_source_record_family",
@@ -23,6 +28,11 @@ _REQUIRED_LABEL_PROVENANCE_FIELDS = (
     "label_decision_basis",
     "label_decided_at",
     "label_linked_subject_record_id",
+)
+_MLFLOW_LOOKUP_EXCEPTIONS = tuple(
+    exception_class
+    for exception_class in (MlflowException,)
+    if exception_class is not None
 )
 
 
@@ -277,10 +287,15 @@ def _ensure_registered_model(
     client: Phase29MlflowClient,
     registered_model_name: str,
 ) -> None:
-    try:
+    if _MLFLOW_LOOKUP_EXCEPTIONS:
+        try:
+            existing = client.get_registered_model(registered_model_name)
+        except _MLFLOW_LOOKUP_EXCEPTIONS as exc:
+            if not _is_missing_registered_model_lookup(exc, registered_model_name):
+                raise
+            existing = None
+    else:
         existing = client.get_registered_model(registered_model_name)
-    except Exception:
-        existing = None
     if existing is not None:
         return
     client.create_registered_model(
@@ -293,6 +308,23 @@ def _ensure_registered_model(
             "Shadow-only candidate registry namespace for Phase 29 reviewed ML lineage. "
             "This registry does not confer control-plane authority."
         ),
+    )
+
+
+def _is_missing_registered_model_lookup(
+    exc: Exception,
+    registered_model_name: str,
+) -> bool:
+    error_code = getattr(exc, "error_code", None)
+    if error_code == "RESOURCE_DOES_NOT_EXIST":
+        return True
+
+    message = str(exc).lower()
+    registered_model_name = registered_model_name.lower()
+    return (
+        "registered model" in message
+        and registered_model_name in message
+        and ("not found" in message or "does not exist" in message)
     )
 
 

--- a/control-plane/tests/test_phase29_ml_shadow_mode_boundary_docs.py
+++ b/control-plane/tests/test_phase29_ml_shadow_mode_boundary_docs.py
@@ -41,6 +41,8 @@ class Phase29MlShadowModeBoundaryDocsTests(unittest.TestCase):
             "Allowed reviewed feature sources",
             "Allowed reviewed labels",
             "ML lineage envelope semantics",
+            "MLflow experiment tracking",
+            "MLflow model registry",
             "separate ML lineage envelope namespace",
             "`provenance.source_family`",
             "`provenance.source_system`",
@@ -62,6 +64,7 @@ class Phase29MlShadowModeBoundaryDocsTests(unittest.TestCase):
             "`model_family`",
             "`model_version`",
             "`training_data_snapshot_id`",
+            "candidate shadow-model records",
             "`shadow_output_id`",
         ):
             self.assertIn(term, text)

--- a/control-plane/tests/test_phase29_mlflow_shadow_model_registry_validation.py
+++ b/control-plane/tests/test_phase29_mlflow_shadow_model_registry_validation.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import pathlib
+import sys
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+for candidate in (CONTROL_PLANE_ROOT, TESTS_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+
+from aegisops_control_plane.models import EvidenceRecord, ReconciliationRecord
+from aegisops_control_plane.phase29_mlflow_shadow_model_registry import (
+    Phase29MlflowShadowModelRegistryError,
+    track_shadow_model_with_mlflow,
+)
+from aegisops_control_plane.phase29_shadow_dataset import (
+    Phase29ShadowDatasetSnapshot,
+    generate_reviewed_shadow_dataset,
+)
+from support.service_persistence import ServicePersistenceTestBase
+
+
+class _FakeRunInfo:
+    def __init__(self, run_id: str) -> None:
+        self.run_id = run_id
+
+
+class _FakeRun:
+    def __init__(self, run_id: str) -> None:
+        self.info = _FakeRunInfo(run_id)
+
+
+class _FakeExperiment:
+    def __init__(self, experiment_id: str, name: str) -> None:
+        self.experiment_id = experiment_id
+        self.name = name
+
+
+class _FakeRegisteredModel:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeModelVersion:
+    def __init__(self, name: str, version: str, source: str, run_id: str) -> None:
+        self.name = name
+        self.version = version
+        self.source = source
+        self.run_id = run_id
+
+
+class FakeMlflowClient:
+    def __init__(self) -> None:
+        self._experiments_by_name: dict[str, _FakeExperiment] = {}
+        self.run_params: dict[str, dict[str, str]] = {}
+        self.run_tags: dict[str, dict[str, str]] = {}
+        self.run_metrics: dict[str, dict[str, float]] = {}
+        self.registered_models: dict[str, dict[str, object]] = {}
+        self.model_versions: dict[tuple[str, str], dict[str, object]] = {}
+
+    def get_experiment_by_name(self, name: str) -> _FakeExperiment | None:
+        return self._experiments_by_name.get(name)
+
+    def create_experiment(
+        self,
+        name: str,
+        tags: dict[str, str] | None = None,
+    ) -> str:
+        experiment_id = f"exp-{len(self._experiments_by_name) + 1}"
+        self._experiments_by_name[name] = _FakeExperiment(experiment_id, name)
+        return experiment_id
+
+    def create_run(
+        self,
+        experiment_id: str,
+        tags: dict[str, str] | None = None,
+        run_name: str | None = None,
+    ) -> _FakeRun:
+        run_id = f"run-{len(self.run_tags) + 1}"
+        tag_bucket = dict(tags or {})
+        if run_name is not None:
+            tag_bucket["mlflow.runName"] = run_name
+        self.run_tags[run_id] = tag_bucket
+        self.run_params[run_id] = {}
+        self.run_metrics[run_id] = {}
+        return _FakeRun(run_id)
+
+    def log_param(self, run_id: str, key: str, value: object) -> None:
+        self.run_params[run_id][key] = str(value)
+
+    def set_tag(self, run_id: str, key: str, value: object) -> None:
+        self.run_tags[run_id][key] = str(value)
+
+    def log_metric(
+        self,
+        run_id: str,
+        key: str,
+        value: float,
+        timestamp: int | None = None,
+        step: int = 0,
+    ) -> None:
+        del timestamp, step
+        self.run_metrics[run_id][key] = float(value)
+
+    def get_registered_model(self, name: str) -> _FakeRegisteredModel | None:
+        payload = self.registered_models.get(name)
+        if payload is None:
+            return None
+        return _FakeRegisteredModel(name)
+
+    def create_registered_model(
+        self,
+        name: str,
+        tags: dict[str, str] | None = None,
+        description: str | None = None,
+    ) -> _FakeRegisteredModel:
+        self.registered_models[name] = {
+            "tags": dict(tags or {}),
+            "description": description,
+        }
+        return _FakeRegisteredModel(name)
+
+    def create_model_version(
+        self,
+        name: str,
+        source: str,
+        run_id: str | None = None,
+        tags: dict[str, str] | None = None,
+        description: str | None = None,
+    ) -> _FakeModelVersion:
+        matching_versions = [
+            version
+            for registered_name, version in self.model_versions
+            if registered_name == name
+        ]
+        version = str(len(matching_versions) + 1)
+        self.model_versions[(name, version)] = {
+            "source": source,
+            "run_id": run_id,
+            "tags": dict(tags or {}),
+            "description": description,
+        }
+        return _FakeModelVersion(name=name, version=version, source=source, run_id=run_id or "")
+
+
+class Phase29MlflowShadowModelRegistryValidationTests(ServicePersistenceTestBase):
+    def test_tracker_records_mlflow_shadow_run_and_registry_lineage(self) -> None:
+        store, service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        initial_record_counts = {
+            record_type.__name__: len(store.list(record_type))
+            for record_type in (EvidenceRecord, ReconciliationRecord)
+        }
+        client = FakeMlflowClient()
+
+        result = track_shadow_model_with_mlflow(
+            client=client,
+            dataset_snapshot=dataset_snapshot,
+            experiment_name="phase29-shadow-model-training",
+            run_name="xgboost-github-audit-candidate",
+            registered_model_name="shadow.models.github_audit_xgboost",
+            model_source_uri="models:/shadow.models.github_audit_xgboost/artifacts/model.pkl",
+            model_family="xgboost",
+            model_version="candidate-2026-04-20",
+            training_spec_version="phase29-shadow-training-v1",
+            feature_schema_version="phase29-shadow-features-v1",
+            label_schema_version="phase29-shadow-labels-v1",
+            lineage_review_note_id="note-phase29-shadow-001",
+            evaluation_metrics={
+                "precision_at_5": 0.8,
+                "recall_at_5": 0.6,
+            },
+            evaluation_metadata={
+                "evaluation_window": "2026-04-01/2026-04-20",
+                "candidate_ranker": "top_k_review_queue",
+            },
+            run_timestamp=decided_at,
+        )
+
+        self.assertEqual(result.dataset_snapshot_id, dataset_snapshot.snapshot_id)
+        self.assertEqual(result.model_family, "xgboost")
+        self.assertEqual(result.model_version, "candidate-2026-04-20")
+        self.assertEqual(result.registry_posture, "shadow-only")
+        self.assertEqual(result.registered_model_name, "shadow.models.github_audit_xgboost")
+        self.assertEqual(result.registered_model_version, "1")
+
+        self.assertIn(result.run_id, client.run_params)
+        self.assertEqual(
+            client.run_params[result.run_id]["training_data_snapshot_id"],
+            dataset_snapshot.snapshot_id,
+        )
+        self.assertEqual(
+            client.run_params[result.run_id]["feature_schema_version"],
+            "phase29-shadow-features-v1",
+        )
+        self.assertEqual(
+            client.run_params[result.run_id]["label_schema_version"],
+            "phase29-shadow-labels-v1",
+        )
+        self.assertEqual(
+            client.run_params[result.run_id]["evaluation_window"],
+            "2026-04-01/2026-04-20",
+        )
+        self.assertEqual(
+            client.run_tags[result.run_id]["aegisops.registry_posture"],
+            "shadow-only",
+        )
+        self.assertEqual(
+            client.run_tags[result.run_id]["aegisops.authority_path"],
+            "outside-control-plane",
+        )
+        self.assertEqual(
+            client.model_versions[
+                (result.registered_model_name, result.registered_model_version)
+            ]["tags"]["aegisops.training_data_snapshot_id"],
+            dataset_snapshot.snapshot_id,
+        )
+        self.assertEqual(
+            client.model_versions[
+                (result.registered_model_name, result.registered_model_version)
+            ]["tags"]["aegisops.candidate_ranker"],
+            "top_k_review_queue",
+        )
+        self.assertEqual(client.run_metrics[result.run_id]["precision_at_5"], 0.8)
+        self.assertEqual(client.run_metrics[result.run_id]["recall_at_5"], 0.6)
+
+        final_record_counts = {
+            record_type.__name__: len(store.list(record_type))
+            for record_type in (EvidenceRecord, ReconciliationRecord)
+        }
+        self.assertEqual(final_record_counts, initial_record_counts)
+
+    def test_tracker_fails_closed_when_feature_provenance_is_missing(self) -> None:
+        snapshot = Phase29ShadowDatasetSnapshot(
+            snapshot_id="snapshot-missing-feature-provenance",
+            extraction_spec_version="phase29-shadow-dataset-v1",
+            snapshot_timestamp=datetime(2026, 4, 20, 0, 0, tzinfo=timezone.utc).isoformat(),
+            example_count=1,
+            examples=(
+                {
+                    "subject_record_family": "recommendation",
+                    "subject_record_id": "recommendation-001",
+                    "linked_case_id": "case-001",
+                    "linked_alert_id": "alert-001",
+                    "features": {
+                        "source_family": {
+                            "value": "github_audit",
+                            "provenance": {
+                                "feature_source_record_family": "Alert",
+                                "feature_source_field_path": "reviewed_context.source.source_family",
+                                "feature_extraction_spec_version": "phase29-shadow-dataset-v1",
+                                "feature_snapshot_timestamp": datetime(
+                                    2026, 4, 20, 0, 0, tzinfo=timezone.utc
+                                ).isoformat(),
+                                "feature_reviewed_linkage": "subject-alert-link",
+                                "feature_source_provenance_classification": None,
+                                "feature_source_reviewed_by": "analyst-001",
+                            },
+                        }
+                    },
+                    "label": {
+                        "value": "accepted",
+                        "provenance": {
+                            "label_record_family": "Recommendation",
+                            "label_record_id": "recommendation-001",
+                            "label_field_path": "lifecycle_state",
+                            "label_decision_basis": "reviewed recommendation lifecycle_state",
+                            "label_decided_at": datetime(
+                                2026, 4, 20, 0, 5, tzinfo=timezone.utc
+                            ).isoformat(),
+                            "label_reviewed_by": "analyst-001",
+                            "label_linked_subject_record_id": "recommendation-001",
+                        },
+                    },
+                },
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            Phase29MlflowShadowModelRegistryError,
+            "missing required feature provenance",
+        ):
+            track_shadow_model_with_mlflow(
+                client=FakeMlflowClient(),
+                dataset_snapshot=snapshot,
+                experiment_name="phase29-shadow-model-training",
+                run_name="broken-run",
+                registered_model_name="shadow.models.broken",
+                model_source_uri="models:/shadow.models.broken/model.pkl",
+                model_family="xgboost",
+                model_version="broken-candidate",
+                training_spec_version="phase29-shadow-training-v1",
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="note-phase29-shadow-001",
+                evaluation_metrics={"precision_at_5": 0.8},
+                evaluation_metadata={"evaluation_window": "2026-04-01/2026-04-20"},
+                run_timestamp=datetime(2026, 4, 20, 0, 10, tzinfo=timezone.utc),
+            )
+
+    def test_tracker_requires_lineage_review_note_for_registry_entries(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+
+        with self.assertRaisesRegex(
+            Phase29MlflowShadowModelRegistryError,
+            "lineage_review_note_id must be a non-empty string",
+        ):
+            track_shadow_model_with_mlflow(
+                client=FakeMlflowClient(),
+                dataset_snapshot=dataset_snapshot,
+                experiment_name="phase29-shadow-model-training",
+                run_name="missing-lineage-review-note",
+                registered_model_name="shadow.models.github_audit_xgboost",
+                model_source_uri="models:/shadow.models.github_audit_xgboost/model.pkl",
+                model_family="xgboost",
+                model_version="candidate-2026-04-20",
+                training_spec_version="phase29-shadow-training-v1",
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="   ",
+                evaluation_metrics={"precision_at_5": 0.8},
+                evaluation_metadata={"evaluation_window": "2026-04-01/2026-04-20"},
+                run_timestamp=decided_at,
+            )
+
+    def _build_shadow_dataset_snapshot(
+        self,
+    ) -> tuple[object, object, Phase29ShadowDatasetSnapshot, datetime]:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Reviewed feature extraction must stay anchored to the case.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting repository change requires bounded review.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            review_owner="analyst-001",
+            intended_outcome="Confirm the reviewed recommendation remains advisory-only.",
+        )
+        decided_at = reviewed_at + timedelta(minutes=5)
+        accepted_recommendation = service.persist_record(
+            replace(
+                recommendation,
+                lifecycle_state="accepted",
+            ),
+            transitioned_at=decided_at,
+        )
+        disposed_case = service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Preserve the reviewed business-hours handoff as bounded context.",
+            recorded_at=decided_at,
+        )
+        anchored_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase29-shadow-anchor-001",
+                source_record_id="reviewed-source-phase29-001",
+                alert_id=disposed_case.alert_id,
+                case_id=disposed_case.case_id,
+                source_system="github_audit",
+                collector_identity="fixture://reviewed/source-health",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_context_anchor",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "authoritative-anchor",
+                    "source_id": "github-audit-event-001",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "ambiguity_badge": "unresolved",
+                },
+                content={"summary": {"kind": "anchor"}},
+            )
+        )
+        service.persist_record(
+            replace(
+                disposed_case,
+                evidence_ids=(*disposed_case.evidence_ids, anchored_evidence.evidence_id),
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase29-shadow-001",
+                subject_linkage={
+                    "alert_ids": (disposed_case.alert_id,),
+                    "case_ids": (disposed_case.case_id,),
+                    "recommendation_ids": (accepted_recommendation.recommendation_id,),
+                },
+                alert_id=disposed_case.alert_id,
+                finding_id=disposed_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id=None,
+                linked_execution_run_ids=(),
+                correlation_key=f"case:{disposed_case.case_id}:source-health",
+                first_seen_at=reviewed_at,
+                last_seen_at=decided_at,
+                ingest_disposition="stale",
+                mismatch_summary="reviewed source-health context only",
+                compared_at=decided_at,
+                lifecycle_state="stale",
+            )
+        )
+        return (
+            store,
+            service,
+            generate_reviewed_shadow_dataset(
+                service,
+                extraction_spec_version="phase29-shadow-dataset-v1",
+                snapshot_timestamp=decided_at,
+            ),
+            decided_at,
+        )

--- a/control-plane/tests/test_phase29_mlflow_shadow_model_registry_validation.py
+++ b/control-plane/tests/test_phase29_mlflow_shadow_model_registry_validation.py
@@ -174,7 +174,7 @@ class UnexpectedRegisteredModelLookupClient(FakeMlflowClient):
 
 class Phase29MlflowShadowModelRegistryValidationTests(ServicePersistenceTestBase):
     def test_tracker_records_mlflow_shadow_run_and_registry_lineage(self) -> None:
-        store, service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
         initial_record_counts = {
             record_type.__name__: len(store.list(record_type))
             for record_type in (EvidenceRecord, ReconciliationRecord)
@@ -226,7 +226,7 @@ class Phase29MlflowShadowModelRegistryValidationTests(ServicePersistenceTestBase
             "phase29-shadow-labels-v1",
         )
         self.assertEqual(
-            client.run_params[result.run_id]["evaluation_window"],
+            client.run_params[result.run_id]["evaluation_metadata.evaluation_window"],
             "2026-04-01/2026-04-20",
         )
         self.assertEqual(
@@ -246,7 +246,7 @@ class Phase29MlflowShadowModelRegistryValidationTests(ServicePersistenceTestBase
         self.assertEqual(
             client.model_versions[
                 (result.registered_model_name, result.registered_model_version)
-            ]["tags"]["aegisops.candidate_ranker"],
+            ]["tags"]["aegisops.evaluation_metadata.candidate_ranker"],
             "top_k_review_queue",
         )
         self.assertEqual(client.run_metrics[result.run_id]["precision_at_5"], 0.8)
@@ -257,6 +257,38 @@ class Phase29MlflowShadowModelRegistryValidationTests(ServicePersistenceTestBase
             for record_type in (EvidenceRecord, ReconciliationRecord)
         }
         self.assertEqual(final_record_counts, initial_record_counts)
+
+    def test_tracker_rejects_dataset_example_count_mismatches(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        client = FakeMlflowClient()
+        mismatched_snapshot = replace(dataset_snapshot, example_count=dataset_snapshot.example_count + 1)
+
+        with self.assertRaisesRegex(
+            Phase29MlflowShadowModelRegistryError,
+            "dataset_snapshot.example_count must match examples payload length: "
+            f"declared={mismatched_snapshot.example_count}, actual={len(mismatched_snapshot.examples)}",
+        ):
+            track_shadow_model_with_mlflow(
+                client=client,
+                dataset_snapshot=mismatched_snapshot,
+                experiment_name="phase29-shadow-model-training",
+                run_name="count-mismatch",
+                registered_model_name="shadow.models.github_audit_xgboost",
+                model_source_uri="models:/shadow.models.github_audit_xgboost/artifacts/model.pkl",
+                model_family="xgboost",
+                model_version="candidate-2026-04-20",
+                training_spec_version="phase29-shadow-training-v1",
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="note-phase29-shadow-001",
+                evaluation_metrics={"precision_at_5": 0.8},
+                evaluation_metadata={"evaluation_window": "2026-04-01/2026-04-20"},
+                run_timestamp=decided_at,
+            )
+
+        self.assertEqual(client._experiments_by_name, {})
+        self.assertEqual(client.run_params, {})
+        self.assertEqual(client.registered_models, {})
 
     def test_tracker_creates_registry_namespace_when_mlflow_reports_missing_model(self) -> None:
         _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
@@ -287,6 +319,39 @@ class Phase29MlflowShadowModelRegistryValidationTests(ServicePersistenceTestBase
 
         self.assertEqual(result.registered_model_version, "1")
         self.assertIn("shadow.models.github_audit_xgboost", client.registered_models)
+
+    def test_tracker_rejects_reserved_evaluation_metadata_keys(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        client = FakeMlflowClient()
+
+        with self.assertRaisesRegex(
+            Phase29MlflowShadowModelRegistryError,
+            "evaluation_metadata contains reserved lineage keys: model_version, training_data_snapshot_id",
+        ):
+            track_shadow_model_with_mlflow(
+                client=client,
+                dataset_snapshot=dataset_snapshot,
+                experiment_name="phase29-shadow-model-training",
+                run_name="reserved-evaluation-metadata",
+                registered_model_name="shadow.models.github_audit_xgboost",
+                model_source_uri="models:/shadow.models.github_audit_xgboost/artifacts/model.pkl",
+                model_family="xgboost",
+                model_version="candidate-2026-04-20",
+                training_spec_version="phase29-shadow-training-v1",
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="note-phase29-shadow-001",
+                evaluation_metrics={"precision_at_5": 0.8},
+                evaluation_metadata={
+                    "training_data_snapshot_id": "override-attempt",
+                    "model_version": "override-attempt",
+                },
+                run_timestamp=decided_at,
+            )
+
+        self.assertEqual(client._experiments_by_name, {})
+        self.assertEqual(client.run_tags, {})
+        self.assertEqual(client.model_versions, {})
 
     def test_tracker_reraises_unexpected_mlflow_registered_model_lookup_failure(self) -> None:
         _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
@@ -319,6 +384,62 @@ class Phase29MlflowShadowModelRegistryValidationTests(ServicePersistenceTestBase
                     run_timestamp=decided_at,
                 )
 
+        self.assertEqual(client.registered_models, {})
+
+    def test_tracker_validates_metadata_and_metrics_before_mlflow_state_is_created(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        client = FakeMlflowClient()
+
+        with self.assertRaisesRegex(
+            Phase29MlflowShadowModelRegistryError,
+            "datetime metadata must be timezone-aware",
+        ):
+            track_shadow_model_with_mlflow(
+                client=client,
+                dataset_snapshot=dataset_snapshot,
+                experiment_name="phase29-shadow-model-training",
+                run_name="invalid-metadata",
+                registered_model_name="shadow.models.github_audit_xgboost",
+                model_source_uri="models:/shadow.models.github_audit_xgboost/artifacts/model.pkl",
+                model_family="xgboost",
+                model_version="candidate-2026-04-20",
+                training_spec_version="phase29-shadow-training-v1",
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="note-phase29-shadow-001",
+                evaluation_metrics={"precision_at_5": 0.8},
+                evaluation_metadata={"evaluated_at": datetime(2026, 4, 20, 0, 0)},
+                run_timestamp=decided_at,
+            )
+
+        self.assertEqual(client._experiments_by_name, {})
+        self.assertEqual(client.run_params, {})
+        self.assertEqual(client.model_versions, {})
+
+        with self.assertRaisesRegex(
+            Phase29MlflowShadowModelRegistryError,
+            "evaluation metric precision_at_5 must be numeric",
+        ):
+            track_shadow_model_with_mlflow(
+                client=client,
+                dataset_snapshot=dataset_snapshot,
+                experiment_name="phase29-shadow-model-training",
+                run_name="invalid-metric",
+                registered_model_name="shadow.models.github_audit_xgboost",
+                model_source_uri="models:/shadow.models.github_audit_xgboost/artifacts/model.pkl",
+                model_family="xgboost",
+                model_version="candidate-2026-04-20",
+                training_spec_version="phase29-shadow-training-v1",
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="note-phase29-shadow-001",
+                evaluation_metrics={"precision_at_5": True},
+                evaluation_metadata={"evaluation_window": "2026-04-01/2026-04-20"},
+                run_timestamp=decided_at,
+            )
+
+        self.assertEqual(client._experiments_by_name, {})
+        self.assertEqual(client.run_metrics, {})
         self.assertEqual(client.registered_models, {})
 
     def test_tracker_fails_closed_when_feature_provenance_is_missing(self) -> None:

--- a/control-plane/tests/test_phase29_mlflow_shadow_model_registry_validation.py
+++ b/control-plane/tests/test_phase29_mlflow_shadow_model_registry_validation.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import pathlib
 import sys
+from unittest import mock
 
 
 CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -13,6 +14,7 @@ for candidate in (CONTROL_PLANE_ROOT, TESTS_ROOT):
         sys.path.insert(0, str(candidate))
 
 
+import aegisops_control_plane.phase29_mlflow_shadow_model_registry as mlflow_shadow_model_registry
 from aegisops_control_plane.models import EvidenceRecord, ReconciliationRecord
 from aegisops_control_plane.phase29_mlflow_shadow_model_registry import (
     Phase29MlflowShadowModelRegistryError,
@@ -52,6 +54,12 @@ class _FakeModelVersion:
         self.version = version
         self.source = source
         self.run_id = run_id
+
+
+class _FakeMlflowLookupError(Exception):
+    def __init__(self, message: str, *, error_code: str | None = None) -> None:
+        super().__init__(message)
+        self.error_code = error_code
 
 
 class FakeMlflowClient:
@@ -148,6 +156,22 @@ class FakeMlflowClient:
         return _FakeModelVersion(name=name, version=version, source=source, run_id=run_id or "")
 
 
+class MissingRegisteredModelLookupClient(FakeMlflowClient):
+    def get_registered_model(self, name: str) -> _FakeRegisteredModel | None:
+        raise _FakeMlflowLookupError(
+            f"Registered Model with name={name} not found",
+            error_code="RESOURCE_DOES_NOT_EXIST",
+        )
+
+
+class UnexpectedRegisteredModelLookupClient(FakeMlflowClient):
+    def get_registered_model(self, name: str) -> _FakeRegisteredModel | None:
+        raise _FakeMlflowLookupError(
+            f"authentication failed while loading {name}",
+            error_code="PERMISSION_DENIED",
+        )
+
+
 class Phase29MlflowShadowModelRegistryValidationTests(ServicePersistenceTestBase):
     def test_tracker_records_mlflow_shadow_run_and_registry_lineage(self) -> None:
         store, service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
@@ -233,6 +257,69 @@ class Phase29MlflowShadowModelRegistryValidationTests(ServicePersistenceTestBase
             for record_type in (EvidenceRecord, ReconciliationRecord)
         }
         self.assertEqual(final_record_counts, initial_record_counts)
+
+    def test_tracker_creates_registry_namespace_when_mlflow_reports_missing_model(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        client = MissingRegisteredModelLookupClient()
+
+        with mock.patch.object(
+            mlflow_shadow_model_registry,
+            "_MLFLOW_LOOKUP_EXCEPTIONS",
+            (_FakeMlflowLookupError,),
+        ):
+            result = track_shadow_model_with_mlflow(
+                client=client,
+                dataset_snapshot=dataset_snapshot,
+                experiment_name="phase29-shadow-model-training",
+                run_name="missing-registry-namespace",
+                registered_model_name="shadow.models.github_audit_xgboost",
+                model_source_uri="models:/shadow.models.github_audit_xgboost/artifacts/model.pkl",
+                model_family="xgboost",
+                model_version="candidate-2026-04-20",
+                training_spec_version="phase29-shadow-training-v1",
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="note-phase29-shadow-001",
+                evaluation_metrics={"precision_at_5": 0.8},
+                evaluation_metadata={"evaluation_window": "2026-04-01/2026-04-20"},
+                run_timestamp=decided_at,
+            )
+
+        self.assertEqual(result.registered_model_version, "1")
+        self.assertIn("shadow.models.github_audit_xgboost", client.registered_models)
+
+    def test_tracker_reraises_unexpected_mlflow_registered_model_lookup_failure(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        client = UnexpectedRegisteredModelLookupClient()
+
+        with mock.patch.object(
+            mlflow_shadow_model_registry,
+            "_MLFLOW_LOOKUP_EXCEPTIONS",
+            (_FakeMlflowLookupError,),
+        ):
+            with self.assertRaisesRegex(
+                _FakeMlflowLookupError,
+                "authentication failed",
+            ):
+                track_shadow_model_with_mlflow(
+                    client=client,
+                    dataset_snapshot=dataset_snapshot,
+                    experiment_name="phase29-shadow-model-training",
+                    run_name="unexpected-registry-error",
+                    registered_model_name="shadow.models.github_audit_xgboost",
+                    model_source_uri="models:/shadow.models.github_audit_xgboost/artifacts/model.pkl",
+                    model_family="xgboost",
+                    model_version="candidate-2026-04-20",
+                    training_spec_version="phase29-shadow-training-v1",
+                    feature_schema_version="phase29-shadow-features-v1",
+                    label_schema_version="phase29-shadow-labels-v1",
+                    lineage_review_note_id="note-phase29-shadow-001",
+                    evaluation_metrics={"precision_at_5": 0.8},
+                    evaluation_metadata={"evaluation_window": "2026-04-01/2026-04-20"},
+                    run_timestamp=decided_at,
+                )
+
+        self.assertEqual(client.registered_models, {})
 
     def test_tracker_fails_closed_when_feature_provenance_is_missing(self) -> None:
         snapshot = Phase29ShadowDatasetSnapshot(

--- a/docs/phase-29-reviewed-ml-shadow-mode-boundary.md
+++ b/docs/phase-29-reviewed-ml-shadow-mode-boundary.md
@@ -178,6 +178,15 @@ The model lineage contract must preserve, at minimum:
 
 Model lineage must make it possible to trace which reviewed feature schema and reviewed label schema produced the model artifact without treating the model as a new authority surface.
 
+An implementation may use MLflow experiment tracking and the MLflow model registry to preserve this lineage only when the MLflow surface stays explicitly shadow-only, audit-focused, and outside the reviewed control-plane authority chain.
+
+If MLflow is used for Phase 29 lineage:
+
+- MLflow experiment runs must record the reviewed `training_data_snapshot_id`, feature-schema version, label-schema version, model family, evaluation metadata, and reviewed lineage reference needed to audit the candidate model later;
+- MLflow registry entries must remain candidate shadow-model records rather than approved operator workflow state;
+- MLflow tags, params, or registry metadata must not be treated as approval truth, case truth, reconciliation truth, or promotion-to-authority state; and
+- missing dataset lineage, missing feature provenance, or missing reviewed lineage references must block the MLflow tracking path rather than silently register a partially grounded candidate.
+
 ### 6.4 Shadow output lineage contract
 
 The shadow output lineage contract must preserve, at minimum:


### PR DESCRIPTION
## Summary
- add a Phase 29 MLflow-compatible shadow-model tracking module that validates dataset and label lineage before logging runs or registry versions
- record shadow-only lineage metadata for dataset snapshots, feature and label schema versions, model family/version, and evaluation metadata without touching authoritative control-plane records
- update the Phase 29 boundary doc/tests to name MLflow as an audit-only shadow registry surface outside the authority path

## Verification
- python3 -m unittest control-plane.tests.test_phase29_shadow_dataset_generation_validation control-plane.tests.test_phase29_mlflow_shadow_model_registry_validation control-plane.tests.test_phase29_ml_shadow_mode_boundary_docs
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 619 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json

Closes #619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MLflow shadow-only model tracking and registration: records reviewed dataset lineage, schema/training IDs, evaluation metadata/metrics, and returns audit-ready tracking results while enforcing strict runtime validation.

* **Documentation**
  * Expanded Phase 29 guidance: MLflow allowed only for shadow/audit use with explicit lineage/schema requirements and fail-closed behavior.

* **Tests**
  * Added tests covering successful tracking, registry-create/lookup failure modes, lineage/metadata/metric validation, and fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->