### PR TITLE
implementation: add baseline offline anomaly scorers and optional online shadow scoring (#620)

### DIFF
--- a/control-plane/aegisops_control_plane/phase29_shadow_scoring.py
+++ b/control-plane/aegisops_control_plane/phase29_shadow_scoring.py
@@ -327,6 +327,10 @@ def _validate_feature_entry(
         raise Phase29ShadowScoringError(
             f"feature {normalized_feature_name} must be a mapping"
         )
+    if "value" not in feature_entry or feature_entry["value"] is None:
+        raise Phase29ShadowScoringError(
+            f"missing required feature value on {normalized_feature_name}"
+        )
     provenance = _expect_mapping(feature_entry.get("provenance"), f"{normalized_feature_name}.provenance")
     missing_fields = [
         field_name
@@ -431,7 +435,16 @@ def _expect_mapping(value: object, field_name: str) -> Mapping[str, object]:
 
 def _require_timestamp_string(value: object, field_name: str) -> str:
     normalized = _require_non_empty_string(value, field_name)
-    datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise Phase29ShadowScoringError(
+            f"{field_name} must be a valid ISO-8601 timestamp: {normalized}"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise Phase29ShadowScoringError(
+            f"{field_name} must include a timezone offset: {normalized}"
+        )
     return normalized
 
 

--- a/control-plane/aegisops_control_plane/phase29_shadow_scoring.py
+++ b/control-plane/aegisops_control_plane/phase29_shadow_scoring.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+from typing import Mapping, Sequence
+
+from .phase29_shadow_dataset import Phase29ShadowDatasetSnapshot
+
+
+_REQUIRED_FEATURE_PROVENANCE_FIELDS = (
+    "feature_source_record_family",
+    "feature_source_record_id",
+    "feature_source_field_path",
+    "feature_extraction_spec_version",
+    "feature_snapshot_timestamp",
+    "feature_reviewed_linkage",
+)
+_REQUIRED_LABEL_PROVENANCE_FIELDS = (
+    "label_record_family",
+    "label_record_id",
+    "label_field_path",
+    "label_decision_basis",
+    "label_decided_at",
+    "label_linked_subject_record_id",
+)
+
+
+class Phase29ShadowScoringError(ValueError):
+    """Raised when shadow scoring cannot stay within the reviewed Phase 29 boundary."""
+
+
+@dataclass(frozen=True)
+class Phase29ShadowScoreResult:
+    shadow_output_id: str
+    shadow_output_type: str
+    model_family: str
+    model_version: str
+    input_snapshot_id: str
+    rendered_at: str
+    subject_record_family: str
+    subject_record_id: str
+    supporting_feature_snapshot_id: str
+    review_required: bool
+    registry_posture: str
+    authority_posture: str
+    status: str
+    anomaly_score: float
+    feature_provenance: Mapping[str, Mapping[str, object]]
+    label_provenance: Mapping[str, object]
+    operator_summary: Mapping[str, object]
+
+
+@dataclass(frozen=True)
+class Phase29OfflineShadowScoringSnapshot:
+    snapshot_id: str
+    scoring_spec_version: str
+    shadow_output_type: str
+    registry_posture: str
+    authority_posture: str
+    example_count: int
+    results: tuple[Phase29ShadowScoreResult, ...]
+
+
+def score_shadow_dataset_offline(
+    *,
+    dataset_snapshot: Phase29ShadowDatasetSnapshot,
+    scoring_spec_version: str,
+    model_family: str,
+    model_version: str,
+    training_data_snapshot_id: str,
+    feature_schema_version: str,
+    label_schema_version: str,
+    lineage_review_note_id: str,
+    scored_at: datetime,
+) -> Phase29OfflineShadowScoringSnapshot:
+    if not isinstance(dataset_snapshot, Phase29ShadowDatasetSnapshot):
+        raise TypeError("dataset_snapshot must be a Phase29ShadowDatasetSnapshot")
+    if dataset_snapshot.example_count != len(dataset_snapshot.examples):
+        raise Phase29ShadowScoringError(
+            "dataset_snapshot.example_count must match examples payload length"
+        )
+    if training_data_snapshot_id != dataset_snapshot.snapshot_id:
+        raise Phase29ShadowScoringError(
+            "training_data_snapshot_id must match dataset_snapshot.snapshot_id"
+        )
+    scoring_spec_version = _require_non_empty_string(
+        scoring_spec_version,
+        "scoring_spec_version",
+    )
+    model_family = _require_non_empty_string(model_family, "model_family")
+    model_version = _require_non_empty_string(model_version, "model_version")
+    _require_non_empty_string(feature_schema_version, "feature_schema_version")
+    _require_non_empty_string(label_schema_version, "label_schema_version")
+    lineage_review_note_id = _require_non_empty_string(
+        lineage_review_note_id,
+        "lineage_review_note_id",
+    )
+    scored_at_iso = _require_aware_datetime(scored_at, "scored_at").isoformat()
+
+    examples = tuple(dataset_snapshot.examples)
+    for example in examples:
+        _validate_dataset_example(example)
+
+    cohort_frequencies = _build_feature_value_frequencies(examples)
+    results = tuple(
+        _score_dataset_example(
+            dataset_example=example,
+            input_snapshot_id=dataset_snapshot.snapshot_id,
+            supporting_feature_snapshot_id=dataset_snapshot.snapshot_id,
+            model_family=model_family,
+            model_version=model_version,
+            rendered_at_iso=scored_at_iso,
+            lineage_review_note_id=lineage_review_note_id,
+            cohort_frequencies=cohort_frequencies,
+        )
+        for example in examples
+    )
+    return Phase29OfflineShadowScoringSnapshot(
+        snapshot_id=dataset_snapshot.snapshot_id,
+        scoring_spec_version=scoring_spec_version,
+        shadow_output_type="recommendation_draft",
+        registry_posture="shadow-only",
+        authority_posture="non-authoritative",
+        example_count=len(results),
+        results=results,
+    )
+
+
+class Phase29ShadowStreamingBaselineScorer:
+    def __init__(
+        self,
+        *,
+        scoring_spec_version: str,
+        model_family: str,
+        model_version: str,
+        feature_schema_version: str,
+        label_schema_version: str,
+        lineage_review_note_id: str,
+    ) -> None:
+        self.scoring_spec_version = _require_non_empty_string(
+            scoring_spec_version,
+            "scoring_spec_version",
+        )
+        self.model_family = _require_non_empty_string(model_family, "model_family")
+        self.model_version = _require_non_empty_string(model_version, "model_version")
+        self.feature_schema_version = _require_non_empty_string(
+            feature_schema_version,
+            "feature_schema_version",
+        )
+        self.label_schema_version = _require_non_empty_string(
+            label_schema_version,
+            "label_schema_version",
+        )
+        self.lineage_review_note_id = _require_non_empty_string(
+            lineage_review_note_id,
+            "lineage_review_note_id",
+        )
+        self._feature_frequencies: dict[str, Counter[str]] = defaultdict(Counter)
+        self._examples_seen = 0
+
+    def score_example(
+        self,
+        *,
+        dataset_example: Mapping[str, object],
+        input_snapshot_id: str,
+        rendered_at: datetime,
+    ) -> Phase29ShadowScoreResult:
+        _require_non_empty_string(input_snapshot_id, "input_snapshot_id")
+        rendered_at_iso = _require_aware_datetime(rendered_at, "rendered_at").isoformat()
+        _validate_dataset_example(dataset_example)
+        features = _expect_mapping(dataset_example.get("features"), "features")
+
+        contributions: list[float] = []
+        for feature_name, feature_entry in sorted(features.items()):
+            del feature_entry
+            value_key = _feature_value_key(features[feature_name]["value"])
+            prior_occurrences = self._feature_frequencies[feature_name][value_key]
+            denominator = max(self._examples_seen, 1)
+            novelty_score = 1.0 - min(prior_occurrences / denominator, 1.0)
+            contributions.append(novelty_score)
+
+        anomaly_score = round(sum(contributions) / max(len(contributions), 1), 6)
+        result = _score_dataset_example(
+            dataset_example=dataset_example,
+            input_snapshot_id=input_snapshot_id,
+            supporting_feature_snapshot_id=input_snapshot_id,
+            model_family=self.model_family,
+            model_version=self.model_version,
+            rendered_at_iso=rendered_at_iso,
+            lineage_review_note_id=self.lineage_review_note_id,
+            cohort_frequencies=None,
+            explicit_score=anomaly_score,
+        )
+        self._examples_seen += 1
+        for feature_name, feature_entry in sorted(features.items()):
+            self._feature_frequencies[feature_name][_feature_value_key(feature_entry["value"])] += 1
+        return result
+
+
+def _score_dataset_example(
+    *,
+    dataset_example: Mapping[str, object],
+    input_snapshot_id: str,
+    supporting_feature_snapshot_id: str,
+    model_family: str,
+    model_version: str,
+    rendered_at_iso: str,
+    lineage_review_note_id: str,
+    cohort_frequencies: Mapping[str, Counter[str]] | None,
+    explicit_score: float | None = None,
+) -> Phase29ShadowScoreResult:
+    subject_record_family = _require_non_empty_string(
+        dataset_example.get("subject_record_family"),
+        "subject_record_family",
+    )
+    subject_record_id = _require_non_empty_string(
+        dataset_example.get("subject_record_id"),
+        "subject_record_id",
+    )
+    features = _expect_mapping(dataset_example.get("features"), "features")
+    label = _expect_mapping(dataset_example.get("label"), "label")
+    label_provenance = _expect_mapping(label.get("provenance"), "label.provenance")
+
+    feature_provenance = {
+        feature_name: dict(_validate_feature_entry(feature_name, feature_entry))
+        for feature_name, feature_entry in sorted(features.items())
+    }
+    validated_label_provenance = dict(_validate_label_provenance(label_provenance))
+
+    if explicit_score is None:
+        explicit_score = _compute_offline_anomaly_score(
+            features=features,
+            cohort_frequencies=cohort_frequencies or {},
+        )
+
+    operator_summary = _build_operator_summary(
+        subject_record_family=subject_record_family,
+        subject_record_id=subject_record_id,
+        anomaly_score=explicit_score,
+        label_value=_require_non_empty_string(label.get("value"), "label.value"),
+        rendered_at_iso=rendered_at_iso,
+        lineage_review_note_id=lineage_review_note_id,
+    )
+    shadow_output_id = _shadow_output_id(
+        subject_record_family=subject_record_family,
+        subject_record_id=subject_record_id,
+        model_family=model_family,
+        model_version=model_version,
+        input_snapshot_id=input_snapshot_id,
+        rendered_at_iso=rendered_at_iso,
+    )
+    return Phase29ShadowScoreResult(
+        shadow_output_id=shadow_output_id,
+        shadow_output_type="recommendation_draft",
+        model_family=model_family,
+        model_version=model_version,
+        input_snapshot_id=input_snapshot_id,
+        rendered_at=rendered_at_iso,
+        subject_record_family=subject_record_family,
+        subject_record_id=subject_record_id,
+        supporting_feature_snapshot_id=supporting_feature_snapshot_id,
+        review_required=True,
+        registry_posture="shadow-only",
+        authority_posture="non-authoritative",
+        status="shadow-ready",
+        anomaly_score=explicit_score,
+        feature_provenance=feature_provenance,
+        label_provenance=validated_label_provenance,
+        operator_summary=operator_summary,
+    )
+
+
+def _compute_offline_anomaly_score(
+    *,
+    features: Mapping[str, Mapping[str, object]],
+    cohort_frequencies: Mapping[str, Counter[str]],
+) -> float:
+    contributions: list[float] = []
+    for feature_name, feature_entry in sorted(features.items()):
+        value_key = _feature_value_key(feature_entry["value"])
+        total = sum(cohort_frequencies.get(feature_name, Counter()).values())
+        if total <= 1:
+            rarity_score = 1.0
+        else:
+            occurrences = cohort_frequencies[feature_name][value_key]
+            rarity_score = 1.0 - min(occurrences / total, 1.0)
+        if feature_name == "ambiguity_badges" and feature_entry["value"]:
+            rarity_score = max(rarity_score, 0.95)
+        if feature_name == "source_health_state" and feature_entry["value"] in {"stale", "degraded", "unresolved"}:
+            rarity_score = max(rarity_score, 0.9)
+        contributions.append(rarity_score)
+    return round(sum(contributions) / max(len(contributions), 1), 6)
+
+
+def _build_feature_value_frequencies(
+    examples: Sequence[Mapping[str, object]],
+) -> dict[str, Counter[str]]:
+    frequencies: dict[str, Counter[str]] = defaultdict(Counter)
+    for example in examples:
+        features = _expect_mapping(example.get("features"), "features")
+        for feature_name, feature_entry in sorted(features.items()):
+            frequencies[feature_name][_feature_value_key(feature_entry["value"])] += 1
+    return dict(frequencies)
+
+
+def _validate_dataset_example(dataset_example: Mapping[str, object]) -> None:
+    if not isinstance(dataset_example, Mapping):
+        raise Phase29ShadowScoringError("dataset_example must be a mapping")
+    features = _expect_mapping(dataset_example.get("features"), "features")
+    if not features:
+        raise Phase29ShadowScoringError("dataset_example.features must not be empty")
+    for feature_name, feature_entry in sorted(features.items()):
+        _validate_feature_entry(feature_name, feature_entry)
+    label = _expect_mapping(dataset_example.get("label"), "label")
+    _validate_label_provenance(_expect_mapping(label.get("provenance"), "label.provenance"))
+
+
+def _validate_feature_entry(
+    feature_name: str,
+    feature_entry: Mapping[str, object],
+) -> Mapping[str, object]:
+    normalized_feature_name = _require_non_empty_string(feature_name, "feature_name")
+    if not isinstance(feature_entry, Mapping):
+        raise Phase29ShadowScoringError(
+            f"feature {normalized_feature_name} must be a mapping"
+        )
+    provenance = _expect_mapping(feature_entry.get("provenance"), f"{normalized_feature_name}.provenance")
+    missing_fields = [
+        field_name
+        for field_name in _REQUIRED_FEATURE_PROVENANCE_FIELDS
+        if _optional_string(provenance.get(field_name)) is None
+    ]
+    if missing_fields:
+        raise Phase29ShadowScoringError(
+            "missing required feature provenance on "
+            f"{normalized_feature_name}: {', '.join(missing_fields)}"
+        )
+    _require_timestamp_string(
+        provenance["feature_snapshot_timestamp"],
+        f"{normalized_feature_name}.feature_snapshot_timestamp",
+    )
+    return provenance
+
+
+def _validate_label_provenance(
+    label_provenance: Mapping[str, object],
+) -> Mapping[str, object]:
+    missing_fields = [
+        field_name
+        for field_name in _REQUIRED_LABEL_PROVENANCE_FIELDS
+        if _optional_string(label_provenance.get(field_name)) is None
+    ]
+    if missing_fields:
+        raise Phase29ShadowScoringError(
+            "missing required label provenance: " + ", ".join(missing_fields)
+        )
+    _require_timestamp_string(
+        label_provenance["label_decided_at"],
+        "label_decided_at",
+    )
+    return label_provenance
+
+
+def _build_operator_summary(
+    *,
+    subject_record_family: str,
+    subject_record_id: str,
+    anomaly_score: float,
+    label_value: str,
+    rendered_at_iso: str,
+    lineage_review_note_id: str,
+) -> dict[str, object]:
+    rounded_score = round(anomaly_score, 6)
+    return {
+        "summary": (
+            "shadow/non-authoritative anomaly score for reviewed "
+            f"{subject_record_family} {subject_record_id}: {rounded_score:.6f}"
+        ),
+        "rendered_at": rendered_at_iso,
+        "lineage_review_note_id": lineage_review_note_id,
+        "candidate_recommendations": [
+            {
+                "shadow_posture": "shadow/non-authoritative",
+                "review_required": True,
+                "recommended_action": (
+                    "Review the scored recommendation manually before any workflow mutation."
+                ),
+                "observed_label": label_value,
+                "anomaly_score": rounded_score,
+            }
+        ],
+    }
+
+
+def _shadow_output_id(
+    *,
+    subject_record_family: str,
+    subject_record_id: str,
+    model_family: str,
+    model_version: str,
+    input_snapshot_id: str,
+    rendered_at_iso: str,
+) -> str:
+    payload = {
+        "subject_record_family": subject_record_family,
+        "subject_record_id": subject_record_id,
+        "model_family": model_family,
+        "model_version": model_version,
+        "input_snapshot_id": input_snapshot_id,
+        "rendered_at": rendered_at_iso,
+    }
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _canonical_json(payload: Mapping[str, object]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _feature_value_key(value: object) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+
+
+def _expect_mapping(value: object, field_name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise Phase29ShadowScoringError(f"{field_name} must be a mapping")
+    return value
+
+
+def _require_timestamp_string(value: object, field_name: str) -> str:
+    normalized = _require_non_empty_string(value, field_name)
+    datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    return normalized
+
+
+def _require_aware_datetime(value: object, field_name: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise Phase29ShadowScoringError(f"{field_name} must be a timezone-aware datetime")
+    return value
+
+
+def _require_non_empty_string(value: object, field_name: str) -> str:
+    normalized = _optional_string(value)
+    if normalized is None:
+        raise Phase29ShadowScoringError(f"{field_name} must be a non-empty string")
+    return normalized
+
+
+def _optional_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None

--- a/control-plane/tests/test_phase29_shadow_scoring_validation.py
+++ b/control-plane/tests/test_phase29_shadow_scoring_validation.py
@@ -161,6 +161,98 @@ class Phase29ShadowScoringValidationTests(ServicePersistenceTestBase):
                 rendered_at=decided_at + timedelta(minutes=3),
             )
 
+    def test_shadow_scoring_fails_closed_when_feature_value_is_missing(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        broken_snapshot = Phase29ShadowDatasetSnapshot(
+            snapshot_id=dataset_snapshot.snapshot_id,
+            extraction_spec_version=dataset_snapshot.extraction_spec_version,
+            snapshot_timestamp=dataset_snapshot.snapshot_timestamp,
+            example_count=1,
+            examples=(
+                {
+                    **dataset_snapshot.examples[0],
+                    "features": {
+                        **dataset_snapshot.examples[0]["features"],
+                        "source_family": {
+                            "provenance": dataset_snapshot.examples[0]["features"]["source_family"][
+                                "provenance"
+                            ],
+                        },
+                    },
+                },
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            Phase29ShadowScoringError,
+            "missing required feature value on source_family",
+        ):
+            score_shadow_dataset_offline(
+                dataset_snapshot=broken_snapshot,
+                scoring_spec_version="phase29-shadow-scoring-v1",
+                model_family="baseline-isolation-forest",
+                model_version="candidate-2026-04-20",
+                training_data_snapshot_id=broken_snapshot.snapshot_id,
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="note-phase29-shadow-001",
+                scored_at=decided_at + timedelta(minutes=1),
+            )
+
+    def test_shadow_scoring_fails_closed_for_invalid_or_naive_feature_timestamps(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+
+        for bad_timestamp, expected_message in (
+            (
+                "not-a-timestamp",
+                "source_family.feature_snapshot_timestamp must be a valid ISO-8601 timestamp",
+            ),
+            (
+                "2026-04-20T10:00:00",
+                "source_family.feature_snapshot_timestamp must include a timezone offset",
+            ),
+        ):
+            with self.subTest(bad_timestamp=bad_timestamp):
+                broken_snapshot = Phase29ShadowDatasetSnapshot(
+                    snapshot_id=dataset_snapshot.snapshot_id,
+                    extraction_spec_version=dataset_snapshot.extraction_spec_version,
+                    snapshot_timestamp=dataset_snapshot.snapshot_timestamp,
+                    example_count=1,
+                    examples=(
+                        {
+                            **dataset_snapshot.examples[0],
+                            "features": {
+                                **dataset_snapshot.examples[0]["features"],
+                                "source_family": {
+                                    **dataset_snapshot.examples[0]["features"]["source_family"],
+                                    "provenance": {
+                                        **dataset_snapshot.examples[0]["features"]["source_family"][
+                                            "provenance"
+                                        ],
+                                        "feature_snapshot_timestamp": bad_timestamp,
+                                    },
+                                },
+                            },
+                        },
+                    ),
+                )
+
+                with self.assertRaisesRegex(
+                    Phase29ShadowScoringError,
+                    expected_message,
+                ):
+                    score_shadow_dataset_offline(
+                        dataset_snapshot=broken_snapshot,
+                        scoring_spec_version="phase29-shadow-scoring-v1",
+                        model_family="baseline-isolation-forest",
+                        model_version="candidate-2026-04-20",
+                        training_data_snapshot_id=broken_snapshot.snapshot_id,
+                        feature_schema_version="phase29-shadow-features-v1",
+                        label_schema_version="phase29-shadow-labels-v1",
+                        lineage_review_note_id="note-phase29-shadow-001",
+                        scored_at=decided_at + timedelta(minutes=1),
+                    )
+
     def _build_shadow_dataset_snapshot(
         self,
     ) -> tuple[object, object, Phase29ShadowDatasetSnapshot, datetime]:

--- a/control-plane/tests/test_phase29_shadow_scoring_validation.py
+++ b/control-plane/tests/test_phase29_shadow_scoring_validation.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import pathlib
+import sys
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+for candidate in (CONTROL_PLANE_ROOT, TESTS_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+
+from aegisops_control_plane.models import EvidenceRecord, ReconciliationRecord
+from aegisops_control_plane.phase29_shadow_dataset import (
+    Phase29ShadowDatasetSnapshot,
+    generate_reviewed_shadow_dataset,
+)
+from aegisops_control_plane.phase29_shadow_scoring import (
+    Phase29ShadowScoringError,
+    Phase29ShadowStreamingBaselineScorer,
+    score_shadow_dataset_offline,
+)
+from support.service_persistence import ServicePersistenceTestBase
+
+
+class Phase29ShadowScoringValidationTests(ServicePersistenceTestBase):
+    def test_offline_shadow_scoring_emits_lineage_backed_shadow_only_results(self) -> None:
+        store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        initial_record_counts = {
+            record_type.__name__: len(store.list(record_type))
+            for record_type in (EvidenceRecord, ReconciliationRecord)
+        }
+
+        scored_snapshot = score_shadow_dataset_offline(
+            dataset_snapshot=dataset_snapshot,
+            scoring_spec_version="phase29-shadow-scoring-v1",
+            model_family="baseline-isolation-forest",
+            model_version="candidate-2026-04-20",
+            training_data_snapshot_id=dataset_snapshot.snapshot_id,
+            feature_schema_version="phase29-shadow-features-v1",
+            label_schema_version="phase29-shadow-labels-v1",
+            lineage_review_note_id="note-phase29-shadow-001",
+            scored_at=decided_at + timedelta(minutes=1),
+        )
+
+        self.assertEqual(scored_snapshot.snapshot_id, dataset_snapshot.snapshot_id)
+        self.assertEqual(scored_snapshot.scoring_spec_version, "phase29-shadow-scoring-v1")
+        self.assertEqual(scored_snapshot.shadow_output_type, "recommendation_draft")
+        self.assertEqual(scored_snapshot.registry_posture, "shadow-only")
+        self.assertEqual(scored_snapshot.authority_posture, "non-authoritative")
+        self.assertEqual(scored_snapshot.example_count, dataset_snapshot.example_count)
+        self.assertEqual(len(scored_snapshot.results), dataset_snapshot.example_count)
+
+        result = scored_snapshot.results[0]
+        self.assertEqual(result.subject_record_family, "recommendation")
+        self.assertEqual(result.subject_record_id, dataset_snapshot.examples[0]["subject_record_id"])
+        self.assertEqual(result.status, "shadow-ready")
+        self.assertTrue(result.review_required)
+        self.assertEqual(result.shadow_output_type, "recommendation_draft")
+        self.assertEqual(result.registry_posture, "shadow-only")
+        self.assertEqual(result.authority_posture, "non-authoritative")
+        self.assertEqual(result.input_snapshot_id, dataset_snapshot.snapshot_id)
+        self.assertGreaterEqual(result.anomaly_score, 0.0)
+        self.assertLessEqual(result.anomaly_score, 1.0)
+        self.assertEqual(result.feature_provenance["source_family"]["feature_source_record_family"], "Alert")
+        self.assertEqual(
+            result.feature_provenance["case_lifecycle_state"]["feature_source_record_family"],
+            "Case",
+        )
+        self.assertIn("shadow/non-authoritative", result.operator_summary["summary"])
+        self.assertEqual(
+            result.operator_summary["candidate_recommendations"][0]["shadow_posture"],
+            "shadow/non-authoritative",
+        )
+
+        final_record_counts = {
+            record_type.__name__: len(store.list(record_type))
+            for record_type in (EvidenceRecord, ReconciliationRecord)
+        }
+        self.assertEqual(final_record_counts, initial_record_counts)
+
+    def test_offline_shadow_scoring_fails_closed_when_training_snapshot_binding_drifts(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+
+        with self.assertRaisesRegex(
+            Phase29ShadowScoringError,
+            "training_data_snapshot_id must match dataset_snapshot.snapshot_id",
+        ):
+            score_shadow_dataset_offline(
+                dataset_snapshot=dataset_snapshot,
+                scoring_spec_version="phase29-shadow-scoring-v1",
+                model_family="baseline-isolation-forest",
+                model_version="candidate-2026-04-20",
+                training_data_snapshot_id="snapshot-drifted",
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="note-phase29-shadow-001",
+                scored_at=decided_at + timedelta(minutes=1),
+            )
+
+    def test_online_shadow_scoring_stays_shadow_only_and_requires_lineage(self) -> None:
+        _store, _service, dataset_snapshot, decided_at = self._build_shadow_dataset_snapshot()
+        scorer = Phase29ShadowStreamingBaselineScorer(
+            scoring_spec_version="phase29-shadow-streaming-v1",
+            model_family="river-half-space-trees",
+            model_version="shadow-stream-2026-04-20",
+            feature_schema_version="phase29-shadow-features-v1",
+            label_schema_version="phase29-shadow-labels-v1",
+            lineage_review_note_id="note-phase29-shadow-001",
+        )
+
+        result = scorer.score_example(
+            dataset_example=dataset_snapshot.examples[0],
+            input_snapshot_id=dataset_snapshot.snapshot_id,
+            rendered_at=decided_at + timedelta(minutes=2),
+        )
+
+        self.assertEqual(result.registry_posture, "shadow-only")
+        self.assertEqual(result.authority_posture, "non-authoritative")
+        self.assertTrue(result.review_required)
+        self.assertIn("shadow/non-authoritative", result.operator_summary["summary"])
+        self.assertEqual(result.supporting_feature_snapshot_id, dataset_snapshot.snapshot_id)
+
+        broken_snapshot = Phase29ShadowDatasetSnapshot(
+            snapshot_id="snapshot-broken",
+            extraction_spec_version=dataset_snapshot.extraction_spec_version,
+            snapshot_timestamp=dataset_snapshot.snapshot_timestamp,
+            example_count=1,
+            examples=(
+                {
+                    **dataset_snapshot.examples[0],
+                    "features": {
+                        **dataset_snapshot.examples[0]["features"],
+                        "source_family": {
+                            "value": "github_audit",
+                            "provenance": {
+                                "feature_source_record_family": "Alert",
+                                "feature_source_record_id": "alert-broken",
+                                "feature_source_field_path": "reviewed_context.source.source_family",
+                                "feature_extraction_spec_version": "phase29-shadow-dataset-v1",
+                                "feature_reviewed_linkage": "subject-alert-link",
+                                "feature_source_provenance_classification": None,
+                                "feature_source_reviewed_by": "analyst-001",
+                            },
+                        },
+                    },
+                },
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            Phase29ShadowScoringError,
+            "missing required feature provenance",
+        ):
+            scorer.score_example(
+                dataset_example=broken_snapshot.examples[0],
+                input_snapshot_id=broken_snapshot.snapshot_id,
+                rendered_at=decided_at + timedelta(minutes=3),
+            )
+
+    def _build_shadow_dataset_snapshot(
+        self,
+    ) -> tuple[object, object, Phase29ShadowDatasetSnapshot, datetime]:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Reviewed feature extraction must stay anchored to the case.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting repository change requires bounded review.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            review_owner="analyst-001",
+            intended_outcome="Confirm the reviewed recommendation remains advisory-only.",
+        )
+        decided_at = reviewed_at + timedelta(minutes=5)
+        accepted_recommendation = service.persist_record(
+            replace(
+                recommendation,
+                lifecycle_state="accepted",
+            ),
+            transitioned_at=decided_at,
+        )
+        disposed_case = service.record_case_disposition(
+            case_id=promoted_case.case_id,
+            disposition="business_hours_handoff",
+            rationale="Preserve the reviewed business-hours handoff as bounded context.",
+            recorded_at=decided_at,
+        )
+        anchored_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase29-shadow-anchor-001",
+                source_record_id="reviewed-source-phase29-001",
+                alert_id=disposed_case.alert_id,
+                case_id=disposed_case.case_id,
+                source_system="github_audit",
+                collector_identity="fixture://reviewed/source-health",
+                acquired_at=reviewed_at,
+                derivation_relationship="reviewed_context_anchor",
+                lifecycle_state="linked",
+                provenance={
+                    "classification": "authoritative-anchor",
+                    "source_id": "github-audit-event-001",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "ambiguity_badge": "unresolved",
+                },
+                content={"summary": {"kind": "anchor"}},
+            )
+        )
+        service.persist_record(
+            replace(
+                disposed_case,
+                evidence_ids=(*disposed_case.evidence_ids, anchored_evidence.evidence_id),
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase29-shadow-001",
+                subject_linkage={
+                    "alert_ids": (disposed_case.alert_id,),
+                    "case_ids": (disposed_case.case_id,),
+                    "recommendation_ids": (accepted_recommendation.recommendation_id,),
+                },
+                alert_id=disposed_case.alert_id,
+                finding_id=disposed_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id=None,
+                linked_execution_run_ids=(),
+                correlation_key=f"case:{disposed_case.case_id}:source-health",
+                first_seen_at=reviewed_at,
+                last_seen_at=decided_at,
+                ingest_disposition="stale",
+                mismatch_summary="reviewed source-health context only",
+                compared_at=decided_at,
+                lifecycle_state="stale",
+            )
+        )
+        return (
+            store,
+            service,
+            generate_reviewed_shadow_dataset(
+                service,
+                extraction_spec_version="phase29-shadow-dataset-v1",
+                snapshot_timestamp=decided_at,
+            ),
+            decided_at,
+        )


### PR DESCRIPTION
Closes #620
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a focused Phase 29 shadow scoring slice and committed it as `16083a2` (`Add phase29 shadow scoring baselines`).

The new module, [phase29_shadow_scoring.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-620/control-plane/aegisops_control_plane/phase29_shadow_scoring.py), adds:
- offline in-memory baseline scoring over reviewed dataset snapshots
- optional streaming shadow scoring with the same shadow-only posture
- fail-closed validation for feature and label provenance plus snapshot binding
- explicit `shadow-only` / `non-authoritative` output metadata and operator summaries
- zero writes to authoritative control-plane records

The focused validation file, [test_phase29_shadow_scoring_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-620/control-plane/tests/test_phase29_shadow_scoring_validation.py), proves:
- offline results preserve lineage and are marked shadow-only
- training snapshot drift is rejected
- online scoring remains shadow-only and fails when required provenance is missing

I also updated the local issue journal in `.codex-supervisor/issues/620/issue-journal.md`. That path is gitignored, so the journal change stays local in the worktree as expected.

Summary: Added baseline Phase 29 shadow scorers with focused validation for shadow-only posture, lineage preservation, and fail-closed snapshot/provenance checks; committed as `16083a2`.
State hint: draft_pr
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase29_m...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shadow scoring for recommendation drafts in both offline batch and streaming baseline modes.
  * Enforced strict input validation (snapshot binding, required provenance, ISO-8601 timestamps with timezone) and deterministic output IDs.
  * Emits per-item anomaly scores, operator summaries, posture markers (shadow-only/non-authoritative) and review-required flags.

* **Tests**
  * Added end-to-end tests covering successful scoring, lineage binding failures, missing feature values, and invalid timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->