### PR TITLE
optional: add a Suricata evidence-pack boundary without promoting network telemetry to mainline (#622)

### DIFF
--- a/control-plane/tests/test_phase29_suricata_evidence_pack_boundary_validation.py
+++ b/control-plane/tests/test_phase29_suricata_evidence_pack_boundary_validation.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase29SuricataEvidencePackBoundaryValidationTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected document at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_phase29_suricata_design_doc_exists_and_keeps_suricata_subordinate(
+        self,
+    ) -> None:
+        text = self._read("docs/phase-29-optional-suricata-evidence-pack-boundary.md")
+
+        for term in (
+            "# AegisOps Phase 29 Optional Suricata Evidence-Pack Boundary",
+            "This document defines the reviewed optional Suricata evidence-pack boundary for Phase 29.",
+            "Suricata integration is optional, disabled by default, and subordinate to the AegisOps-owned control-plane record chain.",
+            "Suricata is approved only as a subordinate evidence-pack and shadow-correlation substrate for this reviewed slice.",
+            "Suricata-derived output is optional augmentation, not a mandatory platform dependency or case-truth authority surface.",
+            "A reviewed Suricata evidence pack may be used only when an existing operating need or explicit evidence gap is already present on the reviewed case chain.",
+            "Suricata collection or parsing must start from an existing AegisOps-owned case, evidence record, or reviewed follow-up decision rather than from free-form network hunting or substrate-first alerting.",
+            "The approved artifact classes for this boundary are:",
+            "`collection_manifest`",
+            "`alert_sample`",
+            "`flow_excerpt`",
+            "`shadow_correlation_note`",
+            "`tool_output_receipt`",
+            "Every Suricata-derived artifact must preserve provenance that identifies the reviewed observer or sensor binding, source family, source event or flow identifier when available, bounded time window, reviewed operator or reviewed automation attribution, and the AegisOps evidence record that admitted it.",
+            "Suricata-derived artifacts and shadow correlation notes must be cited as subordinate evidence linked to an AegisOps-owned evidence record.",
+            "Suricata-derived output must not replace AegisOps-owned alert truth, case truth, evidence truth, approval truth, execution truth, or reconciliation truth.",
+            "This boundary does not approve network-first mainline detection, broad IDS-led workflow redesign, mandatory Suricata deployment, or substrate authority expansion.",
+            "The path must fail closed when provenance is partial, the observer or subject scope is only inferred, the requested artifact class falls outside this reviewed slice, the boundary is enabled without an explicit reviewed need, or a citation would overstate what the subordinate network telemetry actually proved.",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase29_suricata_validation_doc_records_boundary_and_shadow_mode_review(
+        self,
+    ) -> None:
+        text = self._read(
+            "docs/phase-29-optional-suricata-evidence-pack-boundary-validation.md"
+        )
+
+        for term in (
+            "# Phase 29 Optional Suricata Evidence-Pack Boundary Validation",
+            "Validation status: PASS",
+            "ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md",
+            "`README.md`",
+            "`docs/architecture.md`",
+            "`docs/canonical-telemetry-schema-baseline.md`",
+            "`docs/phase-28-optional-endpoint-evidence-pack-boundary.md`",
+            "`docs/phase-29-reviewed-ml-shadow-mode-boundary.md`",
+            "The reviewed Suricata boundary remains optional, disabled by default, provenance-preserving, and fail closed when reviewed linkage or scope is incomplete.",
+            "Suricata integration is optional, disabled by default, and subordinate to the AegisOps-owned control-plane record chain.",
+            "Any Suricata-derived feature, note, or correlation signal must preserve explicit provenance and remain advisory-only.",
+            "Suricata-derived output cannot become an authoritative label source and cannot silently promote network telemetry into mainline workflow truth.",
+            "No reviewed language in this slice promotes network-first product positioning or broad IDS-led workflow redesign.",
+            "python3 -m unittest control-plane.tests.test_phase29_suricata_evidence_pack_boundary_validation",
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-29-optional-suricata-evidence-pack-boundary-validation.md
+++ b/docs/phase-29-optional-suricata-evidence-pack-boundary-validation.md
@@ -1,0 +1,49 @@
+# Phase 29 Optional Suricata Evidence-Pack Boundary Validation
+
+- Validation status: PASS
+- Reviewed on: 2026-04-20
+- Scope: confirm the reviewed Phase 29 optional Suricata evidence-pack boundary keeps network-derived material subordinate, optional, disabled by default, and outside the AegisOps mainline authority path.
+- Reviewed sources: `ObsidianVault/Dev/AegisOps/Plan&Roadmap/Revised Phase23-29 Epic Roadmap.md` (vault-relative path for the reviewed roadmap note that allows one optional network evidence-pack candidate for Phase 29 while keeping network telemetry subordinate to the AegisOps authority model), `README.md`, `docs/architecture.md`, `docs/canonical-telemetry-schema-baseline.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`, `docs/phase-29-reviewed-ml-shadow-mode-boundary.md`, `docs/phase-29-optional-suricata-evidence-pack-boundary.md`
+
+## Validation Summary
+
+The reviewed Suricata boundary remains optional, disabled by default, provenance-preserving, and fail closed when reviewed linkage or scope is incomplete.
+
+## Thesis and Authority Review
+
+`README.md` and `docs/architecture.md` keep AegisOps positioned as a governed SecOps control plane above external detection and automation substrates rather than a network-first SIEM replacement.
+
+The reviewed Suricata boundary preserves that thesis by restricting Suricata to subordinate evidence-pack and shadow-correlation use.
+
+Suricata does not become an authority for alert truth, case truth, approval truth, execution truth, or reconciliation truth.
+
+## Suricata Boundary Review
+
+`docs/phase-29-optional-suricata-evidence-pack-boundary.md` defines a bounded slice for optional Suricata-derived evidence packs and shadow correlation notes.
+
+Suricata integration is optional, disabled by default, and subordinate to the AegisOps-owned control-plane record chain.
+
+Suricata-derived output is optional augmentation, not a mandatory platform dependency or case-truth authority surface.
+
+The boundary requires explicit anchor linkage, explicit observer or sensor provenance, and bounded artifact classes rather than broad network telemetry ingestion.
+
+## Phase 29 Shadow-Mode Review
+
+`docs/phase-29-reviewed-ml-shadow-mode-boundary.md` already requires shadow-only, advisory-only, provenance-preserving behavior for Phase 29.
+
+The reviewed Suricata boundary stays consistent with that contract by allowing Suricata-derived material only as reviewed subordinate context or evidence-pack material.
+
+Any Suricata-derived feature, note, or correlation signal must preserve explicit provenance and remain advisory-only.
+
+Suricata-derived output cannot become an authoritative label source and cannot silently promote network telemetry into mainline workflow truth.
+
+## Review Outcome
+
+One optional network evidence-pack candidate remains permissible for Phase 29 only because the reviewed Suricata slice stays bounded, subordinate, disableable, and explicitly outside the authoritative control-plane path.
+
+No reviewed language in this slice promotes network-first product positioning or broad IDS-led workflow redesign.
+
+## Verification
+
+- `python3 -m unittest control-plane.tests.test_phase29_suricata_evidence_pack_boundary_validation`
+- `bash scripts/verify-phase-29-suricata-evidence-pack-boundary.sh`

--- a/docs/phase-29-optional-suricata-evidence-pack-boundary-validation.md
+++ b/docs/phase-29-optional-suricata-evidence-pack-boundary-validation.md
@@ -39,7 +39,7 @@ Suricata-derived output cannot become an authoritative label source and cannot s
 
 ## Review Outcome
 
-One optional network evidence-pack candidate remains permissible for Phase 29 only because the reviewed Suricata slice stays bounded, subordinate, disableable, and explicitly outside the authoritative control-plane path.
+One optional network evidence-pack candidate remains permissible for Phase 29 only because the reviewed Suricata slice stays bounded, subordinate, disabled by default, and explicitly outside the authoritative control-plane path.
 
 No reviewed language in this slice promotes network-first product positioning or broad IDS-led workflow redesign.
 

--- a/docs/phase-29-optional-suricata-evidence-pack-boundary.md
+++ b/docs/phase-29-optional-suricata-evidence-pack-boundary.md
@@ -32,7 +32,7 @@ Approved triggering conditions for this reviewed path are intentionally narrow:
 
 - a reviewed case already has an explicit host, service, detector, or evidence binding and needs bounded network context to resolve a documented evidence gap;
 - a reviewed evidence record already anchors the specific flow, transaction, alert, or protocol artifact for which Suricata-derived context is being requested; or
-- a reviewed Phase 29 shadow-mode comparison needs bounded non-authoritative correlation context tied to an already-reviewed subject record.
+- a reviewed Phase 29 shadow-mode comparison requires bounded non-authoritative correlation context tied to an already-reviewed subject record.
 
 The path must fail closed when the anchor case or evidence record is missing, the network scope is only implied, the requested flow or observer binding is inferred from weak hints, or the requested intake would widen into general network-first detection coverage.
 

--- a/docs/phase-29-optional-suricata-evidence-pack-boundary.md
+++ b/docs/phase-29-optional-suricata-evidence-pack-boundary.md
@@ -1,0 +1,101 @@
+# AegisOps Phase 29 Optional Suricata Evidence-Pack Boundary
+
+## 1. Purpose
+
+This document defines the reviewed optional Suricata evidence-pack boundary for Phase 29.
+
+It supplements `README.md`, `docs/architecture.md`, `docs/canonical-telemetry-schema-baseline.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`, and `docs/phase-29-reviewed-ml-shadow-mode-boundary.md` by defining the only approved role for Suricata-derived material in the current reviewed design.
+
+This document defines reviewed design scope only. It does not approve network-first product repositioning, mandatory IDS rollout, detection-authority reassignment, case-truth reassignment, approval-surface expansion, execution-surface expansion, or any promotion of network telemetry into the AegisOps mainline authority path.
+
+## 2. Reviewed Optional Suricata Role
+
+Suricata integration is optional, disabled by default, and subordinate to the AegisOps-owned control-plane record chain.
+
+Suricata is approved only as a subordinate evidence-pack and shadow-correlation substrate for this reviewed slice.
+
+Suricata-derived output is optional augmentation, not a mandatory platform dependency or case-truth authority surface.
+
+The reviewed role of this boundary is to let operators preserve bounded network-derived context only when an existing reviewed case chain, evidence gap, or reviewed shadow-mode comparison already justifies collecting it.
+
+Suricata-derived material must remain subordinate to the AegisOps-owned case chain.
+
+Suricata-derived output must not replace AegisOps-owned alert truth, case truth, evidence truth, approval truth, execution truth, or reconciliation truth.
+
+## 3. Enablement Conditions
+
+A reviewed Suricata evidence pack may be used only when an existing operating need or explicit evidence gap is already present on the reviewed case chain.
+
+Suricata collection or parsing must start from an existing AegisOps-owned case, evidence record, or reviewed follow-up decision rather than from free-form network hunting or substrate-first alerting.
+
+Approved triggering conditions for this reviewed path are intentionally narrow:
+
+- a reviewed case already has an explicit host, service, detector, or evidence binding and needs bounded network context to resolve a documented evidence gap;
+- a reviewed evidence record already anchors the specific flow, transaction, alert, or protocol artifact for which Suricata-derived context is being requested; or
+- a reviewed Phase 29 shadow-mode comparison needs bounded non-authoritative correlation context tied to an already-reviewed subject record.
+
+The path must fail closed when the anchor case or evidence record is missing, the network scope is only implied, the requested flow or observer binding is inferred from weak hints, or the requested intake would widen into general network-first detection coverage.
+
+## 4. Approved Artifact Classes
+
+The approved artifact classes for this boundary are:
+
+- `collection_manifest` for the reviewed description of which bounded Suricata source, observer, time window, and case or evidence anchor were requested;
+- `alert_sample` for the explicitly scoped Suricata alert or event material collected under the reviewed anchor;
+- `flow_excerpt` for the bounded flow, transaction, or protocol excerpt tied to the reviewed anchor rather than a broad sensor dump;
+- `shadow_correlation_note` for subordinate correlation context that may inform Phase 29 shadow-only comparison work without becoming workflow truth; and
+- `tool_output_receipt` for the subordinate receipt that records which reviewed Suricata source, parser, or import step produced which artifact and when.
+
+These artifact classes are evidence-pack artifacts only.
+
+They are subordinate evidence that may support reviewed observations, reviewed operator notes, or shadow-only diagnostic context, but they do not become authoritative control-plane lifecycle records on their own.
+
+## 5. Provenance and Citation Requirements
+
+Every Suricata-derived artifact must preserve provenance that identifies the reviewed observer or sensor binding, source family, source event or flow identifier when available, bounded time window, reviewed operator or reviewed automation attribution, and the AegisOps evidence record that admitted it.
+
+Minimum reviewed provenance for this boundary includes:
+
+- the explicitly bound observer, sensor, or reviewed source binding;
+- the reviewed case identifier and admitting evidence identifier;
+- the reviewed Suricata source, rule, parser, or import tool identity and version when available;
+- the collection, parse, or extraction timestamp;
+- the reviewed operator or reviewed automation attribution that initiated the step; and
+- the reviewed event, flow, transaction, or time-window description needed to explain what was collected.
+
+Suricata-derived artifacts and shadow correlation notes must be cited as subordinate evidence linked to an AegisOps-owned evidence record.
+
+Citation must preserve whether the cited material is raw collected output, a bounded derivative, or an operator-authored interpretation.
+
+The case chain must not cite Suricata-derived output as if it decided case scope, actor identity, approval state, execution state, or reconciliation success.
+
+## 6. Boundary Notes for Phase 29 Shadow Mode
+
+Suricata-derived material may inform Phase 29 only as reviewed subordinate context or evidence-pack material consistent with the reviewed ML shadow-mode contract.
+
+Any Suricata-derived feature, note, or correlation signal must preserve explicit provenance and remain advisory-only.
+
+Suricata-derived output must not widen feature scope beyond the anchored reviewed record, must not become an authoritative label source, and must not silently promote network telemetry into mainline workflow truth.
+
+If a reviewed Phase 29 path cannot preserve explicit linkage from the anchored reviewed record to the Suricata-derived artifact, the Suricata path must remain blocked.
+
+## 7. Non-Goals and Fail-Closed Rules
+
+This boundary does not approve network-first mainline detection, broad IDS-led workflow redesign, mandatory Suricata deployment, or substrate authority expansion.
+
+This boundary also does not approve:
+
+- making Suricata a required mainline dependency for first boot, routine case handling, or reviewed ML shadow-mode operation;
+- treating Suricata alert streams, flow logs, signatures, classifications, or metadata as authoritative alert, case, approval, execution, or reconciliation truth;
+- widening from a reviewed anchor into broad sensor sweeps, generalized threat hunting, or passive backlog mining;
+- allowing Suricata rule names, signatures, classifications, or parser convenience fields to become workflow truth by convenience; or
+- using subordinate network telemetry to bypass reviewed evidence linkage, approval controls, or explicit reconciliation checks.
+
+The path must fail closed when provenance is partial, the observer or subject scope is only inferred, the requested artifact class falls outside this reviewed slice, the boundary is enabled without an explicit reviewed need, or a citation would overstate what the subordinate network telemetry actually proved.
+
+## 8. Repository-Local Verification Commands
+
+The repository-local verification commands for this boundary are:
+
+- `python3 -m unittest control-plane.tests.test_phase29_suricata_evidence_pack_boundary_validation`
+- `bash scripts/verify-phase-29-suricata-evidence-pack-boundary.sh`

--- a/scripts/verify-phase-29-suricata-evidence-pack-boundary.sh
+++ b/scripts/verify-phase-29-suricata-evidence-pack-boundary.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+design_doc="${repo_root}/docs/phase-29-optional-suricata-evidence-pack-boundary.md"
+validation_doc="${repo_root}/docs/phase-29-optional-suricata-evidence-pack-boundary-validation.md"
+docs_test="${repo_root}/control-plane/tests/test_phase29_suricata_evidence_pack_boundary_validation.py"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_line() {
+  local path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${path}" >/dev/null; then
+    echo "Missing required line in ${path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${design_doc}" "Missing Phase 29 Suricata evidence-pack boundary doc"
+require_file "${validation_doc}" "Missing Phase 29 Suricata evidence-pack boundary validation doc"
+require_file "${docs_test}" "Missing Phase 29 Suricata evidence-pack boundary unittest"
+
+design_required_lines=(
+  '# AegisOps Phase 29 Optional Suricata Evidence-Pack Boundary'
+  '## 1. Purpose'
+  '## 2. Reviewed Optional Suricata Role'
+  '## 3. Enablement Conditions'
+  '## 4. Approved Artifact Classes'
+  '## 5. Provenance and Citation Requirements'
+  '## 6. Boundary Notes for Phase 29 Shadow Mode'
+  '## 7. Non-Goals and Fail-Closed Rules'
+  '## 8. Repository-Local Verification Commands'
+  'This document defines the reviewed optional Suricata evidence-pack boundary for Phase 29.'
+  'Suricata integration is optional, disabled by default, and subordinate to the AegisOps-owned control-plane record chain.'
+  'Suricata is approved only as a subordinate evidence-pack and shadow-correlation substrate for this reviewed slice.'
+  'Suricata-derived output is optional augmentation, not a mandatory platform dependency or case-truth authority surface.'
+  'A reviewed Suricata evidence pack may be used only when an existing operating need or explicit evidence gap is already present on the reviewed case chain.'
+  'Suricata collection or parsing must start from an existing AegisOps-owned case, evidence record, or reviewed follow-up decision rather than from free-form network hunting or substrate-first alerting.'
+  'The approved artifact classes for this boundary are:'
+  '- `collection_manifest` for the reviewed description of which bounded Suricata source, observer, time window, and case or evidence anchor were requested;'
+  '- `alert_sample` for the explicitly scoped Suricata alert or event material collected under the reviewed anchor;'
+  '- `flow_excerpt` for the bounded flow, transaction, or protocol excerpt tied to the reviewed anchor rather than a broad sensor dump;'
+  '- `shadow_correlation_note` for subordinate correlation context that may inform Phase 29 shadow-only comparison work without becoming workflow truth; and'
+  '- `tool_output_receipt` for the subordinate receipt that records which reviewed Suricata source, parser, or import step produced which artifact and when.'
+  'Every Suricata-derived artifact must preserve provenance that identifies the reviewed observer or sensor binding, source family, source event or flow identifier when available, bounded time window, reviewed operator or reviewed automation attribution, and the AegisOps evidence record that admitted it.'
+  'Suricata-derived artifacts and shadow correlation notes must be cited as subordinate evidence linked to an AegisOps-owned evidence record.'
+  'Suricata-derived output must not replace AegisOps-owned alert truth, case truth, evidence truth, approval truth, execution truth, or reconciliation truth.'
+  'This boundary does not approve network-first mainline detection, broad IDS-led workflow redesign, mandatory Suricata deployment, or substrate authority expansion.'
+)
+
+for line in "${design_required_lines[@]}"; do
+  require_fixed_line "${design_doc}" "${line}"
+done
+
+validation_required_lines=(
+  '# Phase 29 Optional Suricata Evidence-Pack Boundary Validation'
+  '- Validation status: PASS'
+  '- Reviewed on: 2026-04-20'
+  '## Validation Summary'
+  '## Thesis and Authority Review'
+  '## Suricata Boundary Review'
+  '## Phase 29 Shadow-Mode Review'
+  '## Review Outcome'
+  '## Verification'
+  'The reviewed Suricata boundary remains optional, disabled by default, provenance-preserving, and fail closed when reviewed linkage or scope is incomplete.'
+  'Suricata integration is optional, disabled by default, and subordinate to the AegisOps-owned control-plane record chain.'
+  'Any Suricata-derived feature, note, or correlation signal must preserve explicit provenance and remain advisory-only.'
+  'Suricata-derived output cannot become an authoritative label source and cannot silently promote network telemetry into mainline workflow truth.'
+  'No reviewed language in this slice promotes network-first product positioning or broad IDS-led workflow redesign.'
+  '- `python3 -m unittest control-plane.tests.test_phase29_suricata_evidence_pack_boundary_validation`'
+  '- `bash scripts/verify-phase-29-suricata-evidence-pack-boundary.sh`'
+)
+
+for line in "${validation_required_lines[@]}"; do
+  require_fixed_line "${validation_doc}" "${line}"
+done
+
+require_fixed_line "${docs_test}" 'class Phase29SuricataEvidencePackBoundaryValidationTests(unittest.TestCase):'
+require_fixed_line "${docs_test}" '    def test_phase29_suricata_design_doc_exists_and_keeps_suricata_subordinate('
+require_fixed_line "${docs_test}" '    def test_phase29_suricata_validation_doc_records_boundary_and_shadow_mode_review('
+
+echo "Phase 29 Suricata evidence-pack boundary documents are present and aligned."


### PR DESCRIPTION
Closes #622
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the narrowest reproducible fix for #622 and committed it as `f8598bf` on `codex/issue-622`.

The change is documentation-and-verification only, following the existing Phase 28 boundary pattern. It adds a reviewed optional Suricata evidence-pack boundary doc, a validation note, the requested focused unittest module, and a repo-local verifier script. The boundary explicitly keeps Suricata optional, disabled by default, subordinate, provenance-preserving, and outside the authoritative alert/case/approval/execution/reconciliation path.

Verification passed:
- `python3 -m unittest control-plane.tests.test_phase29_suricata_evidence_pack_boundary_validation`
- `bash scripts/verify-phase-29-suricata-evidence-pack-boundary.sh`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 622 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`

Summary: Added and verified the Phase 29 optional Suricata evidence-pack boundary as a subordinate, disableable, non-authoritative slice; committed in `f8598bf`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase29_suricata_evidence_pack_boundary_validation`; `bash scripts/verify-phase-29-suricata-evidence-pack-boundary.sh`; `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 622 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`
Failure signature: none
Next action: Open or upda...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Phase 29 Suricata evidence-pack boundary docs: design, validation record, fail-closed rules, allowed artifact classes, provenance/citation requirements, and verification guidance.

* **Tests**
  * Added a validation test and a verification script that confirm the Phase 29 Suricata boundary docs are present and contain the required statements and sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->