### PR TITLE
refactor: decompose the next authority-bearing service.py hotspot cluster (#633)

### DIFF
--- a/control-plane/aegisops_control_plane/case_workflow.py
+++ b/control-plane/aegisops_control_plane/case_workflow.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Mapping
+
+from .models import (
+    AlertRecord,
+    CaseRecord,
+    LeadRecord,
+    ObservationRecord,
+    RecommendationRecord,
+)
+
+if TYPE_CHECKING:
+    from .service import AegisOpsControlPlaneService
+
+
+class CaseWorkflowService:
+    def __init__(
+        self,
+        service: AegisOpsControlPlaneService,
+        *,
+        merge_reviewed_context: Callable[
+            [Mapping[str, object], Mapping[str, object]],
+            dict[str, object],
+        ],
+    ) -> None:
+        self._service = service
+        self._merge_reviewed_context = merge_reviewed_context
+
+    def record_case_observation(
+        self,
+        *,
+        case_id: str,
+        author_identity: str,
+        observed_at: datetime,
+        scope_statement: str,
+        supporting_evidence_ids: tuple[str, ...] = (),
+        observation_id: str | None = None,
+        lifecycle_state: str = "confirmed",
+    ) -> ObservationRecord:
+        service = self._service
+        service._require_case_record(case_id)
+        author_identity = service._require_non_empty_string(
+            author_identity,
+            "author_identity",
+        )
+        observed_at = service._require_aware_datetime(observed_at, "observed_at")
+        scope_statement = service._require_non_empty_string(
+            scope_statement,
+            "scope_statement",
+        )
+        lifecycle_state = service._require_non_empty_string(
+            lifecycle_state,
+            "lifecycle_state",
+        )
+        normalized_evidence_ids = service._normalize_linked_record_ids(
+            supporting_evidence_ids,
+            "supporting_evidence_ids",
+        )
+        with service._store.transaction():
+            case = service._require_reviewed_operator_case(case_id)
+            service._validate_case_evidence_linkage(
+                case=case,
+                evidence_ids=normalized_evidence_ids,
+                field_name="supporting_evidence_ids",
+            )
+            resolved_observation_id = service._resolve_new_record_identifier(
+                ObservationRecord,
+                observation_id,
+                "observation_id",
+                "observation",
+            )
+            return service.persist_record(
+                ObservationRecord(
+                    observation_id=resolved_observation_id,
+                    hunt_id=None,
+                    hunt_run_id=None,
+                    alert_id=case.alert_id,
+                    case_id=case.case_id,
+                    supporting_evidence_ids=normalized_evidence_ids,
+                    author_identity=author_identity,
+                    observed_at=observed_at,
+                    scope_statement=scope_statement,
+                    lifecycle_state=lifecycle_state,
+                )
+            )
+
+    def record_case_lead(
+        self,
+        *,
+        case_id: str,
+        triage_owner: str,
+        triage_rationale: str,
+        observation_id: str | None = None,
+        lead_id: str | None = None,
+        lifecycle_state: str = "triaged",
+    ) -> LeadRecord:
+        service = self._service
+        triage_owner = service._require_non_empty_string(triage_owner, "triage_owner")
+        triage_rationale = service._require_non_empty_string(
+            triage_rationale,
+            "triage_rationale",
+        )
+        lifecycle_state = service._require_non_empty_string(
+            lifecycle_state,
+            "lifecycle_state",
+        )
+        resolved_observation_id = service._normalize_optional_string(
+            observation_id,
+            "observation_id",
+        )
+        with service._store.transaction():
+            case = service._require_reviewed_operator_case(case_id)
+            if resolved_observation_id is not None:
+                observation = service._store.get(
+                    ObservationRecord,
+                    resolved_observation_id,
+                )
+                if observation is None:
+                    raise LookupError(f"Missing observation {resolved_observation_id!r}")
+                if observation.case_id != case.case_id:
+                    raise ValueError(
+                        f"Observation {resolved_observation_id!r} is not linked to case "
+                        f"{case.case_id!r}"
+                    )
+
+            resolved_lead_id = service._resolve_new_record_identifier(
+                LeadRecord,
+                lead_id,
+                "lead_id",
+                "lead",
+            )
+            return service.persist_record(
+                LeadRecord(
+                    lead_id=resolved_lead_id,
+                    observation_id=resolved_observation_id,
+                    finding_id=case.finding_id,
+                    hunt_run_id=None,
+                    alert_id=case.alert_id,
+                    case_id=case.case_id,
+                    triage_owner=triage_owner,
+                    triage_rationale=triage_rationale,
+                    lifecycle_state=lifecycle_state,
+                )
+            )
+
+    def record_case_recommendation(
+        self,
+        *,
+        case_id: str,
+        review_owner: str,
+        intended_outcome: str,
+        lead_id: str | None = None,
+        recommendation_id: str | None = None,
+        lifecycle_state: str = "under_review",
+    ) -> RecommendationRecord:
+        service = self._service
+        review_owner = service._require_non_empty_string(review_owner, "review_owner")
+        intended_outcome = service._require_non_empty_string(
+            intended_outcome,
+            "intended_outcome",
+        )
+        lifecycle_state = service._require_non_empty_string(
+            lifecycle_state,
+            "lifecycle_state",
+        )
+        resolved_lead_id = service._normalize_optional_string(lead_id, "lead_id")
+        with service._store.transaction():
+            case = service._require_reviewed_operator_case(case_id)
+            if resolved_lead_id is not None:
+                lead = service._store.get(LeadRecord, resolved_lead_id)
+                if lead is None:
+                    raise LookupError(f"Missing lead {resolved_lead_id!r}")
+                if lead.case_id != case.case_id:
+                    raise ValueError(
+                        f"Lead {resolved_lead_id!r} is not linked to case {case.case_id!r}"
+                    )
+
+            resolved_recommendation_id = service._resolve_new_record_identifier(
+                RecommendationRecord,
+                recommendation_id,
+                "recommendation_id",
+                "recommendation",
+            )
+            return service.persist_record(
+                RecommendationRecord(
+                    recommendation_id=resolved_recommendation_id,
+                    lead_id=resolved_lead_id,
+                    hunt_run_id=None,
+                    alert_id=case.alert_id,
+                    case_id=case.case_id,
+                    ai_trace_id=None,
+                    review_owner=review_owner,
+                    intended_outcome=intended_outcome,
+                    lifecycle_state=lifecycle_state,
+                    reviewed_context=case.reviewed_context,
+                )
+            )
+
+    def record_case_handoff(
+        self,
+        *,
+        case_id: str,
+        handoff_at: datetime,
+        handoff_owner: str,
+        handoff_note: str,
+        follow_up_evidence_ids: tuple[str, ...] = (),
+    ) -> CaseRecord:
+        service = self._service
+        service._require_case_record(case_id)
+        handoff_at = service._require_aware_datetime(handoff_at, "handoff_at")
+        handoff_owner = service._require_non_empty_string(
+            handoff_owner,
+            "handoff_owner",
+        )
+        handoff_note = service._require_non_empty_string(handoff_note, "handoff_note")
+        normalized_evidence_ids = service._normalize_linked_record_ids(
+            follow_up_evidence_ids,
+            "follow_up_evidence_ids",
+        )
+        with service._store.transaction():
+            case = service._require_reviewed_operator_case(case_id)
+            service._validate_case_evidence_linkage(
+                case=case,
+                evidence_ids=normalized_evidence_ids,
+                field_name="follow_up_evidence_ids",
+            )
+            updated_reviewed_context = self._merge_reviewed_context(
+                case.reviewed_context,
+                {
+                    "handoff": {
+                        "handoff_at": handoff_at.isoformat(),
+                        "handoff_owner": handoff_owner,
+                        "note": handoff_note,
+                        "follow_up_evidence_ids": normalized_evidence_ids,
+                    }
+                },
+            )
+            return service.persist_record(
+                replace(
+                    case,
+                    reviewed_context=updated_reviewed_context,
+                )
+            )
+
+    def record_case_disposition(
+        self,
+        *,
+        case_id: str,
+        disposition: str,
+        rationale: str,
+        recorded_at: datetime,
+    ) -> CaseRecord:
+        service = self._service
+        disposition = service._require_non_empty_string(disposition, "disposition")
+        rationale = service._require_non_empty_string(rationale, "rationale")
+        recorded_at = service._require_aware_datetime(recorded_at, "recorded_at")
+        lifecycle_state = service._case_lifecycle_for_disposition(disposition)
+        with service._store.transaction():
+            case = service._require_reviewed_operator_case(case_id)
+            updated_reviewed_context = self._merge_reviewed_context(
+                case.reviewed_context,
+                {
+                    "triage": {
+                        "disposition": disposition,
+                        "closure_rationale": rationale,
+                        "recorded_at": recorded_at.isoformat(),
+                    }
+                },
+            )
+            updated_case = service.persist_record(
+                replace(
+                    case,
+                    lifecycle_state=lifecycle_state,
+                    reviewed_context=updated_reviewed_context,
+                ),
+                transitioned_at=recorded_at,
+            )
+            if case.alert_id is not None and lifecycle_state == "closed":
+                alert = service._store.get(AlertRecord, case.alert_id)
+                if alert is not None:
+                    service.persist_record(
+                        replace(
+                            alert,
+                            lifecycle_state="closed",
+                            reviewed_context=self._merge_reviewed_context(
+                                alert.reviewed_context,
+                                {"triage": updated_reviewed_context.get("triage", {})},
+                            ),
+                        ),
+                        transitioned_at=recorded_at,
+                    )
+        return updated_case

--- a/control-plane/aegisops_control_plane/case_workflow.py
+++ b/control-plane/aegisops_control_plane/case_workflow.py
@@ -260,6 +260,11 @@ class CaseWorkflowService:
         lifecycle_state = service._case_lifecycle_for_disposition(disposition)
         with service._store.transaction():
             case = service._require_reviewed_operator_case(case_id)
+            alert = None
+            if case.alert_id is not None and lifecycle_state == "closed":
+                alert = service._store.get(AlertRecord, case.alert_id)
+                if alert is None:
+                    raise LookupError(f"Missing alert {case.alert_id!r}")
             updated_reviewed_context = self._merge_reviewed_context(
                 case.reviewed_context,
                 {
@@ -278,18 +283,16 @@ class CaseWorkflowService:
                 ),
                 transitioned_at=recorded_at,
             )
-            if case.alert_id is not None and lifecycle_state == "closed":
-                alert = service._store.get(AlertRecord, case.alert_id)
-                if alert is not None:
-                    service.persist_record(
-                        replace(
-                            alert,
-                            lifecycle_state="closed",
-                            reviewed_context=self._merge_reviewed_context(
-                                alert.reviewed_context,
-                                {"triage": updated_reviewed_context.get("triage", {})},
-                            ),
+            if alert is not None:
+                service.persist_record(
+                    replace(
+                        alert,
+                        lifecycle_state="closed",
+                        reviewed_context=self._merge_reviewed_context(
+                            alert.reviewed_context,
+                            {"triage": updated_reviewed_context.get("triage", {})},
                         ),
-                        transitioned_at=recorded_at,
-                    )
+                    ),
+                    transitioned_at=recorded_at,
+                )
         return updated_case

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -34,6 +34,7 @@ from .assistant_provider import (
     AssistantProviderResult,
     AssistantProviderTransport,
 )
+from .case_workflow import CaseWorkflowService
 from .config import OpenBaoKVv2SecretTransport, RuntimeConfig
 from .execution_coordinator import (
     ExecutionCoordinator,
@@ -1361,6 +1362,10 @@ class AegisOpsControlPlaneService:
             coordination_reference_payload=_coordination_reference_payload,
             coordination_reference_signature=_coordination_reference_signature,
             dedupe_strings=_dedupe_strings,
+        )
+        self._case_workflow_service = CaseWorkflowService(
+            self,
+            merge_reviewed_context=_merge_reviewed_context,
         )
         self._detection_lifecycle_service = DetectionLifecycleService(
             self,
@@ -4141,51 +4146,15 @@ class AegisOpsControlPlaneService:
         observation_id: str | None = None,
         lifecycle_state: str = "confirmed",
     ) -> ObservationRecord:
-        case = self._require_case_record(case_id)
-        author_identity = self._require_non_empty_string(
-            author_identity,
-            "author_identity",
+        return self._case_workflow_service.record_case_observation(
+            case_id=case_id,
+            author_identity=author_identity,
+            observed_at=observed_at,
+            scope_statement=scope_statement,
+            supporting_evidence_ids=supporting_evidence_ids,
+            observation_id=observation_id,
+            lifecycle_state=lifecycle_state,
         )
-        observed_at = self._require_aware_datetime(observed_at, "observed_at")
-        scope_statement = self._require_non_empty_string(
-            scope_statement,
-            "scope_statement",
-        )
-        lifecycle_state = self._require_non_empty_string(
-            lifecycle_state,
-            "lifecycle_state",
-        )
-        normalized_evidence_ids = self._normalize_linked_record_ids(
-            supporting_evidence_ids,
-            "supporting_evidence_ids",
-        )
-        with self._store.transaction():
-            case = self._require_reviewed_operator_case(case_id)
-            self._validate_case_evidence_linkage(
-                case=case,
-                evidence_ids=normalized_evidence_ids,
-                field_name="supporting_evidence_ids",
-            )
-            resolved_observation_id = self._resolve_new_record_identifier(
-                ObservationRecord,
-                observation_id,
-                "observation_id",
-                "observation",
-            )
-            return self.persist_record(
-                ObservationRecord(
-                    observation_id=resolved_observation_id,
-                    hunt_id=None,
-                    hunt_run_id=None,
-                    alert_id=case.alert_id,
-                    case_id=case.case_id,
-                    supporting_evidence_ids=normalized_evidence_ids,
-                    author_identity=author_identity,
-                    observed_at=observed_at,
-                    scope_statement=scope_statement,
-                    lifecycle_state=lifecycle_state,
-                )
-            )
 
     def record_case_lead(
         self,
@@ -4197,50 +4166,14 @@ class AegisOpsControlPlaneService:
         lead_id: str | None = None,
         lifecycle_state: str = "triaged",
     ) -> LeadRecord:
-        triage_owner = self._require_non_empty_string(triage_owner, "triage_owner")
-        triage_rationale = self._require_non_empty_string(
-            triage_rationale,
-            "triage_rationale",
+        return self._case_workflow_service.record_case_lead(
+            case_id=case_id,
+            triage_owner=triage_owner,
+            triage_rationale=triage_rationale,
+            observation_id=observation_id,
+            lead_id=lead_id,
+            lifecycle_state=lifecycle_state,
         )
-        lifecycle_state = self._require_non_empty_string(
-            lifecycle_state,
-            "lifecycle_state",
-        )
-        resolved_observation_id = self._normalize_optional_string(
-            observation_id,
-            "observation_id",
-        )
-        with self._store.transaction():
-            case = self._require_reviewed_operator_case(case_id)
-            if resolved_observation_id is not None:
-                observation = self._store.get(ObservationRecord, resolved_observation_id)
-                if observation is None:
-                    raise LookupError(f"Missing observation {resolved_observation_id!r}")
-                if observation.case_id != case.case_id:
-                    raise ValueError(
-                        f"Observation {resolved_observation_id!r} is not linked to case "
-                        f"{case.case_id!r}"
-                    )
-
-            resolved_lead_id = self._resolve_new_record_identifier(
-                LeadRecord,
-                lead_id,
-                "lead_id",
-                "lead",
-            )
-            return self.persist_record(
-                LeadRecord(
-                    lead_id=resolved_lead_id,
-                    observation_id=resolved_observation_id,
-                    finding_id=case.finding_id,
-                    hunt_run_id=None,
-                    alert_id=case.alert_id,
-                    case_id=case.case_id,
-                    triage_owner=triage_owner,
-                    triage_rationale=triage_rationale,
-                    lifecycle_state=lifecycle_state,
-                )
-            )
 
     def record_case_recommendation(
         self,
@@ -4252,47 +4185,14 @@ class AegisOpsControlPlaneService:
         recommendation_id: str | None = None,
         lifecycle_state: str = "under_review",
     ) -> RecommendationRecord:
-        review_owner = self._require_non_empty_string(review_owner, "review_owner")
-        intended_outcome = self._require_non_empty_string(
-            intended_outcome,
-            "intended_outcome",
+        return self._case_workflow_service.record_case_recommendation(
+            case_id=case_id,
+            review_owner=review_owner,
+            intended_outcome=intended_outcome,
+            lead_id=lead_id,
+            recommendation_id=recommendation_id,
+            lifecycle_state=lifecycle_state,
         )
-        lifecycle_state = self._require_non_empty_string(
-            lifecycle_state,
-            "lifecycle_state",
-        )
-        resolved_lead_id = self._normalize_optional_string(lead_id, "lead_id")
-        with self._store.transaction():
-            case = self._require_reviewed_operator_case(case_id)
-            if resolved_lead_id is not None:
-                lead = self._store.get(LeadRecord, resolved_lead_id)
-                if lead is None:
-                    raise LookupError(f"Missing lead {resolved_lead_id!r}")
-                if lead.case_id != case.case_id:
-                    raise ValueError(
-                        f"Lead {resolved_lead_id!r} is not linked to case {case.case_id!r}"
-                    )
-
-            resolved_recommendation_id = self._resolve_new_record_identifier(
-                RecommendationRecord,
-                recommendation_id,
-                "recommendation_id",
-                "recommendation",
-            )
-            return self.persist_record(
-                RecommendationRecord(
-                    recommendation_id=resolved_recommendation_id,
-                    lead_id=resolved_lead_id,
-                    hunt_run_id=None,
-                    alert_id=case.alert_id,
-                    case_id=case.case_id,
-                    ai_trace_id=None,
-                    review_owner=review_owner,
-                    intended_outcome=intended_outcome,
-                    lifecycle_state=lifecycle_state,
-                    reviewed_context=case.reviewed_context,
-                )
-            )
 
     def record_case_handoff(
         self,
@@ -4303,41 +4203,13 @@ class AegisOpsControlPlaneService:
         handoff_note: str,
         follow_up_evidence_ids: tuple[str, ...] = (),
     ) -> CaseRecord:
-        case = self._require_case_record(case_id)
-        handoff_at = self._require_aware_datetime(handoff_at, "handoff_at")
-        handoff_owner = self._require_non_empty_string(
-            handoff_owner,
-            "handoff_owner",
+        return self._case_workflow_service.record_case_handoff(
+            case_id=case_id,
+            handoff_at=handoff_at,
+            handoff_owner=handoff_owner,
+            handoff_note=handoff_note,
+            follow_up_evidence_ids=follow_up_evidence_ids,
         )
-        handoff_note = self._require_non_empty_string(handoff_note, "handoff_note")
-        normalized_evidence_ids = self._normalize_linked_record_ids(
-            follow_up_evidence_ids,
-            "follow_up_evidence_ids",
-        )
-        with self._store.transaction():
-            case = self._require_reviewed_operator_case(case_id)
-            self._validate_case_evidence_linkage(
-                case=case,
-                evidence_ids=normalized_evidence_ids,
-                field_name="follow_up_evidence_ids",
-            )
-            updated_reviewed_context = _merge_reviewed_context(
-                case.reviewed_context,
-                {
-                    "handoff": {
-                        "handoff_at": handoff_at.isoformat(),
-                        "handoff_owner": handoff_owner,
-                        "note": handoff_note,
-                        "follow_up_evidence_ids": normalized_evidence_ids,
-                    }
-                },
-            )
-            return self.persist_record(
-                replace(
-                    case,
-                    reviewed_context=updated_reviewed_context,
-                )
-            )
 
     def record_case_disposition(
         self,
@@ -4347,45 +4219,12 @@ class AegisOpsControlPlaneService:
         rationale: str,
         recorded_at: datetime,
     ) -> CaseRecord:
-        disposition = self._require_non_empty_string(disposition, "disposition")
-        rationale = self._require_non_empty_string(rationale, "rationale")
-        recorded_at = self._require_aware_datetime(recorded_at, "recorded_at")
-        lifecycle_state = self._case_lifecycle_for_disposition(disposition)
-        with self._store.transaction():
-            case = self._require_reviewed_operator_case(case_id)
-            updated_reviewed_context = _merge_reviewed_context(
-                case.reviewed_context,
-                {
-                    "triage": {
-                        "disposition": disposition,
-                        "closure_rationale": rationale,
-                        "recorded_at": recorded_at.isoformat(),
-                    }
-                },
-            )
-            updated_case = self.persist_record(
-                replace(
-                    case,
-                    lifecycle_state=lifecycle_state,
-                    reviewed_context=updated_reviewed_context,
-                ),
-                transitioned_at=recorded_at,
-            )
-            if case.alert_id is not None and lifecycle_state == "closed":
-                alert = self._store.get(AlertRecord, case.alert_id)
-                if alert is not None:
-                    self.persist_record(
-                        replace(
-                            alert,
-                            lifecycle_state="closed",
-                            reviewed_context=_merge_reviewed_context(
-                                alert.reviewed_context,
-                                {"triage": updated_reviewed_context.get("triage", {})},
-                            ),
-                        ),
-                        transitioned_at=recorded_at,
-                    )
-        return updated_case
+        return self._case_workflow_service.record_case_disposition(
+            case_id=case_id,
+            disposition=disposition,
+            rationale=rationale,
+            recorded_at=recorded_at,
+        )
 
     def record_action_review_manual_fallback(
         self,

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -2726,6 +2726,56 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             "pending_approval",
         )
 
+    def test_service_fails_closed_when_linked_alert_disappears_after_slice_validation(
+        self,
+    ) -> None:
+        store, service, promoted_case, _, reviewed_at = self._build_phase19_in_scope_case()
+        prior_case = service.get_record(CaseRecord, promoted_case.case_id)
+        prior_alert = service.get_record(AlertRecord, promoted_case.alert_id)
+        prior_transitions = store.list_lifecycle_transitions("case", promoted_case.case_id)
+        original_get = service._store.get
+        alert_reads = 0
+
+        def flaky_get(record_type: object, record_id: str) -> object | None:
+            nonlocal alert_reads
+            record = original_get(record_type, record_id)
+            if record_type is AlertRecord and record_id == promoted_case.alert_id:
+                alert_reads += 1
+                if alert_reads >= 2:
+                    return None
+            return record
+
+        service._store.get = support.mock.Mock(side_effect=flaky_get)
+        try:
+            with self.assertRaises(LookupError) as exc_info:
+                service.record_case_disposition(
+                    case_id=promoted_case.case_id,
+                    disposition="closed_resolved",
+                    rationale=(
+                        "Closing a case after the linked alert disappears must fail closed."
+                    ),
+                    recorded_at=reviewed_at,
+                )
+        finally:
+            service._store.get = original_get
+
+        self.assertEqual(
+            str(exc_info.exception),
+            f"Missing alert {promoted_case.alert_id!r}",
+        )
+        self.assertEqual(
+            service.get_record(CaseRecord, promoted_case.case_id),
+            prior_case,
+        )
+        self.assertEqual(
+            store.list_lifecycle_transitions("case", promoted_case.case_id),
+            prior_transitions,
+        )
+        self.assertEqual(
+            service.get_record(AlertRecord, promoted_case.alert_id),
+            prior_alert,
+        )
+
     def test_service_analyst_queue_prefers_explicit_wazuh_source_for_multi_source_linkage(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -19,6 +19,121 @@ for name, value in vars(support).items():
 
 
 class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
+    def test_service_delegates_case_workflow_mutations(self) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        observed_at = support.datetime(2026, 4, 5, 12, 0, tzinfo=support.timezone.utc)
+        delegate = support.mock.Mock()
+        observation = support.SimpleNamespace(observation_id="observation-delegated-001")
+        lead = support.SimpleNamespace(lead_id="lead-delegated-001")
+        recommendation = support.SimpleNamespace(
+            recommendation_id="recommendation-delegated-001"
+        )
+        handed_off_case = support.SimpleNamespace(case_id="case-delegated-001")
+        disposed_case = support.SimpleNamespace(case_id="case-delegated-001")
+        delegate.record_case_observation.return_value = observation
+        delegate.record_case_lead.return_value = lead
+        delegate.record_case_recommendation.return_value = recommendation
+        delegate.record_case_handoff.return_value = handed_off_case
+        delegate.record_case_disposition.return_value = disposed_case
+        service._case_workflow_service = delegate
+
+        self.assertIs(
+            service.record_case_observation(
+                case_id="case-delegated-001",
+                author_identity="analyst-001",
+                observed_at=observed_at,
+                scope_statement="Delegated case observation.",
+                supporting_evidence_ids=("evidence-delegated-001",),
+                observation_id="observation-delegated-001",
+                lifecycle_state="confirmed",
+            ),
+            observation,
+        )
+        self.assertIs(
+            service.record_case_lead(
+                case_id="case-delegated-001",
+                triage_owner="analyst-001",
+                triage_rationale="Delegated case lead.",
+                observation_id="observation-delegated-001",
+                lead_id="lead-delegated-001",
+                lifecycle_state="triaged",
+            ),
+            lead,
+        )
+        self.assertIs(
+            service.record_case_recommendation(
+                case_id="case-delegated-001",
+                review_owner="analyst-001",
+                intended_outcome="Delegated case recommendation.",
+                lead_id="lead-delegated-001",
+                recommendation_id="recommendation-delegated-001",
+                lifecycle_state="under_review",
+            ),
+            recommendation,
+        )
+        self.assertIs(
+            service.record_case_handoff(
+                case_id="case-delegated-001",
+                handoff_at=observed_at,
+                handoff_owner="analyst-001",
+                handoff_note="Delegated handoff.",
+                follow_up_evidence_ids=("evidence-delegated-001",),
+            ),
+            handed_off_case,
+        )
+        self.assertIs(
+            service.record_case_disposition(
+                case_id="case-delegated-001",
+                disposition="business_hours_handoff",
+                rationale="Delegated disposition.",
+                recorded_at=observed_at,
+            ),
+            disposed_case,
+        )
+
+        delegate.record_case_observation.assert_called_once_with(
+            case_id="case-delegated-001",
+            author_identity="analyst-001",
+            observed_at=observed_at,
+            scope_statement="Delegated case observation.",
+            supporting_evidence_ids=("evidence-delegated-001",),
+            observation_id="observation-delegated-001",
+            lifecycle_state="confirmed",
+        )
+        delegate.record_case_lead.assert_called_once_with(
+            case_id="case-delegated-001",
+            triage_owner="analyst-001",
+            triage_rationale="Delegated case lead.",
+            observation_id="observation-delegated-001",
+            lead_id="lead-delegated-001",
+            lifecycle_state="triaged",
+        )
+        delegate.record_case_recommendation.assert_called_once_with(
+            case_id="case-delegated-001",
+            review_owner="analyst-001",
+            intended_outcome="Delegated case recommendation.",
+            lead_id="lead-delegated-001",
+            recommendation_id="recommendation-delegated-001",
+            lifecycle_state="under_review",
+        )
+        delegate.record_case_handoff.assert_called_once_with(
+            case_id="case-delegated-001",
+            handoff_at=observed_at,
+            handoff_owner="analyst-001",
+            handoff_note="Delegated handoff.",
+            follow_up_evidence_ids=("evidence-delegated-001",),
+        )
+        delegate.record_case_disposition.assert_called_once_with(
+            case_id="case-delegated-001",
+            disposition="business_hours_handoff",
+            rationale="Delegated disposition.",
+            recorded_at=observed_at,
+        )
+
     def test_service_delegates_detection_lifecycle_operations(self) -> None:
         store, _ = support.make_store()
         service = support.AegisOpsControlPlaneService(

--- a/docs/control-plane-service-internal-boundaries.md
+++ b/docs/control-plane-service-internal-boundaries.md
@@ -64,6 +64,11 @@ Representative methods include:
 
 This cluster assembles the approved operator reads and bounded casework mutations for the first daily workflow.
 
+Current extraction status as of issue `#633`:
+
+- approved analyst queue and detail reads already live behind `OperatorInspectionReadSurface`; and
+- bounded case mutation entrypoints now delegate from `AegisOpsControlPlaneService` into `CaseWorkflowService`.
+
 Representative methods include:
 
 - `inspect_analyst_queue`
@@ -157,6 +162,8 @@ The target collaborators are:
   Owns Wazuh/native-detection admission, analytic-signal materialization, alert/evidence/case linkage during intake, and source-admission normalization.
 - `AnalystWorkflowService`
   Owns analyst queue and detail read models plus bounded casework mutation paths for observations, leads, recommendations, handoff, disposition, and alert-to-case promotion.
+- `CaseWorkflowService`
+  Owns the bounded case mutation write path now extracted from `service.py`: observations, leads, recommendations, handoff, and disposition. This is the first extracted write-path slice inside the broader analyst workflow cluster and preserves the stable facade entrypoints on `AegisOpsControlPlaneService`.
 - `AssistantAdvisoryService`
   Owns assistant-context assembly, citation-grounded lineage gathering, advisory output shaping, recommendation draft rendering, and advisory draft attachment.
 - `ActionGovernanceService`
@@ -209,6 +216,10 @@ The facade should be responsible only for:
 - forwarding calls into the correct collaborator;
 - preserving transaction boundaries where a workflow spans multiple collaborators; and
 - preserving current exception text and fail-closed behavior unless a follow-up issue explicitly narrows that change.
+
+For the case mutation slice specifically, the current reviewed delegation path is:
+
+`AegisOpsControlPlaneService.record_case_* -> CaseWorkflowService`
 
 ## 6. Shared Helper Placement Rules
 


### PR DESCRIPTION
Closes #633
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the bounded case mutation hotspot out of `control-plane/aegisops_control_plane/service.py` into a new internal collaborator, `control-plane/aegisops_control_plane/case_workflow.py`. The public `AegisOpsControlPlaneService.record_case_observation`, `record_case_lead`, `record_case_recommendation`, `record_case_handoff`, and `record_case_disposition` entrypoints now delegate to that collaborator, while preserving the existing validation, transaction boundaries, and fail-closed behavior.

I added a narrow delegation regression test in [test_service_persistence_ingest_case_lifecycle.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-633/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py) that initially failed because the service still executed the case write path inline. I also updated [control-plane-service-internal-boundaries.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-633/docs/control-plane-service-internal-boundaries.md) to record the extracted boundary. The checkpoint commit is `9cbfb71` with message `refactor: extract case workflow service`.

Summary: Extracted the `record_case_*` write-path cluster into `CaseWorkflowService`, added a delegation regression test, updated the boundary map, and committed the checkpoint as `9cbfb71`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence_ingest_case_lifecycle.IngestCaseLifecyclePersistenceTests.test_service_delegates_case_workflow...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized case mutation logic into a dedicated workflow component while keeping existing public APIs unchanged.

* **Tests**
  * Added tests to verify delegated case workflow operations and failure handling during disposition when linked data is missing.

* **Documentation**
  * Updated internal architecture docs to reflect the new workflow component and delegation patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->