### PR TITLE
docs/design: add a repo-owned Non-Goals or Expansion Guardrails registry (#634)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Current scope:
 - Parameter catalog structure
 - Implementation guardrails for AI-assisted development
 
+Canonical cross-phase boundary reference:
+
+- `docs/non-goals-and-expansion-guardrails.md`
+
 The repository is no longer design-only: Phase 16 defines the approved first-boot runtime target for Phase 17 bring-up.
 That first-boot target is limited to the AegisOps control-plane service, PostgreSQL for control-plane state, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.
 OpenSearch, n8n, the full analyst-assistant surface, and the high-risk executor path remain optional, deferred, or non-blocking for first boot.
@@ -62,6 +66,8 @@ AegisOps is **not**:
 - a broad autonomous response platform
 - a broad source-coverage platform trying to rebuild Wazuh-class breadth
 - an AI-first SOC that lets an assistant become approval or execution authority
+
+For the cross-phase registry of expansion boundaries that future work should cite directly, see `docs/non-goals-and-expansion-guardrails.md`.
 
 ---
 

--- a/control-plane/tests/test_non_goals_expansion_guardrails_docs.py
+++ b/control-plane/tests/test_non_goals_expansion_guardrails_docs.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class NonGoalsExpansionGuardrailsDocsTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected document at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_canonical_guardrails_registry_exists_and_consolidates_cross_phase_boundaries(
+        self,
+    ) -> None:
+        text = self._read("docs/non-goals-and-expansion-guardrails.md")
+
+        for term in (
+            "# AegisOps Non-Goals and Expansion Guardrails",
+            "canonical cross-phase reference",
+            "AegisOps must not become a self-built replacement for all SIEM features or all SOAR features.",
+            "Assistant and ML paths remain advisory-only and non-authoritative.",
+            "Optional or transitional substrates remain subordinate to the AegisOps control-plane authority model.",
+            "Subordinate evidence packs remain optional augmentation, not a new product core or authority surface.",
+            "External coordination or ticketing systems remain non-authoritative coordination targets.",
+            "Fail-closed handling remains mandatory when reviewed provenance, scope, auth context, or boundary signals are missing, malformed, or only partially trusted.",
+            "Future roadmap work, PRs, ADRs, and validation notes should cite this registry when checking whether a proposed expansion widens AegisOps beyond the approved control-plane thesis.",
+        ):
+            self.assertIn(term, text)
+
+    def test_main_entrypoints_link_to_canonical_guardrails_registry(self) -> None:
+        expected_link = "docs/non-goals-and-expansion-guardrails.md"
+
+        for relative_path in (
+            "README.md",
+            "docs/architecture.md",
+            "docs/requirements-baseline.md",
+        ):
+            with self.subTest(path=relative_path):
+                self.assertIn(expected_link, self._read(relative_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,8 @@ It defines:
 - the separation between governance, automation, and execution, and
 - the baseline assumptions that future issues must preserve unless an ADR approves a change.
 
+For the canonical cross-phase anti-expansion registry that future architecture changes must also preserve, see `docs/non-goals-and-expansion-guardrails.md`.
+
 ## 2. Architecture Overview
 
 AegisOps is a governed SecOps control plane above external detection and automation substrates.

--- a/docs/non-goals-and-expansion-guardrails.md
+++ b/docs/non-goals-and-expansion-guardrails.md
@@ -1,0 +1,87 @@
+# AegisOps Non-Goals and Expansion Guardrails
+
+This document is the canonical cross-phase reference for the expansions AegisOps must continue to reject even as optional extensions, assistant paths, ML shadow mode, evidence-pack families, and coordination integrations grow around the reviewed control-plane core.
+
+Use this registry when evaluating roadmap proposals, ADRs, design docs, implementation issues, PRs, validation notes, and review comments that could widen AegisOps beyond the approved control-plane thesis.
+
+## 1. Purpose
+
+AegisOps is a governed SecOps control plane above external detection and automation substrates.
+
+This registry consolidates the already accepted cross-phase boundaries that answer the question: what must AegisOps continue not to become?
+
+Future roadmap work, PRs, ADRs, and validation notes should cite this registry when checking whether a proposed expansion widens AegisOps beyond the approved control-plane thesis.
+
+## 2. Product-Thesis Guardrails
+
+AegisOps must not become a self-built replacement for all SIEM features or all SOAR features.
+
+AegisOps must not become a broad autonomous response platform, a broad source-coverage platform, or a product thesis defined around any one analytics, ticketing, enrichment, or orchestration substrate.
+
+AegisOps must not become a 24x7 SOC product, a multi-tenant MSSP control plane, or a broad browser-first product expansion that outranks reviewed control-plane depth, bootability, and deployability priorities.
+
+The approved growth model remains narrow, reviewed, fail-closed expansion of the control-plane record chain and its bounded operator workflows one slice at a time.
+
+## 3. Authority Guardrails
+
+AegisOps remains authoritative for alert, case, evidence, recommendation, approval, action-intent, action-execution, and reconciliation truth.
+
+Detection substrates, automation substrates, optional enrichers, ticketing systems, and external evidence sources must remain subordinate to that authority boundary.
+
+No optional path may silently mint or overwrite approval truth, execution truth, case truth, or reconciliation truth.
+
+## 4. Assistant and ML Guardrails
+
+Assistant and ML paths remain advisory-only and non-authoritative.
+
+Assistant output must not become approval authority, delegation authority, execution authority, reconciliation authority, or case-truth authority.
+
+Reviewed ML shadow-mode output must remain outside the authoritative workflow path and must not silently promote itself into alerts, approvals, execution policy, or lifecycle-bearing control-plane state.
+
+If reviewed grounding, citations, labels, provenance, or scope constraints are missing, the assistant or ML path must remain unresolved, degraded, or blocked rather than silently widening authority.
+
+## 5. Optional-Substrate Guardrails
+
+Optional or transitional substrates remain subordinate to the AegisOps control-plane authority model.
+
+OpenSearch, Sigma, n8n, optional network evidence-pack paths, optional endpoint evidence-pack paths, and bounded external enrichment adapters may support reviewed analysis, enrichment, or delegated execution only within explicitly approved boundaries.
+
+Those optional or transitional paths must not redefine the product core, become mandatory mainline dependencies without review, or reframe AegisOps as a substrate-led platform.
+
+## 6. Evidence-Pack and Enrichment Guardrails
+
+Subordinate evidence packs remain optional augmentation, not a new product core or authority surface.
+
+Endpoint, network, or external-enrichment material may support reviewed notes, analyst explanation, or bounded recommendations only when it preserves explicit provenance and stays linked to the authoritative AegisOps-owned record chain.
+
+Subordinate evidence-pack and enrichment outputs must not replace AegisOps-owned alert truth, case truth, evidence truth, approval truth, execution truth, or reconciliation truth.
+
+## 7. Coordination and Ticketing Guardrails
+
+External coordination or ticketing systems remain non-authoritative coordination targets.
+
+Link-first ticket references, downstream ticket identifiers, assignee metadata, comments, queue movement, SLA state, workflow status, or closure flags may be stored as coordination context or receipts, but they must remain subordinate evidence rather than lifecycle authority.
+
+External coordination state must not be treated as approval proof, execution proof, case closure, or reconciliation completion on its own.
+
+## 8. Fail-Closed Expansion Guardrail
+
+Fail-closed handling remains mandatory when reviewed provenance, scope, auth context, or boundary signals are missing, malformed, or only partially trusted.
+
+Missing or obviously fake secrets, placeholder credentials, unsigned tokens, inferred tenant linkage, untrusted forwarded headers, partial evidence-pack provenance, missing authoritative bindings, or mixed-snapshot reads must stay blocked, rejected, degraded explicitly, or escalated for a real prerequisite rather than being treated as success.
+
+When expansion depends on a later authorization, provenance, or scope-validation step, the reviewed proof must anchor at that real enforcement boundary instead of treating an earlier setup step as sufficient evidence.
+
+## 9. Review Use
+
+Use this registry as the default anti-expansion citation target when a proposal touches:
+
+- assistant scope
+- ML lineage or shadow-mode surfaces
+- optional or transitional substrates
+- evidence-pack families
+- external enrichment
+- coordination or ticketing integrations
+- any path that could widen authority, source breadth, or automation breadth
+
+If a proposal conflicts with this registry, treat it as out of scope until an ADR explicitly changes the approved boundary.

--- a/docs/requirements-baseline.md
+++ b/docs/requirements-baseline.md
@@ -19,6 +19,8 @@ This document is intended to serve as both:
 - a human-readable engineering baseline, and
 - an execution contract for AI-assisted implementation workflows, including codex-supervisor.
 
+For the canonical cross-phase registry of non-goals and anti-expansion boundaries that future baseline changes must not silently bypass, see `docs/non-goals-and-expansion-guardrails.md`.
+
 ---
 
 ## 1. Purpose


### PR DESCRIPTION
Closes #634
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a repo-owned canonical guardrails registry at [docs/non-goals-and-expansion-guardrails.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-634/docs/non-goals-and-expansion-guardrails.md) and linked it from [README.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-634/README.md), [docs/architecture.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-634/docs/architecture.md), and [docs/requirements-baseline.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-634/docs/requirements-baseline.md). The new doc consolidates the cross-phase anti-expansion boundaries around authority, advisory-only assistant/ML paths, subordinate optional substrates and evidence packs, non-authoritative ticketing, and fail-closed behavior.

I added the focused regression test at [control-plane/tests/test_non_goals_expansion_guardrails_docs.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-634/control-plane/tests/test_non_goals_expansion_guardrails_docs.py), ran it once to reproduce the missing-doc/link failure, then reran it green after the doc updates. The branch now includes checkpoint commit `7a41cb4` (`docs: add non-goals expansion guardrails registry`).

Summary: Added the canonical Non-Goals / Expansion Guardrails registry, linked the main doc entrypoints to it, added a focused documentation unittest, and committed the coherent docs slice as `7a41cb4`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_non_goals_expansion_guardrails_docs` (failed bef...