### PR TITLE
docs/process: document maintainability decomposition thresholds and backlog triggers (#635)

### DIFF
--- a/control-plane/tests/test_maintainability_decomposition_thresholds_docs.py
+++ b/control-plane/tests/test_maintainability_decomposition_thresholds_docs.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class MaintainabilityDecompositionThresholdsDocsTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected document at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_thresholds_doc_exists_and_captures_repo_specific_backlog_triggers(self) -> None:
+        text = self._read("docs/maintainability-decomposition-thresholds.md")
+
+        for term in (
+            "# AegisOps Maintainability Decomposition Thresholds and Backlog Triggers",
+            "This document converts the recent `service.py` refactor experience into a lightweight rule for when AegisOps should open another maintainability backlog",
+            "`#592`",
+            "`#610`",
+            "`#633`",
+            "responsibility count",
+            "authority-path mixing",
+            "optional-extension mixing",
+            "regression-test coupling",
+            "operator-surface overlap",
+            "line count alone is not enough",
+            "open another maintainability refactor backlog",
+            "continue extending the hotspot in place",
+            "`control-plane/aegisops_control_plane/service.py`",
+            "`control-plane/aegisops_control_plane/restore_readiness.py`",
+            "A hotspot should move to backlog creation when",
+            "A hotspot can stay in place for the current issue only when",
+            "backlog trigger",
+            "decomposition threshold",
+        ):
+            self.assertIn(term, text)
+
+    def test_architecture_and_review_entrypoints_link_to_thresholds_doc(self) -> None:
+        expected_link = "docs/maintainability-decomposition-thresholds.md"
+
+        for relative_path in (
+            "docs/architecture.md",
+            "docs/templates/issue-template.md",
+            "docs/templates/pull-request-review-checklist.md",
+            "docs/control-plane-service-internal-boundaries.md",
+        ):
+            with self.subTest(path=relative_path):
+                self.assertIn(expected_link, self._read(relative_path))
+
+    def test_documentation_ownership_map_tracks_thresholds_doc(self) -> None:
+        text = self._read("docs/documentation-ownership-map.md")
+        self.assertIn(
+            "| `docs/maintainability-decomposition-thresholds.md` | Maintainability decomposition thresholds and backlog triggers | IT Operations, Information Systems Department |",
+            text,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,8 @@ It defines:
 
 For the canonical cross-phase anti-expansion registry that future architecture changes must also preserve, see `docs/non-goals-and-expansion-guardrails.md`.
 
+For the repo-owned maintainability rule that tells future planning and review when a hotspot should move into another decomposition backlog instead of absorbing more unrelated growth, see `docs/maintainability-decomposition-thresholds.md`.
+
 ## 2. Architecture Overview
 
 AegisOps is a governed SecOps control plane above external detection and automation substrates.

--- a/docs/control-plane-service-internal-boundaries.md
+++ b/docs/control-plane-service-internal-boundaries.md
@@ -4,6 +4,8 @@ This document defines the target internal decomposition for `control-plane/aegis
 
 It supplements `docs/control-plane-runtime-service-boundary.md`, `docs/phase-19-thin-operator-surface-and-daily-analyst-workflow.md`, `docs/phase-20-first-live-low-risk-action-and-reviewed-delegation-boundary.md`, and `docs/phase-21-production-like-hardening-boundary-and-sequence.md`.
 
+For the repo-wide rule that decides when a hotspot should move into another maintainability backlog instead of continuing to grow in place, see `docs/maintainability-decomposition-thresholds.md`.
+
 This note is intentionally limited to internal service boundaries and extraction sequencing. It does not approve a broader runtime surface, new external APIs, or behavior changes outside the already-reviewed Phase 19-21 slice.
 
 ## 1. Purpose

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -38,6 +38,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/automation-substrate-contract.md` | Approved automation delegation contract baseline | IT Operations, Information Systems Department |
 | `docs/control-plane-state-model.md` | Control-plane state and reconciliation baseline | IT Operations, Information Systems Department |
 | `docs/control-plane-runtime-service-boundary.md` | Live control-plane runtime service boundary and repository placement baseline | IT Operations, Information Systems Department |
+| `docs/maintainability-decomposition-thresholds.md` | Maintainability decomposition thresholds and backlog triggers | IT Operations, Information Systems Department |
 | `docs/phase-16-release-state-and-first-boot-scope.md` | Approved Phase 16 release-state, first-boot runtime boundary, and definition of done | IT Operations, Information Systems Department |
 | `docs/phase-16-release-state-and-first-boot-validation.md` | Review record for the approved Phase 16 first-boot scope and bootability target | IT Operations, Information Systems Department |
 | `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md` | Concrete Phase 17 first-boot runtime config contract and boot command expectations | IT Operations, Information Systems Department |

--- a/docs/maintainability-decomposition-thresholds.md
+++ b/docs/maintainability-decomposition-thresholds.md
@@ -1,0 +1,194 @@
+# AegisOps Maintainability Decomposition Thresholds and Backlog Triggers
+
+This document converts the recent `service.py` refactor experience into a lightweight rule for when AegisOps should open another maintainability backlog instead of waiting for responsibility concentration to become obvious only in hindsight.
+
+It supplements `docs/architecture.md`, `docs/control-plane-service-internal-boundaries.md`, `docs/templates/issue-template.md`, and `docs/templates/pull-request-review-checklist.md`.
+
+This guidance is maintainability policy only. It does not approve new runtime behavior, new product scope, or authority-boundary changes.
+
+## 1. Purpose
+
+AegisOps now has enough recent refactor history to define a repo-owned decomposition threshold instead of relying on intuition or line-count anxiety alone.
+
+The rule needs to stay lightweight, but it must still help future roadmap planning and PR review answer one concrete question consistently:
+
+- should we continue extending the hotspot in place for one more narrow issue; or
+- should we open another maintainability refactor backlog before the next expansion lands?
+
+Line count alone is not enough for that call.
+In practical review terms, line count alone is not enough because the real pressure comes from responsibility concentration and boundary mixing.
+
+AegisOps hotspots become risky because one module starts carrying too many reviewed responsibilities, too many authority-bearing paths, and too much coupled regression surface at the same time.
+
+## 2. Recent Refactor Signals
+
+The current rule is grounded in three recent repository checkpoints.
+
+### 2.1 `#592`: backlog trigger became obvious after Phase 28 growth
+
+`#592` opened the post-Phase 28 maintainability refactor backlog when the repository still worked functionally, but the change surface had become too concentrated in a small set of files.
+
+The Epic called out:
+
+- `control-plane/aegisops_control_plane/service.py` as the dominant hotspot;
+- mixed ownership of endpoint evidence, subordinate MISP attachment, action review, case promotion, assistant workflow, and reconciliation entrypoints inside one class;
+- large test modules whose size and churn made focused review harder; and
+- CI maintainability pressure from duplicated validation structure.
+
+The important lesson from `#592` is that backlog creation should start before runtime behavior degrades. Concentrated responsibility, test mass, and change friction are already enough.
+
+### 2.2 `#610`: one backlog was not enough once the next concentration point was still obvious
+
+`#610` reopened the maintainability question immediately after `#592` because the first round reduced several hotspots but still left the next concentration points obvious in the host checkout.
+
+That Epic explicitly called out:
+
+- `control-plane/aegisops_control_plane/service.py` as the remaining dominant orchestration hotspot;
+- `control-plane/aegisops_control_plane/restore_readiness.py` as the next large boundary module; and
+- operator read surfaces, detection lifecycle flows, restore/readiness logic, and assistant workflow responsibilities that still remained too concentrated.
+
+The lesson from `#610` is that AegisOps should open another backlog when the next hotspot is already clear after the previous extraction set lands. Waiting for another feature wave to intensify it adds risk without adding clarity.
+
+### 2.3 `#633`: hotspot extraction was still justified even after prior backlog work
+
+`#633` then decomposed the next authority-bearing `service.py` hotspot cluster after the post-`#610` refactors still left one coherent write-path concentration inside the public facade.
+
+That issue focused on:
+
+- the remaining `record_case_*` family;
+- manual fallback or escalation write logic;
+- approval-decision handling; and
+- action-policy evaluation helpers that still lived too close together inside `service.py`.
+
+The lesson from `#633` is that a hotspot remains backlog-worthy when the remaining cluster is still authority-bearing, still cohesive enough to extract safely, and still large enough that future roadmap work would keep landing in the same file.
+
+## 3. Signals That Count Toward a Decomposition Threshold
+
+Future maintainability calls should evaluate the hotspot against the following signals together.
+
+The current checklist is: responsibility count, authority-path mixing, optional-extension mixing, regression-test coupling, and operator-surface overlap.
+
+### 3.1 Responsibility count
+
+Responsibility count asks how many distinct reviewed concerns one file or class owns.
+
+The signal is present when a single hotspot simultaneously owns several of the following:
+
+- runtime or auth boundary behavior;
+- operator-facing read surfaces;
+- casework mutation paths;
+- assistant or advisory assembly;
+- action-governance or reconciliation logic;
+- readiness, backup, restore, or export behavior;
+- source-admission or evidence-ingest logic; or
+- internal policy helpers shared across those paths.
+
+If the same module has to be explained to reviewers as multiple named clusters, that is already pressure toward decomposition.
+
+### 3.2 Authority-path mixing
+
+Authority-path mixing asks whether the hotspot combines read-only shaping with authority-bearing or lifecycle-bearing mutations.
+
+This signal is especially important in AegisOps because modules become harder to review when they mix:
+
+- advisory assembly with approval or execution governance;
+- runtime/auth checks with business workflow mutations;
+- detection intake with authoritative case or reconciliation linking; or
+- restore/readiness operations with current live workflow behavior.
+
+When one file mixes several authority paths, refactors become higher-risk and later feature work becomes easier to broaden accidentally.
+
+### 3.3 Optional-extension mixing
+
+Optional-extension mixing asks whether reviewed optional or subordinate capabilities have accumulated inside a core orchestration hotspot instead of staying visibly subordinate.
+
+Examples from recent history include endpoint evidence augmentation, subordinate MISP flows, assistant workflow assembly, and restore/readiness growth.
+
+This matters because optional or subordinate slices can quietly turn one core module into the repository’s default landing zone for unrelated future work.
+
+### 3.4 Regression-test coupling
+
+Regression-test coupling asks whether proving one behavior now requires touching or re-reading too much unrelated coverage.
+
+This signal is present when:
+
+- one implementation hotspot maps to a broad, hard-to-split test mass;
+- narrow refactors require coordinated edits across unrelated test families;
+- one behavior change forces the reviewer to re-evaluate many older contracts in one pass; or
+- the same hotspot keeps appearing in focused regression suites for otherwise different features.
+
+Large regression surface alone is not the problem. The problem is when one hotspot keeps dragging multiple test families together.
+
+### 3.5 Operator-surface overlap
+
+Operator-surface overlap asks whether the hotspot owns multiple user-visible or reviewer-visible surfaces whose semantics should remain separate.
+
+Examples include:
+
+- queue and detail reads plus casework mutation;
+- assistant context and cited advisory output plus action creation;
+- health or readiness surfaces plus restore execution; or
+- one file defining both public facade behavior and several separate internal boundary rules.
+
+When operator-surface overlap grows, reviewers lose a clean boundary for reasoning about what a change is allowed to alter.
+
+## 4. Threshold Rule
+
+A hotspot should move to backlog creation when the repository shows all of the following:
+
+1. One module or tightly bound file pair is still the obvious landing zone for the next roadmap slice.
+2. At least three of the five signals above are clearly present.
+3. One of those signals is either authority-path mixing or operator-surface overlap.
+4. The remaining cluster is cohesive enough to describe as one follow-up extraction or one ordered child-issue set.
+5. The extraction can preserve the public boundary and reviewed behavior instead of reopening product scope.
+
+The backlog trigger is stronger when the hotspot is already being described in reviews as a "remaining cluster", "next hotspot", "dominant orchestration hotspot", or equivalent language. That vocabulary means the repository has already made the concentration visible.
+
+## 5. In-Place Extension Rule
+
+A hotspot can stay in place for the current issue only when all of the following are true:
+
+1. The change adds one narrow behavior inside an already cohesive responsibility area.
+2. The work does not introduce new authority-path mixing.
+3. The work does not pull another optional or subordinate slice into the hotspot.
+4. Focused regression coverage stays local to one existing test family.
+5. Reviewers can still explain the boundary without inventing a new internal decomposition narrative.
+
+If those conditions no longer hold, the safer choice is to open another maintainability refactor backlog instead of normalizing the concentration.
+
+## 6. Practical Backlog Triggers
+
+Open another maintainability refactor backlog when any of the following repo-specific patterns appear:
+
+- `control-plane/aegisops_control_plane/service.py` or a successor facade is still the obvious home for the next distinct workflow slice after the last extraction backlog completed.
+- `control-plane/aegisops_control_plane/restore_readiness.py` or another large boundary module starts combining operational surfaces that future issues keep revisiting together.
+- a module now requires named responsibility clusters in docs or PR review just to explain why one narrow change is supposedly safe.
+- the next roadmap issue would add a new concern to a hotspot that already mixes read shaping, write-path governance, and operational boundary logic.
+- multiple focused regression suites now depend on the same hotspot even though the user-visible behaviors are supposed to stay separate.
+
+These triggers are intentionally qualitative but still concrete. They are designed to catch concentration early without turning maintainability review into a formula game.
+
+## 7. Backlog Shape Guidance
+
+When the threshold is crossed, the preferred response is not one giant cleanup issue.
+
+Open either:
+
+- one Epic that sequences the next narrow child issues, as in `#592` and `#610`; or
+- one single extraction issue for one clearly isolated remaining cluster, as in `#633`.
+
+The backlog should keep the same AegisOps discipline as the earlier refactors:
+
+- preserve the public facade where possible;
+- preserve the reviewed authority model and fail-closed checks;
+- keep extraction work separate from feature expansion;
+- add focused regression coverage for the extracted seam; and
+- describe dependency order when one extraction improves the safety of the next.
+
+## 8. How To Use This In Planning And Review
+
+Future roadmap planning should cite this document when deciding whether a hotspot deserves another maintainability backlog before the next expansion issue is opened.
+
+Pull-request review should cite this document when a supposedly narrow change is actually landing on a module that already crossed the decomposition threshold.
+
+If a reviewer can point to the threshold rule and the backlog triggers above, the repo should prefer explicit backlog creation over "one more change" reasoning.

--- a/docs/templates/issue-template.md
+++ b/docs/templates/issue-template.md
@@ -4,6 +4,7 @@
 
 This issue MUST comply with:
 - `docs/requirements-baseline.md`
+- `docs/maintainability-decomposition-thresholds.md` when the issue extends an existing hotspot instead of a clearly bounded module
 
 This baseline is the governing implementation contract for **AegisOps**.
 

--- a/docs/templates/pull-request-review-checklist.md
+++ b/docs/templates/pull-request-review-checklist.md
@@ -2,7 +2,7 @@
 
 This checklist is for human reviewers validating whether an AegisOps pull request is acceptable against the platform baseline.
 
-Review this checklist together with `docs/requirements-baseline.md`, the issue scope, and any related ADRs.
+Review this checklist together with `docs/requirements-baseline.md`, `docs/maintainability-decomposition-thresholds.md` when hotspot growth or refactor deferral is part of the change, the issue scope, and any related ADRs.
 
 ## 1. Review Framing
 


### PR DESCRIPTION
Closes #635
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a new repo-owned maintainability guidance document at [docs/maintainability-decomposition-thresholds.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-635/docs/maintainability-decomposition-thresholds.md:1), grounded in `#592`, `#610`, and `#633`. It defines the decomposition signals the repo has actually been using in practice: responsibility count, authority-path mixing, optional-extension mixing, regression-test coupling, and operator-surface overlap, plus explicit rules for when to open another maintainability backlog versus allowing one more in-place extension.

I linked that guidance from the architecture and review entrypoints that will use it: [docs/architecture.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-635/docs/architecture.md:1), [docs/control-plane-service-internal-boundaries.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-635/docs/control-plane-service-internal-boundaries.md:1), [docs/templates/issue-template.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-635/docs/templates/issue-template.md:1), and [docs/templates/pull-request-review-checklist.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-635/docs/templates/pull-request-review-checklist.md:1). I also added ownership tracking in [docs/documentation-ownership-map.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-635/docs/documentation-ownership-map.md:1) and a focused docs unittest at [control-plane/tests/test_maintainability_decomposition_thresholds_docs.py](/Users/jp.infra/Dev/AegisOps-worktre...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New documentation on maintainability decomposition thresholds and backlog triggers
  * Updated architecture overview and control-plane boundaries documentation with additional references
  * Updated issue template and pull-request review checklist with new compliance guidance
  * Updated documentation ownership map with new entry

* **Tests**
  * Added validation tests for documentation consistency and cross-references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->