### PR TITLE
operability: surface optional-extension enablement, readiness, disabled-by-default, and degraded state (#636)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ For the cross-phase registry of expansion boundaries that future work should cit
 | Sigma | Optional research / prototyping asset |
 | n8n | Optional / transitional / experimental orchestration asset |
 
+### Optional extension operability model
+
+Operators must treat optional extension state as a repo-owned runtime interpretation, not as an inference from whether a package, sidecar, or external substrate happens to exist.
+
+The reviewed readiness and inspection surfaces classify optional extensions with explicit enablement, availability, and readiness signals so the mainline guarantee remains clear:
+
+| Extension family | Mainline guarantee | Default posture | Operator-visible interpretation |
+| --- | --- | --- | --- |
+| Assistant | The bounded live summary family may run on reviewed control-plane records, but it remains advisory-only and non-authoritative. | Enabled optional surface with non-blocking secondary enrichment. | `enabled` and `ready` means the bounded reviewed summary provider is available. Missing optional enrichment such as OpenSearch does not block the mainline reviewed workflow. |
+| Endpoint evidence | Subordinate endpoint evidence packs may be collected only from an already reviewed case and approved bounded request. | Disabled by default. | `disabled_by_default` means no reviewed endpoint evidence request is active. `enabled` means a reviewed endpoint evidence request is active. `degraded` means the approved endpoint-evidence review path is lagging or missing receipts and must stay visible without becoming authority. |
+| Optional network evidence | Optional network evidence packs remain subordinate to the reviewed control-plane chain. | Disabled by default. | `disabled_by_default` or `unavailable` means the optional network path is not activated on the mainline runtime and does not block boot, queue review, approval, execution, or reconciliation truth. |
+| ML shadow | ML output remains shadow-only, audit-focused, and outside approval, execution, and reconciliation authority. | Disabled by default. | `disabled_by_default` or `unavailable` means the reviewed runtime is operating without ML shadow mode. Any future `enabled` or `degraded` state must remain explicitly shadow-only and non-blocking. |
+
+If optional extension state is absent, unavailable, or degraded, operators must repair the extension surface or leave it disabled. They must not widen authority, infer healthy state from silence, or treat optional paths as first-boot prerequisites.
+
 ---
 
 ## First-use flow

--- a/control-plane/aegisops_control_plane/restore_readiness.py
+++ b/control-plane/aegisops_control_plane/restore_readiness.py
@@ -41,6 +41,9 @@ class RestoreReadinessService:
         build_readiness_automation_substrate_health: Callable[
             [ReadinessDiagnosticsAggregates, list[dict[str, object]]], dict[str, object]
         ],
+        build_optional_extension_operability: Callable[
+            [ReadinessDiagnosticsAggregates, list[dict[str, object]]], dict[str, object]
+        ],
         build_shutdown_status_snapshot: Callable[..., Any],
         derive_readiness_status: Callable[..., str],
         record_from_backup_payload: Callable[
@@ -70,6 +73,9 @@ class RestoreReadinessService:
         self._build_readiness_automation_substrate_health = (
             build_readiness_automation_substrate_health
         )
+        self._build_optional_extension_operability = (
+            build_optional_extension_operability
+        )
         self._readiness_health_projection = _ReadinessHealthProjection(
             config=config,
             store=store,
@@ -98,6 +104,12 @@ class RestoreReadinessService:
             ),
             build_readiness_automation_substrate_health=(
                 lambda aggregates, snapshots: self._build_readiness_automation_substrate_health(
+                    aggregates,
+                    snapshots,
+                )
+            ),
+            build_optional_extension_operability=(
+                lambda aggregates, snapshots: self._build_optional_extension_operability(
                     aggregates,
                     snapshots,
                 )

--- a/control-plane/aegisops_control_plane/restore_readiness_projection.py
+++ b/control-plane/aegisops_control_plane/restore_readiness_projection.py
@@ -37,6 +37,9 @@ class _ReadinessHealthProjection:
         build_readiness_automation_substrate_health: Callable[
             [ReadinessDiagnosticsAggregates, list[dict[str, object]]], dict[str, object]
         ],
+        build_optional_extension_operability: Callable[
+            [ReadinessDiagnosticsAggregates, list[dict[str, object]]], dict[str, object]
+        ],
         build_shutdown_status_snapshot: Callable[..., Any],
         derive_readiness_status: Callable[..., str],
     ) -> None:
@@ -57,6 +60,9 @@ class _ReadinessHealthProjection:
         self._build_readiness_source_health = build_readiness_source_health
         self._build_readiness_automation_substrate_health = (
             build_readiness_automation_substrate_health
+        )
+        self._build_optional_extension_operability = (
+            build_optional_extension_operability
         )
         self._build_shutdown_status_snapshot = build_shutdown_status_snapshot
         self._derive_readiness_status = derive_readiness_status
@@ -161,6 +167,10 @@ class _ReadinessHealthProjection:
                     readiness_review_snapshots,
                 )
             )
+            optional_extensions = self._build_optional_extension_operability(
+                readiness_aggregates,
+                readiness_review_snapshots,
+            )
 
         shutdown = self._build_shutdown_status_snapshot(
             open_case_ids=readiness_aggregates.open_case_ids,
@@ -246,6 +256,7 @@ class _ReadinessHealthProjection:
             "review_path_health": review_path_health,
             "source_health": source_health,
             "automation_substrate_health": automation_substrate_health,
+            "optional_extensions": optional_extensions,
         }
 
         return self._readiness_diagnostics_snapshot_factory(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -128,6 +128,7 @@ _LIVE_OPTIONAL_EXTENSION_REVIEW_STATES = frozenset(
         "pending",
         "approved",
         "executing",
+        "unresolved",
     }
 )
 

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -65,7 +65,7 @@ from .models import (
 )
 from .operator_inspection import OperatorInspectionReadSurface
 from .restore_readiness import RestoreReadinessService
-from .runtime_boundary import RuntimeBoundaryService
+from .runtime_boundary import RuntimeBoundaryService, _is_missing_runtime_binding
 from .assistant_context import (
     AssistantContextAssembler,
     _advisory_text_claims_authority_or_scope_expansion,
@@ -1404,6 +1404,9 @@ class AegisOpsControlPlaneService:
             build_readiness_source_health=self._build_readiness_source_health,
             build_readiness_automation_substrate_health=(
                 self._build_readiness_automation_substrate_health
+            ),
+            build_optional_extension_operability=(
+                self._build_optional_extension_operability
             ),
             build_shutdown_status_snapshot=_build_shutdown_status_snapshot,
             derive_readiness_status=_derive_readiness_status,
@@ -2897,6 +2900,9 @@ class AegisOpsControlPlaneService:
                         if action_execution is not None
                         else action_request.policy_evaluation.get("execution_surface_id")
                     ),
+                    "requested_action_type": action_request.requested_payload.get(
+                        "action_type"
+                    ),
                     "path_health": path_health,
                 }
             )
@@ -3033,6 +3039,147 @@ class AegisOpsControlPlaneService:
             ),
             "surfaces": surfaces,
         }
+
+    def _build_optional_extension_operability(
+        self,
+        readiness_aggregates: ReadinessDiagnosticsAggregates,
+        readiness_review_snapshots: list[dict[str, object]] | None = None,
+    ) -> dict[str, object]:
+        if readiness_review_snapshots is None:
+            readiness_review_snapshots = self._collect_readiness_review_snapshots(
+                readiness_aggregates
+            )
+
+        extensions = {
+            "assistant": {
+                "enablement": "enabled",
+                "availability": "available",
+                "readiness": "ready",
+                "authority_mode": "advisory_only",
+                "mainline_dependency": "non_blocking",
+                "reason": "bounded_reviewed_summary_provider_available",
+            },
+            "endpoint_evidence": self._build_endpoint_evidence_operability(
+                readiness_review_snapshots
+            ),
+            "network_evidence": {
+                "enablement": "disabled_by_default",
+                "availability": "unavailable",
+                "readiness": "not_applicable",
+                "authority_mode": "augmenting_evidence",
+                "mainline_dependency": "non_blocking",
+                "reason": "reviewed_network_evidence_extension_not_activated",
+            },
+            "ml_shadow": {
+                "enablement": "disabled_by_default",
+                "availability": "unavailable",
+                "readiness": "not_applicable",
+                "authority_mode": "shadow_only",
+                "mainline_dependency": "non_blocking",
+                "reason": "reviewed_ml_shadow_extension_not_activated",
+            },
+        }
+        overall_state = (
+            "degraded"
+            if any(entry["readiness"] == "degraded" for entry in extensions.values())
+            else "ready"
+        )
+        return {
+            "tracked_extensions": len(extensions),
+            "overall_state": overall_state,
+            "summary": self._optional_extension_operability_summary(
+                extensions=extensions,
+                overall_state=overall_state,
+            ),
+            "extensions": extensions,
+        }
+
+    def _build_endpoint_evidence_operability(
+        self,
+        readiness_review_snapshots: Iterable[Mapping[str, object]],
+    ) -> dict[str, object]:
+        endpoint_review_snapshots = [
+            snapshot
+            for snapshot in readiness_review_snapshots
+            if snapshot.get("requested_action_type") == "collect_endpoint_evidence_pack"
+        ]
+        executor_available = not _is_missing_runtime_binding(
+            self._config.isolated_executor_base_url
+        )
+        if not endpoint_review_snapshots:
+            return {
+                "enablement": "disabled_by_default",
+                "availability": "available" if executor_available else "unavailable",
+                "readiness": "not_applicable",
+                "authority_mode": "augmenting_evidence",
+                "mainline_dependency": "non_blocking",
+                "reason": (
+                    "no_reviewed_endpoint_evidence_requests"
+                    if executor_available
+                    else "isolated_executor_runtime_not_configured"
+                ),
+            }
+
+        review_path_health = [
+            snapshot["path_health"] for snapshot in endpoint_review_snapshots
+        ]
+        aggregated_paths = {
+            path_name: self._aggregate_readiness_path_health(
+                path_name=path_name,
+                review_path_health=review_path_health,
+            )
+            for path_name in ("delegation", "provider", "persistence")
+        }
+        overall_state = self._action_review_overall_path_state(aggregated_paths.values())
+        if overall_state == "healthy":
+            readiness = "ready"
+            reason = "reviewed_endpoint_evidence_path_healthy"
+        else:
+            readiness = "degraded"
+            reason = self._readiness_dominant_reason(
+                aggregated_paths.values(),
+                overall_state=overall_state,
+            )
+        if not executor_available:
+            readiness = "degraded"
+            reason = "isolated_executor_runtime_not_configured"
+        return {
+            "enablement": "enabled",
+            "availability": "available" if executor_available else "unavailable",
+            "readiness": readiness,
+            "authority_mode": "augmenting_evidence",
+            "mainline_dependency": "non_blocking",
+            "reason": reason,
+        }
+
+    @staticmethod
+    def _optional_extension_operability_summary(
+        *,
+        extensions: Mapping[str, Mapping[str, object]],
+        overall_state: str,
+    ) -> str:
+        degraded_extensions = [
+            f"{extension_name} {extension['reason'].replace('_', ' ')}"
+            for extension_name, extension in extensions.items()
+            if extension.get("readiness") == "degraded"
+        ]
+        if degraded_extensions:
+            return (
+                f"{overall_state} optional extension operability: "
+                + "; ".join(degraded_extensions[:2])
+            )
+        disabled_extensions = [
+            extension_name
+            for extension_name, extension in extensions.items()
+            if extension.get("enablement") == "disabled_by_default"
+        ]
+        if disabled_extensions:
+            return (
+                "ready optional extension operability: "
+                + ", ".join(disabled_extensions[:3])
+                + " remain disabled by default or unavailable"
+            )
+        return "all reviewed optional extensions are ready"
 
     @staticmethod
     def _readiness_dominant_reason(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -123,6 +123,13 @@ _PHASE24_WORKFLOW_PROMPT_VERSIONS = {
     "case_summary": "phase24-case-summary-v1",
     "queue_triage_summary": "phase24-queue-summary-v1",
 }
+_LIVE_OPTIONAL_EXTENSION_REVIEW_STATES = frozenset(
+    {
+        "pending",
+        "approved",
+        "executing",
+    }
+)
 
 
 class _ReviewedSummaryTransport(AssistantProviderTransport):
@@ -2882,6 +2889,7 @@ class AegisOpsControlPlaneService:
             readiness_review_snapshots.append(
                 {
                     "action_request_id": action_request_id,
+                    "review_state": review_state,
                     "source_family": (
                         self._reviewed_operator_source_family(reviewed_context)
                         if reviewed_context is not None
@@ -3079,11 +3087,11 @@ class AegisOpsControlPlaneService:
                 "reason": "reviewed_ml_shadow_extension_not_activated",
             },
         }
-        overall_state = (
-            "degraded"
-            if any(entry["readiness"] == "degraded" for entry in extensions.values())
-            else "ready"
-        )
+        overall_state = "ready"
+        if any(entry["readiness"] == "degraded" for entry in extensions.values()):
+            overall_state = "degraded"
+        elif any(entry["readiness"] == "delayed" for entry in extensions.values()):
+            overall_state = "delayed"
         return {
             "tracked_extensions": len(extensions),
             "overall_state": overall_state,
@@ -3101,7 +3109,10 @@ class AegisOpsControlPlaneService:
         endpoint_review_snapshots = [
             snapshot
             for snapshot in readiness_review_snapshots
-            if snapshot.get("requested_action_type") == "collect_endpoint_evidence_pack"
+            if (
+                snapshot.get("requested_action_type") == "collect_endpoint_evidence_pack"
+                and snapshot.get("review_state") in _LIVE_OPTIONAL_EXTENSION_REVIEW_STATES
+            )
         ]
         executor_available = not _is_missing_runtime_binding(
             self._config.isolated_executor_base_url
@@ -3134,6 +3145,9 @@ class AegisOpsControlPlaneService:
         if overall_state == "healthy":
             readiness = "ready"
             reason = "reviewed_endpoint_evidence_path_healthy"
+        elif overall_state == "delayed":
+            readiness = "delayed"
+            reason = "reviewed_endpoint_evidence_path_delayed"
         else:
             readiness = "degraded"
             reason = self._readiness_dominant_reason(
@@ -3167,6 +3181,16 @@ class AegisOpsControlPlaneService:
             return (
                 f"{overall_state} optional extension operability: "
                 + "; ".join(degraded_extensions[:2])
+            )
+        delayed_extensions = [
+            f"{extension_name} {extension['reason'].replace('_', ' ')}"
+            for extension_name, extension in extensions.items()
+            if extension.get("readiness") == "delayed"
+        ]
+        if delayed_extensions:
+            return (
+                f"{overall_state} optional extension operability: "
+                + "; ".join(delayed_extensions[:2])
             )
         disabled_extensions = [
             extension_name

--- a/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
+++ b/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
@@ -414,6 +414,63 @@ class Phase28EndpointEvidencePackValidationTests(unittest.TestCase):
             "reviewed_endpoint_evidence_path_delayed",
         )
 
+    def test_readiness_keeps_unresolved_endpoint_evidence_extension_live(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        _store, service, promoted_case, anchor_evidence_id, _reviewed_at = (
+            self._build_host_bound_case(store=store)
+        )
+        service = AegisOpsControlPlaneService(
+            replace(
+                service._config,
+                isolated_executor_base_url="https://executor.internal",
+            ),
+            store=store,
+        )
+
+        action_request = service.create_endpoint_evidence_collection_request(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence_id,
+            requester_identity="analyst-001",
+            host_identifier="host-001",
+            evidence_gap="Need endpoint evidence to resolve the reviewed host-state gap.",
+            artifact_classes=("collection_manifest", "triage_bundle"),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-endpoint-operability-unresolved-001",
+        )
+        service.record_action_approval_decision(
+            action_request_id=action_request.action_request_id,
+            approver_identity="reviewer-001",
+            decision="grant",
+            decision_rationale="Approved bounded read-only endpoint evidence collection.",
+            decided_at=action_request.requested_at + timedelta(minutes=5),
+        )
+        approved_request = service.get_record(
+            ActionRequestRecord,
+            action_request.action_request_id,
+        )
+        assert approved_request is not None
+        service.persist_record(
+            replace(
+                approved_request,
+                lifecycle_state="unresolved",
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        optional_extensions = readiness.metrics["optional_extensions"]
+        endpoint_extension = optional_extensions["extensions"]["endpoint_evidence"]
+
+        self.assertEqual(optional_extensions["overall_state"], "degraded")
+        self.assertEqual(endpoint_extension["enablement"], "enabled")
+        self.assertEqual(endpoint_extension["availability"], "available")
+        self.assertEqual(endpoint_extension["readiness"], "degraded")
+        self.assertEqual(
+            endpoint_extension["reason"],
+            "provider_signal_missing_after_approval",
+        )
+
     def test_readiness_ignores_historical_endpoint_evidence_requests_for_enablement(
         self,
     ) -> None:

--- a/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
+++ b/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
@@ -16,6 +16,7 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 
 from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.models import (
+    ActionExecutionRecord,
     ActionRequestRecord,
     CaseRecord,
     EvidenceRecord,
@@ -364,6 +365,133 @@ class Phase28EndpointEvidencePackValidationTests(unittest.TestCase):
                 "identity_criticality": "standard",
                 "blast_radius": "single_target",
                 "execution_constraint": "requires_isolated_executor",
+            },
+        )
+
+    def test_readiness_surfaces_endpoint_evidence_extension_as_delayed_before_overdue(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        _store, service, promoted_case, anchor_evidence_id, _reviewed_at = (
+            self._build_host_bound_case(store=store)
+        )
+        service = AegisOpsControlPlaneService(
+            replace(
+                service._config,
+                isolated_executor_base_url="https://executor.internal",
+            ),
+            store=store,
+        )
+
+        action_request = service.create_endpoint_evidence_collection_request(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence_id,
+            requester_identity="analyst-001",
+            host_identifier="host-001",
+            evidence_gap="Need endpoint evidence to resolve the reviewed host-state gap.",
+            artifact_classes=("collection_manifest", "triage_bundle"),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-endpoint-operability-delayed-001",
+        )
+        service.record_action_approval_decision(
+            action_request_id=action_request.action_request_id,
+            approver_identity="reviewer-001",
+            decision="grant",
+            decision_rationale="Approved bounded read-only endpoint evidence collection.",
+            decided_at=action_request.requested_at + timedelta(minutes=5),
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        optional_extensions = readiness.metrics["optional_extensions"]
+        endpoint_extension = optional_extensions["extensions"]["endpoint_evidence"]
+
+        self.assertEqual(optional_extensions["overall_state"], "delayed")
+        self.assertEqual(endpoint_extension["enablement"], "enabled")
+        self.assertEqual(endpoint_extension["availability"], "available")
+        self.assertEqual(endpoint_extension["readiness"], "delayed")
+        self.assertEqual(
+            endpoint_extension["reason"],
+            "reviewed_endpoint_evidence_path_delayed",
+        )
+
+    def test_readiness_ignores_historical_endpoint_evidence_requests_for_enablement(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        _store, service, promoted_case, anchor_evidence_id, reviewed_at = (
+            self._build_host_bound_case(store=store)
+        )
+        service = AegisOpsControlPlaneService(
+            replace(
+                service._config,
+                isolated_executor_base_url="https://executor.internal",
+            ),
+            store=store,
+        )
+
+        action_request = service.create_endpoint_evidence_collection_request(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence_id,
+            requester_identity="analyst-001",
+            host_identifier="host-001",
+            evidence_gap="Need endpoint evidence to resolve the reviewed host-state gap.",
+            artifact_classes=("collection_manifest", "triage_bundle"),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-endpoint-operability-completed-001",
+        )
+        service.record_action_approval_decision(
+            action_request_id=action_request.action_request_id,
+            approver_identity="reviewer-001",
+            decision="grant",
+            decision_rationale="Approved bounded read-only endpoint evidence collection.",
+            decided_at=action_request.requested_at + timedelta(minutes=5),
+        )
+        approved_request = service.get_record(
+            ActionRequestRecord,
+            action_request.action_request_id,
+        )
+        assert approved_request is not None
+        service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-endpoint-operability-completed-001",
+                action_request_id=approved_request.action_request_id,
+                approval_decision_id=approved_request.approval_decision_id,
+                delegation_id="delegation-endpoint-operability-completed-001",
+                execution_surface_type="isolated_executor",
+                execution_surface_id="isolated-executor",
+                execution_run_id="execution-run-endpoint-operability-completed-001",
+                idempotency_key=approved_request.idempotency_key,
+                target_scope=dict(approved_request.target_scope),
+                approved_payload=dict(approved_request.requested_payload),
+                payload_hash=approved_request.payload_hash,
+                delegated_at=reviewed_at - timedelta(minutes=30),
+                expires_at=approved_request.expires_at,
+                provenance={"initiated_by": "operator-review"},
+                lifecycle_state="succeeded",
+            )
+        )
+        service.persist_record(
+            replace(
+                approved_request,
+                requested_at=reviewed_at - timedelta(hours=1),
+                lifecycle_state="completed",
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        optional_extensions = readiness.metrics["optional_extensions"]
+        endpoint_extension = optional_extensions["extensions"]["endpoint_evidence"]
+
+        self.assertEqual(optional_extensions["overall_state"], "ready")
+        self.assertEqual(
+            endpoint_extension,
+            {
+                "enablement": "disabled_by_default",
+                "availability": "available",
+                "readiness": "not_applicable",
+                "authority_mode": "augmenting_evidence",
+                "mainline_dependency": "non_blocking",
+                "reason": "no_reviewed_endpoint_evidence_requests",
             },
         )
 

--- a/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
+++ b/control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py
@@ -294,6 +294,66 @@ class Phase28EndpointEvidencePackValidationTests(unittest.TestCase):
             action_request.policy_evaluation["execution_surface_id"],
             "isolated-executor",
         )
+
+    def test_readiness_surfaces_endpoint_evidence_extension_as_degraded_when_review_path_lags(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        _store, service, promoted_case, anchor_evidence_id, reviewed_at = (
+            self._build_host_bound_case(store=store)
+        )
+        service = AegisOpsControlPlaneService(
+            replace(
+                service._config,
+                isolated_executor_base_url="https://executor.internal",
+            ),
+            store=store,
+        )
+
+        action_request = service.create_endpoint_evidence_collection_request(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence_id,
+            requester_identity="analyst-001",
+            host_identifier="host-001",
+            evidence_gap="Need endpoint evidence to resolve the reviewed host-state gap.",
+            artifact_classes=("collection_manifest", "triage_bundle"),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-endpoint-operability-001",
+        )
+        service.record_action_approval_decision(
+            action_request_id=action_request.action_request_id,
+            approver_identity="reviewer-001",
+            decision="grant",
+            decision_rationale="Approved bounded read-only endpoint evidence collection.",
+            decided_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+        approved_request = service.get_record(
+            ActionRequestRecord,
+            action_request.action_request_id,
+        )
+        assert approved_request is not None
+        service.persist_record(
+            replace(
+                approved_request,
+                requested_at=reviewed_at - timedelta(hours=2),
+                expires_at=reviewed_at - timedelta(hours=1),
+                lifecycle_state="executing",
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        endpoint_extension = readiness.metrics["optional_extensions"]["extensions"][
+            "endpoint_evidence"
+        ]
+
+        self.assertEqual(endpoint_extension["enablement"], "enabled")
+        self.assertEqual(endpoint_extension["availability"], "available")
+        self.assertEqual(endpoint_extension["readiness"], "degraded")
+        self.assertEqual(endpoint_extension["authority_mode"], "augmenting_evidence")
+        self.assertEqual(
+            endpoint_extension["reason"],
+            "provider_signal_missing_after_approval",
+        )
         self.assertEqual(
             action_request.policy_basis,
             {

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -3669,6 +3669,65 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             "reconciliation_timeout",
         )
 
+    def test_service_phase21_readiness_surfaces_optional_extension_operability_defaults(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        optional_extensions = readiness.metrics["optional_extensions"]
+
+        self.assertEqual(optional_extensions["tracked_extensions"], 4)
+        self.assertEqual(optional_extensions["overall_state"], "ready")
+        self.assertEqual(
+            optional_extensions["extensions"]["assistant"],
+            {
+                "enablement": "enabled",
+                "availability": "available",
+                "readiness": "ready",
+                "authority_mode": "advisory_only",
+                "mainline_dependency": "non_blocking",
+                "reason": "bounded_reviewed_summary_provider_available",
+            },
+        )
+        self.assertEqual(
+            optional_extensions["extensions"]["endpoint_evidence"],
+            {
+                "enablement": "disabled_by_default",
+                "availability": "unavailable",
+                "readiness": "not_applicable",
+                "authority_mode": "augmenting_evidence",
+                "mainline_dependency": "non_blocking",
+                "reason": "isolated_executor_runtime_not_configured",
+            },
+        )
+        self.assertEqual(
+            optional_extensions["extensions"]["network_evidence"],
+            {
+                "enablement": "disabled_by_default",
+                "availability": "unavailable",
+                "readiness": "not_applicable",
+                "authority_mode": "augmenting_evidence",
+                "mainline_dependency": "non_blocking",
+                "reason": "reviewed_network_evidence_extension_not_activated",
+            },
+        )
+        self.assertEqual(
+            optional_extensions["extensions"]["ml_shadow"],
+            {
+                "enablement": "disabled_by_default",
+                "availability": "unavailable",
+                "readiness": "not_applicable",
+                "authority_mode": "shadow_only",
+                "mainline_dependency": "non_blocking",
+                "reason": "reviewed_ml_shadow_extension_not_activated",
+            },
+        )
+
     def test_service_phase21_readiness_source_health_ignores_predelegation_backlog(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -3672,7 +3672,7 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
     def test_service_phase21_readiness_surfaces_optional_extension_operability_defaults(
         self,
     ) -> None:
-        store, _ = make_store()
+        store, _ = support.make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -89,6 +89,17 @@ Future validation guidance should describe:
 - the conditions that require escalation instead of continued operation, and
 - the repository artifacts that define the expected state.
 
+The reviewed readiness surface must expose optional-extension operability explicitly instead of leaving operators to infer state from missing sidecars or quiet logs.
+
+At minimum, validation should distinguish:
+
+- `enabled` optional paths that are intentionally active but still non-authoritative;
+- `disabled_by_default` optional paths that remain off without blocking the mainline;
+- `unavailable` optional paths whose supporting runtime is absent or intentionally not configured; and
+- `degraded` optional paths whose reviewed receipts, health, or bounded outputs are lagging and therefore require operator-visible follow-up.
+
+Validation must confirm that optional assistant, endpoint evidence, optional network evidence, and ML shadow paths stay subordinate to the reviewed control-plane chain even when their operability state is `unavailable` or `degraded`.
+
 The selected Phase 6 validation slice is limited to the Windows security and endpoint telemetry family and the three reviewed detector artifacts under `opensearch/detectors/windows-security-and-endpoint/`.
 
 This runbook section is limited to replay validation, staging-only detector review, and read-only or notify-only workflow review during business hours.


### PR DESCRIPTION
Closes #636
This PR was opened by codex-supervisor.
Latest Codex summary:

Readiness diagnostics now expose `metrics.optional_extensions`, with explicit per-extension `enablement`, `availability`, `readiness`, `authority_mode`, `mainline_dependency`, and `reason` for `assistant`, `endpoint_evidence`, `network_evidence`, and `ml_shadow`. The endpoint-evidence state is tied to authoritative readiness review snapshots, so an active reviewed endpoint-evidence path now surfaces as `degraded` when receipts or downstream visibility lag, without changing boot-time requirements or promoting optional paths into authority. I also updated [README.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-636/README.md) and [docs/runbook.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-636/docs/runbook.md) so the operator-facing docs use the same model as the runtime surface.

The change is committed on `codex/issue-636` as `510f956` with message `Surface optional extension operability in readiness`.

Summary: Added explicit optional-extension operability classification to readiness, covered default and degraded endpoint-evidence cases with focused tests, and aligned README/runbook guidance.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_surfaces_source_and_automation_health control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_surfaces_optional_...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Readiness diagnostics now report per-extension operability for assistant, endpoint evidence, network evidence, and ML shadow — tracked counts, overall state, and per-extension readiness/enablement/authority/reason.

* **Documentation**
  * Added operator guidance defining enabled/disabled/unavailable/degraded states, default authority modes, and directive to repair or disable absent/degraded extensions.

* **Tests**
  * Added tests validating optional-extension diagnostics and endpoint-evidence timing/degradation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->