### PR TITLE
validation: add cross-boundary negative E2E coverage for assistant, optional-extension, soft-write, and ML shadow failure paths (#637)

### DIFF
--- a/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
+++ b/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
@@ -230,7 +230,10 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
         case_detail = service.inspect_case_detail(promoted_case.case_id).to_dict()
         current_case = store.get(CaseRecord, promoted_case.case_id)
         current_alert = store.get(AlertRecord, promoted_case.alert_id)
-        current_execution = store.list(ActionExecutionRecord)[0]
+        current_execution = store.get(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
 
         self.assertEqual(
             case_detail["current_action_review"]["coordination_ticket_outcome"]["status"],
@@ -249,6 +252,7 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
         self.assertEqual(case_detail["external_ticket_reference"]["status"], "missing")
         self.assertIsNotNone(current_case)
         self.assertIsNotNone(current_alert)
+        self.assertIsNotNone(current_execution)
         self.assertIsNone(current_case.coordination_reference_id)
         self.assertIsNone(current_alert.coordination_reference_id)
         self.assertEqual(current_execution.lifecycle_state, "queued")

--- a/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
+++ b/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+for candidate in (CONTROL_PLANE_ROOT, TESTS_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+
+from _cli_inspection_support import ControlPlaneCliInspectionTestBase
+from aegisops_control_plane.assistant_provider import AssistantProviderAdapter
+from aegisops_control_plane.models import (
+    AITraceRecord,
+    ActionExecutionRecord,
+    ActionRequestRecord,
+    AlertRecord,
+    ApprovalDecisionRecord,
+    CaseRecord,
+    EvidenceRecord,
+    LeadRecord,
+    ObservationRecord,
+    RecommendationRecord,
+    ReconciliationRecord,
+)
+from aegisops_control_plane.phase29_evidently_drift_visibility import (
+    build_phase29_evidently_drift_visibility_report,
+)
+from aegisops_control_plane.phase29_shadow_dataset import Phase29ShadowDatasetSnapshot
+from aegisops_control_plane.phase29_shadow_scoring import (
+    Phase29ShadowScoringError,
+    score_shadow_dataset_offline,
+)
+from aegisops_control_plane.service import AegisOpsControlPlaneService
+import _cli_inspection_support as cli_support
+import test_phase28_endpoint_evidence_pack_validation as phase28_tests
+import test_phase29_no_authority_ml_and_optional_network_validation as phase29_tests
+
+
+_AUTHORITATIVE_RECORD_TYPES = (
+    AlertRecord,
+    CaseRecord,
+    EvidenceRecord,
+    ObservationRecord,
+    LeadRecord,
+    RecommendationRecord,
+    ApprovalDecisionRecord,
+    ActionRequestRecord,
+    ActionExecutionRecord,
+    ReconciliationRecord,
+)
+
+
+class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
+    def test_assistant_unresolved_and_degraded_optional_extension_paths_stay_fail_closed(
+        self,
+    ) -> None:
+        phase28_helper = phase28_tests.Phase28EndpointEvidencePackValidationTests()
+        store, seeded_service, promoted_case, anchor_evidence_id, reviewed_at = (
+            phase28_helper._build_host_bound_case()
+        )
+        service = AegisOpsControlPlaneService(
+            replace(
+                seeded_service._config,
+                isolated_executor_base_url="https://executor.internal",
+            ),
+            store=store,
+        )
+        baseline_case = store.get(CaseRecord, promoted_case.case_id)
+        baseline_reconciliation_count = len(store.list(ReconciliationRecord))
+        self.assertIsNotNone(baseline_case)
+
+        service._assistant_provider_adapter = mock.Mock()
+        service._assistant_provider_adapter.generate.side_effect = RuntimeError(
+            "provider transport failed"
+        )
+        provider_adapter = AssistantProviderAdapter(
+            provider_identity="openai",
+            model_identity="gpt-5.4",
+            prompt_version="phase24-case-summary-v1",
+            request_timeout_seconds=5.0,
+            max_attempts=1,
+            transport=mock.Mock(),
+        )
+        service._assistant_provider_adapter.build_ai_trace_record.side_effect = (
+            provider_adapter.build_ai_trace_record
+        )
+
+        workflow_snapshot = service.run_live_assistant_workflow(
+            workflow_task="case_summary",
+            record_family="case",
+            record_id=promoted_case.case_id,
+        )
+
+        action_request = service.create_endpoint_evidence_collection_request(
+            case_id=promoted_case.case_id,
+            admitting_evidence_id=anchor_evidence_id,
+            requester_identity="analyst-001",
+            host_identifier="host-001",
+            evidence_gap="Need endpoint evidence to resolve the reviewed host-state gap.",
+            artifact_classes=("collection_manifest", "triage_bundle"),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-cross-boundary-endpoint-001",
+        )
+        service.record_action_approval_decision(
+            action_request_id=action_request.action_request_id,
+            approver_identity="reviewer-001",
+            decision="grant",
+            decision_rationale="Approved bounded read-only endpoint evidence collection.",
+            decided_at=action_request.requested_at + timedelta(minutes=5),
+        )
+        approved_request = service.get_record(
+            ActionRequestRecord,
+            action_request.action_request_id,
+        )
+        assert approved_request is not None
+        service.persist_record(
+            replace(
+                approved_request,
+                requested_at=reviewed_at - timedelta(hours=2),
+                expires_at=reviewed_at - timedelta(hours=1),
+                lifecycle_state="executing",
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        optional_extensions = readiness.metrics["optional_extensions"]
+        assistant_extension = optional_extensions["extensions"]["assistant"]
+        endpoint_extension = optional_extensions["extensions"]["endpoint_evidence"]
+        network_extension = optional_extensions["extensions"]["network_evidence"]
+        ml_shadow_extension = optional_extensions["extensions"]["ml_shadow"]
+
+        ai_traces = store.list(AITraceRecord)
+        recommendations = store.list(RecommendationRecord)
+        current_case = store.get(CaseRecord, promoted_case.case_id)
+
+        self.assertEqual(workflow_snapshot.status, "unresolved")
+        self.assertEqual(
+            workflow_snapshot.unresolved_reasons,
+            (
+                "the bounded live assistant did not return a trusted summary within the reviewed retry budget",
+            ),
+        )
+        self.assertEqual(len(ai_traces), 1)
+        self.assertEqual(len(recommendations), 1)
+        self.assertEqual(ai_traces[0].lifecycle_state, "under_review")
+        self.assertEqual(recommendations[0].lifecycle_state, "under_review")
+        self.assertEqual(
+            recommendations[0].assistant_advisory_draft["status"],
+            "unresolved",
+        )
+        self.assertIsNotNone(current_case)
+        self.assertEqual(current_case.lifecycle_state, baseline_case.lifecycle_state)
+        self.assertEqual(current_case.evidence_ids, baseline_case.evidence_ids)
+        self.assertEqual(optional_extensions["overall_state"], "degraded")
+        self.assertEqual(assistant_extension["authority_mode"], "advisory_only")
+        self.assertEqual(assistant_extension["readiness"], "ready")
+        self.assertEqual(endpoint_extension["enablement"], "enabled")
+        self.assertEqual(endpoint_extension["readiness"], "degraded")
+        self.assertEqual(network_extension["enablement"], "disabled_by_default")
+        self.assertEqual(network_extension["readiness"], "not_applicable")
+        self.assertEqual(ml_shadow_extension["enablement"], "disabled_by_default")
+        self.assertEqual(ml_shadow_extension["readiness"], "not_applicable")
+        self.assertEqual(store.list(ActionExecutionRecord), ())
+        self.assertEqual(
+            len(store.list(ReconciliationRecord)),
+            baseline_reconciliation_count,
+        )
+
+    def test_soft_write_receipt_mismatch_stays_non_authoritative_in_case_detail_surface(
+        self,
+    ) -> None:
+        cli_helper = cli_support.ControlPlaneCliInspectionTestBase()
+        store, service, promoted_case, _evidence_id, reviewed_at = (
+            cli_helper._build_phase19_in_scope_case()
+        )
+        seeded = cli_helper._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="cross-boundary-mismatch-001",
+            coordination_reference_id="coord-ref-cross-boundary-mismatch-001",
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=reviewed_at + timedelta(minutes=15),
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        service.reconcile_action_execution(
+            action_request_id=seeded["action_request"].action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": seeded["action_request"].idempotency_key,
+                    "approval_decision_id": seeded["approval"].approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": seeded["payload_hash"],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": "shuffle-receipt-cross-boundary-drift-001",
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": reviewed_at + timedelta(minutes=20),
+                    "status": "success",
+                },
+            ),
+            compared_at=reviewed_at + timedelta(minutes=20),
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+
+        case_detail = service.inspect_case_detail(promoted_case.case_id).to_dict()
+        current_case = store.get(CaseRecord, promoted_case.case_id)
+        current_alert = store.get(AlertRecord, promoted_case.alert_id)
+        current_execution = store.list(ActionExecutionRecord)[0]
+
+        self.assertEqual(
+            case_detail["current_action_review"]["coordination_ticket_outcome"]["status"],
+            "mismatch",
+        )
+        self.assertEqual(
+            case_detail["current_action_review"]["coordination_ticket_outcome"][
+                "mismatch"
+            ]["mismatch_summary"],
+            "coordination receipt mismatch between authoritative action execution and observed downstream execution",
+        )
+        self.assertEqual(
+            case_detail["external_ticket_reference"]["authority"],
+            "non_authoritative",
+        )
+        self.assertEqual(case_detail["external_ticket_reference"]["status"], "missing")
+        self.assertIsNotNone(current_case)
+        self.assertIsNotNone(current_alert)
+        self.assertIsNone(current_case.coordination_reference_id)
+        self.assertIsNone(current_alert.coordination_reference_id)
+        self.assertEqual(current_execution.lifecycle_state, "queued")
+        self.assertEqual(
+            current_execution.provenance["downstream_binding"]["external_receipt_id"],
+            downstream_binding["external_receipt_id"],
+        )
+
+    def test_ml_shadow_and_optional_network_failure_signals_leave_authoritative_state_clean(
+        self,
+    ) -> None:
+        phase29_helper = (
+            phase29_tests.Phase29NoAuthorityMlAndOptionalNetworkValidationTests()
+        )
+        (
+            store,
+            service,
+            linked_case,
+            accepted_recommendation,
+            reference_snapshot,
+            candidate_snapshot,
+            rendered_at,
+        ) = phase29_helper._build_phase29_shadow_and_optional_network_context()
+        baseline_counts = self._record_counts(store)
+        baseline_case = store.get(CaseRecord, linked_case.case_id)
+        baseline_recommendation = store.get(
+            RecommendationRecord,
+            accepted_recommendation.recommendation_id,
+        )
+        self.assertIsNotNone(baseline_case)
+        self.assertIsNotNone(baseline_recommendation)
+
+        example = candidate_snapshot.examples[0]
+        broken_snapshot = Phase29ShadowDatasetSnapshot(
+            snapshot_id=candidate_snapshot.snapshot_id,
+            extraction_spec_version=candidate_snapshot.extraction_spec_version,
+            snapshot_timestamp=candidate_snapshot.snapshot_timestamp,
+            example_count=1,
+            examples=(
+                {
+                    **example,
+                    "label": {
+                        **example["label"],
+                        "provenance": {
+                            key: value
+                            for key, value in example["label"]["provenance"].items()
+                            if key != "label_record_id"
+                        },
+                    },
+                },
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            Phase29ShadowScoringError,
+            "missing required label provenance: label_record_id",
+        ):
+            score_shadow_dataset_offline(
+                dataset_snapshot=broken_snapshot,
+                scoring_spec_version="phase29-shadow-scoring-v1",
+                model_family="baseline-isolation-forest",
+                model_version="candidate-2026-04-20",
+                training_data_snapshot_id=broken_snapshot.snapshot_id,
+                feature_schema_version="phase29-shadow-features-v1",
+                label_schema_version="phase29-shadow-labels-v1",
+                lineage_review_note_id="note-phase29-shadow-001",
+                scored_at=rendered_at,
+            )
+
+        drift_report = build_phase29_evidently_drift_visibility_report(
+            reference_snapshot=reference_snapshot,
+            candidate_snapshot=candidate_snapshot,
+            rendered_at=rendered_at,
+            stale_feature_after=timedelta(minutes=30),
+        )
+        readiness = service.inspect_readiness_diagnostics()
+        optional_extensions = readiness.metrics["optional_extensions"]["extensions"]
+        current_case = store.get(CaseRecord, linked_case.case_id)
+        current_recommendation = store.get(
+            RecommendationRecord,
+            accepted_recommendation.recommendation_id,
+        )
+
+        self.assertEqual(drift_report.status, "degraded")
+        self.assertEqual(drift_report.authority_posture, "non-authoritative")
+        self.assertEqual(optional_extensions["network_evidence"]["enablement"], "disabled_by_default")
+        self.assertEqual(optional_extensions["network_evidence"]["readiness"], "not_applicable")
+        self.assertEqual(optional_extensions["ml_shadow"]["enablement"], "disabled_by_default")
+        self.assertEqual(optional_extensions["ml_shadow"]["readiness"], "not_applicable")
+        self.assertIsNotNone(current_case)
+        self.assertIsNotNone(current_recommendation)
+        self.assertEqual(current_case.lifecycle_state, baseline_case.lifecycle_state)
+        self.assertEqual(current_case.evidence_ids, baseline_case.evidence_ids)
+        self.assertEqual(
+            current_recommendation.lifecycle_state,
+            baseline_recommendation.lifecycle_state,
+        )
+        self.assertEqual(self._record_counts(store), baseline_counts)
+
+    @staticmethod
+    def _record_counts(store: object) -> dict[str, int]:
+        return {
+            record_type.__name__: len(store.list(record_type))
+            for record_type in _AUTHORITATIVE_RECORD_TYPES
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #637
This PR was opened by codex-supervisor.
Latest Codex summary:

Added [test_cross_boundary_negative_e2e_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-637/control-plane/tests/test_cross_boundary_negative_e2e_validation.py) and committed it as `5ef29ba` (`test: add cross-boundary negative e2e coverage`). The new module adds three focused cross-boundary negative E2E scenarios: assistant unresolved output plus degraded optional-extension operability, create-tracking-ticket soft-write mismatch staying non-authoritative in case detail, and ML shadow or optional-network failure signals leaving authoritative state unchanged. I also updated the local issue journal handoff with the hypothesis, commands, and verification status.

Summary: Added and verified a dedicated cross-boundary negative E2E suite for assistant, optional-extension, soft-write, and ML shadow failure paths; committed as `5ef29ba`.
State hint: stabilizing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_cross_boundary_negative_e2e_validation`; `python3 -m unittest control-plane.tests.test_phase24_live_assistant_feedback_loop_validation`; `python3 -m unittest control-plane.tests.test_phase26_end_to_end_validation`; `python3 -m unittest control-plane.tests.test_phase28_endpoint_evidence_pack_validation`; `python3 -m unittest control-plane.tests.test_phase29_no_authority_ml_and_optional_network_validation`
Failure signature: none
Next action: Open or update a draft PR for branch `codex/issue-637`, or continue with any broader validation the s...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end test suite covering three negative cross-boundary failure scenarios: assistant provider failure, soft-write receipt mismatch, and ML shadow plus network degradation. Tests validate fail-closed behavior, degraded readiness and drift visibility, coordination/reference handling, execution provenance, and preservation of authoritative records under adverse conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->