### PR TITLE
cleanup: decide whether phase29_* modules should keep phase-local names or move to domain-oriented names (#638)

### DIFF
--- a/control-plane/tests/test_phase29_ml_shadow_mode_boundary_docs.py
+++ b/control-plane/tests/test_phase29_ml_shadow_mode_boundary_docs.py
@@ -91,6 +91,23 @@ class Phase29MlShadowModeBoundaryDocsTests(unittest.TestCase):
         ):
             self.assertIn(term, text)
 
+    def test_phase29_design_doc_records_module_naming_posture(self) -> None:
+        text = self._read("docs/phase-29-reviewed-ml-shadow-mode-boundary.md")
+
+        for term in (
+            "Module naming posture",
+            "`phase29_shadow_dataset.py`",
+            "`phase29_shadow_scoring.py`",
+            "`phase29_mlflow_shadow_model_registry.py`",
+            "`phase29_evidently_drift_visibility.py`",
+            "keep the current phase-local module names",
+            "boundary-reviewed Phase 29 slice",
+            "domain-oriented",
+            "later roadmap work",
+            "rename",
+        ):
+            self.assertIn(term, text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/control-plane/tests/test_phase29_ml_shadow_mode_boundary_docs.py
+++ b/control-plane/tests/test_phase29_ml_shadow_mode_boundary_docs.py
@@ -103,7 +103,7 @@ class Phase29MlShadowModeBoundaryDocsTests(unittest.TestCase):
             "keep the current phase-local module names",
             "boundary-reviewed Phase 29 slice",
             "domain-oriented",
-            "later roadmap work",
+            "Later roadmap work",
             "rename",
         ):
             self.assertIn(term, text)

--- a/docs/phase-29-reviewed-ml-shadow-mode-boundary.md
+++ b/docs/phase-29-reviewed-ml-shadow-mode-boundary.md
@@ -270,7 +270,21 @@ The reviewed ML shadow-mode boundary explicitly prohibits using ML scores, class
 
 Shadow-mode ML may inform reviewer attention. It must not redefine the durable control-plane truth chain.
 
-## 9. Alignment Notes
+## 9. Module naming posture
+
+The current Python implementation keeps the Phase 29 shadow-mode helpers under phase-local module names.
+
+For this reviewed boundary, `phase29_shadow_dataset.py`, `phase29_shadow_scoring.py`, `phase29_mlflow_shadow_model_registry.py`, and `phase29_evidently_drift_visibility.py` must keep the current phase-local module names.
+
+That naming remains intentional because these modules currently implement one boundary-reviewed Phase 29 slice rather than a settled cross-phase domain package.
+
+Keeping the phase-local names makes the reviewed scope explicit: this code exists to support the bounded Phase 29 shadow dataset, shadow scoring, MLflow lineage, and drift visibility surfaces without implying that the repository has already approved a broader domain-oriented ML subsystem.
+
+Renaming these modules to domain-oriented names now would add churn without a second reviewed consumer, and it would risk overstating stability for interfaces that are still tied to this specific reviewed boundary.
+
+later roadmap work may revisit this posture if the same reviewed contracts need to serve multiple phases or a clearly approved cross-phase package boundary. At that point, a rename or package extraction should happen deliberately across code, tests, scripts, and docs rather than by accidental drift.
+
+## 10. Alignment Notes
 
 This boundary stays aligned with `README.md` and `docs/architecture.md` by keeping AegisOps as the authoritative control plane above reviewed detection and automation substrates.
 

--- a/docs/phase-29-reviewed-ml-shadow-mode-boundary.md
+++ b/docs/phase-29-reviewed-ml-shadow-mode-boundary.md
@@ -282,7 +282,7 @@ Keeping the phase-local names makes the reviewed scope explicit: this code exist
 
 Renaming these modules to domain-oriented names now would add churn without a second reviewed consumer, and it would risk overstating stability for interfaces that are still tied to this specific reviewed boundary.
 
-later roadmap work may revisit this posture if the same reviewed contracts need to serve multiple phases or a clearly approved cross-phase package boundary. At that point, a rename or package extraction should happen deliberately across code, tests, scripts, and docs rather than by accidental drift.
+Later roadmap work may revisit this posture if the same reviewed contracts need to serve multiple phases or a clearly approved cross-phase package boundary. At that point, a rename or package extraction should happen deliberately across code, tests, scripts, and docs rather than by accidental drift.
 
 ## 10. Alignment Notes
 


### PR DESCRIPTION
Closes #638
This PR was opened by codex-supervisor.
Latest Codex summary:

Kept the `phase29_*` modules phase-local and made that decision explicit instead of renaming. The rationale is now documented in [docs/phase-29-reviewed-ml-shadow-mode-boundary.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-638/docs/phase-29-reviewed-ml-shadow-mode-boundary.md:273), and a focused regression guard was added in [control-plane/tests/test_phase29_ml_shadow_mode_boundary_docs.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-638/control-plane/tests/test_phase29_ml_shadow_mode_boundary_docs.py:95) so future roadmap work has to revisit the choice deliberately.

I reproduced the gap first by adding the new doc test and confirming it failed before the doc change. Focused verification is green, `issue-lint` passes, and the branch has a checkpoint commit at `249cfb0` (`Document Phase 29 module naming posture`).

Summary: Documented that `phase29_shadow_dataset.py`, `phase29_shadow_scoring.py`, `phase29_mlflow_shadow_model_registry.py`, and `phase29_evidently_drift_visibility.py` intentionally keep phase-local names for now, and added a focused doc regression test to enforce that decision.
State hint: stabilizing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase29_ml_shadow_mode_boundary_docs` (failed before doc update, passes after); `python3 -m unittest control-plane.tests.test_phase29_shadow_dataset_generation_validation control-plane.tests.test_phase29_shadow_scoring_validation control-plane.tests.test_phase29_mlflow_shadow_model_reg...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated test validating that the design document records the expected module-naming posture.

* **Documentation**
  * Replaced the prior alignment section with a “Module naming posture” section clarifying preservation of phase-local module names and requiring deliberate, coordinated renames across code, tests, scripts, and docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->