### PR TITLE
implementation: build the read-only operator console for queue, alert/case detail, provenance, readiness, and reconciliation (#652)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -15,6 +15,32 @@ function jsonResponse(body: unknown, status = 200) {
   });
 }
 
+function createAuthorizedFetch(
+  handlers: Record<string, unknown>,
+) {
+  return vi.fn<typeof fetch>().mockImplementation((input) => {
+    const url = String(input);
+
+    if (url.startsWith("/api/operator/session")) {
+      return Promise.resolve(
+        jsonResponse({
+          identity: "analyst@example.com",
+          provider: "authentik",
+          roles: ["Analyst"],
+          subject: "operator-7",
+        }),
+      );
+    }
+
+    const match = Object.entries(handlers).find(([prefix]) => url.startsWith(prefix));
+    if (match) {
+      return Promise.resolve(jsonResponse(match[1]));
+    }
+
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  });
+}
+
 describe("OperatorRoutes", () => {
   it("redirects unauthenticated users to the reviewed login route", async () => {
     const dependencies = createDefaultDependencies({
@@ -111,5 +137,271 @@ describe("OperatorRoutes", () => {
         screen.getByRole("heading", { name: "Protected operator shell" }),
       ).toBeInTheDocument();
     });
+  });
+
+  it("renders the reviewed queue route from backend-authoritative queue records", async () => {
+    const fetchFn = createAuthorizedFetch({
+      "/inspect-analyst-queue": {
+        queue_name: "analyst_review",
+        read_only: true,
+        records: [
+          {
+            alert_id: "alert-123",
+            review_state: "degraded",
+            case_id: "case-456",
+            case_lifecycle_state: "open",
+            accountable_source_identities: [
+              "manager:wazuh-manager-github-1",
+            ],
+            reviewed_context: {
+              source: {
+                source_family: "github_audit",
+              },
+            },
+            current_action_review: {
+              review_state: "pending",
+              next_expected_action: "await_approver_decision",
+            },
+          },
+        ],
+        total_records: 1,
+      },
+    });
+    const dependencies = createDefaultDependencies({
+      fetchFn,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/queue"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Analyst Queue" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("alert-123")).toBeInTheDocument();
+    expect(screen.getAllByText(/Review: degraded/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/Primary review surface/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("github_audit")).toBeInTheDocument();
+  });
+
+  it("renders alert detail with authoritative and subordinate sections separated", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-alert-detail": {
+          alert_id: "alert-123",
+          alert: {
+            alert_id: "alert-123",
+            lifecycle_state: "triaged",
+          },
+          case_record: {
+            case_id: "case-456",
+          },
+          review_state: "triaged",
+          escalation_boundary: "case_optional",
+          provenance: {
+            admission_kind: "live",
+            admission_channel: "live_wazuh_webhook",
+          },
+          lineage: {
+            finding_id: "finding-123",
+            analytic_signal_id: "signal-123",
+            source_systems: ["wazuh"],
+            substrate_detection_record_ids: ["wazuh:1731595300.1234567"],
+            accountable_source_identities: ["manager:wazuh-manager-github-1"],
+            evidence_ids: ["evidence-123"],
+            reconciliation_id: "recon-123",
+          },
+          latest_reconciliation: {
+            reconciliation_id: "recon-123",
+          },
+          linked_evidence_records: [
+            {
+              evidence_id: "evidence-123",
+              source_system: "wazuh",
+              derivation_relationship: "native_detection_record",
+            },
+          ],
+        },
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/alerts/alert-123"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Alert Detail" })).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("Authoritative anchor").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Subordinate evidence context").length).toBeGreaterThan(0);
+    expect(screen.getByText("live_wazuh_webhook")).toBeInTheDocument();
+    expect(screen.getByText("recon-123")).toBeInTheDocument();
+  });
+
+  it("renders case detail with provenance summary and subordinate context", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-case-detail": {
+          case_id: "case-456",
+          case_record: {
+            case_id: "case-456",
+            lifecycle_state: "pending_action",
+          },
+          linked_alert_ids: ["alert-123"],
+          linked_observation_ids: ["observation-123"],
+          linked_recommendation_ids: ["recommendation-123"],
+          linked_evidence_ids: ["evidence-123"],
+          linked_reconciliation_ids: ["recon-123"],
+          provenance_summary: {
+            authoritative_anchor: {
+              record_family: "case",
+              record_id: "case-456",
+              source_family: "github_audit",
+              provenance_classification: "authoritative",
+            },
+          },
+          linked_alert_records: [
+            {
+              alert_id: "alert-123",
+            },
+          ],
+          linked_evidence_records: [
+            {
+              evidence_id: "evidence-123",
+            },
+          ],
+          linked_reconciliation_records: [
+            {
+              reconciliation_id: "recon-123",
+            },
+          ],
+          cross_source_timeline: [
+            {
+              record_family: "case",
+              record_id: "case-456",
+              source_family: "github_audit",
+              provenance_classification: "authoritative",
+            },
+          ],
+        },
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Case Detail" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Provenance summary")).toBeInTheDocument();
+    expect(screen.getByText("Subordinate evidence context")).toBeInTheDocument();
+    expect(screen.getAllByText("github_audit").length).toBeGreaterThan(0);
+    expect(screen.getByText("recon-123")).toBeInTheDocument();
+  });
+
+  it("renders readiness from the reviewed diagnostics surface", async () => {
+    const fetchFn = createAuthorizedFetch({
+      "/diagnostics/readiness": {
+        status: "ready",
+        booted: true,
+        startup: {
+          startup_ready: true,
+        },
+        shutdown: {
+          shutdown_ready: false,
+        },
+        persistence_mode: "postgresql",
+        latest_reconciliation: {
+          reconciliation_id: "recon-123",
+        },
+        metrics: {
+          action_requests: {
+            approved: 1,
+          },
+          action_executions: {
+            terminal: 1,
+          },
+          review_path_health: {
+            overall_state: "healthy",
+            review_count: 1,
+          },
+          source_health: {
+            tracked_sources: 1,
+          },
+          automation_substrate_health: {
+            tracked_surfaces: 1,
+          },
+        },
+      },
+    });
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/readiness"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Readiness" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("postgresql")).toBeInTheDocument();
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/diagnostics/readiness?order=ASC&page=1&per_page=1&sort=status",
+      expect.any(Object),
+    );
+  });
+
+  it("renders reconciliation mismatch visibility from reviewed records", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-reconciliation-status": {
+          read_only: true,
+          total_records: 1,
+          records: [
+            {
+              reconciliation_id: "recon-123",
+              lifecycle_state: "mismatch",
+              ingest_disposition: "updated",
+              mismatch_summary: "case linkage mismatch remains unresolved",
+              compared_at: "2026-04-21T00:00:00+00:00",
+              subject_linkage: {
+                case_ids: ["case-456"],
+              },
+            },
+          ],
+        },
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/reconciliation"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Reconciliation" })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getAllByText("case linkage mismatch remains unresolved").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/mismatch/i).length).toBeGreaterThan(0);
   });
 });

--- a/apps/operator-ui/src/app/OperatorRoutes.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import type { AuthProvider } from "react-admin";
 import { OperatorShell } from "./OperatorShell";
+import { createOperatorDataProvider } from "../dataProvider";
 import {
   AuthAccessError,
   createOperatorAuthProvider,
@@ -19,10 +20,12 @@ import {
   SessionStore,
   createSessionStore,
 } from "../auth/session";
+import type { DataProvider } from "react-admin";
 
 export interface OperatorAppDependencies {
   authProvider: AuthProvider;
   config: OperatorUiConfig;
+  dataProvider: DataProvider;
   sessionStore: SessionStore;
 }
 
@@ -40,6 +43,9 @@ export function createDefaultDependencies(
     config,
     fetchFn: overrides.fetchFn,
   });
+  const dataProvider = createOperatorDataProvider({
+    fetchFn: overrides.fetchFn,
+  });
 
   const authProvider = createOperatorAuthProvider({
     config,
@@ -51,6 +57,7 @@ export function createDefaultDependencies(
   return {
     authProvider,
     config,
+    dataProvider,
     sessionStore,
   };
 }
@@ -172,6 +179,7 @@ function InvalidSessionPage({
 function ProtectedOperatorRoute({
   authProvider,
   config,
+  dataProvider,
   sessionStore,
 }: OperatorAppDependencies) {
   const location = useLocation();
@@ -249,7 +257,7 @@ function ProtectedOperatorRoute({
     return <Navigate replace to={loginHref} />;
   }
 
-  return <OperatorShell authProvider={authProvider} />;
+  return <OperatorShell authProvider={authProvider} dataProvider={dataProvider} />;
 }
 
 export function OperatorRoutes({
@@ -257,7 +265,7 @@ export function OperatorRoutes({
 }: {
   dependencies: OperatorAppDependencies;
 }) {
-  const { authProvider, config, sessionStore } = dependencies;
+  const { authProvider, config, dataProvider, sessionStore } = dependencies;
 
   return (
     <Routes>
@@ -278,6 +286,7 @@ export function OperatorRoutes({
           <ProtectedOperatorRoute
             authProvider={authProvider}
             config={config}
+            dataProvider={dataProvider}
             sessionStore={sessionStore}
           />
         }

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -2,6 +2,8 @@ import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import GavelOutlinedIcon from "@mui/icons-material/GavelOutlined";
 import InboxOutlinedIcon from "@mui/icons-material/InboxOutlined";
 import InsightsOutlinedIcon from "@mui/icons-material/InsightsOutlined";
+import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
+import RuleFolderOutlinedIcon from "@mui/icons-material/RuleFolderOutlined";
 import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
 import {
   Card,
@@ -11,7 +13,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import type { AuthProvider } from "react-admin";
+import type { AuthProvider, DataProvider } from "react-admin";
 import {
   AdminContext,
   AppBar,
@@ -21,8 +23,15 @@ import {
   TitlePortal,
 } from "react-admin";
 import { Route, Routes } from "react-router-dom";
-import { operatorDataProvider } from "../dataProvider";
 import { operatorTheme } from "./theme";
+import {
+  AlertDetailPage,
+  CaseDetailPage,
+  ProvenancePage,
+  QueuePage,
+  ReadinessPage,
+  ReconciliationPage,
+} from "./operatorConsolePages";
 
 function OperatorAppBar() {
   return (
@@ -48,17 +57,27 @@ function OperatorMenu() {
       <Menu.Item
         leftIcon={<WarningAmberOutlinedIcon />}
         primaryText="Alerts"
-        to="/operator/alerts"
+        to="/operator/queue"
       />
       <Menu.Item
         leftIcon={<InsightsOutlinedIcon />}
         primaryText="Cases"
-        to="/operator/cases"
+        to="/operator/queue"
+      />
+      <Menu.Item
+        leftIcon={<LinkOutlinedIcon />}
+        primaryText="Provenance"
+        to="/operator/provenance/alerts"
       />
       <Menu.Item
         leftIcon={<CheckCircleOutlineIcon />}
         primaryText="Readiness"
         to="/operator/readiness"
+      />
+      <Menu.Item
+        leftIcon={<RuleFolderOutlinedIcon />}
+        primaryText="Reconciliation"
+        to="/operator/reconciliation"
       />
       <Menu.Item
         leftIcon={<GavelOutlinedIcon />}
@@ -87,9 +106,9 @@ function OverviewPage() {
         {[
           {
             title: "Queue",
-            chip: "Next slice",
+            chip: "Primary surface",
             description:
-              "Queue triage pages will land here once the reviewed data adapter is wired.",
+              "Queue triage stays inside AegisOps as the authoritative review selection surface.",
           },
           {
             title: "Alerts",
@@ -160,54 +179,26 @@ function PlaceholderPage({
 
 export function OperatorShell({
   authProvider,
+  dataProvider,
 }: {
   authProvider: AuthProvider;
+  dataProvider: DataProvider;
 }) {
   return (
     <AdminContext
       authProvider={authProvider}
-      dataProvider={operatorDataProvider}
+      dataProvider={dataProvider}
       theme={operatorTheme}
     >
       <Layout appBar={OperatorAppBar} menu={OperatorMenu}>
         <Routes>
           <Route element={<OverviewPage />} index />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Reviewed queue views will render backend-authoritative queue summaries here."
-                title="Queue"
-              />
-            }
-            path="queue"
-          />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Alert pages remain read-only and anchored to backend-normalized alert records."
-                title="Alerts"
-              />
-            }
-            path="alerts"
-          />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Case pages will preserve authoritative lifecycle state and provenance anchors."
-                title="Cases"
-              />
-            }
-            path="cases"
-          />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Readiness stays derived from authoritative backend state instead of browser-local projections."
-                title="Readiness"
-              />
-            }
-            path="readiness"
-          />
+          <Route element={<QueuePage />} path="queue" />
+          <Route element={<AlertDetailPage />} path="alerts/:alertId" />
+          <Route element={<CaseDetailPage />} path="cases/:caseId" />
+          <Route element={<ProvenancePage />} path="provenance/:family/:recordId" />
+          <Route element={<ReadinessPage />} path="readiness" />
+          <Route element={<ReconciliationPage />} path="reconciliation" />
           <Route
             element={
               <PlaceholderPage
@@ -216,6 +207,33 @@ export function OperatorShell({
               />
             }
             path="action-review"
+          />
+          <Route
+            element={
+              <PlaceholderPage
+                description="Use the queue as the primary route into alert detail."
+                title="Alerts"
+              />
+            }
+            path="alerts"
+          />
+          <Route
+            element={
+              <PlaceholderPage
+                description="Use the queue or linked alert detail to open a specific case."
+                title="Cases"
+              />
+            }
+            path="cases"
+          />
+          <Route
+            element={
+              <PlaceholderPage
+                description="Open provenance from alert or case detail so the page stays anchored to an authoritative record."
+                title="Provenance"
+              />
+            }
+            path="provenance/*"
           />
         </Routes>
       </Layout>

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -1,0 +1,1089 @@
+import LaunchOutlinedIcon from "@mui/icons-material/LaunchOutlined";
+import OpenInNewOutlinedIcon from "@mui/icons-material/OpenInNewOutlined";
+import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  Link,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { Link as ReactRouterLink, useParams } from "react-router-dom";
+import { useDataProvider } from "react-admin";
+
+type UnknownRecord = Record<string, unknown>;
+
+interface QueryState<T> {
+  data: T | null;
+  error: Error | null;
+  loading: boolean;
+}
+
+function asRecord(value: unknown): UnknownRecord | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as UnknownRecord;
+}
+
+function asRecordArray(value: unknown): UnknownRecord[] {
+  return Array.isArray(value)
+    ? value.map((entry) => asRecord(entry)).filter((entry): entry is UnknownRecord => entry !== null)
+    : [];
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .map((entry) => asString(entry))
+        .filter((entry): entry is string => entry !== null)
+    : [];
+}
+
+function getPath(record: UnknownRecord | null, path: string): unknown {
+  if (record === null) {
+    return undefined;
+  }
+
+  return path.split(".").reduce<unknown>((value, segment) => {
+    const next = asRecord(value);
+    return next?.[segment];
+  }, record);
+}
+
+function formatLabel(value: string) {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "Not available";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    const flattened = value
+      .map((entry) => formatValue(entry))
+      .filter((entry) => entry !== "Not available");
+    return flattened.length > 0 ? flattened.join(", ") : "Not available";
+  }
+
+  return JSON.stringify(value);
+}
+
+function statusTone(
+  status: string | null,
+): "default" | "error" | "info" | "success" | "warning" {
+  if (status === null) {
+    return "default";
+  }
+
+  const normalized = status.toLowerCase();
+  if (
+    normalized.includes("failed") ||
+    normalized.includes("forbidden") ||
+    normalized.includes("mismatch") ||
+    normalized.includes("missing") ||
+    normalized.includes("rejected")
+  ) {
+    return "error";
+  }
+  if (
+    normalized.includes("degraded") ||
+    normalized.includes("pending") ||
+    normalized.includes("delayed") ||
+    normalized.includes("expired")
+  ) {
+    return "warning";
+  }
+  if (
+    normalized.includes("matched") ||
+    normalized.includes("healthy") ||
+    normalized.includes("ready") ||
+    normalized.includes("open")
+  ) {
+    return "success";
+  }
+  if (normalized.includes("review") || normalized.includes("triage")) {
+    return "info";
+  }
+
+  return "default";
+}
+
+function useOperatorList(
+  resource: string,
+  filter: Record<string, unknown>,
+  sort: { field: string; order: "ASC" | "DESC" },
+  perPage = 25,
+): QueryState<UnknownRecord[]> {
+  const dataProvider = useDataProvider();
+  const [state, setState] = useState<QueryState<UnknownRecord[]>>({
+    data: null,
+    error: null,
+    loading: true,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    setState({
+      data: null,
+      error: null,
+      loading: true,
+    });
+
+    void dataProvider
+      .getList(resource, {
+        filter,
+        pagination: {
+          page: 1,
+          perPage,
+        },
+        sort,
+      })
+      .then((result) => {
+        if (!active) {
+          return;
+        }
+        setState({
+          data: result.data.map((record) => record as UnknownRecord),
+          error: null,
+          loading: false,
+        });
+      })
+      .catch((error: unknown) => {
+        if (!active) {
+          return;
+        }
+        setState({
+          data: null,
+          error: error instanceof Error ? error : new Error("Unknown operator list error."),
+          loading: false,
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [dataProvider, filter, perPage, resource, sort]);
+
+  return state;
+}
+
+function useOperatorRecord(
+  resource: string,
+  id: string,
+  meta?: Record<string, unknown>,
+): QueryState<UnknownRecord> {
+  const dataProvider = useDataProvider();
+  const [state, setState] = useState<QueryState<UnknownRecord>>({
+    data: null,
+    error: null,
+    loading: true,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    setState({
+      data: null,
+      error: null,
+      loading: true,
+    });
+
+    void dataProvider
+      .getOne(resource, { id, meta })
+      .then((result) => {
+        if (!active) {
+          return;
+        }
+        setState({
+          data: result.data as UnknownRecord,
+          error: null,
+          loading: false,
+        });
+      })
+      .catch((error: unknown) => {
+        if (!active) {
+          return;
+        }
+        setState({
+          data: null,
+          error: error instanceof Error ? error : new Error("Unknown operator record error."),
+          loading: false,
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [dataProvider, id, meta, resource]);
+
+  return state;
+}
+
+function PageFrame({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: ReactNode;
+}) {
+  return (
+    <Stack spacing={3} sx={{ p: { xs: 2, md: 3 } }}>
+      <Stack spacing={1}>
+        <Typography component="h1" variant="h4">
+          {title}
+        </Typography>
+        <Typography color="text.secondary" maxWidth={860} variant="body1">
+          {subtitle}
+        </Typography>
+      </Stack>
+      {children}
+    </Stack>
+  );
+}
+
+function LoadingState({ label }: { label: string }) {
+  return (
+    <Box sx={{ display: "grid", minHeight: 280, placeItems: "center" }}>
+      <Stack alignItems="center" spacing={2}>
+        <CircularProgress aria-label={label} />
+        <Typography color="text.secondary" variant="body2">
+          Loading reviewed operator data.
+        </Typography>
+      </Stack>
+    </Box>
+  );
+}
+
+function ErrorState({ error }: { error: Error }) {
+  return (
+    <Alert severity="error" variant="outlined">
+      {error.message}
+    </Alert>
+  );
+}
+
+function SectionCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+      <CardContent>
+        <Stack spacing={2}>
+          <Stack spacing={0.5}>
+            <Typography variant="h6">{title}</Typography>
+            {subtitle ? (
+              <Typography color="text.secondary" variant="body2">
+                {subtitle}
+              </Typography>
+            ) : null}
+          </Stack>
+          <Divider />
+          {children}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ValueList({
+  entries,
+}: {
+  entries: Array<[string, unknown]>;
+}) {
+  return (
+    <Stack divider={<Divider flexItem />} spacing={0}>
+      {entries.map(([label, value]) => (
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          justifyContent="space-between"
+          key={label}
+          spacing={1}
+          sx={{ py: 1 }}
+        >
+          <Typography color="text.secondary" variant="body2">
+            {label}
+          </Typography>
+          <Typography sx={{ textAlign: { sm: "right" } }} variant="body2">
+            {formatValue(value)}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
+function StatusStrip({
+  values,
+}: {
+  values: Array<[string, string | null]>;
+}) {
+  return (
+    <Stack direction="row" flexWrap="wrap" gap={1}>
+      {values
+        .filter(([, value]) => value !== null)
+        .map(([label, value]) => (
+          <Chip
+            color={statusTone(value)}
+            key={`${label}-${value}`}
+            label={`${label}: ${value}`}
+            size="small"
+            variant={statusTone(value) === "default" ? "outlined" : "filled"}
+          />
+        ))}
+    </Stack>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <Alert severity="info" variant="outlined">
+      {message}
+    </Alert>
+  );
+}
+
+function RecordWarnings({ record }: { record: UnknownRecord }) {
+  const warnings: string[] = [];
+  const reviewState = asString(record.review_state);
+  const externalTicketStatus = asString(getPath(record, "external_ticket_reference.status"));
+
+  if (reviewState !== null && ["degraded", "rejected", "missing_anchor", "mismatch"].includes(reviewState)) {
+    warnings.push(`Review state remains ${reviewState}.`);
+  }
+  if (externalTicketStatus !== null && externalTicketStatus !== "present") {
+    warnings.push(`Non-authoritative coordination reference is ${externalTicketStatus}.`);
+  }
+  if (asString(record.case_id) === null && asString(record.case_lifecycle_state) !== null) {
+    warnings.push("Case lifecycle state is present without an authoritative case identifier.");
+  }
+
+  if (warnings.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={1}>
+      {warnings.map((warning) => (
+        <Alert icon={<ReportProblemOutlinedIcon fontSize="inherit" />} key={warning} severity="warning" variant="outlined">
+          {warning}
+        </Alert>
+      ))}
+    </Stack>
+  );
+}
+
+function extractSubordinateLinks(record: UnknownRecord): Array<{ href: string; label: string }> {
+  const entries: Array<{ href: string; label: string }> = [];
+
+  for (const [key, value] of Object.entries(record)) {
+    const href = asString(value);
+    if (href && /^https?:\/\//.test(href)) {
+      entries.push({
+        href,
+        label: formatLabel(key),
+      });
+    }
+  }
+
+  return entries;
+}
+
+function SubordinateLinks({ records }: { records: UnknownRecord[] }) {
+  const links = records.flatMap((record) => extractSubordinateLinks(record));
+
+  if (links.length === 0) {
+    return (
+      <Typography color="text.secondary" variant="body2">
+        No substrate deep link was exposed by the reviewed backend payload.
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack direction="row" flexWrap="wrap" gap={1}>
+      {links.map((link) => (
+        <Button
+          component={Link}
+          endIcon={<OpenInNewOutlinedIcon />}
+          href={link.href}
+          key={`${link.label}-${link.href}`}
+          rel="noreferrer"
+          size="small"
+          target="_blank"
+          variant="outlined"
+        >
+          {link.label}
+        </Button>
+      ))}
+    </Stack>
+  );
+}
+
+export function QueuePage() {
+  const filter = useMemo(() => ({}), []);
+  const sort = useMemo(
+    () => ({
+      field: "last_seen_at",
+      order: "DESC" as const,
+    }),
+    [],
+  );
+  const { data, error, loading } = useOperatorList("queue", filter, sort);
+
+  return (
+    <PageFrame
+      subtitle="Primary review surface; substrate links stay secondary. AegisOps queue records remain the authoritative selection surface for operator review."
+      title="Analyst Queue"
+    >
+      {loading ? <LoadingState label="Loading analyst queue" /> : null}
+      {error ? <ErrorState error={error} /> : null}
+      {data ? (
+        data.length > 0 ? (
+          <SectionCard
+            subtitle="Explicit degraded, pending, and mismatch states remain visible instead of being smoothed away."
+            title="Queue records"
+          >
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Alert</TableCell>
+                  <TableCell>Review state</TableCell>
+                  <TableCell>Case</TableCell>
+                  <TableCell>Source family</TableCell>
+                  <TableCell>Action review</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {data.map((record) => {
+                  const alertId = asString(record.alert_id) ?? "Unknown alert";
+                  const caseId = asString(record.case_id);
+                  const sourceFamily = asString(
+                    getPath(record, "reviewed_context.source.source_family"),
+                  );
+                  const actionReviewState = asString(
+                    getPath(record, "current_action_review.review_state"),
+                  );
+                  return (
+                    <TableRow hover key={String(record.id ?? alertId)}>
+                      <TableCell>
+                        <Stack spacing={0.75}>
+                          <Link
+                            component={ReactRouterLink}
+                            to={`/operator/alerts/${alertId}`}
+                            underline="hover"
+                          >
+                            {alertId}
+                          </Link>
+                          <Typography color="text.secondary" variant="caption">
+                            {formatValue(record.queue_selection)}
+                          </Typography>
+                        </Stack>
+                      </TableCell>
+                      <TableCell>
+                        <StatusStrip values={[["Review", asString(record.review_state)]]} />
+                      </TableCell>
+                      <TableCell>
+                        {caseId ? (
+                          <Link
+                            component={ReactRouterLink}
+                            to={`/operator/cases/${caseId}`}
+                            underline="hover"
+                          >
+                            {caseId}
+                          </Link>
+                        ) : (
+                          <Typography color="text.secondary" variant="body2">
+                            No case anchor
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>{sourceFamily ?? "Not available"}</TableCell>
+                      <TableCell>{actionReviewState ?? "No active review"}</TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </SectionCard>
+        ) : (
+          <EmptyState message="The reviewed analyst queue is empty." />
+        )
+      ) : null}
+
+      {data?.map((record) => (
+        <SectionCard
+          key={`queue-summary-${String(record.id ?? record.alert_id)}`}
+          subtitle="AegisOps-owned queue state stays primary. Subordinate source hints remain secondary below it."
+          title={`Queue summary: ${formatValue(record.alert_id)}`}
+        >
+          <StatusStrip
+            values={[
+              ["Review", asString(record.review_state)],
+              ["Case", asString(record.case_lifecycle_state)],
+              ["Escalation", asString(record.escalation_boundary)],
+              [
+                "Action review",
+                asString(getPath(record, "current_action_review.review_state")),
+              ],
+            ]}
+          />
+          <RecordWarnings record={record} />
+          <ValueList
+            entries={[
+              ["Accountable identities", asStringArray(record.accountable_source_identities)],
+              ["Subordinate detection ids", asStringArray(record.substrate_detection_record_ids)],
+              ["Correlation key", record.correlation_key],
+            ]}
+          />
+        </SectionCard>
+      ))}
+    </PageFrame>
+  );
+}
+
+function AlertDetailPageBody({ alertId }: { alertId: string }) {
+  const { data, error, loading } = useOperatorRecord("alerts", alertId);
+
+  if (loading) {
+    return <LoadingState label="Loading alert detail" />;
+  }
+
+  if (error) {
+    return <ErrorState error={error} />;
+  }
+
+  if (!data) {
+    return <EmptyState message="Alert detail is unavailable." />;
+  }
+
+  const alertRecord = asRecord(data.alert);
+  const caseRecord = asRecord(data.case_record);
+  const lineage = asRecord(data.lineage);
+  const evidenceRecords = asRecordArray(data.linked_evidence_records);
+  const reconciliationRecord = asRecord(data.latest_reconciliation);
+
+  return (
+    <Stack spacing={3}>
+      <SectionCard
+        subtitle="Authoritative anchor records stay primary even when subordinate substrate context disagrees or is missing."
+        title="Authoritative anchor"
+      >
+        <StatusStrip
+          values={[
+            ["Lifecycle", asString(alertRecord?.lifecycle_state)],
+            ["Review", asString(data.review_state)],
+            ["Escalation", asString(data.escalation_boundary)],
+          ]}
+        />
+        <RecordWarnings record={data} />
+        <ValueList
+          entries={[
+            ["Alert id", alertRecord?.alert_id ?? data.alert_id],
+            ["Case id", caseRecord?.case_id],
+            ["Finding id", lineage?.finding_id],
+            ["Analytic signal", lineage?.analytic_signal_id],
+          ]}
+        />
+        <Stack direction="row" gap={1}>
+          {caseRecord?.case_id ? (
+            <Button
+              component={ReactRouterLink}
+              endIcon={<LaunchOutlinedIcon />}
+              to={`/operator/cases/${String(caseRecord.case_id)}`}
+              variant="outlined"
+            >
+              Open case detail
+            </Button>
+          ) : null}
+          <Button
+            component={ReactRouterLink}
+            endIcon={<LaunchOutlinedIcon />}
+            to={`/operator/provenance/alerts/${alertId}`}
+            variant="outlined"
+          >
+            Open provenance
+          </Button>
+        </Stack>
+      </SectionCard>
+
+      <SectionCard
+        subtitle="Admission path and authoritative lineage stay explicit. Missing or partial linkage is not hidden."
+        title="Provenance"
+      >
+        <ValueList
+          entries={[
+            ["Admission kind", getPath(data, "provenance.admission_kind")],
+            ["Admission channel", getPath(data, "provenance.admission_channel")],
+            ["Source system", data.source_system],
+            ["Source families", lineage?.source_systems],
+            ["Accountable identities", lineage?.accountable_source_identities],
+          ]}
+        />
+      </SectionCard>
+
+      <SectionCard
+        subtitle="These surfaces stay secondary to the authoritative alert record and preserve mismatches instead of smoothing them away."
+        title="Subordinate evidence context"
+      >
+        <ValueList
+          entries={[
+            ["Latest reconciliation", reconciliationRecord?.reconciliation_id],
+            ["Detection ids", lineage?.substrate_detection_record_ids],
+            ["Evidence ids", lineage?.evidence_ids],
+            [
+              "Current action review",
+              getPath(data, "current_action_review.review_state"),
+            ],
+          ]}
+        />
+        {evidenceRecords.length > 0 ? (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Evidence</TableCell>
+                <TableCell>Source</TableCell>
+                <TableCell>Relationship</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {evidenceRecords.map((record) => (
+                <TableRow key={String(record.evidence_id)}>
+                  <TableCell>{formatValue(record.evidence_id)}</TableCell>
+                  <TableCell>{formatValue(record.source_system)}</TableCell>
+                  <TableCell>{formatValue(record.derivation_relationship)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <EmptyState message="No subordinate evidence records were linked." />
+        )}
+        <SubordinateLinks records={[...evidenceRecords, reconciliationRecord].filter((record): record is UnknownRecord => record !== null)} />
+      </SectionCard>
+    </Stack>
+  );
+}
+
+export function AlertDetailPage() {
+  const params = useParams();
+  const alertId = asString(params.alertId);
+
+  return (
+    <PageFrame
+      subtitle="Read-only alert inspection keeps authoritative anchors, provenance, and subordinate evidence context explicitly separated."
+      title="Alert Detail"
+    >
+      {alertId ? (
+        <AlertDetailPageBody alertId={alertId} />
+      ) : (
+        <ErrorState error={new Error("Missing alert identifier in the operator route.")} />
+      )}
+    </PageFrame>
+  );
+}
+
+function CaseDetailPageBody({ caseId }: { caseId: string }) {
+  const { data, error, loading } = useOperatorRecord("cases", caseId);
+
+  if (loading) {
+    return <LoadingState label="Loading case detail" />;
+  }
+
+  if (error) {
+    return <ErrorState error={error} />;
+  }
+
+  if (!data) {
+    return <EmptyState message="Case detail is unavailable." />;
+  }
+
+  const caseRecord = asRecord(data.case_record);
+  const provenanceSummary = asRecord(data.provenance_summary);
+  const authoritativeAnchor = asRecord(getPath(provenanceSummary, "authoritative_anchor"));
+  const reconciliationRecords = asRecordArray(data.linked_reconciliation_records);
+  const alertRecords = asRecordArray(data.linked_alert_records);
+  const evidenceRecords = asRecordArray(data.linked_evidence_records);
+  const timelineEntries = asRecordArray(data.cross_source_timeline);
+
+  return (
+    <Stack spacing={3}>
+      <SectionCard
+        subtitle="Case lifecycle state and linked identifiers come from the authoritative AegisOps case record, not from summaries or substrate convenience surfaces."
+        title="Authoritative anchor"
+      >
+        <StatusStrip
+          values={[
+            ["Lifecycle", asString(caseRecord?.lifecycle_state)],
+            ["Current action review", asString(getPath(data, "current_action_review.review_state"))],
+            ["Coordination reference", asString(getPath(data, "external_ticket_reference.status"))],
+          ]}
+        />
+        <RecordWarnings record={data} />
+        <ValueList
+          entries={[
+            ["Case id", caseRecord?.case_id ?? data.case_id],
+            ["Alert ids", data.linked_alert_ids],
+            ["Observation ids", data.linked_observation_ids],
+            ["Recommendation ids", data.linked_recommendation_ids],
+          ]}
+        />
+        <Stack direction="row" gap={1}>
+          <Button
+            component={ReactRouterLink}
+            endIcon={<LaunchOutlinedIcon />}
+            to={`/operator/provenance/cases/${caseId}`}
+            variant="outlined"
+          >
+            Open provenance
+          </Button>
+        </Stack>
+      </SectionCard>
+
+      <SectionCard
+        subtitle="Cross-source lineage stays anchored to the reviewed case record. Only directly linked context is pulled into this surface."
+        title="Provenance summary"
+      >
+        <ValueList
+          entries={[
+            ["Anchor record family", authoritativeAnchor?.record_family],
+            ["Anchor record id", authoritativeAnchor?.record_id],
+            ["Anchor source family", authoritativeAnchor?.source_family],
+            ["Provenance classification", authoritativeAnchor?.provenance_classification],
+            ["Linked evidence ids", data.linked_evidence_ids],
+            ["Linked reconciliation ids", data.linked_reconciliation_ids],
+          ]}
+        />
+      </SectionCard>
+
+      <SectionCard
+        subtitle="Subordinate alert, evidence, and reconciliation context stays visible but secondary to the authoritative case state."
+        title="Subordinate evidence context"
+      >
+        <ValueList
+          entries={[
+            ["Alert records", alertRecords.length],
+            ["Evidence records", evidenceRecords.length],
+            ["Reconciliation records", reconciliationRecords.length],
+          ]}
+        />
+        {timelineEntries.length > 0 ? (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Record family</TableCell>
+                <TableCell>Record id</TableCell>
+                <TableCell>Source family</TableCell>
+                <TableCell>Classification</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {timelineEntries.map((entry, index) => (
+                <TableRow key={`${String(entry.record_id ?? index)}-${index}`}>
+                  <TableCell>{formatValue(entry.record_family)}</TableCell>
+                  <TableCell>{formatValue(entry.record_id)}</TableCell>
+                  <TableCell>{formatValue(entry.source_family)}</TableCell>
+                  <TableCell>{formatValue(entry.provenance_classification)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <EmptyState message="No subordinate cross-source timeline entries were returned." />
+        )}
+        <SubordinateLinks
+          records={[
+            ...alertRecords,
+            ...evidenceRecords,
+            ...reconciliationRecords,
+          ]}
+        />
+      </SectionCard>
+    </Stack>
+  );
+}
+
+export function CaseDetailPage() {
+  const params = useParams();
+  const caseId = asString(params.caseId);
+
+  return (
+    <PageFrame
+      subtitle="Read-only case inspection keeps authoritative lifecycle state primary and preserves subordinate evidence lineage as secondary context."
+      title="Case Detail"
+    >
+      {caseId ? (
+        <CaseDetailPageBody caseId={caseId} />
+      ) : (
+        <ErrorState error={new Error("Missing case identifier in the operator route.")} />
+      )}
+    </PageFrame>
+  );
+}
+
+function ProvenanceAlertBody({ alertId }: { alertId: string }) {
+  const { data, error, loading } = useOperatorRecord("alerts", alertId);
+
+  if (loading) {
+    return <LoadingState label="Loading alert provenance" />;
+  }
+  if (error) {
+    return <ErrorState error={error} />;
+  }
+  if (!data) {
+    return <EmptyState message="Alert provenance is unavailable." />;
+  }
+
+  const lineage = asRecord(data.lineage);
+
+  return (
+    <SectionCard
+      subtitle="This page is provenance-focused but still anchored to the reviewed alert record rather than to substrate-native summaries."
+      title="Alert provenance"
+    >
+      <ValueList
+        entries={[
+          ["Alert id", data.alert_id],
+          ["Reconciliation id", lineage?.reconciliation_id],
+          ["Detection ids", lineage?.substrate_detection_record_ids],
+          ["Accountable identities", lineage?.accountable_source_identities],
+          ["First seen", lineage?.first_seen_at],
+          ["Last seen", lineage?.last_seen_at],
+        ]}
+      />
+    </SectionCard>
+  );
+}
+
+function ProvenanceCaseBody({ caseId }: { caseId: string }) {
+  const { data, error, loading } = useOperatorRecord("cases", caseId);
+
+  if (loading) {
+    return <LoadingState label="Loading case provenance" />;
+  }
+  if (error) {
+    return <ErrorState error={error} />;
+  }
+  if (!data) {
+    return <EmptyState message="Case provenance is unavailable." />;
+  }
+
+  const provenanceSummary = asRecord(data.provenance_summary);
+  const authoritativeAnchor = asRecord(getPath(provenanceSummary, "authoritative_anchor"));
+
+  return (
+    <SectionCard
+      subtitle="Only directly linked case lineage is shown here. Neighbor or sibling lineage is not widened by inference."
+      title="Case provenance"
+    >
+      <ValueList
+        entries={[
+          ["Case id", data.case_id],
+          ["Anchor family", authoritativeAnchor?.record_family],
+          ["Anchor id", authoritativeAnchor?.record_id],
+          ["Anchor source family", authoritativeAnchor?.source_family],
+          ["Linked reconciliation ids", data.linked_reconciliation_ids],
+          ["Linked evidence ids", data.linked_evidence_ids],
+        ]}
+      />
+    </SectionCard>
+  );
+}
+
+export function ProvenancePage() {
+  const params = useParams();
+  const family = asString(params.family);
+  const recordId = asString(params.recordId);
+
+  return (
+    <PageFrame
+      subtitle="Provenance stays a dedicated inspection surface so anchor linkage, lineage, and subordinate context can be reviewed without collapsing them together."
+      title="Provenance"
+    >
+      {family === "alerts" && recordId ? <ProvenanceAlertBody alertId={recordId} /> : null}
+      {family === "cases" && recordId ? <ProvenanceCaseBody caseId={recordId} /> : null}
+      {(family !== "alerts" && family !== "cases") || recordId === null ? (
+        <ErrorState error={new Error("Unsupported provenance route. Use alerts or cases with an authoritative identifier.")} />
+      ) : null}
+    </PageFrame>
+  );
+}
+
+export function ReadinessPage() {
+  const filter = useMemo(() => ({}), []);
+  const sort = useMemo(
+    () => ({
+      field: "status",
+      order: "ASC" as const,
+    }),
+    [],
+  );
+  const { data, error, loading } = useOperatorList("runtimeReadiness", filter, sort, 1);
+
+  const record = data?.[0] ?? null;
+  const reviewPathHealth = asRecord(getPath(record, "metrics.review_path_health"));
+  const sourceHealth = asRecord(getPath(record, "metrics.source_health"));
+  const automationHealth = asRecord(getPath(record, "metrics.automation_substrate_health"));
+
+  return (
+    <PageFrame
+      subtitle="Readiness remains a reviewed status surface. It does not become a hidden write console or override authoritative backend state."
+      title="Readiness"
+    >
+      {loading ? <LoadingState label="Loading readiness diagnostics" /> : null}
+      {error ? <ErrorState error={error} /> : null}
+      {record ? (
+        <Stack spacing={3}>
+          <SectionCard
+            subtitle="Degraded or missing prerequisite signals remain explicit here."
+            title="Readiness status"
+          >
+            <StatusStrip
+              values={[
+                ["Status", asString(record.status)],
+                ["Booted", String(formatValue(record.booted))],
+                ["Startup", String(formatValue(getPath(record, "startup.startup_ready")))],
+                ["Shutdown", String(formatValue(getPath(record, "shutdown.shutdown_ready")))],
+              ]}
+            />
+            <ValueList
+              entries={[
+                ["Persistence mode", record.persistence_mode],
+                ["Latest reconciliation", getPath(record, "latest_reconciliation.reconciliation_id")],
+                ["Action requests approved", getPath(record, "metrics.action_requests.approved")],
+                ["Terminal executions", getPath(record, "metrics.action_executions.terminal")],
+              ]}
+            />
+          </SectionCard>
+          <SectionCard
+            subtitle="Operator-facing health summaries are derived surfaces and stay subordinate to the authoritative diagnostic payload."
+            title="Diagnostic breakdown"
+          >
+            <ValueList
+              entries={[
+                ["Review path overall state", reviewPathHealth?.overall_state],
+                ["Review count", reviewPathHealth?.review_count],
+                ["Tracked sources", sourceHealth?.tracked_sources],
+                ["Tracked automation surfaces", automationHealth?.tracked_surfaces],
+              ]}
+            />
+          </SectionCard>
+        </Stack>
+      ) : null}
+    </PageFrame>
+  );
+}
+
+export function ReconciliationPage() {
+  const filter = useMemo(() => ({}), []);
+  const sort = useMemo(
+    () => ({
+      field: "latest_compared_at",
+      order: "DESC" as const,
+    }),
+    [],
+  );
+  const { data, error, loading } = useOperatorList("reconciliations", filter, sort);
+
+  return (
+    <PageFrame
+      subtitle="Reconciliation surfaces keep mismatch and linkage problems visible instead of collapsing them into generic success dashboards."
+      title="Reconciliation"
+    >
+      {loading ? <LoadingState label="Loading reconciliation status" /> : null}
+      {error ? <ErrorState error={error} /> : null}
+      {data ? (
+        data.length > 0 ? (
+          <Stack spacing={3}>
+            <SectionCard
+              subtitle="Records are sorted from the latest comparison so unresolved mismatches stay visible first."
+              title="Reconciliation records"
+            >
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Reconciliation</TableCell>
+                    <TableCell>Lifecycle</TableCell>
+                    <TableCell>Ingest disposition</TableCell>
+                    <TableCell>Mismatch summary</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {data.map((record) => (
+                    <TableRow key={String(record.id ?? record.reconciliation_id)}>
+                      <TableCell>{formatValue(record.reconciliation_id)}</TableCell>
+                      <TableCell>{formatValue(record.lifecycle_state)}</TableCell>
+                      <TableCell>{formatValue(record.ingest_disposition)}</TableCell>
+                      <TableCell>{formatValue(record.mismatch_summary)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </SectionCard>
+            {data.map((record) => (
+              <SectionCard
+                key={`reconciliation-${String(record.id ?? record.reconciliation_id)}`}
+                subtitle="Authoritative reconciliation state stays primary. Subject linkage remains subordinate context and is shown without payload expansion."
+                title={`Reconciliation detail: ${formatValue(record.reconciliation_id)}`}
+              >
+                <StatusStrip
+                  values={[
+                    ["Lifecycle", asString(record.lifecycle_state)],
+                    ["Disposition", asString(record.ingest_disposition)],
+                  ]}
+                />
+                <ValueList
+                  entries={[
+                    ["Compared at", record.compared_at],
+                    ["Latest compared at", record.latest_compared_at],
+                    ["Mismatch summary", record.mismatch_summary],
+                    ["Subject linkage", record.subject_linkage],
+                  ]}
+                />
+              </SectionCard>
+            ))}
+          </Stack>
+        ) : (
+          <EmptyState message="No reconciliation records are currently available." />
+        )
+      ) : null}
+    </PageFrame>
+  );
+}

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -119,6 +119,40 @@ describe("createOperatorDataProvider", () => {
     );
   });
 
+  it("uses the reviewed readiness diagnostics route for runtime readiness reads", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        status: "ready",
+        read_only: true,
+      }),
+    );
+    const dataProvider = createOperatorDataProvider({ fetchFn });
+
+    await expect(
+      dataProvider.getList("runtimeReadiness", {
+        filter: {},
+        pagination: { page: 1, perPage: 1 },
+        sort: { field: "status", order: "ASC" },
+      }),
+    ).resolves.toEqual({
+      data: [
+        {
+          id: "ready",
+          read_only: true,
+          status: "ready",
+        },
+      ],
+      total: 1,
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith("/diagnostics/readiness?order=ASC&page=1&per_page=1&sort=status", {
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+  });
+
   it("fails closed when a reviewed queue record is missing its authoritative anchor", async () => {
     const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
       jsonResponse({

--- a/apps/operator-ui/src/dataProvider.ts
+++ b/apps/operator-ui/src/dataProvider.ts
@@ -62,9 +62,9 @@ const RESOURCE_BINDINGS: Record<Exclude<OperatorResourceName, "advisoryOutput" |
       recordFamily: "case",
     },
     runtimeReadiness: {
-      detailPath: "/inspect-readiness-diagnostics",
+      detailPath: "/diagnostics/readiness",
       idField: "status",
-      listPath: "/inspect-readiness-diagnostics",
+      listPath: "/diagnostics/readiness",
       listSemantics: "client",
     },
     reconciliations: {


### PR DESCRIPTION
Closes #652
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Phase 30B read-only operator console in `apps/operator-ui` and committed it as `64d52d6` (`Implement read-only operator console pages`).

The shell now routes to real read-only pages for queue, alert detail, case detail, provenance, readiness, and reconciliation, with authoritative-anchor sections kept primary and subordinate evidence context explicitly separated. I also fixed a real adapter drift on readiness: the UI now calls the reviewed backend route `/diagnostics/readiness` instead of the stale `/inspect-readiness-diagnostics` path.

Verification ran clean:
- `npm --prefix apps/operator-ui test -- --run`
- `npm --prefix apps/operator-ui run build`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 652 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`

Summary: Implemented the read-only operator console pages and tightened focused operator-ui coverage, including the corrected readiness adapter route.
State hint: implementing
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test -- --run`; `npm --prefix apps/operator-ui run build`; `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 652 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`
Failure signature: none
Next action: open or update the draft PR for branch `codex/issue-652`, then do a browser-level visual pass if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Queue, Alert Details, Case Details, Provenance, Readiness, and Reconciliation pages to the operator console.
  * Enhanced navigation with new menu items for Provenance and Reconciliation access.
  * Pages now display authoritative information, provenance summaries, and diagnostic data.

* **Tests**
  * Extended end-to-end test coverage for operator routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->