### PR TITLE
Add operator-ui task-action primitives

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.tsx
@@ -22,12 +22,17 @@ import {
   createSessionStore,
 } from "../auth/session";
 import type { DataProvider } from "react-admin";
+import {
+  createOperatorTaskActionClient,
+  type OperatorTaskActionClient,
+} from "../taskActions/taskActionClient";
 
 export interface OperatorAppDependencies {
   authProvider: AuthProvider;
   config: OperatorUiConfig;
   dataProvider: DataProvider;
   sessionStore: SessionStore;
+  taskActionClient: OperatorTaskActionClient;
 }
 
 interface OperatorDependencyOverrides {
@@ -47,6 +52,9 @@ export function createDefaultDependencies(
   const dataProvider = createOperatorDataProvider({
     fetchFn: overrides.fetchFn,
   });
+  const taskActionClient = createOperatorTaskActionClient({
+    fetchFn: overrides.fetchFn,
+  });
 
   const authProvider = createOperatorAuthProvider({
     config,
@@ -60,6 +68,7 @@ export function createDefaultDependencies(
     config,
     dataProvider,
     sessionStore,
+    taskActionClient,
   };
 }
 
@@ -182,6 +191,7 @@ function ProtectedOperatorRoute({
   config,
   dataProvider,
   sessionStore,
+  taskActionClient,
 }: OperatorAppDependencies) {
   const location = useLocation();
   const [session, setSession] = useState<OperatorSession | null>(null);
@@ -267,6 +277,7 @@ function ProtectedOperatorRoute({
       authProvider={authProvider}
       dataProvider={dataProvider}
       operatorRoles={session?.roles ?? []}
+      taskActionClient={taskActionClient}
     />
   );
 }
@@ -276,7 +287,7 @@ export function OperatorRoutes({
 }: {
   dependencies: OperatorAppDependencies;
 }) {
-  const { authProvider, config, dataProvider, sessionStore } = dependencies;
+  const { authProvider, config, dataProvider, sessionStore, taskActionClient } = dependencies;
 
   return (
     <Routes>
@@ -299,6 +310,7 @@ export function OperatorRoutes({
             config={config}
             dataProvider={dataProvider}
             sessionStore={sessionStore}
+            taskActionClient={taskActionClient}
           />
         }
         path={`${config.basePath}/*`}

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -32,6 +32,8 @@ import {
   ReadinessPage,
   ReconciliationPage,
 } from "./operatorConsolePages";
+import { TaskActionClientProvider } from "../taskActions/taskActionPrimitives";
+import type { OperatorTaskActionClient } from "../taskActions/taskActionClient";
 
 function canInspectActionReview(operatorRoles: readonly string[]) {
   return operatorRoles.some((role) =>
@@ -205,10 +207,12 @@ export function OperatorShell({
   authProvider,
   dataProvider,
   operatorRoles,
+  taskActionClient,
 }: {
   authProvider: AuthProvider;
   dataProvider: DataProvider;
   operatorRoles: string[];
+  taskActionClient: OperatorTaskActionClient;
 }) {
   const canViewActionReview = canInspectActionReview(operatorRoles);
 
@@ -218,60 +222,62 @@ export function OperatorShell({
       dataProvider={dataProvider}
       theme={operatorTheme}
     >
-      <Layout
-        appBar={OperatorAppBar}
-        menu={() => <OperatorMenu operatorRoles={operatorRoles} />}
-      >
-        <Routes>
-          <Route element={<OverviewPage operatorRoles={operatorRoles} />} index />
-          <Route element={<QueuePage />} path="queue" />
-          <Route element={<AlertDetailPage />} path="alerts/:alertId" />
-          <Route element={<CaseDetailPage />} path="cases/:caseId" />
-          <Route element={<ProvenancePage />} path="provenance/:family/:recordId" />
-          <Route element={<ReadinessPage />} path="readiness" />
-          <Route element={<ReconciliationPage />} path="reconciliation" />
-          <Route
-            element={
-              canViewActionReview ? (
+      <TaskActionClientProvider client={taskActionClient}>
+        <Layout
+          appBar={OperatorAppBar}
+          menu={() => <OperatorMenu operatorRoles={operatorRoles} />}
+        >
+          <Routes>
+            <Route element={<OverviewPage operatorRoles={operatorRoles} />} index />
+            <Route element={<QueuePage />} path="queue" />
+            <Route element={<AlertDetailPage />} path="alerts/:alertId" />
+            <Route element={<CaseDetailPage />} path="cases/:caseId" />
+            <Route element={<ProvenancePage />} path="provenance/:family/:recordId" />
+            <Route element={<ReadinessPage />} path="readiness" />
+            <Route element={<ReconciliationPage />} path="reconciliation" />
+            <Route
+              element={
+                canViewActionReview ? (
+                  <PlaceholderPage
+                    description="Action review remains inspection-only until a separately reviewed slice introduces action workflows."
+                    title="Action review"
+                  />
+                ) : (
+                  <Navigate replace to="/operator" />
+                )
+              }
+              path="action-review"
+            />
+            <Route
+              element={
                 <PlaceholderPage
-                  description="Action review remains inspection-only until a separately reviewed slice introduces action workflows."
-                  title="Action review"
+                  description="Use the queue as the primary route into alert detail."
+                  title="Alerts"
                 />
-              ) : (
-                <Navigate replace to="/operator" />
-              )
-            }
-            path="action-review"
-          />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Use the queue as the primary route into alert detail."
-                title="Alerts"
-              />
-            }
-            path="alerts"
-          />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Use the queue or linked alert detail to open a specific case."
-                title="Cases"
-              />
-            }
-            path="cases"
-          />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Open provenance from alert or case detail so the page stays anchored to an authoritative record."
-                title="Provenance"
-              />
-            }
-            path="provenance/*"
-          />
-        </Routes>
-      </Layout>
+              }
+              path="alerts"
+            />
+            <Route
+              element={
+                <PlaceholderPage
+                  description="Use the queue or linked alert detail to open a specific case."
+                  title="Cases"
+                />
+              }
+              path="cases"
+            />
+            <Route
+              element={
+                <PlaceholderPage
+                  description="Open provenance from alert or case detail so the page stays anchored to an authoritative record."
+                  title="Provenance"
+                />
+              }
+              path="provenance/*"
+            />
+          </Routes>
+        </Layout>
+      </TaskActionClientProvider>
     </AdminContext>
   );
 }

--- a/apps/operator-ui/src/taskActions/taskActionClient.ts
+++ b/apps/operator-ui/src/taskActions/taskActionClient.ts
@@ -1,0 +1,194 @@
+interface OperatorTaskActionClientConfig {
+  fetchFn?: typeof fetch;
+}
+
+interface PromoteAlertToCasePayload {
+  alert_id: string;
+  case_id?: string;
+  case_lifecycle_state?: string;
+}
+
+interface RecordCaseObservationPayload {
+  case_id: string;
+  author_identity: string;
+  observed_at: string;
+  scope_statement: string;
+  supporting_evidence_ids: string[];
+}
+
+interface RecordCaseLeadPayload {
+  case_id: string;
+  triage_owner: string;
+  triage_rationale: string;
+  observation_id?: string;
+}
+
+interface RecordCaseRecommendationPayload {
+  case_id: string;
+  review_owner: string;
+  intended_outcome: string;
+  lead_id?: string;
+}
+
+interface CreateReviewedActionRequestPayload {
+  family: string;
+  record_id: string;
+  requester_identity: string;
+  recipient_identity: string;
+  message_intent: string;
+  escalation_reason: string;
+  expires_at: string;
+  action_request_id?: string;
+}
+
+interface RecordActionReviewManualFallbackPayload {
+  action_request_id: string;
+  fallback_at: string;
+  fallback_actor_identity: string;
+  authority_boundary: string;
+  reason: string;
+  action_taken: string;
+  verification_evidence_ids: string[];
+  residual_uncertainty?: string;
+}
+
+interface RecordActionReviewEscalationNotePayload {
+  action_request_id: string;
+  escalated_at: string;
+  escalated_by_identity: string;
+  escalated_to: string;
+  note: string;
+}
+
+interface OperatorTaskActionClient {
+  createReviewedActionRequest(
+    payload: CreateReviewedActionRequestPayload,
+  ): Promise<unknown>;
+  promoteAlertToCase(payload: PromoteAlertToCasePayload): Promise<unknown>;
+  recordActionReviewEscalationNote(
+    payload: RecordActionReviewEscalationNotePayload,
+  ): Promise<unknown>;
+  recordActionReviewManualFallback(
+    payload: RecordActionReviewManualFallbackPayload,
+  ): Promise<unknown>;
+  recordCaseLead(payload: RecordCaseLeadPayload): Promise<unknown>;
+  recordCaseObservation(
+    payload: RecordCaseObservationPayload,
+  ): Promise<unknown>;
+  recordCaseRecommendation(
+    payload: RecordCaseRecommendationPayload,
+  ): Promise<unknown>;
+}
+
+const JSON_HEADERS = {
+  Accept: "application/json",
+  "Content-Type": "application/json",
+};
+
+export class OperatorTaskActionError extends Error {
+  code: string | null;
+  details: unknown;
+  status: number;
+
+  constructor(message: string, options: { code?: string | null; details?: unknown; status: number }) {
+    super(message);
+    this.code = options.code ?? null;
+    this.details = options.details;
+    this.name = "OperatorTaskActionError";
+    this.status = options.status;
+  }
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function getErrorMessage(status: number, body: unknown, path: string) {
+  const payload = asObject(body);
+  const message = payload && typeof payload.message === "string" && payload.message.trim()
+    ? payload.message.trim()
+    : `Reviewed task action request failed with status ${status} for ${path}.`;
+  return message;
+}
+
+async function parseJson(response: Response, path: string): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    throw new OperatorTaskActionError(
+      `Reviewed task action response for ${path} is not valid JSON.`,
+      { status: response.status },
+    );
+  }
+}
+
+async function submitJson(
+  fetchFn: typeof fetch,
+  path: string,
+  payload: unknown,
+): Promise<unknown> {
+  const response = await fetchFn(path, {
+    body: JSON.stringify(payload),
+    credentials: "include",
+    headers: JSON_HEADERS,
+    method: "POST",
+  });
+  const body = await parseJson(response, path);
+
+  if (!response.ok) {
+    const errorPayload = asObject(body);
+    throw new OperatorTaskActionError(getErrorMessage(response.status, body, path), {
+      code:
+        errorPayload && typeof errorPayload.error === "string"
+          ? errorPayload.error
+          : null,
+      details: body,
+      status: response.status,
+    });
+  }
+
+  return body;
+}
+
+export function createOperatorTaskActionClient({
+  fetchFn = fetch,
+}: OperatorTaskActionClientConfig = {}): OperatorTaskActionClient {
+  return {
+    createReviewedActionRequest(payload) {
+      return submitJson(fetchFn, "/operator/create-reviewed-action-request", payload);
+    },
+    promoteAlertToCase(payload) {
+      return submitJson(fetchFn, "/operator/promote-alert-to-case", payload);
+    },
+    recordActionReviewEscalationNote(payload) {
+      return submitJson(fetchFn, "/operator/record-action-review-escalation-note", payload);
+    },
+    recordActionReviewManualFallback(payload) {
+      return submitJson(fetchFn, "/operator/record-action-review-manual-fallback", payload);
+    },
+    recordCaseLead(payload) {
+      return submitJson(fetchFn, "/operator/record-case-lead", payload);
+    },
+    recordCaseObservation(payload) {
+      return submitJson(fetchFn, "/operator/record-case-observation", payload);
+    },
+    recordCaseRecommendation(payload) {
+      return submitJson(fetchFn, "/operator/record-case-recommendation", payload);
+    },
+  };
+}
+
+export type {
+  CreateReviewedActionRequestPayload,
+  OperatorTaskActionClient,
+  PromoteAlertToCasePayload,
+  RecordActionReviewEscalationNotePayload,
+  RecordActionReviewManualFallbackPayload,
+  RecordCaseLeadPayload,
+  RecordCaseObservationPayload,
+  RecordCaseRecommendationPayload,
+};

--- a/apps/operator-ui/src/taskActions/taskActionPrimitives.test.tsx
+++ b/apps/operator-ui/src/taskActions/taskActionPrimitives.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AdminContext } from "react-admin";
+import {
+  createOperatorTaskActionClient,
+  OperatorTaskActionError,
+} from "./taskActionClient";
+import {
+  TaskActionClientProvider,
+  TaskActionFormCard,
+  useTaskActionSubmission,
+} from "./taskActionPrimitives";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    status,
+  });
+}
+
+function TestTaskActionForm() {
+  const submission = useTaskActionSubmission<{ case_id: string }>();
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          refreshTargets: (acknowledgement) => [
+            {
+              id: acknowledgement.case_id,
+              label: "Case detail",
+              resource: "cases",
+            },
+          ],
+          run: (client) =>
+            client.recordCaseObservation({
+              author_identity: "analyst@example.com",
+              case_id: "case-123",
+              observed_at: "2026-04-22T00:00:00+00:00",
+              scope_statement: "Reviewed scoped observation",
+              supporting_evidence_ids: ["evidence-123"],
+            }) as Promise<{ case_id: string }>,
+        });
+      }}
+    >
+      <TaskActionFormCard
+        actor={[
+          ["Identity", "analyst@example.com"],
+          ["Role", "Analyst"],
+        ]}
+        binding={[
+          ["Record family", "case"],
+          ["Record id", "case-123"],
+        ]}
+        provenance={[
+          ["Source", "reviewed case detail"],
+          ["Scope", "observation append"],
+        ]}
+        submission={submission}
+        submitLabel="Record observation"
+        subtitle="Shared bounded task-action framing keeps actor, binding, and authoritative reread explicit."
+        title="Record case observation"
+      >
+        <div>Observation body</div>
+      </TaskActionFormCard>
+    </form>
+  );
+}
+
+describe("taskActionPrimitives", () => {
+  it("submits through the bounded task-action client and re-reads authoritative state", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ case_id: "case-123", observation_id: "observation-123" }),
+    );
+    const dataProvider = {
+      create: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      getList: vi.fn(),
+      getMany: vi.fn(),
+      getManyReference: vi.fn(),
+      getOne: vi.fn().mockResolvedValue({
+        data: {
+          case_id: "case-123",
+          current_action_review: {
+            review_state: "pending",
+          },
+          id: "case-123",
+        },
+      }),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    };
+    const user = userEvent.setup();
+
+    render(
+      <AdminContext dataProvider={dataProvider}>
+        <TaskActionClientProvider
+          client={createOperatorTaskActionClient({ fetchFn })}
+        >
+          <TestTaskActionForm />
+        </TaskActionClientProvider>
+      </AdminContext>,
+    );
+
+    const submitButton = screen.getByRole("button", {
+      name: "Record observation",
+    });
+    expect(submitButton).toBeDisabled();
+
+    await user.click(screen.getByRole("checkbox"));
+    expect(submitButton).toBeEnabled();
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/operator/record-case-observation",
+        expect.objectContaining({
+          body: JSON.stringify({
+            author_identity: "analyst@example.com",
+            case_id: "case-123",
+            observed_at: "2026-04-22T00:00:00+00:00",
+            scope_statement: "Reviewed scoped observation",
+            supporting_evidence_ids: ["evidence-123"],
+          }),
+          method: "POST",
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(dataProvider.getOne).toHaveBeenCalledWith("cases", {
+        id: "case-123",
+        meta: undefined,
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        "Authoritative refresh completed from the reviewed backend record. Refreshed: Case detail.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps uncertainty explicit when the authoritative reread fails after submit", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ case_id: "case-123", observation_id: "observation-123" }),
+    );
+    const dataProvider = {
+      create: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      getList: vi.fn(),
+      getMany: vi.fn(),
+      getManyReference: vi.fn(),
+      getOne: vi.fn().mockRejectedValue(new Error("Case reread unavailable.")),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    };
+    const user = userEvent.setup();
+
+    render(
+      <AdminContext dataProvider={dataProvider}>
+        <TaskActionClientProvider
+          client={createOperatorTaskActionClient({ fetchFn })}
+        >
+          <TestTaskActionForm />
+        </TaskActionClientProvider>
+      </AdminContext>,
+    );
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("button", { name: "Record observation" }));
+
+    expect(
+      await screen.findByText(
+        /Authoritative re-read did not complete after submit\. Treat the result as unresolved until the reviewed record is refreshed\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Case reread unavailable\./i)).toBeInTheDocument();
+  });
+
+  it("classifies conflict submit failures without implying success", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse(
+        {
+          error: "conflict",
+          message: "Action is stale against the reviewed backend record.",
+        },
+        409,
+      ),
+    );
+
+    await expect(
+      createOperatorTaskActionClient({ fetchFn }).recordCaseObservation({
+        author_identity: "analyst@example.com",
+        case_id: "case-123",
+        observed_at: "2026-04-22T00:00:00+00:00",
+        scope_statement: "Reviewed scoped observation",
+        supporting_evidence_ids: ["evidence-123"],
+      }),
+    ).rejects.toMatchObject({
+      code: "conflict",
+      message: "Action is stale against the reviewed backend record.",
+      status: 409,
+    } satisfies Partial<OperatorTaskActionError>);
+  });
+});

--- a/apps/operator-ui/src/taskActions/taskActionPrimitives.tsx
+++ b/apps/operator-ui/src/taskActions/taskActionPrimitives.tsx
@@ -1,0 +1,393 @@
+import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  CircularProgress,
+  Divider,
+  FormControlLabel,
+  Stack,
+  Typography,
+} from "@mui/material";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import type { DataProvider, GetOneParams, GetOneResult } from "react-admin";
+import { useDataProvider } from "react-admin";
+import {
+  type OperatorTaskActionClient,
+  OperatorTaskActionError,
+} from "./taskActionClient";
+
+type TaskActionResource = "advisoryOutput" | "alerts" | "cases" | "reconciliations";
+
+interface TaskActionClientProviderProps {
+  children: ReactNode;
+  client: OperatorTaskActionClient;
+}
+
+interface TaskActionContextValue {
+  client: OperatorTaskActionClient;
+}
+
+interface TaskActionRefreshTarget {
+  id: GetOneParams["id"];
+  label: string;
+  meta?: GetOneParams["meta"];
+  resource: TaskActionResource;
+}
+
+interface TaskActionRefreshRecord {
+  data: GetOneResult["data"];
+  label: string;
+  resource: TaskActionResource;
+}
+
+interface TaskActionSubmissionRequest<TAcknowledgement> {
+  refreshTargets?:
+    | TaskActionRefreshTarget[]
+    | ((acknowledgement: TAcknowledgement) => TaskActionRefreshTarget[]);
+  run(client: OperatorTaskActionClient): Promise<TAcknowledgement>;
+}
+
+interface TaskActionSubmissionState<TAcknowledgement> {
+  acknowledgement: TAcknowledgement | null;
+  error: Error | null;
+  phase: "degraded" | "failed" | "idle" | "refreshing" | "submitting" | "success";
+  refreshRecords: TaskActionRefreshRecord[];
+}
+
+interface TaskActionSubmissionController<TAcknowledgement> {
+  reset(): void;
+  state: TaskActionSubmissionState<TAcknowledgement>;
+  submit(request: TaskActionSubmissionRequest<TAcknowledgement>): Promise<void>;
+}
+
+const TaskActionClientContext = createContext<TaskActionContextValue | null>(null);
+
+function taskActionStatusMessage(error: Error | null) {
+  if (error instanceof OperatorTaskActionError) {
+    if (error.status === 401 || error.status === 403) {
+      return "Reviewed backend authorization denied the task action.";
+    }
+    if (error.status === 409) {
+      return "The reviewed backend rejected a stale or conflicting task action.";
+    }
+  }
+
+  return error?.message ?? "The reviewed task action failed.";
+}
+
+async function rereadAuthoritativeTargets(
+  dataProvider: DataProvider,
+  refreshTargets: TaskActionRefreshTarget[],
+): Promise<TaskActionRefreshRecord[]> {
+  const results = await Promise.all(
+    refreshTargets.map(async (target) => {
+      const reread = await dataProvider.getOne(target.resource, {
+        id: target.id,
+        meta: target.meta,
+      });
+      return {
+        data: reread.data,
+        label: target.label,
+        resource: target.resource,
+      };
+    }),
+  );
+
+  return results;
+}
+
+export function TaskActionClientProvider({
+  children,
+  client,
+}: TaskActionClientProviderProps) {
+  const value = useMemo(() => ({ client }), [client]);
+  return (
+    <TaskActionClientContext.Provider value={value}>
+      {children}
+    </TaskActionClientContext.Provider>
+  );
+}
+
+export function useOperatorTaskActionClient() {
+  const context = useContext(TaskActionClientContext);
+  if (context === null) {
+    throw new Error("Operator task-action client context is unavailable.");
+  }
+
+  return context.client;
+}
+
+export function useTaskActionSubmission<TAcknowledgement>(): TaskActionSubmissionController<TAcknowledgement> {
+  const client = useOperatorTaskActionClient();
+  const dataProvider = useDataProvider();
+  const [state, setState] = useState<TaskActionSubmissionState<TAcknowledgement>>({
+    acknowledgement: null,
+    error: null,
+    phase: "idle",
+    refreshRecords: [],
+  });
+
+  return {
+    reset() {
+      setState({
+        acknowledgement: null,
+        error: null,
+        phase: "idle",
+        refreshRecords: [],
+      });
+    },
+    state,
+    async submit(request) {
+      setState({
+        acknowledgement: null,
+        error: null,
+        phase: "submitting",
+        refreshRecords: [],
+      });
+
+      try {
+        const acknowledgement = await request.run(client);
+        const refreshTargets =
+          typeof request.refreshTargets === "function"
+            ? request.refreshTargets(acknowledgement)
+            : (request.refreshTargets ?? []);
+
+        if (refreshTargets.length === 0) {
+          setState({
+            acknowledgement,
+            error: null,
+            phase: "success",
+            refreshRecords: [],
+          });
+          return;
+        }
+
+        setState({
+          acknowledgement,
+          error: null,
+          phase: "refreshing",
+          refreshRecords: [],
+        });
+
+        try {
+          const refreshRecords = await rereadAuthoritativeTargets(
+            dataProvider,
+            refreshTargets,
+          );
+          setState({
+            acknowledgement,
+            error: null,
+            phase: "success",
+            refreshRecords,
+          });
+        } catch (error: unknown) {
+          setState({
+            acknowledgement,
+            error:
+              error instanceof Error
+                ? error
+                : new Error("Authoritative reread failed after task submit."),
+            phase: "degraded",
+            refreshRecords: [],
+          });
+        }
+      } catch (error: unknown) {
+        setState({
+          acknowledgement: null,
+          error:
+            error instanceof Error
+              ? error
+              : new Error("Unknown task-action submit failure."),
+          phase: "failed",
+          refreshRecords: [],
+        });
+      }
+    },
+  };
+}
+
+function TaskActionStatusBanner<TAcknowledgement>({
+  submission,
+}: {
+  submission: TaskActionSubmissionController<TAcknowledgement>;
+}) {
+  const { error, phase, refreshRecords } = submission.state;
+
+  if (phase === "idle") {
+    return null;
+  }
+
+  if (phase === "submitting" || phase === "refreshing") {
+    return (
+      <Alert
+        icon={<CircularProgress aria-label="Submitting reviewed task action" size={18} />}
+        severity="info"
+        variant="outlined"
+      >
+        {phase === "submitting"
+          ? "Submitting the reviewed task action."
+          : "Re-reading authoritative backend state after submit."}
+      </Alert>
+    );
+  }
+
+  if (phase === "success") {
+    return (
+      <Alert severity="success" variant="outlined">
+        Authoritative refresh completed from the reviewed backend record.
+        {refreshRecords.length > 0 ? ` Refreshed: ${refreshRecords.map((record) => record.label).join(", ")}.` : ""}
+      </Alert>
+    );
+  }
+
+  if (phase === "degraded") {
+    return (
+      <Alert
+        icon={<WarningAmberOutlinedIcon fontSize="inherit" />}
+        severity="warning"
+        variant="outlined"
+      >
+        Authoritative re-read did not complete after submit. Treat the result as unresolved until the reviewed record is refreshed. {taskActionStatusMessage(error)}
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert severity="error" variant="outlined">
+      {taskActionStatusMessage(error)}
+    </Alert>
+  );
+}
+
+function MetadataList({
+  entries,
+  title,
+}: {
+  entries: Array<[string, string]>;
+  title: string;
+}) {
+  return (
+    <Stack spacing={1}>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Stack divider={<Divider flexItem />} spacing={0}>
+        {entries.map(([label, value]) => (
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            justifyContent="space-between"
+            key={`${title}-${label}`}
+            spacing={1}
+            sx={{ py: 0.75 }}
+          >
+            <Typography color="text.secondary" variant="body2">
+              {label}
+            </Typography>
+            <Typography sx={{ textAlign: { sm: "right" } }} variant="body2">
+              {value}
+            </Typography>
+          </Stack>
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+export function TaskActionFormCard<TAcknowledgement>({
+  actor,
+  binding,
+  children,
+  confirmLabel = "I confirm this reviewed task action should be submitted.",
+  provenance,
+  submission,
+  submitLabel,
+  subtitle,
+  title,
+}: {
+  actor: Array<[string, string]>;
+  binding: Array<[string, string]>;
+  children: ReactNode;
+  confirmLabel?: string;
+  provenance: Array<[string, string]>;
+  submission: TaskActionSubmissionController<TAcknowledgement>;
+  submitLabel: string;
+  subtitle: string;
+  title: string;
+}) {
+  const [confirmed, setConfirmed] = useState(false);
+  const busy =
+    submission.state.phase === "submitting" ||
+    submission.state.phase === "refreshing";
+
+  return (
+    <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+      <CardContent>
+        <Stack spacing={3}>
+          <Stack spacing={1}>
+            <Typography variant="h6">{title}</Typography>
+            <Typography color="text.secondary" variant="body2">
+              {subtitle}
+            </Typography>
+          </Stack>
+
+          <Divider />
+
+          <Stack direction={{ xs: "column", md: "row" }} spacing={3}>
+            <Box flex={1}>
+              <MetadataList entries={actor} title="Actor context" />
+            </Box>
+            <Box flex={1}>
+              <MetadataList entries={binding} title="Authoritative binding" />
+            </Box>
+            <Box flex={1}>
+              <MetadataList entries={provenance} title="Provenance context" />
+            </Box>
+          </Stack>
+
+          <Divider />
+
+          {children}
+
+          <TaskActionStatusBanner submission={submission} />
+
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            justifyContent="space-between"
+            spacing={2}
+          >
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={confirmed}
+                  onChange={(event) => {
+                    setConfirmed(event.target.checked);
+                  }}
+                />
+              }
+              label={confirmLabel}
+            />
+            <Button disabled={!confirmed || busy} type="submit" variant="contained">
+              {busy ? "Working..." : submitLabel}
+            </Button>
+          </Stack>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+export type {
+  TaskActionRefreshRecord,
+  TaskActionRefreshTarget,
+  TaskActionSubmissionController,
+  TaskActionSubmissionRequest,
+  TaskActionSubmissionState,
+};


### PR DESCRIPTION
## Summary
- add a bounded operator-ui task-action client separate from the read-only dataProvider
- add shared task-action form/submission primitives with explicit confirmation and authoritative reread handling
- cover success, degraded reread, and conflict submit behavior in operator-ui tests

## Verification
- npm --prefix apps/operator-ui test
- npm --prefix apps/operator-ui run build

Closes #661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced task action submission system enabling operators to submit actions (record observations, manage alerts, create requests, log notes) with real-time status feedback and automatic data refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->