### PR TITLE
implementation: add bounded operator-ui flows for promote, observation, lead, and recommendation (#662)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -585,6 +585,7 @@ describe("OperatorRoutes", () => {
     );
   });
 
+
   it("records bounded case observations, leads, and recommendations from case detail", async () => {
     const user = userEvent.setup();
     let caseDetailPayload: Record<string, unknown> = {

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -383,10 +384,12 @@ describe("OperatorRoutes", () => {
       expect(screen.getByRole("heading", { name: "Alert Detail" })).toBeInTheDocument();
     });
 
-    expect(screen.getAllByText("Authoritative anchor").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Subordinate evidence context").length).toBeGreaterThan(0);
-    expect(screen.getByText("live_wazuh_webhook")).toBeInTheDocument();
-    expect(screen.getByText("recon-123")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText("Authoritative anchor").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Subordinate evidence context").length).toBeGreaterThan(0);
+      expect(screen.getByText("live_wazuh_webhook")).toBeInTheDocument();
+      expect(screen.getByText("recon-123")).toBeInTheDocument();
+    });
   });
 
   it("renders case detail with provenance summary and subordinate context", async () => {
@@ -455,6 +458,356 @@ describe("OperatorRoutes", () => {
       expect(screen.getByText("recon-123")).toBeInTheDocument();
     });
   });
+
+  it("promotes an alert into a case from alert detail and re-renders authoritative state", async () => {
+    const user = userEvent.setup();
+    let alertDetailPayload: Record<string, unknown> = {
+      alert_id: "alert-123",
+      alert: {
+        alert_id: "alert-123",
+        lifecycle_state: "triaged",
+      },
+      review_state: "triaged",
+      escalation_boundary: "case_optional",
+      provenance: {
+        admission_kind: "live",
+        admission_channel: "live_wazuh_webhook",
+      },
+      lineage: {
+        source_systems: ["wazuh"],
+      },
+      linked_evidence_records: [],
+    };
+    let caseDetailPayload: Record<string, unknown> = {
+      case_id: "case-456",
+      case_record: {
+        case_id: "case-456",
+        lifecycle_state: "open",
+      },
+      linked_alert_ids: ["alert-123"],
+      linked_observation_ids: [],
+      linked_lead_ids: [],
+      linked_recommendation_ids: [],
+      linked_evidence_ids: [],
+      linked_reconciliation_ids: [],
+      provenance_summary: {
+        authoritative_anchor: {
+          record_family: "case",
+          record_id: "case-456",
+          source_family: "github_audit",
+          provenance_classification: "authoritative",
+        },
+      },
+      linked_alert_records: [],
+      linked_evidence_records: [],
+      linked_reconciliation_records: [],
+      cross_source_timeline: [],
+    };
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation((input, init) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/operator/session")) {
+        return Promise.resolve(
+          jsonResponse({
+            identity: "analyst@example.com",
+            provider: "authentik",
+            roles: ["Analyst"],
+            subject: "operator-7",
+          }),
+        );
+      }
+
+      if (url.startsWith("/inspect-alert-detail")) {
+        return Promise.resolve(jsonResponse(alertDetailPayload));
+      }
+
+      if (url.startsWith("/inspect-case-detail")) {
+        return Promise.resolve(jsonResponse(caseDetailPayload));
+      }
+
+      if (url.startsWith("/operator/promote-alert-to-case")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            alert_id: "alert-123",
+            case_lifecycle_state: "open",
+          }),
+        );
+        alertDetailPayload = {
+          ...alertDetailPayload,
+          case_record: {
+            case_id: "case-456",
+          },
+        };
+        return Promise.resolve(
+          jsonResponse({
+            alert_id: "alert-123",
+            case_id: "case-456",
+            lifecycle_state: "open",
+          }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/alerts/alert-123"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Alert Detail" })).toBeInTheDocument();
+    });
+
+    const promoteSection = await screen.findByRole("heading", {
+      name: "Promote alert into case",
+    });
+    const promoteCard = promoteSection.closest(".MuiCard-root");
+    expect(promoteCard).not.toBeNull();
+
+    await user.click(within(promoteCard as HTMLElement).getByRole("checkbox"));
+    await user.click(
+      within(promoteCard as HTMLElement).getByRole("button", { name: "Promote alert" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText("case-456").length).toBeGreaterThan(0);
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/operator/promote-alert-to-case",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+
+  it("records bounded case observations, leads, and recommendations from case detail", async () => {
+    const user = userEvent.setup();
+    let caseDetailPayload: Record<string, unknown> = {
+      case_id: "case-456",
+      case_record: {
+        case_id: "case-456",
+        lifecycle_state: "pending_action",
+      },
+      linked_alert_ids: ["alert-123"],
+      linked_observation_ids: [],
+      linked_lead_ids: [],
+      linked_recommendation_ids: [],
+      linked_evidence_ids: ["evidence-123"],
+      linked_reconciliation_ids: ["recon-123"],
+      provenance_summary: {
+        authoritative_anchor: {
+          record_family: "case",
+          record_id: "case-456",
+          source_family: "github_audit",
+          provenance_classification: "authoritative",
+        },
+      },
+      linked_alert_records: [],
+      linked_evidence_records: [],
+      linked_reconciliation_records: [],
+      cross_source_timeline: [],
+    };
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation((input, init) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/operator/session")) {
+        return Promise.resolve(
+          jsonResponse({
+            identity: "analyst@example.com",
+            provider: "authentik",
+            roles: ["Analyst"],
+            subject: "operator-7",
+          }),
+        );
+      }
+
+      if (url.startsWith("/inspect-case-detail")) {
+        return Promise.resolve(jsonResponse(caseDetailPayload));
+      }
+
+      if (url.startsWith("/operator/record-case-observation")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            author_identity: "analyst@example.com",
+            case_id: "case-456",
+            observed_at: "2026-04-22T00:00",
+            scope_statement: "Observed repository permission change requires tracked review.",
+            supporting_evidence_ids: ["evidence-123", "evidence-456"],
+          }),
+        );
+        caseDetailPayload = {
+          ...caseDetailPayload,
+          linked_observation_ids: ["observation-123"],
+        };
+        return Promise.resolve(
+          jsonResponse({
+            case_id: "case-456",
+            observation_id: "observation-123",
+          }),
+        );
+      }
+
+      if (url.startsWith("/operator/record-case-lead")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            case_id: "case-456",
+            observation_id: "observation-123",
+            triage_owner: "analyst@example.com",
+            triage_rationale: "Privilege-impacting change needs durable follow-up.",
+          }),
+        );
+        caseDetailPayload = {
+          ...caseDetailPayload,
+          linked_lead_ids: ["lead-123"],
+        };
+        return Promise.resolve(
+          jsonResponse({
+            case_id: "case-456",
+            lead_id: "lead-123",
+            observation_id: "observation-123",
+          }),
+        );
+      }
+
+      if (url.startsWith("/operator/record-case-recommendation")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            case_id: "case-456",
+            intended_outcome: "Review repository owner change evidence before approval.",
+            lead_id: "lead-123",
+            review_owner: "analyst@example.com",
+          }),
+        );
+        caseDetailPayload = {
+          ...caseDetailPayload,
+          linked_recommendation_ids: ["recommendation-123"],
+        };
+        return Promise.resolve(
+          jsonResponse({
+            case_id: "case-456",
+            lead_id: "lead-123",
+            recommendation_id: "recommendation-123",
+          }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Case Detail" })).toBeInTheDocument();
+    });
+
+    const observationSection = await screen.findByRole("heading", {
+      name: "Record case observation",
+    });
+    const observationCard = observationSection.closest(".MuiCard-root");
+    expect(observationCard).not.toBeNull();
+    await user.type(
+      within(observationCard as HTMLElement).getByRole("textbox", {
+        name: "Observed at",
+      }),
+      "2026-04-22T00:00",
+    );
+    await user.type(
+      within(observationCard as HTMLElement).getByRole("textbox", {
+        name: "Scope statement",
+      }),
+      "Observed repository permission change requires tracked review.",
+    );
+    const supportingEvidenceField = within(observationCard as HTMLElement).getByRole(
+      "textbox",
+      {
+        name: "Supporting evidence ids",
+      },
+    );
+    await user.clear(supportingEvidenceField);
+    await user.type(supportingEvidenceField, "evidence-123, evidence-456");
+    await user.click(within(observationCard as HTMLElement).getByRole("checkbox"));
+    await user.click(
+      within(observationCard as HTMLElement).getByRole("button", { name: "Record observation" }),
+    );
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/operator/record-case-observation",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+      expect(screen.getByText("Known observation ids: observation-123")).toBeInTheDocument();
+    });
+
+    const leadSection = screen.getByRole("heading", { name: "Record case lead" });
+    const leadCard = leadSection.closest(".MuiCard-root");
+    expect(leadCard).not.toBeNull();
+    await user.type(
+      within(leadCard as HTMLElement).getByRole("textbox", {
+        name: "Observation id",
+      }),
+      "observation-123",
+    );
+    await user.type(
+      within(leadCard as HTMLElement).getByRole("textbox", {
+        name: "Triage rationale",
+      }),
+      "Privilege-impacting change needs durable follow-up.",
+    );
+    await user.click(within(leadCard as HTMLElement).getByRole("checkbox"));
+    await user.click(
+      within(leadCard as HTMLElement).getByRole("button", { name: "Record lead" }),
+    );
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/operator/record-case-lead",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+      expect(screen.getByText("Known lead ids: lead-123")).toBeInTheDocument();
+    });
+
+    const recommendationSection = screen.getByRole("heading", {
+      name: "Record case recommendation",
+    });
+    const recommendationCard = recommendationSection.closest(".MuiCard-root");
+    expect(recommendationCard).not.toBeNull();
+    await user.type(
+      within(recommendationCard as HTMLElement).getByRole("textbox", {
+        name: "Lead id",
+      }),
+      "lead-123",
+    );
+    await user.type(
+      within(recommendationCard as HTMLElement).getByRole("textbox", {
+        name: "Intended outcome",
+      }),
+      "Review repository owner change evidence before approval.",
+    );
+    await user.click(within(recommendationCard as HTMLElement).getByRole("checkbox"));
+    await user.click(
+      within(recommendationCard as HTMLElement).getByRole("button", {
+        name: "Record recommendation",
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText("recommendation-123").length).toBeGreaterThan(0);
+    });
+  }, 10000);
 
   it("renders readiness from the reviewed diagnostics surface", async () => {
     const fetchFn = createAuthorizedFetch({

--- a/apps/operator-ui/src/app/OperatorRoutes.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.tsx
@@ -276,6 +276,7 @@ function ProtectedOperatorRoute({
     <OperatorShell
       authProvider={authProvider}
       dataProvider={dataProvider}
+      operatorIdentity={session?.identity ?? ""}
       operatorRoles={session?.roles ?? []}
       taskActionClient={taskActionClient}
     />

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -206,11 +206,13 @@ function PlaceholderPage({
 export function OperatorShell({
   authProvider,
   dataProvider,
+  operatorIdentity,
   operatorRoles,
   taskActionClient,
 }: {
   authProvider: AuthProvider;
   dataProvider: DataProvider;
+  operatorIdentity: string;
   operatorRoles: string[];
   taskActionClient: OperatorTaskActionClient;
 }) {
@@ -230,8 +232,14 @@ export function OperatorShell({
           <Routes>
             <Route element={<OverviewPage operatorRoles={operatorRoles} />} index />
             <Route element={<QueuePage />} path="queue" />
-            <Route element={<AlertDetailPage />} path="alerts/:alertId" />
-            <Route element={<CaseDetailPage />} path="cases/:caseId" />
+            <Route
+              element={<AlertDetailPage operatorIdentity={operatorIdentity} />}
+              path="alerts/:alertId"
+            />
+            <Route
+              element={<CaseDetailPage operatorIdentity={operatorIdentity} />}
+              path="cases/:caseId"
+            />
             <Route element={<ProvenancePage />} path="provenance/:family/:recordId" />
             <Route element={<ReadinessPage />} path="readiness" />
             <Route element={<ReconciliationPage />} path="reconciliation" />

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -715,6 +715,7 @@ function AlertDetailPageBody({
 
       <PromoteAlertToCaseCard
         alertId={alertId}
+        key={alertId}
         currentCaseId={asString(caseRecord?.case_id)}
         onSubmitted={() => {
           setReloadToken((current) => current + 1);
@@ -875,6 +876,7 @@ function CaseDetailPageBody({
 
       <RecordCaseObservationCard
         caseId={caseId}
+        key={`observation-${caseId}`}
         linkedEvidenceIds={asStringArray(data.linked_evidence_ids)}
         onSubmitted={() => {
           setReloadToken((current) => current + 1);
@@ -884,6 +886,7 @@ function CaseDetailPageBody({
 
       <RecordCaseLeadCard
         caseId={caseId}
+        key={`lead-${caseId}`}
         linkedObservationIds={asStringArray(data.linked_observation_ids)}
         onSubmitted={() => {
           setReloadToken((current) => current + 1);
@@ -893,6 +896,7 @@ function CaseDetailPageBody({
 
       <RecordCaseRecommendationCard
         caseId={caseId}
+        key={`recommendation-${caseId}`}
         linkedLeadIds={asStringArray(data.linked_lead_ids)}
         onSubmitted={() => {
           setReloadToken((current) => current + 1);

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -22,6 +22,12 @@ import {
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { Link as ReactRouterLink, useParams } from "react-router-dom";
 import { useDataProvider } from "react-admin";
+import {
+  PromoteAlertToCaseCard,
+  RecordCaseLeadCard,
+  RecordCaseObservationCard,
+  RecordCaseRecommendationCard,
+} from "../taskActions/caseworkActionCards";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -579,8 +585,16 @@ export function QueuePage() {
   );
 }
 
-function AlertDetailPageBody({ alertId }: { alertId: string }) {
-  const { data, error, loading } = useOperatorRecord("alerts", alertId);
+function AlertDetailPageBody({
+  alertId,
+  operatorIdentity,
+}: {
+  alertId: string;
+  operatorIdentity: string;
+}) {
+  const [reloadToken, setReloadToken] = useState(0);
+  const recordMeta = useMemo(() => ({ reloadToken }), [reloadToken]);
+  const { data, error, loading } = useOperatorRecord("alerts", alertId, recordMeta);
 
   if (loading) {
     return <LoadingState label="Loading alert detail" />;
@@ -698,11 +712,24 @@ function AlertDetailPageBody({ alertId }: { alertId: string }) {
         )}
         <SubordinateLinks records={[...evidenceRecords, reconciliationRecord].filter((record): record is UnknownRecord => record !== null)} />
       </SectionCard>
+
+      <PromoteAlertToCaseCard
+        alertId={alertId}
+        currentCaseId={asString(caseRecord?.case_id)}
+        onSubmitted={() => {
+          setReloadToken((current) => current + 1);
+        }}
+        operatorIdentity={operatorIdentity}
+      />
     </Stack>
   );
 }
 
-export function AlertDetailPage() {
+export function AlertDetailPage({
+  operatorIdentity,
+}: {
+  operatorIdentity: string;
+}) {
   const params = useParams();
   const alertId = asString(params.alertId);
 
@@ -712,7 +739,7 @@ export function AlertDetailPage() {
       title="Alert Detail"
     >
       {alertId ? (
-        <AlertDetailPageBody alertId={alertId} />
+        <AlertDetailPageBody alertId={alertId} operatorIdentity={operatorIdentity} />
       ) : (
         <ErrorState error={new Error("Missing alert identifier in the operator route.")} />
       )}
@@ -720,8 +747,16 @@ export function AlertDetailPage() {
   );
 }
 
-function CaseDetailPageBody({ caseId }: { caseId: string }) {
-  const { data, error, loading } = useOperatorRecord("cases", caseId);
+function CaseDetailPageBody({
+  caseId,
+  operatorIdentity,
+}: {
+  caseId: string;
+  operatorIdentity: string;
+}) {
+  const [reloadToken, setReloadToken] = useState(0);
+  const recordMeta = useMemo(() => ({ reloadToken }), [reloadToken]);
+  const { data, error, loading } = useOperatorRecord("cases", caseId, recordMeta);
 
   if (loading) {
     return <LoadingState label="Loading case detail" />;
@@ -762,6 +797,7 @@ function CaseDetailPageBody({ caseId }: { caseId: string }) {
             ["Case id", caseRecord?.case_id ?? data.case_id],
             ["Alert ids", data.linked_alert_ids],
             ["Observation ids", data.linked_observation_ids],
+            ["Lead ids", data.linked_lead_ids],
             ["Recommendation ids", data.linked_recommendation_ids],
           ]}
         />
@@ -836,11 +872,42 @@ function CaseDetailPageBody({ caseId }: { caseId: string }) {
           ]}
         />
       </SectionCard>
+
+      <RecordCaseObservationCard
+        caseId={caseId}
+        linkedEvidenceIds={asStringArray(data.linked_evidence_ids)}
+        onSubmitted={() => {
+          setReloadToken((current) => current + 1);
+        }}
+        operatorIdentity={operatorIdentity}
+      />
+
+      <RecordCaseLeadCard
+        caseId={caseId}
+        linkedObservationIds={asStringArray(data.linked_observation_ids)}
+        onSubmitted={() => {
+          setReloadToken((current) => current + 1);
+        }}
+        operatorIdentity={operatorIdentity}
+      />
+
+      <RecordCaseRecommendationCard
+        caseId={caseId}
+        linkedLeadIds={asStringArray(data.linked_lead_ids)}
+        onSubmitted={() => {
+          setReloadToken((current) => current + 1);
+        }}
+        operatorIdentity={operatorIdentity}
+      />
     </Stack>
   );
 }
 
-export function CaseDetailPage() {
+export function CaseDetailPage({
+  operatorIdentity,
+}: {
+  operatorIdentity: string;
+}) {
   const params = useParams();
   const caseId = asString(params.caseId);
 
@@ -850,7 +917,7 @@ export function CaseDetailPage() {
       title="Case Detail"
     >
       {caseId ? (
-        <CaseDetailPageBody caseId={caseId} />
+        <CaseDetailPageBody caseId={caseId} operatorIdentity={operatorIdentity} />
       ) : (
         <ErrorState error={new Error("Missing case identifier in the operator route.")} />
       )}

--- a/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AdminContext } from "react-admin";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { createOperatorTaskActionClient } from "./taskActionClient";
+import {
+  PromoteAlertToCaseCard,
+  RecordCaseLeadCard,
+  RecordCaseObservationCard,
+  RecordCaseRecommendationCard,
+} from "./caseworkActionCards";
+import { TaskActionClientProvider } from "./taskActionPrimitives";
+
+const testDataProvider = {
+  create: vi.fn(),
+  delete: vi.fn(),
+  deleteMany: vi.fn(),
+  getList: vi.fn(),
+  getMany: vi.fn(),
+  getManyReference: vi.fn(),
+  getOne: vi.fn(),
+  update: vi.fn(),
+  updateMany: vi.fn(),
+};
+
+function renderWithTaskActionProviders(ui: ReactNode) {
+  return render(
+    <AdminContext dataProvider={testDataProvider}>
+      <TaskActionClientProvider
+        client={createOperatorTaskActionClient({ fetchFn: vi.fn<typeof fetch>() })}
+      >
+        {ui}
+      </TaskActionClientProvider>
+    </AdminContext>,
+  );
+}
+
+function PromoteAlertCardHarness({
+  alertId,
+  currentCaseId,
+}: {
+  alertId: string;
+  currentCaseId: string | null;
+}) {
+  return (
+    <PromoteAlertToCaseCard
+      alertId={alertId}
+      currentCaseId={currentCaseId}
+      key={alertId}
+      operatorIdentity="analyst@example.com"
+    />
+  );
+}
+
+function CaseworkCardsHarness({
+  caseId,
+  linkedEvidenceIds,
+  linkedLeadIds,
+  linkedObservationIds,
+}: {
+  caseId: string;
+  linkedEvidenceIds: string[];
+  linkedLeadIds: string[];
+  linkedObservationIds: string[];
+}) {
+  return (
+    <>
+      <RecordCaseObservationCard
+        caseId={caseId}
+        key={`observation-${caseId}`}
+        linkedEvidenceIds={linkedEvidenceIds}
+        operatorIdentity="analyst@example.com"
+      />
+      <RecordCaseLeadCard
+        caseId={caseId}
+        key={`lead-${caseId}`}
+        linkedObservationIds={linkedObservationIds}
+        operatorIdentity="analyst@example.com"
+      />
+      <RecordCaseRecommendationCard
+        caseId={caseId}
+        key={`recommendation-${caseId}`}
+        linkedLeadIds={linkedLeadIds}
+        operatorIdentity="analyst@example.com"
+      />
+    </>
+  );
+}
+
+describe("caseworkActionCards", () => {
+  it("resets promote draft state when the bound alert id changes", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderWithTaskActionProviders(
+      <PromoteAlertCardHarness alertId="alert-123" currentCaseId={null} />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Case id override" }),
+      "case-stale",
+    );
+    expect(screen.getByRole("textbox", { name: "Case id override" })).toHaveValue(
+      "case-stale",
+    );
+
+    rerender(
+      <AdminContext dataProvider={testDataProvider}>
+        <TaskActionClientProvider
+          client={createOperatorTaskActionClient({ fetchFn: vi.fn<typeof fetch>() })}
+        >
+          <PromoteAlertCardHarness alertId="alert-456" currentCaseId="case-456" />
+        </TaskActionClientProvider>
+      </AdminContext>,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Case id override" })).toHaveValue("");
+    expect(screen.getByText("alert-456")).toBeInTheDocument();
+  });
+
+  it("resets observation, lead, and recommendation drafts when the bound case id changes", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderWithTaskActionProviders(
+      <CaseworkCardsHarness
+        caseId="case-456"
+        linkedEvidenceIds={["evidence-123"]}
+        linkedLeadIds={["lead-123"]}
+        linkedObservationIds={["observation-123"]}
+      />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: "Observed at" }), "2026");
+    await user.type(screen.getByRole("textbox", { name: "Scope statement" }), "scope");
+    await user.clear(screen.getByRole("textbox", { name: "Supporting evidence ids" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Supporting evidence ids" }),
+      "stale-evidence",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Observation id" }),
+      "stale-observation",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Triage rationale" }),
+      "stale-rationale",
+    );
+    await user.type(screen.getByRole("textbox", { name: "Lead id" }), "stale-lead");
+    await user.type(
+      screen.getByRole("textbox", { name: "Intended outcome" }),
+      "stale-outcome",
+    );
+
+    rerender(
+      <AdminContext dataProvider={testDataProvider}>
+        <TaskActionClientProvider
+          client={createOperatorTaskActionClient({ fetchFn: vi.fn<typeof fetch>() })}
+        >
+          <CaseworkCardsHarness
+            caseId="case-789"
+            linkedEvidenceIds={["evidence-789"]}
+            linkedLeadIds={["lead-789"]}
+            linkedObservationIds={["observation-789"]}
+          />
+        </TaskActionClientProvider>
+      </AdminContext>,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Observed at" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Scope statement" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Supporting evidence ids" })).toHaveValue(
+      "evidence-789",
+    );
+    expect(screen.getByRole("textbox", { name: "Observation id" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Triage rationale" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Lead id" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Intended outcome" })).toHaveValue("");
+    expect(screen.getByText("Known observation ids: observation-789")).toBeInTheDocument();
+    expect(screen.getByText("Known lead ids: lead-789")).toBeInTheDocument();
+  });
+});

--- a/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
@@ -1,0 +1,379 @@
+import { MenuItem, Stack, TextField } from "@mui/material";
+import { useState } from "react";
+import {
+  TaskActionFormCard,
+  useTaskActionSubmission,
+} from "./taskActionPrimitives";
+
+function normalizeOptionalString(value: string) {
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function splitIdentifierList(value: string) {
+  return value
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function PromoteAlertToCaseCard({
+  alertId,
+  currentCaseId,
+  onSubmitted,
+  operatorIdentity,
+}: {
+  alertId: string;
+  currentCaseId: string | null;
+  onSubmitted?: () => void;
+  operatorIdentity: string;
+}) {
+  const submission = useTaskActionSubmission<{ case_id?: string }>();
+  const [caseIdOverride, setCaseIdOverride] = useState("");
+  const [caseLifecycleState, setCaseLifecycleState] = useState("open");
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          onSubmitted: () => onSubmitted?.(),
+          refreshTargets: (acknowledgement) => [
+            {
+              id: alertId,
+              label: "Alert detail",
+              resource: "alerts",
+            },
+            ...(typeof acknowledgement.case_id === "string" && acknowledgement.case_id.trim()
+              ? [
+                  {
+                    id: acknowledgement.case_id,
+                    label: "Case detail",
+                    resource: "cases" as const,
+                  },
+                ]
+              : []),
+          ],
+          run: (client) =>
+            client.promoteAlertToCase({
+              alert_id: alertId,
+              case_id: normalizeOptionalString(caseIdOverride),
+              case_lifecycle_state: caseLifecycleState,
+            }) as Promise<{ case_id?: string }>,
+        });
+      }}
+    >
+      <TaskActionFormCard
+        actor={[
+          ["Identity", operatorIdentity],
+          ["Action", "Alert promotion"],
+        ]}
+        binding={[
+          ["Record family", "alert"],
+          ["Alert id", alertId],
+          ["Current case", currentCaseId ?? "No authoritative case anchor"],
+        ]}
+        provenance={[
+          ["Backend boundary", "reviewed operator promote endpoint"],
+          ["Refresh target", "alert detail and promoted case detail"],
+        ]}
+        submission={submission}
+        submitLabel="Promote alert"
+        subtitle="This bounded action promotes the reviewed alert into a case and re-reads backend-owned alert and case detail after submit."
+        title="Promote alert into case"
+      >
+        <Stack spacing={2}>
+          <TextField
+            fullWidth
+            label="Case id override"
+            onChange={(event) => {
+              setCaseIdOverride(event.target.value);
+            }}
+            value={caseIdOverride}
+          />
+          <TextField
+            fullWidth
+            label="Lifecycle state"
+            onChange={(event) => {
+              setCaseLifecycleState(event.target.value);
+            }}
+            select
+            value={caseLifecycleState}
+          >
+            <MenuItem value="open">open</MenuItem>
+            <MenuItem value="pending_action">pending_action</MenuItem>
+          </TextField>
+        </Stack>
+      </TaskActionFormCard>
+    </form>
+  );
+}
+
+export function RecordCaseObservationCard({
+  caseId,
+  linkedEvidenceIds,
+  onSubmitted,
+  operatorIdentity,
+}: {
+  caseId: string;
+  linkedEvidenceIds: string[];
+  onSubmitted?: () => void;
+  operatorIdentity: string;
+}) {
+  const submission = useTaskActionSubmission<{ case_id: string }>();
+  const [observedAt, setObservedAt] = useState("");
+  const [scopeStatement, setScopeStatement] = useState("");
+  const [supportingEvidenceIds, setSupportingEvidenceIds] = useState(
+    linkedEvidenceIds.join(", "),
+  );
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          onSubmitted: () => onSubmitted?.(),
+          refreshTargets: [
+            {
+              id: caseId,
+              label: "Case detail",
+              resource: "cases",
+            },
+          ],
+          run: (client) =>
+            client.recordCaseObservation({
+              author_identity: operatorIdentity,
+              case_id: caseId,
+              observed_at: observedAt.trim(),
+              scope_statement: scopeStatement.trim(),
+              supporting_evidence_ids: splitIdentifierList(supportingEvidenceIds),
+            }) as Promise<{ case_id: string }>,
+        });
+      }}
+    >
+      <TaskActionFormCard
+        actor={[
+          ["Identity", operatorIdentity],
+          ["Action", "Case observation"],
+        ]}
+        binding={[
+          ["Record family", "case"],
+          ["Case id", caseId],
+        ]}
+        provenance={[
+          ["Backend boundary", "reviewed operator observation endpoint"],
+          ["Refresh target", "case detail"],
+        ]}
+        submission={submission}
+        submitLabel="Record observation"
+        subtitle="Record a reviewed case observation without dropping into a generic editor or bypassing backend-owned case state."
+        title="Record case observation"
+      >
+        <Stack spacing={2}>
+          <TextField
+            fullWidth
+            label="Observed at"
+            onChange={(event) => {
+              setObservedAt(event.target.value);
+            }}
+            required
+            value={observedAt}
+          />
+          <TextField
+            fullWidth
+            label="Scope statement"
+            minRows={3}
+            multiline
+            onChange={(event) => {
+              setScopeStatement(event.target.value);
+            }}
+            required
+            value={scopeStatement}
+          />
+          <TextField
+            fullWidth
+            label="Supporting evidence ids"
+            onChange={(event) => {
+              setSupportingEvidenceIds(event.target.value);
+            }}
+            value={supportingEvidenceIds}
+          />
+        </Stack>
+      </TaskActionFormCard>
+    </form>
+  );
+}
+
+export function RecordCaseLeadCard({
+  caseId,
+  linkedObservationIds,
+  onSubmitted,
+  operatorIdentity,
+}: {
+  caseId: string;
+  linkedObservationIds: string[];
+  onSubmitted?: () => void;
+  operatorIdentity: string;
+}) {
+  const submission = useTaskActionSubmission<{ case_id: string }>();
+  const [observationId, setObservationId] = useState("");
+  const [triageRationale, setTriageRationale] = useState("");
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          onSubmitted: () => onSubmitted?.(),
+          refreshTargets: [
+            {
+              id: caseId,
+              label: "Case detail",
+              resource: "cases",
+            },
+          ],
+          run: (client) =>
+            client.recordCaseLead({
+              case_id: caseId,
+              observation_id: normalizeOptionalString(observationId),
+              triage_owner: operatorIdentity,
+              triage_rationale: triageRationale.trim(),
+            }) as Promise<{ case_id: string }>,
+        });
+      }}
+    >
+      <TaskActionFormCard
+        actor={[
+          ["Identity", operatorIdentity],
+          ["Action", "Case lead"],
+        ]}
+        binding={[
+          ["Record family", "case"],
+          ["Case id", caseId],
+        ]}
+        provenance={[
+          ["Backend boundary", "reviewed operator lead endpoint"],
+          ["Refresh target", "case detail"],
+        ]}
+        submission={submission}
+        submitLabel="Record lead"
+        subtitle="Record the next reviewed lead for this case while keeping the authoritative case linkage and actor identity backend-owned."
+        title="Record case lead"
+      >
+        <Stack spacing={2}>
+          <TextField
+            fullWidth
+            helperText={
+              linkedObservationIds.length > 0
+                ? `Known observation ids: ${linkedObservationIds.join(", ")}`
+                : "No authoritative observation ids are currently linked."
+            }
+            label="Observation id"
+            onChange={(event) => {
+              setObservationId(event.target.value);
+            }}
+            value={observationId}
+          />
+          <TextField
+            fullWidth
+            label="Triage rationale"
+            minRows={3}
+            multiline
+            onChange={(event) => {
+              setTriageRationale(event.target.value);
+            }}
+            required
+            value={triageRationale}
+          />
+        </Stack>
+      </TaskActionFormCard>
+    </form>
+  );
+}
+
+export function RecordCaseRecommendationCard({
+  caseId,
+  linkedLeadIds,
+  onSubmitted,
+  operatorIdentity,
+}: {
+  caseId: string;
+  linkedLeadIds: string[];
+  onSubmitted?: () => void;
+  operatorIdentity: string;
+}) {
+  const submission = useTaskActionSubmission<{ case_id: string }>();
+  const [leadId, setLeadId] = useState("");
+  const [intendedOutcome, setIntendedOutcome] = useState("");
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          onSubmitted: () => onSubmitted?.(),
+          refreshTargets: [
+            {
+              id: caseId,
+              label: "Case detail",
+              resource: "cases",
+            },
+          ],
+          run: (client) =>
+            client.recordCaseRecommendation({
+              case_id: caseId,
+              intended_outcome: intendedOutcome.trim(),
+              lead_id: normalizeOptionalString(leadId),
+              review_owner: operatorIdentity,
+            }) as Promise<{ case_id: string }>,
+        });
+      }}
+    >
+      <TaskActionFormCard
+        actor={[
+          ["Identity", operatorIdentity],
+          ["Action", "Case recommendation"],
+        ]}
+        binding={[
+          ["Record family", "case"],
+          ["Case id", caseId],
+        ]}
+        provenance={[
+          ["Backend boundary", "reviewed operator recommendation endpoint"],
+          ["Refresh target", "case detail"],
+        ]}
+        submission={submission}
+        submitLabel="Record recommendation"
+        subtitle="Record the reviewed recommendation outcome without widening the workflow into approvals, execution control, or reconciliation mutation."
+        title="Record case recommendation"
+      >
+        <Stack spacing={2}>
+          <TextField
+            fullWidth
+            helperText={
+              linkedLeadIds.length > 0
+                ? `Known lead ids: ${linkedLeadIds.join(", ")}`
+                : "No authoritative lead ids are currently linked."
+            }
+            label="Lead id"
+            onChange={(event) => {
+              setLeadId(event.target.value);
+            }}
+            value={leadId}
+          />
+          <TextField
+            fullWidth
+            label="Intended outcome"
+            minRows={3}
+            multiline
+            onChange={(event) => {
+              setIntendedOutcome(event.target.value);
+            }}
+            required
+            value={intendedOutcome}
+          />
+        </Stack>
+      </TaskActionFormCard>
+    </form>
+  );
+}

--- a/apps/operator-ui/src/taskActions/taskActionPrimitives.tsx
+++ b/apps/operator-ui/src/taskActions/taskActionPrimitives.tsx
@@ -51,6 +51,7 @@ interface TaskActionRefreshRecord {
 }
 
 interface TaskActionSubmissionRequest<TAcknowledgement> {
+  onSubmitted?(acknowledgement: TAcknowledgement): void;
   refreshTargets?:
     | TaskActionRefreshTarget[]
     | ((acknowledgement: TAcknowledgement) => TaskActionRefreshTarget[]);
@@ -163,6 +164,7 @@ export function useTaskActionSubmission<TAcknowledgement>(): TaskActionSubmissio
             : (request.refreshTargets ?? []);
 
         if (refreshTargets.length === 0) {
+          request.onSubmitted?.(acknowledgement);
           setState({
             acknowledgement,
             error: null,
@@ -184,6 +186,7 @@ export function useTaskActionSubmission<TAcknowledgement>(): TaskActionSubmissio
             dataProvider,
             refreshTargets,
           );
+          request.onSubmitted?.(acknowledgement);
           setState({
             acknowledgement,
             error: null,
@@ -191,6 +194,7 @@ export function useTaskActionSubmission<TAcknowledgement>(): TaskActionSubmissio
             refreshRecords,
           });
         } catch (error: unknown) {
+          request.onSubmitted?.(acknowledgement);
           setState({
             acknowledgement,
             error:


### PR DESCRIPTION
Closes #662
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the bounded operator-ui casework flows in `apps/operator-ui` and committed them on `codex/issue-662` as `cd62c48` (`Add bounded operator casework flows`).

The alert detail page now exposes a task-oriented promote flow, and the case detail page exposes bounded observation, lead, and recommendation forms. These flows submit through the reviewed task-action client, use the reviewed operator identity, and trigger page-level rereads so the detail views refresh from backend-authoritative state after acknowledged submits. I also surfaced `linked_lead_ids` in case detail and added route-level coverage for all four flows.

Verification:
- `npm --prefix apps/operator-ui test`
- `npm --prefix apps/operator-ui run build`

Build passed. Vite reported a non-blocking large-chunk warning for the existing bundle.

Summary: Added bounded operator-ui promote, observation, lead, and recommendation flows with authoritative rereads, tests, and a checkpoint commit `cd62c48`
State hint: implementing
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test`; `npm --prefix apps/operator-ui run build`
Failure signature: none
Next action: Open or update the branch PR from `codex/issue-662` and hand off for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promote alerts into cases from the alert detail page.
  * Record case observations, leads, and recommendations via new action cards.
  * Case detail view now shows linked resource identifiers and updates after submissions.

* **Tests**
  * End-to-end tests for alert-to-case promotion and for sequential case recording workflows.
  * Component tests ensuring form state resets when switching alerts/cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->