### PR TITLE
implementation: add reviewed action-request and manual-fallback write flows to the operator UI (#663)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
@@ -807,6 +807,345 @@ describe("OperatorRoutes", () => {
     );
     await waitFor(() => {
       expect(screen.getAllByText("recommendation-123").length).toBeGreaterThan(0);
+    });
+  }, 20000);
+
+  it("creates reviewed action requests and records manual follow-up notes from case detail", async () => {
+    const user = userEvent.setup();
+    let caseDetailPayload: Record<string, unknown> = {
+      case_id: "case-456",
+      case_record: {
+        case_id: "case-456",
+        lifecycle_state: "pending_action",
+      },
+      linked_alert_ids: ["alert-123"],
+      linked_observation_ids: ["observation-123"],
+      linked_lead_ids: ["lead-123"],
+      linked_recommendation_ids: ["recommendation-123"],
+      linked_evidence_ids: ["evidence-123"],
+      linked_reconciliation_ids: ["recon-123"],
+      provenance_summary: {
+        authoritative_anchor: {
+          record_family: "case",
+          record_id: "case-456",
+          source_family: "github_audit",
+          provenance_classification: "authoritative",
+        },
+      },
+      linked_alert_records: [],
+      linked_evidence_records: [],
+      linked_reconciliation_records: [],
+      cross_source_timeline: [],
+      current_action_review: null,
+    };
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation((input, init) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/operator/session")) {
+        return Promise.resolve(
+          jsonResponse({
+            identity: "analyst@example.com",
+            provider: "authentik",
+            roles: ["Analyst"],
+            subject: "operator-7",
+          }),
+        );
+      }
+
+      if (url.startsWith("/inspect-case-detail")) {
+        return Promise.resolve(jsonResponse(caseDetailPayload));
+      }
+
+      if (url.startsWith("/operator/create-reviewed-action-request")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            escalation_reason:
+              "Repository owner notification must stay tracked inside the reviewed request path.",
+            expires_at: "2026-04-23T00:00",
+            family: "recommendation",
+            message_intent:
+              "Notify the accountable repository owner about the reviewed repository change.",
+            recipient_identity: "repo-owner@example.com",
+            record_id: "recommendation-123",
+            requester_identity: "analyst@example.com",
+          }),
+        );
+        caseDetailPayload = {
+          ...caseDetailPayload,
+          current_action_review: {
+            action_request_id: "action-request-123",
+            review_state: "unresolved",
+            next_expected_action: "await_manual_follow_up",
+          },
+        };
+        return Promise.resolve(
+          jsonResponse({
+            action_request_id: "action-request-123",
+            case_id: "case-456",
+          }),
+        );
+      }
+
+      if (url.startsWith("/operator/record-action-review-manual-fallback")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            action_request_id: "action-request-123",
+            action_taken:
+              "Completed the approved owner notification manually using the reviewed fallback path.",
+            authority_boundary: "approved_human_fallback",
+            fallback_actor_identity: "analyst@example.com",
+            fallback_at: "2026-04-22T09:15",
+            reason: "The automation path was unavailable after reviewed approval.",
+            residual_uncertainty: "Awaiting recipient acknowledgement.",
+            verification_evidence_ids: ["evidence-123", "evidence-456"],
+          }),
+        );
+        caseDetailPayload = {
+          ...caseDetailPayload,
+          current_action_review: {
+            ...(caseDetailPayload.current_action_review as Record<string, unknown>),
+            runtime_visibility: {
+              manual_fallback: {
+                fallback_actor_identity: "analyst@example.com",
+              },
+            },
+          },
+        };
+        return Promise.resolve(
+          jsonResponse({
+            action_request_id: "action-request-123",
+          }),
+        );
+      }
+
+      if (url.startsWith("/operator/record-action-review-escalation-note")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            action_request_id: "action-request-123",
+            escalated_at: "2026-04-22T09:30",
+            escalated_by_identity: "analyst@example.com",
+            escalated_to: "on-call-manager-001",
+            note: "Escalated because the unresolved reviewed request could not wait for the next shift.",
+          }),
+        );
+        caseDetailPayload = {
+          ...caseDetailPayload,
+          current_action_review: {
+            ...(caseDetailPayload.current_action_review as Record<string, unknown>),
+            runtime_visibility: {
+              ...((
+                (caseDetailPayload.current_action_review as Record<string, unknown>)
+                  .runtime_visibility as Record<string, unknown> | undefined
+              ) ?? {}),
+              escalation_notes: {
+                escalated_by_identity: "analyst@example.com",
+              },
+            },
+          },
+        };
+        return Promise.resolve(
+          jsonResponse({
+            action_request_id: "action-request-123",
+          }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Case Detail" })).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Create reviewed action request" })).toBeInTheDocument();
+    });
+
+    const actionRequestSection = screen.getByRole("heading", {
+      name: "Create reviewed action request",
+    });
+    const actionRequestCard = actionRequestSection.closest(".MuiCard-root");
+    expect(actionRequestCard).not.toBeNull();
+    fireEvent.change(
+      within(actionRequestCard as HTMLElement).getByRole("textbox", {
+        name: "Recommendation id",
+      }),
+      { target: { value: "recommendation-123" } },
+    );
+    fireEvent.change(
+      within(actionRequestCard as HTMLElement).getByRole("textbox", {
+        name: "Recipient identity",
+      }),
+      { target: { value: "repo-owner@example.com" } },
+    );
+    fireEvent.change(
+      within(actionRequestCard as HTMLElement).getByRole("textbox", {
+        name: "Message intent",
+      }),
+      {
+        target: {
+          value: "Notify the accountable repository owner about the reviewed repository change.",
+        },
+      },
+    );
+    fireEvent.change(
+      within(actionRequestCard as HTMLElement).getByRole("textbox", {
+        name: "Escalation reason",
+      }),
+      {
+        target: {
+          value: "Repository owner notification must stay tracked inside the reviewed request path.",
+        },
+      },
+    );
+    fireEvent.change(
+      within(actionRequestCard as HTMLElement).getByRole("textbox", {
+        name: "Expires at",
+      }),
+      { target: { value: "2026-04-23T00:00" } },
+    );
+    fireEvent.click(within(actionRequestCard as HTMLElement).getByRole("checkbox"));
+    fireEvent.click(
+      within(actionRequestCard as HTMLElement).getByRole("button", {
+        name: "Create action request",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/operator/create-reviewed-action-request",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+      expect(screen.getAllByText("action-request-123").length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Record manual fallback" }),
+      ).toBeInTheDocument();
+    });
+    const manualFallbackSection = screen.getByRole("heading", {
+      name: "Record manual fallback",
+    });
+    const manualFallbackCard = manualFallbackSection.closest(".MuiCard-root");
+    expect(manualFallbackCard).not.toBeNull();
+    fireEvent.change(
+      within(manualFallbackCard as HTMLElement).getByRole("textbox", {
+        name: "Fallback at",
+      }),
+      { target: { value: "2026-04-22T09:15" } },
+    );
+    fireEvent.change(
+      within(manualFallbackCard as HTMLElement).getByRole("textbox", {
+        name: "Reason",
+      }),
+      {
+        target: {
+          value: "The automation path was unavailable after reviewed approval.",
+        },
+      },
+    );
+    fireEvent.change(
+      within(manualFallbackCard as HTMLElement).getByRole("textbox", {
+        name: "Action taken",
+      }),
+      {
+        target: {
+          value:
+            "Completed the approved owner notification manually using the reviewed fallback path.",
+        },
+      },
+    );
+    const verificationEvidenceField = within(manualFallbackCard as HTMLElement).getByRole(
+      "textbox",
+      {
+        name: "Verification evidence ids",
+      },
+    );
+    fireEvent.change(verificationEvidenceField, {
+      target: { value: "evidence-123, evidence-456" },
+    });
+    fireEvent.change(
+      within(manualFallbackCard as HTMLElement).getByRole("textbox", {
+        name: "Residual uncertainty",
+      }),
+      { target: { value: "Awaiting recipient acknowledgement." } },
+    );
+    fireEvent.click(within(manualFallbackCard as HTMLElement).getByRole("checkbox"));
+    fireEvent.click(
+      within(manualFallbackCard as HTMLElement).getByRole("button", {
+        name: "Record manual fallback",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/operator/record-action-review-manual-fallback",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Record escalation note" }),
+      ).toBeInTheDocument();
+    });
+    const escalationNoteSection = screen.getByRole("heading", {
+      name: "Record escalation note",
+    });
+    const escalationNoteCard = escalationNoteSection.closest(".MuiCard-root");
+    expect(escalationNoteCard).not.toBeNull();
+    fireEvent.change(
+      within(escalationNoteCard as HTMLElement).getByRole("textbox", {
+        name: "Escalated at",
+      }),
+      { target: { value: "2026-04-22T09:30" } },
+    );
+    fireEvent.change(
+      within(escalationNoteCard as HTMLElement).getByRole("textbox", {
+        name: "Escalated to",
+      }),
+      { target: { value: "on-call-manager-001" } },
+    );
+    fireEvent.change(
+      within(escalationNoteCard as HTMLElement).getByRole("textbox", {
+        name: "Note",
+      }),
+      {
+        target: {
+          value:
+            "Escalated because the unresolved reviewed request could not wait for the next shift.",
+        },
+      },
+    );
+    fireEvent.click(within(escalationNoteCard as HTMLElement).getByRole("checkbox"));
+    fireEvent.click(
+      within(escalationNoteCard as HTMLElement).getByRole("button", {
+        name: "Record escalation note",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/operator/record-action-review-escalation-note",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
     });
   }, 10000);
 

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -23,7 +23,10 @@ import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { Link as ReactRouterLink, useParams } from "react-router-dom";
 import { useDataProvider } from "react-admin";
 import {
+  CreateReviewedActionRequestCard,
   PromoteAlertToCaseCard,
+  RecordActionReviewEscalationNoteCard,
+  RecordActionReviewManualFallbackCard,
   RecordCaseLeadCard,
   RecordCaseObservationCard,
   RecordCaseRecommendationCard,
@@ -778,6 +781,14 @@ function CaseDetailPageBody({
   const alertRecords = asRecordArray(data.linked_alert_records);
   const evidenceRecords = asRecordArray(data.linked_evidence_records);
   const timelineEntries = asRecordArray(data.cross_source_timeline);
+  const currentActionReview = asRecord(data.current_action_review);
+  const linkedEvidenceIds = asStringArray(data.linked_evidence_ids);
+  const linkedObservationIds = asStringArray(data.linked_observation_ids);
+  const linkedLeadIds = asStringArray(data.linked_lead_ids);
+  const linkedRecommendationIds = asStringArray(data.linked_recommendation_ids);
+  const currentActionRequestId = asString(currentActionReview?.action_request_id);
+  const currentReviewState = asString(currentActionReview?.review_state);
+  const nextExpectedAction = asString(currentActionReview?.next_expected_action);
 
   return (
     <Stack spacing={3}>
@@ -877,7 +888,7 @@ function CaseDetailPageBody({
       <RecordCaseObservationCard
         caseId={caseId}
         key={`observation-${caseId}`}
-        linkedEvidenceIds={asStringArray(data.linked_evidence_ids)}
+        linkedEvidenceIds={linkedEvidenceIds}
         onSubmitted={() => {
           setReloadToken((current) => current + 1);
         }}
@@ -887,7 +898,7 @@ function CaseDetailPageBody({
       <RecordCaseLeadCard
         caseId={caseId}
         key={`lead-${caseId}`}
-        linkedObservationIds={asStringArray(data.linked_observation_ids)}
+        linkedObservationIds={linkedObservationIds}
         onSubmitted={() => {
           setReloadToken((current) => current + 1);
         }}
@@ -897,12 +908,53 @@ function CaseDetailPageBody({
       <RecordCaseRecommendationCard
         caseId={caseId}
         key={`recommendation-${caseId}`}
-        linkedLeadIds={asStringArray(data.linked_lead_ids)}
+        linkedLeadIds={linkedLeadIds}
         onSubmitted={() => {
           setReloadToken((current) => current + 1);
         }}
         operatorIdentity={operatorIdentity}
       />
+
+      {linkedRecommendationIds.length > 0 ? (
+        <CreateReviewedActionRequestCard
+          caseId={caseId}
+          key={`action-request-${caseId}`}
+          linkedRecommendationIds={linkedRecommendationIds}
+          onSubmitted={() => {
+            setReloadToken((current) => current + 1);
+          }}
+          operatorIdentity={operatorIdentity}
+        />
+      ) : null}
+
+      {currentActionRequestId ? (
+        <RecordActionReviewManualFallbackCard
+          actionRequestId={currentActionRequestId}
+          caseId={caseId}
+          key={`manual-fallback-${caseId}-${currentActionRequestId}`}
+          linkedEvidenceIds={linkedEvidenceIds}
+          nextExpectedAction={nextExpectedAction}
+          onSubmitted={() => {
+            setReloadToken((current) => current + 1);
+          }}
+          operatorIdentity={operatorIdentity}
+          reviewState={currentReviewState}
+        />
+      ) : null}
+
+      {currentActionRequestId ? (
+        <RecordActionReviewEscalationNoteCard
+          actionRequestId={currentActionRequestId}
+          caseId={caseId}
+          key={`escalation-note-${caseId}-${currentActionRequestId}`}
+          nextExpectedAction={nextExpectedAction}
+          onSubmitted={() => {
+            setReloadToken((current) => current + 1);
+          }}
+          operatorIdentity={operatorIdentity}
+          reviewState={currentReviewState}
+        />
+      ) : null}
     </Stack>
   );
 }

--- a/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
@@ -5,7 +5,10 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { createOperatorTaskActionClient } from "./taskActionClient";
 import {
+  CreateReviewedActionRequestCard,
   PromoteAlertToCaseCard,
+  RecordActionReviewEscalationNoteCard,
+  RecordActionReviewManualFallbackCard,
   RecordCaseLeadCard,
   RecordCaseObservationCard,
   RecordCaseRecommendationCard,
@@ -54,15 +57,19 @@ function PromoteAlertCardHarness({
 }
 
 function CaseworkCardsHarness({
+  actionRequestId,
   caseId,
   linkedEvidenceIds,
   linkedLeadIds,
   linkedObservationIds,
+  linkedRecommendationIds,
 }: {
+  actionRequestId: string;
   caseId: string;
   linkedEvidenceIds: string[];
   linkedLeadIds: string[];
   linkedObservationIds: string[];
+  linkedRecommendationIds: string[];
 }) {
   return (
     <>
@@ -83,6 +90,29 @@ function CaseworkCardsHarness({
         key={`recommendation-${caseId}`}
         linkedLeadIds={linkedLeadIds}
         operatorIdentity="analyst@example.com"
+      />
+      <CreateReviewedActionRequestCard
+        caseId={caseId}
+        key={`action-request-${caseId}`}
+        linkedRecommendationIds={linkedRecommendationIds}
+        operatorIdentity="analyst@example.com"
+      />
+      <RecordActionReviewManualFallbackCard
+        actionRequestId={actionRequestId}
+        caseId={caseId}
+        key={`manual-fallback-${caseId}-${actionRequestId}`}
+        linkedEvidenceIds={linkedEvidenceIds}
+        nextExpectedAction="await_manual_follow_up"
+        operatorIdentity="analyst@example.com"
+        reviewState="unresolved"
+      />
+      <RecordActionReviewEscalationNoteCard
+        actionRequestId={actionRequestId}
+        caseId={caseId}
+        key={`escalation-note-${caseId}-${actionRequestId}`}
+        nextExpectedAction="await_manual_follow_up"
+        operatorIdentity="analyst@example.com"
+        reviewState="unresolved"
       />
     </>
   );
@@ -121,10 +151,12 @@ describe("caseworkActionCards", () => {
     const user = userEvent.setup();
     const { rerender } = renderWithTaskActionProviders(
       <CaseworkCardsHarness
+        actionRequestId="action-request-456"
         caseId="case-456"
         linkedEvidenceIds={["evidence-123"]}
         linkedLeadIds={["lead-123"]}
         linkedObservationIds={["observation-123"]}
+        linkedRecommendationIds={["recommendation-123"]}
       />,
     );
 
@@ -148,6 +180,47 @@ describe("caseworkActionCards", () => {
       screen.getByRole("textbox", { name: "Intended outcome" }),
       "stale-outcome",
     );
+    await user.type(
+      screen.getByRole("textbox", { name: "Recommendation id" }),
+      "stale-recommendation",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Recipient identity" }),
+      "owner-stale@example.com",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Message intent" }),
+      "stale-intent",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Escalation reason" }),
+      "stale-escalation",
+    );
+    await user.type(screen.getByRole("textbox", { name: "Expires at" }), "2026-05");
+    await user.type(
+      screen.getByRole("textbox", { name: "Action request id override" }),
+      "stale-request",
+    );
+    await user.type(screen.getByRole("textbox", { name: "Fallback at" }), "2026-04");
+    await user.type(screen.getByRole("textbox", { name: "Reason" }), "stale-reason");
+    await user.type(
+      screen.getByRole("textbox", { name: "Action taken" }),
+      "stale-action",
+    );
+    await user.clear(
+      screen.getByRole("textbox", { name: "Verification evidence ids" }),
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Verification evidence ids" }),
+      "stale-evidence-list",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Residual uncertainty" }),
+      "stale-uncertainty",
+    );
+    await user.type(screen.getByRole("textbox", { name: "Escalated at" }), "2026-04");
+    await user.type(screen.getByRole("textbox", { name: "Escalated to" }), "stale-manager");
+    await user.type(screen.getByRole("textbox", { name: "Note" }), "stale-note");
 
     rerender(
       <AdminContext dataProvider={testDataProvider}>
@@ -155,10 +228,12 @@ describe("caseworkActionCards", () => {
           client={createOperatorTaskActionClient({ fetchFn: vi.fn<typeof fetch>() })}
         >
           <CaseworkCardsHarness
+            actionRequestId="action-request-789"
             caseId="case-789"
             linkedEvidenceIds={["evidence-789"]}
             linkedLeadIds={["lead-789"]}
             linkedObservationIds={["observation-789"]}
+            linkedRecommendationIds={["recommendation-789"]}
           />
         </TaskActionClientProvider>
       </AdminContext>,
@@ -173,7 +248,26 @@ describe("caseworkActionCards", () => {
     expect(screen.getByRole("textbox", { name: "Triage rationale" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Lead id" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Intended outcome" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Recommendation id" })).toHaveValue(
+      "recommendation-789",
+    );
+    expect(screen.getByRole("textbox", { name: "Recipient identity" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Message intent" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Escalation reason" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Expires at" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Action request id override" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Fallback at" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Reason" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Action taken" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Verification evidence ids" })).toHaveValue(
+      "evidence-789",
+    );
+    expect(screen.getByRole("textbox", { name: "Residual uncertainty" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Escalated at" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Escalated to" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Note" })).toHaveValue("");
     expect(screen.getByText("Known observation ids: observation-789")).toBeInTheDocument();
     expect(screen.getByText("Known lead ids: lead-789")).toBeInTheDocument();
-  });
+    expect(screen.getByText("Known recommendation ids: recommendation-789")).toBeInTheDocument();
+  }, 10000);
 });

--- a/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
@@ -377,3 +377,385 @@ export function RecordCaseRecommendationCard({
     </form>
   );
 }
+
+export function CreateReviewedActionRequestCard({
+  caseId,
+  linkedRecommendationIds,
+  onSubmitted,
+  operatorIdentity,
+}: {
+  caseId: string;
+  linkedRecommendationIds: string[];
+  onSubmitted?: () => void;
+  operatorIdentity: string;
+}) {
+  const submission = useTaskActionSubmission<{ action_request_id?: string; case_id?: string }>();
+  const [recommendationId, setRecommendationId] = useState(
+    linkedRecommendationIds.length === 1 ? linkedRecommendationIds[0] ?? "" : "",
+  );
+  const [recipientIdentity, setRecipientIdentity] = useState("");
+  const [messageIntent, setMessageIntent] = useState("");
+  const [escalationReason, setEscalationReason] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [actionRequestIdOverride, setActionRequestIdOverride] = useState("");
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          onSubmitted: () => onSubmitted?.(),
+          refreshTargets: [
+            {
+              id: caseId,
+              label: "Case detail",
+              resource: "cases",
+            },
+          ],
+          run: (client) =>
+            client.createReviewedActionRequest({
+              action_request_id: normalizeOptionalString(actionRequestIdOverride),
+              escalation_reason: escalationReason.trim(),
+              expires_at: expiresAt.trim(),
+              family: "recommendation",
+              message_intent: messageIntent.trim(),
+              recipient_identity: recipientIdentity.trim(),
+              record_id: recommendationId.trim(),
+              requester_identity: operatorIdentity,
+            }) as Promise<{ action_request_id?: string; case_id?: string }>,
+        });
+      }}
+    >
+      <TaskActionFormCard
+        actor={[
+          ["Identity", operatorIdentity],
+          ["Action", "Reviewed action request"],
+        ]}
+        binding={[
+          ["Record family", "recommendation"],
+          ["Case id", caseId],
+          ["Recommendation id", recommendationId.trim() || "Select authoritative recommendation id"],
+        ]}
+        provenance={[
+          ["Backend boundary", "reviewed operator action-request endpoint"],
+          ["Refresh target", "case detail"],
+        ]}
+        submission={submission}
+        submitLabel="Create action request"
+        subtitle="Create a reviewed action request from an authoritative recommendation anchor without exposing approval or execution controls."
+        title="Create reviewed action request"
+      >
+        <Stack spacing={2}>
+          <TextField
+            fullWidth
+            helperText={
+              linkedRecommendationIds.length > 0
+                ? `Known recommendation ids: ${linkedRecommendationIds.join(", ")}`
+                : "No authoritative recommendation ids are currently linked."
+            }
+            label="Recommendation id"
+            onChange={(event) => {
+              setRecommendationId(event.target.value);
+            }}
+            required
+            value={recommendationId}
+          />
+          <TextField
+            fullWidth
+            label="Recipient identity"
+            onChange={(event) => {
+              setRecipientIdentity(event.target.value);
+            }}
+            required
+            value={recipientIdentity}
+          />
+          <TextField
+            fullWidth
+            label="Message intent"
+            minRows={3}
+            multiline
+            onChange={(event) => {
+              setMessageIntent(event.target.value);
+            }}
+            required
+            value={messageIntent}
+          />
+          <TextField
+            fullWidth
+            label="Escalation reason"
+            minRows={3}
+            multiline
+            onChange={(event) => {
+              setEscalationReason(event.target.value);
+            }}
+            required
+            value={escalationReason}
+          />
+          <TextField
+            fullWidth
+            label="Expires at"
+            onChange={(event) => {
+              setExpiresAt(event.target.value);
+            }}
+            required
+            value={expiresAt}
+          />
+          <TextField
+            fullWidth
+            label="Action request id override"
+            onChange={(event) => {
+              setActionRequestIdOverride(event.target.value);
+            }}
+            value={actionRequestIdOverride}
+          />
+        </Stack>
+      </TaskActionFormCard>
+    </form>
+  );
+}
+
+export function RecordActionReviewManualFallbackCard({
+  actionRequestId,
+  caseId,
+  linkedEvidenceIds,
+  nextExpectedAction,
+  onSubmitted,
+  operatorIdentity,
+  reviewState,
+}: {
+  actionRequestId: string;
+  caseId: string;
+  linkedEvidenceIds: string[];
+  nextExpectedAction: string | null;
+  onSubmitted?: () => void;
+  operatorIdentity: string;
+  reviewState: string | null;
+}) {
+  const submission = useTaskActionSubmission<{ action_request_id: string }>();
+  const [fallbackAt, setFallbackAt] = useState("");
+  const [authorityBoundary, setAuthorityBoundary] = useState("approved_human_fallback");
+  const [reason, setReason] = useState("");
+  const [actionTaken, setActionTaken] = useState("");
+  const [verificationEvidenceIds, setVerificationEvidenceIds] = useState(
+    linkedEvidenceIds.join(", "),
+  );
+  const [residualUncertainty, setResidualUncertainty] = useState("");
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          onSubmitted: () => onSubmitted?.(),
+          refreshTargets: [
+            {
+              id: caseId,
+              label: "Case detail",
+              resource: "cases",
+            },
+          ],
+          run: (client) =>
+            client.recordActionReviewManualFallback({
+              action_request_id: actionRequestId,
+              action_taken: actionTaken.trim(),
+              authority_boundary: authorityBoundary,
+              fallback_actor_identity: operatorIdentity,
+              fallback_at: fallbackAt.trim(),
+              reason: reason.trim(),
+              residual_uncertainty: normalizeOptionalString(residualUncertainty),
+              verification_evidence_ids: splitIdentifierList(verificationEvidenceIds),
+            }) as Promise<{ action_request_id: string }>,
+        });
+      }}
+    >
+      <TaskActionFormCard
+        actor={[
+          ["Identity", operatorIdentity],
+          ["Action", "Manual fallback note"],
+        ]}
+        binding={[
+          ["Record family", "action_request"],
+          ["Case id", caseId],
+          ["Action request id", actionRequestId],
+        ]}
+        provenance={[
+          ["Backend boundary", "reviewed operator manual-fallback endpoint"],
+          ["Current review state", reviewState ?? "Not available"],
+          ["Next expected action", nextExpectedAction ?? "Not available"],
+        ]}
+        submission={submission}
+        submitLabel="Record manual fallback"
+        subtitle="Record a reviewed manual fallback against the authoritative action request without widening the UI into execution ownership or generic coordination editing."
+        title="Record manual fallback"
+      >
+        <Stack spacing={2}>
+          <TextField
+            fullWidth
+            label="Fallback at"
+            onChange={(event) => {
+              setFallbackAt(event.target.value);
+            }}
+            required
+            value={fallbackAt}
+          />
+          <TextField
+            fullWidth
+            label="Authority boundary"
+            onChange={(event) => {
+              setAuthorityBoundary(event.target.value);
+            }}
+            select
+            value={authorityBoundary}
+          >
+            <MenuItem value="approved_human_fallback">approved_human_fallback</MenuItem>
+          </TextField>
+          <TextField
+            fullWidth
+            label="Reason"
+            minRows={3}
+            multiline
+            onChange={(event) => {
+              setReason(event.target.value);
+            }}
+            required
+            value={reason}
+          />
+          <TextField
+            fullWidth
+            label="Action taken"
+            minRows={3}
+            multiline
+            onChange={(event) => {
+              setActionTaken(event.target.value);
+            }}
+            required
+            value={actionTaken}
+          />
+          <TextField
+            fullWidth
+            helperText={
+              linkedEvidenceIds.length > 0
+                ? `Known evidence ids: ${linkedEvidenceIds.join(", ")}`
+                : "No authoritative evidence ids are currently linked."
+            }
+            label="Verification evidence ids"
+            onChange={(event) => {
+              setVerificationEvidenceIds(event.target.value);
+            }}
+            value={verificationEvidenceIds}
+          />
+          <TextField
+            fullWidth
+            label="Residual uncertainty"
+            minRows={2}
+            multiline
+            onChange={(event) => {
+              setResidualUncertainty(event.target.value);
+            }}
+            value={residualUncertainty}
+          />
+        </Stack>
+      </TaskActionFormCard>
+    </form>
+  );
+}
+
+export function RecordActionReviewEscalationNoteCard({
+  actionRequestId,
+  caseId,
+  nextExpectedAction,
+  onSubmitted,
+  operatorIdentity,
+  reviewState,
+}: {
+  actionRequestId: string;
+  caseId: string;
+  nextExpectedAction: string | null;
+  onSubmitted?: () => void;
+  operatorIdentity: string;
+  reviewState: string | null;
+}) {
+  const submission = useTaskActionSubmission<{ action_request_id: string }>();
+  const [escalatedAt, setEscalatedAt] = useState("");
+  const [escalatedTo, setEscalatedTo] = useState("");
+  const [note, setNote] = useState("");
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          onSubmitted: () => onSubmitted?.(),
+          refreshTargets: [
+            {
+              id: caseId,
+              label: "Case detail",
+              resource: "cases",
+            },
+          ],
+          run: (client) =>
+            client.recordActionReviewEscalationNote({
+              action_request_id: actionRequestId,
+              escalated_at: escalatedAt.trim(),
+              escalated_by_identity: operatorIdentity,
+              escalated_to: escalatedTo.trim(),
+              note: note.trim(),
+            }) as Promise<{ action_request_id: string }>,
+        });
+      }}
+    >
+      <TaskActionFormCard
+        actor={[
+          ["Identity", operatorIdentity],
+          ["Action", "Escalation note"],
+        ]}
+        binding={[
+          ["Record family", "action_request"],
+          ["Case id", caseId],
+          ["Action request id", actionRequestId],
+        ]}
+        provenance={[
+          ["Backend boundary", "reviewed operator escalation-note endpoint"],
+          ["Current review state", reviewState ?? "Not available"],
+          ["Next expected action", nextExpectedAction ?? "Not available"],
+        ]}
+        submission={submission}
+        submitLabel="Record escalation note"
+        subtitle="Record a reviewed escalation note on the authoritative action request while keeping approval decisions and execution controls outside this slice."
+        title="Record escalation note"
+      >
+        <Stack spacing={2}>
+          <TextField
+            fullWidth
+            label="Escalated at"
+            onChange={(event) => {
+              setEscalatedAt(event.target.value);
+            }}
+            required
+            value={escalatedAt}
+          />
+          <TextField
+            fullWidth
+            label="Escalated to"
+            onChange={(event) => {
+              setEscalatedTo(event.target.value);
+            }}
+            required
+            value={escalatedTo}
+          />
+          <TextField
+            fullWidth
+            label="Note"
+            minRows={3}
+            multiline
+            onChange={(event) => {
+              setNote(event.target.value);
+            }}
+            required
+            value={note}
+          />
+        </Stack>
+      </TaskActionFormCard>
+    </form>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4563,22 +4563,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     }
   }
 }


### PR DESCRIPTION
Closes #663
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the missing Phase 30C operator UI write flows on case detail. The operator shell now exposes bounded cards for reviewed action-request creation from authoritative recommendation ids, plus reviewed manual-fallback and escalation-note recording against the authoritative current action review. Each flow stays inside the existing reviewed task-action pattern and re-reads case detail after submit instead of trusting local projections.

Coverage was tightened in the operator route tests and card reset tests, and the slice is committed at `b9aac8f` (`Add reviewed action request and fallback UI flows`). Full `apps/operator-ui` tests passed, and the build passed. The Vite build still emits the existing large-chunk warning, but it does not fail the build.

Summary: Added reviewed action-request, manual-fallback, and escalation-note operator UI flows with focused regression coverage; committed as `b9aac8f`.
State hint: implementing
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test`; `npm --prefix apps/operator-ui run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-663` with commit `b9aac8f` and proceed to supervisor review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added action review workflow forms to case detail pages, enabling operators to create reviewed action requests, record manual fallback decisions, and document escalation notes.

* **Tests**
  * Expanded test coverage for new action review workflow components and API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->