### PR TITLE
implementation: add the action-review read shell, detail route, and reviewed timeline surface (#672)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -221,6 +221,67 @@ describe("OperatorRoutes", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the reviewed action-review detail route from backend-authoritative action review data", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {
+          "/inspect-action-review": {
+            action_request_id: "action-request-123",
+            read_only: true,
+            current_action_review: {
+              action_request_id: "action-request-123",
+              review_state: "approved",
+            },
+            action_review: {
+              action_request_id: "action-request-123",
+              review_state: "approved",
+              requester_identity: "analyst@example.com",
+              recipient_identity: "repo-owner@example.com",
+              next_expected_action: "await_execution_receipt",
+              timeline: [
+                {
+                  label: "Requested",
+                  state: "completed",
+                },
+                {
+                  label: "Approved",
+                  state: "active",
+                },
+              ],
+            },
+            case_record: {
+              case_id: "case-456",
+              lifecycle_state: "open",
+            },
+          },
+        },
+        {
+          identity: "approver@example.com",
+          provider: "authentik",
+          roles: ["Approver"],
+          subject: "operator-8",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/action-review/action-request-123"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("action-request-123").length).toBeGreaterThan(0);
+    expect(screen.getByText("await_execution_receipt")).toBeInTheDocument();
+    expect(screen.getByText("repo-owner@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Requested")).toBeInTheDocument();
+    expect(screen.getByText("Approved")).toBeInTheDocument();
+    expect(screen.queryByText(/remains inspection-only until a separately reviewed slice/i)).not.toBeInTheDocument();
+  });
+
   it("renders the reviewed queue route from backend-authoritative queue records", async () => {
     const fetchFn = createAuthorizedFetch({
       "/inspect-analyst-queue": {

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -235,6 +235,7 @@ describe("OperatorRoutes", () => {
             action_review: {
               action_request_id: "action-request-123",
               review_state: "approved",
+              approval_state: "approved",
               requester_identity: "analyst@example.com",
               recipient_identity: "repo-owner@example.com",
               next_expected_action: "await_execution_receipt",
@@ -279,6 +280,11 @@ describe("OperatorRoutes", () => {
     expect(screen.getByText("repo-owner@example.com")).toBeInTheDocument();
     expect(screen.getByText("Requested")).toBeInTheDocument();
     expect(screen.getByText("Approved")).toBeInTheDocument();
+    const approvalChip = screen
+      .getAllByText("Approval: approved")
+      .map((element) => element.closest(".MuiChip-root"))
+      .find((element): element is HTMLElement => element !== null);
+    expect(approvalChip).toHaveClass("MuiChip-colorSuccess");
     expect(screen.queryByText(/remains inspection-only until a separately reviewed slice/i)).not.toBeInTheDocument();
   });
 

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -25,6 +25,7 @@ import {
 import { Navigate, Route, Routes } from "react-router-dom";
 import { operatorTheme } from "./theme";
 import {
+  ActionReviewPage,
   AlertDetailPage,
   CaseDetailPage,
   ProvenancePage,
@@ -246,15 +247,22 @@ export function OperatorShell({
             <Route
               element={
                 canViewActionReview ? (
-                  <PlaceholderPage
-                    description="Action review remains inspection-only until a separately reviewed slice introduces action workflows."
-                    title="Action review"
-                  />
+                  <ActionReviewPage />
                 ) : (
                   <Navigate replace to="/operator" />
                 )
               }
               path="action-review"
+            />
+            <Route
+              element={
+                canViewActionReview ? (
+                  <ActionReviewPage />
+                ) : (
+                  <Navigate replace to="/operator" />
+                )
+              }
+              path="action-review/:actionRequestId"
             />
             <Route
               element={

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -807,6 +807,7 @@ function CaseDetailPageBody({
         <ValueList
           entries={[
             ["Case id", caseRecord?.case_id ?? data.case_id],
+            ["Current action request", currentActionRequestId],
             ["Alert ids", data.linked_alert_ids],
             ["Observation ids", data.linked_observation_ids],
             ["Lead ids", data.linked_lead_ids],
@@ -814,6 +815,16 @@ function CaseDetailPageBody({
           ]}
         />
         <Stack direction="row" gap={1}>
+          {currentActionRequestId ? (
+            <Button
+              component={ReactRouterLink}
+              endIcon={<LaunchOutlinedIcon />}
+              to={`/operator/action-review/${currentActionRequestId}`}
+              variant="outlined"
+            >
+              Open action review
+            </Button>
+          ) : null}
           <Button
             component={ReactRouterLink}
             endIcon={<LaunchOutlinedIcon />}
@@ -976,6 +987,163 @@ export function CaseDetailPage({
         <CaseDetailPageBody caseId={caseId} operatorIdentity={operatorIdentity} />
       ) : (
         <ErrorState error={new Error("Missing case identifier in the operator route.")} />
+      )}
+    </PageFrame>
+  );
+}
+
+function ActionReviewPageBody({
+  actionRequestId,
+}: {
+  actionRequestId: string;
+}) {
+  const { data, error, loading } = useOperatorRecord("actionReview", actionRequestId);
+
+  if (loading) {
+    return <LoadingState label="Loading action review detail" />;
+  }
+  if (error) {
+    return <ErrorState error={error} />;
+  }
+  if (!data) {
+    return <EmptyState message="Action review detail is unavailable." />;
+  }
+
+  const actionReview = asRecord(data.action_review);
+  const currentActionReview = asRecord(data.current_action_review);
+  const caseRecord = asRecord(data.case_record);
+  const alertRecord = asRecord(data.alert_record);
+  const timelineEntries = asRecordArray(actionReview?.timeline);
+  const selectedActionRequestId = asString(actionReview?.action_request_id) ?? actionRequestId;
+  const currentActionRequestId = asString(currentActionReview?.action_request_id);
+
+  return (
+    <Stack spacing={3}>
+      <SectionCard
+        subtitle="This page stays anchored to one authoritative action-review record. Browser-local routing does not redefine the active review."
+        title="Action request detail"
+      >
+        <StatusStrip
+          values={[
+            ["Review", asString(actionReview?.review_state)],
+            ["Approval", asString(actionReview?.approval_state)],
+            ["Execution", asString(actionReview?.action_execution_state)],
+            ["Reconciliation", asString(actionReview?.reconciliation_state)],
+          ]}
+        />
+        {currentActionRequestId && currentActionRequestId !== selectedActionRequestId ? (
+          <Alert severity="warning" variant="outlined">
+            The requested record is no longer the current authoritative review for this scope.
+            Current review: {currentActionRequestId}.
+          </Alert>
+        ) : null}
+        <ValueList
+          entries={[
+            ["Action request id", selectedActionRequestId],
+            ["Current authoritative review", currentActionRequestId],
+            ["Requester", asString(actionReview?.requester_identity)],
+            ["Recipient", asString(actionReview?.recipient_identity)],
+            ["Recommendation id", asString(actionReview?.recommendation_id)],
+            ["Requested at", asString(actionReview?.requested_at)],
+            ["Expires at", asString(actionReview?.expires_at)],
+            ["Next expected action", asString(actionReview?.next_expected_action)],
+            ["Execution surface", asString(actionReview?.execution_surface_id)],
+            ["Execution surface type", asString(actionReview?.execution_surface_type)],
+            ["Message intent", asString(actionReview?.message_intent)],
+            ["Escalation reason", asString(actionReview?.escalation_reason)],
+          ]}
+        />
+        <Stack direction="row" gap={1}>
+          {caseRecord?.case_id ? (
+            <Button
+              component={ReactRouterLink}
+              endIcon={<LaunchOutlinedIcon />}
+              to={`/operator/cases/${String(caseRecord.case_id)}`}
+              variant="outlined"
+            >
+              Open case detail
+            </Button>
+          ) : null}
+          {alertRecord?.alert_id ? (
+            <Button
+              component={ReactRouterLink}
+              endIcon={<LaunchOutlinedIcon />}
+              to={`/operator/alerts/${String(alertRecord.alert_id)}`}
+              variant="outlined"
+            >
+              Open alert detail
+            </Button>
+          ) : null}
+        </Stack>
+      </SectionCard>
+
+      <SectionCard
+        subtitle="Authoritative linkage stays explicit so later approval, execution, and reconciliation panels can extend this view without inferring broader workflow truth."
+        title="Authoritative linkage"
+      >
+        <ValueList
+          entries={[
+            ["Case id", caseRecord?.case_id],
+            ["Case lifecycle", caseRecord?.lifecycle_state],
+            ["Alert id", alertRecord?.alert_id],
+            ["Alert lifecycle", alertRecord?.lifecycle_state],
+            ["Target scope", actionReview?.target_scope],
+            ["Requested payload", actionReview?.requested_payload],
+          ]}
+        />
+      </SectionCard>
+
+      <SectionCard
+        subtitle="Lifecycle-bearing review history remains visible without collapsing request, approval, execution, and reconciliation into one convenience badge."
+        title="Review timeline"
+      >
+        {timelineEntries.length > 0 ? (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Stage</TableCell>
+                <TableCell>State</TableCell>
+                <TableCell>At</TableCell>
+                <TableCell>Details</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {timelineEntries.map((entry, index) => (
+                <TableRow key={`${String(entry.label ?? entry.state ?? index)}-${index}`}>
+                  <TableCell>{formatValue(entry.label)}</TableCell>
+                  <TableCell>{formatValue(entry.state)}</TableCell>
+                  <TableCell>{formatValue(entry.at)}</TableCell>
+                  <TableCell>{formatValue(entry.details)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <EmptyState message="No action review timeline entries were returned." />
+        )}
+      </SectionCard>
+    </Stack>
+  );
+}
+
+export function ActionReviewPage() {
+  const params = useParams();
+  const actionRequestId = asString(params.actionRequestId);
+
+  return (
+    <PageFrame
+      subtitle="Read-only action-review inspection keeps authoritative request detail, active-review selection, and lifecycle history visible without widening the browser into workflow authority."
+      title="Action Review"
+    >
+      {actionRequestId ? (
+        <ActionReviewPageBody actionRequestId={actionRequestId} />
+      ) : (
+        <SectionCard
+          subtitle="Open action review from a case or alert detail page so the shell stays anchored to one authoritative action-request record."
+          title="Select an action review"
+        >
+          <EmptyState message="No action request is selected yet." />
+        </SectionCard>
       )}
     </PageFrame>
   );

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -132,6 +132,10 @@ function statusTone(
     return "warning";
   }
   if (
+    normalized.includes("approved") ||
+    normalized.includes("completed") ||
+    normalized.includes("executed") ||
+    normalized.includes("reconciled") ||
     normalized.includes("matched") ||
     normalized.includes("healthy") ||
     normalized.includes("ready") ||

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -284,6 +284,47 @@ describe("createOperatorDataProvider", () => {
     );
   });
 
+  it("rejects action-review detail payloads whose selected review is missing or mismatched", async () => {
+    const missingSelectedReviewId = createOperatorDataProvider({
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          action_request_id: "action-request-001",
+          action_review: {
+            review_state: "approved",
+          },
+        }),
+      ),
+    });
+
+    await expect(
+      missingSelectedReviewId.getOne("actionReview", {
+        id: "action-request-001",
+      }),
+    ).rejects.toThrow(
+      "Resource actionReview detail payload is missing action_review.action_request_id.",
+    );
+
+    const mismatchedSelectedReviewId = createOperatorDataProvider({
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          action_request_id: "action-request-001",
+          action_review: {
+            action_request_id: "action-request-999",
+            review_state: "approved",
+          },
+        }),
+      ),
+    });
+
+    await expect(
+      mismatchedSelectedReviewId.getOne("actionReview", {
+        id: "action-request-001",
+      }),
+    ).rejects.toThrow(
+      "Resource actionReview requires action_review.action_request_id to match action-request-001.",
+    );
+  });
+
   it("rejects unsupported standard-resource typos explicitly", async () => {
     const dataProvider = createOperatorDataProvider({
       fetchFn: vi.fn<typeof fetch>(),

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -228,6 +228,62 @@ describe("createOperatorDataProvider", () => {
     });
   });
 
+  it("reads one action review by authoritative action_request_id without enabling list semantics", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        action_request_id: "action-request-001",
+        review_state: "approved",
+        current_action_review: {
+          action_request_id: "action-request-001",
+          review_state: "approved",
+        },
+        action_review: {
+          action_request_id: "action-request-001",
+          review_state: "approved",
+          requester_identity: "analyst-001",
+        },
+        case_record: {
+          case_id: "case-001",
+          lifecycle_state: "open",
+        },
+        read_only: true,
+      }),
+    );
+    const dataProvider = createOperatorDataProvider({ fetchFn });
+
+    await expect(
+      dataProvider.getOne("actionReview", {
+        id: "action-request-001",
+      }),
+    ).resolves.toEqual({
+      data: expect.objectContaining({
+        id: "action-request-001",
+        action_request_id: "action-request-001",
+        read_only: true,
+      }),
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/inspect-action-review?action_request_id=action-request-001",
+      {
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
+
+    await expect(
+      dataProvider.getList("actionReview", {
+        filter: {},
+        pagination: { page: 1, perPage: 25 },
+        sort: { field: "id", order: "ASC" },
+      }),
+    ).rejects.toThrow(
+      UnsupportedOperatorDataProviderOperationError,
+    );
+  });
+
   it("rejects unsupported standard-resource typos explicitly", async () => {
     const dataProvider = createOperatorDataProvider({
       fetchFn: vi.fn<typeof fetch>(),

--- a/apps/operator-ui/src/dataProvider.ts
+++ b/apps/operator-ui/src/dataProvider.ts
@@ -590,6 +590,50 @@ async function getOneForAdvisoryOutput(
   };
 }
 
+async function getOneForActionReview(
+  fetchFn: typeof fetch,
+  params: GetOneParams,
+): Promise<GetOneResult> {
+  const requestedId =
+    typeof params.id === "string" || typeof params.id === "number"
+      ? String(params.id).trim()
+      : "";
+
+  if (!requestedId) {
+    throw new OperatorDataProviderContractError(
+      "Resource actionReview getOne requires a non-empty identifier.",
+    );
+  }
+
+  const url = new URL("/inspect-action-review", "http://operator-ui.local");
+  url.searchParams.set("action_request_id", requestedId);
+
+  const payload = asObject(
+    await fetchJson(fetchFn, `${url.pathname}${url.search}`),
+    "Resource actionReview returned a malformed detail payload.",
+  );
+  const authoritativeId = asString(payload.action_request_id);
+
+  if (authoritativeId === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource actionReview detail payload is missing action_request_id.",
+    );
+  }
+
+  if (authoritativeId !== requestedId) {
+    throw new OperatorDataProviderContractError(
+      `Resource actionReview requires response action_request_id to match ${requestedId}.`,
+    );
+  }
+
+  return {
+    data: {
+      ...payload,
+      id: authoritativeId,
+    },
+  };
+}
+
 export function createOperatorDataProvider({
   fetchFn = fetch,
 }: OperatorDataProviderConfig = {}): DataProvider {
@@ -617,7 +661,7 @@ export function createOperatorDataProvider({
       }
 
       if (resource === "actionReview") {
-        return rejectUnsupported("getOne", resource);
+        return getOneForActionReview(fetchFn, params);
       }
 
       if (!isStandardResource(resource)) {

--- a/apps/operator-ui/src/dataProvider.ts
+++ b/apps/operator-ui/src/dataProvider.ts
@@ -613,6 +613,11 @@ async function getOneForActionReview(
     "Resource actionReview returned a malformed detail payload.",
   );
   const authoritativeId = asString(payload.action_request_id);
+  const selectedReview = asObject(
+    payload.action_review,
+    "Resource actionReview detail payload is missing action_review.",
+  );
+  const selectedReviewId = asString(selectedReview.action_request_id);
 
   if (authoritativeId === null) {
     throw new OperatorDataProviderContractError(
@@ -623,6 +628,16 @@ async function getOneForActionReview(
   if (authoritativeId !== requestedId) {
     throw new OperatorDataProviderContractError(
       `Resource actionReview requires response action_request_id to match ${requestedId}.`,
+    );
+  }
+  if (selectedReviewId === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource actionReview detail payload is missing action_review.action_request_id.",
+    );
+  }
+  if (selectedReviewId !== requestedId) {
+    throw new OperatorDataProviderContractError(
+      `Resource actionReview requires action_review.action_request_id to match ${requestedId}.`,
     );
   }
 

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -163,6 +163,7 @@ def build_handler_class(
                 "/inspect-analyst-queue",
                 "/inspect-alert-detail",
                 "/inspect-case-detail",
+                "/inspect-action-review",
                 "/inspect-assistant-context",
                 "/inspect-advisory-output",
                 "/render-recommendation-draft",
@@ -262,6 +263,42 @@ def build_handler_class(
                     return
                 try:
                     payload = service.inspect_case_detail(case_id).to_dict()
+                except ValueError as exc:
+                    self._write_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {
+                            "error": "invalid_request",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                except LookupError as exc:
+                    self._write_json(
+                        HTTPStatus.NOT_FOUND,
+                        {
+                            "error": "not_found",
+                            "message": str(exc),
+                        },
+                    )
+                    return
+                self._write_json(HTTPStatus.OK, payload)
+                return
+
+            if request_path == "/inspect-action-review":
+                action_request_id = normalize_record_id(
+                    parse_qs(request_target.query).get("action_request_id", [""])[0]
+                )
+                if not action_request_id:
+                    self._write_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {
+                            "error": "invalid_request",
+                            "message": "action_request_id query parameter is required",
+                        },
+                    )
+                    return
+                try:
+                    payload = service.inspect_action_review_detail(action_request_id).to_dict()
                 except ValueError as exc:
                     self._write_json(
                         HTTPStatus.BAD_REQUEST,

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Callable, Mapping, Protocol, Type, TypeVar
 
 from .models import (
+    ActionRequestRecord,
     AlertRecord,
     AnalyticSignalRecord,
     CaseRecord,
@@ -137,6 +138,7 @@ class OperatorInspectionReadSurface:
         analyst_queue_snapshot_factory: Callable[..., object],
         alert_detail_snapshot_factory: Callable[..., object],
         case_detail_snapshot_factory: Callable[..., object],
+        action_review_detail_snapshot_factory: Callable[..., object],
         record_to_dict: Callable[[object], dict[str, object]],
         redacted_reconciliation_payload: Callable[[ReconciliationRecord], dict[str, object]],
         normalize_admission_provenance: Callable[[object], dict[str, str] | None],
@@ -148,6 +150,7 @@ class OperatorInspectionReadSurface:
         self._analyst_queue_snapshot_factory = analyst_queue_snapshot_factory
         self._alert_detail_snapshot_factory = alert_detail_snapshot_factory
         self._case_detail_snapshot_factory = case_detail_snapshot_factory
+        self._action_review_detail_snapshot_factory = action_review_detail_snapshot_factory
         self._record_to_dict = record_to_dict
         self._redacted_reconciliation_payload = redacted_reconciliation_payload
         self._normalize_admission_provenance = normalize_admission_provenance
@@ -425,6 +428,66 @@ class OperatorInspectionReadSurface:
             external_ticket_reference=self._build_case_external_ticket_reference_surface(
                 case=case,
                 linked_alert_records=context_snapshot.linked_alert_records,
+            ),
+        )
+
+    def inspect_action_review_detail(self, action_request_id: str) -> object:
+        action_request_id = self._service._require_non_empty_string(
+            action_request_id,
+            "action_request_id",
+        )
+        action_request = self._service._store.get(ActionRequestRecord, action_request_id)
+        if action_request is None:
+            raise LookupError(
+                f"Missing action request {action_request_id!r} for review inspection"
+            )
+
+        case_record = None
+        if action_request.case_id is not None:
+            case_record = self._service._require_reviewed_operator_case(action_request.case_id)
+
+        alert_record = None
+        if action_request.alert_id is not None:
+            alert = self._service._store.get(AlertRecord, action_request.alert_id)
+            if alert is None:
+                raise LookupError(
+                    f"Missing alert record {action_request.alert_id!r} for review inspection"
+                )
+            alert_record = self._service._require_reviewed_operator_alert_record(alert)
+
+        if case_record is None and alert_record is None:
+            raise LookupError(
+                "Action review inspection requires an authoritative reviewed case or alert scope"
+            )
+
+        action_reviews = self._service._action_review_chains_for_scope(
+            case_id=action_request.case_id,
+            alert_id=action_request.alert_id,
+            record_index=self._service._build_action_review_record_index(),
+        )
+        selected_review = next(
+            (
+                review
+                for review in action_reviews
+                if review.get("action_request_id") == action_request_id
+            ),
+            None,
+        )
+        if selected_review is None:
+            raise LookupError(
+                f"Missing authoritative action review projection for {action_request_id!r}"
+            )
+
+        return self._action_review_detail_snapshot_factory(
+            read_only=True,
+            action_request_id=action_request_id,
+            action_review=dict(selected_review),
+            current_action_review=dict(action_reviews[0]) if action_reviews else None,
+            case_record=(
+                self._record_to_dict(case_record) if case_record is not None else None
+            ),
+            alert_record=(
+                self._record_to_dict(alert_record) if alert_record is not None else None
             ),
         )
 

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -444,16 +444,19 @@ class OperatorInspectionReadSurface:
 
         case_record = None
         if action_request.case_id is not None:
-            case_record = self._service._require_reviewed_operator_case(action_request.case_id)
+            case = self._service._store.get(CaseRecord, action_request.case_id)
+            if case is not None:
+                case_record = self._service._require_reviewed_operator_case(
+                    action_request.case_id
+                )
 
         alert_record = None
         if action_request.alert_id is not None:
             alert = self._service._store.get(AlertRecord, action_request.alert_id)
-            if alert is None:
-                raise LookupError(
-                    f"Missing alert record {action_request.alert_id!r} for review inspection"
+            if alert is not None:
+                alert_record = self._service._require_reviewed_operator_alert_record(
+                    alert
                 )
-            alert_record = self._service._require_reviewed_operator_alert_record(alert)
 
         if case_record is None and alert_record is None:
             raise LookupError(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -405,6 +405,28 @@ class CaseDetailSnapshot:
 
 
 @dataclass(frozen=True)
+class ActionReviewDetailSnapshot:
+    read_only: bool
+    action_request_id: str
+    action_review: dict[str, object]
+    current_action_review: dict[str, object] | None
+    case_record: dict[str, object] | None
+    alert_record: dict[str, object] | None
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(
+            {
+                "read_only": self.read_only,
+                "action_request_id": self.action_request_id,
+                "action_review": self.action_review,
+                "current_action_review": self.current_action_review,
+                "case_record": self.case_record,
+                "alert_record": self.alert_record,
+            }
+        )
+
+
+@dataclass(frozen=True)
 class AnalystAssistantContextSnapshot:
     read_only: bool
     record_family: str
@@ -1364,6 +1386,7 @@ class AegisOpsControlPlaneService:
             analyst_queue_snapshot_factory=AnalystQueueSnapshot,
             alert_detail_snapshot_factory=AlertDetailSnapshot,
             case_detail_snapshot_factory=CaseDetailSnapshot,
+            action_review_detail_snapshot_factory=ActionReviewDetailSnapshot,
             record_to_dict=_record_to_dict,
             redacted_reconciliation_payload=_redacted_reconciliation_payload,
             normalize_admission_provenance=_normalize_admission_provenance,
@@ -4145,6 +4168,14 @@ class AegisOpsControlPlaneService:
 
     def inspect_case_detail(self, case_id: str) -> CaseDetailSnapshot:
         return self._operator_inspection_read_surface.inspect_case_detail(case_id)
+
+    def inspect_action_review_detail(
+        self,
+        action_request_id: str,
+    ) -> ActionReviewDetailSnapshot:
+        return self._operator_inspection_read_surface.inspect_action_review_detail(
+            action_request_id
+        )
 
     def attach_osquery_host_context(
         self,

--- a/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
@@ -81,6 +81,56 @@ class ActionReviewSurfacePersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(detail["case_record"]["case_id"], promoted_case.case_id)
         self.assertEqual(detail["alert_record"]["alert_id"], promoted_case.alert_id)
 
+    def test_service_inspect_action_review_detail_keeps_case_scope_when_optional_alert_link_is_missing(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-detail-002",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-detail-surface-002",
+        )
+        service.persist_record(
+            replace(
+                action_request,
+                alert_id="missing-alert-record",
+            )
+        )
+
+        detail = service.inspect_action_review_detail(
+            action_request.action_request_id
+        ).to_dict()
+
+        self.assertEqual(detail["action_request_id"], action_request.action_request_id)
+        self.assertEqual(detail["case_record"]["case_id"], promoted_case.case_id)
+        self.assertIsNone(detail["alert_record"])
+
     def test_service_delegates_action_review_chain_snapshot_to_projection_module(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
@@ -30,6 +30,57 @@ from _service_persistence_support import (
 )
 
 class ActionReviewSurfacePersistenceTests(ServicePersistenceTestBase):
+    def test_service_inspect_action_review_detail_anchors_selected_and_current_review(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            observation_id=observation.observation_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-detail-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            action_request_id="action-request-detail-surface-001",
+        )
+
+        detail = service.inspect_action_review_detail(action_request.action_request_id).to_dict()
+
+        self.assertTrue(detail["read_only"])
+        self.assertEqual(detail["action_request_id"], action_request.action_request_id)
+        self.assertEqual(
+            detail["action_review"]["action_request_id"],
+            action_request.action_request_id,
+        )
+        self.assertEqual(
+            detail["current_action_review"]["action_request_id"],
+            action_request.action_request_id,
+        )
+        self.assertEqual(detail["case_record"]["case_id"], promoted_case.case_id)
+        self.assertEqual(detail["alert_record"]["alert_id"], promoted_case.alert_id)
+
     def test_service_delegates_action_review_chain_snapshot_to_projection_module(
         self,
     ) -> None:


### PR DESCRIPTION
Closes #672
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Phase 30D read slice for action review on `codex/issue-672` and committed it as `e0940ad` (`Add action review read shell and detail route`).

The control plane now exposes a dedicated read-only `inspect-action-review` contract keyed by authoritative `action_request_id`, the operator-ui data provider supports `getOne("actionReview")` while keeping list/mutations blocked, and `/operator/action-review` now renders a real shell with `/operator/action-review/:actionRequestId` detail plus a case-detail link into the current authoritative review. I also added focused regression coverage for the adapter, route, and backend surface selection. The issue journal was updated locally as required, but that path is gitignored and was not included in the commit.

Summary: Added the action-review read contract, non-placeholder shell/detail route, and reviewed timeline/detail surface; committed as `e0940ad`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_review_surfaces.ActionReviewSurfacePersistenceTests.test_service_inspect_action_review_detail_anchors_selected_and_current_review`; `npm --prefix apps/operator-ui run test -- src/dataProvider.test.ts`; `npm --prefix apps/operator-ui run test -- src/app/OperatorRoutes.test.tsx`; `npm --prefix apps/operator-ui test`; `npm --prefix apps/operator-ui run build`
Failure signature: none
Next action: open or update a draft PR from `codex/is...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Action Review detail page with status chips, timeline, linked case/alert sections, and navigation from case details via an "Open action review" button.
  * Routing updated to support direct Action Review URLs.

* **Tests**
  * Added end-to-end and unit tests covering page rendering, data fetching, validation of authoritative action-review payloads, and service-level projection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->