### PR TITLE
implementation: add the approval decision surface and lifecycle-specific operator rendering (#673)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -276,7 +276,7 @@ describe("OperatorRoutes", () => {
     });
 
     expect(screen.getAllByText("action-request-123").length).toBeGreaterThan(0);
-    expect(screen.getByText("await_execution_receipt")).toBeInTheDocument();
+    expect(screen.getAllByText("await_execution_receipt").length).toBeGreaterThan(0);
     expect(screen.getByText("repo-owner@example.com")).toBeInTheDocument();
     expect(screen.getByText("Requested")).toBeInTheDocument();
     expect(screen.getByText("Approved")).toBeInTheDocument();
@@ -286,6 +286,194 @@ describe("OperatorRoutes", () => {
       .find((element): element is HTMLElement => element !== null);
     expect(approvalChip).toHaveClass("MuiChip-colorSuccess");
     expect(screen.queryByText(/remains inspection-only until a separately reviewed slice/i)).not.toBeInTheDocument();
+  });
+
+  it("submits a reviewed approval decision and waits for the authoritative reread before rendering the approved lifecycle", async () => {
+    const user = userEvent.setup();
+    let actionReviewPayload: Record<string, unknown> = {
+      action_request_id: "action-request-123",
+      read_only: true,
+      current_action_review: {
+        action_request_id: "action-request-123",
+        review_state: "pending",
+      },
+      action_review: {
+        action_request_id: "action-request-123",
+        review_state: "pending",
+        action_request_state: "pending_approval",
+        approval_state: "pending",
+        requester_identity: "analyst@example.com",
+        recipient_identity: "repo-owner@example.com",
+        approver_identities: [],
+        decision_rationale: null,
+        requested_at: "2026-04-22T00:00:00Z",
+        expires_at: "2026-04-23T00:00:00Z",
+        next_expected_action: "await_approver_decision",
+        timeline: [
+          {
+            label: "Requested",
+            state: "completed",
+          },
+          {
+            label: "Approval decision",
+            state: "pending",
+          },
+        ],
+      },
+      case_record: {
+        case_id: "case-456",
+        lifecycle_state: "pending_action",
+      },
+    };
+
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation((input, init) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/operator/session")) {
+        return Promise.resolve(
+          jsonResponse({
+            identity: "approver@example.com",
+            provider: "authentik",
+            roles: ["Approver"],
+            subject: "operator-8",
+          }),
+        );
+      }
+
+      if (url.startsWith("/inspect-action-review")) {
+        return Promise.resolve(jsonResponse(actionReviewPayload));
+      }
+
+      if (url.startsWith("/operator/record-action-approval-decision")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            action_request_id: "action-request-123",
+            approver_identity: "approver@example.com",
+            decided_at: "2026-04-22T09:45",
+            decision: "grant",
+            decision_rationale:
+              "The reviewed owner notification stays within the approved notify boundary.",
+          }),
+        );
+        actionReviewPayload = {
+          ...actionReviewPayload,
+          current_action_review: {
+            action_request_id: "action-request-123",
+            review_state: "approved",
+          },
+          action_review: {
+            ...(actionReviewPayload.action_review as Record<string, unknown>),
+            review_state: "approved",
+            action_request_state: "approved",
+            approval_decision_id: "approval-decision-123",
+            approval_state: "approved",
+            approver_identities: ["approver@example.com"],
+            decision_rationale:
+              "The reviewed owner notification stays within the approved notify boundary.",
+            next_expected_action: "await_execution_receipt",
+            timeline: [
+              {
+                label: "Requested",
+                state: "completed",
+              },
+              {
+                label: "Approval decision",
+                state: "approved",
+                details: {
+                  decision_rationale:
+                    "The reviewed owner notification stays within the approved notify boundary.",
+                },
+              },
+            ],
+          },
+        };
+        return Promise.resolve(
+          jsonResponse({
+            action_request_id: "action-request-123",
+            approval_decision_id: "approval-decision-123",
+            lifecycle_state: "approved",
+          }),
+        );
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/action-review/action-request-123"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Record approval decision" }),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText("pending_approval").length).toBeGreaterThan(0);
+    });
+
+    const approvalDecisionSection = screen.getByRole("heading", {
+      name: "Record approval decision",
+    });
+    const approvalDecisionCard = approvalDecisionSection.closest(".MuiCard-root");
+    expect(approvalDecisionCard).not.toBeNull();
+
+    fireEvent.change(
+      within(approvalDecisionCard as HTMLElement).getByRole("textbox", {
+        name: "Decided at",
+      }),
+      { target: { value: "2026-04-22T09:45" } },
+    );
+    fireEvent.change(
+      within(approvalDecisionCard as HTMLElement).getByRole("textbox", {
+        name: "Decision rationale",
+      }),
+      {
+        target: {
+          value:
+            "The reviewed owner notification stays within the approved notify boundary.",
+        },
+      },
+    );
+    fireEvent.click(within(approvalDecisionCard as HTMLElement).getByRole("checkbox"));
+    fireEvent.click(
+      within(approvalDecisionCard as HTMLElement).getByRole("button", {
+        name: "Record approval decision",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/operator/record-action-approval-decision",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Authoritative refresh completed from the reviewed backend record. Refreshed: Action review detail.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("await_execution_receipt").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("approver@example.com").length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText(
+          "The reviewed owner notification stays within the approved notify boundary.",
+        ).length,
+      ).toBeGreaterThan(0);
+    });
   });
 
   it("renders the reviewed queue route from backend-authoritative queue records", async () => {

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -476,6 +476,64 @@ describe("OperatorRoutes", () => {
     });
   });
 
+  it("keeps approval submission blocked when the backend has not confirmed the current authoritative review", async () => {
+    const fetchFn = createAuthorizedFetch({
+      "/inspect-action-review": {
+        action_request_id: "action-request-123",
+        read_only: true,
+        current_action_review: {
+          review_state: "pending",
+        },
+        action_review: {
+          action_request_id: "action-request-123",
+          review_state: "pending",
+          action_request_state: "pending_approval",
+          approval_state: "pending",
+          requester_identity: "analyst@example.com",
+          recipient_identity: "repo-owner@example.com",
+          approver_identities: [],
+          requested_at: "2026-04-22T00:00:00Z",
+          expires_at: "2026-04-23T00:00:00Z",
+          next_expected_action: "await_approver_decision",
+          timeline: [
+            {
+              label: "Requested",
+              state: "completed",
+            },
+            {
+              label: "Approval decision",
+              state: "pending",
+            },
+          ],
+        },
+      },
+    }, {
+      identity: "approver@example.com",
+      provider: "authentik",
+      roles: ["Approver"],
+      subject: "operator-8",
+    });
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/action-review/action-request-123"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Approval submission stays blocked because this record is no longer the current authoritative review for the selected scope.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("heading", { name: "Record approval decision" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders the reviewed queue route from backend-authoritative queue records", async () => {
     const fetchFn = createAuthorizedFetch({
       "/inspect-analyst-queue": {

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -247,7 +247,10 @@ export function OperatorShell({
             <Route
               element={
                 canViewActionReview ? (
-                  <ActionReviewPage />
+                  <ActionReviewPage
+                    operatorIdentity={operatorIdentity}
+                    operatorRoles={operatorRoles}
+                  />
                 ) : (
                   <Navigate replace to="/operator" />
                 )
@@ -257,7 +260,10 @@ export function OperatorShell({
             <Route
               element={
                 canViewActionReview ? (
-                  <ActionReviewPage />
+                  <ActionReviewPage
+                    operatorIdentity={operatorIdentity}
+                    operatorRoles={operatorRoles}
+                  />
                 ) : (
                   <Navigate replace to="/operator" />
                 )

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -1055,14 +1055,16 @@ function ActionReviewPageBody({
   const caseRecord = asRecord(data.case_record);
   const alertRecord = asRecord(data.alert_record);
   const timelineEntries = asRecordArray(actionReview?.timeline);
-  const selectedActionRequestId = asString(actionReview?.action_request_id) ?? actionRequestId;
+  const selectedActionRequestId = asString(actionReview?.action_request_id);
   const currentActionRequestId = asString(currentActionReview?.action_request_id);
   const actionRequestState = asString(actionReview?.action_request_state);
   const approvalState = asString(actionReview?.approval_state);
   const decisionRationale = asString(actionReview?.decision_rationale);
   const approverIdentities = asStringArray(actionReview?.approver_identities);
   const isCurrentAuthoritativeReview =
-    currentActionRequestId !== null && currentActionRequestId === selectedActionRequestId;
+    selectedActionRequestId !== null &&
+    currentActionRequestId !== null &&
+    currentActionRequestId === selectedActionRequestId;
   const canRecordApproval =
     canRecordActionApprovalDecision(operatorRoles) &&
     isCurrentAuthoritativeReview &&
@@ -1091,7 +1093,7 @@ function ActionReviewPageBody({
         ) : null}
         <ValueList
           entries={[
-            ["Action request id", selectedActionRequestId],
+            ["Action request id", selectedActionRequestId ?? actionRequestId],
             ["Current authoritative review", currentActionRequestId],
             ["Action request lifecycle", actionRequestState],
             ["Approval decision id", asString(actionReview?.approval_decision_id)],
@@ -1222,7 +1224,7 @@ function ActionReviewPageBody({
         )}
       </SectionCard>
 
-      {canRecordApproval ? (
+      {canRecordApproval && selectedActionRequestId ? (
         <RecordActionApprovalDecisionCard
           actionRequestId={selectedActionRequestId}
           actionRequestState={actionRequestState}

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -25,6 +25,7 @@ import { useDataProvider } from "react-admin";
 import {
   CreateReviewedActionRequestCard,
   PromoteAlertToCaseCard,
+  RecordActionApprovalDecisionCard,
   RecordActionReviewEscalationNoteCard,
   RecordActionReviewManualFallbackCard,
   RecordCaseLeadCard,
@@ -148,6 +149,36 @@ function statusTone(
   }
 
   return "default";
+}
+
+function canRecordActionApprovalDecision(operatorRoles: readonly string[]) {
+  return operatorRoles.some((role) => role.toLowerCase() === "approver");
+}
+
+function approvalLifecycleExplanation(approvalState: string | null) {
+  switch ((approvalState ?? "").toLowerCase()) {
+    case "approved":
+      return "Approved remains a lifecycle-bearing reviewed decision. Execution may still be pending, blocked, or later found mismatched by reconciliation.";
+    case "rejected":
+      return "Rejected keeps the reviewed request blocked. The operator console must not imply execution authority returned through a local retry or toggle.";
+    case "expired":
+      return "Expired means the reviewed approval window no longer authorizes this request. Operators must reread authoritative state rather than infer continued validity.";
+    case "superseded":
+      return "Superseded means a newer authoritative request or decision replaced this record. This page stays anchored to the selected record without redefining it as current truth.";
+    case "unresolved":
+      return "Unresolved means authoritative completion is still missing or inconclusive. The UI must keep the decision path explicit instead of implying durable success.";
+    case "pending":
+      return "Pending means approval is still waiting on a reviewed decision or prerequisite. Approval remains a decision surface, not a reversible setting.";
+    default:
+      return "Approval lifecycle stays explicit here so operators can distinguish pending, approved, rejected, expired, superseded, and unresolved states without collapsing them into generic status text.";
+  }
+}
+
+function approvalLifecycleSeverity(
+  approvalState: string | null,
+): "error" | "info" | "success" | "warning" {
+  const tone = statusTone(approvalState);
+  return tone === "default" ? "info" : tone;
 }
 
 function useOperatorList(
@@ -998,10 +1029,16 @@ export function CaseDetailPage({
 
 function ActionReviewPageBody({
   actionRequestId,
+  operatorIdentity,
+  operatorRoles,
 }: {
   actionRequestId: string;
+  operatorIdentity: string;
+  operatorRoles: readonly string[];
 }) {
-  const { data, error, loading } = useOperatorRecord("actionReview", actionRequestId);
+  const [reloadToken, setReloadToken] = useState(0);
+  const recordMeta = useMemo(() => ({ reloadToken }), [reloadToken]);
+  const { data, error, loading } = useOperatorRecord("actionReview", actionRequestId, recordMeta);
 
   if (loading) {
     return <LoadingState label="Loading action review detail" />;
@@ -1020,6 +1057,16 @@ function ActionReviewPageBody({
   const timelineEntries = asRecordArray(actionReview?.timeline);
   const selectedActionRequestId = asString(actionReview?.action_request_id) ?? actionRequestId;
   const currentActionRequestId = asString(currentActionReview?.action_request_id);
+  const actionRequestState = asString(actionReview?.action_request_state);
+  const approvalState = asString(actionReview?.approval_state);
+  const decisionRationale = asString(actionReview?.decision_rationale);
+  const approverIdentities = asStringArray(actionReview?.approver_identities);
+  const isCurrentAuthoritativeReview =
+    currentActionRequestId === null || currentActionRequestId === selectedActionRequestId;
+  const canRecordApproval =
+    canRecordActionApprovalDecision(operatorRoles) &&
+    isCurrentAuthoritativeReview &&
+    actionRequestState === "pending_approval";
 
   return (
     <Stack spacing={3}>
@@ -1045,6 +1092,8 @@ function ActionReviewPageBody({
           entries={[
             ["Action request id", selectedActionRequestId],
             ["Current authoritative review", currentActionRequestId],
+            ["Action request lifecycle", actionRequestState],
+            ["Approval decision id", asString(actionReview?.approval_decision_id)],
             ["Requester", asString(actionReview?.requester_identity)],
             ["Recipient", asString(actionReview?.recipient_identity)],
             ["Recommendation id", asString(actionReview?.recommendation_id)],
@@ -1077,6 +1126,43 @@ function ActionReviewPageBody({
             >
               Open alert detail
             </Button>
+          ) : null}
+        </Stack>
+      </SectionCard>
+
+      <SectionCard
+        subtitle="Approval is rendered as authoritative lifecycle state with explicit actor, rationale, and expiry instead of as a generic mutable field."
+        title="Approval lifecycle"
+      >
+        <Stack spacing={2}>
+          <Alert severity={approvalLifecycleSeverity(approvalState)} variant="outlined">
+            {approvalLifecycleExplanation(approvalState)}
+          </Alert>
+          <ValueList
+            entries={[
+              ["Approval lifecycle", approvalState],
+              ["Approver identities", approverIdentities],
+              ["Decision rationale", decisionRationale],
+              ["Approval binding expires at", asString(actionReview?.expires_at)],
+              ["Next expected action", asString(actionReview?.next_expected_action)],
+            ]}
+          />
+          {!canRecordActionApprovalDecision(operatorRoles) ? (
+            <Alert severity="info" variant="outlined">
+              The current reviewed session can inspect this record but cannot submit approval decisions without approver role authority.
+            </Alert>
+          ) : null}
+          {canRecordActionApprovalDecision(operatorRoles) && !isCurrentAuthoritativeReview ? (
+            <Alert severity="warning" variant="outlined">
+              Approval submission stays blocked because this record is no longer the current authoritative review for the selected scope.
+            </Alert>
+          ) : null}
+          {canRecordActionApprovalDecision(operatorRoles) &&
+          isCurrentAuthoritativeReview &&
+          actionRequestState !== "pending_approval" ? (
+            <Alert severity="info" variant="outlined">
+              Approval submission is only available while the authoritative action-request lifecycle is <strong>pending_approval</strong>.
+            </Alert>
           ) : null}
         </Stack>
       </SectionCard>
@@ -1126,11 +1212,31 @@ function ActionReviewPageBody({
           <EmptyState message="No action review timeline entries were returned." />
         )}
       </SectionCard>
+
+      {canRecordApproval ? (
+        <RecordActionApprovalDecisionCard
+          actionRequestId={selectedActionRequestId}
+          actionRequestState={actionRequestState}
+          approvalState={approvalState}
+          approverIdentity={operatorIdentity}
+          decisionRationale={decisionRationale}
+          expiresAt={asString(actionReview?.expires_at)}
+          onSubmitted={() => {
+            setReloadToken((current) => current + 1);
+          }}
+        />
+      ) : null}
     </Stack>
   );
 }
 
-export function ActionReviewPage() {
+export function ActionReviewPage({
+  operatorIdentity,
+  operatorRoles,
+}: {
+  operatorIdentity: string;
+  operatorRoles: readonly string[];
+}) {
   const params = useParams();
   const actionRequestId = asString(params.actionRequestId);
 
@@ -1140,7 +1246,11 @@ export function ActionReviewPage() {
       title="Action Review"
     >
       {actionRequestId ? (
-        <ActionReviewPageBody actionRequestId={actionRequestId} />
+        <ActionReviewPageBody
+          actionRequestId={actionRequestId}
+          operatorIdentity={operatorIdentity}
+          operatorRoles={operatorRoles}
+        />
       ) : (
         <SectionCard
           subtitle="Open action review from a case or alert detail page so the shell stays anchored to one authoritative action-request record."

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -1062,11 +1062,12 @@ function ActionReviewPageBody({
   const decisionRationale = asString(actionReview?.decision_rationale);
   const approverIdentities = asStringArray(actionReview?.approver_identities);
   const isCurrentAuthoritativeReview =
-    currentActionRequestId === null || currentActionRequestId === selectedActionRequestId;
+    currentActionRequestId !== null && currentActionRequestId === selectedActionRequestId;
   const canRecordApproval =
     canRecordActionApprovalDecision(operatorRoles) &&
     isCurrentAuthoritativeReview &&
-    actionRequestState === "pending_approval";
+    actionRequestState === "pending_approval" &&
+    approvalState === "pending";
 
   return (
     <Stack spacing={3}>
@@ -1162,6 +1163,14 @@ function ActionReviewPageBody({
           actionRequestState !== "pending_approval" ? (
             <Alert severity="info" variant="outlined">
               Approval submission is only available while the authoritative action-request lifecycle is <strong>pending_approval</strong>.
+            </Alert>
+          ) : null}
+          {canRecordActionApprovalDecision(operatorRoles) &&
+          isCurrentAuthoritativeReview &&
+          actionRequestState === "pending_approval" &&
+          approvalState !== "pending" ? (
+            <Alert severity="info" variant="outlined">
+              Approval submission is only available while the authoritative approval lifecycle is <strong>pending</strong>.
             </Alert>
           ) : null}
         </Stack>

--- a/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
@@ -514,6 +514,123 @@ export function CreateReviewedActionRequestCard({
   );
 }
 
+export function RecordActionApprovalDecisionCard({
+  actionRequestId,
+  actionRequestState,
+  approvalState,
+  approverIdentity,
+  decisionRationale,
+  expiresAt,
+  onSubmitted,
+}: {
+  actionRequestId: string;
+  actionRequestState: string | null;
+  approvalState: string | null;
+  approverIdentity: string;
+  decisionRationale: string | null;
+  expiresAt: string | null;
+  onSubmitted?: () => void;
+}) {
+  const submission = useTaskActionSubmission<{ action_request_id: string }>();
+  const [decidedAt, setDecidedAt] = useState("");
+  const [decision, setDecision] = useState("grant");
+  const [approvalDecisionIdOverride, setApprovalDecisionIdOverride] = useState("");
+  const [nextDecisionRationale, setNextDecisionRationale] = useState(
+    decisionRationale ?? "",
+  );
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          onSubmitted: () => onSubmitted?.(),
+          refreshTargets: [
+            {
+              id: actionRequestId,
+              label: "Action review detail",
+              resource: "actionReview",
+            },
+          ],
+          run: (client) =>
+            client.recordActionApprovalDecision({
+              action_request_id: actionRequestId,
+              approval_decision_id: normalizeOptionalString(approvalDecisionIdOverride),
+              approver_identity: approverIdentity,
+              decided_at: decidedAt.trim(),
+              decision,
+              decision_rationale: nextDecisionRationale.trim(),
+            }) as Promise<{ action_request_id: string }>,
+        });
+      }}
+    >
+      <TaskActionFormCard
+        actor={[
+          ["Identity", approverIdentity],
+          ["Action", "Approval decision"],
+        ]}
+        binding={[
+          ["Record family", "action_request"],
+          ["Action request id", actionRequestId],
+          ["Lifecycle", actionRequestState ?? "Not available"],
+        ]}
+        provenance={[
+          ["Backend boundary", "reviewed operator approval-decision endpoint"],
+          ["Current approval state", approvalState ?? "Not available"],
+          ["Approval window", expiresAt ?? "Not available"],
+        ]}
+        submission={submission}
+        submitLabel="Record approval decision"
+        subtitle="Record one reviewed approval decision against the authoritative action request. This surface stays decision-oriented and requires an authoritative reread before the lifecycle is treated as durable."
+        title="Record approval decision"
+      >
+        <Stack spacing={2}>
+          <TextField
+            fullWidth
+            label="Decided at"
+            onChange={(event) => {
+              setDecidedAt(event.target.value);
+            }}
+            required
+            value={decidedAt}
+          />
+          <TextField
+            fullWidth
+            label="Decision"
+            onChange={(event) => {
+              setDecision(event.target.value);
+            }}
+            select
+            value={decision}
+          >
+            <MenuItem value="grant">grant</MenuItem>
+            <MenuItem value="reject">reject</MenuItem>
+          </TextField>
+          <TextField
+            fullWidth
+            label="Decision rationale"
+            minRows={3}
+            multiline
+            onChange={(event) => {
+              setNextDecisionRationale(event.target.value);
+            }}
+            required
+            value={nextDecisionRationale}
+          />
+          <TextField
+            fullWidth
+            label="Approval decision id override"
+            onChange={(event) => {
+              setApprovalDecisionIdOverride(event.target.value);
+            }}
+            value={approvalDecisionIdOverride}
+          />
+        </Stack>
+      </TaskActionFormCard>
+    </form>
+  );
+}
+
 export function RecordActionReviewManualFallbackCard({
   actionRequestId,
   caseId,

--- a/apps/operator-ui/src/taskActions/taskActionClient.ts
+++ b/apps/operator-ui/src/taskActions/taskActionClient.ts
@@ -41,6 +41,15 @@ interface CreateReviewedActionRequestPayload {
   action_request_id?: string;
 }
 
+interface RecordActionApprovalDecisionPayload {
+  action_request_id: string;
+  approval_decision_id?: string;
+  approver_identity: string;
+  decided_at: string;
+  decision: string;
+  decision_rationale: string;
+}
+
 interface RecordActionReviewManualFallbackPayload {
   action_request_id: string;
   fallback_at: string;
@@ -65,6 +74,9 @@ interface OperatorTaskActionClient {
     payload: CreateReviewedActionRequestPayload,
   ): Promise<unknown>;
   promoteAlertToCase(payload: PromoteAlertToCasePayload): Promise<unknown>;
+  recordActionApprovalDecision(
+    payload: RecordActionApprovalDecisionPayload,
+  ): Promise<unknown>;
   recordActionReviewEscalationNote(
     payload: RecordActionReviewEscalationNotePayload,
   ): Promise<unknown>;
@@ -164,6 +176,9 @@ export function createOperatorTaskActionClient({
     promoteAlertToCase(payload) {
       return submitJson(fetchFn, "/operator/promote-alert-to-case", payload);
     },
+    recordActionApprovalDecision(payload) {
+      return submitJson(fetchFn, "/operator/record-action-approval-decision", payload);
+    },
     recordActionReviewEscalationNote(payload) {
       return submitJson(fetchFn, "/operator/record-action-review-escalation-note", payload);
     },
@@ -186,6 +201,7 @@ export type {
   CreateReviewedActionRequestPayload,
   OperatorTaskActionClient,
   PromoteAlertToCasePayload,
+  RecordActionApprovalDecisionPayload,
   RecordActionReviewEscalationNotePayload,
   RecordActionReviewManualFallbackPayload,
   RecordCaseLeadPayload,

--- a/apps/operator-ui/src/taskActions/taskActionPrimitives.tsx
+++ b/apps/operator-ui/src/taskActions/taskActionPrimitives.tsx
@@ -26,7 +26,12 @@ import {
   OperatorTaskActionError,
 } from "./taskActionClient";
 
-type TaskActionResource = "advisoryOutput" | "alerts" | "cases" | "reconciliations";
+type TaskActionResource =
+  | "actionReview"
+  | "advisoryOutput"
+  | "alerts"
+  | "cases"
+  | "reconciliations";
 
 interface TaskActionClientProviderProps {
   children: ReactNode;


### PR DESCRIPTION
Closes #673
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Phase 30D approval decision surface in `apps/operator-ui` and committed it as `c7d97fa` (`Add operator approval decision surface`).

The action-review detail route now renders an explicit approval lifecycle section, shows actor/rationale/binding fields, exposes a bounded `Record approval decision` card only for approver-authorized pending approvals, and forces an authoritative `actionReview` reread after submit. The focused regression test for pending approval -> submit -> reread -> approved lifecycle was added, and the full operator-ui test/build pass succeeded.

Summary: Added the operator approval decision surface, lifecycle-specific approval rendering, authoritative reread wiring, and a focused approval-route regression test; committed as `c7d97fa`.
State hint: implementing
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test`; `npm --prefix apps/operator-ui run build`
Failure signature: none
Next action: push `codex/issue-673` and open or update the draft PR with commit `c7d97fa`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operators with the approver role can record approval decisions (decision, rationale, timestamp); UI shows approval lifecycle, approvers, rationale, decision ID, and expiry.

* **Behavior**
  * Approval submission triggers an authoritative refresh so updated status appears in the UI.
  * Approval form is gated: submission disabled and explanatory message shown when operator lacks authority, the selected record isn't the current authoritative review, or lifecycle states are not appropriate.

* **Tests**
  * Added end-to-end tests for successful approval flow and blocked-submission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->