### PR TITLE
implementation: add execution receipt, reconciliation mismatch, and coordination visibility to action review (#674)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -288,6 +288,123 @@ describe("OperatorRoutes", () => {
     expect(screen.queryByText(/remains inspection-only until a separately reviewed slice/i)).not.toBeInTheDocument();
   });
 
+  it("renders execution receipt, reconciliation mismatch, and coordination visibility on action-review detail", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {
+          "/inspect-action-review": {
+            action_request_id: "action-request-789",
+            read_only: true,
+            current_action_review: {
+              action_request_id: "action-request-789",
+              review_state: "approved",
+            },
+            action_review: {
+              action_request_id: "action-request-789",
+              review_state: "approved",
+              action_request_state: "approved",
+              approval_state: "approved",
+              action_execution_state: "succeeded",
+              reconciliation_state: "mismatched",
+              requester_identity: "analyst@example.com",
+              recipient_identity: "repo-owner@example.com",
+              next_expected_action: "review_reconciliation_mismatch",
+              execution_surface_type: "automation_substrate",
+              execution_surface_id: "shuffle",
+              action_execution_id: "action-execution-789",
+              delegation_id: "delegation-789",
+              execution_run_id: "shuffle-run-789",
+              reconciliation_id: "recon-789",
+              mismatch_inspection: {
+                reconciliation_id: "recon-789",
+                lifecycle_state: "mismatched",
+                ingest_disposition: "mismatch",
+                mismatch_summary: "receipt payload disagrees with the reconciled ticket state",
+                execution_run_id: "shuffle-run-789",
+                linked_execution_run_ids: ["shuffle-run-789"],
+              },
+              coordination_ticket_outcome: {
+                authority: "authoritative_aegisops_review",
+                status: "mismatch",
+                summary: "ticket receipt remains mismatched with the reviewed coordination target",
+                action_request_id: "action-request-789",
+                action_execution_id: "action-execution-789",
+                execution_run_id: "shuffle-run-789",
+                reconciliation_id: "recon-789",
+                coordination_reference_id: "coord-ref-789",
+                coordination_target_type: "zammad",
+                coordination_target_id: "ZM-789",
+                external_receipt_id: "receipt-789",
+                ticket_reference_url: "https://tickets.example.invalid/tickets/ZM-789",
+                mismatch: {
+                  mismatch_summary:
+                    "ticket receipt remains mismatched with the reviewed coordination target",
+                },
+              },
+              timeline: [
+                {
+                  label: "Requested",
+                  state: "completed",
+                },
+                {
+                  label: "Approved",
+                  state: "approved",
+                },
+                {
+                  label: "Delegated",
+                  state: "delegated",
+                },
+                {
+                  label: "Execution",
+                  state: "succeeded",
+                },
+                {
+                  label: "Reconciliation",
+                  state: "mismatched",
+                },
+              ],
+            },
+            case_record: {
+              case_id: "case-789",
+              lifecycle_state: "open",
+            },
+          },
+        },
+        {
+          identity: "approver@example.com",
+          provider: "authentik",
+          roles: ["Approver"],
+          subject: "operator-8",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/action-review/action-request-789"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Execution receipt")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
+    expect(screen.getByText("Execution receipt")).toBeInTheDocument();
+    expect(screen.getByText("Reconciliation visibility")).toBeInTheDocument();
+    expect(screen.getByText("Coordination visibility")).toBeInTheDocument();
+    expect(screen.getAllByText("action-execution-789").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("shuffle-run-789").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(
+        "receipt payload disagrees with the reconciled ticket state",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("coord-ref-789")).toBeInTheDocument();
+    expect(screen.getAllByText("receipt-789").length).toBeGreaterThan(0);
+    expect(screen.getByText("ZM-789")).toBeInTheDocument();
+  });
+
   it("submits a reviewed approval decision and waits for the authoritative reread before rendering the approved lifecycle", async () => {
     const user = userEvent.setup();
     let actionReviewPayload: Record<string, unknown> = {

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -275,11 +275,13 @@ describe("OperatorRoutes", () => {
       expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
     });
 
-    expect(screen.getAllByText("action-request-123").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("await_execution_receipt").length).toBeGreaterThan(0);
-    expect(screen.getByText("repo-owner@example.com")).toBeInTheDocument();
-    expect(screen.getByText("Requested")).toBeInTheDocument();
-    expect(screen.getByText("Approved")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText("action-request-123").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("await_execution_receipt").length).toBeGreaterThan(0);
+      expect(screen.getByText("repo-owner@example.com")).toBeInTheDocument();
+      expect(screen.getByText("Requested")).toBeInTheDocument();
+      expect(screen.getByText("Approved")).toBeInTheDocument();
+    });
     const approvalChip = screen
       .getAllByText("Approval: approved")
       .map((element) => element.closest(".MuiChip-root"))
@@ -315,6 +317,11 @@ describe("OperatorRoutes", () => {
               delegation_id: "delegation-789",
               execution_run_id: "shuffle-run-789",
               reconciliation_id: "recon-789",
+              target_scope: {
+                coordination_reference_id: "coord-ref-requested-789",
+                coordination_target_type: "ticket",
+                coordination_target_id: "ZM-REQ-789",
+              },
               mismatch_inspection: {
                 reconciliation_id: "recon-789",
                 lifecycle_state: "mismatched",
@@ -352,7 +359,7 @@ describe("OperatorRoutes", () => {
                 },
                 {
                   label: "Delegated",
-                  state: "delegated",
+                  state: "delayed",
                 },
                 {
                   label: "Execution",
@@ -400,9 +407,15 @@ describe("OperatorRoutes", () => {
         "receipt payload disagrees with the reconciled ticket state",
       ).length,
     ).toBeGreaterThan(0);
+    expect(screen.getByText("delayed")).toBeInTheDocument();
+    expect(screen.getByText("coord-ref-requested-789")).toBeInTheDocument();
     expect(screen.getByText("coord-ref-789")).toBeInTheDocument();
     expect(screen.getAllByText("receipt-789").length).toBeGreaterThan(0);
+    expect(screen.getByText("ZM-REQ-789")).toBeInTheDocument();
     expect(screen.getByText("ZM-789")).toBeInTheDocument();
+    expect(
+      screen.getByText("Requested and observed coordination references do not match."),
+    ).toBeInTheDocument();
   });
 
   it("submits a reviewed approval decision and waits for the authoritative reread before rendering the approved lifecycle", async () => {

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -181,6 +181,194 @@ function approvalLifecycleSeverity(
   return tone === "default" ? "info" : tone;
 }
 
+function findTimelineStage(
+  actionReview: UnknownRecord | null,
+  stage: string,
+): UnknownRecord | null {
+  return (
+    asRecordArray(actionReview?.timeline).find(
+      (entry) => asString(entry.stage) === stage,
+    ) ?? null
+  );
+}
+
+function dispatchLifecycleState(actionReview: UnknownRecord | null): string | null {
+  const timelineStageState = asString(findTimelineStage(actionReview, "delegation")?.state);
+  if (timelineStageState !== null) {
+    return timelineStageState;
+  }
+  if (asString(actionReview?.delegation_id) !== null) {
+    return "delegated";
+  }
+  if (asString(actionReview?.approval_state) === "approved") {
+    return "awaiting_delegation";
+  }
+  return null;
+}
+
+function ExecutionReceiptSection({ actionReview }: { actionReview: UnknownRecord | null }) {
+  const coordinationOutcome = asRecord(actionReview?.coordination_ticket_outcome);
+  const executionState = asString(actionReview?.action_execution_state);
+  const reconciliationState = asString(actionReview?.reconciliation_state);
+  const dispatchState = dispatchLifecycleState(actionReview);
+  const actionExecutionId = asString(actionReview?.action_execution_id);
+
+  return (
+    <SectionCard
+      subtitle="Dispatch, execution receipt, and reconciliation are rendered as separate lifecycle surfaces so downstream completion is not overstated."
+      title="Execution receipt"
+    >
+      <Stack spacing={2}>
+        <StatusStrip
+          values={[
+            ["Dispatch", dispatchState],
+            ["Execution", executionState],
+            ["Reconciliation", reconciliationState],
+            ["Coordination", asString(coordinationOutcome?.status)],
+          ]}
+        />
+        {!actionExecutionId ? (
+          <Alert severity="warning" variant="outlined">
+            No authoritative execution receipt is attached to this reviewed request yet.
+          </Alert>
+        ) : null}
+        {actionExecutionId && reconciliationState !== "matched" ? (
+          <Alert severity="warning" variant="outlined">
+            Execution receipt visibility is present, but downstream reconciliation is still
+            {reconciliationState ? ` ${reconciliationState}` : " unresolved"}.
+          </Alert>
+        ) : null}
+        <ValueList
+          entries={[
+            ["Action execution id", actionExecutionId],
+            ["Delegation id", asString(actionReview?.delegation_id)],
+            ["Execution run id", asString(actionReview?.execution_run_id)],
+            ["Execution surface type", asString(actionReview?.execution_surface_type)],
+            ["Execution surface id", asString(actionReview?.execution_surface_id)],
+            ["External receipt id", asString(coordinationOutcome?.external_receipt_id)],
+            ["Next expected action", asString(actionReview?.next_expected_action)],
+          ]}
+        />
+      </Stack>
+    </SectionCard>
+  );
+}
+
+function ReconciliationVisibilitySection({
+  actionReview,
+}: {
+  actionReview: UnknownRecord | null;
+}) {
+  const mismatchInspection = asRecord(actionReview?.mismatch_inspection);
+  const reconciliationState = asString(actionReview?.reconciliation_state);
+  const mismatchSummary = asString(mismatchInspection?.mismatch_summary);
+
+  return (
+    <SectionCard
+      subtitle="Mismatch, missing receipt, and unresolved downstream outcomes stay explicit instead of being normalized into generic success."
+      title="Reconciliation visibility"
+    >
+      <Stack spacing={2}>
+        <StatusStrip
+          values={[
+            ["Reconciliation", reconciliationState],
+            ["Ingest", asString(mismatchInspection?.ingest_disposition)],
+          ]}
+        />
+        {mismatchInspection ? (
+          <Alert severity="warning" variant="outlined">
+            {mismatchSummary ??
+              "Authoritative reconciliation still reports a mismatch or unresolved downstream state."}
+          </Alert>
+        ) : null}
+        {!mismatchInspection && !asString(actionReview?.reconciliation_id) ? (
+          <Alert severity="warning" variant="outlined">
+            No authoritative reconciliation record is visible for this reviewed request yet.
+          </Alert>
+        ) : null}
+        <ValueList
+          entries={[
+            ["Reconciliation id", asString(actionReview?.reconciliation_id)],
+            ["Mismatch summary", mismatchSummary],
+            ["Correlation key", asString(mismatchInspection?.correlation_key)],
+            ["Observed execution run", asString(mismatchInspection?.execution_run_id)],
+            ["Linked execution runs", mismatchInspection?.linked_execution_run_ids],
+            ["Compared at", asString(mismatchInspection?.compared_at)],
+            ["Last seen at", asString(mismatchInspection?.last_seen_at)],
+          ]}
+        />
+      </Stack>
+    </SectionCard>
+  );
+}
+
+function CoordinationVisibilitySection({
+  actionReview,
+}: {
+  actionReview: UnknownRecord | null;
+}) {
+  const coordinationOutcome = asRecord(actionReview?.coordination_ticket_outcome);
+  const targetScope = asRecord(actionReview?.target_scope);
+  const ticketReferenceUrl = asString(coordinationOutcome?.ticket_reference_url);
+
+  if (coordinationOutcome === null && targetScope === null) {
+    return null;
+  }
+
+  return (
+    <SectionCard
+      subtitle="Downstream coordination references stay visible as subordinate context without replacing AegisOps-owned request, approval, execution, or reconciliation truth."
+      title="Coordination visibility"
+    >
+      <Stack spacing={2}>
+        <StatusStrip
+          values={[
+            ["Coordination", asString(coordinationOutcome?.status)],
+            ["Authority", asString(coordinationOutcome?.authority)],
+          ]}
+        />
+        {asString(coordinationOutcome?.summary) ? (
+          <Alert severity="info" variant="outlined">
+            {asString(coordinationOutcome?.summary)}
+          </Alert>
+        ) : null}
+        <ValueList
+          entries={[
+            [
+              "Coordination reference id",
+              asString(coordinationOutcome?.coordination_reference_id) ??
+                asString(targetScope?.coordination_reference_id),
+            ],
+            [
+              "Coordination target type",
+              asString(coordinationOutcome?.coordination_target_type) ??
+                asString(targetScope?.coordination_target_type),
+            ],
+            [
+              "Coordination target id",
+              asString(coordinationOutcome?.coordination_target_id) ??
+                asString(targetScope?.coordination_target_id),
+            ],
+            ["External receipt id", asString(coordinationOutcome?.external_receipt_id)],
+            ["Linked action execution", asString(coordinationOutcome?.action_execution_id)],
+            ["Linked reconciliation", asString(coordinationOutcome?.reconciliation_id)],
+          ]}
+        />
+        {ticketReferenceUrl ? (
+          <Link
+            href={ticketReferenceUrl}
+            rel="noreferrer"
+            target="_blank"
+            underline="hover"
+          >
+            Open downstream coordination reference
+          </Link>
+        ) : null}
+      </Stack>
+    </SectionCard>
+  );
+}
+
 function useOperatorList(
   resource: string,
   filter: Record<string, unknown>,
@@ -1177,6 +1365,12 @@ function ActionReviewPageBody({
           ) : null}
         </Stack>
       </SectionCard>
+
+      <ExecutionReceiptSection actionReview={actionReview} />
+
+      <ReconciliationVisibilitySection actionReview={actionReview} />
+
+      <CoordinationVisibilitySection actionReview={actionReview} />
 
       <SectionCard
         subtitle="Authoritative linkage stays explicit so later approval, execution, and reconciliation panels can extend this view without inferring broader workflow truth."

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -185,15 +185,19 @@ function findTimelineStage(
   actionReview: UnknownRecord | null,
   stage: string,
 ): UnknownRecord | null {
+  const normalizedStage = stage.toLowerCase();
   return (
-    asRecordArray(actionReview?.timeline).find(
-      (entry) => asString(entry.stage) === stage,
-    ) ?? null
+    asRecordArray(actionReview?.timeline).find((entry) => {
+      const candidate = (asString(entry.stage) ?? asString(entry.label))?.toLowerCase();
+      return candidate === normalizedStage;
+    }) ?? null
   );
 }
 
 function dispatchLifecycleState(actionReview: UnknownRecord | null): string | null {
-  const timelineStageState = asString(findTimelineStage(actionReview, "delegation")?.state);
+  const timelineStageState =
+    asString(findTimelineStage(actionReview, "delegation")?.state) ??
+    asString(findTimelineStage(actionReview, "delegated")?.state);
   if (timelineStageState !== null) {
     return timelineStageState;
   }
@@ -201,7 +205,7 @@ function dispatchLifecycleState(actionReview: UnknownRecord | null): string | nu
     return "delegated";
   }
   if (asString(actionReview?.approval_state) === "approved") {
-    return "awaiting_delegation";
+    return "pending_delegation";
   }
   return null;
 }
@@ -310,6 +314,24 @@ function CoordinationVisibilitySection({
   const coordinationOutcome = asRecord(actionReview?.coordination_ticket_outcome);
   const targetScope = asRecord(actionReview?.target_scope);
   const ticketReferenceUrl = asString(coordinationOutcome?.ticket_reference_url);
+  const requestedCoordinationReferenceId = asString(targetScope?.coordination_reference_id);
+  const observedCoordinationReferenceId = asString(coordinationOutcome?.coordination_reference_id);
+  const requestedCoordinationTargetType = asString(targetScope?.coordination_target_type);
+  const observedCoordinationTargetType = asString(coordinationOutcome?.coordination_target_type);
+  const requestedCoordinationTargetId = asString(targetScope?.coordination_target_id);
+  const observedCoordinationTargetId = asString(coordinationOutcome?.coordination_target_id);
+  const coordinationReferenceMismatch =
+    requestedCoordinationReferenceId !== null &&
+    observedCoordinationReferenceId !== null &&
+    requestedCoordinationReferenceId !== observedCoordinationReferenceId;
+  const coordinationTargetTypeMismatch =
+    requestedCoordinationTargetType !== null &&
+    observedCoordinationTargetType !== null &&
+    requestedCoordinationTargetType !== observedCoordinationTargetType;
+  const coordinationTargetIdMismatch =
+    requestedCoordinationTargetId !== null &&
+    observedCoordinationTargetId !== null &&
+    requestedCoordinationTargetId !== observedCoordinationTargetId;
 
   if (coordinationOutcome === null && targetScope === null) {
     return null;
@@ -332,22 +354,38 @@ function CoordinationVisibilitySection({
             {asString(coordinationOutcome?.summary)}
           </Alert>
         ) : null}
+        {coordinationReferenceMismatch ||
+        coordinationTargetTypeMismatch ||
+        coordinationTargetIdMismatch ? (
+          <Alert severity="warning" variant="outlined">
+            Requested and observed coordination references do not match.
+          </Alert>
+        ) : null}
         <ValueList
           entries={[
             [
-              "Coordination reference id",
-              asString(coordinationOutcome?.coordination_reference_id) ??
-                asString(targetScope?.coordination_reference_id),
+              "Requested coordination reference id",
+              requestedCoordinationReferenceId,
             ],
             [
-              "Coordination target type",
-              asString(coordinationOutcome?.coordination_target_type) ??
-                asString(targetScope?.coordination_target_type),
+              "Observed coordination reference id",
+              observedCoordinationReferenceId,
             ],
             [
-              "Coordination target id",
-              asString(coordinationOutcome?.coordination_target_id) ??
-                asString(targetScope?.coordination_target_id),
+              "Requested coordination target type",
+              requestedCoordinationTargetType,
+            ],
+            [
+              "Observed coordination target type",
+              observedCoordinationTargetType,
+            ],
+            [
+              "Requested coordination target id",
+              requestedCoordinationTargetId,
+            ],
+            [
+              "Observed coordination target id",
+              observedCoordinationTargetId,
             ],
             ["External receipt id", asString(coordinationOutcome?.external_receipt_id)],
             ["Linked action execution", asString(coordinationOutcome?.action_execution_id)],


### PR DESCRIPTION
Closes #674
This PR was opened by codex-supervisor.
Latest Codex summary:

Added the Phase 30D action-review visibility slice in `apps/operator-ui` and committed it as `a39b537` (`Add action review execution visibility`). The action-review page now renders separate read-only sections for execution receipt, reconciliation visibility, and coordination visibility, and the new regression test covers the authoritative backend fields that were previously not shown together.

Summary: Added dedicated action-review execution receipt, reconciliation mismatch, and coordination visibility sections, plus a focused route regression; committed as `a39b537`.
State hint: implementing
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test`; `npm --prefix apps/operator-ui run build`
Failure signature: none
Next action: Push commit `a39b537` on `codex/issue-674` and open or update the draft PR for issue `#674`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Execution Receipt, Reconciliation Visibility, and Coordination Visibility sections to action review pages, showing dispatch/execution status, execution receipt details, reconciliation mismatch warnings, and coordination ticket identifiers with conditional alerts when authoritative records are missing.

* **Tests**
  * Improved tests to wait for async UI rendering and added coverage validating action review pages display execution receipt, reconciliation visibility, coordination details, mismatch summaries, and timeline status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->