### PR TITLE
validation: add Phase 30D coverage for approval lifecycle, execution receipts, and reconciliation mismatch visibility (#675)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -418,6 +418,84 @@ describe("OperatorRoutes", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps expired approval lifecycle state explicit without implying execution or reconciliation success", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {
+          "/inspect-action-review": {
+            action_request_id: "action-request-expired-789",
+            read_only: true,
+            current_action_review: {
+              action_request_id: "action-request-expired-789",
+              review_state: "expired",
+            },
+            action_review: {
+              action_request_id: "action-request-expired-789",
+              review_state: "expired",
+              action_request_state: "expired",
+              approval_state: "expired",
+              requester_identity: "analyst@example.com",
+              recipient_identity: "repo-owner@example.com",
+              next_expected_action: "request_new_approval",
+              requested_at: "2026-04-21T00:00:00Z",
+              expires_at: "2026-04-21T12:00:00Z",
+              timeline: [
+                {
+                  label: "Requested",
+                  state: "completed",
+                },
+                {
+                  label: "Approval decision",
+                  state: "expired",
+                },
+              ],
+            },
+            case_record: {
+              case_id: "case-expired-789",
+              lifecycle_state: "open",
+            },
+          },
+        },
+        {
+          identity: "approver@example.com",
+          provider: "authentik",
+          roles: ["Approver"],
+          subject: "operator-8",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/action-review/action-request-expired-789"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("Approval lifecycle").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("expired").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(
+        "Expired means the reviewed approval window no longer authorizes this request. Operators must reread authoritative state rather than infer continued validity.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Execution receipt")).toBeInTheDocument();
+    expect(screen.getByText("Reconciliation visibility")).toBeInTheDocument();
+    expect(
+      screen.getByText("No authoritative execution receipt is attached to this reviewed request yet."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No authoritative reconciliation record is visible for this reviewed request yet."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Execution receipt visibility is present, but downstream reconciliation is still/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Coordination visibility")).not.toBeInTheDocument();
+  });
+
   it("submits a reviewed approval decision and waits for the authoritative reread before rendering the approved lifecycle", async () => {
     const user = userEvent.setup();
     let actionReviewPayload: Record<string, unknown> = {
@@ -1680,9 +1758,11 @@ describe("OperatorRoutes", () => {
       expect(screen.getByRole("heading", { name: "Reconciliation" })).toBeInTheDocument();
     });
 
-    expect(
-      screen.getAllByText("case linkage mismatch remains unresolved").length,
-    ).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("case linkage mismatch remains unresolved").length,
+      ).toBeGreaterThan(0);
+    });
     expect(screen.getAllByText(/mismatch/i).length).toBeGreaterThan(0);
   });
 });

--- a/control-plane/tests/test_phase30d_operator_ui_validation.py
+++ b/control-plane/tests/test_phase30d_operator_ui_validation.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase30DOperatorUiValidationTests(unittest.TestCase):
+    def test_phase30d_validation_doc_locks_lifecycle_and_visibility_semantics(self) -> None:
+        text = self._read("docs/phase-30d-approval-execution-reconciliation-ui-validation.md")
+
+        for term in (
+            "# Phase 30D Approval, Execution, and Reconciliation UI Validation",
+            "Validation status: PASS",
+            "approval lifecycle stays explicit",
+            "`pending`, `approved`, `rejected`, `expired`, `superseded`, `unresolved`, and `degraded`",
+            "execution receipt visibility remains separate from approval outcome and reconciliation outcome",
+            "reconciliation mismatch visibility stays explicit",
+            "coordination or Shuffle-derived context stays subordinate",
+            "approval is not a toggle",
+            "execution success is not reconciliation success",
+            "authoritative re-read remains required",
+            "route-gating and role-gating stay posture controls while backend authorization remains the enforcement boundary",
+            "degraded, forbidden, expired, unresolved, and mismatch states stay explicit",
+            "control-plane/tests/test_phase30d_operator_ui_validation.py",
+            "apps/operator-ui/src/app/OperatorRoutes.test.tsx",
+            "keeping expired approval lifecycle state explicit without implying execution or reconciliation success",
+            "python3 -m unittest control-plane.tests.test_phase30d_operator_ui_validation",
+            "python3 -m unittest control-plane.tests.test_phase30d_approval_execution_reconciliation_docs",
+            "npm --prefix apps/operator-ui test",
+            "npm --prefix apps/operator-ui run build",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase30d_frontend_tests_cover_authoritative_split_and_explicit_failure_states(
+        self,
+    ) -> None:
+        operator_routes_tests = self._read("apps/operator-ui/src/app/OperatorRoutes.test.tsx")
+
+        for term in (
+            "renders the reviewed action-review detail route from backend-authoritative action review data",
+            "renders execution receipt, reconciliation mismatch, and coordination visibility on action-review detail",
+            "submits a reviewed approval decision and waits for the authoritative reread before rendering the approved lifecycle",
+            "keeps expired approval lifecycle state explicit without implying execution or reconciliation success",
+            "Execution receipt",
+            "Reconciliation visibility",
+            "Coordination visibility",
+            "Expired means the reviewed approval window no longer authorizes this request.",
+            "No authoritative execution receipt is attached to this reviewed request yet.",
+            "No authoritative reconciliation record is visible for this reviewed request yet.",
+        ):
+            self.assertIn(term, operator_routes_tests)
+
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected file at {path}")
+        return path.read_text(encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-30d-approval-execution-reconciliation-ui-validation.md
+++ b/docs/phase-30d-approval-execution-reconciliation-ui-validation.md
@@ -1,0 +1,41 @@
+# Phase 30D Approval, Execution, and Reconciliation UI Validation
+
+Validation status: PASS
+
+This validation locks the reviewed Phase 30D operator-ui contract for approval lifecycle rendering, execution receipt visibility, reconciliation mismatch visibility, and subordinate coordination context before broader workflow depth lands.
+
+The reviewed validation scope is intentionally narrow:
+
+- approval lifecycle stays explicit for `pending`, `approved`, `rejected`, `expired`, `superseded`, `unresolved`, and `degraded` outcomes;
+- execution receipt visibility remains separate from approval outcome and reconciliation outcome;
+- reconciliation mismatch visibility stays explicit instead of being normalized into generic success; and
+- coordination or Shuffle-derived context stays subordinate instead of replacing AegisOps-owned workflow truth.
+
+This validation confirms the operator UI preserves backend authority:
+
+- approval is not a toggle;
+- execution success is not reconciliation success;
+- authoritative re-read remains required after reviewed approval submission;
+- route-gating and role-gating stay posture controls while backend authorization remains the enforcement boundary; and
+- degraded, forbidden, expired, unresolved, and mismatch states stay explicit instead of implying durable success.
+
+The locked verification surfaces are:
+
+- `docs/phase-30d-approval-execution-reconciliation-ui-boundary.md`
+- `control-plane/tests/test_phase30d_approval_execution_reconciliation_docs.py`
+- `control-plane/tests/test_phase30d_operator_ui_validation.py`
+- `apps/operator-ui/src/app/OperatorRoutes.test.tsx`
+
+Focused frontend validation covers:
+
+- rendering the reviewed action-review detail route from backend-authoritative action review data;
+- rendering execution receipt, reconciliation mismatch, and coordination visibility on action-review detail;
+- submitting a reviewed approval decision and waiting for the authoritative reread before rendering the approved lifecycle; and
+- keeping expired approval lifecycle state explicit without implying execution or reconciliation success.
+
+Focused verification commands:
+
+- `python3 -m unittest control-plane.tests.test_phase30d_operator_ui_validation`
+- `python3 -m unittest control-plane.tests.test_phase30d_approval_execution_reconciliation_docs`
+- `npm --prefix apps/operator-ui test`
+- `npm --prefix apps/operator-ui run build`


### PR DESCRIPTION
Closes #675
This PR was opened by codex-supervisor.
Latest Codex summary:

Added the Phase 30D validation slice and committed it as `75e398e` (`Add Phase 30D UI validation coverage`). The change set adds the new validation doc at [docs/phase-30d-approval-execution-reconciliation-ui-validation.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-675/docs/phase-30d-approval-execution-reconciliation-ui-validation.md), the focused control-plane validation test at [control-plane/tests/test_phase30d_operator_ui_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-675/control-plane/tests/test_phase30d_operator_ui_validation.py), and a new operator-ui route test in [apps/operator-ui/src/app/OperatorRoutes.test.tsx](/Users/jp.infra/Dev/AegisOps-worktrees/issue-675/apps/operator-ui/src/app/OperatorRoutes.test.tsx) that keeps expired approval state explicit without implying execution or reconciliation success. I also updated the ignored supervisor journal in place before finishing.

Verification passed with `python3 -m unittest control-plane.tests.test_phase30d_operator_ui_validation`, `python3 -m unittest control-plane.tests.test_phase30d_approval_execution_reconciliation_docs`, `npm --prefix apps/operator-ui test`, and `npm --prefix apps/operator-ui run build`. Frontend verification initially failed because `apps/operator-ui/node_modules` was missing in this worktree, so I restored dependencies with `npm --prefix apps/operator-ui ci` and reran the exact issue commands successfully.

Summary: Added Phase 30D validation doc/test coverage and an operator-...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for expired approval lifecycle states, including UI messaging and visibility scenarios.
  * Improved test execution timing for reconciliation mismatch assertions.

* **Documentation**
  * Added Phase 30D validation documentation detailing approval lifecycle states, execution receipt visibility, and reconciliation mismatch handling requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->