### PR TITLE
implementation: add the Phase 30E assistant and advisory read surface to the operator shell (#683)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -1726,6 +1726,44 @@ describe("OperatorRoutes", () => {
     );
   });
 
+  it("renders a case-anchored assistant advisory route from reviewed advisory output", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-advisory-output": {
+          read_only: true,
+          record_family: "case",
+          record_id: "case-456",
+          output_kind: "case_summary",
+          status: "ready",
+          summary:
+            "Repository owner membership drift remains bounded to the reviewed case scope.",
+          citations: ["case-456", "alert-123", "evidence-123"],
+        },
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/assistant/case/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("case").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("case-456").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Output: case_summary/i)).toBeInTheDocument();
+    expect(screen.getByText(/Status: ready/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Repository owner membership drift remains bounded to the reviewed case scope.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("evidence-123")).toBeInTheDocument();
+  });
+
   it("renders reconciliation mismatch visibility from reviewed records", async () => {
     const dependencies = createDefaultDependencies({
       fetchFn: createAuthorizedFetch({

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -290,6 +290,64 @@ describe("OperatorRoutes", () => {
     expect(screen.queryByText(/remains inspection-only until a separately reviewed slice/i)).not.toBeInTheDocument();
   });
 
+  it("renders recommendation, approval, and reconciliation advisory links from action review detail", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {
+          "/inspect-action-review": {
+            action_request_id: "action-request-321",
+            read_only: true,
+            current_action_review: {
+              action_request_id: "action-request-321",
+              review_state: "approved",
+            },
+            action_review: {
+              action_request_id: "action-request-321",
+              review_state: "approved",
+              action_request_state: "approved",
+              approval_state: "approved",
+              recommendation_id: "recommendation-321",
+              approval_decision_id: "approval-321",
+              reconciliation_id: "recon-321",
+              requester_identity: "analyst@example.com",
+              recipient_identity: "repo-owner@example.com",
+            },
+            case_record: {
+              case_id: "case-321",
+              lifecycle_state: "open",
+            },
+          },
+        },
+        {
+          identity: "approver@example.com",
+          provider: "authentik",
+          roles: ["Approver"],
+          subject: "operator-8",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/action-review/action-request-321"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("link", { name: "Open recommendation advisory" }),
+    ).toHaveAttribute("href", "/operator/assistant/recommendation/recommendation-321");
+    expect(
+      screen.getByRole("link", { name: "Open approval advisory" }),
+    ).toHaveAttribute("href", "/operator/assistant/approval_decision/approval-321");
+    expect(
+      screen.getByRole("link", { name: "Open reconciliation advisory" }),
+    ).toHaveAttribute("href", "/operator/assistant/reconciliation/recon-321");
+  });
+
   it("renders execution receipt, reconciliation mismatch, and coordination visibility on action-review detail", async () => {
     const dependencies = createDefaultDependencies({
       fetchFn: createAuthorizedFetch(
@@ -1762,6 +1820,48 @@ describe("OperatorRoutes", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("evidence-123")).toBeInTheDocument();
+  });
+
+  it("keeps fallback advisory summary fields out of the detail table", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-advisory-output": {
+          read_only: true,
+          record_family: "recommendation",
+          record_id: "recommendation-123",
+          output_kind: "recommendation_summary",
+          status: "ready",
+          message: "Use the reviewed recommendation as bounded advisory context.",
+          advisory_text: "This fallback field should not be repeated in detail rows.",
+          supporting_note: "Analyst follow-up remains separate from advisory prose.",
+        },
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/assistant/recommendation/recommendation-123"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Use the reviewed recommendation as bounded advisory context."),
+    ).toBeInTheDocument();
+
+    const detailTable = screen.getByRole("table");
+    expect(within(detailTable).queryByText("Message")).not.toBeInTheDocument();
+    expect(within(detailTable).queryByText("Output Text")).not.toBeInTheDocument();
+    expect(within(detailTable).queryByText("Advisory Text")).not.toBeInTheDocument();
+    expect(within(detailTable).getByText("Supporting Note")).toBeInTheDocument();
+    expect(
+      within(detailTable).getByText(
+        "Analyst follow-up remains separate from advisory prose.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("renders reconciliation mismatch visibility from reviewed records", async () => {

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -1,4 +1,5 @@
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import GavelOutlinedIcon from "@mui/icons-material/GavelOutlined";
 import InboxOutlinedIcon from "@mui/icons-material/InboxOutlined";
 import InsightsOutlinedIcon from "@mui/icons-material/InsightsOutlined";
@@ -26,6 +27,7 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import { operatorTheme } from "./theme";
 import {
   ActionReviewPage,
+  AssistantAdvisoryPage,
   AlertDetailPage,
   CaseDetailPage,
   ProvenancePage,
@@ -94,6 +96,11 @@ function OperatorMenu({
         primaryText="Reconciliation"
         to="/operator/reconciliation"
       />
+      <Menu.Item
+        leftIcon={<AutoAwesomeOutlinedIcon />}
+        primaryText="Assistant"
+        to="/operator/assistant"
+      />
       {showActionReview ? (
         <Menu.Item
           leftIcon={<GavelOutlinedIcon />}
@@ -128,6 +135,12 @@ function OverviewPage({
       chip: "Read-only",
       description:
         "Case detail pages will remain task-oriented instead of generic CRUD resources.",
+    },
+    {
+      title: "Assistant",
+      chip: "Advisory only",
+      description:
+        "Assistant advisory stays subordinate to authoritative AegisOps records and remains read-oriented in the reviewed shell.",
     },
     ...(canInspectActionReview(operatorRoles)
       ? [
@@ -244,6 +257,11 @@ export function OperatorShell({
             <Route element={<ProvenancePage />} path="provenance/:family/:recordId" />
             <Route element={<ReadinessPage />} path="readiness" />
             <Route element={<ReconciliationPage />} path="reconciliation" />
+            <Route element={<AssistantAdvisoryPage />} path="assistant" />
+            <Route
+              element={<AssistantAdvisoryPage />}
+              path="assistant/:recordFamily/:recordId"
+            />
             <Route
               element={
                 canViewActionReview ? (

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -84,6 +84,18 @@ function formatLabel(value: string) {
     .replace(/\b\w/g, (character) => character.toUpperCase());
 }
 
+const ADVISORY_SUMMARY_FIELDS = ["summary", "message", "output_text", "advisory_text"] as const;
+const ADVISORY_DETAIL_EXCLUDED_FIELDS = [
+  "id",
+  "record_family",
+  "record_id",
+  "output_kind",
+  "status",
+  "read_only",
+  "citations",
+  ...ADVISORY_SUMMARY_FIELDS,
+] as const;
+
 function formatValue(value: unknown): string {
   if (value === null || value === undefined) {
     return "Not available";
@@ -1327,6 +1339,7 @@ function ActionReviewPageBody({
   const actionRequestState = asString(actionReview?.action_request_state);
   const approvalState = asString(actionReview?.approval_state);
   const approvalDecisionId = asString(actionReview?.approval_decision_id);
+  const reconciliationId = asString(actionReview?.reconciliation_id);
   const decisionRationale = asString(actionReview?.decision_rationale);
   const approverIdentities = asStringArray(actionReview?.approver_identities);
   const recommendationId = asString(actionReview?.recommendation_id);
@@ -1407,6 +1420,16 @@ function ActionReviewPageBody({
               variant="outlined"
             >
               Open approval advisory
+            </Button>
+          ) : null}
+          {reconciliationId ? (
+            <Button
+              component={ReactRouterLink}
+              endIcon={<LaunchOutlinedIcon />}
+              to={`/operator/assistant/reconciliation/${reconciliationId}`}
+              variant="outlined"
+            >
+              Open reconciliation advisory
             </Button>
           ) : null}
           {alertRecord?.alert_id ? (
@@ -1571,16 +1594,9 @@ export function ActionReviewPage({
 
 function AdvisoryDetailTable({ record }: { record: UnknownRecord }) {
   const rows = Object.entries(record).filter(([key]) => {
-    return ![
-      "id",
-      "record_family",
-      "record_id",
-      "output_kind",
-      "status",
-      "read_only",
-      "citations",
-      "summary",
-    ].includes(key);
+    return !ADVISORY_DETAIL_EXCLUDED_FIELDS.includes(
+      key as (typeof ADVISORY_DETAIL_EXCLUDED_FIELDS)[number],
+    );
   });
 
   if (rows.length === 0) {
@@ -1636,10 +1652,9 @@ function AssistantAdvisoryPageBody({
   }
 
   const summary =
-    asString(data.summary) ??
-    asString(data.message) ??
-    asString(data.output_text) ??
-    asString(data.advisory_text);
+    ADVISORY_SUMMARY_FIELDS.map((key) => asString(data[key])).find(
+      (value): value is string => value !== null,
+    ) ?? null;
   const citations = asStringArray(data.citations);
 
   return (

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -650,6 +650,31 @@ function EmptyState({ message }: { message: string }) {
   );
 }
 
+function supportedAnchorRoute(
+  recordFamily: string | null,
+  recordId: string | null,
+): { label: string; to: string } | null {
+  if (recordFamily === null || recordId === null) {
+    return null;
+  }
+
+  if (recordFamily === "alert") {
+    return {
+      label: "Open alert detail",
+      to: `/operator/alerts/${recordId}`,
+    };
+  }
+
+  if (recordFamily === "case") {
+    return {
+      label: "Open case detail",
+      to: `/operator/cases/${recordId}`,
+    };
+  }
+
+  return null;
+}
+
 function RecordWarnings({ record }: { record: UnknownRecord }) {
   const warnings: string[] = [];
   const reviewState = asString(record.review_state);
@@ -914,6 +939,14 @@ function AlertDetailPageBody({
           <Button
             component={ReactRouterLink}
             endIcon={<LaunchOutlinedIcon />}
+            to={`/operator/assistant/alert/${alertId}`}
+            variant="outlined"
+          >
+            Open assistant advisory
+          </Button>
+          <Button
+            component={ReactRouterLink}
+            endIcon={<LaunchOutlinedIcon />}
             to={`/operator/provenance/alerts/${alertId}`}
             variant="outlined"
           >
@@ -1086,6 +1119,14 @@ function CaseDetailPageBody({
               Open action review
             </Button>
           ) : null}
+          <Button
+            component={ReactRouterLink}
+            endIcon={<LaunchOutlinedIcon />}
+            to={`/operator/assistant/case/${caseId}`}
+            variant="outlined"
+          >
+            Open assistant advisory
+          </Button>
           <Button
             component={ReactRouterLink}
             endIcon={<LaunchOutlinedIcon />}
@@ -1285,8 +1326,10 @@ function ActionReviewPageBody({
   const currentActionRequestId = asString(currentActionReview?.action_request_id);
   const actionRequestState = asString(actionReview?.action_request_state);
   const approvalState = asString(actionReview?.approval_state);
+  const approvalDecisionId = asString(actionReview?.approval_decision_id);
   const decisionRationale = asString(actionReview?.decision_rationale);
   const approverIdentities = asStringArray(actionReview?.approver_identities);
+  const recommendationId = asString(actionReview?.recommendation_id);
   const isCurrentAuthoritativeReview =
     selectedActionRequestId !== null &&
     currentActionRequestId !== null &&
@@ -1344,6 +1387,26 @@ function ActionReviewPageBody({
               variant="outlined"
             >
               Open case detail
+            </Button>
+          ) : null}
+          {recommendationId ? (
+            <Button
+              component={ReactRouterLink}
+              endIcon={<LaunchOutlinedIcon />}
+              to={`/operator/assistant/recommendation/${recommendationId}`}
+              variant="outlined"
+            >
+              Open recommendation advisory
+            </Button>
+          ) : null}
+          {approvalDecisionId ? (
+            <Button
+              component={ReactRouterLink}
+              endIcon={<LaunchOutlinedIcon />}
+              to={`/operator/assistant/approval_decision/${approvalDecisionId}`}
+              variant="outlined"
+            >
+              Open approval advisory
             </Button>
           ) : null}
           {alertRecord?.alert_id ? (
@@ -1500,6 +1563,175 @@ export function ActionReviewPage({
           title="Select an action review"
         >
           <EmptyState message="No action request is selected yet." />
+        </SectionCard>
+      )}
+    </PageFrame>
+  );
+}
+
+function AdvisoryDetailTable({ record }: { record: UnknownRecord }) {
+  const rows = Object.entries(record).filter(([key]) => {
+    return ![
+      "id",
+      "record_family",
+      "record_id",
+      "output_kind",
+      "status",
+      "read_only",
+      "citations",
+      "summary",
+    ].includes(key);
+  });
+
+  if (rows.length === 0) {
+    return <EmptyState message="No additional advisory fields were returned for this record." />;
+  }
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>Field</TableCell>
+          <TableCell>Value</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map(([key, value]) => (
+          <TableRow key={key}>
+            <TableCell>{formatLabel(key)}</TableCell>
+            <TableCell>{formatValue(value)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function AssistantAdvisoryPageBody({
+  recordFamily,
+  recordId,
+}: {
+  recordFamily: string;
+  recordId: string;
+}) {
+  const advisoryId = `${recordFamily}:${recordId}`;
+  const meta = useMemo(
+    () => ({
+      recordFamily,
+      recordId,
+    }),
+    [recordFamily, recordId],
+  );
+  const { data, error, loading } = useOperatorRecord("advisoryOutput", advisoryId, meta);
+  const anchorLink = supportedAnchorRoute(recordFamily, recordId);
+
+  if (loading) {
+    return <LoadingState label="Loading assistant advisory" />;
+  }
+  if (error) {
+    return <ErrorState error={error} />;
+  }
+  if (!data) {
+    return <EmptyState message="Assistant advisory is unavailable." />;
+  }
+
+  const summary =
+    asString(data.summary) ??
+    asString(data.message) ??
+    asString(data.output_text) ??
+    asString(data.advisory_text);
+  const citations = asStringArray(data.citations);
+
+  return (
+    <Stack spacing={3}>
+      <SectionCard
+        subtitle="Assistant output stays subordinate to the selected authoritative record and remains read-only inside the reviewed shell."
+        title="Authoritative advisory anchor"
+      >
+        <StatusStrip
+          values={[
+            ["Status", asString(data.status)],
+            ["Output", asString(data.output_kind)],
+          ]}
+        />
+        <ValueList
+          entries={[
+            ["Record family", asString(data.record_family) ?? recordFamily],
+            ["Record id", asString(data.record_id) ?? recordId],
+            ["Read only", formatValue(data.read_only)],
+          ]}
+        />
+        {anchorLink ? (
+          <Button
+            component={ReactRouterLink}
+            endIcon={<LaunchOutlinedIcon />}
+            to={anchorLink.to}
+            variant="outlined"
+          >
+            {anchorLink.label}
+          </Button>
+        ) : null}
+      </SectionCard>
+
+      <SectionCard
+        subtitle="The reviewed shell exposes bounded advisory text without widening this route into a generic assistant workspace."
+        title="Assistant summary"
+      >
+        {summary ? (
+          <Alert severity="info" variant="outlined">
+            {summary}
+          </Alert>
+        ) : (
+          <EmptyState message="No assistant summary text was returned for this record." />
+        )}
+      </SectionCard>
+
+      <SectionCard
+        subtitle="Evidence citations stay visible as directly linked support for this advisory output."
+        title="Evidence anchors"
+      >
+        {citations.length > 0 ? (
+          <Stack direction="row" flexWrap="wrap" gap={1}>
+            {citations.map((citation) => (
+              <Chip key={citation} label={citation} size="small" variant="outlined" />
+            ))}
+          </Stack>
+        ) : (
+          <EmptyState message="No advisory citations were returned for this record." />
+        )}
+      </SectionCard>
+
+      <SectionCard
+        subtitle="Additional reviewed advisory fields remain readable here until richer advisory-specific rendering lands."
+        title="Advisory detail"
+      >
+        <AdvisoryDetailTable record={data} />
+      </SectionCard>
+    </Stack>
+  );
+}
+
+export function AssistantAdvisoryPage() {
+  const params = useParams();
+  const recordFamily = asString(params.recordFamily);
+  const recordId = asString(params.recordId);
+
+  return (
+    <PageFrame
+      subtitle="Assistant advisory stays a dedicated read surface anchored to one authoritative record. It does not become a generic assistant chat or mutable workflow console."
+      title="Assistant Advisory"
+    >
+      {recordFamily && recordId ? (
+        <AssistantAdvisoryPageBody
+          recordFamily={recordFamily}
+          recordId={recordId}
+        />
+      ) : (
+        <SectionCard
+          subtitle="Open assistant advisory from alert, case, or action-review detail so the route stays grounded in one authoritative record."
+          title="Select advisory context"
+        >
+          <EmptyState message="No authoritative record is selected for assistant advisory yet." />
         </SectionCard>
       )}
     </PageFrame>


### PR DESCRIPTION
Closes #683
This PR was opened by codex-supervisor.
Latest Codex summary:

Added the Phase 30E operator-shell advisory surface in commit `62267ed` (`Add operator assistant advisory surface`).

The shell now exposes `/operator/assistant` and `/operator/assistant/:recordFamily/:recordId`, adds an `Assistant` menu entry, renders a read-only `Assistant Advisory` page backed by `advisoryOutput`, and links into it from alert, case, and action-review detail pages using authoritative record context. I also added a focused regression test for a case-anchored advisory deep link, then ran the full `apps/operator-ui` test suite and build successfully.

Summary: added the reviewed assistant advisory route, page, shell entry, and authoritative deep links in `apps/operator-ui`; focused regression test added and full local verification passed
State hint: implementing
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test -- OperatorRoutes.test.tsx -t "renders a case-anchored assistant advisory route from reviewed advisory output"`; `npm --prefix apps/operator-ui test`; `npm --prefix apps/operator-ui run build`
Failure signature: none
Next action: push `codex/issue-683` and open or update the draft PR for issue #683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Assistant" menu navigation to the operator interface
  * New Assistant Advisory pages display advisory summaries, status indicators, citations, and supporting details
  * Added navigation buttons in alert, case, and action review pages to view related advisories

* **Tests**
  * Added test coverage for assistant advisory route rendering and data display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->