### PR TITLE
Issue #684: render cited advisory drafts with assistant framing

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -333,12 +333,8 @@ describe("OperatorRoutes", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
-    });
-
     expect(
-      screen.getByRole("link", { name: "Open recommendation advisory" }),
+      await screen.findByRole("link", { name: "Open recommendation advisory" }),
     ).toHaveAttribute("href", "/operator/assistant/recommendation/recommendation-321");
     expect(
       screen.getByRole("link", { name: "Open approval advisory" }),
@@ -1853,11 +1849,7 @@ describe("OperatorRoutes", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
-    });
-
-    const citedOutputSection = screen.getByRole("heading", { name: "Cited advisory output" });
+    const citedOutputSection = await screen.findByRole("heading", { name: "Cited advisory output" });
     const citedOutputCard = citedOutputSection.closest(".MuiCard-root");
     expect(citedOutputCard).not.toBeNull();
     expect(
@@ -1894,6 +1886,9 @@ describe("OperatorRoutes", () => {
           record_id: "recommendation-123",
           output_kind: "recommendation_summary",
           status: "ready",
+          cited_summary: {
+            citations: ["recommendation-123", "evidence-123"],
+          },
           message: "Use the reviewed recommendation as bounded advisory context.",
           advisory_text: "This fallback field should not be repeated in detail rows.",
           supporting_note: "Analyst follow-up remains separate from advisory prose.",
@@ -1907,13 +1902,20 @@ describe("OperatorRoutes", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
-    });
-
     expect(
-      screen.getByText("Use the reviewed recommendation as bounded advisory context."),
+      await screen.findByText("Use the reviewed recommendation as bounded advisory context."),
     ).toBeInTheDocument();
+
+    const citedOutputSection = await screen.findByRole("heading", { name: "Cited advisory output" });
+    const citedOutputCard = citedOutputSection.closest(".MuiCard-root");
+    expect(citedOutputCard).not.toBeNull();
+    expect(
+      within(citedOutputCard as HTMLElement).getByText(
+        "No cited summary anchors were returned for this advisory output.",
+      ),
+    ).toBeInTheDocument();
+    expect(within(citedOutputCard as HTMLElement).queryByText("recommendation-123")).not.toBeInTheDocument();
+    expect(within(citedOutputCard as HTMLElement).queryByText("evidence-123")).not.toBeInTheDocument();
 
     const detailTable = screen.getByRole("table");
     expect(within(detailTable).queryByText("Message")).not.toBeInTheDocument();

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -1822,6 +1822,69 @@ describe("OperatorRoutes", () => {
     expect(screen.getByText("evidence-123")).toBeInTheDocument();
   });
 
+  it("renders cited recommendation draft output with explicit assistant-only framing", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-advisory-output": {
+          read_only: true,
+          record_family: "recommendation",
+          record_id: "recommendation-123",
+          output_kind: "recommendation_draft",
+          status: "ready",
+          cited_summary: {
+            text: "The assistant draft stays anchored to the cited evidence before any reviewed action.",
+            citations: ["recommendation-123", "evidence-123", "case-456"],
+          },
+          candidate_recommendations: [
+            {
+              text: "Proposal only: confirm the repository ownership change before raising an action request.",
+              citations: ["evidence-123", "case-456"],
+            },
+          ],
+          uncertainty_flags: ["advisory_only"],
+          citations: ["recommendation-123", "evidence-123", "case-456"],
+        },
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/assistant/recommendation/recommendation-123"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
+    });
+
+    const citedOutputSection = screen.getByRole("heading", { name: "Cited advisory output" });
+    const citedOutputCard = citedOutputSection.closest(".MuiCard-root");
+    expect(citedOutputCard).not.toBeNull();
+    expect(
+      within(citedOutputCard as HTMLElement).getByText(
+        "The assistant draft stays anchored to the cited evidence before any reviewed action.",
+      ),
+    ).toBeInTheDocument();
+    expect(within(citedOutputCard as HTMLElement).getByText("recommendation-123")).toBeInTheDocument();
+    expect(within(citedOutputCard as HTMLElement).getByText("evidence-123")).toBeInTheDocument();
+    expect(within(citedOutputCard as HTMLElement).getByText("case-456")).toBeInTheDocument();
+
+    const draftSection = screen.getByRole("heading", { name: "Recommendation draft" });
+    const draftCard = draftSection.closest(".MuiCard-root");
+    expect(draftCard).not.toBeNull();
+    expect(within(draftCard as HTMLElement).getByText("Draft only")).toBeInTheDocument();
+    expect(
+      within(draftCard as HTMLElement).getByText(
+        "Proposal only: confirm the repository ownership change before raising an action request.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(draftCard as HTMLElement).getByText(
+        "Assistant output does not approve, execute, or reconcile workflow state.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("keeps fallback advisory summary fields out of the detail table", async () => {
     const dependencies = createDefaultDependencies({
       fetchFn: createAuthorizedFetch({

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -132,7 +132,7 @@ function advisorySummary(record: UnknownRecord) {
     ) ?? null;
 
   return {
-    citations: citedCitations,
+    citations: citedText ? citedCitations : [],
     text: citedText ?? fallbackText,
   };
 }

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -92,6 +92,9 @@ const ADVISORY_DETAIL_EXCLUDED_FIELDS = [
   "output_kind",
   "status",
   "read_only",
+  "cited_summary",
+  "candidate_recommendations",
+  "uncertainty_flags",
   "citations",
   ...ADVISORY_SUMMARY_FIELDS,
 ] as const;
@@ -117,6 +120,28 @@ function formatValue(value: unknown): string {
   }
 
   return JSON.stringify(value);
+}
+
+function advisorySummary(record: UnknownRecord) {
+  const citedSummary = asRecord(record.cited_summary);
+  const citedText = asString(citedSummary?.text);
+  const citedCitations = asStringArray(citedSummary?.citations);
+  const fallbackText =
+    ADVISORY_SUMMARY_FIELDS.map((key) => asString(record[key])).find(
+      (value): value is string => value !== null,
+    ) ?? null;
+
+  return {
+    citations: citedCitations,
+    text: citedText ?? fallbackText,
+  };
+}
+
+function advisoryRecommendations(record: UnknownRecord) {
+  return asRecordArray(record.candidate_recommendations).map((entry) => ({
+    citations: asStringArray(entry.citations),
+    text: asString(entry.text),
+  }));
 }
 
 function statusTone(
@@ -1651,11 +1676,14 @@ function AssistantAdvisoryPageBody({
     return <EmptyState message="Assistant advisory is unavailable." />;
   }
 
-  const summary =
-    ADVISORY_SUMMARY_FIELDS.map((key) => asString(data[key])).find(
-      (value): value is string => value !== null,
-    ) ?? null;
+  const summary = advisorySummary(data);
+  const recommendationDrafts = advisoryRecommendations(data).filter(
+    (entry): entry is { citations: string[]; text: string } => entry.text !== null,
+  );
   const citations = asStringArray(data.citations);
+  const uncertaintyFlags = asStringArray(data.uncertainty_flags);
+  const showsRecommendationDraft =
+    asString(data.output_kind) === "recommendation_draft" || recommendationDrafts.length > 0;
 
   return (
     <Stack spacing={3}>
@@ -1689,17 +1717,71 @@ function AssistantAdvisoryPageBody({
       </SectionCard>
 
       <SectionCard
-        subtitle="The reviewed shell exposes bounded advisory text without widening this route into a generic assistant workspace."
-        title="Assistant summary"
+        subtitle="Citation-led assistant output stays visibly subordinate to the authoritative anchor and remains advisory only."
+        title="Cited advisory output"
       >
-        {summary ? (
-          <Alert severity="info" variant="outlined">
-            {summary}
-          </Alert>
+        {summary.text ? (
+          <Stack spacing={2}>
+            <Alert severity="info" variant="outlined">
+              {summary.text}
+            </Alert>
+            {summary.citations.length > 0 ? (
+              <Stack direction="row" flexWrap="wrap" gap={1}>
+                {summary.citations.map((citation) => (
+                  <Chip key={citation} label={citation} size="small" variant="outlined" />
+                ))}
+              </Stack>
+            ) : (
+              <EmptyState message="No cited summary anchors were returned for this advisory output." />
+            )}
+          </Stack>
         ) : (
           <EmptyState message="No assistant summary text was returned for this record." />
         )}
       </SectionCard>
+
+      {showsRecommendationDraft ? (
+        <SectionCard
+          subtitle="Recommendation proposals remain explicit assistant drafts and do not replace reviewed workflow state."
+          title="Recommendation draft"
+        >
+          <Stack spacing={2}>
+            <Stack direction="row" flexWrap="wrap" gap={1}>
+              <Chip color="warning" label="Draft only" size="small" />
+              {uncertaintyFlags.map((flag) => (
+                <Chip key={flag} label={formatLabel(flag)} size="small" variant="outlined" />
+              ))}
+            </Stack>
+            <Alert severity="warning" variant="outlined">
+              Assistant output does not approve, execute, or reconcile workflow state.
+            </Alert>
+            {recommendationDrafts.length > 0 ? (
+              <Stack spacing={2}>
+                {recommendationDrafts.map((draft, index) => (
+                  <Card elevation={0} key={`${draft.text}-${index}`} sx={{ border: "1px solid", borderColor: "divider" }}>
+                    <CardContent>
+                      <Stack spacing={2}>
+                        <Typography variant="body1">{draft.text}</Typography>
+                        {draft.citations.length > 0 ? (
+                          <Stack direction="row" flexWrap="wrap" gap={1}>
+                            {draft.citations.map((citation) => (
+                              <Chip key={`${draft.text}-${citation}`} label={citation} size="small" variant="outlined" />
+                            ))}
+                          </Stack>
+                        ) : (
+                          <EmptyState message="This recommendation draft did not include supporting citations." />
+                        )}
+                      </Stack>
+                    </CardContent>
+                  </Card>
+                ))}
+              </Stack>
+            ) : (
+              <EmptyState message="No recommendation draft proposals were returned for this advisory output." />
+            )}
+          </Stack>
+        </SectionCard>
+      ) : null}
 
       <SectionCard
         subtitle="Evidence citations stay visible as directly linked support for this advisory output."


### PR DESCRIPTION
## Summary
- render cited advisory output from `cited_summary` as the primary assistant surface
- show recommendation proposals in a dedicated draft-only card with explicit non-authoritative wording
- add focused operator-ui coverage for recommendation advisory rendering

## Verification
- npm --prefix apps/operator-ui test
- npm --prefix apps/operator-ui run build

Closes #684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advisory summaries now show a separate "Cited advisory output" with source text and citation chips; advisory detail table omits duplicated cited fields.
  * Recommendation drafts render as a distinct "Recommendation draft" section with draft-only warning, uncertainty flags, and per-draft cards; empty states shown when absent.

* **Tests**
  * Added and updated tests covering cited advisory output, recommendation draft rendering, and cited-summary empty-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->