### PR TITLE
validation: add Phase 30E coverage for advisory citations, ambiguity visibility, and no-authority semantics (#686)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -1818,6 +1818,37 @@ describe("OperatorRoutes", () => {
     expect(screen.getByText("evidence-123")).toBeInTheDocument();
   });
 
+  it("keeps no-authority semantics explicit for cited advisory output without a recommendation draft", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-advisory-output": {
+          read_only: true,
+          record_family: "case",
+          record_id: "case-456",
+          output_kind: "case_summary",
+          status: "ready",
+          cited_summary: {
+            text: "The reviewed case remains open while the assistant summary stays advisory-only.",
+            citations: ["case-456", "alert-123"],
+          },
+          uncertainty_flags: ["advisory_only"],
+          citations: ["case-456", "alert-123"],
+        },
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/assistant/case/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Assistant output does not approve, execute, or reconcile workflow state."),
+    ).toBeInTheDocument();
+  });
+
   it("renders cited recommendation draft output with explicit assistant-only framing", async () => {
     const dependencies = createDefaultDependencies({
       fetchFn: createAuthorizedFetch({
@@ -1981,7 +2012,7 @@ describe("OperatorRoutes", () => {
     );
 
     expect(await screen.findByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Advisory failure visibility" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Advisory failure visibility" })).toBeInTheDocument();
     expect(
       screen.getByText(/Missing citation support is visible here/i),
     ).toBeInTheDocument();

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -1844,6 +1844,7 @@ describe("OperatorRoutes", () => {
     );
 
     expect(await screen.findByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Recommendation draft" })).not.toBeInTheDocument();
     expect(
       screen.getByText("Assistant output does not approve, execute, or reconcile workflow state."),
     ).toBeInTheDocument();

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -1823,6 +1823,9 @@ function AssistantAdvisoryPageBody({
             {anchorLink.label}
           </Button>
         ) : null}
+        <Alert severity="warning" variant="outlined">
+          Assistant output does not approve, execute, or reconcile workflow state.
+        </Alert>
       </SectionCard>
 
       {hasFailureVisibility ? (

--- a/control-plane/tests/test_phase30e_assistant_advisory_ui_boundary_docs.py
+++ b/control-plane/tests/test_phase30e_assistant_advisory_ui_boundary_docs.py
@@ -56,11 +56,14 @@ class Phase30EAssistantAdvisoryUiBoundaryDocsTests(unittest.TestCase):
             "docs/phase-24-first-live-assistant-workflow-family-and-trusted-output-contract.md",
             "docs/phase-30-react-admin-foundation-and-read-only-operator-console-boundary.md",
             "docs/phase-30d-approval-execution-reconciliation-ui-boundary.md",
+            "apps/operator-ui/src/app/OperatorRoutes.test.tsx",
             "citation-first rendering",
             "ambiguity visibility",
             "draft-versus-authoritative split",
             "no-authority posture",
             "python3 -m unittest control-plane.tests.test_phase30e_assistant_advisory_ui_boundary_docs",
+            "npm --prefix apps/operator-ui test -- src/app/OperatorRoutes.test.tsx",
+            "npm --prefix apps/operator-ui run build",
         ):
             self.assertIn(term, text)
 

--- a/docs/phase-30e-assistant-advisory-integration-validation.md
+++ b/docs/phase-30e-assistant-advisory-integration-validation.md
@@ -26,15 +26,18 @@ The locked verification surfaces are:
 - `docs/phase-30-react-admin-foundation-and-read-only-operator-console-boundary.md`
 - `docs/phase-30d-approval-execution-reconciliation-ui-boundary.md`
 - `control-plane/tests/test_phase30e_assistant_advisory_ui_boundary_docs.py`
+- `apps/operator-ui/src/app/OperatorRoutes.test.tsx`
 
 Focused validation covers:
 
 - citation-first rendering rules for advisory output detail;
 - ambiguity visibility, conflicting context visibility, unresolved visibility, and missing-citation failure posture;
 - draft-versus-authoritative split between recommendation draft rendering and reviewed lifecycle truth; and
-- no-authority posture for assistant content rendered beside authoritative anchor records and action-review or case detail surfaces.
+- no-authority posture for assistant content rendered beside authoritative anchor records and action-review or case detail surfaces; and
+- explicit browser rendering that assistant content does not approve, execute, or reconcile workflow state even when no recommendation draft card is present.
 
 Focused verification commands:
 
 - `python3 -m unittest control-plane.tests.test_phase30e_assistant_advisory_ui_boundary_docs`
-- `node ../codex-supervisor/dist/index.js issue-lint 682 --config ../codex-supervisor/supervisor.config.aegisops.coderabbit.json`
+- `npm --prefix apps/operator-ui test -- src/app/OperatorRoutes.test.tsx`
+- `npm --prefix apps/operator-ui run build`


### PR DESCRIPTION
Closes #686
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused Phase 30E validation slice and committed it as `c728fab` (`Add Phase 30E advisory validation coverage`).

The operator advisory page now always renders an explicit no-authority warning, even when there is no recommendation draft card. I also added a narrow `OperatorRoutes` regression test for that case, fixed the existing unresolved-advisory test to wait for the failure-visibility section to render, and updated the Phase 30E validation doc plus its docs test so the locked verification surface now includes the operator-ui test file and the actual frontend verification commands.

Tests I ran:
- `python3 -m unittest control-plane.tests.test_phase30e_assistant_advisory_ui_boundary_docs`
- `npm --prefix apps/operator-ui test -- src/app/OperatorRoutes.test.tsx`
- `npm --prefix apps/operator-ui run build`

Summary: Added focused Phase 30E UI and docs validation coverage for citations, ambiguity visibility, and explicit no-authority semantics; committed as `c728fab`.
State hint: implementing
Blocked reason: none
Tests: `python3 -m unittest control-plane.tests.test_phase30e_assistant_advisory_ui_boundary_docs`; `npm --prefix apps/operator-ui test -- src/app/OperatorRoutes.test.tsx`; `npm --prefix apps/operator-ui run build`
Failure signature: none
Next action: open or update the draft PR for `codex/issue-686` with commit `c728fab` and continue with any requested broader validation or review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warning alerts in Assistant Advisory sections clarifying that assistant output does not approve, execute, or reconcile workflow state, including when a recommendation draft is shown.

* **Tests**
  * Added tests covering advisory routes and adjusted assertions for more reliable UI visibility checks.

* **Documentation**
  * Expanded validation docs to include the new test coverage and updated verification steps for advisory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->