### PR TITLE
implementation: add shared optional-extension visibility primitives and shell surfaces (#696)

### DIFF
--- a/apps/operator-ui/package-lock.json
+++ b/apps/operator-ui/package-lock.json
@@ -4554,22 +4554,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     }
   }
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -16,6 +16,61 @@ function jsonResponse(body: unknown, status = 200) {
   });
 }
 
+function createOptionalExtensionPayload(
+  overrides: Partial<Record<"assistant" | "endpoint_evidence" | "network_evidence" | "ml_shadow", unknown>> = {},
+) {
+  return {
+    overall_state: "ready",
+    tracked_extensions: 4,
+    extensions: {
+      assistant: {
+        authority_mode: "advisory_only",
+        availability: "available",
+        enablement: "enabled",
+        mainline_dependency: "non_blocking",
+        readiness: "ready",
+        reason: "bounded_reviewed_summary_provider_available",
+      },
+      endpoint_evidence: {
+        authority_mode: "augmenting_evidence",
+        availability: "unavailable",
+        enablement: "disabled_by_default",
+        mainline_dependency: "non_blocking",
+        readiness: "not_applicable",
+        reason: "isolated_executor_runtime_not_configured",
+      },
+      network_evidence: {
+        authority_mode: "augmenting_evidence",
+        availability: "unavailable",
+        enablement: "disabled_by_default",
+        mainline_dependency: "non_blocking",
+        readiness: "not_applicable",
+        reason: "reviewed_network_evidence_extension_not_activated",
+      },
+      ml_shadow: {
+        authority_mode: "shadow_only",
+        availability: "unavailable",
+        enablement: "disabled_by_default",
+        mainline_dependency: "non_blocking",
+        readiness: "not_applicable",
+        reason: "reviewed_ml_shadow_extension_not_activated",
+      },
+      ...overrides,
+    },
+  };
+}
+
+function createReadinessResponse(
+  optionalExtensionsOverrides?: Partial<Record<"assistant" | "endpoint_evidence" | "network_evidence" | "ml_shadow", unknown>>,
+) {
+  return {
+    metrics: {
+      optional_extensions: createOptionalExtensionPayload(optionalExtensionsOverrides),
+    },
+    status: "ready",
+  };
+}
+
 function createAuthorizedFetch(
   handlers: Record<string, unknown>,
   sessionOverride?: {
@@ -44,6 +99,10 @@ function createAuthorizedFetch(
     const match = Object.entries(handlers).find(([prefix]) => url.startsWith(prefix));
     if (match) {
       return Promise.resolve(jsonResponse(match[1]));
+    }
+
+    if (url.startsWith("/diagnostics/readiness")) {
+      return Promise.resolve(jsonResponse(createReadinessResponse()));
     }
 
     return Promise.reject(new Error(`Unexpected fetch: ${url}`));
@@ -124,15 +183,21 @@ describe("OperatorRoutes", () => {
   });
 
   it("restores an authorized session into the protected shell", async () => {
+    const fetchFn = createAuthorizedFetch({
+      "/diagnostics/readiness": createReadinessResponse({
+        ml_shadow: {
+          authority_mode: "shadow_only",
+          availability: "available",
+          enablement: "enabled",
+          mainline_dependency: "non_blocking",
+          readiness: "degraded",
+          reason: "reviewed_ml_shadow_extension_provider_lagging",
+        },
+        network_evidence: undefined,
+      }),
+    });
     const dependencies = createDefaultDependencies({
-      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
-        jsonResponse({
-          identity: "analyst@example.com",
-          provider: "authentik",
-          roles: ["Analyst"],
-          subject: "operator-7",
-        }),
-      ),
+      fetchFn,
     });
 
     render(
@@ -155,15 +220,26 @@ describe("OperatorRoutes", () => {
         "Optional-path posture stays subordinate to authoritative workflow pages and reviewed runtime truth.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Enabled")).toBeInTheDocument();
-    expect(screen.getAllByText("Disabled By Default").length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(screen.getByText("Enabled")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Disabled By Default")).toBeInTheDocument();
     expect(screen.getByText("Unavailable")).toBeInTheDocument();
     expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Reviewed status source: reviewed ml shadow extension provider lagging\./i,
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         "Missing optional paths do not imply a control-plane failure when the mainline reviewed workflow remains healthy.",
       ),
     ).toBeInTheDocument();
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/diagnostics/readiness?order=ASC&page=1&per_page=1&sort=status",
+      expect.any(Object),
+    );
   });
 
   it("hides action-review navigation for analyst-only sessions", async () => {

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -146,6 +146,24 @@ describe("OperatorRoutes", () => {
         screen.getByRole("heading", { name: "Protected operator shell" }),
       ).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByRole("heading", { name: "Optional extension visibility" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Optional-path posture stays subordinate to authoritative workflow pages and reviewed runtime truth.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
+    expect(screen.getAllByText("Disabled By Default").length).toBeGreaterThan(0);
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Missing optional paths do not imply a control-plane failure when the mainline reviewed workflow remains healthy.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("hides action-review navigation for analyst-only sessions", async () => {

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import GavelOutlinedIcon from "@mui/icons-material/GavelOutlined";
@@ -22,6 +23,7 @@ import {
   Logout,
   Menu,
   TitlePortal,
+  useDataProvider,
 } from "react-admin";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { operatorTheme } from "./theme";
@@ -35,7 +37,10 @@ import {
   ReadinessPage,
   ReconciliationPage,
 } from "./operatorConsolePages";
-import { OptionalExtensionVisibilityPanel } from "./optionalExtensionVisibility";
+import {
+  OptionalExtensionVisibilityPanel,
+  buildOptionalExtensionDefinitionsFromPayload,
+} from "./optionalExtensionVisibility";
 import { TaskActionClientProvider } from "../taskActions/taskActionPrimitives";
 import type { OperatorTaskActionClient } from "../taskActions/taskActionClient";
 
@@ -118,6 +123,50 @@ function OverviewPage({
 }: {
   operatorRoles: readonly string[];
 }) {
+  const dataProvider = useDataProvider();
+  const [optionalExtensionDefinitions, setOptionalExtensionDefinitions] = useState(() =>
+    buildOptionalExtensionDefinitionsFromPayload(null),
+  );
+
+  useEffect(() => {
+    let active = true;
+
+    void dataProvider
+      .getList("runtimeReadiness", {
+        filter: {},
+        pagination: {
+          page: 1,
+          perPage: 1,
+        },
+        sort: {
+          field: "status",
+          order: "ASC",
+        },
+      })
+      .then((result) => {
+        if (!active) {
+          return;
+        }
+
+        setOptionalExtensionDefinitions(
+          buildOptionalExtensionDefinitionsFromPayload(
+            result.data[0]?.metrics?.optional_extensions,
+          ),
+        );
+      })
+      .catch(() => {
+        if (!active) {
+          return;
+        }
+
+        setOptionalExtensionDefinitions(buildOptionalExtensionDefinitionsFromPayload(null));
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [dataProvider]);
+
   const sections = [
     {
       title: "Queue",
@@ -192,7 +241,7 @@ function OverviewPage({
         ))}
       </Grid>
 
-      <OptionalExtensionVisibilityPanel />
+      <OptionalExtensionVisibilityPanel definitions={optionalExtensionDefinitions} />
     </Stack>
   );
 }

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -35,6 +35,7 @@ import {
   ReadinessPage,
   ReconciliationPage,
 } from "./operatorConsolePages";
+import { OptionalExtensionVisibilityPanel } from "./optionalExtensionVisibility";
 import { TaskActionClientProvider } from "../taskActions/taskActionPrimitives";
 import type { OperatorTaskActionClient } from "../taskActions/taskActionClient";
 
@@ -190,6 +191,8 @@ function OverviewPage({
           </Grid>
         ))}
       </Grid>
+
+      <OptionalExtensionVisibilityPanel />
     </Stack>
   );
 }

--- a/apps/operator-ui/src/app/optionalExtensionVisibility.tsx
+++ b/apps/operator-ui/src/app/optionalExtensionVisibility.tsx
@@ -1,0 +1,119 @@
+import { Alert, Card, CardContent, Chip, Grid, Stack, Typography } from "@mui/material";
+
+export type OptionalExtensionStatus =
+  | "enabled"
+  | "disabled_by_default"
+  | "unavailable"
+  | "degraded";
+
+interface OptionalExtensionDefinition {
+  description: string;
+  status: OptionalExtensionStatus;
+  title: string;
+}
+
+const OPTIONAL_EXTENSION_DEFINITIONS: OptionalExtensionDefinition[] = [
+  {
+    title: "Assistant",
+    status: "enabled",
+    description:
+      "Enabled and ready means the bounded reviewed summary provider is available. Secondary enrichment remains non-blocking and never outranks authoritative workflow truth.",
+  },
+  {
+    title: "Endpoint evidence",
+    status: "disabled_by_default",
+    description:
+      "Disabled by default means no reviewed endpoint-evidence request is active. The operator shell keeps that posture visible without implying a control-plane gap.",
+  },
+  {
+    title: "Optional network evidence",
+    status: "unavailable",
+    description:
+      "Unavailable means the optional path is not activated on this reviewed runtime and does not block boot, queue review, approval, execution, or reconciliation truth.",
+  },
+  {
+    title: "ML shadow",
+    status: "degraded",
+    description:
+      "Degraded remains shadow-only and non-authoritative. Operators must repair or disable the optional path instead of widening authority or inferring healthy state from silence.",
+  },
+];
+
+function optionalExtensionStatusMetadata(status: OptionalExtensionStatus): {
+  color: "default" | "error" | "info" | "success" | "warning";
+  label: string;
+} {
+  switch (status) {
+    case "enabled":
+      return {
+        color: "success",
+        label: "Enabled",
+      };
+    case "disabled_by_default":
+      return {
+        color: "default",
+        label: "Disabled By Default",
+      };
+    case "unavailable":
+      return {
+        color: "info",
+        label: "Unavailable",
+      };
+    case "degraded":
+      return {
+        color: "warning",
+        label: "Degraded",
+      };
+  }
+}
+
+export function OptionalExtensionStatusChip({
+  status,
+}: {
+  status: OptionalExtensionStatus;
+}) {
+  const metadata = optionalExtensionStatusMetadata(status);
+
+  return <Chip color={metadata.color} label={metadata.label} size="small" />;
+}
+
+export function OptionalExtensionVisibilityPanel() {
+  return (
+    <Stack spacing={2.5}>
+      <Stack spacing={1}>
+        <Typography component="h2" variant="h5">
+          Optional extension visibility
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Optional-path posture stays subordinate to authoritative workflow pages and reviewed
+          runtime truth.
+        </Typography>
+      </Stack>
+
+      <Alert severity="info" variant="outlined">
+        Missing optional paths do not imply a control-plane failure when the mainline reviewed
+        workflow remains healthy.
+      </Alert>
+
+      <Grid container spacing={2}>
+        {OPTIONAL_EXTENSION_DEFINITIONS.map((definition) => (
+          <Grid key={definition.title} size={{ xs: 12, md: 6 }}>
+            <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+              <CardContent>
+                <Stack spacing={1.5}>
+                  <Stack direction="row" justifyContent="space-between" spacing={2}>
+                    <Typography variant="h6">{definition.title}</Typography>
+                    <OptionalExtensionStatusChip status={definition.status} />
+                  </Stack>
+                  <Typography color="text.secondary" variant="body2">
+                    {definition.description}
+                  </Typography>
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Stack>
+  );
+}

--- a/apps/operator-ui/src/app/optionalExtensionVisibility.tsx
+++ b/apps/operator-ui/src/app/optionalExtensionVisibility.tsx
@@ -6,38 +6,125 @@ export type OptionalExtensionStatus =
   | "unavailable"
   | "degraded";
 
-interface OptionalExtensionDefinition {
+export interface OptionalExtensionDefinition {
   description: string;
   status: OptionalExtensionStatus;
   title: string;
 }
 
-const OPTIONAL_EXTENSION_DEFINITIONS: OptionalExtensionDefinition[] = [
+interface OptionalExtensionSignal {
+  availability?: unknown;
+  enablement?: unknown;
+  reason?: unknown;
+  readiness?: unknown;
+}
+
+const OPTIONAL_EXTENSION_FAMILY_METADATA = [
   {
+    baseDescription:
+      "Assistant posture remains advisory-only and never outranks authoritative workflow truth.",
+    key: "assistant",
     title: "Assistant",
-    status: "enabled",
-    description:
-      "Enabled and ready means the bounded reviewed summary provider is available. Secondary enrichment remains non-blocking and never outranks authoritative workflow truth.",
   },
   {
+    baseDescription:
+      "Endpoint evidence stays subordinate to an already reviewed case and approved bounded request.",
+    key: "endpoint_evidence",
     title: "Endpoint evidence",
-    status: "disabled_by_default",
-    description:
-      "Disabled by default means no reviewed endpoint-evidence request is active. The operator shell keeps that posture visible without implying a control-plane gap.",
   },
   {
+    baseDescription:
+      "Optional network evidence remains subordinate to reviewed control-plane truth and non-blocking for the mainline runtime.",
+    key: "network_evidence",
     title: "Optional network evidence",
-    status: "unavailable",
-    description:
-      "Unavailable means the optional path is not activated on this reviewed runtime and does not block boot, queue review, approval, execution, or reconciliation truth.",
   },
   {
+    baseDescription:
+      "ML shadow remains shadow-only, audit-focused, and outside approval, execution, and reconciliation authority.",
+    key: "ml_shadow",
     title: "ML shadow",
-    status: "degraded",
-    description:
-      "Degraded remains shadow-only and non-authoritative. Operators must repair or disable the optional path instead of widening authority or inferring healthy state from silence.",
   },
-];
+] as const;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function humanizeReason(reason: string | null): string | null {
+  if (reason === null) {
+    return null;
+  }
+
+  return reason.replaceAll("_", " ");
+}
+
+function deriveOptionalExtensionStatus(extension: OptionalExtensionSignal | null): OptionalExtensionStatus {
+  const enablement = asString(extension?.enablement);
+  const availability = asString(extension?.availability);
+  const readiness = asString(extension?.readiness);
+
+  if (readiness === "degraded" || readiness === "delayed") {
+    return "degraded";
+  }
+
+  if (enablement === "disabled_by_default") {
+    return "disabled_by_default";
+  }
+
+  if (availability === "unavailable") {
+    return "unavailable";
+  }
+
+  if (enablement === "enabled") {
+    return "enabled";
+  }
+
+  return "unavailable";
+}
+
+function optionalExtensionStatusExplanation(status: OptionalExtensionStatus): string {
+  switch (status) {
+    case "enabled":
+      return "The reviewed optional path is active for its bounded role and remains subordinate to authoritative workflow truth.";
+    case "disabled_by_default":
+      return "The reviewed runtime is operating on the mainline path without this optional extension, which is expected behavior.";
+    case "unavailable":
+      return "A reviewed prerequisite or binding is missing, but mainline queue, case, approval, execution, and reconciliation truth stay separate.";
+    case "degraded":
+      return "Subordinate optional context may be incomplete, stale, or delayed while mainline workflow truth remains separate.";
+  }
+}
+
+export function buildOptionalExtensionDefinitionsFromPayload(
+  optionalExtensions: unknown,
+): OptionalExtensionDefinition[] {
+  const extensionEntries = asRecord(asRecord(optionalExtensions)?.extensions);
+
+  return OPTIONAL_EXTENSION_FAMILY_METADATA.map((family) => {
+    const extension = asRecord(extensionEntries?.[family.key]);
+    const status = deriveOptionalExtensionStatus(extension);
+    const reason = humanizeReason(asString(extension?.reason));
+    const description = [family.baseDescription, optionalExtensionStatusExplanation(status)];
+
+    if (reason) {
+      description.push(`Reviewed status source: ${reason}.`);
+    }
+
+    return {
+      description: description.join(" "),
+      status,
+      title: family.title,
+    };
+  });
+}
 
 function optionalExtensionStatusMetadata(status: OptionalExtensionStatus): {
   color: "default" | "error" | "info" | "success" | "warning";
@@ -77,7 +164,11 @@ export function OptionalExtensionStatusChip({
   return <Chip color={metadata.color} label={metadata.label} size="small" />;
 }
 
-export function OptionalExtensionVisibilityPanel() {
+export function OptionalExtensionVisibilityPanel({
+  definitions,
+}: {
+  definitions: readonly OptionalExtensionDefinition[];
+}) {
   return (
     <Stack spacing={2.5}>
       <Stack spacing={1}>
@@ -96,7 +187,7 @@ export function OptionalExtensionVisibilityPanel() {
       </Alert>
 
       <Grid container spacing={2}>
-        {OPTIONAL_EXTENSION_DEFINITIONS.map((definition) => (
+        {definitions.map((definition) => (
           <Grid key={definition.title} size={{ xs: 12, md: 6 }}>
             <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
               <CardContent>


### PR DESCRIPTION
Closes #696
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused reproducer in `apps/operator-ui/src/app/OperatorRoutes.test.tsx`, implemented a shared optional-extension overview panel in `apps/operator-ui/src/app/optionalExtensionVisibility.tsx`, and mounted it from the protected shell overview in `apps/operator-ui/src/app/OperatorShell.tsx`. The shell now exposes one reviewed status vocabulary for `Enabled`, `Disabled By Default`, `Unavailable`, and `Degraded`, plus mainline-expectation messaging that keeps optional paths subordinate to authoritative workflow truth. I also updated the local supervisor journal and committed the checkpoint as `78a612f` (`Add optional extension shell visibility primitives`).

Summary: Added shared optional-extension visibility primitives and an overview shell surface, proved the gap with a focused route test, and verified the operator-ui suite and build.
State hint: implementing
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test -- OperatorRoutes.test.tsx`; `npm --prefix apps/operator-ui test`; `npm --prefix apps/operator-ui run build`
Failure signature: missing-optional-extension-visibility-overview
Next action: open or update the branch PR/checkpoint from commit `78a612f` and continue with any follow-on optional-extension cards against the shared overview primitives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Optional Extension Visibility panel to the operator overview that displays per-extension status (Enabled, Disabled By Default, Unavailable, Degraded), human-readable descriptions, and guidance clarifying that missing optional extensions don’t imply control-plane failure.

* **Tests**
  * Updated UI tests to verify readiness endpoint interaction and to assert the new panel’s content and status labels render as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->