### PR TITLE
implementation: add optional endpoint and network evidence visibility to the operator UI (#697)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -6,6 +6,7 @@ import {
   OperatorRoutes,
   createDefaultDependencies,
 } from "./OperatorRoutes";
+import { buildOptionalEvidenceDefinitionsFromPayload } from "./optionalExtensionVisibility";
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -110,6 +111,23 @@ function createAuthorizedFetch(
 }
 
 describe("OperatorRoutes", () => {
+  it("keeps unavailable endpoint and network evidence posture visible when the optional path is disabled by default", () => {
+    const definitions = buildOptionalEvidenceDefinitionsFromPayload(
+      createOptionalExtensionPayload(),
+    );
+
+    expect(definitions).toEqual([
+      expect.objectContaining({
+        status: "unavailable",
+        title: "Endpoint evidence",
+      }),
+      expect.objectContaining({
+        status: "unavailable",
+        title: "Optional network evidence",
+      }),
+    ]);
+  });
+
   it("redirects unauthenticated users to the reviewed login route", async () => {
     const dependencies = createDefaultDependencies({
       fetchFn: vi
@@ -223,8 +241,7 @@ describe("OperatorRoutes", () => {
     await waitFor(() => {
       expect(screen.getByText("Enabled")).toBeInTheDocument();
     });
-    expect(screen.getByText("Disabled By Default")).toBeInTheDocument();
-    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(screen.getAllByText("Unavailable")).toHaveLength(2);
     expect(screen.getByText("Degraded")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -1840,6 +1857,7 @@ describe("OperatorRoutes", () => {
           action_executions: {
             terminal: 1,
           },
+          optional_extensions: createOptionalExtensionPayload(),
           review_path_health: {
             overall_state: "healthy",
             review_count: 1,
@@ -1868,6 +1886,13 @@ describe("OperatorRoutes", () => {
     await waitFor(() => {
       expect(screen.getByText("postgresql")).toBeInTheDocument();
     });
+    expect(
+      screen.getByRole("heading", { name: "Optional evidence posture" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Endpoint evidence")).toBeInTheDocument();
+    expect(screen.getByText("Optional network evidence")).toBeInTheDocument();
+    expect(screen.getAllByText("Unavailable")).toHaveLength(2);
+    expect(screen.queryByText("ML shadow")).not.toBeInTheDocument();
     expect(fetchFn).toHaveBeenCalledWith(
       "/diagnostics/readiness?order=ASC&page=1&per_page=1&sort=status",
       expect.any(Object),

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -32,6 +32,10 @@ import {
   RecordCaseObservationCard,
   RecordCaseRecommendationCard,
 } from "../taskActions/caseworkActionCards";
+import {
+  OptionalExtensionVisibilityPanel,
+  buildOptionalEvidenceDefinitionsFromPayload,
+} from "./optionalExtensionVisibility";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -2119,6 +2123,9 @@ export function ReadinessPage() {
   const reviewPathHealth = asRecord(getPath(record, "metrics.review_path_health"));
   const sourceHealth = asRecord(getPath(record, "metrics.source_health"));
   const automationHealth = asRecord(getPath(record, "metrics.automation_substrate_health"));
+  const optionalEvidenceDefinitions = buildOptionalEvidenceDefinitionsFromPayload(
+    getPath(record, "metrics.optional_extensions"),
+  );
 
   return (
     <PageFrame
@@ -2162,6 +2169,12 @@ export function ReadinessPage() {
                 ["Tracked automation surfaces", automationHealth?.tracked_surfaces],
               ]}
             />
+          </SectionCard>
+          <SectionCard
+            subtitle="Optional endpoint and network evidence paths stay visibly subordinate to authoritative alerts, cases, evidence anchors, and workflow records."
+            title="Optional evidence posture"
+          >
+            <OptionalExtensionVisibilityPanel definitions={optionalEvidenceDefinitions} />
           </SectionCard>
         </Stack>
       ) : null}

--- a/apps/operator-ui/src/app/optionalExtensionVisibility.tsx
+++ b/apps/operator-ui/src/app/optionalExtensionVisibility.tsx
@@ -75,12 +75,12 @@ function deriveOptionalExtensionStatus(extension: OptionalExtensionSignal | null
     return "degraded";
   }
 
-  if (enablement === "disabled_by_default") {
-    return "disabled_by_default";
-  }
-
   if (availability === "unavailable") {
     return "unavailable";
+  }
+
+  if (enablement === "disabled_by_default") {
+    return "disabled_by_default";
   }
 
   if (enablement === "enabled") {
@@ -124,6 +124,14 @@ export function buildOptionalExtensionDefinitionsFromPayload(
       title: family.title,
     };
   });
+}
+
+export function buildOptionalEvidenceDefinitionsFromPayload(
+  optionalExtensions: unknown,
+): OptionalExtensionDefinition[] {
+  return buildOptionalExtensionDefinitionsFromPayload(optionalExtensions).filter((definition) =>
+    ["Endpoint evidence", "Optional network evidence"].includes(definition.title),
+  );
 }
 
 function optionalExtensionStatusMetadata(status: OptionalExtensionStatus): {


### PR DESCRIPTION
Closes #697
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the operator UI change on `codex/issue-697` and committed it as `d721567` (`Add optional evidence posture visibility`).

The fix does two things: it preserves reviewed `unavailable` endpoint/network posture instead of collapsing it into `disabled_by_default`, and it adds a dedicated `Optional evidence posture` section on the Readiness page so operators can inspect endpoint and network evidence state without leaving the reviewed shell. I also tightened the focused operator-ui tests around that taxonomy and readiness rendering, then ran the package test suite and build successfully.

Summary: Added dedicated optional endpoint/network evidence visibility in the operator UI, fixed status precedence so `unavailable` remains visible, updated focused tests, and committed the checkpoint as `d721567`
State hint: local_review
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test -- --run OperatorRoutes.test.tsx`; `npm --prefix apps/operator-ui test`; `npm --prefix apps/operator-ui run build`
Failure signature: none
Next action: Open or update a draft PR for issue #697 with commit `d721567`, or continue with any requested follow-up review adjustments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Optional evidence posture" section to the Readiness page, displaying the availability status of optional evidence items such as "Endpoint evidence" and "Optional network evidence."

* **Bug Fixes**
  * Fixed optional extension status determination logic to correctly prioritize unavailability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->