### PR TITLE
validation: add Phase 30F coverage for optional-extension visibility and subordinate-status semantics (#699)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -6,7 +6,10 @@ import {
   OperatorRoutes,
   createDefaultDependencies,
 } from "./OperatorRoutes";
-import { buildOptionalEvidenceDefinitionsFromPayload } from "./optionalExtensionVisibility";
+import {
+  buildOptionalEvidenceDefinitionsFromPayload,
+  buildOptionalExtensionDefinitionsFromPayload,
+} from "./optionalExtensionVisibility";
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -111,21 +114,42 @@ function createAuthorizedFetch(
 }
 
 describe("OperatorRoutes", () => {
-  it("keeps unavailable endpoint and network evidence posture visible when the optional path is disabled by default", () => {
+  it("keeps disabled-by-default endpoint and network evidence posture visible", () => {
     const definitions = buildOptionalEvidenceDefinitionsFromPayload(
       createOptionalExtensionPayload(),
     );
 
     expect(definitions).toEqual([
       expect.objectContaining({
-        status: "unavailable",
+        status: "disabled_by_default",
         title: "Endpoint evidence",
       }),
       expect.objectContaining({
-        status: "unavailable",
+        status: "disabled_by_default",
         title: "Optional network evidence",
       }),
     ]);
+  });
+
+  it("fails closed when optional enablement is present without backend availability", () => {
+    const definitions = buildOptionalExtensionDefinitionsFromPayload(
+      createOptionalExtensionPayload({
+        endpoint_evidence: {
+          authority_mode: "augmenting_evidence",
+          enablement: "enabled",
+          mainline_dependency: "non_blocking",
+          readiness: "ready",
+          reason: "reviewed_endpoint_extension_binding_missing",
+        },
+      }),
+    );
+
+    expect(definitions).toContainEqual(
+      expect.objectContaining({
+        status: "unavailable",
+        title: "Endpoint evidence",
+      }),
+    );
   });
 
   it("redirects unauthenticated users to the reviewed login route", async () => {
@@ -241,7 +265,8 @@ describe("OperatorRoutes", () => {
     await waitFor(() => {
       expect(screen.getByText("Enabled")).toBeInTheDocument();
     });
-    expect(screen.getAllByText("Unavailable")).toHaveLength(2);
+    expect(screen.getByText("Disabled By Default")).toBeInTheDocument();
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
     expect(screen.getByText("Degraded")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -1893,7 +1918,7 @@ describe("OperatorRoutes", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Endpoint evidence")).toBeInTheDocument();
     expect(screen.getByText("Optional network evidence")).toBeInTheDocument();
-    expect(screen.getAllByText("Unavailable")).toHaveLength(2);
+    expect(screen.getAllByText("Disabled By Default")).toHaveLength(2);
     expect(screen.queryByText("ML shadow")).not.toBeInTheDocument();
     expect(fetchFn).toHaveBeenCalledWith(
       "/diagnostics/readiness?order=ASC&page=1&per_page=1&sort=status",

--- a/apps/operator-ui/src/app/optionalExtensionVisibility.test.tsx
+++ b/apps/operator-ui/src/app/optionalExtensionVisibility.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { buildOptionalExtensionDefinitionsFromPayload } from "./optionalExtensionVisibility";
+
+function createOptionalExtensionPayload(
+  overrides: Partial<Record<"assistant" | "endpoint_evidence" | "network_evidence" | "ml_shadow", unknown>> = {},
+) {
+  return {
+    overall_state: "ready",
+    tracked_extensions: 4,
+    extensions: {
+      assistant: {
+        authority_mode: "advisory_only",
+        availability: "available",
+        enablement: "enabled",
+        mainline_dependency: "non_blocking",
+        readiness: "ready",
+        reason: "bounded_reviewed_summary_provider_available",
+      },
+      endpoint_evidence: {
+        authority_mode: "augmenting_evidence",
+        availability: "unavailable",
+        enablement: "disabled_by_default",
+        mainline_dependency: "non_blocking",
+        readiness: "not_applicable",
+        reason: "isolated_executor_runtime_not_configured",
+      },
+      network_evidence: {
+        authority_mode: "augmenting_evidence",
+        availability: "unavailable",
+        enablement: "disabled_by_default",
+        mainline_dependency: "non_blocking",
+        readiness: "not_applicable",
+        reason: "reviewed_network_evidence_extension_not_activated",
+      },
+      ml_shadow: {
+        authority_mode: "shadow_only",
+        availability: "unavailable",
+        enablement: "disabled_by_default",
+        mainline_dependency: "non_blocking",
+        readiness: "not_applicable",
+        reason: "reviewed_ml_shadow_extension_not_activated",
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe("optionalExtensionVisibility", () => {
+  it("keeps disabled-by-default posture distinct from unavailable", () => {
+    const definitions = buildOptionalExtensionDefinitionsFromPayload(
+      createOptionalExtensionPayload(),
+    );
+
+    expect(definitions).toEqual([
+      expect.objectContaining({
+        status: "enabled",
+        title: "Assistant",
+      }),
+      expect.objectContaining({
+        status: "disabled_by_default",
+        title: "Endpoint evidence",
+      }),
+      expect.objectContaining({
+        status: "disabled_by_default",
+        title: "Optional network evidence",
+      }),
+      expect.objectContaining({
+        status: "disabled_by_default",
+        title: "ML shadow",
+      }),
+    ]);
+  });
+
+  it("fails closed when enablement says enabled but availability is missing", () => {
+    const definitions = buildOptionalExtensionDefinitionsFromPayload(
+      createOptionalExtensionPayload({
+        endpoint_evidence: {
+          authority_mode: "augmenting_evidence",
+          enablement: "enabled",
+          mainline_dependency: "non_blocking",
+          readiness: "ready",
+          reason: "reviewed_endpoint_extension_binding_missing",
+        },
+      }),
+    );
+
+    expect(definitions).toContainEqual(
+      expect.objectContaining({
+        status: "unavailable",
+        title: "Endpoint evidence",
+      }),
+    );
+  });
+
+  it("keeps degraded posture primary over other optional signals", () => {
+    const definitions = buildOptionalExtensionDefinitionsFromPayload(
+      createOptionalExtensionPayload({
+        ml_shadow: {
+          authority_mode: "shadow_only",
+          availability: "available",
+          enablement: "enabled",
+          mainline_dependency: "non_blocking",
+          readiness: "degraded",
+          reason: "reviewed_ml_shadow_extension_provider_lagging",
+        },
+      }),
+    );
+
+    expect(definitions).toContainEqual(
+      expect.objectContaining({
+        status: "degraded",
+        title: "ML shadow",
+      }),
+    );
+  });
+});

--- a/apps/operator-ui/src/app/optionalExtensionVisibility.tsx
+++ b/apps/operator-ui/src/app/optionalExtensionVisibility.tsx
@@ -75,16 +75,16 @@ function deriveOptionalExtensionStatus(extension: OptionalExtensionSignal | null
     return "degraded";
   }
 
-  if (availability === "unavailable") {
-    return "unavailable";
-  }
-
   if (enablement === "disabled_by_default") {
     return "disabled_by_default";
   }
 
   if (enablement === "enabled") {
-    return "enabled";
+    return availability === "available" ? "enabled" : "unavailable";
+  }
+
+  if (availability === "unavailable") {
+    return "unavailable";
   }
 
   return "unavailable";

--- a/control-plane/tests/test_phase30f_operator_ui_validation.py
+++ b/control-plane/tests/test_phase30f_operator_ui_validation.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase30FOperatorUiValidationTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected file at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_phase30f_validation_doc_locks_taxonomy_and_subordinate_status_semantics(
+        self,
+    ) -> None:
+        text = self._read("docs/phase-30f-optional-extension-visibility-validation.md")
+
+        for term in (
+            "# Phase 30F Optional-Extension Visibility Validation",
+            "Validation status: PASS",
+            "disabled-by-default posture remains distinct from unavailable posture",
+            "enabled posture still fails closed unless backend-owned availability is explicit",
+            "optional-extension visibility remains subordinate context rather than authoritative lifecycle truth",
+            "mainline expectation messaging remains explicit when optional paths are absent",
+            "control-plane/tests/test_phase30f_operator_ui_validation.py",
+            "apps/operator-ui/src/app/optionalExtensionVisibility.test.tsx",
+            "apps/operator-ui/src/app/OperatorRoutes.test.tsx",
+            "python3 -m unittest control-plane.tests.test_phase30f_operator_ui_validation",
+            "npm --prefix apps/operator-ui test -- --run src/app/optionalExtensionVisibility.test.tsx src/app/OperatorRoutes.test.tsx",
+            "npm --prefix apps/operator-ui run build",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase30f_readiness_defaults_keep_optional_extension_status_subordinate(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        optional_extensions = readiness.metrics["optional_extensions"]["extensions"]
+
+        self.assertEqual(
+            optional_extensions["assistant"]["enablement"],
+            "enabled",
+        )
+        self.assertEqual(
+            optional_extensions["assistant"]["authority_mode"],
+            "advisory_only",
+        )
+
+        for extension_name, authority_mode in (
+            ("endpoint_evidence", "augmenting_evidence"),
+            ("network_evidence", "augmenting_evidence"),
+            ("ml_shadow", "shadow_only"),
+        ):
+            with self.subTest(extension=extension_name):
+                self.assertEqual(
+                    optional_extensions[extension_name]["enablement"],
+                    "disabled_by_default",
+                )
+                self.assertEqual(
+                    optional_extensions[extension_name]["mainline_dependency"],
+                    "non_blocking",
+                )
+                self.assertEqual(
+                    optional_extensions[extension_name]["authority_mode"],
+                    authority_mode,
+                )
+
+    def test_phase30f_frontend_tests_lock_taxonomy_and_non_authority_rendering(
+        self,
+    ) -> None:
+        mapper_tests = self._read(
+            "apps/operator-ui/src/app/optionalExtensionVisibility.test.tsx"
+        )
+        route_tests = self._read("apps/operator-ui/src/app/OperatorRoutes.test.tsx")
+
+        for term in (
+            "keeps disabled-by-default posture distinct from unavailable",
+            "fails closed when enablement says enabled but availability is missing",
+            "keeps degraded posture primary over other optional signals",
+        ):
+            self.assertIn(term, mapper_tests)
+
+        for term in (
+            "keeps disabled-by-default endpoint and network evidence posture visible",
+            "fails closed when optional enablement is present without backend availability",
+            "Optional extension visibility",
+            "Optional evidence posture",
+            "Disabled By Default",
+            "Optional-path posture stays subordinate to authoritative workflow pages and reviewed runtime truth.",
+            "Missing optional paths do not imply a control-plane failure when the mainline reviewed workflow remains healthy.",
+        ):
+            self.assertIn(term, route_tests)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-30f-optional-extension-visibility-validation.md
+++ b/docs/phase-30f-optional-extension-visibility-validation.md
@@ -1,0 +1,37 @@
+# Phase 30F Optional-Extension Visibility Validation
+
+- Validation status: PASS
+- Scope: confirm the reviewed Phase 30F optional-extension visibility contract keeps enabled, disabled-by-default, unavailable, and degraded posture distinct while preserving subordinate optional-context semantics in the operator console.
+- Reviewed sources: `README.md`, `docs/phase-30f-optional-extension-visibility-boundary.md`, `docs/phase-30-react-admin-foundation-and-read-only-operator-console-boundary.md`, `docs/phase-30e-assistant-advisory-integration-boundary.md`, `docs/phase-28-optional-endpoint-evidence-pack-boundary.md`, `docs/phase-29-reviewed-ml-shadow-mode-boundary.md`, `docs/phase-29-optional-suricata-evidence-pack-boundary.md`, `docs/runbook.md`, `apps/operator-ui/src/app/optionalExtensionVisibility.tsx`, `apps/operator-ui/src/app/optionalExtensionVisibility.test.tsx`, `apps/operator-ui/src/app/OperatorRoutes.test.tsx`, `control-plane/tests/test_phase30f_operator_ui_validation.py`
+
+## Verdict
+
+Phase 30F validation is now locked at the narrow boundary required by issue `#699`.
+
+The shared taxonomy distinguishes `enabled`, `disabled-by-default`, `unavailable`, and `degraded` without collapsing disabled-by-default posture into generic unavailability.
+
+Enabled posture still fails closed unless backend-owned availability is explicit, so client-local enablement hints do not become trusted status on their own.
+
+Optional-extension visibility remains subordinate context rather than authoritative lifecycle truth, and mainline expectation messaging remains explicit when optional paths are absent.
+
+## Locked Behaviors
+
+- disabled-by-default posture remains distinct from unavailable posture for optional endpoint evidence, optional network evidence, and ML shadow surfaces
+- enabled posture still fails closed unless backend-owned availability is explicit
+- degraded posture remains visible without being normalized into generic missing data
+- optional-extension visibility remains subordinate context rather than authoritative lifecycle truth
+- mainline expectation messaging remains explicit when optional paths are absent
+
+## Evidence
+
+`apps/operator-ui/src/app/optionalExtensionVisibility.test.tsx` locks the mapper contract so disabled-by-default optional families stay visible as intentional mainline posture, enabled status requires backend-reported availability, and degraded state keeps precedence over weaker optional signals.
+
+`apps/operator-ui/src/app/OperatorRoutes.test.tsx` locks overview and readiness rendering so the operator console shows subordinate optional-extension badges and mainline expectation text without overstating optional-path trouble as workflow failure.
+
+`control-plane/tests/test_phase30f_operator_ui_validation.py` locks the validation document, the operator-ui regression coverage, and the control-plane readiness defaults that keep optional families non-blocking and subordinate by authority mode.
+
+## Verification
+
+- `python3 -m unittest control-plane.tests.test_phase30f_operator_ui_validation`
+- `npm --prefix apps/operator-ui test -- --run src/app/optionalExtensionVisibility.test.tsx src/app/OperatorRoutes.test.tsx`
+- `npm --prefix apps/operator-ui run build`


### PR DESCRIPTION
Closes #699
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Phase 30F validation slice and committed it as `9f52d4b` on `codex/issue-699`.

The functional fix is in [apps/operator-ui/src/app/optionalExtensionVisibility.tsx](/Users/jp.infra/Dev/AegisOps-worktrees/issue-699/apps/operator-ui/src/app/optionalExtensionVisibility.tsx): `disabled_by_default` now stays distinct from `unavailable`, and `enabled` only renders when backend-owned availability is explicitly `available`, otherwise it fails closed to `unavailable`. I added focused frontend regression coverage in [optionalExtensionVisibility.test.tsx](/Users/jp.infra/Dev/AegisOps-worktrees/issue-699/apps/operator-ui/src/app/optionalExtensionVisibility.test.tsx) and tightened [OperatorRoutes.test.tsx](/Users/jp.infra/Dev/AegisOps-worktrees/issue-699/apps/operator-ui/src/app/OperatorRoutes.test.tsx) so the overview/readiness surfaces keep subordinate optional status semantics explicit. I also added the validation artifacts in [test_phase30f_operator_ui_validation.py](/Users/jp.infra/Dev/AegisOps-worktrees/issue-699/control-plane/tests/test_phase30f_operator_ui_validation.py) and [phase-30f-optional-extension-visibility-validation.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-699/docs/phase-30f-optional-extension-visibility-validation.md).

Verification run in this worktree:
`python3 -m unittest control-plane.tests.test_phase30f_operator_ui_validation`
`python3 -m unittest control-plane.tests.test_phase30f_optional_extension_visibility_boundary_docs`
`npm --prefix ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced optional extension visibility with clearer status labels distinguishing "Disabled By Default" from "Unavailable."
  * Improved fail-closed behavior: extensions enabled without backend availability now correctly display as "Unavailable."
  * Added support for degraded posture visibility.

* **Tests**
  * Added comprehensive test coverage for optional extension visibility status derivation.

* **Documentation**
  * Added validation documentation for optional extension visibility behavior and status taxonomy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->