### PR TITLE
validation: stabilize the assistant-advisory no-authority route test after Phase 30F (#705)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -1994,8 +1994,16 @@ describe("OperatorRoutes", () => {
 
     expect(await screen.findByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Recommendation draft" })).not.toBeInTheDocument();
+
+    const anchorSection = screen.getByRole("heading", { name: "Authoritative advisory anchor" });
+    const anchorCard = anchorSection.closest(".MuiCard-root");
+    expect(anchorCard).not.toBeNull();
+    expect(within(anchorCard as HTMLElement).getByText("Read only")).toBeInTheDocument();
+    expect(within(anchorCard as HTMLElement).getByText("true")).toBeInTheDocument();
     expect(
-      screen.getByText("Assistant output does not approve, execute, or reconcile workflow state."),
+      within(anchorCard as HTMLElement).getByText(
+        /Assistant output does not approve, execute, or reconcile workflow state\./i,
+      ),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Closes #705
This PR was opened by codex-supervisor.
Latest Codex summary:

Tightened the failing route test in [OperatorRoutes.test.tsx](/Users/jp.infra/Dev/AegisOps-worktrees/issue-705/apps/operator-ui/src/app/OperatorRoutes.test.tsx:1970) so it asserts the no-authority contract at the real enforcement boundary: the `Authoritative advisory anchor` card. Instead of a page-wide exact-text lookup, it now scopes to that card, verifies the advisory stays `Read only`, and checks the no-authority warning there while still asserting that no `Recommendation draft` section is rendered.

I also restored `apps/operator-ui` dependencies in this worktree so the requested focused Vitest command could run, updated the issue journal working notes, and committed the change as `6e5ba0d` (`test: stabilize advisory no-authority route assertion`).

Summary: Scoped the assistant-advisory no-authority test to the authoritative anchor card and verified the focused frontend path/build pass.
State hint: stabilizing
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test -- src/app/optionalExtensionVisibility.test.tsx src/app/OperatorRoutes.test.tsx`; `npm --prefix apps/operator-ui run build`
Failure signature: none
Next action: Push `codex/issue-705` and open or update the draft PR with commit `6e5ba0d` if supervisor wants the checkpoint published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the "Authoritative advisory anchor" UI card to verify correct state display and improve message matching validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->