### PR TITLE
implementation: refine Phase 31 route, menu, page gating, and deep-link access handling (#709)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -332,6 +332,44 @@ describe("OperatorRoutes", () => {
     expect(screen.getAllByText(/action review/i).length).toBeGreaterThan(0);
   });
 
+  it("uses the configured base path for reviewed operator navigation links", async () => {
+    const dependencies = createDefaultDependencies({
+      config: {
+        basePath: "/reviewed-operator",
+      },
+      fetchFn: createAuthorizedFetch(
+        {},
+        {
+          identity: "approver@example.com",
+          provider: "authentik",
+          roles: ["Approver"],
+          subject: "operator-8",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/reviewed-operator"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Protected operator shell" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("menuitem", { name: "Queue" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/reviewed-operator/queue"),
+    );
+    expect(screen.getByRole("menuitem", { name: "Action Review" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/reviewed-operator/action-review"),
+    );
+  });
+
   it("shows an explicit forbidden outcome for analyst-only action-review landing routes", async () => {
     const dependencies = createDefaultDependencies({
       fetchFn: createAuthorizedFetch({}),
@@ -384,6 +422,69 @@ describe("OperatorRoutes", () => {
       expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
     });
 
+    expect(
+      screen.getByText(
+        "The current reviewed session can inspect this record but cannot submit approval decisions without approver role authority.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("honors allowed-role extensions for reviewed action-review detail routes", async () => {
+    const dependencies = createDefaultDependencies({
+      config: {
+        allowedRoles: [
+          "analyst",
+          "approver",
+          "platform-administrator",
+          "security-auditor",
+        ],
+        basePath: "/reviewed-operator",
+      },
+      fetchFn: createAuthorizedFetch(
+        {
+          "/inspect-action-review": {
+            action_request_id: "action-request-123",
+            read_only: true,
+            current_action_review: {
+              action_request_id: "action-request-123",
+              review_state: "pending",
+            },
+            action_review: {
+              action_request_id: "action-request-123",
+              review_state: "pending",
+              approval_state: "pending",
+              requester_identity: "analyst@example.com",
+              recipient_identity: "repo-owner@example.com",
+              next_expected_action: "await_approver_decision",
+            },
+            case_record: {
+              case_id: "case-456",
+              lifecycle_state: "pending_action",
+            },
+          },
+        },
+        {
+          identity: "security.auditor@example.com",
+          provider: "authentik",
+          roles: ["Security-Auditor"],
+          subject: "operator-42",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter
+        initialEntries={["/reviewed-operator/action-review/action-request-123"]}
+      >
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("heading", { name: "Access denied" })).not.toBeInTheDocument();
     expect(
       screen.getByText(
         "The current reviewed session can inspect this record but cannot submit approval decisions without approver role authority.",

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -332,7 +332,7 @@ describe("OperatorRoutes", () => {
     expect(screen.getAllByText(/action review/i).length).toBeGreaterThan(0);
   });
 
-  it("redirects analyst-only deep links away from the action-review route", async () => {
+  it("shows an explicit forbidden outcome for analyst-only action-review landing routes", async () => {
     const dependencies = createDefaultDependencies({
       fetchFn: createAuthorizedFetch({}),
     });
@@ -344,15 +344,49 @@ describe("OperatorRoutes", () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "Protected operator shell" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Access denied" })).toBeInTheDocument();
+    });
+  });
+
+  it("allows analyst deep links into reviewed action-review detail as read-only inspection", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-action-review": {
+          action_request_id: "action-request-123",
+          read_only: true,
+          current_action_review: {
+            action_request_id: "action-request-123",
+            review_state: "pending",
+          },
+          action_review: {
+            action_request_id: "action-request-123",
+            review_state: "pending",
+            approval_state: "pending",
+            requester_identity: "analyst@example.com",
+            recipient_identity: "repo-owner@example.com",
+            next_expected_action: "await_approver_decision",
+          },
+          case_record: {
+            case_id: "case-456",
+            lifecycle_state: "pending_action",
+          },
+        },
+      }),
     });
 
-    expect(screen.queryByText(/action review/i)).not.toBeInTheDocument();
+    render(
+      <MemoryRouter initialEntries={["/operator/action-review/action-request-123"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Action Review" })).toBeInTheDocument();
+    });
+
     expect(
       screen.getByText(
-        "Queue triage stays inside AegisOps as the authoritative review selection surface.",
+        "The current reviewed session can inspect this record but cannot submit approval decisions without approver role authority.",
       ),
     ).toBeInTheDocument();
   });
@@ -2241,5 +2275,57 @@ describe("OperatorRoutes", () => {
       ).toBeGreaterThan(0);
     });
     expect(screen.getAllByText(/mismatch/i).length).toBeGreaterThan(0);
+  });
+
+  it("fails closed on unsupported assistant advisory route families", async () => {
+    const fetchFn = createAuthorizedFetch({});
+    const dependencies = createDefaultDependencies({
+      fetchFn,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/assistant/not-reviewed/record-123"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Assistant Advisory" })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        "Unsupported assistant advisory route. Use alert, case, recommendation, approval decision, or reconciliation with an authoritative identifier.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      fetchFn.mock.calls.some(([url]) =>
+        String(url).includes("/inspect-advisory-output"),
+      ),
+    ).toBe(false);
+  });
+
+  it("renders an explicit unsupported-route outcome for unknown operator shell paths", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({}),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/not-reviewed-path"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Unsupported operator route" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        "Use the queue, authoritative detail links, reviewed diagnostics, or other approved operator entrypoints instead of guessing route shape.",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/operator-ui/src/app/OperatorRoutes.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.tsx
@@ -275,6 +275,7 @@ function ProtectedOperatorRoute({
   return (
     <OperatorShell
       authProvider={authProvider}
+      basePath={config.basePath}
       dataProvider={dataProvider}
       operatorIdentity={session?.identity ?? ""}
       operatorRoles={session?.roles ?? []}

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -44,10 +44,27 @@ import {
 import { TaskActionClientProvider } from "../taskActions/taskActionPrimitives";
 import type { OperatorTaskActionClient } from "../taskActions/taskActionClient";
 
-function canInspectActionReview(operatorRoles: readonly string[]) {
+function hasReviewedOperatorRole(
+  operatorRoles: readonly string[],
+  allowedRoles: readonly string[],
+) {
+  return operatorRoles.some((role) =>
+    allowedRoles.includes(role.toLowerCase()),
+  );
+}
+
+function canBrowseActionReview(operatorRoles: readonly string[]) {
   return operatorRoles.some((role) =>
     ["approver", "platform-administrator"].includes(role),
   );
+}
+
+function canInspectActionReviewDetail(operatorRoles: readonly string[]) {
+  return hasReviewedOperatorRole(operatorRoles, [
+    "analyst",
+    "approver",
+    "platform-administrator",
+  ]);
 }
 
 function OperatorAppBar() {
@@ -67,7 +84,7 @@ function OperatorMenu({
 }: {
   operatorRoles: readonly string[];
 }) {
-  const showActionReview = canInspectActionReview(operatorRoles);
+  const showActionReview = canBrowseActionReview(operatorRoles);
 
   return (
     <Menu>
@@ -192,7 +209,7 @@ function OverviewPage({
       description:
         "Assistant advisory stays subordinate to authoritative AegisOps records and remains read-oriented in the reviewed shell.",
     },
-    ...(canInspectActionReview(operatorRoles)
+    ...(canBrowseActionReview(operatorRoles)
       ? [
           {
             title: "Action review",
@@ -246,6 +263,23 @@ function OverviewPage({
   );
 }
 
+function UnsupportedOperatorRoutePage() {
+  return (
+    <Stack spacing={2} sx={{ p: 3 }}>
+      <Typography component="h1" variant="h4">
+        Unsupported operator route
+      </Typography>
+      <Typography color="text.secondary" variant="body1">
+        The requested path is not part of the reviewed operator shell.
+      </Typography>
+      <Typography variant="body2">
+        Use the queue, authoritative detail links, reviewed diagnostics, or
+        other approved operator entrypoints instead of guessing route shape.
+      </Typography>
+    </Stack>
+  );
+}
+
 function PlaceholderPage({
   title,
   description,
@@ -282,7 +316,8 @@ export function OperatorShell({
   operatorRoles: string[];
   taskActionClient: OperatorTaskActionClient;
 }) {
-  const canViewActionReview = canInspectActionReview(operatorRoles);
+  const canViewActionReview = canBrowseActionReview(operatorRoles);
+  const canInspectActionReview = canInspectActionReviewDetail(operatorRoles);
 
   return (
     <AdminContext
@@ -322,20 +357,20 @@ export function OperatorShell({
                     operatorRoles={operatorRoles}
                   />
                 ) : (
-                  <Navigate replace to="/operator" />
+                  <Navigate replace to="/operator/forbidden" />
                 )
               }
               path="action-review"
             />
             <Route
               element={
-                canViewActionReview ? (
+                canInspectActionReview ? (
                   <ActionReviewPage
                     operatorIdentity={operatorIdentity}
                     operatorRoles={operatorRoles}
                   />
                 ) : (
-                  <Navigate replace to="/operator" />
+                  <Navigate replace to="/operator/forbidden" />
                 )
               }
               path="action-review/:actionRequestId"
@@ -367,6 +402,7 @@ export function OperatorShell({
               }
               path="provenance/*"
             />
+            <Route element={<UnsupportedOperatorRoutePage />} path="*" />
           </Routes>
         </Layout>
       </TaskActionClientProvider>

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -46,10 +46,14 @@ import type { OperatorTaskActionClient } from "../taskActions/taskActionClient";
 
 function hasReviewedOperatorRole(
   operatorRoles: readonly string[],
-  allowedRoles: readonly string[],
+  allowedRoles: readonly string[] = operatorRoles,
 ) {
+  const normalizedAllowedRoles = new Set(
+    allowedRoles.map((role) => role.trim().toLowerCase()),
+  );
+
   return operatorRoles.some((role) =>
-    allowedRoles.includes(role.toLowerCase()),
+    normalizedAllowedRoles.has(role.toLowerCase()),
   );
 }
 
@@ -60,11 +64,15 @@ function canBrowseActionReview(operatorRoles: readonly string[]) {
 }
 
 function canInspectActionReviewDetail(operatorRoles: readonly string[]) {
-  return hasReviewedOperatorRole(operatorRoles, [
-    "analyst",
-    "approver",
-    "platform-administrator",
-  ]);
+  return hasReviewedOperatorRole(operatorRoles);
+}
+
+function buildOperatorShellPath(basePath: string, path = "") {
+  if (!path) {
+    return basePath;
+  }
+
+  return `${basePath}/${path}`;
 }
 
 function OperatorAppBar() {
@@ -80,8 +88,10 @@ function OperatorAppBar() {
 }
 
 function OperatorMenu({
+  basePath,
   operatorRoles,
 }: {
+  basePath: string;
   operatorRoles: readonly string[];
 }) {
   const showActionReview = canBrowseActionReview(operatorRoles);
@@ -92,43 +102,43 @@ function OperatorMenu({
       <Menu.Item
         leftIcon={<InboxOutlinedIcon />}
         primaryText="Queue"
-        to="/operator/queue"
+        to={buildOperatorShellPath(basePath, "queue")}
       />
       <Menu.Item
         leftIcon={<WarningAmberOutlinedIcon />}
         primaryText="Alerts"
-        to="/operator/queue"
+        to={buildOperatorShellPath(basePath, "queue")}
       />
       <Menu.Item
         leftIcon={<InsightsOutlinedIcon />}
         primaryText="Cases"
-        to="/operator/queue"
+        to={buildOperatorShellPath(basePath, "queue")}
       />
       <Menu.Item
         leftIcon={<LinkOutlinedIcon />}
         primaryText="Provenance"
-        to="/operator/provenance/alerts"
+        to={buildOperatorShellPath(basePath, "provenance/alerts")}
       />
       <Menu.Item
         leftIcon={<CheckCircleOutlineIcon />}
         primaryText="Readiness"
-        to="/operator/readiness"
+        to={buildOperatorShellPath(basePath, "readiness")}
       />
       <Menu.Item
         leftIcon={<RuleFolderOutlinedIcon />}
         primaryText="Reconciliation"
-        to="/operator/reconciliation"
+        to={buildOperatorShellPath(basePath, "reconciliation")}
       />
       <Menu.Item
         leftIcon={<AutoAwesomeOutlinedIcon />}
         primaryText="Assistant"
-        to="/operator/assistant"
+        to={buildOperatorShellPath(basePath, "assistant")}
       />
       {showActionReview ? (
         <Menu.Item
           leftIcon={<GavelOutlinedIcon />}
           primaryText="Action Review"
-          to="/operator/action-review"
+          to={buildOperatorShellPath(basePath, "action-review")}
         />
       ) : null}
     </Menu>
@@ -305,12 +315,14 @@ function PlaceholderPage({
 
 export function OperatorShell({
   authProvider,
+  basePath,
   dataProvider,
   operatorIdentity,
   operatorRoles,
   taskActionClient,
 }: {
   authProvider: AuthProvider;
+  basePath: string;
   dataProvider: DataProvider;
   operatorIdentity: string;
   operatorRoles: string[];
@@ -328,7 +340,9 @@ export function OperatorShell({
       <TaskActionClientProvider client={taskActionClient}>
         <Layout
           appBar={OperatorAppBar}
-          menu={() => <OperatorMenu operatorRoles={operatorRoles} />}
+          menu={() => (
+            <OperatorMenu basePath={basePath} operatorRoles={operatorRoles} />
+          )}
         >
           <Routes>
             <Route element={<OverviewPage operatorRoles={operatorRoles} />} index />
@@ -357,7 +371,10 @@ export function OperatorShell({
                     operatorRoles={operatorRoles}
                   />
                 ) : (
-                  <Navigate replace to="/operator/forbidden" />
+                  <Navigate
+                    replace
+                    to={buildOperatorShellPath(basePath, "forbidden")}
+                  />
                 )
               }
               path="action-review"
@@ -370,7 +387,10 @@ export function OperatorShell({
                     operatorRoles={operatorRoles}
                   />
                 ) : (
-                  <Navigate replace to="/operator/forbidden" />
+                  <Navigate
+                    replace
+                    to={buildOperatorShellPath(basePath, "forbidden")}
+                  />
                 )
               }
               path="action-review/:actionRequestId"

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -103,6 +103,14 @@ const ADVISORY_DETAIL_EXCLUDED_FIELDS = [
   ...ADVISORY_SUMMARY_FIELDS,
 ] as const;
 
+const SUPPORTED_ADVISORY_RECORD_FAMILIES = new Set([
+  "alert",
+  "case",
+  "recommendation",
+  "approval_decision",
+  "reconciliation",
+]);
+
 function formatValue(value: unknown): string {
   if (value === null || value === undefined) {
     return "Not available";
@@ -1997,24 +2005,38 @@ export function AssistantAdvisoryPage() {
   const params = useParams();
   const recordFamily = asString(params.recordFamily);
   const recordId = asString(params.recordId);
+  const hasSupportedAdvisoryBinding =
+    recordFamily !== null && SUPPORTED_ADVISORY_RECORD_FAMILIES.has(recordFamily);
 
   return (
     <PageFrame
       subtitle="Assistant advisory stays a dedicated read surface anchored to one authoritative record. It does not become a generic assistant chat or mutable workflow console."
       title="Assistant Advisory"
     >
-      {recordFamily && recordId ? (
+      {hasSupportedAdvisoryBinding && recordId ? (
         <AssistantAdvisoryPageBody
           recordFamily={recordFamily}
           recordId={recordId}
         />
       ) : (
-        <SectionCard
-          subtitle="Open assistant advisory from alert, case, or action-review detail so the route stays grounded in one authoritative record."
-          title="Select advisory context"
-        >
-          <EmptyState message="No authoritative record is selected for assistant advisory yet." />
-        </SectionCard>
+        <>
+          {recordFamily === null || recordId === null ? (
+            <SectionCard
+              subtitle="Open assistant advisory from alert, case, or action-review detail so the route stays grounded in one authoritative record."
+              title="Select advisory context"
+            >
+              <EmptyState message="No authoritative record is selected for assistant advisory yet." />
+            </SectionCard>
+          ) : (
+            <ErrorState
+              error={
+                new Error(
+                  "Unsupported assistant advisory route. Use alert, case, recommendation, approval decision, or reconciliation with an authoritative identifier.",
+                )
+              }
+            />
+          )}
+        </>
       )}
     </PageFrame>
   );

--- a/control-plane/tests/test_phase31_operator_ui_validation.py
+++ b/control-plane/tests/test_phase31_operator_ui_validation.py
@@ -43,7 +43,9 @@ class Phase31OperatorUiValidationTests(unittest.TestCase):
             "Return path: /operator/queue",
             "routes unsupported backend roles to the forbidden page",
             "fails closed on malformed reviewed session responses",
+            "uses the configured base path for reviewed operator navigation links",
             "allows analyst deep links into reviewed action-review detail as read-only inspection",
+            "honors allowed-role extensions for reviewed action-review detail routes",
             "fails closed on unsupported assistant advisory route families",
             "renders a case-anchored assistant advisory route from reviewed advisory output",
             "keeps no-authority semantics explicit for cited advisory output without a recommendation draft",
@@ -66,8 +68,9 @@ class Phase31OperatorUiValidationTests(unittest.TestCase):
             self.assertIn(term, operator_routes)
 
         for term in (
-            'to="/operator/action-review"',
-            '<Navigate replace to="/operator/forbidden" />',
+            "function buildOperatorShellPath(basePath: string, path = \"\")",
+            'to={buildOperatorShellPath(basePath, "action-review")}',
+            'to={buildOperatorShellPath(basePath, "forbidden")}',
             'path="assistant/:recordFamily/:recordId"',
             'path="action-review/:actionRequestId"',
             'path="*"',

--- a/control-plane/tests/test_phase31_operator_ui_validation.py
+++ b/control-plane/tests/test_phase31_operator_ui_validation.py
@@ -43,6 +43,8 @@ class Phase31OperatorUiValidationTests(unittest.TestCase):
             "Return path: /operator/queue",
             "routes unsupported backend roles to the forbidden page",
             "fails closed on malformed reviewed session responses",
+            "allows analyst deep links into reviewed action-review detail as read-only inspection",
+            "fails closed on unsupported assistant advisory route families",
             "renders a case-anchored assistant advisory route from reviewed advisory output",
             "keeps no-authority semantics explicit for cited advisory output without a recommendation draft",
         ):
@@ -65,9 +67,11 @@ class Phase31OperatorUiValidationTests(unittest.TestCase):
 
         for term in (
             'to="/operator/action-review"',
-            '<Navigate replace to="/operator" />',
+            '<Navigate replace to="/operator/forbidden" />',
             'path="assistant/:recordFamily/:recordId"',
             'path="action-review/:actionRequestId"',
+            'path="*"',
+            "Unsupported operator route",
             "Open provenance from alert or case detail so the page stays anchored to an authoritative record.",
         ):
             self.assertIn(term, operator_shell)


### PR DESCRIPTION
Closes #709
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed `26bf272` (`Refine operator route gating for Phase 31`).

The shell now distinguishes action-review discoverability from detail inspection: analyst sessions still do not get the action-review landing surface in menu/navigation, but deep links to `/operator/action-review/:actionRequestId` now render the reviewed read-only detail instead of falling through. Analyst hits to `/operator/action-review` now resolve to an explicit forbidden outcome, unsupported assistant advisory families fail closed before any advisory fetch, and unknown `/operator/*` paths render an explicit unsupported-route page instead of partial shell chrome. I also updated the Phase 31 validation test to lock the new contract.

Tests run:
- `npm --prefix apps/operator-ui test -- src/auth/authProvider.test.ts src/auth/session.test.ts src/app/OperatorRoutes.test.tsx`
- `python3 -m unittest control-plane.tests.test_phase31_operator_ui_validation`
- `npm --prefix apps/operator-ui run build`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 709 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`

Summary: refined Phase 31 operator-shell gating so analyst action-review deep links inspect read-only detail, landing-route denial is explicit, unsupported assistant families fail closed, and unknown operator routes render explicit unsupported state; committed as `26bf272`
State hint: stabilizing
Blocked reason: none
Tests: npm --prefix ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu links and in-app navigation now respect configured base path prefixes.
  * Unknown operator routes render an “Unsupported operator route” page with guidance.

* **Bug Fixes**
  * Analyst access now shows clear “Access denied” or read-only messages for action review routes.
  * Unsupported assistant advisory route families now fail closed with an explicit error message.

* **Tests**
  * Expanded tests covering base-path navigation, access-denied/read-only flows, and unsupported-route behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->