### PR TITLE
implementation: add resilient query caching, refetch policy, and consistent operator state surfaces (#710)

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   OperatorRoutes,
   createDefaultDependencies,
@@ -10,6 +10,7 @@ import {
   buildOptionalEvidenceDefinitionsFromPayload,
   buildOptionalExtensionDefinitionsFromPayload,
 } from "./optionalExtensionVisibility";
+import { resetOperatorQueryCacheForTests } from "./operatorQueryCache";
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -113,7 +114,45 @@ function createAuthorizedFetch(
   });
 }
 
+function createDeferredResponse() {
+  let rejectPromise: (error: unknown) => void = () => {};
+  let resolvePromise: (response: Response) => void = () => {};
+  const promise = new Promise<Response>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  return {
+    promise,
+    reject(error: unknown) {
+      rejectPromise(error);
+    },
+    resolve(body: unknown, status = 200) {
+      resolvePromise(jsonResponse(body, status));
+    },
+  };
+}
+
+function TestRouteNavigator() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button onClick={() => navigate("/operator/readiness")} type="button">
+        Go to readiness
+      </button>
+      <button onClick={() => navigate("/operator/alerts/alert-123")} type="button">
+        Go to alert detail
+      </button>
+    </>
+  );
+}
+
 describe("OperatorRoutes", () => {
+  beforeEach(() => {
+    resetOperatorQueryCacheForTests();
+  });
+
   it("keeps disabled-by-default endpoint and network evidence posture visible", () => {
     const definitions = buildOptionalEvidenceDefinitionsFromPayload(
       createOptionalExtensionPayload(),
@@ -1238,6 +1277,175 @@ describe("OperatorRoutes", () => {
       expect(screen.getByText("live_wazuh_webhook")).toBeInTheDocument();
       expect(screen.getByText("recon-123")).toBeInTheDocument();
     });
+  });
+
+  it("reuses last verified alert detail during refetch and keeps transient refresh failures explicit", async () => {
+    const user = userEvent.setup();
+    const deferredAlertRefresh = createDeferredResponse();
+    let alertDetailRequests = 0;
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation((input) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/operator/session")) {
+        return Promise.resolve(
+          jsonResponse({
+            identity: "analyst@example.com",
+            provider: "authentik",
+            roles: ["Analyst"],
+            subject: "operator-7",
+          }),
+        );
+      }
+
+      if (url.startsWith("/inspect-alert-detail")) {
+        alertDetailRequests += 1;
+
+        if (alertDetailRequests === 1) {
+          return Promise.resolve(
+            jsonResponse({
+              alert_id: "alert-123",
+              alert: {
+                alert_id: "alert-123",
+                lifecycle_state: "triaged",
+              },
+              review_state: "triaged",
+              provenance: {
+                admission_channel: "live_wazuh_webhook",
+              },
+              linked_evidence_records: [],
+            }),
+          );
+        }
+
+        return deferredAlertRefresh.promise;
+      }
+
+      if (url.startsWith("/diagnostics/readiness")) {
+        return Promise.resolve(jsonResponse(createReadinessResponse()));
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/alerts/alert-123"]}>
+        <TestRouteNavigator />
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Alert Detail" })).toBeInTheDocument();
+    });
+    expect(screen.getByText("live_wazuh_webhook")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Go to readiness" }));
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Readiness" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Go to alert detail" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Alert Detail" })).toBeInTheDocument();
+    });
+    expect(screen.getByText("live_wazuh_webhook")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Loading alert detail")).not.toBeInTheDocument();
+
+    deferredAlertRefresh.reject(new Error("Alert detail refresh unavailable."));
+
+    expect(
+      await screen.findByText((content) =>
+        content.includes("Showing the last verified operator data while refresh is unavailable."),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((content) => content.includes("Alert detail refresh unavailable.")),
+    ).toBeInTheDocument();
+    expect(screen.getByText("live_wazuh_webhook")).toBeInTheDocument();
+  });
+
+  it("fails closed on malformed alert-detail refetch instead of rendering cached data as current", async () => {
+    const user = userEvent.setup();
+    let alertDetailRequests = 0;
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation((input) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/operator/session")) {
+        return Promise.resolve(
+          jsonResponse({
+            identity: "analyst@example.com",
+            provider: "authentik",
+            roles: ["Analyst"],
+            subject: "operator-7",
+          }),
+        );
+      }
+
+      if (url.startsWith("/inspect-alert-detail")) {
+        alertDetailRequests += 1;
+
+        if (alertDetailRequests === 1) {
+          return Promise.resolve(
+            jsonResponse({
+              alert_id: "alert-123",
+              alert: {
+                alert_id: "alert-123",
+                lifecycle_state: "triaged",
+              },
+              review_state: "triaged",
+              provenance: {
+                admission_channel: "live_wazuh_webhook",
+              },
+              linked_evidence_records: [],
+            }),
+          );
+        }
+
+        return Promise.resolve(
+          new Response("{", {
+            headers: {
+              "Content-Type": "application/json",
+            },
+            status: 200,
+          }),
+        );
+      }
+
+      if (url.startsWith("/diagnostics/readiness")) {
+        return Promise.resolve(jsonResponse(createReadinessResponse()));
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/alerts/alert-123"]}>
+        <TestRouteNavigator />
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Alert Detail" })).toBeInTheDocument();
+    });
+    expect(screen.getByText("live_wazuh_webhook")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Go to readiness" }));
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Readiness" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Go to alert detail" }));
+
+    expect(
+      await screen.findByText(
+        "Reviewed operator data could not be verified. The browser stayed fail-closed instead of rendering an untrusted record.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("live_wazuh_webhook")).not.toBeInTheDocument();
   });
 
   it("renders case detail with provenance summary and subordinate context", async () => {

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -19,7 +19,7 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { Link as ReactRouterLink, useParams } from "react-router-dom";
 import { useDataProvider } from "react-admin";
 import {
@@ -36,6 +36,11 @@ import {
   OptionalExtensionVisibilityPanel,
   buildOptionalEvidenceDefinitionsFromPayload,
 } from "./optionalExtensionVisibility";
+import {
+  buildOperatorQueryKey,
+  useOperatorQueryLoader,
+  useOperatorQueryState,
+} from "./operatorQueryCache";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -43,6 +48,7 @@ interface QueryState<T> {
   data: T | null;
   error: Error | null;
   loading: boolean;
+  refreshing: boolean;
 }
 
 function asRecord(value: unknown): UnknownRecord | null {
@@ -524,55 +530,34 @@ function useOperatorList(
   perPage = 25,
 ): QueryState<UnknownRecord[]> {
   const dataProvider = useDataProvider();
-  const [state, setState] = useState<QueryState<UnknownRecord[]>>({
-    data: null,
-    error: null,
-    loading: true,
-  });
-
-  useEffect(() => {
-    let active = true;
-
-    setState({
-      data: null,
-      error: null,
-      loading: true,
-    });
-
-    void dataProvider
-      .getList(resource, {
+  const key = useMemo(
+    () => buildOperatorQueryKey(["list", resource, filter, perPage, sort]),
+    [filter, perPage, resource, sort],
+  );
+  const queryFn = useMemo(
+    () => async () => {
+      const result = await dataProvider.getList(resource, {
         filter,
         pagination: {
           page: 1,
           perPage,
         },
         sort,
-      })
-      .then((result) => {
-        if (!active) {
-          return;
-        }
-        setState({
-          data: result.data.map((record) => record as UnknownRecord),
-          error: null,
-          loading: false,
-        });
-      })
-      .catch((error: unknown) => {
-        if (!active) {
-          return;
-        }
-        setState({
-          data: null,
-          error: error instanceof Error ? error : new Error("Unknown operator list error."),
-          loading: false,
-        });
       });
 
-    return () => {
-      active = false;
-    };
-  }, [dataProvider, filter, perPage, resource, sort]);
+      return result.data.map((record) => record as UnknownRecord);
+    },
+    [dataProvider, filter, perPage, resource, sort],
+  );
+  const state = useOperatorQueryState<UnknownRecord[]>(key);
+
+  useOperatorQueryLoader({
+    key,
+    policy: {
+      refetchOnMount: true,
+    },
+    queryFn,
+  });
 
   return state;
 }
@@ -583,48 +568,45 @@ function useOperatorRecord(
   meta?: Record<string, unknown>,
 ): QueryState<UnknownRecord> {
   const dataProvider = useDataProvider();
-  const [state, setState] = useState<QueryState<UnknownRecord>>({
-    data: null,
-    error: null,
-    loading: true,
-  });
-
-  useEffect(() => {
-    let active = true;
-
-    setState({
-      data: null,
-      error: null,
-      loading: true,
-    });
-
-    void dataProvider
-      .getOne(resource, { id, meta })
-      .then((result) => {
-        if (!active) {
-          return;
-        }
-        setState({
-          data: result.data as UnknownRecord,
-          error: null,
-          loading: false,
-        });
-      })
-      .catch((error: unknown) => {
-        if (!active) {
-          return;
-        }
-        setState({
-          data: null,
-          error: error instanceof Error ? error : new Error("Unknown operator record error."),
-          loading: false,
-        });
+  const metaRecord =
+    meta && typeof meta === "object" ? meta : {};
+  const { reloadToken, ...cacheableMeta } = metaRecord;
+  const refreshToken =
+    typeof reloadToken === "number" && reloadToken > 0 ? reloadToken : undefined;
+  const requestMetaKey = useMemo(
+    () => buildOperatorQueryKey(["request-meta", metaRecord]),
+    [metaRecord],
+  );
+  const requestMeta = useMemo(
+    () => (Object.keys(metaRecord).length > 0 ? metaRecord : undefined),
+    [requestMetaKey],
+  );
+  const key = useMemo(
+    () => buildOperatorQueryKey(["record", resource, id, cacheableMeta]),
+    [cacheableMeta, id, resource],
+  );
+  const queryFn = useMemo(
+    () => async () => {
+      const result = await dataProvider.getOne(resource, {
+        id,
+        meta: requestMeta,
       });
 
-    return () => {
-      active = false;
-    };
-  }, [dataProvider, id, meta, resource]);
+      return result.data as UnknownRecord;
+    },
+    [dataProvider, id, requestMeta, requestMetaKey, resource],
+  );
+  const state = useOperatorQueryState<UnknownRecord>(key);
+
+  useOperatorQueryLoader({
+    force: refreshToken !== undefined,
+    key,
+    policy: {
+      refetchOnMount: true,
+    },
+    queryFn,
+    refreshToken,
+  });
 
   return state;
 }
@@ -667,11 +649,55 @@ function LoadingState({ label }: { label: string }) {
 }
 
 function ErrorState({ error }: { error: Error }) {
+  if (error.name === "OperatorDataProviderAuthorizationError") {
+    return (
+      <Alert severity="warning" variant="outlined">
+        Reviewed backend authorization is required before this operator surface can render.
+      </Alert>
+    );
+  }
+
+  if (error.name === "OperatorDataProviderContractError") {
+    return (
+      <Alert severity="error" variant="outlined">
+        Reviewed operator data could not be verified. The browser stayed fail-closed instead of rendering an untrusted record.
+      </Alert>
+    );
+  }
+
   return (
     <Alert severity="error" variant="outlined">
       {error.message}
     </Alert>
   );
+}
+
+function QueryStateNotice({
+  error,
+  refreshing,
+}: {
+  error: Error | null;
+  refreshing: boolean;
+}) {
+  if (error) {
+    return (
+      <Alert severity="warning" variant="outlined">
+        Showing the last verified operator data while refresh is unavailable.
+        <br />
+        {error.message}
+      </Alert>
+    );
+  }
+
+  if (refreshing) {
+    return (
+      <Alert severity="info" variant="outlined">
+        Refreshing reviewed operator data while the last verified state remains visible.
+      </Alert>
+    );
+  }
+
+  return null;
 }
 
 function SectionCard({
@@ -910,15 +936,16 @@ export function QueuePage() {
     }),
     [],
   );
-  const { data, error, loading } = useOperatorList("queue", filter, sort);
+  const { data, error, loading, refreshing } = useOperatorList("queue", filter, sort);
 
   return (
     <PageFrame
       subtitle="Primary review surface; substrate links stay secondary. AegisOps queue records remain the authoritative selection surface for operator review."
       title="Analyst Queue"
     >
-      {loading ? <LoadingState label="Loading analyst queue" /> : null}
-      {error ? <ErrorState error={error} /> : null}
+      {loading && !data ? <LoadingState label="Loading analyst queue" /> : null}
+      {error && !data ? <ErrorState error={error} /> : null}
+      {data ? <QueryStateNotice error={error} refreshing={refreshing} /> : null}
       {data ? (
         data.length > 0 ? (
           <SectionCard
@@ -1032,13 +1059,13 @@ function AlertDetailPageBody({
 }) {
   const [reloadToken, setReloadToken] = useState(0);
   const recordMeta = useMemo(() => ({ reloadToken }), [reloadToken]);
-  const { data, error, loading } = useOperatorRecord("alerts", alertId, recordMeta);
+  const { data, error, loading, refreshing } = useOperatorRecord("alerts", alertId, recordMeta);
 
-  if (loading) {
+  if (loading && !data) {
     return <LoadingState label="Loading alert detail" />;
   }
 
-  if (error) {
+  if (error && !data) {
     return <ErrorState error={error} />;
   }
 
@@ -1054,6 +1081,7 @@ function AlertDetailPageBody({
 
   return (
     <Stack spacing={3}>
+      <QueryStateNotice error={error} refreshing={refreshing} />
       <SectionCard
         subtitle="Authoritative anchor records stay primary even when subordinate substrate context disagrees or is missing."
         title="Authoritative anchor"
@@ -1203,13 +1231,13 @@ function CaseDetailPageBody({
 }) {
   const [reloadToken, setReloadToken] = useState(0);
   const recordMeta = useMemo(() => ({ reloadToken }), [reloadToken]);
-  const { data, error, loading } = useOperatorRecord("cases", caseId, recordMeta);
+  const { data, error, loading, refreshing } = useOperatorRecord("cases", caseId, recordMeta);
 
-  if (loading) {
+  if (loading && !data) {
     return <LoadingState label="Loading case detail" />;
   }
 
-  if (error) {
+  if (error && !data) {
     return <ErrorState error={error} />;
   }
 
@@ -1235,6 +1263,7 @@ function CaseDetailPageBody({
 
   return (
     <Stack spacing={3}>
+      <QueryStateNotice error={error} refreshing={refreshing} />
       <SectionCard
         subtitle="Case lifecycle state and linked identifiers come from the authoritative AegisOps case record, not from summaries or substrate convenience surfaces."
         title="Authoritative anchor"
@@ -1454,12 +1483,12 @@ function ActionReviewPageBody({
 }) {
   const [reloadToken, setReloadToken] = useState(0);
   const recordMeta = useMemo(() => ({ reloadToken }), [reloadToken]);
-  const { data, error, loading } = useOperatorRecord("actionReview", actionRequestId, recordMeta);
+  const { data, error, loading, refreshing } = useOperatorRecord("actionReview", actionRequestId, recordMeta);
 
-  if (loading) {
+  if (loading && !data) {
     return <LoadingState label="Loading action review detail" />;
   }
-  if (error) {
+  if (error && !data) {
     return <ErrorState error={error} />;
   }
   if (!data) {
@@ -1492,6 +1521,7 @@ function ActionReviewPageBody({
 
   return (
     <Stack spacing={3}>
+      <QueryStateNotice error={error} refreshing={refreshing} />
       <SectionCard
         subtitle="This page stays anchored to one authoritative action-review record. Browser-local routing does not redefine the active review."
         title="Action request detail"
@@ -1775,13 +1805,13 @@ function AssistantAdvisoryPageBody({
     }),
     [recordFamily, recordId],
   );
-  const { data, error, loading } = useOperatorRecord("advisoryOutput", advisoryId, meta);
+  const { data, error, loading, refreshing } = useOperatorRecord("advisoryOutput", advisoryId, meta);
   const anchorLink = supportedAnchorRoute(recordFamily, recordId);
 
-  if (loading) {
+  if (loading && !data) {
     return <LoadingState label="Loading assistant advisory" />;
   }
-  if (error) {
+  if (error && !data) {
     return <ErrorState error={error} />;
   }
   if (!data) {
@@ -1808,6 +1838,7 @@ function AssistantAdvisoryPageBody({
 
   return (
     <Stack spacing={3}>
+      <QueryStateNotice error={error} refreshing={refreshing} />
       <SectionCard
         subtitle="Assistant output stays subordinate to the selected authoritative record and remains read-only inside the reviewed shell."
         title="Authoritative advisory anchor"
@@ -2043,12 +2074,12 @@ export function AssistantAdvisoryPage() {
 }
 
 function ProvenanceAlertBody({ alertId }: { alertId: string }) {
-  const { data, error, loading } = useOperatorRecord("alerts", alertId);
+  const { data, error, loading, refreshing } = useOperatorRecord("alerts", alertId);
 
-  if (loading) {
+  if (loading && !data) {
     return <LoadingState label="Loading alert provenance" />;
   }
-  if (error) {
+  if (error && !data) {
     return <ErrorState error={error} />;
   }
   if (!data) {
@@ -2058,31 +2089,34 @@ function ProvenanceAlertBody({ alertId }: { alertId: string }) {
   const lineage = asRecord(data.lineage);
 
   return (
-    <SectionCard
-      subtitle="This page is provenance-focused but still anchored to the reviewed alert record rather than to substrate-native summaries."
-      title="Alert provenance"
-    >
-      <ValueList
-        entries={[
-          ["Alert id", data.alert_id],
-          ["Reconciliation id", lineage?.reconciliation_id],
-          ["Detection ids", lineage?.substrate_detection_record_ids],
-          ["Accountable identities", lineage?.accountable_source_identities],
-          ["First seen", lineage?.first_seen_at],
-          ["Last seen", lineage?.last_seen_at],
-        ]}
-      />
-    </SectionCard>
+    <Stack spacing={3}>
+      <QueryStateNotice error={error} refreshing={refreshing} />
+      <SectionCard
+        subtitle="This page is provenance-focused but still anchored to the reviewed alert record rather than to substrate-native summaries."
+        title="Alert provenance"
+      >
+        <ValueList
+          entries={[
+            ["Alert id", data.alert_id],
+            ["Reconciliation id", lineage?.reconciliation_id],
+            ["Detection ids", lineage?.substrate_detection_record_ids],
+            ["Accountable identities", lineage?.accountable_source_identities],
+            ["First seen", lineage?.first_seen_at],
+            ["Last seen", lineage?.last_seen_at],
+          ]}
+        />
+      </SectionCard>
+    </Stack>
   );
 }
 
 function ProvenanceCaseBody({ caseId }: { caseId: string }) {
-  const { data, error, loading } = useOperatorRecord("cases", caseId);
+  const { data, error, loading, refreshing } = useOperatorRecord("cases", caseId);
 
-  if (loading) {
+  if (loading && !data) {
     return <LoadingState label="Loading case provenance" />;
   }
-  if (error) {
+  if (error && !data) {
     return <ErrorState error={error} />;
   }
   if (!data) {
@@ -2093,21 +2127,24 @@ function ProvenanceCaseBody({ caseId }: { caseId: string }) {
   const authoritativeAnchor = asRecord(getPath(provenanceSummary, "authoritative_anchor"));
 
   return (
-    <SectionCard
-      subtitle="Only directly linked case lineage is shown here. Neighbor or sibling lineage is not widened by inference."
-      title="Case provenance"
-    >
-      <ValueList
-        entries={[
-          ["Case id", data.case_id],
-          ["Anchor family", authoritativeAnchor?.record_family],
-          ["Anchor id", authoritativeAnchor?.record_id],
-          ["Anchor source family", authoritativeAnchor?.source_family],
-          ["Linked reconciliation ids", data.linked_reconciliation_ids],
-          ["Linked evidence ids", data.linked_evidence_ids],
-        ]}
-      />
-    </SectionCard>
+    <Stack spacing={3}>
+      <QueryStateNotice error={error} refreshing={refreshing} />
+      <SectionCard
+        subtitle="Only directly linked case lineage is shown here. Neighbor or sibling lineage is not widened by inference."
+        title="Case provenance"
+      >
+        <ValueList
+          entries={[
+            ["Case id", data.case_id],
+            ["Anchor family", authoritativeAnchor?.record_family],
+            ["Anchor id", authoritativeAnchor?.record_id],
+            ["Anchor source family", authoritativeAnchor?.source_family],
+            ["Linked reconciliation ids", data.linked_reconciliation_ids],
+            ["Linked evidence ids", data.linked_evidence_ids],
+          ]}
+        />
+      </SectionCard>
+    </Stack>
   );
 }
 
@@ -2139,7 +2176,7 @@ export function ReadinessPage() {
     }),
     [],
   );
-  const { data, error, loading } = useOperatorList("runtimeReadiness", filter, sort, 1);
+  const { data, error, loading, refreshing } = useOperatorList("runtimeReadiness", filter, sort, 1);
 
   const record = data?.[0] ?? null;
   const reviewPathHealth = asRecord(getPath(record, "metrics.review_path_health"));
@@ -2154,8 +2191,9 @@ export function ReadinessPage() {
       subtitle="Readiness remains a reviewed status surface. It does not become a hidden write console or override authoritative backend state."
       title="Readiness"
     >
-      {loading ? <LoadingState label="Loading readiness diagnostics" /> : null}
-      {error ? <ErrorState error={error} /> : null}
+      {loading && !record ? <LoadingState label="Loading readiness diagnostics" /> : null}
+      {error && !record ? <ErrorState error={error} /> : null}
+      {record ? <QueryStateNotice error={error} refreshing={refreshing} /> : null}
       {record ? (
         <Stack spacing={3}>
           <SectionCard
@@ -2213,15 +2251,16 @@ export function ReconciliationPage() {
     }),
     [],
   );
-  const { data, error, loading } = useOperatorList("reconciliations", filter, sort);
+  const { data, error, loading, refreshing } = useOperatorList("reconciliations", filter, sort);
 
   return (
     <PageFrame
       subtitle="Reconciliation surfaces keep mismatch and linkage problems visible instead of collapsing them into generic success dashboards."
       title="Reconciliation"
     >
-      {loading ? <LoadingState label="Loading reconciliation status" /> : null}
-      {error ? <ErrorState error={error} /> : null}
+      {loading && !data ? <LoadingState label="Loading reconciliation status" /> : null}
+      {error && !data ? <ErrorState error={error} /> : null}
+      {data ? <QueryStateNotice error={error} refreshing={refreshing} /> : null}
       {data ? (
         data.length > 0 ? (
           <Stack spacing={3}>

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -555,6 +555,7 @@ function useOperatorList(
     key,
     policy: {
       refetchOnMount: true,
+      retainStaleOnError: true,
     },
     queryFn,
   });
@@ -603,6 +604,7 @@ function useOperatorRecord(
     key,
     policy: {
       refetchOnMount: true,
+      retainStaleOnError: true,
     },
     queryFn,
     refreshToken,

--- a/apps/operator-ui/src/app/operatorQueryCache.test.ts
+++ b/apps/operator-ui/src/app/operatorQueryCache.test.ts
@@ -97,4 +97,74 @@ describe("operatorQueryCache", () => {
       refreshing: false,
     });
   });
+
+  it("retains the last successful data when a forced reread fails", async () => {
+    const key = "alerts/detail/alert-789";
+    const initialData = { id: "alert-789", source: "cached-success" };
+    const forcedRequest = createDeferred<typeof initialData>();
+
+    await expect(
+      loadOperatorQuery({
+        key,
+        queryFn: async () => initialData,
+      }),
+    ).resolves.toEqual(initialData);
+
+    const forcedPromise = loadOperatorQuery({
+      force: true,
+      key,
+      queryFn: () => forcedRequest.promise,
+    });
+
+    expect(getOperatorQuerySnapshot<typeof initialData>(key)).toEqual({
+      data: null,
+      error: null,
+      loading: true,
+      refreshing: false,
+    });
+
+    forcedRequest.reject(new Error("authoritative reread failed"));
+    await expect(forcedPromise).resolves.toEqual(initialData);
+
+    expect(getOperatorQuerySnapshot<typeof initialData>(key)).toEqual({
+      data: initialData,
+      error: expect.objectContaining({
+        message: "authoritative reread failed",
+      }),
+      loading: false,
+      refreshing: false,
+    });
+  });
+
+  it("drops stale data when retainStaleOnError is disabled", async () => {
+    const key = "alerts/detail/alert-999";
+    const initialData = { id: "alert-999", source: "cached-success" };
+    const forcedRequest = createDeferred<typeof initialData>();
+
+    await expect(
+      loadOperatorQuery({
+        key,
+        queryFn: async () => initialData,
+      }),
+    ).resolves.toEqual(initialData);
+
+    const forcedPromise = loadOperatorQuery({
+      force: true,
+      key,
+      queryFn: () => forcedRequest.promise,
+      retainStaleOnError: false,
+    });
+
+    forcedRequest.reject(new Error("authoritative reread failed"));
+    await expect(forcedPromise).rejects.toThrow("authoritative reread failed");
+
+    expect(getOperatorQuerySnapshot<typeof initialData>(key)).toEqual({
+      data: null,
+      error: expect.objectContaining({
+        message: "authoritative reread failed",
+      }),
+      loading: false,
+      refreshing: false,
+    });
+  });
 });

--- a/apps/operator-ui/src/app/operatorQueryCache.test.ts
+++ b/apps/operator-ui/src/app/operatorQueryCache.test.ts
@@ -218,18 +218,23 @@ describe("operatorQueryCache", () => {
       }),
     ).resolves.toEqual(cachedData);
 
-    renderHook(() =>
-      useOperatorQueryLoader({
-        force: true,
-        key,
-        policy: {
-          refetchOnMount: false,
-          retainStaleOnError: true,
-        },
-        queryFn,
-        refreshToken: 1,
-      }),
+    const { rerender } = renderHook(
+      ({ refreshToken }: { refreshToken?: number }) =>
+        useOperatorQueryLoader({
+          force: false,
+          key,
+          policy: {
+            refetchOnMount: false,
+            retainStaleOnError: true,
+          },
+          queryFn,
+          refreshToken,
+        }),
+      { initialProps: {} as { refreshToken?: number } },
     );
+
+    expect(queryFn).not.toHaveBeenCalled();
+    rerender({ refreshToken: 1 });
 
     await waitFor(() => {
       expect(queryFn).toHaveBeenCalledTimes(1);

--- a/apps/operator-ui/src/app/operatorQueryCache.test.ts
+++ b/apps/operator-ui/src/app/operatorQueryCache.test.ts
@@ -1,8 +1,10 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getOperatorQuerySnapshot,
   loadOperatorQuery,
   resetOperatorQueryCacheForTests,
+  useOperatorQueryLoader,
 } from "./operatorQueryCache";
 
 function createDeferred<T>() {
@@ -165,6 +167,81 @@ describe("operatorQueryCache", () => {
       }),
       loading: false,
       refreshing: false,
+    });
+  });
+
+  it("skips mount rereads when cached data exists and refetchOnMount is disabled", async () => {
+    const key = "alerts/detail/alert-skip";
+    const cachedData = { id: "alert-skip", source: "cached-success" };
+    const queryFn = vi.fn().mockResolvedValue({
+      id: "alert-skip",
+      source: "unexpected-reread",
+    });
+
+    await expect(
+      loadOperatorQuery({
+        key,
+        queryFn: async () => cachedData,
+      }),
+    ).resolves.toEqual(cachedData);
+
+    renderHook(() =>
+      useOperatorQueryLoader({
+        key,
+        policy: {
+          refetchOnMount: false,
+          retainStaleOnError: true,
+        },
+        queryFn,
+      }),
+    );
+
+    expect(queryFn).not.toHaveBeenCalled();
+    expect(getOperatorQuerySnapshot<typeof cachedData>(key)).toEqual({
+      data: cachedData,
+      error: null,
+      loading: false,
+      refreshing: false,
+    });
+  });
+
+  it("keeps explicit refresh tokens authoritative even when refetchOnMount is disabled", async () => {
+    const key = "alerts/detail/alert-refresh";
+    const cachedData = { id: "alert-refresh", source: "cached-success" };
+    const refreshedData = { id: "alert-refresh", source: "authoritative-reread" };
+    const queryFn = vi.fn().mockResolvedValue(refreshedData);
+
+    await expect(
+      loadOperatorQuery({
+        key,
+        queryFn: async () => cachedData,
+      }),
+    ).resolves.toEqual(cachedData);
+
+    renderHook(() =>
+      useOperatorQueryLoader({
+        force: true,
+        key,
+        policy: {
+          refetchOnMount: false,
+          retainStaleOnError: true,
+        },
+        queryFn,
+        refreshToken: 1,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(queryFn).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(getOperatorQuerySnapshot<typeof refreshedData>(key)).toEqual({
+        data: refreshedData,
+        error: null,
+        loading: false,
+        refreshing: false,
+      });
     });
   });
 });

--- a/apps/operator-ui/src/app/operatorQueryCache.test.ts
+++ b/apps/operator-ui/src/app/operatorQueryCache.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getOperatorQuerySnapshot,
+  loadOperatorQuery,
+  resetOperatorQueryCacheForTests,
+} from "./operatorQueryCache";
+
+function createDeferred<T>() {
+  let rejectPromise: (error: unknown) => void = () => {};
+  let resolvePromise: (value: T) => void = () => {};
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  return {
+    promise,
+    reject(error: unknown) {
+      rejectPromise(error);
+    },
+    resolve(value: T) {
+      resolvePromise(value);
+    },
+  };
+}
+
+describe("operatorQueryCache", () => {
+  beforeEach(() => {
+    resetOperatorQueryCacheForTests();
+  });
+
+  it("keeps the latest forced reread result authoritative when an older request resolves later", async () => {
+    const key = "alerts/detail/alert-123";
+    const olderRequest = createDeferred<{ id: string; source: string }>();
+    const newerRequest = createDeferred<{ id: string; source: string }>();
+
+    const olderPromise = loadOperatorQuery({
+      key,
+      queryFn: () => olderRequest.promise,
+    });
+
+    const newerPromise = loadOperatorQuery({
+      force: true,
+      key,
+      queryFn: () => newerRequest.promise,
+    });
+
+    newerRequest.resolve({ id: "alert-123", source: "authoritative-reread" });
+    await expect(newerPromise).resolves.toEqual({
+      id: "alert-123",
+      source: "authoritative-reread",
+    });
+
+    olderRequest.resolve({ id: "alert-123", source: "stale-initial-read" });
+    await expect(olderPromise).resolves.toEqual({
+      id: "alert-123",
+      source: "stale-initial-read",
+    });
+
+    expect(getOperatorQuerySnapshot<{ id: string; source: string }>(key)).toEqual({
+      data: { id: "alert-123", source: "authoritative-reread" },
+      error: null,
+      loading: false,
+      refreshing: false,
+    });
+  });
+
+  it("ignores stale forced-reread predecessors that fail after a newer response succeeds", async () => {
+    const key = "alerts/detail/alert-456";
+    const olderRequest = createDeferred<{ id: string; source: string }>();
+    const newerRequest = createDeferred<{ id: string; source: string }>();
+
+    const olderPromise = loadOperatorQuery({
+      key,
+      queryFn: () => olderRequest.promise,
+    });
+
+    const newerPromise = loadOperatorQuery({
+      force: true,
+      key,
+      queryFn: () => newerRequest.promise,
+    });
+
+    newerRequest.resolve({ id: "alert-456", source: "authoritative-reread" });
+    await expect(newerPromise).resolves.toEqual({
+      id: "alert-456",
+      source: "authoritative-reread",
+    });
+
+    olderRequest.reject(new Error("stale request failed"));
+    await expect(olderPromise).rejects.toThrow("stale request failed");
+
+    expect(getOperatorQuerySnapshot<{ id: string; source: string }>(key)).toEqual({
+      data: { id: "alert-456", source: "authoritative-reread" },
+      error: null,
+      loading: false,
+      refreshing: false,
+    });
+  });
+});

--- a/apps/operator-ui/src/app/operatorQueryCache.ts
+++ b/apps/operator-ui/src/app/operatorQueryCache.ts
@@ -1,0 +1,195 @@
+import { useEffect, useSyncExternalStore } from "react";
+
+interface QueryPolicy {
+  refetchOnMount: boolean;
+}
+
+interface QueryState<T> {
+  data: T | null;
+  error: Error | null;
+  loading: boolean;
+  refreshing: boolean;
+}
+
+interface CacheEntry<T> {
+  inFlight: Promise<T> | null;
+  listeners: Set<() => void>;
+  state: QueryState<T>;
+}
+
+interface LoadQueryArgs<T> {
+  force?: boolean;
+  key: string;
+  queryFn: () => Promise<T>;
+  retainStaleOnError?: boolean;
+}
+
+const DEFAULT_QUERY_STATE = {
+  data: null,
+  error: null,
+  loading: true,
+  refreshing: false,
+};
+
+const queryCache = new Map<string, CacheEntry<unknown>>();
+
+function getOrCreateEntry<T>(key: string): CacheEntry<T> {
+  const existing = queryCache.get(key) as CacheEntry<T> | undefined;
+  if (existing) {
+    return existing;
+  }
+
+  const created: CacheEntry<T> = {
+    inFlight: null,
+    listeners: new Set(),
+    state: DEFAULT_QUERY_STATE,
+  };
+  queryCache.set(key, created as CacheEntry<unknown>);
+  return created;
+}
+
+function notifyEntry(entry: CacheEntry<unknown>) {
+  entry.listeners.forEach((listener) => listener());
+}
+
+function shouldRetainDataOnError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return !(
+    error.name === "OperatorDataProviderAuthorizationError" ||
+    error.name === "OperatorDataProviderContractError"
+  );
+}
+
+export function buildOperatorQueryKey(parts: unknown[]): string {
+  return JSON.stringify(parts);
+}
+
+export function subscribeToOperatorQuery(
+  key: string,
+  listener: () => void,
+) {
+  const entry = getOrCreateEntry(key);
+  entry.listeners.add(listener);
+
+  return () => {
+    entry.listeners.delete(listener);
+  };
+}
+
+export function getOperatorQuerySnapshot<T>(key: string): QueryState<T> {
+  return getOrCreateEntry<T>(key).state;
+}
+
+export async function loadOperatorQuery<T>({
+  force = false,
+  key,
+  queryFn,
+  retainStaleOnError = true,
+}: LoadQueryArgs<T>): Promise<T> {
+  const entry = getOrCreateEntry<T>(key);
+  const hasData = entry.state.data !== null;
+
+  if (!force && entry.inFlight !== null) {
+    return entry.inFlight;
+  }
+
+  if (!force && hasData) {
+    entry.state = {
+      ...entry.state,
+      error: null,
+      loading: false,
+      refreshing: true,
+    };
+    notifyEntry(entry);
+  } else {
+    entry.state = {
+      data: null,
+      error: null,
+      loading: true,
+      refreshing: false,
+    };
+    notifyEntry(entry);
+  }
+
+  const request = queryFn()
+    .then((data) => {
+      entry.state = {
+        data,
+        error: null,
+        loading: false,
+        refreshing: false,
+      };
+      notifyEntry(entry);
+      return data;
+    })
+    .catch((error: unknown) => {
+      const normalizedError =
+        error instanceof Error
+          ? error
+          : new Error("Unknown operator query failure.");
+
+      if (hasData && retainStaleOnError && shouldRetainDataOnError(normalizedError)) {
+        entry.state = {
+          data: entry.state.data,
+          error: normalizedError,
+          loading: false,
+          refreshing: false,
+        };
+        notifyEntry(entry);
+        return entry.state.data as T;
+      }
+
+      entry.state = {
+        data: null,
+        error: normalizedError,
+        loading: false,
+        refreshing: false,
+      };
+      notifyEntry(entry);
+      throw normalizedError;
+    })
+    .finally(() => {
+      entry.inFlight = null;
+    });
+
+  entry.inFlight = request;
+  return request;
+}
+
+export function useOperatorQueryState<T>(key: string): QueryState<T> {
+  return useSyncExternalStore(
+    (listener) => subscribeToOperatorQuery(key, listener),
+    () => getOperatorQuerySnapshot<T>(key),
+    () => DEFAULT_QUERY_STATE,
+  );
+}
+
+export function useOperatorQueryLoader<T>({
+  force = false,
+  key,
+  policy,
+  queryFn,
+  refreshToken,
+}: {
+  force?: boolean;
+  key: string;
+  policy: QueryPolicy;
+  queryFn: () => Promise<T>;
+  refreshToken?: number;
+}) {
+  useEffect(() => {
+    void loadOperatorQuery<T>({
+      force: force || refreshToken !== undefined,
+      key,
+      queryFn,
+      retainStaleOnError: policy.refetchOnMount,
+    }).catch(() => undefined);
+  }, [force, key, policy.refetchOnMount, queryFn, refreshToken]);
+}
+
+export function resetOperatorQueryCacheForTests() {
+  queryCache.clear();
+}

--- a/apps/operator-ui/src/app/operatorQueryCache.ts
+++ b/apps/operator-ui/src/app/operatorQueryCache.ts
@@ -2,6 +2,7 @@ import { useEffect, useSyncExternalStore } from "react";
 
 interface QueryPolicy {
   refetchOnMount: boolean;
+  retainStaleOnError: boolean;
 }
 
 interface QueryState<T> {
@@ -92,7 +93,8 @@ export async function loadOperatorQuery<T>({
   retainStaleOnError = true,
 }: LoadQueryArgs<T>): Promise<T> {
   const entry = getOrCreateEntry<T>(key);
-  const hasData = entry.state.data !== null;
+  const previousData = entry.state.data;
+  const hasData = previousData !== null;
 
   if (!force && entry.inFlight !== null) {
     return entry.inFlight;
@@ -144,15 +146,19 @@ export async function loadOperatorQuery<T>({
         throw normalizedError;
       }
 
-      if (hasData && retainStaleOnError && shouldRetainDataOnError(normalizedError)) {
+      if (
+        previousData !== null &&
+        retainStaleOnError &&
+        shouldRetainDataOnError(normalizedError)
+      ) {
         entry.state = {
-          data: entry.state.data,
+          data: previousData,
           error: normalizedError,
           loading: false,
           refreshing: false,
         };
         notifyEntry(entry);
-        return entry.state.data as T;
+        return previousData;
       }
 
       entry.state = {
@@ -182,6 +188,8 @@ export function useOperatorQueryState<T>(key: string): QueryState<T> {
   );
 }
 
+// `queryFn` should stay stable for a given cache key so renders do not trigger
+// redundant rereads for the same authoritative request identity.
 export function useOperatorQueryLoader<T>({
   force = false,
   key,
@@ -200,9 +208,16 @@ export function useOperatorQueryLoader<T>({
       force: force || refreshToken !== undefined,
       key,
       queryFn,
-      retainStaleOnError: policy.refetchOnMount,
+      retainStaleOnError: policy.retainStaleOnError,
     }).catch(() => undefined);
-  }, [force, key, policy.refetchOnMount, queryFn, refreshToken]);
+  }, [
+    force,
+    key,
+    policy.refetchOnMount,
+    policy.retainStaleOnError,
+    queryFn,
+    refreshToken,
+  ]);
 }
 
 export function resetOperatorQueryCacheForTests() {

--- a/apps/operator-ui/src/app/operatorQueryCache.ts
+++ b/apps/operator-ui/src/app/operatorQueryCache.ts
@@ -204,6 +204,17 @@ export function useOperatorQueryLoader<T>({
   refreshToken?: number;
 }) {
   useEffect(() => {
+    const snapshot = getOperatorQuerySnapshot<T>(key);
+    const shouldLoad =
+      force ||
+      refreshToken !== undefined ||
+      snapshot.data === null ||
+      policy.refetchOnMount;
+
+    if (!shouldLoad) {
+      return;
+    }
+
     void loadOperatorQuery<T>({
       force: force || refreshToken !== undefined,
       key,

--- a/apps/operator-ui/src/app/operatorQueryCache.ts
+++ b/apps/operator-ui/src/app/operatorQueryCache.ts
@@ -14,6 +14,7 @@ interface QueryState<T> {
 interface CacheEntry<T> {
   inFlight: Promise<T> | null;
   listeners: Set<() => void>;
+  requestVersion: number;
   state: QueryState<T>;
 }
 
@@ -42,6 +43,7 @@ function getOrCreateEntry<T>(key: string): CacheEntry<T> {
   const created: CacheEntry<T> = {
     inFlight: null,
     listeners: new Set(),
+    requestVersion: 0,
     state: DEFAULT_QUERY_STATE,
   };
   queryCache.set(key, created as CacheEntry<unknown>);
@@ -96,6 +98,9 @@ export async function loadOperatorQuery<T>({
     return entry.inFlight;
   }
 
+  const requestVersion = entry.requestVersion + 1;
+  entry.requestVersion = requestVersion;
+
   if (!force && hasData) {
     entry.state = {
       ...entry.state,
@@ -116,6 +121,10 @@ export async function loadOperatorQuery<T>({
 
   const request = queryFn()
     .then((data) => {
+      if (entry.requestVersion !== requestVersion) {
+        return data;
+      }
+
       entry.state = {
         data,
         error: null,
@@ -130,6 +139,10 @@ export async function loadOperatorQuery<T>({
         error instanceof Error
           ? error
           : new Error("Unknown operator query failure.");
+
+      if (entry.requestVersion !== requestVersion) {
+        throw normalizedError;
+      }
 
       if (hasData && retainStaleOnError && shouldRetainDataOnError(normalizedError)) {
         entry.state = {
@@ -152,7 +165,9 @@ export async function loadOperatorQuery<T>({
       throw normalizedError;
     })
     .finally(() => {
-      entry.inFlight = null;
+      if (entry.requestVersion === requestVersion) {
+        entry.inFlight = null;
+      }
     });
 
   entry.inFlight = request;

--- a/apps/operator-ui/src/dataProvider.ts
+++ b/apps/operator-ui/src/dataProvider.ts
@@ -77,7 +77,22 @@ const RESOURCE_BINDINGS: Record<Exclude<OperatorResourceName, "advisoryOutput" |
 
 export class UnsupportedOperatorDataProviderOperationError extends Error {}
 
-class OperatorDataProviderContractError extends Error {}
+export class OperatorDataProviderAuthorizationError extends Error {
+  status: number;
+
+  constructor(status: number) {
+    super("Backend operator boundary rejected the request.");
+    this.name = "OperatorDataProviderAuthorizationError";
+    this.status = status;
+  }
+}
+
+export class OperatorDataProviderContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OperatorDataProviderContractError";
+  }
+}
 
 function rejectUnsupported(method: string, resource: string): Promise<never> {
   return Promise.reject(
@@ -396,9 +411,7 @@ async function fetchJson(fetchFn: typeof fetch, path: string): Promise<unknown> 
   });
 
   if (response.status === 401 || response.status === 403) {
-    const error = new Error("Backend operator boundary rejected the request.");
-    Object.assign(error, { status: response.status });
-    throw error;
+    throw new OperatorDataProviderAuthorizationError(response.status);
   }
 
   if (!response.ok) {


### PR DESCRIPTION
Closes #710
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed `00c1a52` on `codex/issue-710`.

The operator UI now uses a shared query cache for list/detail reads, keeps last verified data visible during transient background refresh failures, and fails closed on malformed refresh responses instead of continuing to show cached data as current. I also made the page-level state surfaces more consistent across queue, detail, provenance, readiness, and reconciliation routes, and added route tests that reproduce the new cache/refetch behavior.

Verification passed with:
- `npm --prefix apps/operator-ui test -- src/dataProvider.test.ts src/taskActions/taskActionPrimitives.test.tsx src/app/OperatorRoutes.test.tsx`
- `npm --prefix apps/operator-ui run build`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 710 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`

Summary: Added shared operator query caching with stale-while-revalidate reads, explicit fail-closed refresh handling, consistent state notices, focused route regressions, and committed the slice as `00c1a52`.
State hint: stabilizing
Blocked reason: none
Tests: `npm --prefix apps/operator-ui test -- src/dataProvider.test.ts src/taskActions/taskActionPrimitives.test.tsx src/app/OperatorRoutes.test.tsx`; `npm --prefix apps/operator-ui run build`; `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 710 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.jso...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized query caching for operator pages with in-content refresh status notices and smarter refresh handling.

* **Bug Fixes**
  * Suppress full loading/error screens when cached data exists; show discrete notices instead.
  * Preserve last verified alert detail during transient refresh failures and indicate refresh unavailable.
  * Treat malformed alert-detail responses as verification errors and avoid surfacing stale data.
  * Distinct handling for authorization vs contract errors.

* **Tests**
  * Added navigation-driven refetch and cache race-condition coverage with isolated cache resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->