### PR TITLE
Add Phase 31 operator workflow E2E validation

### DIFF
--- a/apps/operator-ui/e2e/operator-workflows.spec.ts
+++ b/apps/operator-ui/e2e/operator-workflows.spec.ts
@@ -1,0 +1,209 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+const defaultSession = {
+  identity: "analyst@example.com",
+  provider: "authentik",
+  roles: ["Analyst"],
+  subject: "operator-7",
+};
+
+const defaultReadiness = {
+  metrics: {
+    optional_extensions: {
+      overall_state: "ready",
+      tracked_extensions: 4,
+      extensions: {
+        assistant: {
+          authority_mode: "advisory_only",
+          availability: "available",
+          enablement: "enabled",
+          mainline_dependency: "non_blocking",
+          readiness: "ready",
+          reason: "bounded_reviewed_summary_provider_available",
+        },
+        endpoint_evidence: {
+          authority_mode: "augmenting_evidence",
+          availability: "unavailable",
+          enablement: "disabled_by_default",
+          mainline_dependency: "non_blocking",
+          readiness: "not_applicable",
+          reason: "isolated_executor_runtime_not_configured",
+        },
+        network_evidence: {
+          authority_mode: "augmenting_evidence",
+          availability: "unavailable",
+          enablement: "disabled_by_default",
+          mainline_dependency: "non_blocking",
+          readiness: "not_applicable",
+          reason: "reviewed_network_evidence_extension_not_activated",
+        },
+        ml_shadow: {
+          authority_mode: "shadow_only",
+          availability: "available",
+          enablement: "enabled",
+          mainline_dependency: "non_blocking",
+          readiness: "degraded",
+          reason: "reviewed_ml_shadow_extension_provider_lagging",
+        },
+      },
+    },
+  },
+  status: "ready",
+};
+
+const queuePayload = {
+  queue_name: "analyst_review",
+  read_only: true,
+  records: [
+    {
+      alert_id: "alert-789",
+      review_state: "degraded",
+      case_lifecycle_state: "open",
+      external_ticket_reference: {
+        status: "missing_anchor",
+      },
+      reviewed_context: {
+        source: {
+          source_family: "microsoft_365_audit",
+        },
+      },
+      current_action_review: {
+        review_state: "pending",
+      },
+    },
+  ],
+  total_records: 1,
+};
+
+const actionReviewPayload = {
+  action_request_id: "action-request-123",
+  read_only: true,
+  action_review: {
+    action_request_id: "action-request-123",
+    action_request_state: "pending_approval",
+    approval_state: "pending",
+    review_state: "pending",
+    action_execution_state: "not_started",
+    reconciliation_state: "not_started",
+    requester_identity: "analyst@example.com",
+    recipient_identity: "security-team@example.com",
+    message_intent: "notify",
+    next_expected_action: "await_approver_decision",
+    timeline: [
+      {
+        label: "Action request",
+        state: "pending_approval",
+      },
+    ],
+  },
+  current_action_review: {
+    action_request_id: "action-request-123",
+    review_state: "pending",
+  },
+  case_record: {
+    case_id: "case-456",
+    lifecycle_state: "open",
+  },
+  alert_record: {
+    alert_id: "alert-789",
+    lifecycle_state: "open",
+  },
+};
+
+function fulfillJson(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    body: JSON.stringify(body),
+    contentType: "application/json",
+    status,
+  });
+}
+
+async function stubOperatorBackend(
+  page: Page,
+  options: {
+    session?: unknown;
+    sessionStatus?: number;
+  } = {},
+) {
+  await page.route("**/api/operator/session", (route) =>
+    fulfillJson(
+      route,
+      options.session ?? defaultSession,
+      options.sessionStatus ?? 200,
+    ),
+  );
+  await page.route("**/diagnostics/readiness?**", (route) =>
+    fulfillJson(route, defaultReadiness),
+  );
+  await page.route("**/inspect-analyst-queue?**", (route) =>
+    fulfillJson(route, queuePayload),
+  );
+  await page.route("**/inspect-action-review?**", (route) =>
+    fulfillJson(route, actionReviewPayload),
+  );
+}
+
+test("unauthenticated protected deep links preserve a bounded return path without rendering shell data", async ({
+  page,
+}) => {
+  await stubOperatorBackend(page, { sessionStatus: 401 });
+
+  await page.goto("/operator/queue?focus=degraded#summary");
+
+  await expect(
+    page.getByRole("heading", { name: "Operator Sign-In" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Return path: /operator/queue?focus=degraded#summary"),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Analyst Queue" }),
+  ).toHaveCount(0);
+});
+
+test("role gating blocks analyst browser navigation to action review collection routes", async ({
+  page,
+}) => {
+  await stubOperatorBackend(page);
+
+  await page.goto("/operator/action-review");
+
+  await expect(page.getByRole("heading", { name: "Access denied" })).toBeVisible();
+  await expect(page).toHaveURL(/\/operator\/forbidden$/);
+  await expect(page.getByRole("heading", { name: "Action Review" })).toHaveCount(0);
+});
+
+test("operator workflows render degraded queue state and approver action-review detail from backend records", async ({
+  page,
+}) => {
+  await stubOperatorBackend(page, {
+    session: {
+      identity: "approver@example.com",
+      provider: "authentik",
+      roles: ["Approver"],
+      subject: "operator-8",
+    },
+  });
+
+  await page.goto("/operator/queue");
+
+  await expect(page.getByRole("heading", { name: "Analyst Queue" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "alert-789" })).toBeVisible();
+  await expect(page.getByText("Review: degraded").first()).toBeVisible();
+  await expect(page.getByText("No case anchor")).toBeVisible();
+  await expect(
+    page.getByText("Review state remains degraded."),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Non-authoritative coordination reference is missing_anchor."),
+  ).toBeVisible();
+
+  await page.goto("/operator/action-review/action-request-123");
+
+  await expect(page.getByRole("heading", { name: "Action Review" })).toBeVisible();
+  await expect(page.getByText("Action request id").first()).toBeVisible();
+  await expect(page.getByText("action-request-123").first()).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Record approval decision" }),
+  ).toBeVisible();
+});

--- a/apps/operator-ui/package-lock.json
+++ b/apps/operator-ui/package-lock.json
@@ -18,6 +18,7 @@
         "react-router-dom": "^7.9.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -1410,6 +1411,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3479,6 +3496,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/apps/operator-ui/package.json
+++ b/apps/operator-ui/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -19,6 +20,7 @@
     "react-router-dom": "^7.9.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/apps/operator-ui/playwright.config.ts
+++ b/apps/operator-ui/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1",
+    reuseExistingServer: !process.env.CI,
+    url: "http://127.0.0.1:4173/operator",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/apps/operator-ui/vitest.config.ts
+++ b/apps/operator-ui/vitest.config.ts
@@ -1,10 +1,11 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
+    exclude: [...configDefaults.exclude, "e2e/**"],
     globals: true,
     setupFiles: "./src/test/setup.ts",
   },

--- a/control-plane/tests/test_phase31_operator_ui_validation.py
+++ b/control-plane/tests/test_phase31_operator_ui_validation.py
@@ -28,8 +28,11 @@ class Phase31OperatorUiValidationTests(unittest.TestCase):
             "client-event logging remains bounded, audit-friendly, and subordinate to backend audit records",
             "caching, refetch, reload, and fixed-theme guardrails remain product-grade browser behavior rather than workflow authority expansion",
             "control-plane/tests/test_phase31_operator_ui_validation.py",
+            "apps/operator-ui/e2e/operator-workflows.spec.ts",
+            "playwright.config.ts",
             "apps/operator-ui/src/app/OperatorRoutes.test.tsx",
             "python3 -m unittest control-plane.tests.test_phase31_operator_ui_validation",
+            "npm --prefix apps/operator-ui exec playwright test",
             "npm --prefix apps/operator-ui test -- --run src/app/OperatorRoutes.test.tsx",
             "npm --prefix apps/operator-ui run build",
         ):
@@ -51,6 +54,46 @@ class Phase31OperatorUiValidationTests(unittest.TestCase):
             "keeps no-authority semantics explicit for cited advisory output without a recommendation draft",
         ):
             self.assertIn(term, operator_routes_tests)
+
+    def test_phase31_browser_workflow_suite_locks_product_grade_operator_paths(
+        self,
+    ) -> None:
+        playwright_config = self._read("playwright.config.ts")
+        package_config = self._read("apps/operator-ui/playwright.config.ts")
+        operator_workflows = self._read("apps/operator-ui/e2e/operator-workflows.spec.ts")
+        package_json = self._read("apps/operator-ui/package.json")
+
+        for term in (
+            'testDir: "./apps/operator-ui/e2e"',
+            'command: "npm --prefix apps/operator-ui run dev -- --host 127.0.0.1"',
+            'baseURL: "http://127.0.0.1:4173"',
+        ):
+            self.assertIn(term, playwright_config)
+
+        for term in (
+            'testDir: "./e2e"',
+            'command: "npm run dev -- --host 127.0.0.1"',
+            'baseURL: "http://127.0.0.1:4173"',
+        ):
+            self.assertIn(term, package_config)
+
+        for term in (
+            "@playwright/test",
+            '"test:e2e": "playwright test"',
+        ):
+            self.assertIn(term, package_json)
+
+        for term in (
+            "unauthenticated protected deep links preserve a bounded return path without rendering shell data",
+            "role gating blocks analyst browser navigation to action review collection routes",
+            "operator workflows render degraded queue state and approver action-review detail from backend records",
+            "Return path: /operator/queue?focus=degraded#summary",
+            "Access denied",
+            "Review state remains degraded.",
+            "Non-authoritative coordination reference is missing_anchor.",
+            "Record approval decision",
+        ):
+            self.assertIn(term, operator_workflows)
 
     def test_phase31_shell_and_route_sources_expose_reviewed_gating_and_binding_points(
         self,

--- a/control-plane/tests/test_phase31_product_grade_hardening_boundary_docs.py
+++ b/control-plane/tests/test_phase31_product_grade_hardening_boundary_docs.py
@@ -77,15 +77,18 @@ class Phase31ProductGradeHardeningBoundaryDocsTests(unittest.TestCase):
             "apps/operator-ui/src/app/OperatorRoutes.tsx",
             "apps/operator-ui/src/app/OperatorShell.tsx",
             "apps/operator-ui/src/app/OperatorRoutes.test.tsx",
+            "apps/operator-ui/e2e/operator-workflows.spec.ts",
+            "playwright.config.ts",
             "route, menu, and page-level gating remain posture controls while backend authorization stays authoritative",
             "deep-link and `returnTo` handling remain bounded",
             "unauthorized, forbidden, invalid-session, empty, error, and degraded shell states remain explicit and non-interchangeable",
             "client-event logging remains bounded, audit-friendly, and subordinate to backend audit records",
             "python3 -m unittest control-plane.tests.test_phase31_product_grade_hardening_boundary_docs",
             "python3 -m unittest control-plane.tests.test_phase31_operator_ui_validation",
+            "npm --prefix apps/operator-ui exec playwright test",
             "npm --prefix apps/operator-ui test -- --run src/app/OperatorRoutes.test.tsx",
             "npm --prefix apps/operator-ui run build",
-            "issue-lint 708",
+            "issue-lint 712",
         ):
             self.assertIn(term, text)
 

--- a/docs/phase-31-product-grade-hardening-boundary-validation.md
+++ b/docs/phase-31-product-grade-hardening-boundary-validation.md
@@ -1,13 +1,13 @@
 # Phase 31 Product-Grade Hardening Boundary Validation
 
 - Validation status: PASS
-- Reviewed on: 2026-04-22
+- Reviewed on: 2026-04-23
 - Scope: confirm the reviewed Phase 31 browser hardening contract keeps access posture, deep-link handling, shell-state rendering, client-event logging, and product-grade browser guardrails explicit without turning the operator console into workflow or audit authority.
-- Reviewed sources: `docs/phase-31-product-grade-hardening-boundary.md`, `docs/phase-30-react-admin-foundation-and-read-only-operator-console-boundary.md`, `docs/phase-30d-approval-execution-reconciliation-ui-boundary.md`, `docs/phase-30e-assistant-advisory-integration-boundary.md`, `docs/phase-30f-optional-extension-visibility-boundary.md`, `docs/auth-baseline.md`, `docs/phase-21-production-like-hardening-boundary-and-sequence.md`, `docs/phase-22-operator-trust-and-workflow-ergonomics-boundary-and-sequence.md`, `apps/operator-ui/src/app/OperatorRoutes.tsx`, `apps/operator-ui/src/app/OperatorShell.tsx`, `apps/operator-ui/src/app/OperatorRoutes.test.tsx`
+- Reviewed sources: `docs/phase-31-product-grade-hardening-boundary.md`, `docs/phase-30-react-admin-foundation-and-read-only-operator-console-boundary.md`, `docs/phase-30d-approval-execution-reconciliation-ui-boundary.md`, `docs/phase-30e-assistant-advisory-integration-boundary.md`, `docs/phase-30f-optional-extension-visibility-boundary.md`, `docs/auth-baseline.md`, `docs/phase-21-production-like-hardening-boundary-and-sequence.md`, `docs/phase-22-operator-trust-and-workflow-ergonomics-boundary-and-sequence.md`, `apps/operator-ui/src/app/OperatorRoutes.tsx`, `apps/operator-ui/src/app/OperatorShell.tsx`, `apps/operator-ui/src/app/OperatorRoutes.test.tsx`, `apps/operator-ui/e2e/operator-workflows.spec.ts`, `playwright.config.ts`, `apps/operator-ui/playwright.config.ts`
 
 ## Verdict
 
-Phase 31 validation is now locked at the narrow design boundary required by issue `#708`.
+Phase 31 validation is now locked at the narrow design boundary required by issue `#708` and the browser-level operator workflow coverage required by issue `#712`.
 
 The reviewed browser contract keeps route, menu, and page-level gating explicit while preserving backend authorization as the enforcement boundary.
 
@@ -36,12 +36,17 @@ Client-event logging remains subordinate to backend audit authority and explicit
 
 `apps/operator-ui/src/app/OperatorRoutes.test.tsx` already locks narrow route behaviors around unauthenticated redirect, forbidden routing, malformed session failure, reviewed advisory route binding, and subordinate optional-extension posture so later Phase 31 implementation can extend from reviewed route semantics instead of inventing them.
 
+`apps/operator-ui/e2e/operator-workflows.spec.ts` exercises the bundled operator console in Chromium with backend-boundary network stubs. The suite verifies unauthenticated protected deep links preserve a bounded `returnTo` without rendering shell data, analyst sessions remain blocked from action-review collection routes, degraded queue warnings stay visible, and approver action-review detail renders from backend-returned authoritative records.
+
+`playwright.config.ts` keeps the supervisor-requested `npm --prefix apps/operator-ui exec playwright test` command scoped to the operator workflow E2E directory when run from the repository root. `apps/operator-ui/playwright.config.ts` keeps the same browser suite runnable from the package directory.
+
 `control-plane/tests/test_phase31_product_grade_hardening_boundary_docs.py` and `control-plane/tests/test_phase31_operator_ui_validation.py` lock the design and validation docs so the Phase 31 contract cannot drift away from the reviewed route and shell boundary without failing focused regression checks.
 
 ## Verification
 
 - `python3 -m unittest control-plane.tests.test_phase31_product_grade_hardening_boundary_docs`
 - `python3 -m unittest control-plane.tests.test_phase31_operator_ui_validation`
+- `npm --prefix apps/operator-ui exec playwright test`
 - `npm --prefix apps/operator-ui test -- --run src/app/OperatorRoutes.test.tsx`
 - `npm --prefix apps/operator-ui run build`
-- `node <codex-supervisor-checkout>/dist/index.js issue-lint 708 --config <codex-supervisor-checkout>/supervisor.config.aegisops.coderabbit.json`
+- `node <codex-supervisor-checkout>/dist/index.js issue-lint 712 --config <codex-supervisor-checkout>/supervisor.config.aegisops.coderabbit.json`

--- a/docs/repository-skeleton-validation.md
+++ b/docs/repository-skeleton-validation.md
@@ -25,6 +25,7 @@ The approved top-level repository baseline allows these tracked entries:
 - `opensearch/`
 - `package-lock.json`
 - `package.json`
+- `playwright.config.ts`
 - `postgres/`
 - `proxy/`
 - `scripts/`
@@ -49,6 +50,7 @@ The repository currently tracks these top-level entries in the verified pull req
 - `opensearch/`
 - `package-lock.json`
 - `package.json`
+- `playwright.config.ts`
 - `postgres/`
 - `proxy/`
 - `scripts/`
@@ -64,5 +66,6 @@ Disposition decisions:
 - `.gitignore` is an approved tracked top-level metadata file because the repository baseline depends on committed ignore rules for transient local and supervisor artifacts.
 - `LICENSE.txt` and `README.md` are approved tracked top-level files and are part of the documented baseline.
 - `apps/`, `package.json`, and `package-lock.json` are approved Phase 30 operator-console baseline entries that support the dedicated frontend workspace while preserving backend authority.
+- `playwright.config.ts` is an approved Phase 31 browser-validation shim for repository-root E2E invocation and does not create a new top-level application home.
 
 No approved baseline top-level entries are missing.

--- a/docs/repository-structure-baseline.md
+++ b/docs/repository-structure-baseline.md
@@ -31,6 +31,7 @@ Until a later ADR approves a repository rebaseline, contributors must treat the 
 | `apps/` | Approved frontend application workspace home for reviewed operator-facing surfaces such as `apps/operator-ui/`; this directory does not make the UI the authority source. |
 | `package.json` | Root Node.js workspace manifest that defines approved shared frontend tooling and workspace entrypoints for reviewed UI slices. |
 | `package-lock.json` | Root npm lockfile tracked to keep reviewed workspace dependency resolution reproducible across operator-UI and related frontend changes. |
+| `playwright.config.ts` | Root Playwright shim that keeps repository-root E2E invocation scoped to approved operator-UI browser validation without creating a new frontend authority boundary. |
 
 ## Repository Rules
 
@@ -41,6 +42,7 @@ Until a later ADR approves a repository rebaseline, contributors must treat the 
 - Only intentionally versioned repository guidance is approved under `.codex-supervisor/`; supervisor-local journals and other transient execution files in that directory must remain untracked.
 - This document defines structure only and does not authorize runtime, deployment, or workflow implementation.
 - The reviewed Phase 30 operator-console foundation explicitly approves `apps/`, `package.json`, and `package-lock.json` as repository-baseline entries so the React-Admin operator UI can ship as a dedicated workspace without dissolving backend authority into the frontend shell.
+- The reviewed Phase 31 browser-validation slice explicitly approves `playwright.config.ts` as a root-level test shim for operator-UI E2E execution; it does not approve a new top-level application home or browser-owned workflow authority.
 
 Within `sigma/`, placeholder marker files may reserve approved homes such as `curated/` and `suppressed/` before any real detection or suppression content is admitted.
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+export default {
+  testDir: "./apps/operator-ui/e2e",
+  fullyParallel: true,
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm --prefix apps/operator-ui run dev -- --host 127.0.0.1",
+    reuseExistingServer: !process.env.CI,
+    url: "http://127.0.0.1:4173/operator",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        browserName: "chromium",
+        viewport: {
+          height: 720,
+          width: 1280,
+        },
+      },
+    },
+  ],
+};

--- a/scripts/test-verify-phase-9-control-plane-runtime-boundary-validation.sh
+++ b/scripts/test-verify-phase-9-control-plane-runtime-boundary-validation.sh
@@ -62,11 +62,12 @@ create_repo() {
   printf 'fixture license\n' > "${target}/LICENSE.txt"
   printf '{\"name\":\"fixture-root-workspace\",\"private\":true}\n' > "${target}/package.json"
   printf '{\"name\":\"fixture-root-workspace\",\"lockfileVersion\":3}\n' > "${target}/package-lock.json"
+  printf 'export default {};\n' > "${target}/playwright.config.ts"
   git -C "${target}" add .codex-supervisor/.gitkeep .github/workflows/.gitkeep \
     apps/operator-ui/.gitkeep \
     config/.gitkeep ingest/.gitkeep n8n/.gitkeep opensearch/.gitkeep \
     proxy/.gitkeep scripts/.gitkeep sigma/.gitkeep .env.sample .gitignore LICENSE.txt \
-    package.json package-lock.json
+    package.json package-lock.json playwright.config.ts
 }
 
 write_required_artifacts() {

--- a/scripts/test-verify-repository-skeleton.sh
+++ b/scripts/test-verify-repository-skeleton.sh
@@ -81,6 +81,7 @@ create_repo \
   "opensearch/" \
   "package-lock.json" \
   "package.json" \
+  "playwright.config.ts" \
   "postgres/" \
   "proxy/" \
   "scripts/" \
@@ -106,6 +107,7 @@ create_repo \
   "opensearch/" \
   "package-lock.json" \
   "package.json" \
+  "playwright.config.ts" \
   "postgres/" \
   "proxy/" \
   "scripts/" \
@@ -131,6 +133,7 @@ create_repo \
   "opensearch/" \
   "package-lock.json" \
   "package.json" \
+  "playwright.config.ts" \
   "postgres/" \
   "proxy/" \
   "scripts/" \

--- a/scripts/verify-repository-skeleton.sh
+++ b/scripts/verify-repository-skeleton.sh
@@ -21,6 +21,7 @@ expected_top_level_entries=(
   "opensearch"
   "package-lock.json"
   "package.json"
+  "playwright.config.ts"
   "postgres"
   "proxy"
   "scripts"

--- a/scripts/verify-repository-structure-doc.sh
+++ b/scripts/verify-repository-structure-doc.sh
@@ -20,6 +20,7 @@ required_entries=(
   "ingest/"
   "package.json"
   "package-lock.json"
+  "playwright.config.ts"
   "postgres/"
   "proxy/"
   "scripts/"


### PR DESCRIPTION
## Summary
- add Playwright browser-level operator workflow coverage for Phase 31 protected navigation, role gating, degraded queue rendering, and approver action-review detail
- add root and package Playwright configs so `npm --prefix apps/operator-ui exec playwright test` is scoped to operator E2E specs
- document the Phase 31 validation posture and lock the new E2E artifacts in repository validation tests

## Verification
- `npm --prefix apps/operator-ui exec playwright test`
- `npm --prefix apps/operator-ui test`
- `npm --prefix apps/operator-ui run build`
- `python3 -m unittest control-plane.tests.test_phase31_product_grade_hardening_boundary_docs control-plane.tests.test_phase31_operator_ui_validation`
- `node <codex-supervisor-checkout>/dist/index.js issue-lint 712 --config <codex-supervisor-checkout>/supervisor.config.aegisops.coderabbit.json`

Closes #712


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end testing suite for operator UI

* **Tests**
  * Configured automated browser tests validating authentication, access control, and operator workflows

* **Documentation**
  * Updated validation documentation to reflect new testing infrastructure

* **Chores**
  * Added testing configuration and dependencies; updated verification scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->