### PR TITLE
refactor: extract shared task-action form primitives from caseworkActionCards.tsx (#720)

### DIFF
--- a/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
@@ -7,6 +7,7 @@ import { createOperatorTaskActionClient } from "./taskActionClient";
 import {
   CreateReviewedActionRequestCard,
   PromoteAlertToCaseCard,
+  RecordActionApprovalDecisionCard,
   RecordActionReviewEscalationNoteCard,
   RecordActionReviewManualFallbackCard,
   RecordCaseLeadCard,
@@ -58,14 +59,22 @@ function PromoteAlertCardHarness({
 
 function CaseworkCardsHarness({
   actionRequestId,
+  approvalState,
   caseId,
+  decisionRationale,
+  expiresAt,
   linkedEvidenceIds,
   linkedLeadIds,
   linkedObservationIds,
   linkedRecommendationIds,
+  actionRequestState,
 }: {
   actionRequestId: string;
+  actionRequestState: string | null;
+  approvalState: string | null;
   caseId: string;
+  decisionRationale: string | null;
+  expiresAt: string | null;
   linkedEvidenceIds: string[];
   linkedLeadIds: string[];
   linkedObservationIds: string[];
@@ -97,6 +106,15 @@ function CaseworkCardsHarness({
         linkedRecommendationIds={linkedRecommendationIds}
         operatorIdentity="analyst@example.com"
       />
+      <RecordActionApprovalDecisionCard
+        actionRequestId={actionRequestId}
+        actionRequestState={actionRequestState}
+        approvalState={approvalState}
+        approverIdentity="approver@example.com"
+        decisionRationale={decisionRationale}
+        expiresAt={expiresAt}
+        key={`approval-decision-${actionRequestId}`}
+      />
       <RecordActionReviewManualFallbackCard
         actionRequestId={actionRequestId}
         caseId={caseId}
@@ -125,7 +143,11 @@ describe("caseworkActionCards", () => {
         <PromoteAlertCardHarness alertId="alert-123" currentCaseId="case-123" />
         <CaseworkCardsHarness
           actionRequestId="action-request-456"
+          actionRequestState="pending_approval"
+          approvalState="pending"
+          decisionRationale="Pending review"
           caseId="case-456"
+          expiresAt="2026-05-01T00:00:00Z"
           linkedEvidenceIds={["evidence-123"]}
           linkedLeadIds={["lead-123"]}
           linkedObservationIds={["observation-123"]}
@@ -140,6 +162,7 @@ describe("caseworkActionCards", () => {
       "Record case lead",
       "Record case recommendation",
       "Create reviewed action request",
+      "Record approval decision",
       "Record manual fallback",
       "Record escalation note",
     ]) {
@@ -152,6 +175,7 @@ describe("caseworkActionCards", () => {
       "reviewed operator lead endpoint",
       "reviewed operator recommendation endpoint",
       "reviewed operator action-request endpoint",
+      "reviewed operator approval-decision endpoint",
       "reviewed operator manual-fallback endpoint",
       "reviewed operator escalation-note endpoint",
       "Current review state",
@@ -196,7 +220,11 @@ describe("caseworkActionCards", () => {
     const { rerender } = renderWithTaskActionProviders(
       <CaseworkCardsHarness
         actionRequestId="action-request-456"
+        actionRequestState="pending_approval"
+        approvalState="pending"
         caseId="case-456"
+        decisionRationale="Pending review"
+        expiresAt="2026-05-01T00:00:00Z"
         linkedEvidenceIds={["evidence-123"]}
         linkedLeadIds={["lead-123"]}
         linkedObservationIds={["observation-123"]}
@@ -245,6 +273,11 @@ describe("caseworkActionCards", () => {
       screen.getByRole("textbox", { name: "Action request id override" }),
       "stale-request",
     );
+    await user.type(screen.getByRole("textbox", { name: "Decided at" }), "2026-04");
+    await user.type(
+      screen.getByRole("textbox", { name: "Decision rationale" }),
+      "stale-decision-rationale",
+    );
     await user.type(screen.getByRole("textbox", { name: "Fallback at" }), "2026-04");
     await user.type(screen.getByRole("textbox", { name: "Reason" }), "stale-reason");
     await user.type(
@@ -273,7 +306,11 @@ describe("caseworkActionCards", () => {
         >
           <CaseworkCardsHarness
             actionRequestId="action-request-789"
+            actionRequestState="granted"
+            approvalState="approved"
             caseId="case-789"
+            decisionRationale="Already granted"
+            expiresAt="2026-06-01T00:00:00Z"
             linkedEvidenceIds={["evidence-789"]}
             linkedLeadIds={["lead-789"]}
             linkedObservationIds={["observation-789"]}
@@ -300,6 +337,10 @@ describe("caseworkActionCards", () => {
     expect(screen.getByRole("textbox", { name: "Escalation reason" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Expires at" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Action request id override" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Decided at" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Decision rationale" })).toHaveValue(
+      "Already granted",
+    );
     expect(screen.getByRole("textbox", { name: "Fallback at" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Reason" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Action taken" })).toHaveValue("");
@@ -313,5 +354,5 @@ describe("caseworkActionCards", () => {
     expect(screen.getByText("Known observation ids: observation-789")).toBeInTheDocument();
     expect(screen.getByText("Known lead ids: lead-789")).toBeInTheDocument();
     expect(screen.getByText("Known recommendation ids: recommendation-789")).toBeInTheDocument();
-  }, 10000);
+  }, 15000);
 });

--- a/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
@@ -2,6 +2,7 @@ import { MenuItem, Stack, TextField } from "@mui/material";
 import { useState } from "react";
 import {
   TaskActionFormCard,
+  TaskActionSubmissionForm,
   useTaskActionSubmission,
 } from "./taskActionPrimitives";
 
@@ -33,35 +34,32 @@ export function PromoteAlertToCaseCard({
   const [caseLifecycleState, setCaseLifecycleState] = useState("open");
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submission.submit({
-          onSubmitted: () => onSubmitted?.(),
-          refreshTargets: (acknowledgement) => [
-            {
-              id: alertId,
-              label: "Alert detail",
-              resource: "alerts",
-            },
-            ...(typeof acknowledgement.case_id === "string" && acknowledgement.case_id.trim()
-              ? [
-                  {
-                    id: acknowledgement.case_id,
-                    label: "Case detail",
-                    resource: "cases" as const,
-                  },
-                ]
-              : []),
-          ],
-          run: (client) =>
-            client.promoteAlertToCase({
-              alert_id: alertId,
-              case_id: normalizeOptionalString(caseIdOverride),
-              case_lifecycle_state: caseLifecycleState,
-            }) as Promise<{ case_id?: string }>,
-        });
-      }}
+    <TaskActionSubmissionForm
+      onSubmitted={onSubmitted}
+      refreshTargets={(acknowledgement) => [
+        {
+          id: alertId,
+          label: "Alert detail",
+          resource: "alerts",
+        },
+        ...(typeof acknowledgement.case_id === "string" && acknowledgement.case_id.trim()
+          ? [
+              {
+                id: acknowledgement.case_id,
+                label: "Case detail",
+                resource: "cases" as const,
+              },
+            ]
+          : []),
+      ]}
+      run={(client) =>
+        client.promoteAlertToCase({
+          alert_id: alertId,
+          case_id: normalizeOptionalString(caseIdOverride),
+          case_lifecycle_state: caseLifecycleState,
+        }) as Promise<{ case_id?: string }>
+      }
+      submission={submission}
     >
       <TaskActionFormCard
         actor={[
@@ -105,7 +103,7 @@ export function PromoteAlertToCaseCard({
           </TextField>
         </Stack>
       </TaskActionFormCard>
-    </form>
+    </TaskActionSubmissionForm>
   );
 }
 
@@ -128,28 +126,25 @@ export function RecordCaseObservationCard({
   );
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submission.submit({
-          onSubmitted: () => onSubmitted?.(),
-          refreshTargets: [
-            {
-              id: caseId,
-              label: "Case detail",
-              resource: "cases",
-            },
-          ],
-          run: (client) =>
-            client.recordCaseObservation({
-              author_identity: operatorIdentity,
-              case_id: caseId,
-              observed_at: observedAt.trim(),
-              scope_statement: scopeStatement.trim(),
-              supporting_evidence_ids: splitIdentifierList(supportingEvidenceIds),
-            }) as Promise<{ case_id: string }>,
-        });
-      }}
+    <TaskActionSubmissionForm
+      onSubmitted={onSubmitted}
+      refreshTargets={[
+        {
+          id: caseId,
+          label: "Case detail",
+          resource: "cases",
+        },
+      ]}
+      run={(client) =>
+        client.recordCaseObservation({
+          author_identity: operatorIdentity,
+          case_id: caseId,
+          observed_at: observedAt.trim(),
+          scope_statement: scopeStatement.trim(),
+          supporting_evidence_ids: splitIdentifierList(supportingEvidenceIds),
+        }) as Promise<{ case_id: string }>
+      }
+      submission={submission}
     >
       <TaskActionFormCard
         actor={[
@@ -200,7 +195,7 @@ export function RecordCaseObservationCard({
           />
         </Stack>
       </TaskActionFormCard>
-    </form>
+    </TaskActionSubmissionForm>
   );
 }
 
@@ -220,27 +215,24 @@ export function RecordCaseLeadCard({
   const [triageRationale, setTriageRationale] = useState("");
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submission.submit({
-          onSubmitted: () => onSubmitted?.(),
-          refreshTargets: [
-            {
-              id: caseId,
-              label: "Case detail",
-              resource: "cases",
-            },
-          ],
-          run: (client) =>
-            client.recordCaseLead({
-              case_id: caseId,
-              observation_id: normalizeOptionalString(observationId),
-              triage_owner: operatorIdentity,
-              triage_rationale: triageRationale.trim(),
-            }) as Promise<{ case_id: string }>,
-        });
-      }}
+    <TaskActionSubmissionForm
+      onSubmitted={onSubmitted}
+      refreshTargets={[
+        {
+          id: caseId,
+          label: "Case detail",
+          resource: "cases",
+        },
+      ]}
+      run={(client) =>
+        client.recordCaseLead({
+          case_id: caseId,
+          observation_id: normalizeOptionalString(observationId),
+          triage_owner: operatorIdentity,
+          triage_rationale: triageRationale.trim(),
+        }) as Promise<{ case_id: string }>
+      }
+      submission={submission}
     >
       <TaskActionFormCard
         actor={[
@@ -287,7 +279,7 @@ export function RecordCaseLeadCard({
           />
         </Stack>
       </TaskActionFormCard>
-    </form>
+    </TaskActionSubmissionForm>
   );
 }
 
@@ -307,27 +299,24 @@ export function RecordCaseRecommendationCard({
   const [intendedOutcome, setIntendedOutcome] = useState("");
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submission.submit({
-          onSubmitted: () => onSubmitted?.(),
-          refreshTargets: [
-            {
-              id: caseId,
-              label: "Case detail",
-              resource: "cases",
-            },
-          ],
-          run: (client) =>
-            client.recordCaseRecommendation({
-              case_id: caseId,
-              intended_outcome: intendedOutcome.trim(),
-              lead_id: normalizeOptionalString(leadId),
-              review_owner: operatorIdentity,
-            }) as Promise<{ case_id: string }>,
-        });
-      }}
+    <TaskActionSubmissionForm
+      onSubmitted={onSubmitted}
+      refreshTargets={[
+        {
+          id: caseId,
+          label: "Case detail",
+          resource: "cases",
+        },
+      ]}
+      run={(client) =>
+        client.recordCaseRecommendation({
+          case_id: caseId,
+          intended_outcome: intendedOutcome.trim(),
+          lead_id: normalizeOptionalString(leadId),
+          review_owner: operatorIdentity,
+        }) as Promise<{ case_id: string }>
+      }
+      submission={submission}
     >
       <TaskActionFormCard
         actor={[
@@ -374,7 +363,7 @@ export function RecordCaseRecommendationCard({
           />
         </Stack>
       </TaskActionFormCard>
-    </form>
+    </TaskActionSubmissionForm>
   );
 }
 
@@ -400,31 +389,28 @@ export function CreateReviewedActionRequestCard({
   const [actionRequestIdOverride, setActionRequestIdOverride] = useState("");
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submission.submit({
-          onSubmitted: () => onSubmitted?.(),
-          refreshTargets: [
-            {
-              id: caseId,
-              label: "Case detail",
-              resource: "cases",
-            },
-          ],
-          run: (client) =>
-            client.createReviewedActionRequest({
-              action_request_id: normalizeOptionalString(actionRequestIdOverride),
-              escalation_reason: escalationReason.trim(),
-              expires_at: expiresAt.trim(),
-              family: "recommendation",
-              message_intent: messageIntent.trim(),
-              recipient_identity: recipientIdentity.trim(),
-              record_id: recommendationId.trim(),
-              requester_identity: operatorIdentity,
-            }) as Promise<{ action_request_id?: string; case_id?: string }>,
-        });
-      }}
+    <TaskActionSubmissionForm
+      onSubmitted={onSubmitted}
+      refreshTargets={[
+        {
+          id: caseId,
+          label: "Case detail",
+          resource: "cases",
+        },
+      ]}
+      run={(client) =>
+        client.createReviewedActionRequest({
+          action_request_id: normalizeOptionalString(actionRequestIdOverride),
+          escalation_reason: escalationReason.trim(),
+          expires_at: expiresAt.trim(),
+          family: "recommendation",
+          message_intent: messageIntent.trim(),
+          recipient_identity: recipientIdentity.trim(),
+          record_id: recommendationId.trim(),
+          requester_identity: operatorIdentity,
+        }) as Promise<{ action_request_id?: string; case_id?: string }>
+      }
+      submission={submission}
     >
       <TaskActionFormCard
         actor={[
@@ -510,7 +496,7 @@ export function CreateReviewedActionRequestCard({
           />
         </Stack>
       </TaskActionFormCard>
-    </form>
+    </TaskActionSubmissionForm>
   );
 }
 
@@ -540,29 +526,26 @@ export function RecordActionApprovalDecisionCard({
   );
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submission.submit({
-          onSubmitted: () => onSubmitted?.(),
-          refreshTargets: [
-            {
-              id: actionRequestId,
-              label: "Action review detail",
-              resource: "actionReview",
-            },
-          ],
-          run: (client) =>
-            client.recordActionApprovalDecision({
-              action_request_id: actionRequestId,
-              approval_decision_id: normalizeOptionalString(approvalDecisionIdOverride),
-              approver_identity: approverIdentity,
-              decided_at: decidedAt.trim(),
-              decision,
-              decision_rationale: nextDecisionRationale.trim(),
-            }) as Promise<{ action_request_id: string }>,
-        });
-      }}
+    <TaskActionSubmissionForm
+      onSubmitted={onSubmitted}
+      refreshTargets={[
+        {
+          id: actionRequestId,
+          label: "Action review detail",
+          resource: "actionReview",
+        },
+      ]}
+      run={(client) =>
+        client.recordActionApprovalDecision({
+          action_request_id: actionRequestId,
+          approval_decision_id: normalizeOptionalString(approvalDecisionIdOverride),
+          approver_identity: approverIdentity,
+          decided_at: decidedAt.trim(),
+          decision,
+          decision_rationale: nextDecisionRationale.trim(),
+        }) as Promise<{ action_request_id: string }>
+      }
+      submission={submission}
     >
       <TaskActionFormCard
         actor={[
@@ -627,7 +610,7 @@ export function RecordActionApprovalDecisionCard({
           />
         </Stack>
       </TaskActionFormCard>
-    </form>
+    </TaskActionSubmissionForm>
   );
 }
 
@@ -659,31 +642,28 @@ export function RecordActionReviewManualFallbackCard({
   const [residualUncertainty, setResidualUncertainty] = useState("");
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submission.submit({
-          onSubmitted: () => onSubmitted?.(),
-          refreshTargets: [
-            {
-              id: caseId,
-              label: "Case detail",
-              resource: "cases",
-            },
-          ],
-          run: (client) =>
-            client.recordActionReviewManualFallback({
-              action_request_id: actionRequestId,
-              action_taken: actionTaken.trim(),
-              authority_boundary: authorityBoundary,
-              fallback_actor_identity: operatorIdentity,
-              fallback_at: fallbackAt.trim(),
-              reason: reason.trim(),
-              residual_uncertainty: normalizeOptionalString(residualUncertainty),
-              verification_evidence_ids: splitIdentifierList(verificationEvidenceIds),
-            }) as Promise<{ action_request_id: string }>,
-        });
-      }}
+    <TaskActionSubmissionForm
+      onSubmitted={onSubmitted}
+      refreshTargets={[
+        {
+          id: caseId,
+          label: "Case detail",
+          resource: "cases",
+        },
+      ]}
+      run={(client) =>
+        client.recordActionReviewManualFallback({
+          action_request_id: actionRequestId,
+          action_taken: actionTaken.trim(),
+          authority_boundary: authorityBoundary,
+          fallback_actor_identity: operatorIdentity,
+          fallback_at: fallbackAt.trim(),
+          reason: reason.trim(),
+          residual_uncertainty: normalizeOptionalString(residualUncertainty),
+          verification_evidence_ids: splitIdentifierList(verificationEvidenceIds),
+        }) as Promise<{ action_request_id: string }>
+      }
+      submission={submission}
     >
       <TaskActionFormCard
         actor={[
@@ -773,7 +753,7 @@ export function RecordActionReviewManualFallbackCard({
           />
         </Stack>
       </TaskActionFormCard>
-    </form>
+    </TaskActionSubmissionForm>
   );
 }
 
@@ -798,28 +778,25 @@ export function RecordActionReviewEscalationNoteCard({
   const [note, setNote] = useState("");
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submission.submit({
-          onSubmitted: () => onSubmitted?.(),
-          refreshTargets: [
-            {
-              id: caseId,
-              label: "Case detail",
-              resource: "cases",
-            },
-          ],
-          run: (client) =>
-            client.recordActionReviewEscalationNote({
-              action_request_id: actionRequestId,
-              escalated_at: escalatedAt.trim(),
-              escalated_by_identity: operatorIdentity,
-              escalated_to: escalatedTo.trim(),
-              note: note.trim(),
-            }) as Promise<{ action_request_id: string }>,
-        });
-      }}
+    <TaskActionSubmissionForm
+      onSubmitted={onSubmitted}
+      refreshTargets={[
+        {
+          id: caseId,
+          label: "Case detail",
+          resource: "cases",
+        },
+      ]}
+      run={(client) =>
+        client.recordActionReviewEscalationNote({
+          action_request_id: actionRequestId,
+          escalated_at: escalatedAt.trim(),
+          escalated_by_identity: operatorIdentity,
+          escalated_to: escalatedTo.trim(),
+          note: note.trim(),
+        }) as Promise<{ action_request_id: string }>
+      }
+      submission={submission}
     >
       <TaskActionFormCard
         actor={[
@@ -873,6 +850,6 @@ export function RecordActionReviewEscalationNoteCard({
           />
         </Stack>
       </TaskActionFormCard>
-    </form>
+    </TaskActionSubmissionForm>
   );
 }

--- a/apps/operator-ui/src/taskActions/taskActionPrimitives.test.tsx
+++ b/apps/operator-ui/src/taskActions/taskActionPrimitives.test.tsx
@@ -9,6 +9,7 @@ import {
 import {
   TaskActionClientProvider,
   TaskActionFormCard,
+  TaskActionSubmissionForm,
   useTaskActionSubmission,
 } from "./taskActionPrimitives";
 
@@ -25,27 +26,24 @@ function TestTaskActionForm() {
   const submission = useTaskActionSubmission<{ case_id: string }>();
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submission.submit({
-          refreshTargets: (acknowledgement) => [
-            {
-              id: acknowledgement.case_id,
-              label: "Case detail",
-              resource: "cases",
-            },
-          ],
-          run: (client) =>
-            client.recordCaseObservation({
-              author_identity: "analyst@example.com",
-              case_id: "case-123",
-              observed_at: "2026-04-22T00:00:00+00:00",
-              scope_statement: "Reviewed scoped observation",
-              supporting_evidence_ids: ["evidence-123"],
-            }) as Promise<{ case_id: string }>,
-        });
-      }}
+    <TaskActionSubmissionForm
+      refreshTargets={(acknowledgement) => [
+        {
+          id: acknowledgement.case_id,
+          label: "Case detail",
+          resource: "cases",
+        },
+      ]}
+      run={(client) =>
+        client.recordCaseObservation({
+          author_identity: "analyst@example.com",
+          case_id: "case-123",
+          observed_at: "2026-04-22T00:00:00+00:00",
+          scope_statement: "Reviewed scoped observation",
+          supporting_evidence_ids: ["evidence-123"],
+        }) as Promise<{ case_id: string }>
+      }
+      submission={submission}
     >
       <TaskActionFormCard
         actor={[
@@ -67,7 +65,7 @@ function TestTaskActionForm() {
       >
         <div>Observation body</div>
       </TaskActionFormCard>
-    </form>
+    </TaskActionSubmissionForm>
   );
 }
 

--- a/apps/operator-ui/src/taskActions/taskActionPrimitives.tsx
+++ b/apps/operator-ui/src/taskActions/taskActionPrimitives.tsx
@@ -76,6 +76,12 @@ interface TaskActionSubmissionController<TAcknowledgement> {
   submit(request: TaskActionSubmissionRequest<TAcknowledgement>): Promise<void>;
 }
 
+interface TaskActionSubmissionFormProps<TAcknowledgement>
+  extends TaskActionSubmissionRequest<TAcknowledgement> {
+  children: ReactNode;
+  submission: TaskActionSubmissionController<TAcknowledgement>;
+}
+
 const TaskActionClientContext = createContext<TaskActionContextValue | null>(null);
 
 function taskActionStatusMessage(error: Error | null) {
@@ -223,6 +229,29 @@ export function useTaskActionSubmission<TAcknowledgement>(): TaskActionSubmissio
       }
     },
   };
+}
+
+export function TaskActionSubmissionForm<TAcknowledgement>({
+  children,
+  onSubmitted,
+  refreshTargets,
+  run,
+  submission,
+}: TaskActionSubmissionFormProps<TAcknowledgement>) {
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submission.submit({
+          onSubmitted,
+          refreshTargets,
+          run,
+        });
+      }}
+    >
+      {children}
+    </form>
+  );
 }
 
 function TaskActionStatusBanner<TAcknowledgement>({


### PR DESCRIPTION
Closes #720
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted a shared `TaskActionSubmissionForm` primitive into [taskActionPrimitives.tsx](/Users/jp.infra/Dev/AegisOps-worktrees/issue-720/apps/operator-ui/src/taskActions/taskActionPrimitives.tsx) and moved every bounded write-action card in [caseworkActionCards.tsx](/Users/jp.infra/Dev/AegisOps-worktrees/issue-720/apps/operator-ui/src/taskActions/caseworkActionCards.tsx) onto it. That removes the repeated `<form onSubmit>` / `submission.submit(...)` skeleton while keeping each card’s fields, refresh targets, and copy explicit. I also tightened [caseworkActionCards.test.tsx](/Users/jp.infra/Dev/AegisOps-worktrees/issue-720/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx) to cover the approval-decision card and updated [taskActionPrimitives.test.tsx](/Users/jp.infra/Dev/AegisOps-worktrees/issue-720/apps/operator-ui/src/taskActions/taskActionPrimitives.test.tsx) to exercise the new wrapper directly.

Checkpoint commit: `a91e3ce` (`refactor operator-ui task action submit wrappers`). I updated the local supervisor journal as requested; it remains outside git because `.codex-supervisor/issues` is ignored. I did not run `issue-lint` here because this worktree does not include a local `<codex-supervisor-checkout>` path to target.

Summary: Extracted a shared task-action submit-form primitive, migrated all casework/action-review cards to it, added approval-card coverage, and committed the refactor as `a91e3ce`.
State hint: implementing
Blocked reason: none
Tests: `npm...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval decision card now integrated into casework workflow, enabling operators to record approval decisions with decision date and rationale fields.

* **Tests**
  * Expanded test coverage for approval decision functionality and form field validation during state changes.

* **Refactor**
  * Standardized form submission handling across task action components for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->