### PR TITLE
refactor: continue domain extraction out of AegisOpsControlPlaneService (#721)

### DIFF
--- a/control-plane/aegisops_control_plane/action_review_write_surface.py
+++ b/control-plane/aegisops_control_plane/action_review_write_surface.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+import logging
+from typing import TYPE_CHECKING, Protocol
+
+from .models import (
+    ActionRequestRecord,
+    AlertRecord,
+    ApprovalDecisionRecord,
+    CaseRecord,
+)
+
+if TYPE_CHECKING:
+    from .service import AegisOpsControlPlaneService
+
+
+class ActionReviewWriteSurfaceDependencies(Protocol):
+    _store: object
+
+    def _require_non_empty_string(self, value: object, field_name: str) -> str:
+        ...
+
+    def _require_aware_datetime(self, value: datetime, field_name: str) -> datetime:
+        ...
+
+    def _normalize_linked_record_ids(
+        self,
+        value: object,
+        field_name: str,
+    ) -> tuple[str, ...]:
+        ...
+
+    def _normalize_optional_string(
+        self,
+        value: object,
+        field_name: str,
+    ) -> str | None:
+        ...
+
+    def _require_review_bound_action_request(
+        self,
+        action_request_id: str,
+    ) -> ActionRequestRecord:
+        ...
+
+    def _action_review_approval_decision(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> ApprovalDecisionRecord | None:
+        ...
+
+    def _action_review_approval_state(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approval_decision: ApprovalDecisionRecord | None,
+    ) -> str:
+        ...
+
+    def _action_review_execution(self, action_request: ActionRequestRecord) -> object:
+        ...
+
+    def _action_review_state(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approval_state: str,
+        action_execution: object,
+    ) -> str:
+        ...
+
+    def _require_action_review_visibility_context_record(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> CaseRecord | AlertRecord:
+        ...
+
+    def _validate_case_evidence_linkage(
+        self,
+        *,
+        case: CaseRecord,
+        evidence_ids: tuple[str, ...],
+        field_name: str,
+    ) -> None:
+        ...
+
+    def _validate_alert_evidence_linkage(
+        self,
+        *,
+        alert: AlertRecord,
+        evidence_ids: tuple[str, ...],
+        field_name: str,
+    ) -> None:
+        ...
+
+    def _persist_action_review_visibility_context_record(
+        self,
+        *,
+        context_record: CaseRecord | AlertRecord,
+        reviewed_context_update: dict[str, object],
+    ) -> CaseRecord | AlertRecord:
+        ...
+
+    def _action_review_visibility_update(
+        self,
+        *,
+        action_request_id: str,
+        context_key: str,
+        context_value: dict[str, object],
+    ) -> dict[str, object]:
+        ...
+
+    def _apply_action_policy_evaluation_overrides(
+        self,
+        *,
+        computed_policy_evaluation: dict[str, object],
+        persisted_policy_evaluation: dict[str, object],
+    ) -> dict[str, object]:
+        ...
+
+    def _determine_action_policy(
+        self,
+        action_policy_basis: dict[str, object],
+    ) -> dict[str, object]:
+        ...
+
+    def _normalize_action_policy_basis(
+        self,
+        policy_basis: object,
+    ) -> dict[str, object]:
+        ...
+
+    def _require_reviewed_action_approver_policy(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approver_identity: str,
+    ) -> None:
+        ...
+
+    def _resolve_new_record_identifier(
+        self,
+        record_type: type,
+        requested_identifier: str | None,
+        field_name: str,
+        prefix: str,
+    ) -> str:
+        ...
+
+    def persist_record(
+        self,
+        record: object,
+        *,
+        transitioned_at: datetime | None = None,
+    ) -> object:
+        ...
+
+    def _emit_structured_event(
+        self,
+        level: int,
+        event: str,
+        **fields: object,
+    ) -> None:
+        ...
+
+
+class ActionReviewWriteSurface:
+    def __init__(self, service: ActionReviewWriteSurfaceDependencies) -> None:
+        self._service = service
+
+    def record_action_review_manual_fallback(
+        self,
+        *,
+        action_request_id: str,
+        fallback_at: datetime,
+        fallback_actor_identity: str,
+        authority_boundary: str,
+        reason: str,
+        action_taken: str,
+        verification_evidence_ids: tuple[str, ...] = (),
+        residual_uncertainty: str | None = None,
+    ) -> CaseRecord | AlertRecord:
+        service = self._service
+        fallback_at = service._require_aware_datetime(fallback_at, "fallback_at")
+        fallback_actor_identity = service._require_non_empty_string(
+            fallback_actor_identity,
+            "fallback_actor_identity",
+        )
+        authority_boundary = service._require_non_empty_string(
+            authority_boundary,
+            "authority_boundary",
+        )
+        reason = service._require_non_empty_string(reason, "reason")
+        action_taken = service._require_non_empty_string(action_taken, "action_taken")
+        normalized_evidence_ids = service._normalize_linked_record_ids(
+            verification_evidence_ids,
+            "verification_evidence_ids",
+        )
+        normalized_residual_uncertainty = service._normalize_optional_string(
+            residual_uncertainty,
+            "residual_uncertainty",
+        )
+        with service._store.transaction():
+            action_request = service._require_review_bound_action_request(action_request_id)
+            approval_decision = service._action_review_approval_decision(action_request)
+            approval_state = service._action_review_approval_state(
+                action_request=action_request,
+                approval_decision=approval_decision,
+            )
+            review_state = service._action_review_state(
+                action_request=action_request,
+                approval_state=approval_state,
+                action_execution=service._action_review_execution(action_request),
+            )
+            if (
+                approval_decision is None
+                or approval_decision.lifecycle_state != "approved"
+                or review_state in {"pending", "rejected", "expired", "superseded"}
+            ):
+                raise ValueError(
+                    "manual fallback requires an approved action review in a live post-approval state"
+                )
+            context_record = service._require_action_review_visibility_context_record(
+                action_request
+            )
+            if isinstance(context_record, CaseRecord):
+                service._validate_case_evidence_linkage(
+                    case=context_record,
+                    evidence_ids=normalized_evidence_ids,
+                    field_name="verification_evidence_ids",
+                )
+            else:
+                service._validate_alert_evidence_linkage(
+                    alert=context_record,
+                    evidence_ids=normalized_evidence_ids,
+                    field_name="verification_evidence_ids",
+                )
+            manual_fallback_context: dict[str, object] = {
+                "action_request_id": action_request.action_request_id,
+                "approval_decision_id": approval_decision.approval_decision_id,
+                "fallback_at": fallback_at.isoformat(),
+                "fallback_actor_identity": fallback_actor_identity,
+                "authority_boundary": authority_boundary,
+                "reason": reason,
+                "action_taken": action_taken,
+                "verification_evidence_ids": normalized_evidence_ids,
+            }
+            if normalized_residual_uncertainty is not None:
+                manual_fallback_context["residual_uncertainty"] = (
+                    normalized_residual_uncertainty
+                )
+            return service._persist_action_review_visibility_context_record(
+                context_record=context_record,
+                reviewed_context_update=service._action_review_visibility_update(
+                    action_request_id=action_request.action_request_id,
+                    context_key="manual_fallback",
+                    context_value=manual_fallback_context,
+                ),
+            )
+
+    def record_action_review_escalation_note(
+        self,
+        *,
+        action_request_id: str,
+        escalated_at: datetime,
+        escalated_by_identity: str,
+        escalated_to: str,
+        note: str,
+    ) -> CaseRecord | AlertRecord:
+        service = self._service
+        escalated_at = service._require_aware_datetime(escalated_at, "escalated_at")
+        escalated_by_identity = service._require_non_empty_string(
+            escalated_by_identity,
+            "escalated_by_identity",
+        )
+        escalated_to = service._require_non_empty_string(
+            escalated_to,
+            "escalated_to",
+        )
+        note = service._require_non_empty_string(note, "note")
+        with service._store.transaction():
+            action_request = service._require_review_bound_action_request(action_request_id)
+            approval_decision = service._action_review_approval_decision(action_request)
+            approval_state = service._action_review_approval_state(
+                action_request=action_request,
+                approval_decision=approval_decision,
+            )
+            review_state = service._action_review_state(
+                action_request=action_request,
+                approval_state=approval_state,
+                action_execution=service._action_review_execution(action_request),
+            )
+            context_record = service._require_action_review_visibility_context_record(
+                action_request
+            )
+            escalation_context: dict[str, object] = {
+                "action_request_id": action_request.action_request_id,
+                "escalated_at": escalated_at.isoformat(),
+                "escalated_by_identity": escalated_by_identity,
+                "escalated_to": escalated_to,
+                "note": note,
+                "review_state": review_state,
+            }
+            if approval_decision is not None:
+                escalation_context["approval_decision_id"] = (
+                    approval_decision.approval_decision_id
+                )
+            return service._persist_action_review_visibility_context_record(
+                context_record=context_record,
+                reviewed_context_update=service._action_review_visibility_update(
+                    action_request_id=action_request.action_request_id,
+                    context_key="escalation",
+                    context_value=escalation_context,
+                ),
+            )
+
+    def record_action_approval_decision(
+        self,
+        *,
+        action_request_id: str,
+        approver_identity: str,
+        authenticated_approver_identity: str | None = None,
+        decision: str,
+        decision_rationale: str,
+        decided_at: datetime,
+        approval_decision_id: str | None = None,
+    ) -> ApprovalDecisionRecord:
+        service = self._service
+        approver_identity = service._require_non_empty_string(
+            approver_identity,
+            "approver_identity",
+        )
+        normalized_decision = service._require_non_empty_string(
+            decision,
+            "decision",
+        ).lower()
+        if normalized_decision not in {"grant", "reject"}:
+            raise ValueError("decision must be 'grant' or 'reject'")
+        decision_rationale = service._require_non_empty_string(
+            decision_rationale,
+            "decision_rationale",
+        )
+        decided_at = service._require_aware_datetime(decided_at, "decided_at")
+        if authenticated_approver_identity is not None:
+            authenticated_approver_identity = service._require_non_empty_string(
+                authenticated_approver_identity,
+                "authenticated_approver_identity",
+            )
+            if authenticated_approver_identity != approver_identity:
+                raise PermissionError(
+                    "authenticated approver identity must match the asserted control-plane approver identity"
+                )
+
+        approval_decision: ApprovalDecisionRecord | None = None
+        request_expired = False
+        with service._store.transaction(isolation_level="SERIALIZABLE"):
+            action_request = service._require_review_bound_action_request(action_request_id)
+            if action_request.lifecycle_state != "pending_approval":
+                raise ValueError(
+                    "approval decisions can only be recorded for pending reviewed action requests"
+                )
+            if action_request.approval_decision_id is not None:
+                raise ValueError(
+                    f"action request {action_request.action_request_id!r} already has an approval decision"
+                )
+            if (
+                action_request.requester_identity is not None
+                and action_request.requester_identity == approver_identity
+            ):
+                raise PermissionError(
+                    "approver identity must be distinct from requester identity"
+                )
+            if decided_at < action_request.requested_at:
+                raise ValueError("decided_at must be on or after requested_at")
+
+            policy_evaluation = service._apply_action_policy_evaluation_overrides(
+                computed_policy_evaluation=service._determine_action_policy(
+                    service._normalize_action_policy_basis(action_request.policy_basis)
+                ),
+                persisted_policy_evaluation=action_request.policy_evaluation,
+            )
+            if policy_evaluation.get("approval_requirement") == "policy_authorized":
+                raise PermissionError(
+                    "reviewed approval decisions are not authorized when the re-evaluated action policy is policy_authorized"
+                )
+            if policy_evaluation.get("approval_requirement") != "human_required":
+                raise PermissionError(
+                    "reviewed approval decisions require a human-required action policy"
+                )
+            service._require_reviewed_action_approver_policy(
+                action_request=action_request,
+                approver_identity=approver_identity,
+            )
+
+            now = datetime.now(timezone.utc)
+            if action_request.expires_at is not None and (
+                now > action_request.expires_at or decided_at > action_request.expires_at
+            ):
+                service.persist_record(
+                    replace(action_request, lifecycle_state="expired"),
+                    transitioned_at=action_request.expires_at,
+                )
+                request_expired = True
+            else:
+                resolved_approval_decision_id = service._resolve_new_record_identifier(
+                    ApprovalDecisionRecord,
+                    approval_decision_id,
+                    "approval_decision_id",
+                    "approval-decision",
+                )
+                decision_state = (
+                    "approved" if normalized_decision == "grant" else "rejected"
+                )
+                approval_decision = service.persist_record(
+                    ApprovalDecisionRecord(
+                        approval_decision_id=resolved_approval_decision_id,
+                        action_request_id=action_request.action_request_id,
+                        approver_identities=(approver_identity,),
+                        target_snapshot=dict(action_request.target_scope),
+                        payload_hash=action_request.payload_hash,
+                        decided_at=decided_at,
+                        lifecycle_state=decision_state,
+                        decision_rationale=decision_rationale,
+                        approved_expires_at=(
+                            action_request.expires_at
+                            if decision_state == "approved"
+                            else None
+                        ),
+                    ),
+                    transitioned_at=decided_at,
+                )
+                service.persist_record(
+                    replace(
+                        action_request,
+                        approval_decision_id=approval_decision.approval_decision_id,
+                        lifecycle_state=decision_state,
+                        policy_evaluation=policy_evaluation,
+                    ),
+                    transitioned_at=decided_at,
+                )
+        if request_expired:
+            raise PermissionError(
+                "reviewed action request expired before the approval decision was recorded"
+            )
+        if approval_decision is None:
+            raise RuntimeError(
+                "approval decision transaction completed without recording a decision"
+            )
+        service._emit_structured_event(
+            logging.INFO,
+            "action_approval_decision_recorded",
+            approval_decision_id=approval_decision.approval_decision_id,
+            action_request_id=approval_decision.action_request_id,
+            decision=normalized_decision,
+            approver_identity=approver_identity,
+            lifecycle_state=approval_decision.lifecycle_state,
+        )
+        return approval_decision

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -34,6 +34,7 @@ from .assistant_provider import (
     AssistantProviderResult,
     AssistantProviderTransport,
 )
+from .action_review_write_surface import ActionReviewWriteSurface
 from .case_workflow import CaseWorkflowService
 from .config import OpenBaoKVv2SecretTransport, RuntimeConfig
 from .execution_coordinator import (
@@ -1394,6 +1395,7 @@ class AegisOpsControlPlaneService:
             coordination_reference_signature=_coordination_reference_signature,
             dedupe_strings=_dedupe_strings,
         )
+        self._action_review_write_surface = ActionReviewWriteSurface(self)
         self._case_workflow_service = CaseWorkflowService(
             self,
             merge_reviewed_context=_merge_reviewed_context,
@@ -4441,82 +4443,16 @@ class AegisOpsControlPlaneService:
         verification_evidence_ids: tuple[str, ...] = (),
         residual_uncertainty: str | None = None,
     ) -> CaseRecord | AlertRecord:
-        fallback_at = self._require_aware_datetime(fallback_at, "fallback_at")
-        fallback_actor_identity = self._require_non_empty_string(
-            fallback_actor_identity,
-            "fallback_actor_identity",
+        return self._action_review_write_surface.record_action_review_manual_fallback(
+            action_request_id=action_request_id,
+            fallback_at=fallback_at,
+            fallback_actor_identity=fallback_actor_identity,
+            authority_boundary=authority_boundary,
+            reason=reason,
+            action_taken=action_taken,
+            verification_evidence_ids=verification_evidence_ids,
+            residual_uncertainty=residual_uncertainty,
         )
-        authority_boundary = self._require_non_empty_string(
-            authority_boundary,
-            "authority_boundary",
-        )
-        reason = self._require_non_empty_string(reason, "reason")
-        action_taken = self._require_non_empty_string(action_taken, "action_taken")
-        normalized_evidence_ids = self._normalize_linked_record_ids(
-            verification_evidence_ids,
-            "verification_evidence_ids",
-        )
-        normalized_residual_uncertainty = self._normalize_optional_string(
-            residual_uncertainty,
-            "residual_uncertainty",
-        )
-        with self._store.transaction():
-            action_request = self._require_review_bound_action_request(action_request_id)
-            approval_decision = self._action_review_approval_decision(action_request)
-            approval_state = self._action_review_approval_state(
-                action_request=action_request,
-                approval_decision=approval_decision,
-            )
-            review_state = self._action_review_state(
-                action_request=action_request,
-                approval_state=approval_state,
-                action_execution=self._action_review_execution(action_request),
-            )
-            if (
-                approval_decision is None
-                or approval_decision.lifecycle_state != "approved"
-                or review_state in {"pending", "rejected", "expired", "superseded"}
-            ):
-                raise ValueError(
-                    "manual fallback requires an approved action review in a live post-approval state"
-                )
-            context_record = self._require_action_review_visibility_context_record(
-                action_request
-            )
-            if isinstance(context_record, CaseRecord):
-                self._validate_case_evidence_linkage(
-                    case=context_record,
-                    evidence_ids=normalized_evidence_ids,
-                    field_name="verification_evidence_ids",
-                )
-            else:
-                self._validate_alert_evidence_linkage(
-                    alert=context_record,
-                    evidence_ids=normalized_evidence_ids,
-                    field_name="verification_evidence_ids",
-                )
-            manual_fallback_context: dict[str, object] = {
-                "action_request_id": action_request.action_request_id,
-                "approval_decision_id": approval_decision.approval_decision_id,
-                "fallback_at": fallback_at.isoformat(),
-                "fallback_actor_identity": fallback_actor_identity,
-                "authority_boundary": authority_boundary,
-                "reason": reason,
-                "action_taken": action_taken,
-                "verification_evidence_ids": normalized_evidence_ids,
-            }
-            if normalized_residual_uncertainty is not None:
-                manual_fallback_context["residual_uncertainty"] = (
-                    normalized_residual_uncertainty
-                )
-            return self._persist_action_review_visibility_context_record(
-                context_record=context_record,
-                reviewed_context_update=self._action_review_visibility_update(
-                    action_request_id=action_request.action_request_id,
-                    context_key="manual_fallback",
-                    context_value=manual_fallback_context,
-                ),
-            )
 
     def record_action_review_escalation_note(
         self,
@@ -4527,48 +4463,13 @@ class AegisOpsControlPlaneService:
         escalated_to: str,
         note: str,
     ) -> CaseRecord | AlertRecord:
-        escalated_at = self._require_aware_datetime(escalated_at, "escalated_at")
-        escalated_by_identity = self._require_non_empty_string(
-            escalated_by_identity,
-            "escalated_by_identity",
+        return self._action_review_write_surface.record_action_review_escalation_note(
+            action_request_id=action_request_id,
+            escalated_at=escalated_at,
+            escalated_by_identity=escalated_by_identity,
+            escalated_to=escalated_to,
+            note=note,
         )
-        escalated_to = self._require_non_empty_string(escalated_to, "escalated_to")
-        note = self._require_non_empty_string(note, "note")
-        with self._store.transaction():
-            action_request = self._require_review_bound_action_request(action_request_id)
-            approval_decision = self._action_review_approval_decision(action_request)
-            approval_state = self._action_review_approval_state(
-                action_request=action_request,
-                approval_decision=approval_decision,
-            )
-            review_state = self._action_review_state(
-                action_request=action_request,
-                approval_state=approval_state,
-                action_execution=self._action_review_execution(action_request),
-            )
-            context_record = self._require_action_review_visibility_context_record(
-                action_request
-            )
-            escalation_context: dict[str, object] = {
-                "action_request_id": action_request.action_request_id,
-                "escalated_at": escalated_at.isoformat(),
-                "escalated_by_identity": escalated_by_identity,
-                "escalated_to": escalated_to,
-                "note": note,
-                "review_state": review_state,
-            }
-            if approval_decision is not None:
-                escalation_context["approval_decision_id"] = (
-                    approval_decision.approval_decision_id
-                )
-            return self._persist_action_review_visibility_context_record(
-                context_record=context_record,
-                reviewed_context_update=self._action_review_visibility_update(
-                    action_request_id=action_request.action_request_id,
-                    context_key="escalation",
-                    context_value=escalation_context,
-                ),
-            )
 
     def inspect_advisory_output(
         self,
@@ -4681,136 +4582,15 @@ class AegisOpsControlPlaneService:
         decided_at: datetime,
         approval_decision_id: str | None = None,
     ) -> ApprovalDecisionRecord:
-        approver_identity = self._require_non_empty_string(
-            approver_identity,
-            "approver_identity",
-        )
-        normalized_decision = self._require_non_empty_string(
-            decision,
-            "decision",
-        ).lower()
-        if normalized_decision not in {"grant", "reject"}:
-            raise ValueError("decision must be 'grant' or 'reject'")
-        decision_rationale = self._require_non_empty_string(
-            decision_rationale,
-            "decision_rationale",
-        )
-        decided_at = self._require_aware_datetime(decided_at, "decided_at")
-        if authenticated_approver_identity is not None:
-            authenticated_approver_identity = self._require_non_empty_string(
-                authenticated_approver_identity,
-                "authenticated_approver_identity",
-            )
-            if authenticated_approver_identity != approver_identity:
-                raise PermissionError(
-                    "authenticated approver identity must match the asserted control-plane approver identity"
-                )
-
-        approval_decision: ApprovalDecisionRecord | None = None
-        request_expired = False
-        with self._store.transaction(isolation_level="SERIALIZABLE"):
-            action_request = self._require_review_bound_action_request(action_request_id)
-            if action_request.lifecycle_state != "pending_approval":
-                raise ValueError(
-                    "approval decisions can only be recorded for pending reviewed action requests"
-                )
-            if action_request.approval_decision_id is not None:
-                raise ValueError(
-                    f"action request {action_request.action_request_id!r} already has an approval decision"
-                )
-            if (
-                action_request.requester_identity is not None
-                and action_request.requester_identity == approver_identity
-            ):
-                raise PermissionError(
-                    "approver identity must be distinct from requester identity"
-                )
-            if decided_at < action_request.requested_at:
-                raise ValueError("decided_at must be on or after requested_at")
-
-            policy_evaluation = self._apply_action_policy_evaluation_overrides(
-                computed_policy_evaluation=self._determine_action_policy(
-                    self._normalize_action_policy_basis(action_request.policy_basis)
-                ),
-                persisted_policy_evaluation=action_request.policy_evaluation,
-            )
-            if policy_evaluation.get("approval_requirement") == "policy_authorized":
-                raise PermissionError(
-                    "reviewed approval decisions are not authorized when the re-evaluated action policy is policy_authorized"
-                )
-            if policy_evaluation.get("approval_requirement") != "human_required":
-                raise PermissionError(
-                    "reviewed approval decisions require a human-required action policy"
-                )
-            self._require_reviewed_action_approver_policy(
-                action_request=action_request,
-                approver_identity=approver_identity,
-            )
-
-            now = datetime.now(timezone.utc)
-            if action_request.expires_at is not None and (
-                now > action_request.expires_at or decided_at > action_request.expires_at
-            ):
-                self.persist_record(
-                    replace(action_request, lifecycle_state="expired"),
-                    transitioned_at=action_request.expires_at,
-                )
-                request_expired = True
-            else:
-                resolved_approval_decision_id = self._resolve_new_record_identifier(
-                    ApprovalDecisionRecord,
-                    approval_decision_id,
-                    "approval_decision_id",
-                    "approval-decision",
-                )
-                decision_state = (
-                    "approved" if normalized_decision == "grant" else "rejected"
-                )
-                approval_decision = self.persist_record(
-                    ApprovalDecisionRecord(
-                        approval_decision_id=resolved_approval_decision_id,
-                        action_request_id=action_request.action_request_id,
-                        approver_identities=(approver_identity,),
-                        target_snapshot=dict(action_request.target_scope),
-                        payload_hash=action_request.payload_hash,
-                        decided_at=decided_at,
-                        lifecycle_state=decision_state,
-                        decision_rationale=decision_rationale,
-                        approved_expires_at=(
-                            action_request.expires_at
-                            if decision_state == "approved"
-                            else None
-                        ),
-                    ),
-                    transitioned_at=decided_at,
-                )
-                self.persist_record(
-                    replace(
-                        action_request,
-                        approval_decision_id=approval_decision.approval_decision_id,
-                        lifecycle_state=decision_state,
-                        policy_evaluation=policy_evaluation,
-                    ),
-                    transitioned_at=decided_at,
-                )
-        if request_expired:
-            raise PermissionError(
-                "reviewed action request expired before the approval decision was recorded"
-            )
-        if approval_decision is None:
-            raise RuntimeError(
-                "approval decision transaction completed without recording a decision"
-            )
-        self._emit_structured_event(
-            logging.INFO,
-            "action_approval_decision_recorded",
-            approval_decision_id=approval_decision.approval_decision_id,
-            action_request_id=approval_decision.action_request_id,
-            decision=normalized_decision,
+        return self._action_review_write_surface.record_action_approval_decision(
+            action_request_id=action_request_id,
             approver_identity=approver_identity,
-            lifecycle_state=approval_decision.lifecycle_state,
+            authenticated_approver_identity=authenticated_approver_identity,
+            decision=decision,
+            decision_rationale=decision_rationale,
+            decided_at=decided_at,
+            approval_decision_id=approval_decision_id,
         )
-        return approval_decision
 
     def _require_reviewed_action_approver_policy(
         self,

--- a/control-plane/tests/test_action_review_write_boundary.py
+++ b/control-plane/tests/test_action_review_write_boundary.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
+
+
+class ActionReviewWriteBoundaryTests(unittest.TestCase):
+    def _build_service(self) -> AegisOpsControlPlaneService:
+        store, _ = make_store()
+        return AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+            ),
+            store=store,
+        )
+
+    def test_service_initializes_dedicated_action_review_write_surface(self) -> None:
+        service = self._build_service()
+
+        self.assertTrue(
+            hasattr(service, "_action_review_write_surface"),
+            "expected AegisOpsControlPlaneService to compose a dedicated action-review write surface",
+        )
+
+    def test_service_delegates_action_review_write_entrypoints_to_write_surface(
+        self,
+    ) -> None:
+        service = self._build_service()
+        approval_decision = object()
+        fallback_result = object()
+        escalation_result = object()
+        write_surface = mock.Mock()
+        write_surface.record_action_approval_decision.return_value = approval_decision
+        write_surface.record_action_review_manual_fallback.return_value = fallback_result
+        write_surface.record_action_review_escalation_note.return_value = (
+            escalation_result
+        )
+        service._action_review_write_surface = write_surface
+        decided_at = datetime(2026, 4, 24, 9, 0, tzinfo=timezone.utc)
+        fallback_at = datetime(2026, 4, 24, 10, 0, tzinfo=timezone.utc)
+        escalated_at = datetime(2026, 4, 24, 11, 0, tzinfo=timezone.utc)
+
+        self.assertIs(
+            service.record_action_approval_decision(
+                action_request_id="action-request-001",
+                approver_identity="approver-001",
+                authenticated_approver_identity="approver-001",
+                decision="grant",
+                decision_rationale="Reviewed notify request is bounded to the approved operator slice.",
+                decided_at=decided_at,
+                approval_decision_id="approval-001",
+            ),
+            approval_decision,
+        )
+        self.assertIs(
+            service.record_action_review_manual_fallback(
+                action_request_id="action-request-001",
+                fallback_at=fallback_at,
+                fallback_actor_identity="analyst-001",
+                authority_boundary="business-hours operator",
+                reason="Downstream execution surface timed out before authoritative confirmation.",
+                action_taken="Recorded a manual follow-up and preserved the reviewed boundary.",
+                verification_evidence_ids=("evidence-001",),
+                residual_uncertainty="Awaiting durable downstream reconciliation.",
+            ),
+            fallback_result,
+        )
+        self.assertIs(
+            service.record_action_review_escalation_note(
+                action_request_id="action-request-001",
+                escalated_at=escalated_at,
+                escalated_by_identity="analyst-001",
+                escalated_to="team-lead-001",
+                note="Escalated for explicit after-hours accountability.",
+            ),
+            escalation_result,
+        )
+
+        write_surface.record_action_approval_decision.assert_called_once_with(
+            action_request_id="action-request-001",
+            approver_identity="approver-001",
+            authenticated_approver_identity="approver-001",
+            decision="grant",
+            decision_rationale="Reviewed notify request is bounded to the approved operator slice.",
+            decided_at=decided_at,
+            approval_decision_id="approval-001",
+        )
+        write_surface.record_action_review_manual_fallback.assert_called_once_with(
+            action_request_id="action-request-001",
+            fallback_at=fallback_at,
+            fallback_actor_identity="analyst-001",
+            authority_boundary="business-hours operator",
+            reason="Downstream execution surface timed out before authoritative confirmation.",
+            action_taken="Recorded a manual follow-up and preserved the reviewed boundary.",
+            verification_evidence_ids=("evidence-001",),
+            residual_uncertainty="Awaiting durable downstream reconciliation.",
+        )
+        write_surface.record_action_review_escalation_note.assert_called_once_with(
+            action_request_id="action-request-001",
+            escalated_at=escalated_at,
+            escalated_by_identity="analyst-001",
+            escalated_to="team-lead-001",
+            note="Escalated for explicit after-hours accountability.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -216,6 +216,23 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         ):
             self.assertIn(term, boundary_tests)
 
+    def test_phase31_regression_validation_keeps_action_review_write_boundary_coverage(
+        self,
+    ) -> None:
+        boundary_tests = self._defined_test_names(
+            "control-plane/tests/test_action_review_write_boundary.py",
+            "control-plane/tests/test_phase22_end_to_end_validation.py",
+            "control-plane/tests/test_phase26_end_to_end_validation.py",
+        )
+
+        for term in (
+            "test_service_initializes_dedicated_action_review_write_surface",
+            "test_service_delegates_action_review_write_entrypoints_to_write_surface",
+            "test_phase22_end_to_end_keeps_review_states_and_visibility_explicit",
+            "test_phase26_end_to_end_surfaces_create_tracking_ticket_manual_fallback",
+        ):
+            self.assertIn(term, boundary_tests)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #721
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the action-review write-side slice out of [`control-plane/aegisops_control_plane/service.py`](/Users/jp.infra/Dev/AegisOps-worktrees/issue-721/control-plane/aegisops_control_plane/service.py) into [`control-plane/aegisops_control_plane/action_review_write_surface.py`](/Users/jp.infra/Dev/AegisOps-worktrees/issue-721/control-plane/aegisops_control_plane/action_review_write_surface.py). `AegisOpsControlPlaneService` now delegates `record_action_approval_decision`, `record_action_review_manual_fallback`, and `record_action_review_escalation_note` through a dedicated collaborator, and the service file dropped from 6281 to 6061 lines in this worktree.

I first reproduced the missing boundary with a focused failing test in [`control-plane/tests/test_action_review_write_boundary.py`](/Users/jp.infra/Dev/AegisOps-worktrees/issue-721/control-plane/tests/test_action_review_write_boundary.py), then tightened [`control-plane/tests/test_service_boundary_refactor_regression_validation.py`](/Users/jp.infra/Dev/AegisOps-worktrees/issue-721/control-plane/tests/test_service_boundary_refactor_regression_validation.py) so this extraction stays covered. The checkpoint is committed as `162b56d` (`refactor: extract action review write surface`). I also updated the local issue journal before finishing.

Summary: Extracted action-review approval/manual-fallback/escalation writes into a dedicated write-surface collaborator, added boundary regression coverage, verified locally, and committ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added action review recording capabilities including manual fallback visibility updates, escalation notes, and approval decisions.
  * Enhanced validation, state management, and error handling for action review workflows.

* **Refactor**
  * Reorganized internal service architecture to improve code modularity and maintainability.

* **Tests**
  * Added comprehensive boundary and regression tests for action review operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->