### PR TITLE
operations: define the reviewed startup and shutdown procedure for Phase 32 operational readiness (#729)

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,52 +1,140 @@
-# AegisOps Runbook Skeleton
+# AegisOps Runbook
 
-This runbook is an initial skeleton for approved future operational procedures.
+This runbook defines the reviewed operator procedure for the current AegisOps startup and shutdown path.
 
-It supplements `docs/requirements-baseline.md` by reserving a structured home for startup, shutdown, restore, approval handling, and validation guidance as implementation artifacts mature.
+It supplements `docs/requirements-baseline.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, and `docs/control-plane-runtime-service-boundary.md` by turning the approved first-boot runtime contract into one repo-owned daily procedure.
 
-It does not claim production completeness and does not authorize environment-specific commands.
+It does not authorize environment-specific secrets in version control, optional-extension startup blockers, direct backend exposure, HA or multi-node operating patterns, or unsupported emergency shortcuts.
 
 ## 1. Purpose and Status
 
-This document exists to define the minimum approved structure for future operator procedures without implying that those procedures are complete today.
+This document exists to define one reviewed startup and shutdown path that operators can rehearse without reconstructing the sequence from multiple phase notes.
 
-The current content is intentionally limited to placeholders, constraints, and documentation expectations that align with the AegisOps baseline.
+The reviewed procedure is limited to the current first-boot runtime floor:
 
-Any future operational detail added here must remain consistent with the approved architecture, repository assets, and validation requirements.
+- the AegisOps control-plane service under `control-plane/`;
+- PostgreSQL as the authoritative control-plane persistence dependency;
+- the approved reverse proxy boundary as the only reviewed user-facing ingress path; and
+- reviewed Wazuh-facing analytic-signal intake expectations.
 
 Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.
-
-## 2. Startup
-
-Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist.
 
 Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.
 
 Operators must not treat optional OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path as first-boot prerequisites.
 
-Operators should size startup expectations, maintenance windows, and review burden against `docs/smb-footprint-and-deployment-profile-baseline.md` rather than against enterprise-cluster assumptions.
+## 2. Startup
 
-Future startup guidance should describe:
+The reviewed startup path is business-hours oriented and must begin from a change-aware operator session with repository access, the approved runtime env file, and access to the reviewed secret source referenced by that env file.
 
-- approved prerequisites and dependencies,
-- the order in which platform components may be started,
-- the records or evidence operators must capture during startup, and
-- the validation checkpoints required before the platform is treated as ready.
+### 2.1 Startup Preconditions
 
-This section must not be expanded with environment-specific commands until those commands are backed by approved version-controlled artifacts.
+Before starting anything, the operator must confirm all of the following:
+
+- the workspace is on the reviewed repository revision for the maintenance window or first-boot rehearsal;
+- an untracked runtime env file has been prepared from `control-plane/deployment/first-boot/bootstrap.env.sample` without committing live secrets, DSNs, or tokens;
+- the required Phase 17 runtime keys are present and intentionally set: `AEGISOPS_CONTROL_PLANE_HOST`, `AEGISOPS_CONTROL_PLANE_PORT`, `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`, `AEGISOPS_CONTROL_PLANE_BOOT_MODE`, and `AEGISOPS_CONTROL_PLANE_LOG_LEVEL`;
+- `AEGISOPS_CONTROL_PLANE_BOOT_MODE` remains `first-boot`;
+- the reviewed reverse-proxy-first ingress posture remains in force, with no plan to publish the control-plane backend port directly; and
+- the operator has a place to capture startup evidence for the window, including command output, readiness results, and any refusal or retry reason.
+
+Optional environment keys such as `AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL`, `AEGISOPS_CONTROL_PLANE_N8N_BASE_URL`, `AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL`, and `AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL` may remain unset without blocking startup.
+
+If required bootstrap state is absent, malformed, contradictory, or would bypass the approved reverse-proxy boundary, startup must stop and remain failed closed instead of guessing a broader runtime context.
+
+### 2.2 Reviewed Startup Sequence
+
+The reviewed repo-owned startup sequence is:
+
+1. Confirm the env file and secret references are ready without echoing secret values into the evidence record.
+2. Start the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml up -d`.
+3. Let the reviewed control-plane entrypoint perform runtime-config validation, PostgreSQL reachability proof, and migration bootstrap before the system is treated as ready.
+4. Confirm the reverse proxy, not the backend container port, is the user-facing access path for health, readiness, and runtime inspection.
+5. Capture the resulting container state and reviewed ingress evidence before admitting normal operator use.
+
+The reviewed startup order is PostgreSQL dependency first, then the control-plane service with migration bootstrap, then the reverse proxy admission surface.
+
+Operators must not reorder startup to make optional components authoritative, bypass the reverse proxy with direct backend publication, or treat partial container creation as proof of readiness.
+
+### 2.3 Startup Evidence Capture
+
+The minimum startup evidence set is:
+
+- the reviewed repository revision or release identifier used for the startup window;
+- confirmation that the runtime env file was sourced from the reviewed sample contract and kept untracked;
+- `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml ps`;
+- a bounded log capture from the startup window such as `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml logs --tail=200`;
+- the reverse-proxy health result from `curl -fsS http://127.0.0.1:<proxy-port>/healthz`;
+- the reverse-proxy readiness result from `curl -fsS http://127.0.0.1:<proxy-port>/readyz`; and
+- the runtime inspection snapshot from `curl -fsS http://127.0.0.1:<proxy-port>/runtime`.
+
+Evidence capture must record whether any startup step initially failed, what was corrected, and whether the final ready state was achieved without changing the approved boundary or adding new prerequisites.
+
+Operators must redact or omit secret material from saved evidence.
+
+### 2.4 Ready-to-Operate Checks
+
+The platform may be treated as ready for the reviewed operational baseline only when all of the following are true:
+
+- the control-plane service has not failed closed on missing runtime config, missing migration assets, PostgreSQL connection failure, partial migration application, or readiness-proof failure;
+- `/healthz` succeeds through the reverse proxy;
+- `/readyz` succeeds through the reverse proxy, proving required bootstrap state, PostgreSQL reachability, and the expected reviewed schema state;
+- `/runtime` shows the reviewed first-boot surface rather than an expanded optional-extension claim;
+- the operator can confirm the startup remained limited to the control-plane, PostgreSQL, reverse proxy, and reviewed Wazuh-facing first-boot boundary; and
+- optional extensions, if shown at all, remain explicitly subordinate and non-blocking rather than being inferred as part of mainline readiness.
+
+If readiness fails, operators must stop at evidence capture and correction review. They must not admit normal traffic, widen ingress, or substitute optional-extension health for first-boot readiness.
 
 ## 3. Shutdown
 
-Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist.
+The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.
 
-Future shutdown guidance should describe:
+### 3.1 Controlled Shutdown Conditions
 
-- when a controlled shutdown is permitted,
-- the sequence that preserves data integrity and auditability,
-- what approvals or change records are required before shutdown, and
-- what post-shutdown checks confirm the platform is in a safe state.
+Controlled shutdown is permitted only when one of the following applies:
 
-This section must not be expanded with unsupported emergency procedures or ad-hoc manual shortcuts.
+- a reviewed maintenance window is active;
+- a restore, rollback, or platform hygiene change requires the runtime to stop cleanly; or
+- the runtime has already failed a reviewed readiness or safety gate and operators need to preserve state while preventing further admission.
+
+Shutdown must be paused for manual review if the operator cannot account for active review work, in-flight approval handling, unresolved reconciliation state, or another circumstance where immediate stop would make the audit trail or operator handoff ambiguous.
+
+### 3.2 Reviewed Shutdown Sequence
+
+The reviewed repo-owned shutdown sequence is:
+
+1. Capture a final pre-shutdown readiness snapshot through the reverse proxy.
+2. Record container state and bounded logs for the shutdown window.
+3. Stop the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml down`.
+4. Confirm that the reverse proxy is no longer admitting the reviewed inspection and readiness routes.
+5. Confirm the reviewed runtime surface is fully stopped before declaring the environment safe for follow-on maintenance, restore, or rollback work.
+
+The shutdown order must preserve the operator evidence trail: inspect first, stop the repo-owned stack second, then confirm ingress withdrawal and runtime absence.
+
+Operators must not use ad hoc container deletion, direct data-path manipulation, or undocumented shortcuts as the reviewed shutdown path.
+
+### 3.3 Shutdown Evidence Capture
+
+The minimum shutdown evidence set is:
+
+- the shutdown reason and approved maintenance or recovery context;
+- the final `curl -fsS http://127.0.0.1:<proxy-port>/readyz` result before stopping the stack, or the exact refusal if readiness was already unavailable;
+- `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml ps` captured before shutdown;
+- a bounded shutdown-window log capture such as `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml logs --tail=200`; and
+- post-stop confirmation that the reviewed stack is down and the proxy-facing routes are no longer serving the runtime.
+
+If shutdown follows a fault, the evidence must preserve the failing signal instead of overwriting it with a clean retry narrative.
+
+### 3.4 Safe-State Confirmation
+
+Shutdown is complete only when operators can confirm all of the following:
+
+- the reviewed compose stack reports no running first-boot services;
+- the reverse proxy no longer exposes the reviewed `/healthz`, `/readyz`, or `/runtime` path for this stack;
+- there is no claim that optional services remained authoritative or that the backend stayed intentionally exposed after shutdown; and
+- the evidence record is sufficient for later restore, rollback, or health review work to understand the state that was stopped.
+
+If any part of the stack remains running unexpectedly, shutdown is incomplete and must stay open until the drift is resolved or escalated.
 
 ## 4. Restore
 
@@ -80,7 +168,7 @@ This section must remain consistent with the business-hours-oriented operating m
 
 ## 6. Validation
 
-Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure.
+Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure beyond the reviewed startup and shutdown path.
 
 Future validation guidance should describe:
 

--- a/scripts/test-verify-phase-10-thesis-consistency.sh
+++ b/scripts/test-verify-phase-10-thesis-consistency.sh
@@ -135,7 +135,7 @@ create_repo "${missing_runbook_marker_repo}"
 write_canonical_docs "${missing_runbook_marker_repo}"
 remove_text_from_doc "${missing_runbook_marker_repo}" "docs/runbook.md" "Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations."
 commit_fixture "${missing_runbook_marker_repo}"
-assert_fails_with "${missing_runbook_marker_repo}" "Missing thesis marker in docs/runbook.md: Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations."
+assert_fails_with "${missing_runbook_marker_repo}" "Missing runbook statement: Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations."
 
 missing_marker_repo="${workdir}/missing-marker"
 create_repo "${missing_marker_repo}"

--- a/scripts/test-verify-runbook-doc.sh
+++ b/scripts/test-verify-runbook-doc.sh
@@ -54,25 +54,67 @@ assert_fails_with() {
 
 valid_repo="${workdir}/valid"
 create_repo "${valid_repo}"
-write_doc "${valid_repo}" '# AegisOps Runbook Skeleton
+write_doc "${valid_repo}" '# AegisOps Runbook
 
-This runbook is an initial skeleton for approved future operational procedures.
+This runbook defines the reviewed operator procedure for the current AegisOps startup and shutdown path.
 
-It supplements `docs/requirements-baseline.md` by reserving a structured home for startup, shutdown, restore, approval handling, and validation guidance as implementation artifacts mature.
+It supplements `docs/requirements-baseline.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, and `docs/control-plane-runtime-service-boundary.md` by turning the approved first-boot runtime contract into one repo-owned daily procedure.
 
-It does not claim production completeness and does not authorize environment-specific commands.
+It does not authorize environment-specific secrets in version control, optional-extension startup blockers, direct backend exposure, HA or multi-node operating patterns, or unsupported emergency shortcuts.
 
 ## 1. Purpose and Status
 
-This document exists to define the minimum approved structure for future operator procedures without implying that those procedures are complete today.
+The reviewed procedure is limited to the current first-boot runtime floor:
+
+Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.
+
+Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.
+
+Operators must not treat optional OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path as first-boot prerequisites.
 
 ## 2. Startup
 
-Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist.
+The reviewed startup path is business-hours oriented and must begin from a change-aware operator session with repository access, the approved runtime env file, and access to the reviewed secret source referenced by that env file.
+
+### 2.1 Startup Preconditions
+
+Preconditions are documented for the reviewed startup path.
+
+### 2.2 Reviewed Startup Sequence
+
+Start the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml up -d`.
+
+The reviewed startup order is PostgreSQL dependency first, then the control-plane service with migration bootstrap, then the reverse proxy admission surface.
+
+### 2.3 Startup Evidence Capture
+
+- the reverse-proxy health result from `curl -fsS http://127.0.0.1:<proxy-port>/healthz`;
+- the reverse-proxy readiness result from `curl -fsS http://127.0.0.1:<proxy-port>/readyz`; and
+- the runtime inspection snapshot from `curl -fsS http://127.0.0.1:<proxy-port>/runtime`.
+
+### 2.4 Ready-to-Operate Checks
+
+Ready-to-operate checks remain limited to the reviewed first-boot floor.
 
 ## 3. Shutdown
 
-Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist.
+The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.
+
+### 3.1 Controlled Shutdown Conditions
+
+Controlled shutdown remains maintenance-window or fail-closed oriented.
+
+### 3.2 Reviewed Shutdown Sequence
+
+Stop the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml down`.
+
+### 3.3 Shutdown Evidence Capture
+
+- the final `curl -fsS http://127.0.0.1:<proxy-port>/readyz` result before stopping the stack, or the exact refusal if readiness was already unavailable;
+
+### 3.4 Safe-State Confirmation
+
+- the reverse proxy no longer exposes the reviewed `/healthz`, `/readyz`, or `/runtime` path for this stack;
 
 ## 4. Restore
 
@@ -86,7 +128,7 @@ Approval handling procedures must preserve human review, auditability, and the s
 
 ## 6. Validation
 
-Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure.
+Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure beyond the reviewed startup and shutdown path.
 
 The selected Phase 6 validation slice is limited to the Windows security and endpoint telemetry family and the three reviewed detector artifacts under `opensearch/detectors/windows-security-and-endpoint/`.
 
@@ -111,27 +153,69 @@ If validation fails, disable the selected slice by keeping the detector artifact
 The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.'
 assert_passes "${valid_repo}"
 
-missing_rollback_repo="${workdir}/missing-rollback"
-create_repo "${missing_rollback_repo}"
-write_doc "${missing_rollback_repo}" '# AegisOps Runbook Skeleton
+missing_shutdown_repo="${workdir}/missing-shutdown"
+create_repo "${missing_shutdown_repo}"
+write_doc "${missing_shutdown_repo}" '# AegisOps Runbook
 
-This runbook is an initial skeleton for approved future operational procedures.
+This runbook defines the reviewed operator procedure for the current AegisOps startup and shutdown path.
 
-It supplements `docs/requirements-baseline.md` by reserving a structured home for startup, shutdown, restore, approval handling, and validation guidance as implementation artifacts mature.
+It supplements `docs/requirements-baseline.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, and `docs/control-plane-runtime-service-boundary.md` by turning the approved first-boot runtime contract into one repo-owned daily procedure.
 
-It does not claim production completeness and does not authorize environment-specific commands.
+It does not authorize environment-specific secrets in version control, optional-extension startup blockers, direct backend exposure, HA or multi-node operating patterns, or unsupported emergency shortcuts.
 
 ## 1. Purpose and Status
 
-This document exists to define the minimum approved structure for future operator procedures without implying that those procedures are complete today.
+The reviewed procedure is limited to the current first-boot runtime floor:
+
+Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.
+
+Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.
+
+Operators must not treat optional OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path as first-boot prerequisites.
 
 ## 2. Startup
 
-Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist.
+The reviewed startup path is business-hours oriented and must begin from a change-aware operator session with repository access, the approved runtime env file, and access to the reviewed secret source referenced by that env file.
+
+### 2.1 Startup Preconditions
+
+Preconditions are documented for the reviewed startup path.
+
+### 2.2 Reviewed Startup Sequence
+
+Start the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml up -d`.
+
+The reviewed startup order is PostgreSQL dependency first, then the control-plane service with migration bootstrap, then the reverse proxy admission surface.
+
+### 2.3 Startup Evidence Capture
+
+- the reverse-proxy health result from `curl -fsS http://127.0.0.1:<proxy-port>/healthz`;
+- the reverse-proxy readiness result from `curl -fsS http://127.0.0.1:<proxy-port>/readyz`; and
+- the runtime inspection snapshot from `curl -fsS http://127.0.0.1:<proxy-port>/runtime`.
+
+### 2.4 Ready-to-Operate Checks
+
+Ready-to-operate checks remain limited to the reviewed first-boot floor.
 
 ## 3. Shutdown
 
-Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist.
+The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.
+
+### 3.1 Controlled Shutdown Conditions
+
+Controlled shutdown remains maintenance-window or fail-closed oriented.
+
+### 3.2 Reviewed Shutdown Sequence
+
+Shutdown sequence text intentionally omitted here.
+
+### 3.3 Shutdown Evidence Capture
+
+- the final `curl -fsS http://127.0.0.1:<proxy-port>/readyz` result before stopping the stack, or the exact refusal if readiness was already unavailable;
+
+### 3.4 Safe-State Confirmation
+
+- the reverse proxy no longer exposes the reviewed `/healthz`, `/readyz`, or `/runtime` path for this stack;
 
 ## 4. Restore
 
@@ -145,7 +229,7 @@ Approval handling procedures must preserve human review, auditability, and the s
 
 ## 6. Validation
 
-Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure.
+Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure beyond the reviewed startup and shutdown path.
 
 The selected Phase 6 validation slice is limited to the Windows security and endpoint telemetry family and the three reviewed detector artifacts under `opensearch/detectors/windows-security-and-endpoint/`.
 
@@ -165,7 +249,112 @@ Operators must review replay evidence from `ingest/replay/windows-security-and-e
 
 ### 6.4 Disable and Rollback Path
 
+If validation fails, disable the selected slice by keeping the detector artifacts out of production activation and by withdrawing `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json` from the active workflow set until the issue is corrected and re-reviewed.
+
 The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.'
-assert_fails_with "${missing_rollback_repo}" 'Missing runbook statement: If validation fails, disable the selected slice by keeping the detector artifacts out of production activation and by withdrawing `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json` from the active workflow set until the issue is corrected and re-reviewed.'
+assert_fails_with "${missing_shutdown_repo}" 'Missing runbook statement: Stop the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml down`.'
+
+deferred_startup_repo="${workdir}/deferred-startup"
+create_repo "${deferred_startup_repo}"
+write_doc "${deferred_startup_repo}" '# AegisOps Runbook
+
+This runbook defines the reviewed operator procedure for the current AegisOps startup and shutdown path.
+
+It supplements `docs/requirements-baseline.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, and `docs/control-plane-runtime-service-boundary.md` by turning the approved first-boot runtime contract into one repo-owned daily procedure.
+
+It does not authorize environment-specific secrets in version control, optional-extension startup blockers, direct backend exposure, HA or multi-node operating patterns, or unsupported emergency shortcuts.
+
+## 1. Purpose and Status
+
+The reviewed procedure is limited to the current first-boot runtime floor:
+
+Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.
+
+Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.
+
+Operators must not treat optional OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path as first-boot prerequisites.
+
+## 2. Startup
+
+Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+The reviewed startup path is business-hours oriented and must begin from a change-aware operator session with repository access, the approved runtime env file, and access to the reviewed secret source referenced by that env file.
+
+### 2.1 Startup Preconditions
+
+Preconditions are documented for the reviewed startup path.
+
+### 2.2 Reviewed Startup Sequence
+
+Start the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml up -d`.
+
+The reviewed startup order is PostgreSQL dependency first, then the control-plane service with migration bootstrap, then the reverse proxy admission surface.
+
+### 2.3 Startup Evidence Capture
+
+- the reverse-proxy health result from `curl -fsS http://127.0.0.1:<proxy-port>/healthz`;
+- the reverse-proxy readiness result from `curl -fsS http://127.0.0.1:<proxy-port>/readyz`; and
+- the runtime inspection snapshot from `curl -fsS http://127.0.0.1:<proxy-port>/runtime`.
+
+### 2.4 Ready-to-Operate Checks
+
+Ready-to-operate checks remain limited to the reviewed first-boot floor.
+
+## 3. Shutdown
+
+The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.
+
+### 3.1 Controlled Shutdown Conditions
+
+Controlled shutdown remains maintenance-window or fail-closed oriented.
+
+### 3.2 Reviewed Shutdown Sequence
+
+Stop the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml down`.
+
+### 3.3 Shutdown Evidence Capture
+
+- the final `curl -fsS http://127.0.0.1:<proxy-port>/readyz` result before stopping the stack, or the exact refusal if readiness was already unavailable;
+
+### 3.4 Safe-State Confirmation
+
+- the reverse proxy no longer exposes the reviewed `/healthz`, `/readyz`, or `/runtime` path for this stack;
+
+## 4. Restore
+
+Detailed restore steps are intentionally deferred until implementation artifacts and validation procedures exist.
+
+## 5. Approval Handling
+
+The approved baseline requires explicit approval for SOAR workflows that perform write or destructive actions by default.
+
+Approval handling procedures must preserve human review, auditability, and the separation between detection and execution.
+
+## 6. Validation
+
+Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure beyond the reviewed startup and shutdown path.
+
+The selected Phase 6 validation slice is limited to the Windows security and endpoint telemetry family and the three reviewed detector artifacts under `opensearch/detectors/windows-security-and-endpoint/`.
+
+This runbook section is limited to replay validation, staging-only detector review, and read-only or notify-only workflow review during business hours.
+
+### 6.1 Selected Slice and Preconditions
+
+Preconditions are documented for the selected slice only.
+
+### 6.2 Analyst Validation Path
+
+Analyst validation remains replay-oriented and business-hours only.
+
+### 6.3 Required Evidence Review
+
+Operators must review replay evidence from `ingest/replay/windows-security-and-endpoint/normalized/success.ndjson`, the staging-only detector metadata, and the read-only or notify-only workflow assets before treating the slice as validated.
+
+### 6.4 Disable and Rollback Path
+
+If validation fails, disable the selected slice by keeping the detector artifacts out of production activation and by withdrawing `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json` from the active workflow set until the issue is corrected and re-reviewed.
+
+The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.'
+assert_fails_with "${deferred_startup_repo}" "Forbidden runbook statement still present: Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist."
 
 echo "Runbook verifier tests passed."

--- a/scripts/verify-runbook-doc.sh
+++ b/scripts/verify-runbook-doc.sh
@@ -6,9 +6,18 @@ repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 doc_path="${repo_root}/docs/runbook.md"
 
 required_headings=(
+  "# AegisOps Runbook"
   "## 1. Purpose and Status"
   "## 2. Startup"
+  "### 2.1 Startup Preconditions"
+  "### 2.2 Reviewed Startup Sequence"
+  "### 2.3 Startup Evidence Capture"
+  "### 2.4 Ready-to-Operate Checks"
   "## 3. Shutdown"
+  "### 3.1 Controlled Shutdown Conditions"
+  "### 3.2 Reviewed Shutdown Sequence"
+  "### 3.3 Shutdown Evidence Capture"
+  "### 3.4 Safe-State Confirmation"
   "## 4. Restore"
   "## 5. Approval Handling"
   "## 6. Validation"
@@ -19,19 +28,38 @@ required_headings=(
 )
 
 required_phrases=(
-  "This runbook is an initial skeleton for approved future operational procedures."
-  "It does not claim production completeness and does not authorize environment-specific commands."
+  "This runbook defines the reviewed operator procedure for the current AegisOps startup and shutdown path."
+  'It supplements `docs/requirements-baseline.md`, `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, and `docs/control-plane-runtime-service-boundary.md` by turning the approved first-boot runtime contract into one repo-owned daily procedure.'
+  "It does not authorize environment-specific secrets in version control, optional-extension startup blockers, direct backend exposure, HA or multi-node operating patterns, or unsupported emergency shortcuts."
+  "The reviewed procedure is limited to the current first-boot runtime floor:"
+  'Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.'
+  "Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations."
+  "Operators must not treat optional OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path as first-boot prerequisites."
+  "The reviewed startup path is business-hours oriented and must begin from a change-aware operator session with repository access, the approved runtime env file, and access to the reviewed secret source referenced by that env file."
+  'Start the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml up -d`.'
+  "The reviewed startup order is PostgreSQL dependency first, then the control-plane service with migration bootstrap, then the reverse proxy admission surface."
+  'the reverse-proxy health result from `curl -fsS http://127.0.0.1:<proxy-port>/healthz`;'
+  'the reverse-proxy readiness result from `curl -fsS http://127.0.0.1:<proxy-port>/readyz`; and'
+  'the runtime inspection snapshot from `curl -fsS http://127.0.0.1:<proxy-port>/runtime`.'
+  "The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress."
+  'Stop the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml down`.'
+  'the final `curl -fsS http://127.0.0.1:<proxy-port>/readyz` result before stopping the stack, or the exact refusal if readiness was already unavailable;'
+  'the reverse proxy no longer exposes the reviewed `/healthz`, `/readyz`, or `/runtime` path for this stack;'
   "The approved baseline requires explicit approval for SOAR workflows that perform write or destructive actions by default."
-  "Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist."
-  "Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist."
   "Detailed restore steps are intentionally deferred until implementation artifacts and validation procedures exist."
   "Approval handling procedures must preserve human review, auditability, and the separation between detection and execution."
-  "Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure."
+  "Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure beyond the reviewed startup and shutdown path."
   'The selected Phase 6 validation slice is limited to the Windows security and endpoint telemetry family and the three reviewed detector artifacts under `opensearch/detectors/windows-security-and-endpoint/`.'
   "This runbook section is limited to replay validation, staging-only detector review, and read-only or notify-only workflow review during business hours."
   'Operators must review replay evidence from `ingest/replay/windows-security-and-endpoint/normalized/success.ndjson`, the staging-only detector metadata, and the read-only or notify-only workflow assets before treating the slice as validated.'
   'If validation fails, disable the selected slice by keeping the detector artifacts out of production activation and by withdrawing `aegisops_enrich_windows_selected_detector_outputs.json` and `aegisops_notify_windows_selected_detector_outputs.json` from the active workflow set until the issue is corrected and re-reviewed.'
   "The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation."
+)
+
+forbidden_phrases=(
+  "This runbook is an initial skeleton for approved future operational procedures."
+  "Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist."
+  "Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist."
 )
 
 if [[ ! -f "${doc_path}" ]]; then
@@ -53,4 +81,11 @@ for phrase in "${required_phrases[@]}"; do
   fi
 done
 
-echo "Runbook document is present and covers the approved Phase 6 analyst validation and rollback slice."
+for phrase in "${forbidden_phrases[@]}"; do
+  if grep -Fq "${phrase}" "${doc_path}"; then
+    echo "Forbidden runbook statement still present: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+echo "Runbook document is present and covers the reviewed startup, shutdown, and retained Phase 6 validation slice."


### PR DESCRIPTION
Closes #729
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated [docs/runbook.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-729/docs/runbook.md) from a deferred skeleton into a concrete reviewed startup/shutdown procedure for the current first-boot floor. The new contract defines startup preconditions, repo-owned bring-up/shutdown commands, evidence capture, ready-to-operate checks, and safe-state confirmation while keeping optional extensions, secrets, HA, and bypass paths out of scope.

I also tightened [scripts/verify-runbook-doc.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-729/scripts/verify-runbook-doc.sh) and [scripts/test-verify-runbook-doc.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-729/scripts/test-verify-runbook-doc.sh) so the repo now requires the reviewed startup/shutdown wording and fails if the old deferred-only startup/shutdown text comes back. The change is committed on `codex/issue-729` as `afd4aa9` (`Define reviewed Phase 32 startup and shutdown runbook`).

Summary: Replaced the runbook startup/shutdown skeleton with a reviewed Phase 32 operator procedure, added focused regression checks for the new contract, and committed the result as `afd4aa9`.
State hint: implementing
Blocked reason: none
Tests: `bash scripts/verify-runbook-doc.sh`; `bash scripts/test-verify-runbook-doc.sh`; `bash scripts/verify-phase-10-thesis-consistency.sh`; `bash scripts/verify-phase-16-first-boot-contract.sh`; `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 729 --config /Users/jp.infra/Dev/codex-supervi...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced runbook with comprehensive startup/shutdown procedures, including explicit commands, validation steps, and evidence-capture requirements.
  * Added detailed preconditions and fail-closed stopping rules for safe operations.
  * Formalized readiness checks and reverse-proxy-based health verification.

* **Tests**
  * Updated test fixtures to validate complete operational procedures.
  * Added verification for forbidden legacy placeholder statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->