### PR TITLE
operations: make lab and single-customer profile differences operator-visible (#738)

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -19,6 +19,32 @@ The reviewed procedure is limited to the current first-boot runtime floor:
 
 Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.
 
+### 1.1 Reviewed Lab and Single-Customer Operator Profile Map
+
+Operators must use this profile map to decide which reviewed cadence, backup review, restore rehearsal, upgrade-window, and secret-custody expectations apply before a startup, maintenance, or recovery window begins.
+
+Shared expectations that stay the same across the reviewed lab and single-customer profiles are:
+
+- both profiles remain business-hours oriented, operator-led, and limited to the reviewed control-plane, PostgreSQL, reverse-proxy, and Wazuh-facing path rather than HA, multi-node, or multi-customer expansion;
+- both profiles require PostgreSQL-aware backup custody, configuration backup, restore validation for the approval, evidence, execution, and reconciliation record chain, and rollback to a prior known-good state; and
+- both profiles require named ownership for approval and secret handling, with break-glass use kept documented, explicit, and subordinate to the reviewed fail-closed boundary.
+
+For the reviewed lab profile, operators should plan for:
+
+- startup, queue, backup, and reverse-proxy health review at least three times per business week, with one operator capturing the readiness result;
+- daily PostgreSQL-aware backup plus configuration backup after reviewed changes, with one named operator verifying the backup job outcome;
+- at least one restore rehearsal per quarter against the reviewed lab path, including confirmation that approval, evidence, action-execution, and reconciliation records remain intact after recovery;
+- upgrades that fit one business-hours maintenance window, with rollback returning to the prior known-good backup without extra platform staff or high-availability failover machinery; and
+- one named approver owner, one reviewed secret rotation touch point, and a documented break-glass contact list as sufficient custody for the lab path.
+
+For the reviewed single-customer profile, operators should plan for:
+
+- daily queue and health review on business days plus weekly platform hygiene review for certificates, storage growth, and backup drift;
+- daily PostgreSQL-aware backup, weekly backup review, and reviewed configuration backup before platform changes that affect customer operations;
+- monthly restore rehearsal against a reviewed single-customer recovery target, including validation that customer-scoped workflow truth and linked evidence return cleanly;
+- one planned maintenance window per month, with rollback remaining operator-led and free of cluster failover tooling or multi-customer coordination assumptions; and
+- named customer-scoped approver ownership, a reviewed secret rotation checklist, and explicit break-glass custody for customer credentials.
+
 Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.
 
 Operators must not treat optional OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path as first-boot prerequisites.

--- a/scripts/test-verify-runbook-doc.sh
+++ b/scripts/test-verify-runbook-doc.sh
@@ -26,6 +26,49 @@ write_doc() {
   printf '%s\n' "${doc_content}" >"${target}/docs/runbook.md"
 }
 
+inject_profile_map() {
+  local target="$1"
+
+  python3 - <<'PY' "${target}/docs/runbook.md"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+marker = "Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.\n\n"
+block = """### 1.1 Reviewed Lab and Single-Customer Operator Profile Map
+
+Operators must use this profile map to decide which reviewed cadence, backup review, restore rehearsal, upgrade-window, and secret-custody expectations apply before a startup, maintenance, or recovery window begins.
+
+Shared expectations that stay the same across the reviewed lab and single-customer profiles are:
+
+- both profiles remain business-hours oriented, operator-led, and limited to the reviewed control-plane, PostgreSQL, reverse-proxy, and Wazuh-facing path rather than HA, multi-node, or multi-customer expansion;
+- both profiles require PostgreSQL-aware backup custody, configuration backup, restore validation for the approval, evidence, execution, and reconciliation record chain, and rollback to a prior known-good state; and
+- both profiles require named ownership for approval and secret handling, with break-glass use kept documented, explicit, and subordinate to the reviewed fail-closed boundary.
+
+For the reviewed lab profile, operators should plan for:
+
+- startup, queue, backup, and reverse-proxy health review at least three times per business week, with one operator capturing the readiness result;
+- daily PostgreSQL-aware backup plus configuration backup after reviewed changes, with one named operator verifying the backup job outcome;
+- at least one restore rehearsal per quarter against the reviewed lab path, including confirmation that approval, evidence, action-execution, and reconciliation records remain intact after recovery;
+- upgrades that fit one business-hours maintenance window, with rollback returning to the prior known-good backup without extra platform staff or high-availability failover machinery; and
+- one named approver owner, one reviewed secret rotation touch point, and a documented break-glass contact list as sufficient custody for the lab path.
+
+For the reviewed single-customer profile, operators should plan for:
+
+- daily queue and health review on business days plus weekly platform hygiene review for certificates, storage growth, and backup drift;
+- daily PostgreSQL-aware backup, weekly backup review, and reviewed configuration backup before platform changes that affect customer operations;
+- monthly restore rehearsal against a reviewed single-customer recovery target, including validation that customer-scoped workflow truth and linked evidence return cleanly;
+- one planned maintenance window per month, with rollback remaining operator-led and free of cluster failover tooling or multi-customer coordination assumptions; and
+- named customer-scoped approver ownership, a reviewed secret rotation checklist, and explicit break-glass custody for customer credentials.
+
+"""
+if "### 1.1 Reviewed Lab and Single-Customer Operator Profile Map" not in text:
+    text = text.replace(marker, marker + block)
+    path.write_text(text)
+PY
+}
+
 inject_validation_contract() {
   local target="$1"
 
@@ -186,6 +229,32 @@ It does not authorize environment-specific secrets in version control, optional-
 The reviewed procedure is limited to the current first-boot runtime floor:
 
 Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.
+
+### 1.1 Reviewed Lab and Single-Customer Operator Profile Map
+
+Operators must use this profile map to decide which reviewed cadence, backup review, restore rehearsal, upgrade-window, and secret-custody expectations apply before a startup, maintenance, or recovery window begins.
+
+Shared expectations that stay the same across the reviewed lab and single-customer profiles are:
+
+- both profiles remain business-hours oriented, operator-led, and limited to the reviewed control-plane, PostgreSQL, reverse-proxy, and Wazuh-facing path rather than HA, multi-node, or multi-customer expansion;
+- both profiles require PostgreSQL-aware backup custody, configuration backup, restore validation for the approval, evidence, execution, and reconciliation record chain, and rollback to a prior known-good state; and
+- both profiles require named ownership for approval and secret handling, with break-glass use kept documented, explicit, and subordinate to the reviewed fail-closed boundary.
+
+For the reviewed lab profile, operators should plan for:
+
+- startup, queue, backup, and reverse-proxy health review at least three times per business week, with one operator capturing the readiness result;
+- daily PostgreSQL-aware backup plus configuration backup after reviewed changes, with one named operator verifying the backup job outcome;
+- at least one restore rehearsal per quarter against the reviewed lab path, including confirmation that approval, evidence, action-execution, and reconciliation records remain intact after recovery;
+- upgrades that fit one business-hours maintenance window, with rollback returning to the prior known-good backup without extra platform staff or high-availability failover machinery; and
+- one named approver owner, one reviewed secret rotation touch point, and a documented break-glass contact list as sufficient custody for the lab path.
+
+For the reviewed single-customer profile, operators should plan for:
+
+- daily queue and health review on business days plus weekly platform hygiene review for certificates, storage growth, and backup drift;
+- daily PostgreSQL-aware backup, weekly backup review, and reviewed configuration backup before platform changes that affect customer operations;
+- monthly restore rehearsal against a reviewed single-customer recovery target, including validation that customer-scoped workflow truth and linked evidence return cleanly;
+- one planned maintenance window per month, with rollback remaining operator-led and free of cluster failover tooling or multi-customer coordination assumptions; and
+- named customer-scoped approver ownership, a reviewed secret rotation checklist, and explicit break-glass custody for customer credentials.
 
 Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.
 
@@ -441,6 +510,7 @@ If validation fails, disable the selected slice by keeping the detector artifact
 
 The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.'
 inject_secret_rotation_contract "${missing_shutdown_repo}"
+inject_profile_map "${missing_shutdown_repo}"
 inject_upgrade_contract "${missing_shutdown_repo}"
 inject_validation_contract "${missing_shutdown_repo}"
 assert_fails_with "${missing_shutdown_repo}" 'Missing runbook statement: Stop the reviewed first-boot runtime surface with `docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml down`.'
@@ -570,6 +640,7 @@ If validation fails, disable the selected slice by keeping the detector artifact
 
 The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.'
 inject_secret_rotation_contract "${deferred_startup_repo}"
+inject_profile_map "${deferred_startup_repo}"
 inject_upgrade_contract "${deferred_startup_repo}"
 inject_validation_contract "${deferred_startup_repo}"
 assert_fails_with "${deferred_startup_repo}" "Forbidden runbook statement still present: Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist."
@@ -700,6 +771,7 @@ If validation fails, disable the selected slice by keeping the detector artifact
 
 The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.'
 inject_secret_rotation_contract "${missing_rollback_evidence_repo}"
+inject_profile_map "${missing_rollback_evidence_repo}"
 inject_upgrade_contract "${missing_rollback_evidence_repo}"
 inject_validation_contract "${missing_rollback_evidence_repo}"
 assert_fails_with "${missing_rollback_evidence_repo}" "Missing runbook statement: Operators must retain rollback evidence showing the trigger, the backup set or configuration revision used, the restoration point selected, the post-rollback readiness results, and the confirmation that the prior known-good approval, evidence, execution, and reconciliation chain was restored."
@@ -826,8 +898,44 @@ If validation fails, disable the selected slice by keeping the detector artifact
 
 The selected slice remains business-hours oriented and does not imply 24x7 monitoring, production write behavior, or uncontrolled activation.'
 inject_secret_rotation_contract "${missing_rollback_trigger_bullet_repo}"
+inject_profile_map "${missing_rollback_trigger_bullet_repo}"
 inject_upgrade_contract "${missing_rollback_trigger_bullet_repo}"
 inject_validation_contract "${missing_rollback_trigger_bullet_repo}"
 assert_fails_with "${missing_rollback_trigger_bullet_repo}" "Rollback trigger block must include a bullet immediately after header: Rollback must begin when any of the following apply:"
+
+missing_profile_map_repo="${workdir}/missing-profile-map"
+create_repo "${missing_profile_map_repo}"
+cp "${valid_repo}/docs/runbook.md" "${missing_profile_map_repo}/docs/runbook.md"
+python3 - <<'PY' "${missing_profile_map_repo}/docs/runbook.md"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+text = text.replace(
+    "### 1.1 Reviewed Lab and Single-Customer Operator Profile Map\n\n"
+    "Operators must use this profile map to decide which reviewed cadence, backup review, restore rehearsal, upgrade-window, and secret-custody expectations apply before a startup, maintenance, or recovery window begins.\n\n"
+    "Shared expectations that stay the same across the reviewed lab and single-customer profiles are:\n\n"
+    "- both profiles remain business-hours oriented, operator-led, and limited to the reviewed control-plane, PostgreSQL, reverse-proxy, and Wazuh-facing path rather than HA, multi-node, or multi-customer expansion;\n"
+    "- both profiles require PostgreSQL-aware backup custody, configuration backup, restore validation for the approval, evidence, execution, and reconciliation record chain, and rollback to a prior known-good state; and\n"
+    "- both profiles require named ownership for approval and secret handling, with break-glass use kept documented, explicit, and subordinate to the reviewed fail-closed boundary.\n\n"
+    "For the reviewed lab profile, operators should plan for:\n\n"
+    "- startup, queue, backup, and reverse-proxy health review at least three times per business week, with one operator capturing the readiness result;\n"
+    "- daily PostgreSQL-aware backup plus configuration backup after reviewed changes, with one named operator verifying the backup job outcome;\n"
+    "- at least one restore rehearsal per quarter against the reviewed lab path, including confirmation that approval, evidence, action-execution, and reconciliation records remain intact after recovery;\n"
+    "- upgrades that fit one business-hours maintenance window, with rollback returning to the prior known-good backup without extra platform staff or high-availability failover machinery; and\n"
+    "- one named approver owner, one reviewed secret rotation touch point, and a documented break-glass contact list as sufficient custody for the lab path.\n\n"
+    "For the reviewed single-customer profile, operators should plan for:\n\n"
+    "- daily queue and health review on business days plus weekly platform hygiene review for certificates, storage growth, and backup drift;\n"
+    "- daily PostgreSQL-aware backup, weekly backup review, and reviewed configuration backup before platform changes that affect customer operations;\n"
+    "- monthly restore rehearsal against a reviewed single-customer recovery target, including validation that customer-scoped workflow truth and linked evidence return cleanly;\n"
+    "- one planned maintenance window per month, with rollback remaining operator-led and free of cluster failover tooling or multi-customer coordination assumptions; and\n"
+    "- named customer-scoped approver ownership, a reviewed secret rotation checklist, and explicit break-glass custody for customer credentials.\n\n",
+    "",
+    1,
+)
+path.write_text(text)
+PY
+assert_fails_with "${missing_profile_map_repo}" "Missing runbook statement: ### 1.1 Reviewed Lab and Single-Customer Operator Profile Map"
 
 echo "Runbook verifier tests passed."

--- a/scripts/verify-runbook-doc.sh
+++ b/scripts/verify-runbook-doc.sh
@@ -37,6 +37,24 @@ required_phrases=(
   "It does not authorize environment-specific secrets in version control, optional-extension startup blockers, direct backend exposure, HA or multi-node operating patterns, or unsupported emergency shortcuts."
   "The reviewed procedure is limited to the current first-boot runtime floor:"
   'Startup, restore, and operator-load assumptions referenced by this runbook must stay aligned with `docs/smb-footprint-and-deployment-profile-baseline.md`.'
+  "### 1.1 Reviewed Lab and Single-Customer Operator Profile Map"
+  "Operators must use this profile map to decide which reviewed cadence, backup review, restore rehearsal, upgrade-window, and secret-custody expectations apply before a startup, maintenance, or recovery window begins."
+  "Shared expectations that stay the same across the reviewed lab and single-customer profiles are:"
+  "- both profiles remain business-hours oriented, operator-led, and limited to the reviewed control-plane, PostgreSQL, reverse-proxy, and Wazuh-facing path rather than HA, multi-node, or multi-customer expansion;"
+  "- both profiles require PostgreSQL-aware backup custody, configuration backup, restore validation for the approval, evidence, execution, and reconciliation record chain, and rollback to a prior known-good state; and"
+  "- both profiles require named ownership for approval and secret handling, with break-glass use kept documented, explicit, and subordinate to the reviewed fail-closed boundary."
+  "For the reviewed lab profile, operators should plan for:"
+  "- startup, queue, backup, and reverse-proxy health review at least three times per business week, with one operator capturing the readiness result;"
+  "- daily PostgreSQL-aware backup plus configuration backup after reviewed changes, with one named operator verifying the backup job outcome;"
+  "- at least one restore rehearsal per quarter against the reviewed lab path, including confirmation that approval, evidence, action-execution, and reconciliation records remain intact after recovery;"
+  "- upgrades that fit one business-hours maintenance window, with rollback returning to the prior known-good backup without extra platform staff or high-availability failover machinery; and"
+  "- one named approver owner, one reviewed secret rotation touch point, and a documented break-glass contact list as sufficient custody for the lab path."
+  "For the reviewed single-customer profile, operators should plan for:"
+  "- daily queue and health review on business days plus weekly platform hygiene review for certificates, storage growth, and backup drift;"
+  "- daily PostgreSQL-aware backup, weekly backup review, and reviewed configuration backup before platform changes that affect customer operations;"
+  "- monthly restore rehearsal against a reviewed single-customer recovery target, including validation that customer-scoped workflow truth and linked evidence return cleanly;"
+  "- one planned maintenance window per month, with rollback remaining operator-led and free of cluster failover tooling or multi-customer coordination assumptions; and"
+  "- named customer-scoped approver ownership, a reviewed secret rotation checklist, and explicit break-glass custody for customer credentials."
   "Until implementation-specific commands are approved, operators must treat first boot as limited to the AegisOps control-plane service, PostgreSQL, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations."
   "Operators must not treat optional OpenSearch, n8n, the full analyst-assistant surface, or the high-risk executor path as first-boot prerequisites."
   "The reviewed startup path is business-hours oriented and must begin from a change-aware operator session with repository access, the approved runtime env file, and access to the reviewed secret source referenced by that env file."
@@ -119,14 +137,14 @@ if [[ ! -f "${doc_path}" ]]; then
 fi
 
 for heading in "${required_headings[@]}"; do
-  if ! grep -Fq "${heading}" "${doc_path}"; then
+  if ! grep -Fq -- "${heading}" "${doc_path}"; then
     echo "Missing runbook heading: ${heading}" >&2
     exit 1
   fi
 done
 
 for phrase in "${required_phrases[@]}"; do
-  if ! grep -Fq "${phrase}" "${doc_path}"; then
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
     echo "Missing runbook statement: ${phrase}" >&2
     exit 1
   fi
@@ -153,7 +171,7 @@ if ! sed -n "$((rollback_trigger_line + 1))p" "${doc_path}" | grep -Eq '^[[:spac
 fi
 
 for phrase in "${forbidden_phrases[@]}"; do
-  if grep -Fq "${phrase}" "${doc_path}"; then
+  if grep -Fq -- "${phrase}" "${doc_path}"; then
     echo "Forbidden runbook statement still present: ${phrase}" >&2
     exit 1
   fi


### PR DESCRIPTION
Closes #738
This PR was opened by codex-supervisor.
Latest Codex summary:

Added an explicit operator-facing lab vs single-customer profile map to [docs/runbook.md](/Users/jp.infra/Dev/AegisOps-worktrees/issue-738/docs/runbook.md), covering the required differences for startup cadence, backup review, restore rehearsal, upgrade windows, and secret/break-glass ownership while also calling out shared expectations. I tightened [scripts/verify-runbook-doc.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-738/scripts/verify-runbook-doc.sh) so that map is now mandatory, and updated [scripts/test-verify-runbook-doc.sh](/Users/jp.infra/Dev/AegisOps-worktrees/issue-738/scripts/test-verify-runbook-doc.sh) with a focused regression case proving the verifier fails when the map is removed. I also fixed a macOS `grep` portability bug in the verifier for required lines starting with `-`.

Verification ran clean with `bash scripts/verify-runbook-doc.sh`, `bash scripts/test-verify-runbook-doc.sh`, and `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 738 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`. The issue journal was updated locally as requested; it remains ignored by git, so the tracked checkpoint commit is `f4c999e` (`Add operator-visible SMB profile map`).

Summary: Added an explicit lab vs single-customer operator profile map to the runbook and enforced it with focused verifier coverage.
State hint: implementing
Blocked reason: none
Tests: `bash scripts/verify-runbook-doc.sh`; `bash scripts/test...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an operator decision framework defining lab and single-customer profiles with shared operational constraints, backup/restore procedures, and maintenance cadences for each profile type.

* **Tests**
  * Updated test suite to verify the new documentation section is present and complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->