### PR TITLE
Package single-customer deployment profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           bash scripts/verify-sigma-curated-skeleton.sh
           bash scripts/verify-sigma-n8n-skeleton-validation.sh
           bash scripts/verify-sigma-to-opensearch-translation-strategy-doc.sh
+          bash scripts/verify-single-customer-deployment-profile.sh
           bash scripts/verify-storage-policy-doc.sh
           bash scripts/verify-source-onboarding-contract-doc.sh
           bash scripts/verify-wazuh-rule-lifecycle-runbook.sh
@@ -295,6 +296,7 @@ jobs:
           bash scripts/test-verify-sigma-curated-skeleton.sh
           bash scripts/test-verify-sigma-n8n-skeleton-validation.sh
           bash scripts/test-verify-sigma-to-opensearch-translation-strategy-doc.sh
+          bash scripts/test-verify-single-customer-deployment-profile.sh
           bash scripts/test-verify-source-onboarding-contract-doc.sh
           bash scripts/test-verify-wazuh-rule-lifecycle-runbook.sh
           bash scripts/test-verify-windows-source-onboarding-assets.sh

--- a/docs/deployment/single-customer-profile.md
+++ b/docs/deployment/single-customer-profile.md
@@ -1,0 +1,106 @@
+# Single-Customer Deployment Profile
+
+## 1. Package Status
+
+This document is the repo-owned single-customer deployment profile package for the reviewed Phase 33 deployment boundary.
+
+It packages the current first-boot runtime surface into the default reviewed deployment shape for one customer environment without adding multi-customer, HA, or optional-service prerequisites.
+
+The package is anchored to `docs/runbook.md`, `docs/smb-footprint-and-deployment-profile-baseline.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/storage-layout-and-mount-policy.md`, and `control-plane/deployment/first-boot/`.
+
+This package is operational guidance for the reviewed single-customer profile. It does not store customer-specific values, live secrets, DSNs, certificates, tokens, or vendor automation settings.
+
+Package inventory:
+
+| Artifact | Role in this package |
+| --- | --- |
+| `docs/deployment/single-customer-profile.md` | Reviewed operator-facing package boundary for one customer environment |
+| `control-plane/deployment/first-boot/docker-compose.yml` | Repo-owned startup surface for the current control-plane, PostgreSQL, and proxy stack |
+| `control-plane/deployment/first-boot/bootstrap.env.sample` | Approved runtime input template to copy into an untracked customer-specific env file |
+| `docs/runbook.md` | Startup, shutdown, upgrade, restore, rollback, secret-rotation, and evidence procedure |
+| `docs/smb-footprint-and-deployment-profile-baseline.md` | Reviewed single-customer cadence, backup, restore, upgrade, and ownership expectations |
+| `docs/network-exposure-and-access-path-policy.md` | Reverse-proxy and internal-service exposure policy |
+| `docs/storage-layout-and-mount-policy.md` | PostgreSQL storage and backup separation policy |
+
+## 2. Deployable Shape
+
+The required services for this profile are limited to:
+
+- AegisOps control-plane service from `control-plane/`;
+- PostgreSQL for authoritative AegisOps-owned state;
+- the approved reverse proxy boundary as the only reviewed user-facing ingress path; and
+- the Wazuh-facing analytic-signal intake path admitted through the reviewed proxy and control-plane boundary.
+
+The approved repo-owned startup surface remains `control-plane/deployment/first-boot/docker-compose.yml` with `control-plane/deployment/first-boot/bootstrap.env.sample` copied into an untracked runtime env file.
+
+The service order remains PostgreSQL dependency first, then control-plane runtime-config validation, PostgreSQL reachability proof, and migration bootstrap, then reverse-proxy admission. Partial container creation is not readiness.
+
+The reviewed profile assumes one named customer environment, one reviewed control-plane state boundary, and one operator-owned evidence trail for startup, shutdown, upgrade, restore, and rollback windows.
+
+## 3. Approved Inputs
+
+The approved required runtime inputs are:
+
+- `AEGISOPS_CONTROL_PLANE_HOST`;
+- `AEGISOPS_CONTROL_PLANE_PORT`;
+- `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`;
+- `AEGISOPS_CONTROL_PLANE_BOOT_MODE`; and
+- `AEGISOPS_CONTROL_PLANE_LOG_LEVEL`.
+
+The approved secret and boundary inputs are the PostgreSQL credential source, the Wazuh ingest shared secret source, the Wazuh ingest reverse-proxy secret source, the protected-surface reverse-proxy secret source, the protected-surface trusted proxy CIDRs, the protected-surface proxy service account, the reviewed identity-provider binding, the admin bootstrap token source, the break-glass token source, and any reviewed OpenBao address, token, token-file, and mount bindings used to resolve those secrets.
+
+Live secret values, customer credentials, DSNs, bootstrap tokens, break-glass tokens, and environment-specific certificates must stay outside Git.
+
+Configuration values must be explicit, reviewed, and bound to the named customer environment. Operators must not infer customer, tenant, repository, account, source, or environment linkage from naming conventions, path shape, comments, or nearby metadata alone.
+
+Placeholder credentials, sample tokens, empty secret paths, unsigned identity hints, and TODO values are not approved runtime inputs. Startup, rotation, restore, or upgrade work must stop until a trusted credential source and reviewed binding are available.
+
+## 4. Service and Path Boundary
+
+The reverse proxy is the only reviewed user-facing ingress path for health, readiness, runtime inspection, operator UI, and Wazuh-facing intake admission.
+
+The control-plane backend port, PostgreSQL port, and secret backend are internal service surfaces and must not become independently published front doors.
+
+The Wazuh-facing path is a substrate-detection intake path into AegisOps-owned records, not a direct Wazuh-to-automation or Wazuh-owned case-authority shortcut.
+
+Forwarded headers, host hints, tenant hints, source labels, and client-supplied user identity fields are not trusted unless the reviewed proxy and identity-provider boundary has authenticated, normalized, and bound them to the request.
+
+The control plane remains the authority for approval, evidence, action-execution, and reconciliation records. PostgreSQL stores that AegisOps-owned record chain; Wazuh remains an upstream detection substrate.
+
+## 5. First-Boot to Single-Customer Delta
+
+The single-customer profile keeps the same first-boot service boundary but changes the operator-visible operating contract from a lab rehearsal to one named customer environment.
+
+The single-customer delta is daily business-day queue and health review, weekly platform hygiene review, daily PostgreSQL-aware backup, weekly backup review, pre-change configuration backup, monthly restore rehearsal, one planned maintenance window per month, named customer-scoped approver ownership, reviewed secret rotation, and explicit break-glass custody for customer credentials.
+
+The delta does not add direct backend exposure, browser authority, substrate authority, direct automation shortcuts, HA topology, multi-customer coordination, or optional-service installation.
+
+Readiness and runtime inspection still prove the reviewed first-boot contract: valid required runtime inputs, PostgreSQL reachability, migration bootstrap success, reverse-proxy admission, and no hidden dependency on optional services.
+
+Customer-visible operation begins only after the operator can show the startup evidence, reverse-proxy health and readiness checks, runtime inspection, backup custody, and customer-scoped approval and secret ownership expected by the runbook.
+
+## 6. Optional Extensions
+
+Optional OpenSearch, n8n, Shuffle, endpoint evidence, optional network evidence, assistant, ML shadow, and isolated-executor paths are disabled by default, unavailable, or explicitly non-blocking unless a later reviewed package enables one for a bounded purpose.
+
+Optional extensions must not become startup prerequisites, readiness gates, upgrade success gates, or reasons to widen the control-plane, PostgreSQL, reverse-proxy, or Wazuh-facing boundary.
+
+If an optional surface is displayed, it must remain subordinate to the authoritative control-plane record chain and must report `disabled_by_default`, `unavailable`, `degraded`, or `enabled` only from reviewed backend-owned state.
+
+Operators must not repair optional-extension absence by adding endpoint, network, assistant, ML, or automation prerequisites to this deployment package.
+
+## 7. Day-2 Operating Shape
+
+Day-2 operation follows the cadence in `docs/runbook.md` and `docs/smb-footprint-and-deployment-profile-baseline.md` for the reviewed single-customer profile.
+
+Operators must preserve PostgreSQL-aware backup custody, restore validation for approval, evidence, execution, and reconciliation records, same-day rollback readiness, certificate and storage-growth hygiene review, and reviewed secret rotation evidence.
+
+Backup, restore, export, readiness, and detail rollup evidence must represent one committed runtime state. If an operator detects mixed-snapshot results, partial restore state, orphan records, or half-restored records, normal operation must stay blocked until the durable state is clean.
+
+Rejected startup, rotation, restore, upgrade, or intake attempts must leave no new authoritative customer-scoped record, partial durable write, orphan evidence item, or half-restored state that later operators could mistake for truth.
+
+## 8. Out of Scope
+
+HA topology, multi-customer packaging, optional-service auto-installation, vendor-specific deployment automation, direct browser authority, direct substrate authority, and endpoint, network, assistant, or ML shadow paths as deployment prerequisites are out of scope.
+
+This package also does not approve broad source coverage, enterprise-cluster sizing, dedicated database-team operation, continuous overnight staffing, or fleet-wide MSSP coordination.

--- a/scripts/test-verify-single-customer-deployment-profile.sh
+++ b/scripts/test-verify-single-customer-deployment-profile.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-single-customer-deployment-profile.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_shared_docs() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/runbook.md"
+# AegisOps Runbook
+
+For the reviewed single-customer profile, operators should plan for:
+EOF
+
+  cat <<'EOF' > "${target}/docs/smb-footprint-and-deployment-profile-baseline.md"
+# SMB Footprint and Deployment-Profile Baseline
+
+| Profile | Managed endpoints | vCPU | Memory | Primary storage |
+| --- | --- | --- | --- | --- |
+| Single-customer | 500 to 1,000 | 12 to 16 | 40 to 56 GB | 0.8 to 1.5 TB usable persistent storage |
+EOF
+}
+
+write_valid_profile() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/deployment/single-customer-profile.md"
+# Single-Customer Deployment Profile
+
+## 1. Package Status
+
+This document is the repo-owned single-customer deployment profile package for the reviewed Phase 33 deployment boundary.
+
+It packages the current first-boot runtime surface into the default reviewed deployment shape for one customer environment without adding multi-customer, HA, or optional-service prerequisites.
+
+The package is anchored to `docs/runbook.md`, `docs/smb-footprint-and-deployment-profile-baseline.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/storage-layout-and-mount-policy.md`, and `control-plane/deployment/first-boot/`.
+
+## 2. Deployable Shape
+
+The required services for this profile are limited to:
+
+- AegisOps control-plane service from `control-plane/`;
+- PostgreSQL for authoritative AegisOps-owned state;
+- the approved reverse proxy boundary as the only reviewed user-facing ingress path; and
+- the Wazuh-facing analytic-signal intake path admitted through the reviewed proxy and control-plane boundary.
+
+The approved repo-owned startup surface remains `control-plane/deployment/first-boot/docker-compose.yml` with `control-plane/deployment/first-boot/bootstrap.env.sample` copied into an untracked runtime env file.
+
+## 3. Approved Inputs
+
+The approved required runtime inputs are:
+
+- `AEGISOPS_CONTROL_PLANE_HOST`;
+- `AEGISOPS_CONTROL_PLANE_PORT`;
+- `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`;
+- `AEGISOPS_CONTROL_PLANE_BOOT_MODE`; and
+- `AEGISOPS_CONTROL_PLANE_LOG_LEVEL`.
+
+The approved secret and boundary inputs are the PostgreSQL credential source, the Wazuh ingest shared secret source, the Wazuh ingest reverse-proxy secret source, the protected-surface reverse-proxy secret source, the protected-surface trusted proxy CIDRs, the protected-surface proxy service account, the reviewed identity-provider binding, the admin bootstrap token source, the break-glass token source, and any reviewed OpenBao address, token, token-file, and mount bindings used to resolve those secrets.
+
+Live secret values, customer credentials, DSNs, bootstrap tokens, break-glass tokens, and environment-specific certificates must stay outside Git.
+
+## 4. Service and Path Boundary
+
+The reverse proxy is the only reviewed user-facing ingress path for health, readiness, runtime inspection, operator UI, and Wazuh-facing intake admission.
+
+The control-plane backend port, PostgreSQL port, and secret backend are internal service surfaces and must not become independently published front doors.
+
+The Wazuh-facing path is a substrate-detection intake path into AegisOps-owned records, not a direct Wazuh-to-automation or Wazuh-owned case-authority shortcut.
+
+## 5. First-Boot to Single-Customer Delta
+
+The single-customer profile keeps the same first-boot service boundary but changes the operator-visible operating contract from a lab rehearsal to one named customer environment.
+
+The single-customer delta is daily business-day queue and health review, weekly platform hygiene review, daily PostgreSQL-aware backup, weekly backup review, pre-change configuration backup, monthly restore rehearsal, one planned maintenance window per month, named customer-scoped approver ownership, reviewed secret rotation, and explicit break-glass custody for customer credentials.
+
+The delta does not add direct backend exposure, browser authority, substrate authority, direct automation shortcuts, HA topology, multi-customer coordination, or optional-service installation.
+
+## 6. Optional Extensions
+
+Optional OpenSearch, n8n, Shuffle, endpoint evidence, optional network evidence, assistant, ML shadow, and isolated-executor paths are disabled by default, unavailable, or explicitly non-blocking unless a later reviewed package enables one for a bounded purpose.
+
+Optional extensions must not become startup prerequisites, readiness gates, upgrade success gates, or reasons to widen the control-plane, PostgreSQL, reverse-proxy, or Wazuh-facing boundary.
+
+## 7. Day-2 Operating Shape
+
+Day-2 operation follows the cadence in `docs/runbook.md` and `docs/smb-footprint-and-deployment-profile-baseline.md` for the reviewed single-customer profile.
+
+Operators must preserve PostgreSQL-aware backup custody, restore validation for approval, evidence, execution, and reconciliation records, same-day rollback readiness, certificate and storage-growth hygiene review, and reviewed secret rotation evidence.
+
+## 8. Out of Scope
+
+HA topology, multi-customer packaging, optional-service auto-installation, vendor-specific deployment automation, direct browser authority, direct substrate authority, and endpoint, network, assistant, or ML shadow paths as deployment prerequisites are out of scope.
+EOF
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" add .
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_shared_docs "${valid_repo}"
+write_valid_profile "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_profile_repo="${workdir}/missing-profile"
+create_repo "${missing_profile_repo}"
+write_shared_docs "${missing_profile_repo}"
+commit_fixture "${missing_profile_repo}"
+assert_fails_with "${missing_profile_repo}" "Missing single-customer deployment profile package:"
+
+missing_boundary_repo="${workdir}/missing-boundary"
+create_repo "${missing_boundary_repo}"
+write_shared_docs "${missing_boundary_repo}"
+write_valid_profile "${missing_boundary_repo}"
+perl -0pi -e 's/The reverse proxy is the only reviewed user-facing ingress path for health, readiness, runtime inspection, operator UI, and Wazuh-facing intake admission\.\n\n//' "${missing_boundary_repo}/docs/deployment/single-customer-profile.md"
+commit_fixture "${missing_boundary_repo}"
+assert_fails_with "${missing_boundary_repo}" "Missing single-customer deployment profile statement: The reverse proxy is the only reviewed user-facing ingress path"
+
+missing_optional_default_repo="${workdir}/missing-optional-default"
+create_repo "${missing_optional_default_repo}"
+write_shared_docs "${missing_optional_default_repo}"
+write_valid_profile "${missing_optional_default_repo}"
+perl -0pi -e 's/Optional OpenSearch, n8n, Shuffle, endpoint evidence, optional network evidence, assistant, ML shadow, and isolated-executor paths are disabled by default, unavailable, or explicitly non-blocking unless a later reviewed package enables one for a bounded purpose\.\n\n//' "${missing_optional_default_repo}/docs/deployment/single-customer-profile.md"
+commit_fixture "${missing_optional_default_repo}"
+assert_fails_with "${missing_optional_default_repo}" "Missing single-customer deployment profile statement: Optional OpenSearch, n8n, Shuffle"
+
+forbidden_required_extension_repo="${workdir}/forbidden-required-extension"
+create_repo "${forbidden_required_extension_repo}"
+write_shared_docs "${forbidden_required_extension_repo}"
+write_valid_profile "${forbidden_required_extension_repo}"
+printf '\nThis profile requires OpenSearch before startup.\n' >> "${forbidden_required_extension_repo}/docs/deployment/single-customer-profile.md"
+commit_fixture "${forbidden_required_extension_repo}"
+assert_fails_with "${forbidden_required_extension_repo}" "Forbidden single-customer deployment profile statement: requires OpenSearch"
+
+missing_runbook_map_repo="${workdir}/missing-runbook-map"
+create_repo "${missing_runbook_map_repo}"
+write_shared_docs "${missing_runbook_map_repo}"
+write_valid_profile "${missing_runbook_map_repo}"
+printf '# AegisOps Runbook\n' > "${missing_runbook_map_repo}/docs/runbook.md"
+commit_fixture "${missing_runbook_map_repo}"
+assert_fails_with "${missing_runbook_map_repo}" "Missing runbook single-customer profile map: For the reviewed single-customer profile, operators should plan for:"
+
+echo "verify-single-customer-deployment-profile tests passed"

--- a/scripts/verify-single-customer-deployment-profile.sh
+++ b/scripts/verify-single-customer-deployment-profile.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/single-customer-profile.md"
+runbook_path="${repo_root}/docs/runbook.md"
+profile_baseline_path="${repo_root}/docs/smb-footprint-and-deployment-profile-baseline.md"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+require_file "${doc_path}" "single-customer deployment profile package"
+require_file "${runbook_path}" "runbook document"
+require_file "${profile_baseline_path}" "SMB deployment profile baseline"
+
+required_headings=(
+  "# Single-Customer Deployment Profile"
+  "## 1. Package Status"
+  "## 2. Deployable Shape"
+  "## 3. Approved Inputs"
+  "## 4. Service and Path Boundary"
+  "## 5. First-Boot to Single-Customer Delta"
+  "## 6. Optional Extensions"
+  "## 7. Day-2 Operating Shape"
+  "## 8. Out of Scope"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${doc_path}" "${heading}" "single-customer deployment profile heading"
+done
+
+required_phrases=(
+  'This document is the repo-owned single-customer deployment profile package for the reviewed Phase 33 deployment boundary.'
+  'It packages the current first-boot runtime surface into the default reviewed deployment shape for one customer environment without adding multi-customer, HA, or optional-service prerequisites.'
+  'The package is anchored to `docs/runbook.md`, `docs/smb-footprint-and-deployment-profile-baseline.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/storage-layout-and-mount-policy.md`, and `control-plane/deployment/first-boot/`.'
+  'The required services for this profile are limited to:'
+  '- AegisOps control-plane service from `control-plane/`;'
+  '- PostgreSQL for authoritative AegisOps-owned state;'
+  '- the approved reverse proxy boundary as the only reviewed user-facing ingress path; and'
+  '- the Wazuh-facing analytic-signal intake path admitted through the reviewed proxy and control-plane boundary.'
+  'The approved repo-owned startup surface remains `control-plane/deployment/first-boot/docker-compose.yml` with `control-plane/deployment/first-boot/bootstrap.env.sample` copied into an untracked runtime env file.'
+  'The approved required runtime inputs are:'
+  '- `AEGISOPS_CONTROL_PLANE_HOST`;'
+  '- `AEGISOPS_CONTROL_PLANE_PORT`;'
+  '- `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`;'
+  '- `AEGISOPS_CONTROL_PLANE_BOOT_MODE`; and'
+  '- `AEGISOPS_CONTROL_PLANE_LOG_LEVEL`.'
+  'The approved secret and boundary inputs are the PostgreSQL credential source, the Wazuh ingest shared secret source, the Wazuh ingest reverse-proxy secret source, the protected-surface reverse-proxy secret source, the protected-surface trusted proxy CIDRs, the protected-surface proxy service account, the reviewed identity-provider binding, the admin bootstrap token source, the break-glass token source, and any reviewed OpenBao address, token, token-file, and mount bindings used to resolve those secrets.'
+  'Live secret values, customer credentials, DSNs, bootstrap tokens, break-glass tokens, and environment-specific certificates must stay outside Git.'
+  'The reverse proxy is the only reviewed user-facing ingress path for health, readiness, runtime inspection, operator UI, and Wazuh-facing intake admission.'
+  'The control-plane backend port, PostgreSQL port, and secret backend are internal service surfaces and must not become independently published front doors.'
+  'The Wazuh-facing path is a substrate-detection intake path into AegisOps-owned records, not a direct Wazuh-to-automation or Wazuh-owned case-authority shortcut.'
+  'The single-customer profile keeps the same first-boot service boundary but changes the operator-visible operating contract from a lab rehearsal to one named customer environment.'
+  'The single-customer delta is daily business-day queue and health review, weekly platform hygiene review, daily PostgreSQL-aware backup, weekly backup review, pre-change configuration backup, monthly restore rehearsal, one planned maintenance window per month, named customer-scoped approver ownership, reviewed secret rotation, and explicit break-glass custody for customer credentials.'
+  'The delta does not add direct backend exposure, browser authority, substrate authority, direct automation shortcuts, HA topology, multi-customer coordination, or optional-service installation.'
+  'Optional OpenSearch, n8n, Shuffle, endpoint evidence, optional network evidence, assistant, ML shadow, and isolated-executor paths are disabled by default, unavailable, or explicitly non-blocking unless a later reviewed package enables one for a bounded purpose.'
+  'Optional extensions must not become startup prerequisites, readiness gates, upgrade success gates, or reasons to widen the control-plane, PostgreSQL, reverse-proxy, or Wazuh-facing boundary.'
+  'Day-2 operation follows the cadence in `docs/runbook.md` and `docs/smb-footprint-and-deployment-profile-baseline.md` for the reviewed single-customer profile.'
+  'Operators must preserve PostgreSQL-aware backup custody, restore validation for approval, evidence, execution, and reconciliation records, same-day rollback readiness, certificate and storage-growth hygiene review, and reviewed secret rotation evidence.'
+  'HA topology, multi-customer packaging, optional-service auto-installation, vendor-specific deployment automation, direct browser authority, direct substrate authority, and endpoint, network, assistant, or ML shadow paths as deployment prerequisites are out of scope.'
+)
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${doc_path}" "${phrase}" "single-customer deployment profile statement"
+done
+
+require_phrase "${runbook_path}" "For the reviewed single-customer profile, operators should plan for:" "runbook single-customer profile map"
+require_phrase "${profile_baseline_path}" "| Single-customer | 500 to 1,000 | 12 to 16 | 40 to 56 GB | 0.8 to 1.5 TB usable persistent storage |" "SMB baseline single-customer row"
+
+for forbidden in "high availability" "multi-tenant deployment package" "publish the control-plane backend port directly" "requires OpenSearch" "requires n8n" "requires Shuffle" "requires ML shadow"; do
+  if grep -Fqi -- "${forbidden}" "${doc_path}"; then
+    echo "Forbidden single-customer deployment profile statement: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Single-customer deployment profile package is present and preserves the reviewed service, input, boundary, and optional-extension expectations."


### PR DESCRIPTION
## Summary
- add a repo-owned Phase 33 single-customer deployment profile package
- document the required control-plane, PostgreSQL, reverse-proxy, and Wazuh-facing boundaries plus approved runtime/secret inputs
- add a focused verifier, regression shell tests, and CI wiring for the package expectations

## Verification
- bash scripts/verify-single-customer-deployment-profile.sh
- bash scripts/test-verify-single-customer-deployment-profile.sh
- bash scripts/verify-runbook-doc.sh
- bash scripts/verify-smb-footprint-baseline.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node dist/index.js issue-lint 744 --config supervisor.config.aegisops.coderabbit.json

Part of #743
Closes #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for single-customer deployment profiles, specifying required services, environment configuration, secret management, ingress routing, and operational requirements.
  * Introduced automated verification to validate deployment profile compliance and configuration correctness.

* **Chores**
  * Enhanced CI pipeline with automated deployment profile verification during build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->