### PR TITLE
Define Phase 33 rollback rehearsal contract

### DIFF
--- a/docs/deployment/single-customer-profile.md
+++ b/docs/deployment/single-customer-profile.md
@@ -89,7 +89,23 @@ If an optional surface is displayed, it must remain subordinate to the authorita
 
 Operators must not repair optional-extension absence by adding endpoint, network, assistant, ML, or automation prerequisites to this deployment package.
 
-## 7. Day-2 Operating Shape
+## 7. Upgrade and Same-Day Rollback Rehearsal Contract
+
+The Phase 33 upgrade rehearsal is the single-customer maintenance-window exercise that proves a reviewed repository revision can be introduced and, if needed, returned to the prior known-good state the same day.
+
+Before the rehearsal begins, operators must confirm the daily PostgreSQL-aware backup is current, the pre-change configuration backup has been captured, the restore point for rollback is named, and the backup custody record identifies the operator or break-glass owner for the window.
+
+The rehearsal assumes one planned business-hours maintenance window for the named customer environment, not zero-downtime rollout, HA failover, multi-region recovery, or infrastructure-vendor-specific upgrade tooling.
+
+Rollback decision review happens before the maintenance window closes and must choose one of two recorded outcomes: keep the upgraded revision only if post-upgrade checks pass, or start same-day rollback to the selected restore point if readiness, runtime inspection, reverse-proxy boundary, or record-chain trust cannot be proven.
+
+Post-upgrade smoke checks are the reviewed runtime smoke bundle: reverse-proxy `/readyz`, reverse-proxy `/runtime`, repo-owned compose status, bounded upgrade-window logs, and operator-visible queue or alert review from the mainline surface.
+
+Restore compatibility for the rehearsal is inherited from the Phase 32 runbook baseline: approval, evidence, execution, and reconciliation records must return cleanly from the selected PostgreSQL-aware restore point before normal operation resumes.
+
+The rehearsal evidence must retain the maintenance-window approval, named operator, pre-change backup custody confirmation, selected restore point, before-and-after repository revisions, pre-change and post-change smoke results, rollback decision, and any post-rollback restore validation.
+
+## 8. Day-2 Operating Shape
 
 Day-2 operation follows the cadence in `docs/runbook.md` and `docs/smb-footprint-and-deployment-profile-baseline.md` for the reviewed single-customer profile.
 
@@ -99,7 +115,7 @@ Backup, restore, export, readiness, and detail rollup evidence must represent on
 
 Rejected startup, rotation, restore, upgrade, or intake attempts must leave no new authoritative customer-scoped record, partial durable write, orphan evidence item, or half-restored state that later operators could mistake for truth.
 
-## 8. Out of Scope
+## 9. Out of Scope
 
 HA topology, multi-customer packaging, optional-service auto-installation, vendor-specific deployment automation, direct browser authority, direct substrate authority, and endpoint, network, assistant, or ML shadow paths as deployment prerequisites are out of scope.
 

--- a/scripts/test-verify-single-customer-deployment-profile.sh
+++ b/scripts/test-verify-single-customer-deployment-profile.sh
@@ -101,13 +101,29 @@ Optional OpenSearch, n8n, Shuffle, endpoint evidence, optional network evidence,
 
 Optional extensions must not become startup prerequisites, readiness gates, upgrade success gates, or reasons to widen the control-plane, PostgreSQL, reverse-proxy, or Wazuh-facing boundary.
 
-## 7. Day-2 Operating Shape
+## 7. Upgrade and Same-Day Rollback Rehearsal Contract
+
+The Phase 33 upgrade rehearsal is the single-customer maintenance-window exercise that proves a reviewed repository revision can be introduced and, if needed, returned to the prior known-good state the same day.
+
+Before the rehearsal begins, operators must confirm the daily PostgreSQL-aware backup is current, the pre-change configuration backup has been captured, the restore point for rollback is named, and the backup custody record identifies the operator or break-glass owner for the window.
+
+The rehearsal assumes one planned business-hours maintenance window for the named customer environment, not zero-downtime rollout, HA failover, multi-region recovery, or infrastructure-vendor-specific upgrade tooling.
+
+Rollback decision review happens before the maintenance window closes and must choose one of two recorded outcomes: keep the upgraded revision only if post-upgrade checks pass, or start same-day rollback to the selected restore point if readiness, runtime inspection, reverse-proxy boundary, or record-chain trust cannot be proven.
+
+Post-upgrade smoke checks are the reviewed runtime smoke bundle: reverse-proxy `/readyz`, reverse-proxy `/runtime`, repo-owned compose status, bounded upgrade-window logs, and operator-visible queue or alert review from the mainline surface.
+
+Restore compatibility for the rehearsal is inherited from the Phase 32 runbook baseline: approval, evidence, execution, and reconciliation records must return cleanly from the selected PostgreSQL-aware restore point before normal operation resumes.
+
+The rehearsal evidence must retain the maintenance-window approval, named operator, pre-change backup custody confirmation, selected restore point, before-and-after repository revisions, pre-change and post-change smoke results, rollback decision, and any post-rollback restore validation.
+
+## 8. Day-2 Operating Shape
 
 Day-2 operation follows the cadence in `docs/runbook.md` and `docs/smb-footprint-and-deployment-profile-baseline.md` for the reviewed single-customer profile.
 
 Operators must preserve PostgreSQL-aware backup custody, restore validation for approval, evidence, execution, and reconciliation records, same-day rollback readiness, certificate and storage-growth hygiene review, and reviewed secret rotation evidence.
 
-## 8. Out of Scope
+## 9. Out of Scope
 
 HA topology, multi-customer packaging, optional-service auto-installation, vendor-specific deployment automation, direct browser authority, direct substrate authority, and endpoint, network, assistant, or ML shadow paths as deployment prerequisites are out of scope.
 EOF
@@ -174,6 +190,14 @@ write_valid_profile "${missing_optional_default_repo}"
 perl -0pi -e 's/Optional OpenSearch, n8n, Shuffle, endpoint evidence, optional network evidence, assistant, ML shadow, and isolated-executor paths are disabled by default, unavailable, or explicitly non-blocking unless a later reviewed package enables one for a bounded purpose\.\n\n//' "${missing_optional_default_repo}/docs/deployment/single-customer-profile.md"
 commit_fixture "${missing_optional_default_repo}"
 assert_fails_with "${missing_optional_default_repo}" "Missing single-customer deployment profile statement: Optional OpenSearch, n8n, Shuffle"
+
+missing_upgrade_rehearsal_repo="${workdir}/missing-upgrade-rehearsal"
+create_repo "${missing_upgrade_rehearsal_repo}"
+write_shared_docs "${missing_upgrade_rehearsal_repo}"
+write_valid_profile "${missing_upgrade_rehearsal_repo}"
+perl -0pi -e 's/## 7\. Upgrade and Same-Day Rollback Rehearsal Contract\n\n.*?\n\n## 8\. Day-2 Operating Shape/## 8. Day-2 Operating Shape/s' "${missing_upgrade_rehearsal_repo}/docs/deployment/single-customer-profile.md"
+commit_fixture "${missing_upgrade_rehearsal_repo}"
+assert_fails_with "${missing_upgrade_rehearsal_repo}" "Missing single-customer deployment profile heading: ## 7. Upgrade and Same-Day Rollback Rehearsal Contract"
 
 forbidden_required_extension_repo="${workdir}/forbidden-required-extension"
 create_repo "${forbidden_required_extension_repo}"

--- a/scripts/verify-single-customer-deployment-profile.sh
+++ b/scripts/verify-single-customer-deployment-profile.sh
@@ -40,8 +40,9 @@ required_headings=(
   "## 4. Service and Path Boundary"
   "## 5. First-Boot to Single-Customer Delta"
   "## 6. Optional Extensions"
-  "## 7. Day-2 Operating Shape"
-  "## 8. Out of Scope"
+  "## 7. Upgrade and Same-Day Rollback Rehearsal Contract"
+  "## 8. Day-2 Operating Shape"
+  "## 9. Out of Scope"
 )
 
 for heading in "${required_headings[@]}"; do
@@ -74,6 +75,13 @@ required_phrases=(
   'The delta does not add direct backend exposure, browser authority, substrate authority, direct automation shortcuts, HA topology, multi-customer coordination, or optional-service installation.'
   'Optional OpenSearch, n8n, Shuffle, endpoint evidence, optional network evidence, assistant, ML shadow, and isolated-executor paths are disabled by default, unavailable, or explicitly non-blocking unless a later reviewed package enables one for a bounded purpose.'
   'Optional extensions must not become startup prerequisites, readiness gates, upgrade success gates, or reasons to widen the control-plane, PostgreSQL, reverse-proxy, or Wazuh-facing boundary.'
+  'The Phase 33 upgrade rehearsal is the single-customer maintenance-window exercise that proves a reviewed repository revision can be introduced and, if needed, returned to the prior known-good state the same day.'
+  'Before the rehearsal begins, operators must confirm the daily PostgreSQL-aware backup is current, the pre-change configuration backup has been captured, the restore point for rollback is named, and the backup custody record identifies the operator or break-glass owner for the window.'
+  'The rehearsal assumes one planned business-hours maintenance window for the named customer environment, not zero-downtime rollout, HA failover, multi-region recovery, or infrastructure-vendor-specific upgrade tooling.'
+  'Rollback decision review happens before the maintenance window closes and must choose one of two recorded outcomes: keep the upgraded revision only if post-upgrade checks pass, or start same-day rollback to the selected restore point if readiness, runtime inspection, reverse-proxy boundary, or record-chain trust cannot be proven.'
+  'Post-upgrade smoke checks are the reviewed runtime smoke bundle: reverse-proxy `/readyz`, reverse-proxy `/runtime`, repo-owned compose status, bounded upgrade-window logs, and operator-visible queue or alert review from the mainline surface.'
+  'Restore compatibility for the rehearsal is inherited from the Phase 32 runbook baseline: approval, evidence, execution, and reconciliation records must return cleanly from the selected PostgreSQL-aware restore point before normal operation resumes.'
+  'The rehearsal evidence must retain the maintenance-window approval, named operator, pre-change backup custody confirmation, selected restore point, before-and-after repository revisions, pre-change and post-change smoke results, rollback decision, and any post-rollback restore validation.'
   'Day-2 operation follows the cadence in `docs/runbook.md` and `docs/smb-footprint-and-deployment-profile-baseline.md` for the reviewed single-customer profile.'
   'Operators must preserve PostgreSQL-aware backup custody, restore validation for approval, evidence, execution, and reconciliation records, same-day rollback readiness, certificate and storage-growth hygiene review, and reviewed secret rotation evidence.'
   'HA topology, multi-customer packaging, optional-service auto-installation, vendor-specific deployment automation, direct browser authority, direct substrate authority, and endpoint, network, assistant, or ML shadow paths as deployment prerequisites are out of scope.'


### PR DESCRIPTION
## Summary
- add the Phase 33 single-customer upgrade and same-day rollback rehearsal contract to the deployment package
- require backup custody, maintenance-window assumptions, rollback decision evidence, runtime smoke checks, and Phase 32 restore compatibility in the package verifier
- add a focused negative verifier fixture for a missing rehearsal contract

## Verification
- bash scripts/verify-single-customer-deployment-profile.sh
- bash scripts/test-verify-single-customer-deployment-profile.sh
- bash scripts/verify-runbook-doc.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node dist/index.js issue-lint 745 --config supervisor.config.aegisops.coderabbit.json

Closes #745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new "Upgrade and Same-Day Rollback Rehearsal Contract" section detailing same-day rollback procedures, operator prerequisites, post-upgrade validation checks, and required evidence retention.

* **Tests**
  * Updated validation to enforce new rollback rehearsal requirements and detect missing contract sections in deployment profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->