### PR TITLE
Define Phase 33 evidence handoff pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           bash scripts/verify-sigma-n8n-skeleton-validation.sh
           bash scripts/verify-sigma-to-opensearch-translation-strategy-doc.sh
           bash scripts/verify-phase-33-runtime-smoke-bundle.sh
+          bash scripts/verify-phase-33-operational-evidence-handoff-pack.sh
           bash scripts/verify-single-customer-deployment-profile.sh
           bash scripts/verify-storage-policy-doc.sh
           bash scripts/verify-source-onboarding-contract-doc.sh
@@ -298,6 +299,7 @@ jobs:
           bash scripts/test-verify-sigma-n8n-skeleton-validation.sh
           bash scripts/test-verify-sigma-to-opensearch-translation-strategy-doc.sh
           bash scripts/test-verify-phase-33-runtime-smoke-bundle.sh
+          bash scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
           bash scripts/test-verify-single-customer-deployment-profile.sh
           bash scripts/test-verify-source-onboarding-contract-doc.sh
           bash scripts/test-verify-wazuh-rule-lifecycle-runbook.sh

--- a/docs/deployment/operational-evidence-handoff-pack.md
+++ b/docs/deployment/operational-evidence-handoff-pack.md
@@ -1,0 +1,89 @@
+# Phase 33 Operational Evidence Retention and Audit Handoff Pack
+
+## 1. Purpose and Boundary
+
+This document defines the Phase 33 operational evidence retention and audit handoff pack for the reviewed single-customer profile.
+
+The handoff pack is a small-team operational package, not a new archive platform, SIEM replacement, or external authority source.
+
+The authoritative record chain remains inside AegisOps reviewed records for approval, evidence, execution, and reconciliation truth.
+
+The pack is anchored to `docs/runbook.md`, `docs/deployment/single-customer-profile.md`, and `docs/deployment/runtime-smoke-bundle.md`.
+
+Use this pack when an operator needs a compact, reviewable evidence bundle after deployment, upgrade, restore, approval, execution, reconciliation review, rollback, or a planned handoff window.
+
+The pack may reference external substrate receipts, backup custody notes, or bounded logs, but those references remain evidence attached to reviewed AegisOps records. They do not create a parallel source of authority.
+
+## 2. Retained Evidence Categories
+
+| Event category | Retained evidence | Authority boundary |
+| --- | --- | --- |
+| Upgrade | Approved maintenance window, named operator, pre-change backup custody confirmation, selected restore point, before-and-after repository revisions, pre-change and post-change smoke results, bounded upgrade-window logs, and rollback decision. | Handoff evidence only; upgrade success is accepted only when the reviewed runtime checks and AegisOps record chain remain trustworthy. |
+| Restore | Triggering reason, selected restore point, backup custody confirmation, repository revision or release identifier, post-restore readiness checks, and approval, evidence, execution, and reconciliation record-chain validation outcome. | Restore evidence supports return-to-service review but does not redefine record truth outside AegisOps. |
+| Approval | Customer-scoped approver ownership, approval decision reference, reviewed case or action scope, timeout or rejection reason when applicable, and any break-glass custody note. | Approval truth remains the reviewed AegisOps approval record, not the handoff note. |
+| Execution | Action request reference, approved execution surface, dispatch or refusal receipt, bounded executor or substrate receipt when present, and idempotency or correlation evidence needed for review. | Execution truth remains the AegisOps action-execution record and linked receipt, not vendor-local status alone. |
+| Reconciliation | Reconciliation record reference, expected outcome, observed outcome, mismatch or terminal marker, reviewer decision, and linked evidence used to close or escalate the outcome. | Reconciliation truth remains the reviewed AegisOps reconciliation record. |
+
+For deployment-only handoff where no approval, execution, or reconciliation event occurred, retain the startup, readiness, runtime inspection, smoke, backup custody, and named-operator evidence required by the runbook and single-customer profile.
+
+For failed, rejected, or refused events, retain the refusal reason and the clean-state confirmation. Do not replace a failed path with a later successful retry summary unless the failed outcome remains reviewable.
+
+## 3. Operator-Visible Handoff Artifacts
+
+The operator-visible artifacts are the maintenance or review record, runtime smoke result, backup and restore custody note, bounded logs with secrets redacted, readiness and runtime inspection outputs, and reviewed record-chain references.
+
+Operator-visible artifacts should be compact enough for the next business-hours reviewer to answer four questions:
+
+- what event happened and who owned it;
+- which reviewed AegisOps record or repository revision anchors it;
+- which evidence category entries prove the outcome; and
+- what follow-up owner or next review must still act.
+
+Saved artifacts must avoid live secrets, DSNs, customer credentials, bootstrap tokens, break-glass tokens, unsigned identity hints, sample credentials, and raw forwarded-header values that have not already been normalized by the reviewed boundary.
+
+Bounded logs should preserve the relevant startup, upgrade, restore, execution, or reconciliation signal without becoming a raw log archive.
+
+## 4. Minimal Handoff Package
+
+The minimal handoff package after deployment, upgrade, restore, approval, execution, or reconciliation review contains:
+
+- the reviewed event type and named operator;
+- the repository revision or release identifier when the event changes runtime state;
+- the customer-scoped scope reference without embedding live customer secrets;
+- the required evidence category entries for the event;
+- the runtime smoke result when deployment, upgrade, rollback, or handoff readiness is in scope;
+- the backup, restore, or rollback custody reference when recovery state is in scope;
+- the AegisOps reviewed record identifiers for approval, execution, evidence, or reconciliation when workflow truth is in scope; and
+- the next daily queue, health review, restore review, or reconciliation follow-up owner.
+
+The package can be a short maintenance note, ticket comment, reviewed runbook entry, or other operator-visible record if it preserves the required fields and links back to the authoritative AegisOps records.
+
+The package should not duplicate full record payloads when stable AegisOps identifiers and redacted, bounded evidence references are sufficient for review.
+
+## 5. Retention Expectations
+
+Retention is bounded to the reviewed small-team operating need: keep the latest deploy or upgrade handoff, the latest successful restore rehearsal or restore event, open approval, execution, and reconciliation review evidence, and the evidence required for the next daily or weekly operator review.
+
+Older handoff packs may be summarized or superseded after the reviewed follow-up is complete, provided the AegisOps reviewed records and required backup or restore custody evidence remain intact.
+
+Evidence retention is event-oriented and review-oriented. It is not a promise to preserve every raw log line, every external substrate status, every runtime sample, or every historical smoke command forever.
+
+If a review remains open, disputed, failed, or under reconciliation, retain the directly linked handoff evidence until the reviewed record reaches a clear terminal or escalation state.
+
+## 6. Restore and Reconciliation Alignment
+
+Retention expectations must remain aligned with the Phase 32 restore contract: approval, evidence, execution, and reconciliation records must return cleanly from the selected PostgreSQL-aware restore point before normal operation resumes.
+
+The handoff pack must reference the Phase 33 runtime smoke bundle for deployment, upgrade, rollback, and operator handoff readiness evidence.
+
+If restore, export, readiness, or detail rollup evidence appears to combine mixed snapshots, the handoff must stay blocked until operators can prove one committed state or preserve the refusal as the review outcome.
+
+When reconciliation evidence exists, the handoff must point to the directly linked reconciliation record and its evidence. It must not generalize a mismatch, terminal marker, or reviewer decision to sibling records, nearby cases, or substrate-local status without an explicit authoritative link.
+
+For recovery events, the handoff must include clean-state validation. It is not enough to record that an exception was raised or a restore command returned; the operator must preserve whether approval, evidence, execution, and reconciliation state remained intact and free of orphan or partial records.
+
+## 7. Out of Scope
+
+Enterprise SIEM archive design, unlimited retention, new authority sources, broad external archive integration, vendor-specific archive automation, multi-customer evidence warehouses, and raw secret-bearing evidence bundles are out of scope.
+
+This pack also does not approve direct backend exposure, inferred customer binding, placeholder credentials, unreviewed forwarded headers, optional-extension prerequisites, or substrate-local status as authority for AegisOps approval, execution, or reconciliation truth.

--- a/docs/deployment/runtime-smoke-bundle.md
+++ b/docs/deployment/runtime-smoke-bundle.md
@@ -117,6 +117,8 @@ If a command returns an authentication refusal, readiness refusal, route refusal
 
 The smoke result must be attached to the deployment, upgrade, or handoff record and referenced by the next daily queue and health review.
 
+The smoke result is one input to the Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md`; it does not replace approval, execution, restore, or reconciliation record evidence.
+
 For daily business-day health review, the smoke result is a recent handoff checkpoint only. Operators still review readiness, runtime scope, the queue and alert surfaces, degraded-state markers, and escalation conditions under `docs/runbook.md`.
 
 The weekly platform hygiene review still owns certificate expiry, storage growth, backup drift, and restore-readiness evidence.

--- a/docs/deployment/single-customer-profile.md
+++ b/docs/deployment/single-customer-profile.md
@@ -105,6 +105,8 @@ Restore compatibility for the rehearsal is inherited from the Phase 32 runbook b
 
 The rehearsal evidence must retain the maintenance-window approval, named operator, pre-change backup custody confirmation, selected restore point, before-and-after repository revisions, pre-change and post-change smoke results, rollback decision, and any post-rollback restore validation.
 
+The Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md` defines the minimal retained audit package for upgrade, restore, approval, execution, and reconciliation events.
+
 ## 8. Day-2 Operating Shape
 
 Day-2 operation follows the cadence in `docs/runbook.md` and `docs/smb-footprint-and-deployment-profile-baseline.md` for the reviewed single-customer profile.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -115,6 +115,8 @@ The Phase 33 runtime smoke bundle in `docs/deployment/runtime-smoke-bundle.md` i
 
 Operators should run that bundle after startup, upgrade, rollback, or handoff windows when they need a bounded confidence check for startup status, readiness, protected read-only reachability, queue sanity, and first low-risk action preconditions without running exhaustive E2E validation.
 
+The Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md` is the reviewed minimum package for deployment, upgrade, restore, approval, execution, and reconciliation handoff evidence.
+
 ## 3. Shutdown
 
 The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.

--- a/scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
+++ b/scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-33-operational-evidence-handoff-pack.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_shared_docs() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/runbook.md"
+# AegisOps Runbook
+
+The Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md` is the reviewed minimum package for deployment, upgrade, restore, approval, execution, and reconciliation handoff evidence.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/single-customer-profile.md"
+# Single-Customer Deployment Profile
+
+The Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md` defines the minimal retained audit package for upgrade, restore, approval, execution, and reconciliation events.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/runtime-smoke-bundle.md"
+# Phase 33 Runtime Smoke Bundle
+
+The smoke result is one input to the Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md`; it does not replace approval, execution, restore, or reconciliation record evidence.
+EOF
+}
+
+write_valid_pack() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/deployment/operational-evidence-handoff-pack.md"
+# Phase 33 Operational Evidence Retention and Audit Handoff Pack
+
+## 1. Purpose and Boundary
+
+This document defines the Phase 33 operational evidence retention and audit handoff pack for the reviewed single-customer profile.
+
+The handoff pack is a small-team operational package, not a new archive platform, SIEM replacement, or external authority source.
+
+The authoritative record chain remains inside AegisOps reviewed records for approval, evidence, execution, and reconciliation truth.
+
+The pack is anchored to `docs/runbook.md`, `docs/deployment/single-customer-profile.md`, and `docs/deployment/runtime-smoke-bundle.md`.
+
+## 2. Retained Evidence Categories
+
+| Event category | Retained evidence | Authority boundary |
+| --- | --- | --- |
+| Upgrade | Approved maintenance window, named operator, pre-change backup custody confirmation, selected restore point, before-and-after repository revisions, pre-change and post-change smoke results, bounded upgrade-window logs, and rollback decision. | Handoff evidence only; upgrade success is accepted only when the reviewed runtime checks and AegisOps record chain remain trustworthy. |
+| Restore | Triggering reason, selected restore point, backup custody confirmation, repository revision or release identifier, post-restore readiness checks, and approval, evidence, execution, and reconciliation record-chain validation outcome. | Restore evidence supports return-to-service review but does not redefine record truth outside AegisOps. |
+| Approval | Customer-scoped approver ownership, approval decision reference, reviewed case or action scope, timeout or rejection reason when applicable, and any break-glass custody note. | Approval truth remains the reviewed AegisOps approval record, not the handoff note. |
+| Execution | Action request reference, approved execution surface, dispatch or refusal receipt, bounded executor or substrate receipt when present, and idempotency or correlation evidence needed for review. | Execution truth remains the AegisOps action-execution record and linked receipt, not vendor-local status alone. |
+| Reconciliation | Reconciliation record reference, expected outcome, observed outcome, mismatch or terminal marker, reviewer decision, and linked evidence used to close or escalate the outcome. | Reconciliation truth remains the reviewed AegisOps reconciliation record. |
+
+## 3. Operator-Visible Handoff Artifacts
+
+The operator-visible artifacts are the maintenance or review record, runtime smoke result, backup and restore custody note, bounded logs with secrets redacted, readiness and runtime inspection outputs, and reviewed record-chain references.
+
+## 4. Minimal Handoff Package
+
+The minimal handoff package after deployment, upgrade, restore, approval, execution, or reconciliation review contains:
+
+- the reviewed event type and named operator;
+- the repository revision or release identifier when the event changes runtime state;
+- the customer-scoped scope reference without embedding live customer secrets;
+- the required evidence category entries for the event;
+- the runtime smoke result when deployment, upgrade, rollback, or handoff readiness is in scope;
+- the backup, restore, or rollback custody reference when recovery state is in scope;
+- the AegisOps reviewed record identifiers for approval, execution, evidence, or reconciliation when workflow truth is in scope; and
+- the next daily queue, health review, restore review, or reconciliation follow-up owner.
+
+## 5. Retention Expectations
+
+Retention is bounded to the reviewed small-team operating need: keep the latest deploy or upgrade handoff, the latest successful restore rehearsal or restore event, open approval, execution, and reconciliation review evidence, and the evidence required for the next daily or weekly operator review.
+
+Older handoff packs may be summarized or superseded after the reviewed follow-up is complete, provided the AegisOps reviewed records and required backup or restore custody evidence remain intact.
+
+## 6. Restore and Reconciliation Alignment
+
+Retention expectations must remain aligned with the Phase 32 restore contract: approval, evidence, execution, and reconciliation records must return cleanly from the selected PostgreSQL-aware restore point before normal operation resumes.
+
+The handoff pack must reference the Phase 33 runtime smoke bundle for deployment, upgrade, rollback, and operator handoff readiness evidence.
+
+If restore, export, readiness, or detail rollup evidence appears to combine mixed snapshots, the handoff must stay blocked until operators can prove one committed state or preserve the refusal as the review outcome.
+
+## 7. Out of Scope
+
+Enterprise SIEM archive design, unlimited retention, new authority sources, broad external archive integration, vendor-specific archive automation, multi-customer evidence warehouses, and raw secret-bearing evidence bundles are out of scope.
+EOF
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" add .
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_shared_docs "${valid_repo}"
+write_valid_pack "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_pack_repo="${workdir}/missing-pack"
+create_repo "${missing_pack_repo}"
+write_shared_docs "${missing_pack_repo}"
+commit_fixture "${missing_pack_repo}"
+assert_fails_with "${missing_pack_repo}" "Missing Phase 33 operational evidence handoff pack:"
+
+missing_restore_repo="${workdir}/missing-restore-category"
+create_repo "${missing_restore_repo}"
+write_shared_docs "${missing_restore_repo}"
+write_valid_pack "${missing_restore_repo}"
+perl -0pi -e 's/\| Restore \| Triggering reason, selected restore point, backup custody confirmation, repository revision or release identifier, post-restore readiness checks, and approval, evidence, execution, and reconciliation record-chain validation outcome\. \| Restore evidence supports return-to-service review but does not redefine record truth outside AegisOps\. \|\n//' "${missing_restore_repo}/docs/deployment/operational-evidence-handoff-pack.md"
+commit_fixture "${missing_restore_repo}"
+assert_fails_with "${missing_restore_repo}" "Missing Phase 33 operational evidence handoff pack statement: | Restore | Triggering reason"
+
+missing_minimal_package_repo="${workdir}/missing-minimal-package"
+create_repo "${missing_minimal_package_repo}"
+write_shared_docs "${missing_minimal_package_repo}"
+write_valid_pack "${missing_minimal_package_repo}"
+perl -0pi -e 's/- the AegisOps reviewed record identifiers for approval, execution, evidence, or reconciliation when workflow truth is in scope; and\n//' "${missing_minimal_package_repo}/docs/deployment/operational-evidence-handoff-pack.md"
+commit_fixture "${missing_minimal_package_repo}"
+assert_fails_with "${missing_minimal_package_repo}" "Missing Phase 33 operational evidence handoff pack statement: - the AegisOps reviewed record identifiers"
+
+missing_retention_boundary_repo="${workdir}/missing-retention-boundary"
+create_repo "${missing_retention_boundary_repo}"
+write_shared_docs "${missing_retention_boundary_repo}"
+write_valid_pack "${missing_retention_boundary_repo}"
+perl -0pi -e 's/Retention is bounded to the reviewed small-team operating need: keep the latest deploy or upgrade handoff, the latest successful restore rehearsal or restore event, open approval, execution, and reconciliation review evidence, and the evidence required for the next daily or weekly operator review\.\n\n//' "${missing_retention_boundary_repo}/docs/deployment/operational-evidence-handoff-pack.md"
+commit_fixture "${missing_retention_boundary_repo}"
+assert_fails_with "${missing_retention_boundary_repo}" "Missing Phase 33 operational evidence handoff pack statement: Retention is bounded"
+
+missing_runbook_link_repo="${workdir}/missing-runbook-link"
+create_repo "${missing_runbook_link_repo}"
+write_shared_docs "${missing_runbook_link_repo}"
+write_valid_pack "${missing_runbook_link_repo}"
+printf '# AegisOps Runbook\n' > "${missing_runbook_link_repo}/docs/runbook.md"
+commit_fixture "${missing_runbook_link_repo}"
+assert_fails_with "${missing_runbook_link_repo}" "Missing runbook Phase 33 operational evidence handoff pack link:"
+
+forbidden_archive_repo="${workdir}/forbidden-archive"
+create_repo "${forbidden_archive_repo}"
+write_shared_docs "${forbidden_archive_repo}"
+write_valid_pack "${forbidden_archive_repo}"
+printf '\nAn external archive integration is required before approval handoff can close.\n' >> "${forbidden_archive_repo}/docs/deployment/operational-evidence-handoff-pack.md"
+commit_fixture "${forbidden_archive_repo}"
+assert_fails_with "${forbidden_archive_repo}" "Forbidden Phase 33 operational evidence handoff pack statement: external archive integration is required"
+
+echo "verify-phase-33-operational-evidence-handoff-pack tests passed"

--- a/scripts/verify-phase-33-operational-evidence-handoff-pack.sh
+++ b/scripts/verify-phase-33-operational-evidence-handoff-pack.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/operational-evidence-handoff-pack.md"
+runbook_path="${repo_root}/docs/runbook.md"
+profile_path="${repo_root}/docs/deployment/single-customer-profile.md"
+smoke_path="${repo_root}/docs/deployment/runtime-smoke-bundle.md"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+require_file "${doc_path}" "Phase 33 operational evidence handoff pack"
+require_file "${runbook_path}" "runbook document"
+require_file "${profile_path}" "single-customer deployment profile"
+require_file "${smoke_path}" "Phase 33 runtime smoke bundle"
+
+required_headings=(
+  "# Phase 33 Operational Evidence Retention and Audit Handoff Pack"
+  "## 1. Purpose and Boundary"
+  "## 2. Retained Evidence Categories"
+  "## 3. Operator-Visible Handoff Artifacts"
+  "## 4. Minimal Handoff Package"
+  "## 5. Retention Expectations"
+  "## 6. Restore and Reconciliation Alignment"
+  "## 7. Out of Scope"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${doc_path}" "${heading}" "Phase 33 operational evidence handoff pack heading"
+done
+
+required_phrases=(
+  "This document defines the Phase 33 operational evidence retention and audit handoff pack for the reviewed single-customer profile."
+  "The handoff pack is a small-team operational package, not a new archive platform, SIEM replacement, or external authority source."
+  'The authoritative record chain remains inside AegisOps reviewed records for approval, evidence, execution, and reconciliation truth.'
+  'The pack is anchored to `docs/runbook.md`, `docs/deployment/single-customer-profile.md`, and `docs/deployment/runtime-smoke-bundle.md`.'
+  '| Event category | Retained evidence | Authority boundary |'
+  '| Upgrade | Approved maintenance window, named operator, pre-change backup custody confirmation, selected restore point, before-and-after repository revisions, pre-change and post-change smoke results, bounded upgrade-window logs, and rollback decision. | Handoff evidence only; upgrade success is accepted only when the reviewed runtime checks and AegisOps record chain remain trustworthy. |'
+  '| Restore | Triggering reason, selected restore point, backup custody confirmation, repository revision or release identifier, post-restore readiness checks, and approval, evidence, execution, and reconciliation record-chain validation outcome. | Restore evidence supports return-to-service review but does not redefine record truth outside AegisOps. |'
+  '| Approval | Customer-scoped approver ownership, approval decision reference, reviewed case or action scope, timeout or rejection reason when applicable, and any break-glass custody note. | Approval truth remains the reviewed AegisOps approval record, not the handoff note. |'
+  '| Execution | Action request reference, approved execution surface, dispatch or refusal receipt, bounded executor or substrate receipt when present, and idempotency or correlation evidence needed for review. | Execution truth remains the AegisOps action-execution record and linked receipt, not vendor-local status alone. |'
+  '| Reconciliation | Reconciliation record reference, expected outcome, observed outcome, mismatch or terminal marker, reviewer decision, and linked evidence used to close or escalate the outcome. | Reconciliation truth remains the reviewed AegisOps reconciliation record. |'
+  'The operator-visible artifacts are the maintenance or review record, runtime smoke result, backup and restore custody note, bounded logs with secrets redacted, readiness and runtime inspection outputs, and reviewed record-chain references.'
+  'The minimal handoff package after deployment, upgrade, restore, approval, execution, or reconciliation review contains:'
+  '- the reviewed event type and named operator;'
+  '- the repository revision or release identifier when the event changes runtime state;'
+  '- the customer-scoped scope reference without embedding live customer secrets;'
+  '- the required evidence category entries for the event;'
+  '- the runtime smoke result when deployment, upgrade, rollback, or handoff readiness is in scope;'
+  '- the backup, restore, or rollback custody reference when recovery state is in scope;'
+  '- the AegisOps reviewed record identifiers for approval, execution, evidence, or reconciliation when workflow truth is in scope; and'
+  '- the next daily queue, health review, restore review, or reconciliation follow-up owner.'
+  'Retention is bounded to the reviewed small-team operating need: keep the latest deploy or upgrade handoff, the latest successful restore rehearsal or restore event, open approval, execution, and reconciliation review evidence, and the evidence required for the next daily or weekly operator review.'
+  'Older handoff packs may be summarized or superseded after the reviewed follow-up is complete, provided the AegisOps reviewed records and required backup or restore custody evidence remain intact.'
+  'Retention expectations must remain aligned with the Phase 32 restore contract: approval, evidence, execution, and reconciliation records must return cleanly from the selected PostgreSQL-aware restore point before normal operation resumes.'
+  'The handoff pack must reference the Phase 33 runtime smoke bundle for deployment, upgrade, rollback, and operator handoff readiness evidence.'
+  'If restore, export, readiness, or detail rollup evidence appears to combine mixed snapshots, the handoff must stay blocked until operators can prove one committed state or preserve the refusal as the review outcome.'
+  'Enterprise SIEM archive design, unlimited retention, new authority sources, broad external archive integration, vendor-specific archive automation, multi-customer evidence warehouses, and raw secret-bearing evidence bundles are out of scope.'
+)
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${doc_path}" "${phrase}" "Phase 33 operational evidence handoff pack statement"
+done
+
+require_phrase "${runbook_path}" 'The Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md` is the reviewed minimum package for deployment, upgrade, restore, approval, execution, and reconciliation handoff evidence.' "runbook Phase 33 operational evidence handoff pack link"
+require_phrase "${profile_path}" 'The Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md` defines the minimal retained audit package for upgrade, restore, approval, execution, and reconciliation events.' "single-customer profile Phase 33 operational evidence handoff pack link"
+require_phrase "${smoke_path}" 'The smoke result is one input to the Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md`; it does not replace approval, execution, restore, or reconciliation record evidence.' "runtime smoke bundle Phase 33 operational evidence handoff pack link"
+
+for forbidden in "requires unlimited retention" "requires enterprise SIEM archive" "external archive integration is required" "creates a new authority source" "retain raw secret-bearing evidence"; do
+  if grep -Fqi -- "${forbidden}" "${doc_path}"; then
+    echo "Forbidden Phase 33 operational evidence handoff pack statement: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 33 operational evidence handoff pack is present and preserves the reviewed evidence, authority, retention, and archive boundaries."


### PR DESCRIPTION
## Summary
- define the Phase 33 operational evidence retention and audit handoff pack for the single-customer profile
- add a focused verifier and shell test for required evidence categories, retention boundaries, and archive guardrails
- link the handoff pack from the runbook, single-customer deployment profile, runtime smoke bundle, and CI

## Verification
- bash scripts/verify-phase-33-operational-evidence-handoff-pack.sh
- bash scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
- bash scripts/verify-phase-33-runtime-smoke-bundle.sh
- bash scripts/test-verify-phase-33-runtime-smoke-bundle.sh
- bash scripts/verify-single-customer-deployment-profile.sh
- bash scripts/test-verify-single-customer-deployment-profile.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node dist/index.js issue-lint 747 --config supervisor.config.aegisops.coderabbit.json