### PR TITLE
Uplift GitHub audit source profile to detection-ready

### DIFF
--- a/control-plane/tests/test_github_audit_source_profile_docs.py
+++ b/control-plane/tests/test_github_audit_source_profile_docs.py
@@ -15,13 +15,20 @@ class GitHubAuditSourceProfileDocsTests(unittest.TestCase):
 
         for term in (
             "GitHub Audit Wazuh-Backed Source Profile Onboarding Package",
-            "Readiness state: `schema-reviewed`",
+            "Readiness state: `detection-ready`",
             "Wazuh-backed source profile",
+            "Reviewed detection-ready scope",
+            "Parser and Version Evidence",
+            "Reviewed parser evidence source",
+            "Field Coverage Verification",
+            "Provenance Evidence",
+            "Detector-Use Approval and Limits",
             "accountable source identity",
             "actor identity",
             "target identity",
             "repository or organization context",
             "privilege-change metadata",
+            "Detector activation still requires separate rule review, rollout review, and Wazuh rule lifecycle validation.",
             "Direct GitHub API actioning",
             "Non-audit GitHub telemetry families",
         ):

--- a/control-plane/tests/test_phase14_identity_rich_source_profile_docs.py
+++ b/control-plane/tests/test_phase14_identity_rich_source_profile_docs.py
@@ -192,17 +192,17 @@ class Phase14IdentityRichSourceProfileDocsTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
 
         shared_terms = (
-            "Readiness state: `schema-reviewed`",
             "Parser ownership remains with IT Operations, Information Systems Department.",
             "Representative raw payload references are stored in `control-plane/tests/fixtures/wazuh/`.",
             "The reviewed fixture is sufficient for future parser and mapping validation without claiming that live source onboarding is approved.",
-            "Versioned parser changes remain future implementation work.",
         )
         family_specific_terms = (
             (
                 "github-audit",
                 github_text,
                 (
+                    "Readiness state: `detection-ready`",
+                    "Reviewed parser evidence source",
                     "This package does not approve live GitHub API actioning, response automation, source-side credentials, or non-audit GitHub telemetry families.",
                     "GitHub repository privilege change",
                     "GitHub audit",
@@ -212,6 +212,8 @@ class Phase14IdentityRichSourceProfileDocsTests(unittest.TestCase):
                 "microsoft-365-audit",
                 microsoft_text,
                 (
+                    "Readiness state: `schema-reviewed`",
+                    "Versioned parser changes remain future implementation work.",
                     "This package does not approve direct Microsoft 365 actioning, non-audit Microsoft 365 telemetry families, source-side credentials, or runtime automation.",
                     "Microsoft 365 mailbox permission change",
                     "Microsoft 365 audit",
@@ -221,6 +223,8 @@ class Phase14IdentityRichSourceProfileDocsTests(unittest.TestCase):
                 "entra-id",
                 entra_text,
                 (
+                    "Readiness state: `schema-reviewed`",
+                    "Versioned parser changes remain future implementation work.",
                     "This package does not approve direct Entra ID actioning, non-audit Entra ID telemetry families, source-side credentials, or runtime automation.",
                     "Entra ID privileged role assignment",
                     "Entra ID",
@@ -232,6 +236,50 @@ class Phase14IdentityRichSourceProfileDocsTests(unittest.TestCase):
             with self.subTest(family=family_name):
                 for term in shared_terms + terms:
                     self.assertIn(term, text)
+
+    def test_github_audit_detection_ready_package_requires_reviewed_evidence(
+        self,
+    ) -> None:
+        onboarding_text = (
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "github-audit"
+            / "onboarding-package.md"
+        ).read_text(encoding="utf-8")
+        runbook_text = (
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "github-audit"
+            / "analyst-triage-runbook.md"
+        ).read_text(encoding="utf-8")
+
+        required_onboarding_terms = (
+            "Readiness state: `detection-ready`",
+            "Reviewed detection-ready scope",
+            "Parser and Version Evidence",
+            "Reviewed parser evidence source",
+            "Field Coverage Verification",
+            "Provenance Evidence",
+            "Detector-Use Approval and Limits",
+            "Future detection content may reference GitHub audit only for repository and organization privilege, access, and workflow-administration review signals that preserve accountable source identity, actor identity, target identity, repository or organization context, privilege-change or workflow-administration metadata, timestamp quality, and Wazuh provenance.",
+            "Detector activation still requires separate rule review, rollout review, and Wazuh rule lifecycle validation.",
+            "This package does not approve live GitHub API actioning, response automation, source-side credentials, GitHub-owned case authority, direct vendor workflow truth, non-audit GitHub telemetry families, or detector activation without separate detector review.",
+        )
+        required_runbook_terms = (
+            "Detector-use handling",
+            "GitHub audit may support detector review only within the approved detection-ready scope in the onboarding package.",
+            "Analysts must treat GitHub audit as source evidence for AegisOps review, not as GitHub-owned workflow truth or direct action authority.",
+            "Family-specific false-positive review",
+            "Provenance handling",
+            "If accountable source identity, actor identity, target identity, repository or organization context, timestamp quality, parser evidence, or Wazuh provenance is missing or malformed, the analyst keeps the item out of detector-ready handling until the prerequisite is repaired or a documented exception path applies.",
+        )
+
+        for term in required_onboarding_terms:
+            self.assertIn(term, onboarding_text)
+        for term in required_runbook_terms:
+            self.assertIn(term, runbook_text)
 
 
 if __name__ == "__main__":

--- a/docs/source-families/github-audit/analyst-triage-runbook.md
+++ b/docs/source-families/github-audit/analyst-triage-runbook.md
@@ -14,7 +14,7 @@ This runbook applies to reviewed GitHub audit alerts and cases that enter AegisO
 
 It covers read-oriented triage, evidence capture, disposition decisions, and fixture refresh expectations for the reviewed GitHub audit source profile.
 
-Direct GitHub API actioning remains out of scope. This runbook does not authorize repository changes, secret rotation, privilege enforcement, or any unsupported source family.
+Direct GitHub API actioning remains out of scope. This runbook does not authorize repository changes, secret rotation, privilege enforcement, GitHub-owned case authority, direct vendor workflow truth, detector activation, or any unsupported source family.
 
 It also does not replace the source onboarding contract or the Wazuh rule lifecycle runbook. Those documents remain authoritative for onboarding evidence and rule-change validation.
 
@@ -42,7 +42,39 @@ Analysts must not assume that every GitHub audit alert indicates malicious activ
 
 Unsupported GitHub telemetry families remain out of scope. Direct vendor-local actioning remains out of scope even when a repository event looks urgent.
 
-## 5. Evidence to Collect
+## 5. Detector-use handling
+
+GitHub audit may support detector review only within the approved detection-ready scope in the onboarding package.
+
+Future detector-use review must confirm that the event is a reviewed GitHub audit signal entering through the Wazuh-backed intake boundary and that the detector depends only on reviewed field coverage, parser evidence, timestamp quality, and Wazuh provenance.
+
+Analysts must treat GitHub audit as source evidence for AegisOps review, not as GitHub-owned workflow truth or direct action authority.
+
+Detector-ready handling remains blocked when the event depends on direct GitHub API actioning, non-audit GitHub telemetry, repository naming conventions alone, untrusted forwarded identity, placeholder credentials, missing parser evidence, or missing provenance.
+
+Detector activation still requires separate detector review, rollout review, and Wazuh rule lifecycle validation. The runbook does not let a detection-ready source-family package bypass rule QA, staging, expected-volume review, false-positive review, or production activation approval.
+
+## 6. Family-specific false-positive review
+
+Family-specific false-positive review must remain visible in each triage record and each future detector review that depends on GitHub audit.
+
+Reviewers should compare the event against normal repository administration, maintainer activity, workflow maintenance, access review cleanup, approved automation identity behavior, scheduled change windows, and business-hours operating expectations before escalating.
+
+False-positive notes must state why the event is benign, suspicious, deferred, or still ambiguous. They must also state whether the explanation comes from reviewed AegisOps records, an approved change-management path, or read-oriented GitHub audit evidence.
+
+Analysts must not suppress or downgrade an event solely because the actor, repository, team, or workflow name looks familiar. The benign explanation needs an explicit reviewed linkage to the authoritative scope record or the item remains queued for review.
+
+## 7. Provenance handling
+
+Provenance handling starts from the reviewed Wazuh boundary and the GitHub audit onboarding package, not from GitHub-authored text as independent authority.
+
+The analyst preserves Wazuh manager identity, decoder identity, rule identity, rule severity, rule description, source location, event timestamp, source family, GitHub audit action, actor, target, organization, repository, privilege or workflow-administration context, and request context when present.
+
+If accountable source identity, actor identity, target identity, repository or organization context, timestamp quality, parser evidence, or Wazuh provenance is missing or malformed, the analyst keeps the item out of detector-ready handling until the prerequisite is repaired or a documented exception path applies.
+
+Missing or malformed provenance is not treated as a reason to infer success from repository names, path shape, comments, nearby metadata, or raw GitHub-authored prose. The analyst records the gap and keeps the AegisOps control-plane guard in place.
+
+## 8. Evidence to Collect
 
 The analyst captures read-oriented evidence that answers what changed, who or what changed it, which target object was affected, and why the item is or is not interesting.
 
@@ -50,15 +82,18 @@ At minimum, the analyst records:
 
 - the reviewed GitHub audit event summary;
 - the accountable source identity and delivery path;
+- Wazuh manager, decoder, rule, location, timestamp, and parser evidence used for detector-ready handling;
 - the actor identity, including whether it was a human, app, bot, or other automation identity when present;
 - the target object, repository, organization, or membership context;
 - the privilege or access change context, if any;
+- workflow-administration context, if detector review depends on it;
+- the family-specific false-positive review outcome;
 - the raw payload or fixture reference used for review; and
 - the reason the event is benign, escalated, or deferred.
 
 The reviewer should keep evidence aligned with `docs/source-onboarding-contract.md` and the reviewed GitHub audit onboarding package. If a new reviewed alert shape appears, the corresponding fixture under `control-plane/tests/fixtures/wazuh/github-audit-alert.json` and the related Wazuh rule lifecycle evidence must be refreshed before downstream workflow assumptions change.
 
-## 6. Business-Hours Handling
+## 9. Business-Hours Handling
 
 This runbook follows the Business-hours SecOps daily operating model.
 
@@ -68,7 +103,7 @@ If an item appears to require escalation, the analyst records the reason, the af
 
 After-hours handling remains explicit and bounded. The reviewed path does not imply 24x7 analyst watchstanding, and it does not authorize vendor-local actioning or automatic enforcement.
 
-## 7. Validation and Fixture Expectations
+## 10. Validation and Fixture Expectations
 
 The reviewer treats the reviewed GitHub audit fixture as the canonical replay reference for this family.
 
@@ -76,8 +111,8 @@ Any new reviewed GitHub audit rule shape, provenance expectation, or identity br
 
 The analyst triage record should note whether the current fixture set still explains the alert clearly, whether the event remains compatible with the control-plane-first analyst workflow, and whether a new fixture or mapping update is required.
 
-## 8. Baseline Alignment Notes
+## 11. Baseline Alignment Notes
 
-This runbook remains aligned with `docs/source-onboarding-contract.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
+This runbook remains aligned with `docs/source-onboarding-contract.md`, `docs/detection-lifecycle-and-rule-qa-framework.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
 
-It preserves the Wazuh-backed source boundary, keeps false-positive expectations explicit, and avoids any promise of production expansion beyond the reviewed GitHub audit family.
+It preserves the Wazuh-backed source boundary, keeps false-positive expectations explicit, keeps detector-use approval separate from detector activation, and avoids any promise of production expansion beyond the reviewed GitHub audit family.

--- a/docs/source-families/github-audit/onboarding-package.md
+++ b/docs/source-families/github-audit/onboarding-package.md
@@ -2,13 +2,19 @@
 
 ## 1. Family Scope and Readiness State
 
-Readiness state: `schema-reviewed`
+Readiness state: `detection-ready`
 
 The approved Phase 14 source family is GitHub audit.
 
 This package documents the reviewed Wazuh-backed source profile for GitHub audit alerts entering AegisOps as vendor-neutral analytic signals.
 
-It preserves accountable source identity, actor identity, target identity, repository or organization context, and privilege-change metadata in the shared control-plane language.
+Reviewed detection-ready scope: GitHub audit records admitted through the reviewed Wazuh-backed intake boundary for repository and organization privilege, access, and workflow-administration review signals.
+
+It preserves accountable source identity, actor identity, target identity, repository or organization context, privilege-change metadata, workflow-administration metadata, timestamp quality, and Wazuh provenance in the shared control-plane language.
+
+Future detection content may reference GitHub audit only for repository and organization privilege, access, and workflow-administration review signals that preserve accountable source identity, actor identity, target identity, repository or organization context, privilege-change or workflow-administration metadata, timestamp quality, and Wazuh provenance.
+
+This package does not approve live GitHub API actioning, response automation, source-side credentials, GitHub-owned case authority, direct vendor workflow truth, non-audit GitHub telemetry families, or detector activation without separate detector review.
 
 This package does not approve live GitHub API actioning, response automation, source-side credentials, or non-audit GitHub telemetry families.
 
@@ -16,15 +22,21 @@ This package does not approve live GitHub API actioning, response automation, so
 
 Parser ownership remains with IT Operations, Information Systems Department.
 
-The parser implementation boundary is the reviewed Wazuh intake handling that preserves the GitHub audit signal shape, accountable source identity, actor identity, target identity, repository or organization context, and privilege-change metadata.
+The parser implementation boundary is the reviewed Wazuh intake handling that preserves the GitHub audit signal shape, accountable source identity, actor identity, target identity, repository or organization context, privilege-change metadata, workflow-administration metadata, timestamp quality, and Wazuh provenance.
 
-Versioned parser changes remain future implementation work. Until a parser exists, this package treats the reviewed fixture and mapping notes as the review baseline that future parser work must satisfy.
+## 3. Parser and Version Evidence
 
-## 3. Raw Payload References
+Reviewed parser evidence source: Wazuh `github_audit` decoder evidence represented by `decoder.name`, Wazuh rule metadata, the reviewed `github-audit-alert.json` fixture, and the parser ownership boundary in this package.
+
+Reviewed parser version evidence: the approved detection-ready scope is pinned to the documented Wazuh-backed fixture shape and the `github_audit` decoder identity until a separately reviewed parser package introduces a stronger semantic version. Parser or decoder changes that alter source field names, timestamp semantics, identity mapping, repository mapping, or provenance mapping must refresh this package before detector dependencies can rely on the changed shape.
+
+This parser/version evidence is sufficient for the bounded detection-ready scope above. It is not approval for broad parser rollout, live source enrollment, direct GitHub collection, or non-audit telemetry expansion.
+
+## 4. Raw Payload References
 
 Representative raw payload references are stored in `control-plane/tests/fixtures/wazuh/`.
 
-The reviewed success-path reference in this package covers a GitHub repository privilege-change record.
+The reviewed success-path reference in this package covers a GitHub repository privilege-change record. It is the current parser/version evidence anchor for the approved detection-ready scope.
 
 Raw payload reference set:
 
@@ -32,9 +44,9 @@ Raw payload reference set:
 | ---- | ---- | ---- |
 | `github-audit-alert.json` | GitHub repository privilege change | Synthetic Wazuh alert shaped after a GitHub audit record; preserves accountable source identity, actor identity, target identity, repository and organization context, and privilege-change metadata. |
 
-All raw payload references in this package are synthetic review artifacts. They exist to anchor mapping review and replay validation, not to stand in for production enrollment evidence.
+All raw payload references in this package are synthetic review artifacts. They exist to anchor mapping review, replay validation, parser/version evidence, and detector-use scope review, not to stand in for production enrollment evidence.
 
-## 4. Normalization Mapping Summary
+## 5. Normalization Mapping Summary
 
 | Source-native evidence | Normalized target | Review status | Notes |
 | ---- | ---- | ---- | ---- |
@@ -43,9 +55,10 @@ All raw payload references in this package are synthetic review artifacts. They 
 | `data.target.*` | `identity.target` | Required | Target identity remains reviewable when the audit event names a user, team, role, or other impacted object. |
 | `data.organization.*`, `data.repository.*` | `asset.organization`, `asset.repository` | Required | Repository or organization context remains explicit and vendor-neutral. |
 | `data.privilege.*`, `data.audit_action` | `privilege.*` and `provenance.audit_action` | Required | Privilege-change metadata remains reviewable without turning the control plane into a GitHub API client. |
-| `rule.id`, `rule.level`, `rule.description`, `decoder.name`, `location`, `timestamp` | `provenance.*` | Required | Native Wazuh provenance remains preserved for later review and reconciliation. |
+| Workflow-administration action metadata when present in `data.audit_action` and related `data.*` fields | `provenance.audit_action` and reviewed event context | Required within approved scope | Workflow-administration signals are detection-ready only when the action, actor, target, repository or organization, timestamp, and Wazuh provenance remain explicit. |
+| `rule.id`, `rule.level`, `rule.description`, `decoder.name`, `location`, `timestamp` | `provenance.*`, `@timestamp`, `event.created` | Required | Native Wazuh provenance and source event time remain preserved for later review and reconciliation. |
 
-## 5. Field Coverage Verification
+## 6. Field Coverage Verification
 
 | Semantic area | Coverage status | Evidence or exception path |
 | ---- | ---- | ---- |
@@ -54,17 +67,58 @@ All raw payload references in this package are synthetic review artifacts. They 
 | Target identity | Required | Preserved through `data.target.*` and mapped into `identity.target`. |
 | Repository or organization context | Required | Preserved through `data.organization.*` and `data.repository.*` and mapped into `asset.*`. |
 | Privilege-change metadata | Required | Preserved through `data.privilege.*` and `data.audit_action`. |
-| Direct GitHub API actioning | Intentionally deferred | Not part of the reviewed source profile or control-plane intake behavior. |
-| Non-audit GitHub telemetry families | Unavailable | This package only reviews the GitHub audit family. |
+| Workflow-administration metadata | Required within approved scope | Detection-ready only when `data.audit_action` and related GitHub audit fields preserve the reviewed workflow-administration event, actor, target, repository or organization, timestamp, and provenance context. |
+| Timestamp quality | Required | Preserved through the Wazuh alert `timestamp`; collector-created and ingest-arrival timestamps require separate runtime evidence before detector activation can treat them as activation-gating fields. |
+| Parser version traceability | Required | Anchored to the reviewed Wazuh `github_audit` decoder identity, Wazuh rule metadata, and the `github-audit-alert.json` fixture shape until a versioned parser package supersedes it. |
+| Direct GitHub API actioning | Prohibited non-goal | Not part of the reviewed source profile or control-plane intake behavior. |
+| GitHub-owned case or workflow truth | Prohibited non-goal | AegisOps remains the authoritative control plane for case state, approval state, action state, and reconciliation. |
+| Non-audit GitHub telemetry families | Unavailable | This package only reviews the GitHub audit family. Non-audit source families require separate onboarding before detection content can depend on them. |
 
-## 6. Replay Fixture Plan
+No required baseline coverage is intentionally deferred for the approved detection-ready scope. Any detector that needs fields outside the rows above remains blocked until the onboarding package documents a reviewed exception path or a separate source-family package.
+
+## 7. Provenance Evidence
+
+Provenance Evidence: GitHub audit records remain detection-ready only when the Wazuh intake boundary preserves `rule.id`, `rule.level`, `rule.description`, `decoder.name`, `location`, `timestamp`, `manager.name`, and the GitHub audit `data.request_id` or equivalent source request context when present.
+
+The reviewed fixture preserves Wazuh manager identity, decoder identity, rule identity, rule severity, rule description, source location, event timestamp, source family, GitHub audit action, actor, target, organization, repository, privilege metadata, and request context.
+
+AegisOps treats those fields as source evidence for review and detector prerequisites. They do not make GitHub the authority for AegisOps case state, approval state, response state, or reconciliation outcomes.
+
+If accountable source identity, actor identity, target identity, repository or organization context, timestamp quality, parser evidence, or Wazuh provenance is missing or malformed, the event is outside the approved detection-ready scope unless a future reviewed exception path explicitly states otherwise.
+
+## 8. Replay Fixture Plan
 
 Replay fixtures are represented by `control-plane/tests/fixtures/wazuh/github-audit-alert.json`.
 
 The reviewed fixture is sufficient for future parser and mapping validation without claiming that live source onboarding is approved.
 
-## 7. Known Gaps and Non-Goals
+The fixture also anchors the current detector-use approval package by proving the source family can preserve identity, repository context, privilege context, timestamp, and provenance evidence for the bounded GitHub audit scope.
 
-This package remains `schema-reviewed` rather than `detection-ready` because parser version evidence, broader GitHub audit field coverage, and explicit detector-use approval remain future work.
+## 9. Detector-Use Approval and Limits
 
-The current review package does not introduce live source enrollment, credentials, parser rollout, direct GitHub API actioning, response automation, or any telemetry family beyond GitHub audit.
+Detector-Use Approval and Limits: GitHub audit is approved as a detection-ready source family only for future detection content whose source prerequisites fit the reviewed repository and organization audit scope documented here.
+
+Detector activation still requires separate rule review, rollout review, and Wazuh rule lifecycle validation.
+
+Approved detector-use prerequisites:
+
+- source family is GitHub audit through the Wazuh-backed intake boundary;
+- detector fields are limited to the reviewed field coverage and provenance evidence in this package;
+- the detector records false-positive expectations and analyst handling notes from the GitHub audit triage runbook;
+- production activation is separately reviewed under the detection lifecycle and Wazuh rule lifecycle documents; and
+- any missing prerequisite signal blocks detector-ready handling rather than being inferred from repository names, path shape, comments, or nearby metadata.
+
+Blocked detector-use paths:
+
+- direct GitHub API actioning or source-side mutation;
+- GitHub-owned case authority, approval state, action state, or workflow truth;
+- non-audit GitHub telemetry families;
+- detectors that need GitHub fields outside the reviewed coverage table without an explicit exception path;
+- detector activation without separate detector review; and
+- treating placeholder, malformed, or missing provenance as valid detector evidence.
+
+## 10. Known Gaps and Non-Goals
+
+This package is detection-ready only for the reviewed GitHub audit scope above. It does not claim unlimited GitHub audit coverage, broad GitHub telemetry coverage, source credential readiness, live enrollment approval, direct GitHub actioning, response automation, or production detector activation.
+
+The current review package does not introduce live source enrollment, credentials, parser rollout beyond the reviewed Wazuh-backed boundary, direct GitHub API actioning, response automation, GitHub-owned workflow truth, or any telemetry family beyond GitHub audit.

--- a/scripts/verify-phase-14-identity-rich-source-expansion-ci-validation.sh
+++ b/scripts/verify-phase-14-identity-rich-source-expansion-ci-validation.sh
@@ -196,7 +196,16 @@ done
 require_fixed_string "${github_onboarding_doc}" "Parser ownership remains with IT Operations, Information Systems Department."
 require_fixed_string "${github_onboarding_doc}" "The reviewed fixture is sufficient for future parser and mapping validation without claiming that live source onboarding is approved."
 require_fixed_string "${github_onboarding_doc}" "This package does not approve live GitHub API actioning, response automation, source-side credentials, or non-audit GitHub telemetry families."
+require_fixed_string "${github_onboarding_doc}" 'Readiness state: `detection-ready`'
+require_fixed_string "${github_onboarding_doc}" "Reviewed detection-ready scope: GitHub audit records admitted through the reviewed Wazuh-backed intake boundary for repository and organization privilege, access, and workflow-administration review signals."
+require_fixed_string "${github_onboarding_doc}" "Reviewed parser evidence source: Wazuh \`github_audit\` decoder evidence represented by \`decoder.name\`, Wazuh rule metadata, the reviewed \`github-audit-alert.json\` fixture, and the parser ownership boundary in this package."
+require_fixed_string "${github_onboarding_doc}" "Provenance Evidence: GitHub audit records remain detection-ready only when the Wazuh intake boundary preserves \`rule.id\`, \`rule.level\`, \`rule.description\`, \`decoder.name\`, \`location\`, \`timestamp\`, \`manager.name\`, and the GitHub audit \`data.request_id\` or equivalent source request context when present."
+require_fixed_string "${github_onboarding_doc}" "Detector-Use Approval and Limits: GitHub audit is approved as a detection-ready source family only for future detection content whose source prerequisites fit the reviewed repository and organization audit scope documented here."
+require_fixed_string "${github_onboarding_doc}" "Detector activation still requires separate rule review, rollout review, and Wazuh rule lifecycle validation."
 require_fixed_string "${github_runbook_doc}" "The runbook keeps GitHub audit handling inside the control-plane-first analyst workflow and makes the family-specific false-positive expectations, evidence requirements, and business-hours handling explicit."
+require_fixed_string "${github_runbook_doc}" "GitHub audit may support detector review only within the approved detection-ready scope in the onboarding package."
+require_fixed_string "${github_runbook_doc}" "Analysts must treat GitHub audit as source evidence for AegisOps review, not as GitHub-owned workflow truth or direct action authority."
+require_fixed_string "${github_runbook_doc}" "If accountable source identity, actor identity, target identity, repository or organization context, timestamp quality, parser evidence, or Wazuh provenance is missing or malformed, the analyst keeps the item out of detector-ready handling until the prerequisite is repaired or a documented exception path applies."
 
 require_fixed_string "${microsoft_onboarding_doc}" "Parser ownership remains with IT Operations, Information Systems Department."
 require_fixed_string "${microsoft_onboarding_doc}" "The reviewed fixture is sufficient for future parser and mapping validation without claiming that live source onboarding is approved."
@@ -210,6 +219,7 @@ require_fixed_string "${entra_runbook_doc}" "The runbook keeps Entra ID handling
 
 require_test_name "${profile_tests}" "test_phase14_onboarding_packages_define_reviewed_ownership_and_prerequisites"
 require_test_name "${profile_tests}" "test_phase14_family_triage_runbooks_define_the_reviewed_posture"
+require_test_name "${profile_tests}" "test_github_audit_detection_ready_package_requires_reviewed_evidence"
 require_test_name "${wazuh_tests}" "test_adapter_builds_reviewed_source_profile_for_github_audit_fixture"
 require_test_name "${wazuh_tests}" "test_adapter_builds_reviewed_source_profile_for_microsoft_365_audit_fixture"
 require_test_name "${wazuh_tests}" "test_adapter_builds_reviewed_source_profile_for_entra_id_fixture"


### PR DESCRIPTION
## Summary
- mark GitHub audit as detection-ready for a bounded Wazuh-backed repository and organization audit scope
- document parser/version evidence, field coverage, provenance evidence, detector-use approval, and blocked non-goals
- tighten analyst triage guidance and focused validation for the detection-ready claim

## Verification
- python3 -m unittest control-plane.tests.test_phase14_identity_rich_source_profile_docs
- bash scripts/verify-phase-14-identity-rich-source-expansion-ci-validation.sh
- node dist/index.js issue-lint 753 --config supervisor.config.aegisops.coderabbit.json
- git diff --check

Part of #752
Closes #753