### PR TITLE
Uplift Entra ID source profile to detection-ready

### DIFF
--- a/control-plane/tests/test_phase14_identity_rich_source_profile_docs.py
+++ b/control-plane/tests/test_phase14_identity_rich_source_profile_docs.py
@@ -85,8 +85,9 @@ class Phase14IdentityRichSourceProfileDocsTests(unittest.TestCase):
 
         for term in (
             "Entra ID Wazuh-Backed Source Profile Onboarding Package",
-            "Readiness state: `schema-reviewed`",
+            "Readiness state: `detection-ready`",
             "Wazuh-backed source profile",
+            "Reviewed detection-ready scope",
             "tenant context",
             "actor identity",
             "target identity",
@@ -223,9 +224,9 @@ class Phase14IdentityRichSourceProfileDocsTests(unittest.TestCase):
                 "entra-id",
                 entra_text,
                 (
-                    "Readiness state: `schema-reviewed`",
-                    "Versioned parser changes remain future implementation work.",
-                    "This package does not approve direct Entra ID actioning, non-audit Entra ID telemetry families, source-side credentials, or runtime automation.",
+                    "Readiness state: `detection-ready`",
+                    "Reviewed parser evidence source",
+                    "This package does not approve direct Entra ID actioning, directory changes, credential changes, source-side credentials, Entra ID-owned case authority, non-audit Entra ID telemetry families, or detector activation without separate detector review.",
                     "Entra ID privileged role assignment",
                     "Entra ID",
                 ),
@@ -280,6 +281,61 @@ class Phase14IdentityRichSourceProfileDocsTests(unittest.TestCase):
             self.assertIn(term, onboarding_text)
         for term in required_runbook_terms:
             self.assertIn(term, runbook_text)
+
+    def test_phase34_entra_id_is_the_only_second_detection_ready_family(
+        self,
+    ) -> None:
+        entra_onboarding_text = (
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "entra-id"
+            / "onboarding-package.md"
+        ).read_text(encoding="utf-8")
+        entra_runbook_text = (
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "entra-id"
+            / "analyst-triage-runbook.md"
+        ).read_text(encoding="utf-8")
+        microsoft_onboarding_text = (
+            REPO_ROOT
+            / "docs"
+            / "source-families"
+            / "microsoft-365-audit"
+            / "onboarding-package.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Readiness state: `detection-ready`", entra_onboarding_text)
+        self.assertIn("Readiness state: `schema-reviewed`", microsoft_onboarding_text)
+        self.assertNotIn("Readiness state: `detection-ready`", microsoft_onboarding_text)
+
+        required_onboarding_terms = (
+            "Phase 34 selects Entra ID as the second detection-ready family because it already has the clearer reviewed multi-source evidence path from the approved Entra ID case-admission slice.",
+            "Reviewed detection-ready scope",
+            "Parser and Version Evidence",
+            "Reviewed parser evidence source",
+            "Field Coverage Verification",
+            "Provenance Evidence",
+            "Detector-Use Approval and Limits",
+            "Future detection content may reference Entra ID only for tenant, directory, authentication, and privilege-change review signals that preserve accountable source identity, actor identity, target identity, timestamp quality, and Wazuh provenance.",
+            "Detector activation still requires separate rule review, rollout review, and Wazuh rule lifecycle validation.",
+            "This package does not approve direct Entra ID actioning, directory changes, credential changes, source-side credentials, Entra ID-owned case authority, non-audit Entra ID telemetry families, or detector activation without separate detector review.",
+        )
+        required_runbook_terms = (
+            "Detector-use handling",
+            "Entra ID may support detector review only within the approved detection-ready scope in the onboarding package.",
+            "Analysts must treat Entra ID as source evidence for AegisOps review, not as Entra ID-owned workflow truth or direct action authority.",
+            "Family-specific false-positive review",
+            "Provenance handling",
+            "If accountable source identity, actor identity, target identity, tenant context, timestamp quality, parser evidence, or Wazuh provenance is missing or malformed, the analyst keeps the item out of detector-ready handling until the prerequisite is repaired or a documented exception path applies.",
+        )
+
+        for term in required_onboarding_terms:
+            self.assertIn(term, entra_onboarding_text)
+        for term in required_runbook_terms:
+            self.assertIn(term, entra_runbook_text)
 
 
 if __name__ == "__main__":

--- a/docs/source-families/entra-id/analyst-triage-runbook.md
+++ b/docs/source-families/entra-id/analyst-triage-runbook.md
@@ -14,7 +14,7 @@ This runbook applies to reviewed Entra ID alerts and cases that enter AegisOps t
 
 It covers read-oriented triage, evidence capture, disposition decisions, and fixture refresh expectations for the reviewed Entra ID source profile.
 
-Direct Entra ID actioning remains out of scope. This runbook does not authorize directory changes, credential changes, source-side credentials, or any unsupported source family.
+Direct Entra ID actioning remains out of scope. This runbook does not authorize directory changes, credential changes, source-side credentials, detector activation, Entra ID-owned case authority, or any unsupported source family.
 
 It also does not replace the source onboarding contract or the Wazuh rule lifecycle runbook. Those documents remain authoritative for onboarding evidence and rule-change validation.
 
@@ -44,7 +44,39 @@ Analysts must not assume that every Entra ID alert indicates malicious activity.
 
 Unsupported Entra ID telemetry families remain out of scope. Direct vendor-local actioning remains out of scope even when a directory event looks urgent.
 
-## 5. Evidence to Collect
+## 5. Detector-use handling
+
+Entra ID may support detector review only within the approved detection-ready scope in the onboarding package.
+
+Future detector-use review must confirm that the event is a reviewed Entra ID audit signal entering through the Wazuh-backed intake boundary and that the detector depends only on reviewed field coverage, parser evidence, timestamp quality, and Wazuh provenance.
+
+Analysts must treat Entra ID as source evidence for AegisOps review, not as Entra ID-owned workflow truth or direct action authority.
+
+Detector-ready handling remains blocked when the event depends on direct Entra ID actioning, non-audit Entra ID telemetry, tenant or directory-object naming conventions alone, untrusted forwarded identity, placeholder credentials, missing parser evidence, or missing provenance.
+
+Detector activation still requires separate detector review, rollout review, and Wazuh rule lifecycle validation. The runbook does not let a detection-ready source-family package bypass rule QA, staging, expected-volume review, false-positive review, or production activation approval.
+
+## 6. Family-specific false-positive review
+
+Family-specific false-positive review must remain visible in each triage record and each future detector review that depends on Entra ID.
+
+Reviewers should compare the event against routine directory administration, approved identity operations, reviewed service identity behavior, role assignment maintenance, app registration maintenance, credential lifecycle work, scheduled change windows, and business-hours operating expectations before escalating.
+
+False-positive notes must state why the event is benign, suspicious, deferred, or still ambiguous. They must also state whether the explanation comes from reviewed AegisOps records, an approved change-management path, or read-oriented Entra ID audit evidence.
+
+Analysts must not suppress or downgrade an event solely because the actor, tenant, group, role, app, or target object name looks familiar. The benign explanation needs an explicit reviewed linkage to the authoritative scope record or the item remains queued for review.
+
+## 7. Provenance handling
+
+Provenance handling starts from the reviewed Wazuh boundary and the Entra ID onboarding package, not from directory-authored text as independent authority.
+
+The analyst preserves Wazuh manager identity, decoder identity, rule identity, rule severity, rule description, source location, event timestamp, source family, Entra ID audit action, actor, target, tenant, app or service-principal context, authentication context, privilege context, correlation id, and request context when present.
+
+If accountable source identity, actor identity, target identity, tenant context, timestamp quality, parser evidence, or Wazuh provenance is missing or malformed, the analyst keeps the item out of detector-ready handling until the prerequisite is repaired or a documented exception path applies.
+
+Missing or malformed provenance is not treated as a reason to infer success from tenant names, directory object names, comments, nearby metadata, or raw vendor-authored prose. The analyst records the gap and keeps the AegisOps control-plane guard in place.
+
+## 8. Evidence to Collect
 
 The analyst captures read-oriented evidence that answers what changed, who or what changed it, which target object was affected, and why the item is or is not interesting.
 
@@ -52,16 +84,18 @@ At minimum, the analyst records:
 
 - the reviewed Entra ID event summary;
 - the accountable source identity and delivery path;
+- Wazuh manager, decoder, rule, location, timestamp, and parser evidence used for detector-ready handling;
 - the actor identity, including whether it was a human, service principal, managed identity, or other automation identity when present;
 - the target object, user, group, role assignment, app registration, credential object, or policy context;
 - the tenant, directory, authentication, and correlation context;
 - the privilege or access change context, if any;
+- the family-specific false-positive review outcome;
 - the raw payload or fixture reference used for review; and
 - the reason the event is benign, escalated, or deferred.
 
 The reviewer should keep evidence aligned with `docs/source-onboarding-contract.md` and the reviewed Entra ID onboarding package. If a new reviewed alert shape appears, the corresponding fixture under `control-plane/tests/fixtures/wazuh/entra-id-alert.json` and the related Wazuh rule lifecycle evidence must be refreshed before downstream workflow assumptions change.
 
-## 6. Business-Hours Handling
+## 9. Business-Hours Handling
 
 This runbook follows the Business-hours SecOps daily operating model.
 
@@ -71,7 +105,7 @@ If an item appears to require escalation, the analyst records the reason, the af
 
 After-hours handling remains explicit and bounded. The reviewed path does not imply 24x7 analyst watchstanding, and it does not authorize vendor-local actioning or automatic enforcement.
 
-## 7. Validation and Fixture Expectations
+## 10. Validation and Fixture Expectations
 
 The reviewer treats the reviewed Entra ID fixture as the canonical replay reference for this family.
 
@@ -79,8 +113,8 @@ Any new reviewed Entra ID rule shape, provenance expectation, or identity branch
 
 The analyst triage record should note whether the current fixture set still explains the alert clearly, whether the event remains compatible with the control-plane-first analyst workflow, and whether a new fixture or mapping update is required.
 
-## 8. Baseline Alignment Notes
+## 11. Baseline Alignment Notes
 
-This runbook remains aligned with `docs/source-onboarding-contract.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
+This runbook remains aligned with `docs/source-onboarding-contract.md`, `docs/detection-lifecycle-and-rule-qa-framework.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
 
-It preserves the Wazuh-backed source boundary, keeps false-positive expectations explicit, and avoids any promise of production expansion beyond the reviewed Entra ID family.
+It preserves the Wazuh-backed source boundary, keeps false-positive expectations explicit, keeps detector-use approval separate from detector activation, and avoids any promise of production expansion beyond the reviewed Entra ID family.

--- a/docs/source-families/entra-id/onboarding-package.md
+++ b/docs/source-families/entra-id/onboarding-package.md
@@ -2,13 +2,21 @@
 
 ## 1. Family Scope and Readiness State
 
-Readiness state: `schema-reviewed`
+Readiness state: `detection-ready`
 
 The approved Phase 14 source family is Entra ID.
 
 This package documents the reviewed Wazuh-backed source profile for Entra ID alerts entering AegisOps as vendor-neutral analytic signals.
 
+Phase 34 selects Entra ID as the second detection-ready family because it already has the clearer reviewed multi-source evidence path from the approved Entra ID case-admission slice.
+
+Reviewed detection-ready scope: Entra ID audit records admitted through the reviewed Wazuh-backed intake boundary for tenant, directory, authentication, and privilege-change review signals.
+
 It preserves tenant context, actor identity, target identity, authentication context, privilege-change metadata, and directory provenance in the shared control-plane language.
+
+Future detection content may reference Entra ID only for tenant, directory, authentication, and privilege-change review signals that preserve accountable source identity, actor identity, target identity, timestamp quality, and Wazuh provenance.
+
+This package does not approve direct Entra ID actioning, directory changes, credential changes, source-side credentials, Entra ID-owned case authority, non-audit Entra ID telemetry families, or detector activation without separate detector review.
 
 This package does not approve direct Entra ID actioning, non-audit Entra ID telemetry families, source-side credentials, or runtime automation.
 
@@ -16,15 +24,21 @@ This package does not approve direct Entra ID actioning, non-audit Entra ID tele
 
 Parser ownership remains with IT Operations, Information Systems Department.
 
-The parser implementation boundary is the reviewed Wazuh intake handling that preserves Entra ID tenant context, actor identity, target identity, authentication context, privilege metadata, and directory provenance.
+The parser implementation boundary is the reviewed Wazuh intake handling that preserves Entra ID tenant context, actor identity, target identity, authentication context, privilege metadata, timestamp quality, and directory provenance.
 
-Versioned parser changes remain future implementation work. Until a parser exists, this package treats the reviewed fixture and mapping notes as the review baseline that future parser work must satisfy.
+## 3. Parser and Version Evidence
 
-## 3. Raw Payload References
+Reviewed parser evidence source: Wazuh `entra_id` decoder evidence represented by `decoder.name`, Wazuh rule metadata, the reviewed `entra-id-alert.json` fixture, the Phase 25 reviewed Entra ID case-admission slice, and the parser ownership boundary in this package.
+
+Reviewed parser version evidence: the approved detection-ready scope is pinned to the documented Wazuh-backed fixture shape and the `entra_id` decoder identity until a separately reviewed parser package introduces a stronger semantic version. Parser or decoder changes that alter source field names, timestamp semantics, identity mapping, tenant mapping, directory-object mapping, or provenance mapping must refresh this package before detector dependencies can rely on the changed shape.
+
+This parser/version evidence is sufficient for the bounded detection-ready scope above. It is not approval for broad parser rollout, live source enrollment, direct Entra ID collection, or non-audit telemetry expansion.
+
+## 4. Raw Payload References
 
 Representative raw payload references are stored in `control-plane/tests/fixtures/wazuh/`.
 
-The reviewed success-path reference in this package covers a privileged role assignment record.
+The reviewed success-path reference in this package covers an Entra ID privileged role assignment record. It is the current parser/version evidence anchor for the approved detection-ready scope.
 
 Raw payload reference set:
 
@@ -32,12 +46,12 @@ Raw payload reference set:
 | ---- | ---- | ---- |
 | `entra-id-alert.json` | Entra ID privileged role assignment | Synthetic Wazuh alert shaped after an Entra ID audit record; preserves tenant context, actor identity, target identity, authentication context, directory provenance, and privilege-change metadata. |
 
-All raw payload references in this package are synthetic review artifacts. They exist to anchor mapping review and replay validation, not to stand in for production enrollment evidence.
+All raw payload references in this package are synthetic review artifacts. They exist to anchor mapping review, replay validation, parser/version evidence, and detector-use scope review, not to stand in for production enrollment evidence.
 
-## 4. Normalization Mapping Summary
+## 5. Normalization Mapping Summary
 
 | Source-native evidence | Normalized target | Review status | Notes |
-| ---- | ---- | ---- |
+| ---- | ---- | ---- | ---- |
 | `manager.name`, `agent.id` when present | `source.accountable_source_identity` | Required | Wazuh remains the reviewed intake boundary, and the accountable source identity must stay explicit. |
 | `data.actor.*` | `identity.actor` | Required | Actor identity remains reviewable for triage and recommendation. |
 | `data.target.*` | `identity.target` | Required | Target identity remains reviewable when the audit event names a user, group, role assignment, app registration, credential object, or policy object. |
@@ -45,28 +59,69 @@ All raw payload references in this package are synthetic review artifacts. They 
 | `data.app.*` | `asset.app` | Required | App or service-principal context remains explicit without collapsing it into a source-local vendor label. |
 | `data.authentication.*` | `authentication.*` | Required | Authentication context remains reviewable without implying direct directory enforcement. |
 | `data.privilege.*`, `data.audit_action`, `data.correlation_id`, `data.operation`, `data.record_type` | `privilege.*` and `provenance.*` | Required | Privilege-change metadata, correlation identifiers, and directory provenance remain reviewable without turning the control plane into an Entra ID API client. |
-| `rule.id`, `rule.level`, `rule.description`, `decoder.name`, `location`, `timestamp` | `provenance.*` | Required | Native Wazuh provenance remains preserved for later review and reconciliation. |
+| `rule.id`, `rule.level`, `rule.description`, `decoder.name`, `location`, `timestamp` | `provenance.*`, `@timestamp`, `event.created` | Required | Native Wazuh provenance and source event time remain preserved for later review and reconciliation. |
 
-## 5. Field Coverage Verification
+## 6. Field Coverage Verification
 
 | Semantic area | Coverage status | Evidence or exception path |
 | ---- | ---- | ---- |
+| Accountable source identity | Required | Preserved through `manager.name` in the reviewed Wazuh alert and surfaced as `source.accountable_source_identity`. |
 | Tenant context and directory boundary | Required | Preserved through `data.tenant.*` in the reviewed fixture. |
 | Actor identity and target identity | Required | Preserved through `data.actor.*` and `data.target.*` and mapped into `identity.*`. |
 | Authentication context | Required | Preserved through `data.authentication.*` and mapped into `authentication.*`. |
 | App context | Required | Preserved through `data.app.*` and mapped into `asset.app`. |
 | Privilege-change metadata | Required | Preserved through `data.privilege.*`, `data.audit_action`, and `data.operation`. |
-| Direct Entra ID actioning | Intentionally deferred | Not part of the reviewed source profile or control-plane intake behavior. |
-| Non-audit Entra ID telemetry families | Unavailable | This package only reviews the Entra ID family. |
+| Timestamp quality | Required | Preserved through the Wazuh alert `timestamp`; collector-created and ingest-arrival timestamps require separate runtime evidence before detector activation can treat them as activation-gating fields. |
+| Parser version traceability | Required | Anchored to the reviewed Wazuh `entra_id` decoder identity, Wazuh rule metadata, and the `entra-id-alert.json` fixture shape until a versioned parser package supersedes it. |
+| Direct Entra ID actioning | Prohibited non-goal | Not part of the reviewed source profile or control-plane intake behavior. |
+| Entra ID-owned case or workflow truth | Prohibited non-goal | AegisOps remains the authoritative control plane for case state, approval state, action state, and reconciliation. |
+| Non-audit Entra ID telemetry families | Unavailable | This package only reviews the Entra ID audit family. Non-audit source families require separate onboarding before detection content can depend on them. |
 
-## 6. Replay Fixture Plan
+No required baseline coverage is intentionally deferred for the approved detection-ready scope. Any detector that needs fields outside the rows above remains blocked until the onboarding package documents a reviewed exception path or a separate source-family package.
+
+## 7. Provenance Evidence
+
+Provenance Evidence: Entra ID records remain detection-ready only when the Wazuh intake boundary preserves `rule.id`, `rule.level`, `rule.description`, `decoder.name`, `location`, `timestamp`, `manager.name`, and the Entra ID `data.request_id` or `data.correlation_id` source request context when present.
+
+The reviewed fixture preserves Wazuh manager identity, decoder identity, rule identity, rule severity, rule description, source location, event timestamp, source family, Entra ID audit action, actor, target, tenant, app or service-principal context, authentication context, privilege metadata, correlation id, and request context.
+
+AegisOps treats those fields as source evidence for review and detector prerequisites. They do not make Entra ID the authority for AegisOps case state, approval state, response state, or reconciliation outcomes.
+
+If accountable source identity, actor identity, target identity, tenant context, timestamp quality, parser evidence, or Wazuh provenance is missing or malformed, the event is outside the approved detection-ready scope unless a future reviewed exception path explicitly states otherwise.
+
+## 8. Replay Fixture Plan
 
 Replay fixtures are represented by `control-plane/tests/fixtures/wazuh/entra-id-alert.json`.
 
 The reviewed fixture is sufficient for future parser and mapping validation without claiming that live source onboarding is approved.
 
-## 7. Known Gaps and Non-Goals
+The fixture also anchors the current detector-use approval package by proving the source family can preserve tenant context, actor identity, target identity, authentication context, privilege context, timestamp, and provenance evidence for the bounded Entra ID scope.
 
-This package remains `schema-reviewed` rather than `detection-ready` because parser version evidence, broader Entra ID field coverage, and explicit detector-use approval remain future work.
+## 9. Detector-Use Approval and Limits
 
-The current review package does not introduce live source enrollment, credentials, parser rollout, direct Entra ID actioning, runtime automation, or any telemetry family beyond Entra ID.
+Detector-Use Approval and Limits: Entra ID is approved as a detection-ready source family only for future detection content whose source prerequisites fit the reviewed tenant, directory, authentication, and privilege-change audit scope documented here.
+
+Detector activation still requires separate rule review, rollout review, and Wazuh rule lifecycle validation.
+
+Approved detector-use prerequisites:
+
+- source family is Entra ID through the Wazuh-backed intake boundary;
+- detector fields are limited to the reviewed field coverage and provenance evidence in this package;
+- the detector records false-positive expectations and analyst handling notes from the Entra ID triage runbook;
+- production activation is separately reviewed under the detection lifecycle and Wazuh rule lifecycle documents; and
+- any missing prerequisite signal blocks detector-ready handling rather than being inferred from tenant names, directory object names, comments, or nearby metadata.
+
+Blocked detector-use paths:
+
+- direct Entra ID actioning or source-side mutation;
+- Entra ID-owned case authority, approval state, action state, or workflow truth;
+- non-audit Entra ID telemetry families;
+- detectors that need Entra ID fields outside the reviewed coverage table without an explicit exception path;
+- detector activation without separate detector review; and
+- treating placeholder, malformed, or missing provenance as valid detector evidence.
+
+## 10. Known Gaps and Non-Goals
+
+This package is detection-ready only for the reviewed Entra ID scope above. It does not claim unlimited Entra ID coverage, broad Microsoft cloud telemetry coverage, source credential readiness, live enrollment approval, direct Entra ID actioning, response automation, or production detector activation.
+
+The current review package does not introduce live source enrollment, credentials, parser rollout beyond the reviewed Wazuh-backed boundary, direct Entra ID actioning, response automation, Entra ID-owned workflow truth, or any telemetry family beyond Entra ID audit.

--- a/scripts/verify-phase-34-identity-rich-detection-ready-family.sh
+++ b/scripts/verify-phase-34-identity-rich-detection-ready-family.sh
@@ -8,6 +8,7 @@ repo_root="${1:-${default_repo_root}}"
 
 entra_onboarding_doc="${repo_root}/docs/source-families/entra-id/onboarding-package.md"
 entra_runbook_doc="${repo_root}/docs/source-families/entra-id/analyst-triage-runbook.md"
+github_onboarding_doc="${repo_root}/docs/source-families/github-audit/onboarding-package.md"
 microsoft_onboarding_doc="${repo_root}/docs/source-families/microsoft-365-audit/onboarding-package.md"
 profile_tests="${repo_root}/control-plane/tests/test_phase14_identity_rich_source_profile_docs.py"
 
@@ -90,9 +91,11 @@ PY
 
 require_file "${entra_onboarding_doc}" "Missing Entra ID onboarding package"
 require_file "${entra_runbook_doc}" "Missing Entra ID triage runbook"
+require_file "${github_onboarding_doc}" "Missing GitHub audit onboarding package"
 require_file "${microsoft_onboarding_doc}" "Missing Microsoft 365 audit onboarding package"
 require_file "${profile_tests}" "Missing identity-rich source profile docs tests"
 
+require_fixed_string "${github_onboarding_doc}" 'Readiness state: `detection-ready`'
 require_fixed_string "${entra_onboarding_doc}" 'Readiness state: `detection-ready`'
 require_fixed_string "${microsoft_onboarding_doc}" 'Readiness state: `schema-reviewed`'
 

--- a/scripts/verify-phase-34-identity-rich-detection-ready-family.sh
+++ b/scripts/verify-phase-34-identity-rich-detection-ready-family.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+default_repo_root="$(cd "${script_dir}/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+entra_onboarding_doc="${repo_root}/docs/source-families/entra-id/onboarding-package.md"
+entra_runbook_doc="${repo_root}/docs/source-families/entra-id/analyst-triage-runbook.md"
+microsoft_onboarding_doc="${repo_root}/docs/source-families/microsoft-365-audit/onboarding-package.md"
+profile_tests="${repo_root}/control-plane/tests/test_phase14_identity_rich_source_profile_docs.py"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_fixed_string() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fqx -- "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required line in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_contains() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "${expected}" "${file_path}" >/dev/null; then
+    echo "Missing required text in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_test_name() {
+  local file_path="$1"
+  local test_name="$2"
+
+  if ! python3 - "${file_path}" "${test_name}" <<'PY'
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+
+def base_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = base_name(node.value)
+        if parent is None:
+            return None
+        return f"{parent}.{node.attr}"
+    return None
+
+
+target_path = pathlib.Path(sys.argv[1])
+target_test = sys.argv[2]
+tree = ast.parse(target_path.read_text(encoding="utf-8"))
+
+for node in tree.body:
+    if not isinstance(node, ast.ClassDef):
+        continue
+    bases = {name for base in node.bases if (name := base_name(base))}
+    if "unittest.TestCase" not in bases:
+        continue
+    if any(
+        isinstance(child, ast.FunctionDef) and child.name == target_test
+        for child in node.body
+    ):
+        raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+  then
+    echo "Missing required Phase 34 unittest-discoverable test in ${file_path}: ${test_name}" >&2
+    exit 1
+  fi
+}
+
+require_file "${entra_onboarding_doc}" "Missing Entra ID onboarding package"
+require_file "${entra_runbook_doc}" "Missing Entra ID triage runbook"
+require_file "${microsoft_onboarding_doc}" "Missing Microsoft 365 audit onboarding package"
+require_file "${profile_tests}" "Missing identity-rich source profile docs tests"
+
+require_fixed_string "${entra_onboarding_doc}" 'Readiness state: `detection-ready`'
+require_fixed_string "${microsoft_onboarding_doc}" 'Readiness state: `schema-reviewed`'
+
+if grep -Fqx -- 'Readiness state: `detection-ready`' "${microsoft_onboarding_doc}" >/dev/null; then
+  echo "Microsoft 365 audit must not be silently uplifted to detection-ready in Phase 34." >&2
+  exit 1
+fi
+
+required_onboarding_text=(
+  "Phase 34 selects Entra ID as the second detection-ready family because it already has the clearer reviewed multi-source evidence path from the approved Entra ID case-admission slice."
+  "Reviewed detection-ready scope: Entra ID audit records admitted through the reviewed Wazuh-backed intake boundary for tenant, directory, authentication, and privilege-change review signals."
+  "Reviewed parser evidence source: Wazuh \`entra_id\` decoder evidence represented by \`decoder.name\`, Wazuh rule metadata, the reviewed \`entra-id-alert.json\` fixture, the Phase 25 reviewed Entra ID case-admission slice, and the parser ownership boundary in this package."
+  "Provenance Evidence: Entra ID records remain detection-ready only when the Wazuh intake boundary preserves \`rule.id\`, \`rule.level\`, \`rule.description\`, \`decoder.name\`, \`location\`, \`timestamp\`, \`manager.name\`, and the Entra ID \`data.request_id\` or \`data.correlation_id\` source request context when present."
+  "Detector-Use Approval and Limits: Entra ID is approved as a detection-ready source family only for future detection content whose source prerequisites fit the reviewed tenant, directory, authentication, and privilege-change audit scope documented here."
+  "Detector activation still requires separate rule review, rollout review, and Wazuh rule lifecycle validation."
+)
+
+for expected in "${required_onboarding_text[@]}"; do
+  require_fixed_string "${entra_onboarding_doc}" "${expected}"
+done
+
+required_runbook_text=(
+  "Entra ID may support detector review only within the approved detection-ready scope in the onboarding package."
+  "Analysts must treat Entra ID as source evidence for AegisOps review, not as Entra ID-owned workflow truth or direct action authority."
+  "If accountable source identity, actor identity, target identity, tenant context, timestamp quality, parser evidence, or Wazuh provenance is missing or malformed, the analyst keeps the item out of detector-ready handling until the prerequisite is repaired or a documented exception path applies."
+  "Family-specific false-positive review must remain visible in each triage record and each future detector review that depends on Entra ID."
+)
+
+for expected in "${required_runbook_text[@]}"; do
+  require_fixed_string "${entra_runbook_doc}" "${expected}"
+done
+
+require_contains "${microsoft_onboarding_doc}" "This package remains \`schema-reviewed\` rather than \`detection-ready\` because parser version evidence, broader Microsoft 365 audit field coverage, and explicit detector-use approval remain future work."
+require_test_name "${profile_tests}" "test_phase34_entra_id_is_the_only_second_detection_ready_family"
+
+echo "Phase 34 identity-rich detection-ready source family validation remains reviewable and fail closed."


### PR DESCRIPTION
## Summary
- Select Entra ID as the Phase 34 second detection-ready identity-rich family and leave Microsoft 365 audit schema-reviewed
- Add parser/version, field coverage, provenance, detector-use approval, limits, and exception-path language to the Entra ID onboarding package
- Extend the Entra ID triage runbook with detector-use, false-positive, and provenance handling guidance
- Add focused Phase 34 validation to prevent a silent Microsoft 365 audit uplift

## Verification
- `python3 -m unittest control-plane.tests.test_phase14_identity_rich_source_profile_docs`
- `bash scripts/verify-phase-34-identity-rich-detection-ready-family.sh`
- `bash scripts/verify-phase-14-identity-rich-source-expansion-ci-validation.sh`
- `python3 -m unittest control-plane.tests.test_wazuh_adapter control-plane.tests.test_service_persistence_ingest_case_lifecycle control-plane.tests.test_cli_inspection`
- `node dist/index.js issue-lint 754 --config <supervisor-config-path>`

Closes #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Entra ID onboarding to "detection-ready" status with enhanced constraints on detector use and case authority ownership.
  * Expanded triage runbook with stricter provenance handling, false-positive capture rules, and evidence collection requirements.

* **Tests**
  * Added validation for cross-family detection-ready readiness enforcement.

* **Chores**
  * Added verification script to enforce Phase 34 readiness requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->