### PR TITLE
[codex] Document Windows endpoint detection blockers

### DIFF
--- a/docs/source-families/windows-security-and-endpoint/onboarding-package.md
+++ b/docs/source-families/windows-security-and-endpoint/onboarding-package.md
@@ -73,7 +73,22 @@ This package remains `schema-reviewed`, so the classifications above are evidenc
 
 Within the reviewed Phase 6 slice, `schema-reviewed` evidence is sufficient only for staging translation review against the documented success-path fixtures. Production activation remains blocked until the family reaches `detection-ready` for any rule dependency classified as activation-gating.
 
-## 6. Replay Fixture Plan
+## 6. Detection-Ready Blocker Inventory
+
+Detection-ready approval remains blocked for this family until the reviewed blockers below are resolved or a separately approved exception path states the bounded detector-use scope.
+
+| Blocker | Detector-use impact | Resolution required before approval |
+| ---- | ---- | ---- |
+| Missing actor attribution for edge-case records | Blocks actor-dependent detections | Parser and mapping evidence must preserve authoritative actor identity when present and must explicitly reject or mark records where the actor cannot be trusted. |
+| Process lineage and command-line gap | Blocks process-dependent detections | Reviewed Windows endpoint evidence must provide credible `process.*`, `process.parent.*`, `process.command_line`, and `related.process` coverage before detections depend on lineage or command execution context. |
+| Remote-network context gap | Blocks remote-access and lateral-movement detections | Reviewed source evidence must provide credible `source.*`, `destination.*`, and `related.ip` coverage before detections depend on remote origin, destination, or lateral movement network context. |
+| Parser version and broader Windows event coverage evidence | Blocks source-family detection-ready promotion | A reviewed parser/version anchor and field-by-field sign-off across the intended Windows event range must be documented before this family can move beyond `schema-reviewed`. |
+
+Downstream detections must not depend on unresolved `user.*` actor fields, `process.*` lineage fields, `related.process`, `source.*`, `destination.*`, or `related.ip` coverage from this family until the blocker inventory is updated by review.
+
+The existing Phase 6 detector artifacts remain staging-only review artifacts and do not approve production detector use for any unresolved blocker above.
+
+## 7. Replay Fixture Plan
 
 Replay fixtures are stored under `ingest/replay/windows-security-and-endpoint/normalized/`.
 
@@ -90,7 +105,7 @@ The `edge.ndjson` corpus contains reviewed edge cases that future parser validat
 
 The raw and normalized fixtures together are sufficient for future parser and mapping validation without claiming that the family is already detection-ready.
 
-## 7. Known Gaps and Non-Goals
+## 8. Known Gaps and Non-Goals
 
 This package remains `schema-reviewed` rather than `detection-ready` because parser version evidence, field-by-field coverage sign-off across a broader Windows event range, and explicit detector-use approval remain future work.
 

--- a/scripts/test-verify-windows-source-onboarding-assets.sh
+++ b/scripts/test-verify-windows-source-onboarding-assets.sh
@@ -69,11 +69,26 @@ The field coverage matrix below classifies the reviewed Windows semantic areas a
 | Related user, host, IP, and process correlation fields | Required derived coverage | related.user and related.hosts are present where supported, and related.ip or related.process are omitted because the reviewed source records do not credibly expose them. |
 | AegisOps-specific provenance annotations under aegisops.* | Required derived coverage | Covered by aegisops.provenance.* and aegisops.validation.* in the normalized fixtures. |
 
-## 6. Replay Fixture Plan
+## 6. Detection-Ready Blocker Inventory
+
+Detection-ready approval remains blocked for this family until the reviewed blockers below are resolved or a separately approved exception path states the bounded detector-use scope.
+
+| Blocker | Detector-use impact | Resolution required before approval |
+| ---- | ---- | ---- |
+| Missing actor attribution for edge-case records | Blocks actor-dependent detections | Parser and mapping evidence must preserve authoritative actor identity when present and must explicitly reject or mark records where the actor cannot be trusted. |
+| Process lineage and command-line gap | Blocks process-dependent detections | Reviewed Windows endpoint evidence must provide credible process.*, process.parent.*, process.command_line, and related.process coverage before detections depend on lineage or command execution context. |
+| Remote-network context gap | Blocks remote-access and lateral-movement detections | Reviewed source evidence must provide credible source.*, destination.*, and related.ip coverage before detections depend on remote origin, destination, or lateral movement network context. |
+| Parser version and broader Windows event coverage evidence | Blocks source-family detection-ready promotion | A reviewed parser/version anchor and field-by-field sign-off across the intended Windows event range must be documented before this family can move beyond schema-reviewed. |
+
+Downstream detections must not depend on unresolved `user.*` actor fields, `process.*` lineage fields, `related.process`, `source.*`, `destination.*`, or `related.ip` coverage from this family until the blocker inventory is updated by review.
+
+The existing Phase 6 detector artifacts remain staging-only review artifacts and do not approve production detector use for any unresolved blocker above.
+
+## 7. Replay Fixture Plan
 
 Replay fixtures are stored under `ingest/replay/windows-security-and-endpoint/normalized/`.
 
-## 7. Known Gaps and Non-Goals
+## 8. Known Gaps and Non-Goals
 
 No live rollout is included in this review package.' >"${target}/docs/source-families/windows-security-and-endpoint/onboarding-package.md"
 
@@ -176,11 +191,43 @@ import sys
 path = Path(sys.argv[1])
 text = path.read_text()
 start = text.index("## 5. Field Coverage Verification")
-end = text.index("## 6. Replay Fixture Plan")
+end = text.index("## 6. Detection-Ready Blocker Inventory")
 path.write_text(text[:start] + text[end:])
 PY
 git -C "${missing_coverage_repo}" add .
 commit_fixture "${missing_coverage_repo}"
 assert_fails_with "${missing_coverage_repo}" "Missing Windows onboarding package heading: ## 5. Field Coverage Verification"
+
+missing_blocker_inventory_repo="${workdir}/missing-blocker-inventory"
+create_repo "${missing_blocker_inventory_repo}"
+write_valid_assets "${missing_blocker_inventory_repo}"
+python3 - <<'PY' "${missing_blocker_inventory_repo}/docs/source-families/windows-security-and-endpoint/onboarding-package.md"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+start = text.index("## 6. Detection-Ready Blocker Inventory")
+end = text.index("## 7. Replay Fixture Plan")
+path.write_text(text[:start] + text[end:])
+PY
+git -C "${missing_blocker_inventory_repo}" add .
+commit_fixture "${missing_blocker_inventory_repo}"
+assert_fails_with "${missing_blocker_inventory_repo}" "Missing Windows onboarding package heading: ## 6. Detection-Ready Blocker Inventory"
+
+detection_ready_claim_repo="${workdir}/detection-ready-claim"
+create_repo "${detection_ready_claim_repo}"
+write_valid_assets "${detection_ready_claim_repo}"
+python3 - <<'PY' "${detection_ready_claim_repo}/docs/source-families/windows-security-and-endpoint/onboarding-package.md"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text().replace("Readiness state: `schema-reviewed`", "Readiness state: `detection-ready`")
+path.write_text(text)
+PY
+git -C "${detection_ready_claim_repo}" add .
+commit_fixture "${detection_ready_claim_repo}"
+assert_fails_with "${detection_ready_claim_repo}" "Windows security and endpoint must remain schema-reviewed unless blocker resolution or approved exception paths are documented."
 
 echo "Windows source onboarding asset verifier tests passed."

--- a/scripts/verify-windows-source-onboarding-assets.sh
+++ b/scripts/verify-windows-source-onboarding-assets.sh
@@ -26,8 +26,9 @@ required_doc_headings=(
   "## 3. Raw Payload References"
   "## 4. Normalization Mapping Summary"
   "## 5. Field Coverage Verification"
-  "## 6. Replay Fixture Plan"
-  "## 7. Known Gaps and Non-Goals"
+  "## 6. Detection-Ready Blocker Inventory"
+  "## 7. Replay Fixture Plan"
+  "## 8. Known Gaps and Non-Goals"
 )
 
 required_doc_phrases=(
@@ -52,6 +53,12 @@ required_doc_phrases=(
   "The missing-actor edge fixture documents that absent actor identity is a detection-ready blocker for actor-dependent detections but remains an allowed schema-reviewed exception path for fixture validation"
   "Windows security records in this narrow fixture set do not yet provide reviewed process lineage evidence, so broader process-context validation remains future work before detection-ready approval."
   "The reviewed administrative-security fixture set does not credibly supply remote network context and therefore cannot claim it without fabrication."
+  "Detection-ready approval remains blocked for this family until the reviewed blockers below are resolved or a separately approved exception path states the bounded detector-use scope."
+  "| Missing actor attribution for edge-case records | Blocks actor-dependent detections |"
+  "| Process lineage and command-line gap | Blocks process-dependent detections |"
+  "| Remote-network context gap | Blocks remote-access and lateral-movement detections |"
+  "| Parser version and broader Windows event coverage evidence | Blocks source-family detection-ready promotion |"
+  'Downstream detections must not depend on unresolved `user.*` actor fields, `process.*` lineage fields, `related.process`, `source.*`, `destination.*`, or `related.ip` coverage from this family until the blocker inventory is updated by review.'
 )
 
 required_replay_phrases=(
@@ -73,6 +80,11 @@ for required_file in "${required_files[@]}"; do
     exit 1
   fi
 done
+
+if grep -Fqx 'Readiness state: `detection-ready`' "${doc_path}"; then
+  echo "Windows security and endpoint must remain schema-reviewed unless blocker resolution or approved exception paths are documented." >&2
+  exit 1
+fi
 
 for heading in "${required_doc_headings[@]}"; do
   if ! grep -Fq "${heading}" "${doc_path}"; then


### PR DESCRIPTION
## Summary

- Adds a dedicated Windows endpoint detection-ready blocker inventory to the onboarding package.
- Keeps the family explicitly `schema-reviewed` and documents prohibited downstream detector dependencies for unresolved actor, process lineage, and remote-network gaps.
- Tightens the focused Windows onboarding verifier and self-test so missing blocker inventory or accidental detection-ready promotion fails closed.

## Validation

- `bash scripts/verify-windows-source-onboarding-assets.sh`
- `bash scripts/test-verify-windows-source-onboarding-assets.sh`
- `git diff --check`
- fixed-string absolute path hygiene scans for `/Users/`, `C:\Users\`, and `/home/` in touched files
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 755 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`

Part of #752.
Closes #755.