### PR TITLE
refactor: extract assistant advisory draft attachment

### DIFF
--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import re
 from typing import Any, Callable, Mapping
 
@@ -223,6 +224,31 @@ def _advisory_text_claims_authority_or_scope_expansion(text: object) -> tuple[st
         flags.append("scope_expansion_attempt")
 
     return _dedupe_strings(tuple(flags))
+
+
+def _assistant_advisory_draft_without_revision_history(
+    draft: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        str(key): value
+        for key, value in draft.items()
+        if str(key) != "revision_history"
+    }
+
+
+def _assistant_advisory_draft_revision_history(
+    draft: Mapping[str, object],
+) -> tuple[dict[str, object], ...]:
+    raw_history = draft.get("revision_history", ())
+    if not isinstance(raw_history, (list, tuple)):
+        return ()
+    revision_history: list[dict[str, object]] = []
+    for entry in raw_history:
+        if isinstance(entry, Mapping):
+            revision_history.append(
+                _assistant_advisory_draft_without_revision_history(entry)
+            )
+    return tuple(revision_history)
 
 
 def _build_assistant_advisory_output(
@@ -905,3 +931,61 @@ class AssistantContextAssembler:
         context_snapshot = self.inspect_assistant_context(record_family, record_id)
         self._service._require_reviewed_case_scoped_advisory_read(context_snapshot)
         return self._recommendation_draft_snapshot_from_context(context_snapshot)
+
+    def attach_assistant_advisory_draft(
+        self,
+        record_family: str,
+        record_id: str,
+    ) -> RecommendationRecord | AITraceRecord:
+        record_family = self._service._require_non_empty_string(
+            record_family,
+            "record_family",
+        )
+        record_id = self._service._require_non_empty_string(record_id, "record_id")
+        if record_family not in {"recommendation", "ai_trace"}:
+            raise ValueError(
+                "assistant advisory drafts may only be attached to "
+                "'recommendation' or 'ai_trace' records"
+            )
+
+        record_type = self._record_types_by_family[record_family]
+        record = self._service._store.get(record_type, record_id)
+        if record is None:
+            raise LookupError(
+                f"Missing {record_family} record {record_id!r} for advisory draft attachment"
+            )
+        if not isinstance(record, (RecommendationRecord, AITraceRecord)):
+            raise TypeError(
+                "assistant advisory drafts may only be attached to recommendation "
+                "or ai_trace records"
+            )
+
+        draft_snapshot = self.render_recommendation_draft(record_family, record_id)
+        attached_draft = {
+            "draft_id": f"assistant-advisory-draft:{record_family}:{record_id}",
+            "source_record_family": record_family,
+            "source_record_id": record_id,
+            "review_lifecycle_state": record.lifecycle_state,
+            **draft_snapshot.recommendation_draft,
+            "linked_alert_ids": draft_snapshot.linked_alert_ids,
+            "linked_case_ids": draft_snapshot.linked_case_ids,
+            "linked_evidence_ids": draft_snapshot.linked_evidence_ids,
+            "linked_recommendation_ids": draft_snapshot.linked_recommendation_ids,
+            "linked_reconciliation_ids": draft_snapshot.linked_reconciliation_ids,
+        }
+        current_attached_draft = _assistant_advisory_draft_without_revision_history(
+            record.assistant_advisory_draft
+        )
+        if current_attached_draft == attached_draft:
+            return record
+        revision_history = _assistant_advisory_draft_revision_history(
+            record.assistant_advisory_draft
+        )
+        if current_attached_draft:
+            attached_draft["revision_history"] = (
+                *revision_history,
+                current_attached_draft,
+            )
+        return self._service.persist_record(
+            replace(record, assistant_advisory_draft=attached_draft)
+        )

--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -949,43 +949,46 @@ class AssistantContextAssembler:
             )
 
         record_type = self._record_types_by_family[record_family]
-        record = self._service._store.get(record_type, record_id)
-        if record is None:
-            raise LookupError(
-                f"Missing {record_family} record {record_id!r} for advisory draft attachment"
-            )
-        if not isinstance(record, (RecommendationRecord, AITraceRecord)):
-            raise TypeError(
-                "assistant advisory drafts may only be attached to recommendation "
-                "or ai_trace records"
-            )
+        with self._service._store.transaction():
+            self._service._lock_lifecycle_transition_subject(record_family, record_id)
+            record = self._service._store.get(record_type, record_id)
+            if record is None:
+                raise LookupError(
+                    f"Missing {record_family} record {record_id!r} "
+                    "for advisory draft attachment"
+                )
+            if not isinstance(record, (RecommendationRecord, AITraceRecord)):
+                raise TypeError(
+                    "assistant advisory drafts may only be attached to recommendation "
+                    "or ai_trace records"
+                )
 
-        draft_snapshot = self.render_recommendation_draft(record_family, record_id)
-        attached_draft = {
-            "draft_id": f"assistant-advisory-draft:{record_family}:{record_id}",
-            "source_record_family": record_family,
-            "source_record_id": record_id,
-            "review_lifecycle_state": record.lifecycle_state,
-            **draft_snapshot.recommendation_draft,
-            "linked_alert_ids": draft_snapshot.linked_alert_ids,
-            "linked_case_ids": draft_snapshot.linked_case_ids,
-            "linked_evidence_ids": draft_snapshot.linked_evidence_ids,
-            "linked_recommendation_ids": draft_snapshot.linked_recommendation_ids,
-            "linked_reconciliation_ids": draft_snapshot.linked_reconciliation_ids,
-        }
-        current_attached_draft = _assistant_advisory_draft_without_revision_history(
-            record.assistant_advisory_draft
-        )
-        if current_attached_draft == attached_draft:
-            return record
-        revision_history = _assistant_advisory_draft_revision_history(
-            record.assistant_advisory_draft
-        )
-        if current_attached_draft:
-            attached_draft["revision_history"] = (
-                *revision_history,
-                current_attached_draft,
+            draft_snapshot = self.render_recommendation_draft(record_family, record_id)
+            attached_draft = {
+                "draft_id": f"assistant-advisory-draft:{record_family}:{record_id}",
+                "source_record_family": record_family,
+                "source_record_id": record_id,
+                "review_lifecycle_state": record.lifecycle_state,
+                **draft_snapshot.recommendation_draft,
+                "linked_alert_ids": draft_snapshot.linked_alert_ids,
+                "linked_case_ids": draft_snapshot.linked_case_ids,
+                "linked_evidence_ids": draft_snapshot.linked_evidence_ids,
+                "linked_recommendation_ids": draft_snapshot.linked_recommendation_ids,
+                "linked_reconciliation_ids": draft_snapshot.linked_reconciliation_ids,
+            }
+            current_attached_draft = _assistant_advisory_draft_without_revision_history(
+                record.assistant_advisory_draft
             )
-        return self._service.persist_record(
-            replace(record, assistant_advisory_draft=attached_draft)
-        )
+            if current_attached_draft == attached_draft:
+                return record
+            revision_history = _assistant_advisory_draft_revision_history(
+                record.assistant_advisory_draft
+            )
+            if current_attached_draft:
+                attached_draft["revision_history"] = (
+                    *revision_history,
+                    current_attached_draft,
+                )
+            return self._service._store.save(
+                replace(record, assistant_advisory_draft=attached_draft)
+            )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1298,31 +1298,6 @@ def _phase24_live_assistant_snapshot(
     )
 
 
-def _assistant_advisory_draft_without_revision_history(
-    draft: Mapping[str, object],
-) -> dict[str, object]:
-    return {
-        str(key): value
-        for key, value in draft.items()
-        if str(key) != "revision_history"
-    }
-
-
-def _assistant_advisory_draft_revision_history(
-    draft: Mapping[str, object],
-) -> tuple[dict[str, object], ...]:
-    raw_history = draft.get("revision_history", ())
-    if not isinstance(raw_history, (list, tuple)):
-        return ()
-    revision_history: list[dict[str, object]] = []
-    for entry in raw_history:
-        if isinstance(entry, Mapping):
-            revision_history.append(
-                _assistant_advisory_draft_without_revision_history(entry)
-            )
-    return tuple(revision_history)
-
-
 class AegisOpsControlPlaneService:
     """Minimal local runtime skeleton for the first control-plane service."""
 
@@ -4661,54 +4636,9 @@ class AegisOpsControlPlaneService:
         record_family: str,
         record_id: str,
     ) -> RecommendationRecord | AITraceRecord:
-        record_family = self._require_non_empty_string(record_family, "record_family")
-        record_id = self._require_non_empty_string(record_id, "record_id")
-        if record_family not in {"recommendation", "ai_trace"}:
-            raise ValueError(
-                "assistant advisory drafts may only be attached to "
-                "'recommendation' or 'ai_trace' records"
-            )
-
-        record_type = RECORD_TYPES_BY_FAMILY[record_family]
-        record = self._store.get(record_type, record_id)
-        if record is None:
-            raise LookupError(
-                f"Missing {record_family} record {record_id!r} for advisory draft attachment"
-            )
-        if not isinstance(record, (RecommendationRecord, AITraceRecord)):
-            raise TypeError(
-                "assistant advisory drafts may only be attached to recommendation "
-                "or ai_trace records"
-            )
-
-        draft_snapshot = self.render_recommendation_draft(record_family, record_id)
-        attached_draft = {
-            "draft_id": f"assistant-advisory-draft:{record_family}:{record_id}",
-            "source_record_family": record_family,
-            "source_record_id": record_id,
-            "review_lifecycle_state": record.lifecycle_state,
-            **draft_snapshot.recommendation_draft,
-            "linked_alert_ids": draft_snapshot.linked_alert_ids,
-            "linked_case_ids": draft_snapshot.linked_case_ids,
-            "linked_evidence_ids": draft_snapshot.linked_evidence_ids,
-            "linked_recommendation_ids": draft_snapshot.linked_recommendation_ids,
-            "linked_reconciliation_ids": draft_snapshot.linked_reconciliation_ids,
-        }
-        current_attached_draft = _assistant_advisory_draft_without_revision_history(
-            record.assistant_advisory_draft
-        )
-        if current_attached_draft == attached_draft:
-            return record
-        revision_history = _assistant_advisory_draft_revision_history(
-            record.assistant_advisory_draft
-        )
-        if current_attached_draft:
-            attached_draft["revision_history"] = (
-                *revision_history,
-                current_attached_draft,
-            )
-        return self.persist_record(
-            replace(record, assistant_advisory_draft=attached_draft)
+        return self._assistant_context_assembler.attach_assistant_advisory_draft(
+            record_family,
+            record_id,
         )
 
     def _reconciliation_has_detection_lineage(

--- a/control-plane/tests/test_service_persistence_assistant_advisory.py
+++ b/control-plane/tests/test_service_persistence_assistant_advisory.py
@@ -52,6 +52,9 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
         service._assistant_context_assembler.render_recommendation_draft.return_value = (
             mock.sentinel.recommendation_draft_snapshot
         )
+        service._assistant_context_assembler.attach_assistant_advisory_draft.return_value = (
+            mock.sentinel.attached_advisory_draft_record
+        )
 
         self.assertIs(
             service.inspect_assistant_context("case", "case-delegated-001"),
@@ -65,6 +68,13 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
             service.render_recommendation_draft("case", "case-delegated-001"),
             mock.sentinel.recommendation_draft_snapshot,
         )
+        self.assertIs(
+            service.attach_assistant_advisory_draft(
+                "recommendation",
+                "recommendation-delegated-001",
+            ),
+            mock.sentinel.attached_advisory_draft_record,
+        )
         service._assistant_context_assembler.inspect_assistant_context.assert_called_once_with(
             "case",
             "case-delegated-001",
@@ -76,6 +86,13 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
         service._assistant_context_assembler.render_recommendation_draft.assert_called_once_with(
             "case",
             "case-delegated-001",
+        )
+        (
+            service._assistant_context_assembler.attach_assistant_advisory_draft
+            .assert_called_once_with(
+                "recommendation",
+                "recommendation-delegated-001",
+            )
         )
 
     def test_service_routes_reviewed_slice_checks_through_policy_module(self) -> None:

--- a/control-plane/tests/test_service_persistence_assistant_advisory.py
+++ b/control-plane/tests/test_service_persistence_assistant_advisory.py
@@ -24,6 +24,7 @@ from _service_persistence_support import (
     _approved_binding_hash,
     _load_wazuh_fixture,
     _phase20_notify_identity_owner_payload,
+    _TransactionMutationStore,
     datetime,
     make_store,
     mock,
@@ -784,6 +785,83 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
             updated_attachment.assistant_advisory_draft["citations"],
         )
         self.assertEqual(
+            updated_attachment.assistant_advisory_draft["revision_history"][0],
+            initial_snapshot,
+        )
+
+    def test_service_merges_advisory_draft_revision_after_transactional_race(
+        self,
+    ) -> None:
+        inner_store, base_service, promoted_case, _, first_seen_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = base_service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-advisory-race-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                ai_trace_id=None,
+                review_owner="reviewer-001",
+                intended_outcome="review the draft race handling",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+        initial_attachment = base_service.attach_assistant_advisory_draft(
+            "recommendation",
+            recommendation.recommendation_id,
+        )
+        initial_snapshot = dict(initial_attachment.assistant_advisory_draft)
+        raced_draft = {
+            **initial_snapshot,
+            "summary": "Concurrent advisory update persisted before draft merge.",
+        }
+        base_service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-advisory-race-001",
+                source_record_id="artifact-advisory-race-001",
+                alert_id=recommendation.alert_id,
+                case_id=recommendation.case_id,
+                source_system="reviewed-source",
+                collector_identity="control-plane-test",
+                acquired_at=first_seen_at,
+                derivation_relationship="original",
+                lifecycle_state="collected",
+            )
+        )
+        racing_store = _TransactionMutationStore(
+            inner=inner_store,
+            mutate_once=lambda transactional_store: transactional_store.save(
+                replace(
+                    transactional_store.get(
+                        RecommendationRecord,
+                        recommendation.recommendation_id,
+                    ),
+                    assistant_advisory_draft=raced_draft,
+                )
+            ),
+        )
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=racing_store,
+        )
+
+        updated_attachment = service.attach_assistant_advisory_draft(
+            "recommendation",
+            recommendation.recommendation_id,
+        )
+
+        self.assertIn(
+            "evidence-advisory-race-001",
+            updated_attachment.assistant_advisory_draft["citations"],
+        )
+        self.assertEqual(
+            updated_attachment.assistant_advisory_draft["revision_history"][0],
+            raced_draft,
+        )
+        self.assertNotEqual(
             updated_attachment.assistant_advisory_draft["revision_history"][0],
             initial_snapshot,
         )

--- a/docs/control-plane-service-internal-boundaries.md
+++ b/docs/control-plane-service-internal-boundaries.md
@@ -89,6 +89,10 @@ Representative methods include:
 
 This cluster builds citation-grounded assistant context, advisory output, recommendation drafts, and advisory attachments from reviewed control-plane records.
 
+Current extraction status as of issue `#760`:
+
+- assistant context, advisory output, recommendation draft rendering, and advisory draft attachment now delegate from `AegisOpsControlPlaneService` into `AssistantContextAssembler`.
+
 Representative methods include:
 
 - `inspect_assistant_context`


### PR DESCRIPTION
## Summary
- Extracts assistant advisory draft attachment from the public service facade into AssistantContextAssembler.
- Keeps AegisOpsControlPlaneService as the stable public facade for attach_assistant_advisory_draft.
- Updates the internal boundary note to record the issue #760 assistant/advisory extraction status.

## Verification
- python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory.AssistantAdvisoryPersistenceTests.test_service_delegates_assistant_context_and_advisory_rendering_to_assembler
- python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory.AssistantAdvisoryPersistenceTests.test_service_materializes_assistant_advisory_drafts_on_review_records control-plane.tests.test_service_persistence_assistant_advisory.AssistantAdvisoryPersistenceTests.test_service_preserves_prior_assistant_advisory_draft_revisions_on_repeat_attachment
- python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory
- python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation
- python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_operational_runtime_surfaces_are_extracted_into_dedicated_collaborators
- python3 -m py_compile control-plane/aegisops_control_plane/assistant_context.py control-plane/aegisops_control_plane/service.py
- node dist/index.js issue-lint 760 --config supervisor.config.aegisops.coderabbit.json

Part of #759
Closes #760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft versioning for assistant advisories with revision-history tracking and idempotent attachment.

* **Refactor**
  * Advisory draft assembly and persistence logic moved to a dedicated assembler for clearer responsibilities.

* **Tests**
  * New tests covering advisory draft persistence and concurrent update/race scenarios.

* **Documentation**
  * Internal docs updated to reflect the new assembly/delegation boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->