### PR TITLE
Refactor HTTP protected surface routing

### DIFF
--- a/control-plane/aegisops_control_plane/http_protected_surface.py
+++ b/control-plane/aegisops_control_plane/http_protected_surface.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from http.server import BaseHTTPRequestHandler
 from typing import Callable
 
-from .entrypoint_support import peer_addr_is_loopback, require_loopback_operator_request
+from .entrypoint_support import require_loopback_operator_request
 from .service import AegisOpsControlPlaneService
 
 
@@ -84,10 +84,8 @@ def authenticate_protected_write(
     if allowed_roles is None:
         return None
 
-    peer_addr = handler.client_address[0] if handler.client_address else None
     if request_path in OPERATOR_ANALYST_PATHS | OPERATOR_APPROVER_PATHS:
-        if peer_addr_is_loopback(peer_addr):
-            require_loopback_operator_request_fn(handler)
+        require_loopback_operator_request_fn(handler)
 
     return _authenticate_protected_surface(
         service=service,

--- a/control-plane/aegisops_control_plane/http_protected_surface.py
+++ b/control-plane/aegisops_control_plane/http_protected_surface.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler
+from typing import Callable
+
+from .entrypoint_support import peer_addr_is_loopback, require_loopback_operator_request
+from .service import AegisOpsControlPlaneService
+
+
+READ_ONLY_PROTECTED_ROLES = ("analyst", "approver", "platform_admin")
+PLATFORM_ADMIN_ROLES = ("platform_admin",)
+OPERATOR_ANALYST_ROLES = ("analyst",)
+OPERATOR_APPROVER_ROLES = ("approver",)
+
+PROTECTED_READ_ROLES_BY_PATH: dict[str, tuple[str, ...]] = {
+    "/runtime": PLATFORM_ADMIN_ROLES,
+    "/diagnostics/readiness": READ_ONLY_PROTECTED_ROLES,
+    "/admin/bootstrap-status": PLATFORM_ADMIN_ROLES,
+    "/inspect-records": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-reconciliation-status": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-analyst-queue": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-alert-detail": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-case-detail": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-action-review": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-assistant-context": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-advisory-output": READ_ONLY_PROTECTED_ROLES,
+    "/render-recommendation-draft": READ_ONLY_PROTECTED_ROLES,
+}
+
+OPERATOR_ANALYST_PATHS = {
+    "/operator/promote-alert-to-case",
+    "/operator/record-case-observation",
+    "/operator/record-case-lead",
+    "/operator/record-case-recommendation",
+    "/operator/record-case-handoff",
+    "/operator/record-case-disposition",
+    "/operator/record-action-review-manual-fallback",
+    "/operator/record-action-review-escalation-note",
+    "/operator/create-reviewed-action-request",
+}
+OPERATOR_APPROVER_PATHS = {
+    "/operator/record-action-approval-decision",
+}
+
+
+def protected_read_roles(request_path: str) -> tuple[str, ...] | None:
+    return PROTECTED_READ_ROLES_BY_PATH.get(request_path)
+
+
+def protected_write_roles(request_path: str) -> tuple[str, ...] | None:
+    if request_path in OPERATOR_ANALYST_PATHS:
+        return OPERATOR_ANALYST_ROLES
+    if request_path in OPERATOR_APPROVER_PATHS:
+        return OPERATOR_APPROVER_ROLES
+    if request_path.startswith("/admin/"):
+        return PLATFORM_ADMIN_ROLES
+    return None
+
+
+def authenticate_protected_read(
+    *,
+    service: AegisOpsControlPlaneService,
+    handler: BaseHTTPRequestHandler,
+    allowed_roles: tuple[str, ...],
+) -> object:
+    return _authenticate_protected_surface(
+        service=service,
+        handler=handler,
+        allowed_roles=allowed_roles,
+    )
+
+
+def authenticate_protected_write(
+    *,
+    service: AegisOpsControlPlaneService,
+    handler: BaseHTTPRequestHandler,
+    request_path: str,
+    require_loopback_operator_request_fn: Callable[
+        [BaseHTTPRequestHandler],
+        None,
+    ] = require_loopback_operator_request,
+) -> object | None:
+    allowed_roles = protected_write_roles(request_path)
+    if allowed_roles is None:
+        return None
+
+    peer_addr = handler.client_address[0] if handler.client_address else None
+    if request_path in OPERATOR_ANALYST_PATHS | OPERATOR_APPROVER_PATHS:
+        if peer_addr_is_loopback(peer_addr):
+            require_loopback_operator_request_fn(handler)
+
+    return _authenticate_protected_surface(
+        service=service,
+        handler=handler,
+        allowed_roles=allowed_roles,
+    )
+
+
+def _authenticate_protected_surface(
+    *,
+    service: AegisOpsControlPlaneService,
+    handler: BaseHTTPRequestHandler,
+    allowed_roles: tuple[str, ...],
+) -> object:
+    return service.authenticate_protected_surface_request(
+        peer_addr=handler.client_address[0] if handler.client_address else None,
+        forwarded_proto=handler.headers.get("X-Forwarded-Proto"),
+        reverse_proxy_secret_header=handler.headers.get("X-AegisOps-Proxy-Secret"),
+        proxy_service_account_header=handler.headers.get(
+            "X-AegisOps-Proxy-Service-Account"
+        ),
+        authenticated_identity_provider_header=handler.headers.get(
+            "X-AegisOps-Authenticated-IdP"
+        ),
+        authenticated_subject_header=handler.headers.get(
+            "X-AegisOps-Authenticated-Subject"
+        ),
+        authenticated_identity_header=handler.headers.get(
+            "X-AegisOps-Authenticated-Identity"
+        ),
+        authenticated_role_header=handler.headers.get("X-AegisOps-Authenticated-Role"),
+        allowed_roles=allowed_roles,
+    )
+
+
+__all__ = [
+    "OPERATOR_ANALYST_PATHS",
+    "OPERATOR_APPROVER_PATHS",
+    "PROTECTED_READ_ROLES_BY_PATH",
+    "READ_ONLY_PROTECTED_ROLES",
+    "authenticate_protected_read",
+    "authenticate_protected_write",
+    "protected_read_roles",
+    "protected_write_roles",
+]

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -17,12 +17,16 @@ from .entrypoint_support import (
     normalize_optional_string,
     normalize_record_family,
     normalize_record_id,
-    peer_addr_is_loopback,
     read_json_request_body,
     require_json_datetime,
     require_json_string,
     require_json_string_sequence,
     require_loopback_operator_request,
+)
+from .http_protected_surface import (
+    authenticate_protected_read,
+    authenticate_protected_write,
+    protected_read_roles,
 )
 from .service import AegisOpsControlPlaneService
 
@@ -51,23 +55,9 @@ def build_handler_class(
             *,
             allowed_roles: tuple[str, ...],
         ) -> object:
-            return service.authenticate_protected_surface_request(
-                peer_addr=self.client_address[0] if self.client_address else None,
-                forwarded_proto=self.headers.get("X-Forwarded-Proto"),
-                reverse_proxy_secret_header=self.headers.get("X-AegisOps-Proxy-Secret"),
-                proxy_service_account_header=self.headers.get(
-                    "X-AegisOps-Proxy-Service-Account"
-                ),
-                authenticated_identity_provider_header=self.headers.get(
-                    "X-AegisOps-Authenticated-IdP"
-                ),
-                authenticated_subject_header=self.headers.get(
-                    "X-AegisOps-Authenticated-Subject"
-                ),
-                authenticated_identity_header=self.headers.get(
-                    "X-AegisOps-Authenticated-Identity"
-                ),
-                authenticated_role_header=self.headers.get("X-AegisOps-Authenticated-Role"),
+            return authenticate_protected_read(
+                service=service,
+                handler=self,
                 allowed_roles=allowed_roles,
             )
 
@@ -106,25 +96,20 @@ def build_handler_class(
                 )
                 return
 
-            if request_path == "/runtime":
+            if allowed_roles := protected_read_roles(request_path):
                 try:
                     self._require_authenticated_surface_access(
-                        allowed_roles=("platform_admin",),
+                        allowed_roles=allowed_roles,
                     )
                 except PermissionError as exc:
                     self._write_forbidden(str(exc))
                     return
+
+            if request_path == "/runtime":
                 self._write_json(HTTPStatus.OK, service.describe_runtime().to_dict())
                 return
 
             if request_path == "/diagnostics/readiness":
-                try:
-                    self._require_authenticated_surface_access(
-                        allowed_roles=("analyst", "approver", "platform_admin"),
-                    )
-                except PermissionError as exc:
-                    self._write_forbidden(str(exc))
-                    return
                 self._write_json(
                     HTTPStatus.OK,
                     service.inspect_readiness_diagnostics().to_dict(),
@@ -132,13 +117,6 @@ def build_handler_class(
                 return
 
             if request_path == "/admin/bootstrap-status":
-                try:
-                    self._require_authenticated_surface_access(
-                        allowed_roles=("platform_admin",),
-                    )
-                except PermissionError as exc:
-                    self._write_forbidden(str(exc))
-                    return
                 self._write_json(
                     HTTPStatus.OK,
                     {
@@ -156,25 +134,6 @@ def build_handler_class(
                     },
                 )
                 return
-
-            if request_path in {
-                "/inspect-records",
-                "/inspect-reconciliation-status",
-                "/inspect-analyst-queue",
-                "/inspect-alert-detail",
-                "/inspect-case-detail",
-                "/inspect-action-review",
-                "/inspect-assistant-context",
-                "/inspect-advisory-output",
-                "/render-recommendation-draft",
-            }:
-                try:
-                    self._require_authenticated_surface_access(
-                        allowed_roles=("analyst", "approver", "platform_admin"),
-                    )
-                except PermissionError as exc:
-                    self._write_forbidden(str(exc))
-                    return
 
             if request_path == "/inspect-records":
                 family = parse_qs(request_target.query).get("family", [""])[0]
@@ -398,47 +357,18 @@ def build_handler_class(
             request_target = urlsplit(self.path)
             request_path = request_target.path
 
-            operator_analyst_paths = {
-                "/operator/promote-alert-to-case",
-                "/operator/record-case-observation",
-                "/operator/record-case-lead",
-                "/operator/record-case-recommendation",
-                "/operator/record-case-handoff",
-                "/operator/record-case-disposition",
-                "/operator/record-action-review-manual-fallback",
-                "/operator/record-action-review-escalation-note",
-                "/operator/create-reviewed-action-request",
-            }
-            operator_approver_paths = {
-                "/operator/record-action-approval-decision",
-            }
-
-            if request_path in operator_analyst_paths | operator_approver_paths:
-                try:
-                    peer_addr = self.client_address[0] if self.client_address else None
-                    if peer_addr_is_loopback(peer_addr):
-                        require_loopback_operator_request_fn(self)
-                    allowed_roles = (
-                        ("analyst",)
-                        if request_path in operator_analyst_paths
-                        else ("approver",)
-                    )
-                    principal = self._require_authenticated_surface_access(
-                        allowed_roles=allowed_roles,
-                    )
-                except PermissionError as exc:
-                    self._write_forbidden(str(exc))
-                    return
-            elif request_path.startswith("/admin/"):
-                try:
-                    principal = self._require_authenticated_surface_access(
-                        allowed_roles=("platform_admin",),
-                    )
-                except PermissionError as exc:
-                    self._write_forbidden(str(exc))
-                    return
-            else:
-                principal = None
+            try:
+                principal = authenticate_protected_write(
+                    service=service,
+                    handler=self,
+                    request_path=request_path,
+                    require_loopback_operator_request_fn=(
+                        require_loopback_operator_request_fn
+                    ),
+                )
+            except PermissionError as exc:
+                self._write_forbidden(str(exc))
+                return
 
             if request_path == "/operator/promote-alert-to-case":
                 try:

--- a/control-plane/tests/test_phase21_runtime_auth_validation.py
+++ b/control-plane/tests/test_phase21_runtime_auth_validation.py
@@ -20,6 +20,7 @@ from aegisops_control_plane.http_protected_surface import (
     OPERATOR_ANALYST_PATHS,
     OPERATOR_APPROVER_PATHS,
     PROTECTED_READ_ROLES_BY_PATH,
+    authenticate_protected_write,
     protected_read_roles,
     protected_write_roles,
 )
@@ -100,6 +101,33 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
             OPERATOR_APPROVER_PATHS,
         )
         self.assertIn("/diagnostics/readiness", PROTECTED_READ_ROLES_BY_PATH)
+
+    def test_operator_write_auth_invokes_loopback_gate_before_surface_auth(
+        self,
+    ) -> None:
+        service = mock.Mock()
+        handler = mock.Mock()
+        handler.client_address = ("203.0.113.10", 44321)
+        handler.headers.get.return_value = None
+        loopback_gate = mock.Mock(
+            side_effect=PermissionError(
+                "operator write surface only accepts loopback callers until a reviewed operator auth boundary exists"
+            )
+        )
+
+        with self.assertRaisesRegex(
+            PermissionError,
+            "operator write surface only accepts loopback callers",
+        ):
+            authenticate_protected_write(
+                service=service,
+                handler=handler,
+                request_path="/operator/promote-alert-to-case",
+                require_loopback_operator_request_fn=loopback_gate,
+            )
+
+        loopback_gate.assert_called_once_with(handler)
+        service.authenticate_protected_surface_request.assert_not_called()
 
     def test_operational_runtime_surfaces_are_extracted_into_dedicated_collaborators(
         self,

--- a/control-plane/tests/test_phase21_runtime_auth_validation.py
+++ b/control-plane/tests/test_phase21_runtime_auth_validation.py
@@ -16,6 +16,13 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 
 import main
 from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.http_protected_surface import (
+    OPERATOR_ANALYST_PATHS,
+    OPERATOR_APPROVER_PATHS,
+    PROTECTED_READ_ROLES_BY_PATH,
+    protected_read_roles,
+    protected_write_roles,
+)
 from aegisops_control_plane.operations import (
     RestoreReadinessService,
     RuntimeBoundaryService,
@@ -65,6 +72,35 @@ def _build_service(*, host: str = "127.0.0.1") -> AegisOpsControlPlaneService:
 
 
 class Phase21RuntimeAuthValidationTests(unittest.TestCase):
+    def test_http_protected_surface_route_roles_are_declared_outside_handler_dispatch(
+        self,
+    ) -> None:
+        self.assertEqual(protected_read_roles("/runtime"), ("platform_admin",))
+        self.assertEqual(
+            protected_read_roles("/inspect-case-detail"),
+            ("analyst", "approver", "platform_admin"),
+        )
+        self.assertEqual(
+            protected_write_roles("/operator/promote-alert-to-case"),
+            ("analyst",),
+        )
+        self.assertEqual(
+            protected_write_roles("/operator/record-action-approval-decision"),
+            ("approver",),
+        )
+        self.assertEqual(
+            protected_write_roles("/admin/bootstrap/claim"),
+            ("platform_admin",),
+        )
+        self.assertIsNone(protected_read_roles("/healthz"))
+        self.assertIsNone(protected_write_roles("/intake/wazuh"))
+        self.assertIn("/operator/create-reviewed-action-request", OPERATOR_ANALYST_PATHS)
+        self.assertIn(
+            "/operator/record-action-approval-decision",
+            OPERATOR_APPROVER_PATHS,
+        )
+        self.assertIn("/diagnostics/readiness", PROTECTED_READ_ROLES_BY_PATH)
+
     def test_operational_runtime_surfaces_are_extracted_into_dedicated_collaborators(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- extract protected HTTP route role mapping and auth binding into `http_protected_surface.py`
- keep `http_surface.py` focused on handler construction and endpoint dispatch
- add a focused regression for protected read/write route role policy

## Verification
- `python3 -m py_compile control-plane/aegisops_control_plane/http_surface.py control-plane/aegisops_control_plane/http_protected_surface.py control-plane/tests/test_phase21_runtime_auth_validation.py`
- `python3 -m unittest test_phase21_runtime_auth_validation`
- `python3 -m unittest test_cli_inspection_runtime_surface`
- `python3 -m unittest test_phase19_operator_workflow_validation.Phase19OperatorWorkflowValidationTests.test_reviewed_runtime_path_covers_approved_operator_workflow test_phase19_operator_workflow_validation.Phase19OperatorWorkflowValidationTests.test_create_reviewed_action_request_rejects_platform_admin_identity`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`\n- `node dist/index.js issue-lint 762 --config supervisor.config.aegisops.coderabbit.json`\n\nPart of #759\nCloses #762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and reorganized protected HTTP authorization and role mappings into shared helpers, simplifying read/write authorization flows and delegating authentication checks.

* **Tests**
  * Added unit tests to validate endpoint role mappings and the ordering/behavior of authorization gates for protected write operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->