### PR TITLE
Add reviewed tracking ticket action request

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.controlPlane.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.controlPlane.testSuite.tsx
@@ -67,7 +67,9 @@ export function registerOperatorRoutesControlPlaneTests() {
       );
 
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: "Case Detail" })).toBeInTheDocument();
+        expect(
+          screen.getByRole("heading", { name: "Case Detail" }),
+        ).toBeInTheDocument();
       });
 
       await waitFor(() => {
@@ -764,6 +766,162 @@ export function registerOperatorRoutesControlPlaneTests() {
             method: "POST",
           }),
         );
+      });
+    }, 10000);
+
+    it("creates reviewed tracking-ticket action requests from case detail", async () => {
+      let caseDetailPayload: Record<string, unknown> = {
+        case_id: "case-789",
+        case_record: {
+          case_id: "case-789",
+          lifecycle_state: "pending_action",
+        },
+        linked_alert_ids: ["alert-789"],
+        linked_observation_ids: [],
+        linked_lead_ids: [],
+        linked_recommendation_ids: ["recommendation-789"],
+        linked_evidence_ids: ["evidence-789"],
+        linked_reconciliation_ids: ["recon-789"],
+        provenance_summary: {
+          authoritative_anchor: {
+            record_family: "case",
+            record_id: "case-789",
+            source_family: "github_audit",
+            provenance_classification: "authoritative",
+          },
+        },
+        linked_alert_records: [],
+        linked_evidence_records: [],
+        linked_reconciliation_records: [],
+        cross_source_timeline: [],
+        current_action_review: null,
+      };
+      const fetchFn = vi.fn<typeof fetch>().mockImplementation((input, init) => {
+        const url = String(input);
+
+        if (url.startsWith("/api/operator/session")) {
+          return Promise.resolve(
+            jsonResponse({
+              identity: "analyst@example.com",
+              provider: "authentik",
+              roles: ["Analyst"],
+              subject: "operator-7",
+            }),
+          );
+        }
+
+        if (url.startsWith("/inspect-case-detail")) {
+          return Promise.resolve(jsonResponse(caseDetailPayload));
+        }
+
+        if (url.startsWith("/operator/create-reviewed-action-request")) {
+          expect(init?.method).toBe("POST");
+          expect(init?.body).toBe(
+            JSON.stringify({
+              action_type: "create_tracking_ticket",
+              coordination_reference_id: "coord-ref-ui-ticket-001",
+              coordination_target_type: "zammad",
+              expires_at: "2026-04-23T00:00",
+              family: "recommendation",
+              record_id: "recommendation-789",
+              requester_identity: "analyst@example.com",
+              ticket_description: "Open one reviewed ticket for daily operator follow-up.",
+              ticket_severity: "medium",
+              ticket_title: "Review repository owner change",
+            }),
+          );
+          caseDetailPayload = {
+            ...caseDetailPayload,
+            current_action_review: {
+              action_request_id: "action-request-ticket-789",
+              review_state: "unresolved",
+              next_expected_action: "await_approval_decision",
+            },
+          };
+          return Promise.resolve(
+            jsonResponse({
+              action_request_id: "action-request-ticket-789",
+              case_id: "case-789",
+            }),
+          );
+        }
+
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      });
+      const dependencies = createDefaultDependencies({ fetchFn });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/cases/case-789"]}>
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Case Detail" })).toBeInTheDocument();
+      });
+
+      const actionRequestSection = screen.getByRole("heading", {
+        name: "Create reviewed action request",
+      });
+      const actionRequestCard = actionRequestSection.closest(".MuiCard-root");
+      expect(actionRequestCard).not.toBeNull();
+      fireEvent.mouseDown(
+        within(actionRequestCard as HTMLElement).getByRole("combobox", {
+          name: "Action type",
+        }),
+      );
+      fireEvent.click(screen.getByRole("option", { name: "create_tracking_ticket" }));
+      fireEvent.change(
+        within(actionRequestCard as HTMLElement).getByRole("textbox", {
+          name: "Recommendation id",
+        }),
+        { target: { value: "recommendation-789" } },
+      );
+      fireEvent.change(
+        within(actionRequestCard as HTMLElement).getByRole("textbox", {
+          name: "Coordination reference id",
+        }),
+        { target: { value: "coord-ref-ui-ticket-001" } },
+      );
+      fireEvent.change(
+        within(actionRequestCard as HTMLElement).getByRole("textbox", {
+          name: "Ticket title",
+        }),
+        { target: { value: "Review repository owner change" } },
+      );
+      fireEvent.change(
+        within(actionRequestCard as HTMLElement).getByRole("textbox", {
+          name: "Ticket description",
+        }),
+        {
+          target: {
+            value: "Open one reviewed ticket for daily operator follow-up.",
+          },
+        },
+      );
+      fireEvent.change(
+        within(actionRequestCard as HTMLElement).getByRole("textbox", {
+          name: "Expires at",
+        }),
+        { target: { value: "2026-04-23T00:00" } },
+      );
+      fireEvent.click(within(actionRequestCard as HTMLElement).getByRole("checkbox"));
+      fireEvent.click(
+        within(actionRequestCard as HTMLElement).getByRole("button", {
+          name: "Create action request",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledWith(
+          "/operator/create-reviewed-action-request",
+          expect.objectContaining({
+            method: "POST",
+          }),
+        );
+        expect(
+          screen.getAllByText("action-request-ticket-789").length,
+        ).toBeGreaterThan(0);
       });
     }, 10000);
 

--- a/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.tsx
@@ -382,9 +382,15 @@ export function CreateReviewedActionRequestCard({
   const [recommendationId, setRecommendationId] = useState(
     linkedRecommendationIds.length === 1 ? linkedRecommendationIds[0] ?? "" : "",
   );
+  const [actionType, setActionType] = useState("notify_identity_owner");
   const [recipientIdentity, setRecipientIdentity] = useState("");
   const [messageIntent, setMessageIntent] = useState("");
   const [escalationReason, setEscalationReason] = useState("");
+  const [coordinationReferenceId, setCoordinationReferenceId] = useState("");
+  const [coordinationTargetType, setCoordinationTargetType] = useState("zammad");
+  const [ticketTitle, setTicketTitle] = useState("");
+  const [ticketDescription, setTicketDescription] = useState("");
+  const [ticketSeverity, setTicketSeverity] = useState("medium");
   const [expiresAt, setExpiresAt] = useState("");
   const [actionRequestIdOverride, setActionRequestIdOverride] = useState("");
 
@@ -399,16 +405,32 @@ export function CreateReviewedActionRequestCard({
         },
       ]}
       run={(client) =>
-        client.createReviewedActionRequest({
-          action_request_id: normalizeOptionalString(actionRequestIdOverride),
-          escalation_reason: escalationReason.trim(),
-          expires_at: expiresAt.trim(),
-          family: "recommendation",
-          message_intent: messageIntent.trim(),
-          recipient_identity: recipientIdentity.trim(),
-          record_id: recommendationId.trim(),
-          requester_identity: operatorIdentity,
-        }) as Promise<{ action_request_id?: string; case_id?: string }>
+        client.createReviewedActionRequest(
+          actionType === "create_tracking_ticket"
+            ? {
+                action_request_id: normalizeOptionalString(actionRequestIdOverride),
+                action_type: "create_tracking_ticket",
+                coordination_reference_id: coordinationReferenceId.trim(),
+                coordination_target_type: coordinationTargetType.trim(),
+                expires_at: expiresAt.trim(),
+                family: "recommendation",
+                record_id: recommendationId.trim(),
+                requester_identity: operatorIdentity,
+                ticket_description: ticketDescription.trim(),
+                ticket_severity: ticketSeverity.trim(),
+                ticket_title: ticketTitle.trim(),
+              }
+            : {
+                action_request_id: normalizeOptionalString(actionRequestIdOverride),
+                escalation_reason: escalationReason.trim(),
+                expires_at: expiresAt.trim(),
+                family: "recommendation",
+                message_intent: messageIntent.trim(),
+                recipient_identity: recipientIdentity.trim(),
+                record_id: recommendationId.trim(),
+                requester_identity: operatorIdentity,
+              },
+        ) as Promise<{ action_request_id?: string; case_id?: string }>
       }
       submission={submission}
     >
@@ -420,7 +442,11 @@ export function CreateReviewedActionRequestCard({
         binding={[
           ["Record family", "recommendation"],
           ["Case id", caseId],
-          ["Recommendation id", recommendationId.trim() || "Select authoritative recommendation id"],
+          [
+            "Recommendation id",
+            recommendationId.trim() || "Select authoritative recommendation id",
+          ],
+          ["Action type", actionType],
         ]}
         provenance={[
           ["Backend boundary", "reviewed operator action-request endpoint"],
@@ -434,6 +460,109 @@ export function CreateReviewedActionRequestCard({
         <Stack spacing={2}>
           <TextField
             fullWidth
+            label="Action type"
+            onChange={(event) => {
+              setActionType(event.target.value);
+            }}
+            select
+            value={actionType}
+          >
+            <MenuItem value="notify_identity_owner">notify_identity_owner</MenuItem>
+            <MenuItem value="create_tracking_ticket">create_tracking_ticket</MenuItem>
+          </TextField>
+          {actionType === "create_tracking_ticket" ? (
+            <>
+              <TextField
+                fullWidth
+                label="Coordination reference id"
+                onChange={(event) => {
+                  setCoordinationReferenceId(event.target.value);
+                }}
+                required
+                value={coordinationReferenceId}
+              />
+              <TextField
+                fullWidth
+                label="Coordination target type"
+                onChange={(event) => {
+                  setCoordinationTargetType(event.target.value);
+                }}
+                select
+                value={coordinationTargetType}
+              >
+                <MenuItem value="zammad">zammad</MenuItem>
+                <MenuItem value="glpi">glpi</MenuItem>
+              </TextField>
+              <TextField
+                fullWidth
+                label="Ticket title"
+                onChange={(event) => {
+                  setTicketTitle(event.target.value);
+                }}
+                required
+                value={ticketTitle}
+              />
+              <TextField
+                fullWidth
+                label="Ticket description"
+                minRows={3}
+                multiline
+                onChange={(event) => {
+                  setTicketDescription(event.target.value);
+                }}
+                required
+                value={ticketDescription}
+              />
+              <TextField
+                fullWidth
+                label="Ticket severity"
+                onChange={(event) => {
+                  setTicketSeverity(event.target.value);
+                }}
+                select
+                value={ticketSeverity}
+              >
+                <MenuItem value="low">low</MenuItem>
+                <MenuItem value="medium">medium</MenuItem>
+              </TextField>
+            </>
+          ) : (
+            <>
+              <TextField
+                fullWidth
+                label="Recipient identity"
+                onChange={(event) => {
+                  setRecipientIdentity(event.target.value);
+                }}
+                required
+                value={recipientIdentity}
+              />
+              <TextField
+                fullWidth
+                label="Message intent"
+                minRows={3}
+                multiline
+                onChange={(event) => {
+                  setMessageIntent(event.target.value);
+                }}
+                required
+                value={messageIntent}
+              />
+              <TextField
+                fullWidth
+                label="Escalation reason"
+                minRows={3}
+                multiline
+                onChange={(event) => {
+                  setEscalationReason(event.target.value);
+                }}
+                required
+                value={escalationReason}
+              />
+            </>
+          )}
+          <TextField
+            fullWidth
             helperText={
               linkedRecommendationIds.length > 0
                 ? `Known recommendation ids: ${linkedRecommendationIds.join(", ")}`
@@ -445,37 +574,6 @@ export function CreateReviewedActionRequestCard({
             }}
             required
             value={recommendationId}
-          />
-          <TextField
-            fullWidth
-            label="Recipient identity"
-            onChange={(event) => {
-              setRecipientIdentity(event.target.value);
-            }}
-            required
-            value={recipientIdentity}
-          />
-          <TextField
-            fullWidth
-            label="Message intent"
-            minRows={3}
-            multiline
-            onChange={(event) => {
-              setMessageIntent(event.target.value);
-            }}
-            required
-            value={messageIntent}
-          />
-          <TextField
-            fullWidth
-            label="Escalation reason"
-            minRows={3}
-            multiline
-            onChange={(event) => {
-              setEscalationReason(event.target.value);
-            }}
-            required
-            value={escalationReason}
           />
           <TextField
             fullWidth

--- a/apps/operator-ui/src/taskActions/taskActionClient.ts
+++ b/apps/operator-ui/src/taskActions/taskActionClient.ts
@@ -31,12 +31,18 @@ interface RecordCaseRecommendationPayload {
 }
 
 interface CreateReviewedActionRequestPayload {
+  action_type?: string;
   family: string;
   record_id: string;
   requester_identity: string;
-  recipient_identity: string;
-  message_intent: string;
-  escalation_reason: string;
+  recipient_identity?: string;
+  message_intent?: string;
+  escalation_reason?: string;
+  coordination_reference_id?: string;
+  coordination_target_type?: string;
+  ticket_title?: string;
+  ticket_description?: string;
+  ticket_severity?: string;
   expires_at: string;
   action_request_id?: string;
 }

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -170,6 +170,33 @@ class ExecutionCoordinator:
             action_request_id=action_request_id,
         )
 
+    def create_reviewed_tracking_ticket_request_from_advisory(
+        self,
+        *,
+        record_family: str,
+        record_id: str,
+        requester_identity: str,
+        coordination_reference_id: str,
+        coordination_target_type: str,
+        ticket_title: str,
+        ticket_description: str,
+        expires_at: datetime,
+        ticket_severity: str = "medium",
+        action_request_id: str | None = None,
+    ) -> ActionRequestRecord:
+        return self._action_requests.create_reviewed_tracking_ticket_request_from_advisory(
+            record_family=record_family,
+            record_id=record_id,
+            requester_identity=requester_identity,
+            coordination_reference_id=coordination_reference_id,
+            coordination_target_type=coordination_target_type,
+            ticket_title=ticket_title,
+            ticket_description=ticket_description,
+            expires_at=expires_at,
+            ticket_severity=ticket_severity,
+            action_request_id=action_request_id,
+        )
+
     def delegate_approved_action_to_shuffle(
         self,
         *,

--- a/control-plane/aegisops_control_plane/execution_coordinator_action_requests.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator_action_requests.py
@@ -13,6 +13,9 @@ from .execution_coordinator import (
 from .models import ActionRequestRecord
 
 
+_PHASE26_REVIEWED_TICKET_SEVERITIES = frozenset(("low", "medium"))
+
+
 class ReviewedActionRequestCoordinator:
     def __init__(self, service: ExecutionCoordinatorServiceDependencies) -> None:
         self._service = service
@@ -231,6 +234,10 @@ class ReviewedActionRequestCoordinator:
             ticket_severity,
             "ticket_severity",
         )
+        if ticket_severity not in _PHASE26_REVIEWED_TICKET_SEVERITIES:
+            raise ValueError(
+                "ticket_severity is outside the reviewed tracking-ticket scope"
+            )
         expires_at = self._service._require_aware_datetime(expires_at, "expires_at")
 
         with self._service._store.transaction():

--- a/control-plane/aegisops_control_plane/execution_coordinator_action_requests.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator_action_requests.py
@@ -6,6 +6,7 @@ import json
 
 from .execution_coordinator import (
     ExecutionCoordinatorServiceDependencies,
+    _PHASE26_REVIEWED_COORDINATION_TARGET_TYPES,
     _approved_payload_binding_hash,
     _json_ready,
 )
@@ -158,6 +159,195 @@ class ReviewedActionRequestCoordinator:
                         "severity": "low",
                         "target_scope": "single_identity",
                         "action_reversibility": "reversible",
+                        "asset_criticality": "standard",
+                        "identity_criticality": "standard",
+                        "blast_radius": "single_target",
+                        "execution_constraint": "routine_allowed",
+                    },
+                    policy_evaluation={
+                        "approval_requirement": "human_required",
+                        "approval_requirement_override": "human_required",
+                        "routing_target": "approval",
+                        "execution_surface_type": "automation_substrate",
+                        "execution_surface_id": "shuffle",
+                    },
+                ),
+                transitioned_at=requested_at,
+            )
+        self._service._emit_structured_event(
+            20,
+            "action_request_created",
+            action_request_id=created_request.action_request_id,
+            action_type=created_request.requested_payload.get("action_type"),
+            requester_identity=created_request.requester_identity,
+            case_id=created_request.case_id,
+            alert_id=created_request.alert_id,
+            lifecycle_state=created_request.lifecycle_state,
+            expires_at=created_request.expires_at.isoformat()
+            if created_request.expires_at is not None
+            else None,
+        )
+        return created_request
+
+    def create_reviewed_tracking_ticket_request_from_advisory(
+        self,
+        *,
+        record_family: str,
+        record_id: str,
+        requester_identity: str,
+        coordination_reference_id: str,
+        coordination_target_type: str,
+        ticket_title: str,
+        ticket_description: str,
+        expires_at: datetime,
+        ticket_severity: str = "medium",
+        action_request_id: str | None = None,
+    ) -> ActionRequestRecord:
+        requester_identity = self._service._require_non_empty_string(
+            requester_identity,
+            "requester_identity",
+        )
+        coordination_reference_id = self._service._require_non_empty_string(
+            coordination_reference_id,
+            "coordination_reference_id",
+        )
+        coordination_target_type = self._service._require_non_empty_string(
+            coordination_target_type,
+            "coordination_target_type",
+        )
+        if coordination_target_type not in _PHASE26_REVIEWED_COORDINATION_TARGET_TYPES:
+            raise ValueError(
+                "coordination_target_type is outside the reviewed tracking-ticket scope"
+            )
+        ticket_title = self._service._require_non_empty_string(
+            ticket_title,
+            "ticket_title",
+        )
+        ticket_description = self._service._require_non_empty_string(
+            ticket_description,
+            "ticket_description",
+        )
+        ticket_severity = self._service._require_non_empty_string(
+            ticket_severity,
+            "ticket_severity",
+        )
+        expires_at = self._service._require_aware_datetime(expires_at, "expires_at")
+
+        with self._service._store.transaction():
+            context_snapshot = self._service.inspect_assistant_context(
+                record_family,
+                record_id,
+            )
+            self._service._require_reviewed_case_scoped_advisory_read(context_snapshot)
+            recommendation_draft = self._service.render_recommendation_draft(
+                record_family,
+                record_id,
+            )
+            if recommendation_draft.recommendation_draft.get("status") != "ready":
+                raise ValueError(
+                    "reviewed advisory context is not ready for approval-bound action requests"
+                )
+
+            recommendation_id = self._service._require_single_recommendation_binding(
+                record_family=record_family,
+                record_id=record_id,
+                linked_recommendation_ids=recommendation_draft.linked_recommendation_ids,
+            )
+            case_id = self._service._require_single_linked_case_id(
+                recommendation_draft.linked_case_ids
+            )
+            case = self._service._require_reviewed_operator_case(case_id)
+            if expires_at <= datetime.now(timezone.utc):
+                raise ValueError("expires_at must be in the future")
+
+            requested_payload = {
+                "action_type": "create_tracking_ticket",
+                "case_id": case.case_id,
+                "alert_id": case.alert_id,
+                "finding_id": case.finding_id,
+                "coordination_reference_id": coordination_reference_id,
+                "coordination_target_type": coordination_target_type,
+                "ticket_title": ticket_title,
+                "ticket_description": ticket_description,
+                "ticket_severity": ticket_severity,
+                "source_record_family": record_family,
+                "source_record_id": record_id,
+                "recommendation_id": recommendation_id,
+                "linked_evidence_ids": recommendation_draft.linked_evidence_ids,
+            }
+            target_scope = {
+                "record_family": record_family,
+                "record_id": record_id,
+                "case_id": case.case_id,
+                "alert_id": case.alert_id,
+                "finding_id": case.finding_id,
+                "coordination_reference_id": coordination_reference_id,
+                "coordination_target_type": coordination_target_type,
+            }
+            payload_hash = _approved_payload_binding_hash(
+                target_scope=target_scope,
+                approved_payload=requested_payload,
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+            )
+            requested_at = datetime.now(timezone.utc)
+            if expires_at <= requested_at:
+                raise ValueError("expires_at must be after requested_at")
+
+            idempotency_material = json.dumps(
+                _json_ready(
+                    {
+                        "payload_hash": payload_hash,
+                        "record_family": record_family,
+                        "record_id": record_id,
+                        "requester_identity": requester_identity,
+                        "expires_at": expires_at,
+                    }
+                ),
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            idempotency_key = (
+                "create-tracking-ticket:"
+                + hashlib.sha256(idempotency_material.encode("utf-8")).hexdigest()
+            )
+            for existing in self._service._store.list(ActionRequestRecord):
+                if existing.idempotency_key == idempotency_key:
+                    self._service._emit_structured_event(
+                        20,
+                        "action_request_reused",
+                        action_request_id=existing.action_request_id,
+                        action_type=existing.requested_payload.get("action_type"),
+                        lifecycle_state=existing.lifecycle_state,
+                        case_id=existing.case_id,
+                    )
+                    return existing
+
+            normalized_action_request_id = self._service._resolve_new_record_identifier(
+                ActionRequestRecord,
+                action_request_id,
+                "action_request_id",
+                "action-request",
+            )
+            created_request = self._service.persist_record(
+                ActionRequestRecord(
+                    action_request_id=normalized_action_request_id,
+                    approval_decision_id=None,
+                    case_id=case.case_id,
+                    alert_id=case.alert_id,
+                    finding_id=case.finding_id,
+                    idempotency_key=idempotency_key,
+                    target_scope=target_scope,
+                    payload_hash=payload_hash,
+                    requested_at=requested_at,
+                    expires_at=expires_at,
+                    lifecycle_state="pending_approval",
+                    requester_identity=requester_identity,
+                    requested_payload=requested_payload,
+                    policy_basis={
+                        "severity": "low",
+                        "target_scope": "single_asset",
+                        "action_reversibility": "bounded_reversible",
                         "asset_criticality": "standard",
                         "identity_criticality": "standard",
                         "blast_radius": "single_target",

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -695,9 +695,11 @@ def build_handler_class(
                             principal.identity,
                             require_json_string(payload, "requester_identity"),
                         )
-                    action_type = normalize_optional_string(
-                        payload.get("action_type")
-                    ) or "notify_identity_owner"
+                    action_type = (
+                        require_json_string(payload, "action_type")
+                        if "action_type" in payload
+                        else "notify_identity_owner"
+                    )
                     if action_type == "notify_identity_owner":
                         action_request = service.create_reviewed_action_request_from_advisory(
                             record_family=require_json_string(payload, "family"),
@@ -741,10 +743,11 @@ def build_handler_class(
                                 payload,
                                 "ticket_description",
                             ),
-                            ticket_severity=normalize_optional_string(
-                                payload.get("ticket_severity")
-                            )
-                            or "medium",
+                            ticket_severity=(
+                                require_json_string(payload, "ticket_severity")
+                                if "ticket_severity" in payload
+                                else "medium"
+                            ),
                             expires_at=require_json_datetime(payload, "expires_at"),
                             action_request_id=normalize_optional_string(
                                 payload.get("action_request_id")

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -695,27 +695,65 @@ def build_handler_class(
                             principal.identity,
                             require_json_string(payload, "requester_identity"),
                         )
-                    action_request = service.create_reviewed_action_request_from_advisory(
-                        record_family=require_json_string(payload, "family"),
-                        record_id=require_json_string(payload, "record_id"),
-                        requester_identity=require_json_string(
-                            payload,
-                            "requester_identity",
-                        ),
-                        recipient_identity=require_json_string(
-                            payload,
-                            "recipient_identity",
-                        ),
-                        message_intent=require_json_string(payload, "message_intent"),
-                        escalation_reason=require_json_string(
-                            payload,
-                            "escalation_reason",
-                        ),
-                        expires_at=require_json_datetime(payload, "expires_at"),
-                        action_request_id=normalize_optional_string(
-                            payload.get("action_request_id")
-                        ),
-                    )
+                    action_type = normalize_optional_string(
+                        payload.get("action_type")
+                    ) or "notify_identity_owner"
+                    if action_type == "notify_identity_owner":
+                        action_request = service.create_reviewed_action_request_from_advisory(
+                            record_family=require_json_string(payload, "family"),
+                            record_id=require_json_string(payload, "record_id"),
+                            requester_identity=require_json_string(
+                                payload,
+                                "requester_identity",
+                            ),
+                            recipient_identity=require_json_string(
+                                payload,
+                                "recipient_identity",
+                            ),
+                            message_intent=require_json_string(payload, "message_intent"),
+                            escalation_reason=require_json_string(
+                                payload,
+                                "escalation_reason",
+                            ),
+                            expires_at=require_json_datetime(payload, "expires_at"),
+                            action_request_id=normalize_optional_string(
+                                payload.get("action_request_id")
+                            ),
+                        )
+                    elif action_type == "create_tracking_ticket":
+                        action_request = service.create_reviewed_tracking_ticket_request_from_advisory(
+                            record_family=require_json_string(payload, "family"),
+                            record_id=require_json_string(payload, "record_id"),
+                            requester_identity=require_json_string(
+                                payload,
+                                "requester_identity",
+                            ),
+                            coordination_reference_id=require_json_string(
+                                payload,
+                                "coordination_reference_id",
+                            ),
+                            coordination_target_type=require_json_string(
+                                payload,
+                                "coordination_target_type",
+                            ),
+                            ticket_title=require_json_string(payload, "ticket_title"),
+                            ticket_description=require_json_string(
+                                payload,
+                                "ticket_description",
+                            ),
+                            ticket_severity=normalize_optional_string(
+                                payload.get("ticket_severity")
+                            )
+                            or "medium",
+                            expires_at=require_json_datetime(payload, "expires_at"),
+                            action_request_id=normalize_optional_string(
+                                payload.get("action_request_id")
+                            ),
+                        )
+                    else:
+                        raise ValueError(
+                            "action_type is outside the reviewed action request scope"
+                        )
                 except RequestTooLargeError as exc:
                     self._write_json(
                         HTTPStatus.REQUEST_ENTITY_TOO_LARGE,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4506,6 +4506,33 @@ class AegisOpsControlPlaneService:
             action_request_id=action_request_id,
         )
 
+    def create_reviewed_tracking_ticket_request_from_advisory(
+        self,
+        *,
+        record_family: str,
+        record_id: str,
+        requester_identity: str,
+        coordination_reference_id: str,
+        coordination_target_type: str,
+        ticket_title: str,
+        ticket_description: str,
+        expires_at: datetime,
+        ticket_severity: str = "medium",
+        action_request_id: str | None = None,
+    ) -> ActionRequestRecord:
+        return self._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory(
+            record_family=record_family,
+            record_id=record_id,
+            requester_identity=requester_identity,
+            coordination_reference_id=coordination_reference_id,
+            coordination_target_type=coordination_target_type,
+            ticket_title=ticket_title,
+            ticket_description=ticket_description,
+            expires_at=expires_at,
+            ticket_severity=ticket_severity,
+            action_request_id=action_request_id,
+        )
+
     def create_endpoint_evidence_collection_request(
         self,
         *,

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -1481,6 +1481,111 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                     servers[0].shutdown()
                 thread.join(timeout=2)
 
+    def test_reviewed_action_request_http_surface_rejects_blank_defaulted_fields(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret=REVIEWED_SHARED_SECRET,
+                wazuh_ingest_reverse_proxy_secret=REVIEWED_PROXY_SECRET,
+            ),
+            store=store,
+        )
+
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(
+            main,
+            "ThreadingHTTPServer",
+            RecordingServer,
+        ), self._mock_authenticated_surface_access(
+            service
+        ), mock.patch.object(
+            service,
+            "create_reviewed_action_request_from_advisory",
+            wraps=service.create_reviewed_action_request_from_advisory,
+        ) as create_notify_request, mock.patch.object(
+            service,
+            "create_reviewed_tracking_ticket_request_from_advisory",
+            wraps=service.create_reviewed_tracking_ticket_request_from_advisory,
+        ) as create_ticket_request:
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+
+                def post_invalid(payload: dict[str, object]) -> dict[str, object]:
+                    with self.assertRaises(error.HTTPError) as request_error:
+                        request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                            request.Request(  # noqa: S310 - local in-process test HTTP server
+                                f"{base_url}/operator/create-reviewed-action-request",
+                                data=json.dumps(payload).encode("utf-8"),
+                                headers={"Content-Type": "application/json"},
+                                method="POST",
+                            ),
+                            timeout=2,
+                        )
+                    self.assertEqual(request_error.exception.code, 400)
+                    return json.loads(request_error.exception.read().decode("utf-8"))
+
+                blank_action_type_error = post_invalid(
+                    {
+                        "action_type": " ",
+                        "family": "recommendation",
+                        "record_id": "recommendation-blank-action-type",
+                        "requester_identity": "analyst-001",
+                    }
+                )
+                self.assertIn(
+                    "action_type must be a non-empty string",
+                    blank_action_type_error["message"],
+                )
+
+                blank_ticket_severity_error = post_invalid(
+                    {
+                        "action_type": "create_tracking_ticket",
+                        "coordination_reference_id": "coord-ref-reviewed-ticket-003",
+                        "coordination_target_type": "zammad",
+                        "expires_at": (
+                            datetime.now(timezone.utc) + timedelta(hours=4)
+                        ).isoformat(),
+                        "family": "recommendation",
+                        "record_id": "recommendation-blank-ticket-severity",
+                        "requester_identity": "analyst-001",
+                        "ticket_description": "Track one reviewed daily follow-up.",
+                        "ticket_severity": " ",
+                        "ticket_title": "Track reviewed follow-up",
+                    }
+                )
+                self.assertIn(
+                    "ticket_severity must be a non-empty string",
+                    blank_ticket_severity_error["message"],
+                )
+                create_notify_request.assert_not_called()
+                create_ticket_request.assert_not_called()
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(timeout=2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py
@@ -278,6 +278,207 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
             reconciliation.subject_linkage["evidence_ids"],
             (evidence_id,),
         )
+
+    def test_service_executes_second_low_risk_tracking_ticket_action_from_reviewed_recommendation(
+        self,
+    ) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs a bounded tracking ticket.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Open one reviewed tracking ticket for daily operator follow-up.",
+            lead_id=lead.lead_id,
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=4)
+
+        action_request = service.create_reviewed_tracking_ticket_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            coordination_reference_id="coord-ref-reviewed-ticket-001",
+            coordination_target_type="zammad",
+            ticket_title="Review repository owner change",
+            ticket_description=(
+                "Open one reviewed tracking ticket for the repository owner change."
+            ),
+            expires_at=expires_at,
+            action_request_id="action-request-reviewed-ticket-001",
+        )
+
+        self.assertIsNone(action_request.approval_decision_id)
+        self.assertEqual(action_request.case_id, promoted_case.case_id)
+        self.assertEqual(action_request.alert_id, promoted_case.alert_id)
+        self.assertEqual(action_request.finding_id, promoted_case.finding_id)
+        self.assertEqual(action_request.lifecycle_state, "pending_approval")
+        self.assertEqual(action_request.requester_identity, "analyst-001")
+        self.assertEqual(
+            action_request.target_scope,
+            {
+                "record_family": "recommendation",
+                "record_id": recommendation.recommendation_id,
+                "case_id": promoted_case.case_id,
+                "alert_id": promoted_case.alert_id,
+                "finding_id": promoted_case.finding_id,
+                "coordination_reference_id": "coord-ref-reviewed-ticket-001",
+                "coordination_target_type": "zammad",
+            },
+        )
+        self.assertEqual(
+            action_request.requested_payload,
+            {
+                "action_type": "create_tracking_ticket",
+                "case_id": promoted_case.case_id,
+                "alert_id": promoted_case.alert_id,
+                "finding_id": promoted_case.finding_id,
+                "coordination_reference_id": "coord-ref-reviewed-ticket-001",
+                "coordination_target_type": "zammad",
+                "ticket_title": "Review repository owner change",
+                "ticket_description": (
+                    "Open one reviewed tracking ticket for the repository owner change."
+                ),
+                "ticket_severity": "medium",
+                "source_record_family": "recommendation",
+                "source_record_id": recommendation.recommendation_id,
+                "recommendation_id": recommendation.recommendation_id,
+                "linked_evidence_ids": (evidence_id,),
+            },
+        )
+        self.assertEqual(
+            action_request.payload_hash,
+            _approved_binding_hash(
+                target_scope=dict(action_request.target_scope),
+                approved_payload=dict(action_request.requested_payload),
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+            ),
+        )
+        self.assertEqual(action_request.expires_at, expires_at)
+        self.assertEqual(
+            action_request.policy_evaluation,
+            {
+                "approval_requirement": "human_required",
+                "approval_requirement_override": "human_required",
+                "routing_target": "approval",
+                "execution_surface_type": "automation_substrate",
+                "execution_surface_id": "shuffle",
+            },
+        )
+        self.assertEqual(
+            service.get_record(ActionRequestRecord, action_request.action_request_id),
+            action_request,
+        )
+        self.assertEqual(store.list(ActionExecutionRecord), ())
+        approval_decision = service.record_action_approval_decision(
+            action_request_id=action_request.action_request_id,
+            approver_identity="approver-001",
+            authenticated_approver_identity="approver-001",
+            decision="grant",
+            decision_rationale="Reviewed low-risk tracking ticket remains bounded to one case.",
+            decided_at=action_request.requested_at + timedelta(minutes=5),
+            approval_decision_id="approval-reviewed-ticket-001",
+        )
+        approved_request = service.get_record(
+            ActionRequestRecord,
+            action_request.action_request_id,
+        )
+        self.assertIsNotNone(approved_request)
+        assert approved_request is not None
+        self.assertEqual(approval_decision.lifecycle_state, "approved")
+        self.assertEqual(approved_request.lifecycle_state, "approved")
+        self.assertEqual(
+            approved_request.approval_decision_id,
+            approval_decision.approval_decision_id,
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=action_request.requested_at + timedelta(minutes=10),
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": action_request.requested_at + timedelta(minutes=15),
+                    "status": "success",
+                },
+            ),
+            compared_at=action_request.requested_at + timedelta(minutes=16),
+            stale_after=action_request.requested_at + timedelta(hours=1),
+        )
+
+        stored_execution = service.get_record(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertIsNotNone(stored_execution)
+        assert stored_execution is not None
+        self.assertEqual(stored_execution.lifecycle_state, "succeeded")
+        self.assertEqual(
+            execution.approval_decision_id,
+            approval_decision.approval_decision_id,
+        )
+        self.assertEqual(execution.action_request_id, action_request.action_request_id)
+        self.assertEqual(reconciliation.lifecycle_state, "matched")
+        self.assertEqual(reconciliation.ingest_disposition, "matched")
+        self.assertEqual(
+            reconciliation.subject_linkage["action_request_ids"],
+            (action_request.action_request_id,),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["approval_decision_ids"],
+            (approval_decision.approval_decision_id,),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["action_execution_ids"],
+            (execution.action_execution_id,),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["coordination_reference_ids"],
+            ("coord-ref-reviewed-ticket-001",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["coordination_target_types"],
+            ("zammad",),
+        )
+
     def test_service_phase20_first_live_action_fail_closes_on_downstream_execution_surface_mismatch(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py
@@ -479,6 +479,54 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
             ("zammad",),
         )
 
+    def test_service_rejects_out_of_scope_reviewed_tracking_ticket_severity(
+        self,
+    ) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs a bounded tracking ticket.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Open one reviewed tracking ticket for daily operator follow-up.",
+            lead_id=lead.lead_id,
+        )
+        baseline_requests = store.list(ActionRequestRecord)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "ticket_severity is outside the reviewed tracking-ticket scope",
+        ):
+            service.create_reviewed_tracking_ticket_request_from_advisory(
+                record_family="recommendation",
+                record_id=recommendation.recommendation_id,
+                requester_identity="analyst-001",
+                coordination_reference_id="coord-ref-reviewed-ticket-002",
+                coordination_target_type="zammad",
+                ticket_title="Review repository owner change",
+                ticket_description=(
+                    "Open one reviewed tracking ticket for the repository owner change."
+                ),
+                ticket_severity="high",
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+                action_request_id="action-request-reviewed-ticket-002",
+            )
+
+        self.assertEqual(store.list(ActionRequestRecord), baseline_requests)
+
     def test_service_phase20_first_live_action_fail_closes_on_downstream_execution_surface_mismatch(
         self,
     ) -> None:

--- a/docs/response-action-safety-model.md
+++ b/docs/response-action-safety-model.md
@@ -76,7 +76,7 @@ Approval reuse is prohibited across materially different targets, payloads, or t
 
 At minimum, the action-request lifecycle must distinguish `draft`, `pending_approval`, `approved`, `rejected`, `expired`, `canceled`, `superseded`, `executing`, `completed`, `failed`, and `unresolved`, while the approval-decision lifecycle must distinguish `pending`, `approved`, `rejected`, `expired`, `canceled`, and `superseded`.
 
-The future reviewed create-ticket path remains a `Soft Write` coordination action, not a transfer of case, approval, execution, or reconciliation authority into the external ticket system.
+The reviewed `create_tracking_ticket` path is the second low-risk candidate after `notify_identity_owner`. It remains a `Soft Write` coordination action, not a transfer of case, approval, execution, or reconciliation authority into the external ticket system.
 
 ## 5. Execution Safeguards
 

--- a/docs/response-action-safety-model.md
+++ b/docs/response-action-safety-model.md
@@ -76,7 +76,9 @@ Approval reuse is prohibited across materially different targets, payloads, or t
 
 At minimum, the action-request lifecycle must distinguish `draft`, `pending_approval`, `approved`, `rejected`, `expired`, `canceled`, `superseded`, `executing`, `completed`, `failed`, and `unresolved`, while the approval-decision lifecycle must distinguish `pending`, `approved`, `rejected`, `expired`, `canceled`, and `superseded`.
 
-The reviewed `create_tracking_ticket` path is the second low-risk candidate after `notify_identity_owner`. It remains a `Soft Write` coordination action, not a transfer of case, approval, execution, or reconciliation authority into the external ticket system.
+The future reviewed create-ticket path remains a `Soft Write` coordination action, not a transfer of case, approval, execution, or reconciliation authority into the external ticket system.
+
+The reviewed `create_tracking_ticket` path is the second low-risk candidate after `notify_identity_owner`.
 
 ## 5. Execution Safeguards
 


### PR DESCRIPTION
## Summary
- add `create_tracking_ticket` as the second low-risk reviewed action request candidate from advisory context
- preserve request, approval, Shuffle delegation, execution receipt, and reconciliation as separate authoritative records
- add the operator case-detail form branch for the bounded tracking-ticket request and document the candidate

## Verification
- `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation`
- `npm --prefix apps/operator-ui run test -- src/app/OperatorRoutes.test.tsx -t "creates reviewed tracking-ticket action requests|creates reviewed action requests and records manual follow-up"`
- `npm --prefix apps/operator-ui run build`

Part of #769


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operators can create tracking tickets as a reviewed action-request type with title, description, severity, coordination fields, and expiry.
  * Action-request forms dynamically switch fields based on selected action type.

* **Tests**
  * End-to-end and persistence tests cover tracking-ticket workflow, reconciliation, idempotency, and validation.
  * HTTP-surface tests assert validation rejects blank action_type/ticket_severity.

* **Documentation**
  * Clarified tracking-ticket risk positioning in response-action safety model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->