### PR TITLE
Tighten coordination visibility on case detail

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.controlPlane.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.controlPlane.testSuite.tsx
@@ -80,6 +80,97 @@ export function registerOperatorRoutesControlPlaneTests() {
       });
     });
 
+    it("renders reviewed tracking-ticket posture on case detail without making the ticket authoritative", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-case-detail": {
+            case_id: "case-ticket-456",
+            case_record: {
+              case_id: "case-ticket-456",
+              lifecycle_state: "pending_action",
+            },
+            linked_alert_ids: ["alert-ticket-456"],
+            linked_observation_ids: [],
+            linked_recommendation_ids: ["recommendation-ticket-456"],
+            linked_evidence_ids: ["evidence-ticket-456"],
+            linked_reconciliation_ids: ["recon-ticket-456"],
+            provenance_summary: {
+              authoritative_anchor: {
+                record_family: "case",
+                record_id: "case-ticket-456",
+                source_family: "github_audit",
+                provenance_classification: "authoritative",
+              },
+            },
+            linked_alert_records: [],
+            linked_evidence_records: [],
+            linked_reconciliation_records: [],
+            cross_source_timeline: [],
+            external_ticket_reference: {
+              authority: "non_authoritative",
+              status: "present",
+              coordination_reference_id: "coord-ref-case-ticket-456",
+              coordination_target_type: "zammad",
+              coordination_target_id: "ZM-456",
+              ticket_reference_url: "https://tickets.example.invalid/tickets/ZM-456",
+            },
+            current_action_review: {
+              action_request_id: "action-request-ticket-456",
+              review_state: "approved",
+              next_expected_action: "review_created_ticket",
+              target_scope: {
+                coordination_reference_id: "coord-ref-case-ticket-456",
+                coordination_target_type: "zammad",
+              },
+              coordination_ticket_outcome: {
+                authority: "authoritative_aegisops_review",
+                status: "created",
+                summary:
+                  "reviewed create-ticket outcome recorded from authoritative execution and reconciliation",
+                action_request_id: "action-request-ticket-456",
+                action_execution_id: "action-execution-ticket-456",
+                reconciliation_id: "recon-ticket-456",
+                coordination_reference_id: "coord-ref-case-ticket-456",
+                coordination_target_type: "zammad",
+                coordination_target_id: "ZM-456",
+                external_receipt_id: "receipt-ticket-456",
+                ticket_reference_url: "https://tickets.example.invalid/tickets/ZM-456",
+              },
+            },
+          },
+        }),
+      });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/cases/case-ticket-456"]}>
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Case Detail" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Coordination visibility")).toBeInTheDocument();
+      expect(screen.getByText("Coordination: created")).toBeInTheDocument();
+      expect(screen.getByText("Authority: authoritative_aegisops_review")).toBeInTheDocument();
+      expect(screen.getAllByText("coord-ref-case-ticket-456").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("zammad").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("ZM-456").length).toBeGreaterThan(0);
+      expect(screen.getByText("receipt-ticket-456")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Open downstream coordination reference" })).toHaveAttribute(
+        "href",
+        "https://tickets.example.invalid/tickets/ZM-456",
+      );
+      expect(
+        screen.getByText(
+          "External tickets remain non-authoritative coordination context for this case.",
+        ),
+      ).toBeInTheDocument();
+    });
+
     it("promotes an alert into a case from alert detail and re-renders authoritative state", async () => {
       const user = userEvent.setup();
       let alertDetailPayload: Record<string, unknown> = {

--- a/apps/operator-ui/src/app/operatorConsolePages/actionReviewSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/actionReviewSurfaces.tsx
@@ -213,6 +213,9 @@ export function CoordinationVisibilitySection({
             ["Authority", asString(coordinationOutcome?.authority)],
           ]}
         />
+        <Alert severity="info" variant="outlined">
+          External tickets remain non-authoritative coordination context for this case.
+        </Alert>
         {asString(coordinationOutcome?.summary) ? (
           <Alert severity="info" variant="outlined">
             {asString(coordinationOutcome?.summary)}

--- a/apps/operator-ui/src/app/operatorConsolePages/caseworkPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseworkPages.tsx
@@ -16,6 +16,7 @@ import {
   asString,
   asStringArray,
   AuditedRouteButton,
+  CoordinationVisibilitySection,
   EmptyState,
   ErrorState,
   formatValue,
@@ -286,6 +287,8 @@ function CaseDetailPageBody({
           </AuditedRouteButton>
         </Stack>
       </SectionCard>
+
+      <CoordinationVisibilitySection actionReview={currentActionReview} />
 
       <SectionCard
         subtitle="Cross-source lineage stays anchored to the reviewed case record. Only directly linked context is pulled into this surface."

--- a/docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md
+++ b/docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md
@@ -62,7 +62,15 @@ Missing ticket links, stale coordination URLs, or absent downstream receipts mus
 
 Operator convenience does not justify inferring authority from whichever ticket status or comment was updated last.
 
-## 7. Downstream Follow-On Scope
+## 7. Daily Operator Visibility
+
+Daily operator surfaces may show the reviewed coordination reference, create-ticket posture, external receipt id, and downstream ticket link when those values come from the reviewed AegisOps action-review projection or the non-authoritative coordination reference recorded on the case or alert.
+
+Those surfaces must keep the authority label explicit. The reviewed `create_tracking_ticket` posture describes the AegisOps-owned request, approval, execution, and reconciliation chain; the external ticket remains coordination context only.
+
+The daily path must not ask operators to treat ticket lifecycle, queue status, assignee, or closure as case or action truth. If the reviewed action outcome and the external coordination reference disagree, the mismatch remains visible and the authoritative AegisOps record chain wins.
+
+## 8. Downstream Follow-On Scope
 
 This decision is intended to unblock later issues that define:
 


### PR DESCRIPTION
## Summary
- render reviewed tracking-ticket coordination posture on case detail daily path
- keep downstream ticket links explicitly non-authoritative
- document daily operator visibility boundaries for Phase 26 coordination

## Tests
- npm --prefix apps/operator-ui run test -- OperatorRoutes.test.tsx -t "renders reviewed tracking-ticket posture on case detail"
- npm --prefix apps/operator-ui run test -- OperatorRoutes.test.tsx
- bash scripts/verify-phase-26-ticket-coordination-validation.sh
- python3 -m unittest control-plane.tests.test_phase26_end_to_end_validation
- python3 -m unittest control-plane.tests.test_phase26_coordination_substrate_boundary_docs control-plane.tests.test_phase26_create_tracking_ticket_soft_write_contract_docs
- bash scripts/test-verify-phase-26-ticket-coordination-validation.sh
- npm --prefix apps/operator-ui run build

Part of #768
Closes #771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordination visibility section to case detail page with alert distinguishing external tickets from authoritative coordination context.

* **Tests**
  * Added test case verifying tracking-ticket posture rendering for case detail review.

* **Documentation**
  * Updated documentation clarifying operator visibility requirements for coordination-related fields and data provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->