### PR TITLE
Surface assistant provider failure in advisory inspection

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.assistant.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.assistant.testSuite.tsx
@@ -283,6 +283,51 @@ export function registerOperatorRoutesAssistantTests() {
       ).toBeInTheDocument();
     });
 
+    it("renders provider-degraded advisory visibility for unresolved assistant output", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-advisory-output": {
+            read_only: true,
+            record_family: "recommendation",
+            record_id: "recommendation-789",
+            output_kind: "recommendation_draft",
+            status: "unresolved",
+            cited_summary: {
+              text: "Reviewed recommendation recommendation-789 remains bounded to the last trusted summary.",
+              citations: ["recommendation-789", "case-456"],
+            },
+            unresolved_questions: [
+              {
+                text: "Which reviewed provider result, retry evidence, or citation repair resolves this advisory failure?",
+                citations: ["recommendation-789", "ai-trace-789"],
+              },
+            ],
+            uncertainty_flags: ["advisory_only", "provider_generation_failed"],
+            citations: ["recommendation-789", "case-456", "ai-trace-789"],
+          },
+        }),
+      });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/assistant/recommendation/recommendation-789"]}>
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      expect(await screen.findByRole("heading", { name: "Advisory failure visibility" })).toBeInTheDocument();
+      expect(screen.getByText("Provider degraded")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Provider degraded state is visible here/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "The bounded assistant provider did not return a trusted summary, so the reviewed advisory remains unresolved.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /execute/i })).not.toBeInTheDocument();
+    });
+
     it("fails closed on unsupported assistant advisory route families", async () => {
       const fetchFn = createAuthorizedFetch({});
       const dependencies = createDefaultDependencies({

--- a/apps/operator-ui/src/app/operatorConsolePages/advisorySurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/advisorySurfaces.tsx
@@ -72,6 +72,8 @@ export function advisoryUncertaintyMessage(flag: string): string {
       return "Linked evidence citations required for this advisory output are missing.";
     case "conflicting_reviewed_context":
       return "Reviewed context conflicts remain unresolved and must stay visible before any operator action.";
+    case "provider_generation_failed":
+      return "The bounded assistant provider did not return a trusted summary, so the reviewed advisory remains unresolved.";
     case "ambiguous_identity_alias_only":
       return "Alias-style identity context is still unresolved; stable reviewed identifiers are still required.";
     case "reviewed_casework_identity_ambiguity":
@@ -99,6 +101,8 @@ export function advisoryUncertaintyLabel(flag: string): string {
       return "Missing evidence citation";
     case "conflicting_reviewed_context":
       return "Conflicting reviewed context";
+    case "provider_generation_failed":
+      return "Provider degraded";
     case "ambiguous_identity_alias_only":
       return "Alias-only identity ambiguity";
     case "reviewed_casework_identity_ambiguity":

--- a/apps/operator-ui/src/app/operatorConsolePages/assistantPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/assistantPages.tsx
@@ -112,10 +112,11 @@ function AssistantAdvisoryPageBody({
   const hasCitationFailure =
     uncertaintyFlags.includes("missing_supporting_citations") ||
     uncertaintyFlags.includes("missing_evidence_citation");
+  const hasProviderFailure = uncertaintyFlags.includes("provider_generation_failed");
   const hasUnresolvedState = asString(data.status) === "unresolved";
   const hasReviewedContextConflict = uncertaintyFlags.includes("conflicting_reviewed_context");
   const hasFailureVisibility =
-    hasCitationFailure || hasUnresolvedState || hasReviewedContextConflict;
+    hasCitationFailure || hasProviderFailure || hasUnresolvedState || hasReviewedContextConflict;
 
   return (
     <Stack spacing={3}>
@@ -172,6 +173,11 @@ function AssistantAdvisoryPageBody({
             {hasCitationFailure ? (
               <Alert severity="error" variant="outlined">
                 Missing citation support is visible here so uncited assistant prose does not resemble reviewed workflow truth.
+              </Alert>
+            ) : null}
+            {hasProviderFailure ? (
+              <Alert severity="error" variant="outlined">
+                Provider degraded state is visible here so a timeout or failed assistant response does not resemble reviewed workflow truth.
               </Alert>
             ) : null}
             {hasReviewedContextConflict ? (

--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -121,6 +121,32 @@ def _normalized_optional_string(value: object) -> str | None:
     return normalized or None
 
 
+def _normalized_string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    normalized: list[str] = []
+    for item in value:
+        normalized_item = _normalized_optional_string(item)
+        if normalized_item is not None and normalized_item not in normalized:
+            normalized.append(normalized_item)
+    return tuple(normalized)
+
+
+def _assistant_draft_failure_flags(unresolved_reasons: tuple[str, ...]) -> tuple[str, ...]:
+    flags: list[str] = []
+    for reason in unresolved_reasons:
+        lowered = reason.lower()
+        if "bounded live assistant did not return a trusted summary" in lowered:
+            flags.append("provider_generation_failed")
+        elif "provider" in lowered and "trusted summary" in lowered:
+            flags.append("provider_generation_failed")
+        elif "citation" in lowered:
+            flags.append("missing_supporting_citations")
+        elif "conflict" in lowered:
+            flags.append("conflicting_reviewed_context")
+    return _dedupe_strings(tuple(flags))
+
+
 def _linked_casework_identity_ambiguity_records(
     linked_evidence_records: tuple[dict[str, object], ...],
 ) -> tuple[dict[str, str], ...]:
@@ -311,6 +337,39 @@ def _build_assistant_advisory_output(
     unsafe_intended_outcome_flags = _advisory_text_claims_authority_or_scope_expansion(
         intended_outcome
     )
+    assistant_advisory_draft = record.get("assistant_advisory_draft")
+    if isinstance(assistant_advisory_draft, Mapping):
+        draft_status = _normalized_optional_string(assistant_advisory_draft.get("status"))
+        draft_unresolved_reasons = _normalized_string_tuple(
+            assistant_advisory_draft.get("unresolved_reasons")
+        )
+        if draft_status == "unresolved" and draft_unresolved_reasons:
+            fail_closed = True
+            draft_failure_flags = _assistant_draft_failure_flags(draft_unresolved_reasons)
+            uncertainty_flags.extend(draft_failure_flags or ("assistant_advisory_unresolved",))
+            draft_cited_summary = assistant_advisory_draft.get("cited_summary")
+            if isinstance(draft_cited_summary, Mapping):
+                unresolved_summary_override = _normalized_optional_string(
+                    draft_cited_summary.get("text")
+                )
+            unresolved_questions.append(
+                {
+                    "text": (
+                        "Which reviewed provider result, retry evidence, or citation repair "
+                        "resolves this advisory failure: "
+                        + "; ".join(draft_unresolved_reasons)
+                        + "?"
+                    ),
+                    "citations": _dedupe_strings(
+                        (
+                            record_id,
+                            _normalized_optional_string(
+                                assistant_advisory_draft.get("source_ai_trace_id")
+                            ),
+                        )
+                    ),
+                }
+            )
 
     if not supporting_citations:
         fail_closed = True

--- a/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
@@ -222,6 +222,45 @@ class Phase24LiveAssistantFeedbackLoopValidationTests(ServicePersistenceTestBase
             recommendation.assistant_advisory_draft["unresolved_reasons"][0],
         )
 
+    def test_live_assistant_provider_failure_stays_visible_on_recommendation_advisory_inspection(
+        self,
+    ) -> None:
+        store, service, promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        service._assistant_provider_adapter = mock.Mock()
+        service._assistant_provider_adapter.generate.side_effect = RuntimeError(
+            "provider transport failed"
+        )
+
+        snapshot = service.run_live_assistant_workflow(
+            workflow_task="case_summary",
+            record_family="case",
+            record_id=promoted_case.case_id,
+        )
+
+        self.assertEqual(snapshot.status, "unresolved")
+        recommendations = store.list(RecommendationRecord)
+        self.assertEqual(len(recommendations), 1)
+
+        advisory_snapshot = service.inspect_assistant_context(
+            "recommendation",
+            recommendations[0].recommendation_id,
+        )
+
+        self.assertEqual(advisory_snapshot.advisory_output["status"], "unresolved")
+        self.assertIn(
+            "provider_generation_failed",
+            advisory_snapshot.advisory_output["uncertainty_flags"],
+        )
+        self.assertTrue(
+            any(
+                "bounded live assistant did not return a trusted summary"
+                in question["text"]
+                for question in advisory_snapshot.advisory_output["unresolved_questions"]
+            )
+        )
+
     def test_live_assistant_workflow_persists_already_unresolved_advisory_feedback_loop(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- preserve unresolved live-assistant draft failures when recommendation advisory output is re-inspected
- surface provider_generation_failed as an explicit operator UI advisory failure state
- add focused control-plane and operator UI regression coverage

## Verification
- python3 -m unittest control-plane.tests.test_phase24_live_assistant_feedback_loop_validation control-plane.tests.test_phase24_live_assistant_fallback_validation control-plane.tests.test_phase24_live_assistant_surface_validation
- python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory
- npm --prefix apps/operator-ui test -- --run src/app/OperatorRoutes.test.tsx --testNamePattern "assistant routes"
- npm --prefix apps/operator-ui run build

Part of #770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UI support for provider generation failures, displaying "Provider degraded" messaging when the assistant provider fails to produce a trusted summary, keeping advisories unresolved and preventing action buttons from appearing.

* **Tests**
  * Added test coverage for provider degradation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->