### PR TITLE
Define customer-like rehearsal environment

### DIFF
--- a/docs/deployment/customer-like-rehearsal-environment.md
+++ b/docs/deployment/customer-like-rehearsal-environment.md
@@ -1,0 +1,154 @@
+# Customer-Like Rehearsal Environment
+
+## 1. Purpose and Boundary
+
+This document defines the disposable customer-like rehearsal environment for the Phase 37 single-customer live rehearsal gate.
+
+The rehearsal exists to replay the reviewed first-boot to single-customer operating path before AegisOps is treated as ready for a single-customer pilot.
+
+It is anchored to `docs/runbook.md`, `docs/deployment/single-customer-profile.md`, `docs/deployment/runtime-smoke-bundle.md`, `docs/deployment/operational-evidence-handoff-pack.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/storage-layout-and-mount-policy.md`, and `control-plane/deployment/first-boot/`.
+
+The rehearsal environment must be disposable, customer-like, and free of private customer context. It must not add HA, Kubernetes, multi-customer packaging, customer-private credentials, direct backend exposure, optional extension requirements, or vendor-specific automation.
+
+## 2. Disposable Topology
+
+The smallest approved rehearsal topology is:
+
+- one disposable operator workstation or VM with repository access and Docker Compose;
+- the repo-owned first-boot compose surface in `control-plane/deployment/first-boot/docker-compose.yml`;
+- PostgreSQL as the authoritative AegisOps control-plane persistence dependency;
+- the AegisOps control-plane service from `control-plane/`;
+- the approved reverse proxy boundary as the only user-facing ingress path; and
+- a reviewed Wazuh-facing intake path admitted through the reverse proxy and control-plane boundary.
+
+The rehearsal uses one named rehearsal customer scope such as `<rehearsal-customer-id>`, but that value is a reviewed rehearsal binding only. Operators must not infer tenant, customer, source, account, repository, or environment linkage from names, comments, paths, hostnames, or nearby metadata.
+
+The first-boot to single-customer delta is operational rather than architectural: the service boundary stays control plane, PostgreSQL, reverse proxy, and Wazuh-facing intake, while the operator evidence changes to customer-scoped ownership, daily queue and health review, backup custody, restore rehearsal, secret rotation, and break-glass custody.
+
+## 3. Services and Ports
+
+The required rehearsal services are limited to:
+
+| Service | Required role | Exposure |
+| --- | --- | --- |
+| Reverse proxy | User-facing ingress for health, readiness, runtime inspection, protected read-only inspection, operator UI, and Wazuh-facing intake admission | Bind only the reviewed rehearsal proxy port such as `AEGISOPS_FIRST_BOOT_PROXY_PORT` |
+| Control plane | Authoritative AegisOps record, readiness, runtime, inspection, approval, evidence, execution, and reconciliation surface | Internal only; do not publish the backend port as a front door |
+| PostgreSQL | Authoritative AegisOps-owned state | Internal only; persistent data and backup targets stay separated |
+| Wazuh-facing intake path | Reviewed analytic-signal intake into AegisOps-owned records | Through the reverse proxy and required intake secret boundary |
+
+The default reviewed command remains:
+
+```sh
+docker compose --env-file <runtime-env-file> -f control-plane/deployment/first-boot/docker-compose.yml up -d
+```
+
+Health, readiness, runtime inspection, and smoke checks must use the reverse proxy:
+
+```sh
+curl -fsS http://127.0.0.1:<proxy-port>/healthz
+curl -fsS http://127.0.0.1:<proxy-port>/readyz
+curl -fsS <trusted-platform-admin-proxy-auth-headers> http://127.0.0.1:<proxy-port>/runtime
+```
+
+## 4. Required Runtime Inputs
+
+Operators must prepare an untracked runtime env file from `control-plane/deployment/first-boot/bootstrap.env.sample`.
+
+The required non-secret runtime values are:
+
+- `AEGISOPS_CONTROL_PLANE_HOST`;
+- `AEGISOPS_CONTROL_PLANE_PORT`;
+- `AEGISOPS_CONTROL_PLANE_BOOT_MODE`;
+- `AEGISOPS_CONTROL_PLANE_LOG_LEVEL`;
+- `AEGISOPS_FIRST_BOOT_PROXY_PORT`;
+- `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_TRUSTED_PROXY_CIDRS`;
+- `AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_TRUSTED_PROXY_CIDRS`;
+- `AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT`; and
+- `AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER`.
+
+The PostgreSQL DSN must resolve from either `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`, `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_FILE`, or `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_OPENBAO_PATH`.
+
+Each required secret must resolve from a reviewed file binding or OpenBao binding:
+
+- Wazuh ingest shared secret from `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE` or `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH`;
+- Wazuh ingest reverse-proxy secret from `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET_FILE` or `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET_OPENBAO_PATH`;
+- protected-surface reverse-proxy secret from `AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET_FILE` or `AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET_OPENBAO_PATH`;
+- admin bootstrap token from `AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN_FILE` or `AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN_OPENBAO_PATH`; and
+- break-glass token from `AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_FILE` or `AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_OPENBAO_PATH`.
+
+If an OpenBao path is used for any required secret, the rehearsal env must also provide a reviewed OpenBao binding through `AEGISOPS_OPENBAO_ADDRESS` plus either `AEGISOPS_OPENBAO_TOKEN_FILE` or a runtime-injected `AEGISOPS_OPENBAO_TOKEN`, and `AEGISOPS_OPENBAO_KV_MOUNT`.
+
+Missing, empty, placeholder, TODO, sample, fake, guessed, or unsigned values are not approved rehearsal inputs. The rehearsal must stop and remain failed closed until a trusted binding is available.
+
+## 5. Approved Assumptions
+
+Environment assumptions:
+
+- the rehearsal env file is untracked and scoped to the disposable rehearsal;
+- `AEGISOPS_CONTROL_PLANE_BOOT_MODE` remains `first-boot`; and
+- optional extension URL variables may remain unset.
+
+Secret assumptions:
+
+- live DSNs, tokens, customer credentials, certificates, and break-glass material stay outside Git;
+- file or OpenBao bindings may be checked for presence, but secret values must not be echoed into evidence; and
+- placeholder credentials are refused even when they appear in sample files.
+
+Reverse-proxy assumptions:
+
+- the reverse proxy is the only reviewed user-facing ingress path;
+- forwarded headers and identity fields are trusted only after the reviewed proxy and identity-provider boundary authenticates and normalizes them; and
+- direct backend, PostgreSQL, or secret-backend publication is not part of the rehearsal.
+
+Storage assumptions:
+
+- PostgreSQL state uses a dedicated runtime mount;
+- backup output is separated from primary runtime data; and
+- VM snapshots may support infrastructure rollback but do not replace PostgreSQL-aware backup and restore validation.
+
+Wazuh-facing intake assumptions:
+
+- Wazuh remains an upstream detection substrate;
+- intake admission requires the reviewed shared-secret and reverse-proxy secret boundary; and
+- admitted signals become AegisOps-owned records only after the control-plane boundary validates and persists them.
+
+## 6. Rehearsal Flow
+
+The reviewed rehearsal sequence is:
+
+1. Create a disposable rehearsal workspace or VM and select the reviewed repository revision.
+2. Copy `control-plane/deployment/first-boot/bootstrap.env.sample` into an untracked `<runtime-env-file>`.
+3. Replace placeholders with reviewed rehearsal values and trusted secret references without storing live values in Git.
+4. Run `scripts/verify-customer-like-rehearsal-environment.sh --env-file <runtime-env-file>` before startup.
+5. Start the stack through the repo-owned first-boot compose command.
+6. Run the Phase 33 runtime smoke bundle in `docs/deployment/runtime-smoke-bundle.md` through the reverse proxy.
+7. Capture the evidence required by `docs/deployment/operational-evidence-handoff-pack.md`.
+8. Shut down the disposable stack through the runbook and confirm no rehearsal state is treated as customer production truth.
+
+The rehearsal passes only when startup, readiness, runtime inspection, protected read-only inspection, backup custody, customer-scoped ownership, and clean-state evidence can be shown without widening the reviewed boundary.
+
+## 7. Optional Extensions
+
+Assistant, ML shadow, endpoint evidence, optional network evidence, OpenSearch, n8n, Shuffle, and isolated-executor paths remain disabled by default, unavailable, or explicitly non-blocking.
+
+Optional extensions must not become startup prerequisites, readiness gates, smoke prerequisites, upgrade success gates, evidence handoff prerequisites, or reasons to widen the control-plane, PostgreSQL, reverse-proxy, or Wazuh-facing boundary.
+
+If an optional extension is present in a rehearsal, it must be recorded as subordinate evidence only and must not redefine approval, evidence, execution, reconciliation, readiness, runtime scope, or intake authority.
+
+## 8. Fail-Closed Validation
+
+The focused rehearsal verifier is:
+
+```sh
+scripts/verify-customer-like-rehearsal-environment.sh --env-file <runtime-env-file>
+```
+
+The verifier must fail when the rehearsal document is missing, cross-links are missing, required runtime inputs are absent, secret bindings are absent, placeholder values are still present, `AEGISOPS_CONTROL_PLANE_BOOT_MODE` is not `first-boot`, optional extensions are described as prerequisites, or publishable guidance uses workstation-local absolute paths.
+
+Rejected startup, intake, restore, upgrade, or smoke attempts must also prove that no orphan customer-scoped record, partial durable write, half-restored state, or misleading handoff evidence survived the failed path.
+
+## 9. Out of Scope
+
+HA, Kubernetes, multi-node operation, multi-customer operation, customer-private credentials, direct customer production access, optional-service auto-installation, endpoint or network evidence prerequisites, assistant or ML prerequisites, broad E2E validation, and vendor-specific deployment automation are out of scope.
+
+This environment does not authorize external substrates as AegisOps authority. Wazuh, backup tooling, proxy logs, and runtime smoke output remain evidence around the AegisOps record chain, not substitutes for it.

--- a/docs/deployment/operational-evidence-handoff-pack.md
+++ b/docs/deployment/operational-evidence-handoff-pack.md
@@ -26,6 +26,8 @@ The pack may reference external substrate receipts, backup custody notes, or bou
 
 For deployment-only handoff where no approval, execution, or reconciliation event occurred, retain the startup, readiness, runtime inspection, smoke, backup custody, and named-operator evidence required by the runbook and single-customer profile.
 
+For Phase 37 customer-like rehearsal, include the verifier result from `scripts/verify-customer-like-rehearsal-environment.sh --env-file <runtime-env-file>` with the startup, smoke, backup-custody, and clean-state evidence.
+
 For failed, rejected, or refused events, retain the refusal reason and the clean-state confirmation. Do not replace a failed path with a later successful retry summary unless the failed outcome remains reviewable.
 
 ## 3. Operator-Visible Handoff Artifacts

--- a/docs/deployment/runtime-smoke-bundle.md
+++ b/docs/deployment/runtime-smoke-bundle.md
@@ -22,6 +22,8 @@ The operator has a prepared untracked runtime env file copied from `control-plan
 
 The operator has a named repository revision or release identifier for the handoff record.
 
+For Phase 37 rehearsal, run this bundle after `scripts/verify-customer-like-rehearsal-environment.sh --env-file <runtime-env-file>` passes for the disposable customer-like environment.
+
 The operator has the reviewed proxy authentication headers or equivalent trusted proxy session needed for protected read-only inspection without writing those secret values into the evidence record.
 
 The approved reverse proxy is the user-facing ingress path for the smoke window, and the backend control-plane port remains internal.

--- a/docs/deployment/single-customer-profile.md
+++ b/docs/deployment/single-customer-profile.md
@@ -10,11 +10,14 @@ The package is anchored to `docs/runbook.md`, `docs/smb-footprint-and-deployment
 
 This package is operational guidance for the reviewed single-customer profile. It does not store customer-specific values, live secrets, DSNs, certificates, tokens, or vendor automation settings.
 
+The customer-like rehearsal environment in `docs/deployment/customer-like-rehearsal-environment.md` defines the disposable topology and preflight validation used to rehearse this profile without private customer context.
+
 Package inventory:
 
 | Artifact | Role in this package |
 | --- | --- |
 | `docs/deployment/single-customer-profile.md` | Reviewed operator-facing package boundary for one customer environment |
+| `docs/deployment/customer-like-rehearsal-environment.md` | Disposable customer-like rehearsal topology and fail-closed preflight validation |
 | `control-plane/deployment/first-boot/docker-compose.yml` | Repo-owned startup surface for the current control-plane, PostgreSQL, and proxy stack |
 | `control-plane/deployment/first-boot/bootstrap.env.sample` | Approved runtime input template to copy into an untracked customer-specific env file |
 | `docs/runbook.md` | Startup, shutdown, upgrade, restore, rollback, secret-rotation, and evidence procedure |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -117,6 +117,8 @@ Operators should run that bundle after startup, upgrade, rollback, or handoff wi
 
 The Phase 33 operational evidence handoff pack in `docs/deployment/operational-evidence-handoff-pack.md` is the reviewed minimum package for deployment, upgrade, restore, approval, execution, and reconciliation handoff evidence.
 
+The customer-like rehearsal environment in `docs/deployment/customer-like-rehearsal-environment.md` is the reviewed disposable topology for replaying the first-boot to single-customer path before a pilot readiness decision.
+
 ## 3. Shutdown
 
 The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.

--- a/scripts/test-verify-customer-like-rehearsal-environment.sh
+++ b/scripts/test-verify-customer-like-rehearsal-environment.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-customer-like-rehearsal-environment.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+write_valid_env() {
+  local path="$1"
+
+  cat > "${path}" <<'EOF'
+AEGISOPS_CONTROL_PLANE_HOST=0.0.0.0
+AEGISOPS_CONTROL_PLANE_PORT=8080
+AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_FILE=/run/aegisops-secrets/control-plane-postgres-dsn
+AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot
+AEGISOPS_CONTROL_PLANE_LOG_LEVEL=INFO
+AEGISOPS_FIRST_BOOT_PROXY_PORT=8080
+AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE=/run/aegisops-secrets/wazuh-shared-secret
+AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET_FILE=/run/aegisops-secrets/wazuh-reverse-proxy-secret
+AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_TRUSTED_PROXY_CIDRS=172.20.0.10/32
+AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET_FILE=/run/aegisops-secrets/protected-surface-reverse-proxy-secret
+AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_TRUSTED_PROXY_CIDRS=172.20.0.10/32
+AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT=svc-aegisops-proxy-control-plane
+AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER=authentik
+AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN_FILE=/run/aegisops-secrets/admin-bootstrap-token
+AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_FILE=/run/aegisops-secrets/break-glass-token
+AEGISOPS_CONTROL_PLANE_OPENSEARCH_URL=
+AEGISOPS_CONTROL_PLANE_N8N_BASE_URL=
+AEGISOPS_CONTROL_PLANE_SHUFFLE_BASE_URL=
+AEGISOPS_CONTROL_PLANE_ISOLATED_EXECUTOR_BASE_URL=
+EOF
+}
+
+assert_passes() {
+  local env_path="$1"
+
+  if ! bash "${verifier}" --env-file "${env_path}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${env_path}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local env_path="$1"
+  local expected="$2"
+
+  if bash "${verifier}" --env-file "${env_path}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${env_path}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_env="${workdir}/valid.env"
+write_valid_env "${valid_env}"
+assert_passes "${valid_env}"
+
+missing_secret_env="${workdir}/missing-secret.env"
+write_valid_env "${missing_secret_env}"
+perl -0pi -e 's/^AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE=.*\n//m' "${missing_secret_env}"
+assert_fails_with "${missing_secret_env}" "Missing required rehearsal input binding: Wazuh ingest shared secret"
+
+placeholder_env="${workdir}/placeholder.env"
+write_valid_env "${placeholder_env}"
+perl -0pi -e 's|^AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_FILE=.*$|AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=postgresql://<user>:<password>@postgres:5432/aegisops_control_plane|m' "${placeholder_env}"
+assert_fails_with "${placeholder_env}" "Placeholder rehearsal input is not allowed: AEGISOPS_CONTROL_PLANE_POSTGRES_DSN"
+
+wrong_boot_mode_env="${workdir}/wrong-boot-mode.env"
+write_valid_env "${wrong_boot_mode_env}"
+perl -0pi -e 's/^AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot$/AEGISOPS_CONTROL_PLANE_BOOT_MODE=single-customer/m' "${wrong_boot_mode_env}"
+assert_fails_with "${wrong_boot_mode_env}" "Invalid rehearsal boot mode: AEGISOPS_CONTROL_PLANE_BOOT_MODE must be first-boot"
+
+openbao_env="${workdir}/openbao.env"
+write_valid_env "${openbao_env}"
+perl -0pi -e 's/^AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_FILE=.*\n/AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_OPENBAO_PATH=kv\/aegisops\/break-glass-token\n/m' "${openbao_env}"
+assert_fails_with "${openbao_env}" "Missing required rehearsal input: AEGISOPS_OPENBAO_ADDRESS"
+
+echo "verify-customer-like-rehearsal-environment tests passed"

--- a/scripts/test-verify-customer-like-rehearsal-environment.sh
+++ b/scripts/test-verify-customer-like-rehearsal-environment.sh
@@ -65,6 +65,22 @@ assert_fails_with() {
   fi
 }
 
+assert_repo_fails_with() {
+  local repo_path="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${repo_path}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${repo_path}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
 valid_env="${workdir}/valid.env"
 write_valid_env "${valid_env}"
 assert_passes "${valid_env}"
@@ -79,6 +95,16 @@ write_valid_env "${placeholder_env}"
 perl -0pi -e 's|^AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_FILE=.*$|AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=postgresql://<user>:<password>@postgres:5432/aegisops_control_plane|m' "${placeholder_env}"
 assert_fails_with "${placeholder_env}" "Placeholder rehearsal input is not allowed: AEGISOPS_CONTROL_PLANE_POSTGRES_DSN"
 
+guessed_env="${workdir}/guessed.env"
+write_valid_env "${guessed_env}"
+perl -0pi -e 's|^AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_FILE=.*$|AEGISOPS_CONTROL_PLANE_POSTGRES_DSN=postgresql://guessed-user:reviewed-password@postgres:5432/aegisops_control_plane|m' "${guessed_env}"
+assert_fails_with "${guessed_env}" "Placeholder rehearsal input is not allowed: AEGISOPS_CONTROL_PLANE_POSTGRES_DSN"
+
+unsigned_env="${workdir}/unsigned.env"
+write_valid_env "${unsigned_env}"
+perl -0pi -e 's|^AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE=.*$|AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE=/run/aegisops-secrets/unsigned-wazuh-shared-secret|m' "${unsigned_env}"
+assert_fails_with "${unsigned_env}" "Placeholder rehearsal input is not allowed: AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE"
+
 wrong_boot_mode_env="${workdir}/wrong-boot-mode.env"
 write_valid_env "${wrong_boot_mode_env}"
 perl -0pi -e 's/^AEGISOPS_CONTROL_PLANE_BOOT_MODE=first-boot$/AEGISOPS_CONTROL_PLANE_BOOT_MODE=single-customer/m' "${wrong_boot_mode_env}"
@@ -88,5 +114,14 @@ openbao_env="${workdir}/openbao.env"
 write_valid_env "${openbao_env}"
 perl -0pi -e 's/^AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_FILE=.*\n/AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_OPENBAO_PATH=kv\/aegisops\/break-glass-token\n/m' "${openbao_env}"
 assert_fails_with "${openbao_env}" "Missing required rehearsal input: AEGISOPS_OPENBAO_ADDRESS"
+
+path_hygiene_repo="${workdir}/path-hygiene-repo"
+mkdir -p "${path_hygiene_repo}"
+cp -R "${repo_root}/docs" "${path_hygiene_repo}/docs"
+cat >> "${path_hygiene_repo}/docs/deployment/customer-like-rehearsal-environment.md" <<'EOF'
+
+Invalid workstation-local example: /Users/example/AegisOps
+EOF
+assert_repo_fails_with "${path_hygiene_repo}" "Forbidden customer-like rehearsal environment statement: workstation-local absolute path detected"
 
 echo "verify-customer-like-rehearsal-environment tests passed"

--- a/scripts/verify-customer-like-rehearsal-environment.sh
+++ b/scripts/verify-customer-like-rehearsal-environment.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/verify-customer-like-rehearsal-environment.sh [<repo-root>] [--env-file <runtime-env-file>]
+
+Validates the customer-like rehearsal environment document and, when an env file
+is supplied, fails closed on missing required rehearsal inputs.
+EOF
+}
+
+repo_root=""
+env_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 2
+      fi
+      env_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "${repo_root}" ]]; then
+        usage
+        exit 2
+      fi
+      repo_root="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${repo_root}" ]]; then
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+doc_path="${repo_root}/docs/deployment/customer-like-rehearsal-environment.md"
+runbook_path="${repo_root}/docs/runbook.md"
+profile_path="${repo_root}/docs/deployment/single-customer-profile.md"
+smoke_path="${repo_root}/docs/deployment/runtime-smoke-bundle.md"
+handoff_path="${repo_root}/docs/deployment/operational-evidence-handoff-pack.md"
+network_path="${repo_root}/docs/network-exposure-and-access-path-policy.md"
+storage_path="${repo_root}/docs/storage-layout-and-mount-policy.md"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+load_env_value() {
+  local key="$1"
+  local line value
+
+  line="$(grep -E "^${key}=" "${env_file}" | tail -n 1 || true)"
+  if [[ -z "${line}" ]]; then
+    printf ''
+    return
+  fi
+
+  value="${line#*=}"
+  value="$(trim "${value}")"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  printf '%s' "${value}"
+}
+
+is_placeholder_value() {
+  local value="$1"
+  local lowered
+
+  lowered="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
+  [[ "${value}" == *"<"*">"* ]] || [[ "${lowered}" == *"todo"* ]] || [[ "${lowered}" == *"sample"* ]] || [[ "${lowered}" == *"fake"* ]] || [[ "${lowered}" == *"placeholder"* ]] || [[ "${lowered}" == *"change-me"* ]]
+}
+
+require_env_value() {
+  local key="$1"
+  local value
+
+  value="$(load_env_value "${key}")"
+  if [[ -z "${value}" ]]; then
+    echo "Missing required rehearsal input: ${key}" >&2
+    exit 1
+  fi
+  if is_placeholder_value "${value}"; then
+    echo "Placeholder rehearsal input is not allowed: ${key}" >&2
+    exit 1
+  fi
+}
+
+require_one_of() {
+  local description="$1"
+  shift
+  local key value has_value=0
+
+  for key in "$@"; do
+    value="$(load_env_value "${key}")"
+    if [[ -n "${value}" ]]; then
+      has_value=1
+      if is_placeholder_value "${value}"; then
+        echo "Placeholder rehearsal input is not allowed: ${key}" >&2
+        exit 1
+      fi
+    fi
+  done
+
+  if [[ "${has_value}" -eq 0 ]]; then
+    echo "Missing required rehearsal input binding: ${description}" >&2
+    exit 1
+  fi
+}
+
+uses_openbao_path() {
+  local key value
+
+  for key in \
+    AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_OPENBAO_PATH \
+    AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH \
+    AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET_OPENBAO_PATH \
+    AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET_OPENBAO_PATH \
+    AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN_OPENBAO_PATH \
+    AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_OPENBAO_PATH; do
+    value="$(load_env_value "${key}")"
+    if [[ -n "${value}" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+require_file "${doc_path}" "customer-like rehearsal environment profile"
+require_file "${runbook_path}" "runbook document"
+require_file "${profile_path}" "single-customer deployment profile"
+require_file "${smoke_path}" "runtime smoke bundle"
+require_file "${handoff_path}" "operational evidence handoff pack"
+require_file "${network_path}" "network exposure policy"
+require_file "${storage_path}" "storage layout policy"
+
+required_headings=(
+  "# Customer-Like Rehearsal Environment"
+  "## 1. Purpose and Boundary"
+  "## 2. Disposable Topology"
+  "## 3. Services and Ports"
+  "## 4. Required Runtime Inputs"
+  "## 5. Approved Assumptions"
+  "## 6. Rehearsal Flow"
+  "## 7. Optional Extensions"
+  "## 8. Fail-Closed Validation"
+  "## 9. Out of Scope"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${doc_path}" "${heading}" "customer-like rehearsal environment heading"
+done
+
+required_phrases=(
+  "This document defines the disposable customer-like rehearsal environment for the Phase 37 single-customer live rehearsal gate."
+  "The rehearsal exists to replay the reviewed first-boot to single-customer operating path before AegisOps is treated as ready for a single-customer pilot."
+  'It is anchored to `docs/runbook.md`, `docs/deployment/single-customer-profile.md`, `docs/deployment/runtime-smoke-bundle.md`, `docs/deployment/operational-evidence-handoff-pack.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/storage-layout-and-mount-policy.md`, and `control-plane/deployment/first-boot/`.'
+  "The rehearsal environment must be disposable, customer-like, and free of private customer context."
+  "The smallest approved rehearsal topology is:"
+  'the repo-owned first-boot compose surface in `control-plane/deployment/first-boot/docker-compose.yml`'
+  "PostgreSQL as the authoritative AegisOps control-plane persistence dependency"
+  "the approved reverse proxy boundary as the only user-facing ingress path"
+  "a reviewed Wazuh-facing intake path admitted through the reverse proxy and control-plane boundary"
+  "The first-boot to single-customer delta is operational rather than architectural:"
+  "The required rehearsal services are limited to:"
+  "Control plane | Authoritative AegisOps record, readiness, runtime, inspection, approval, evidence, execution, and reconciliation surface | Internal only; do not publish the backend port as a front door"
+  "PostgreSQL | Authoritative AegisOps-owned state | Internal only; persistent data and backup targets stay separated"
+  'Operators must prepare an untracked runtime env file from `control-plane/deployment/first-boot/bootstrap.env.sample`.'
+  '`AEGISOPS_FIRST_BOOT_PROXY_PORT`'
+  '`AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_TRUSTED_PROXY_CIDRS`'
+  '`AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_TRUSTED_PROXY_CIDRS`'
+  'The PostgreSQL DSN must resolve from either `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN`, `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_FILE`, or `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_OPENBAO_PATH`.'
+  "Each required secret must resolve from a reviewed file binding or OpenBao binding:"
+  "Missing, empty, placeholder, TODO, sample, fake, guessed, or unsigned values are not approved rehearsal inputs."
+  "the reverse proxy is the only reviewed user-facing ingress path"
+  "PostgreSQL state uses a dedicated runtime mount"
+  "Wazuh remains an upstream detection substrate"
+  'Run `scripts/verify-customer-like-rehearsal-environment.sh --env-file <runtime-env-file>` before startup.'
+  'Run the Phase 33 runtime smoke bundle in `docs/deployment/runtime-smoke-bundle.md` through the reverse proxy.'
+  'Capture the evidence required by `docs/deployment/operational-evidence-handoff-pack.md`.'
+  "Assistant, ML shadow, endpoint evidence, optional network evidence, OpenSearch, n8n, Shuffle, and isolated-executor paths remain disabled by default, unavailable, or explicitly non-blocking."
+  "Optional extensions must not become startup prerequisites, readiness gates, smoke prerequisites, upgrade success gates, evidence handoff prerequisites, or reasons to widen the control-plane, PostgreSQL, reverse-proxy, or Wazuh-facing boundary."
+  'The verifier must fail when the rehearsal document is missing, cross-links are missing, required runtime inputs are absent, secret bindings are absent, placeholder values are still present, `AEGISOPS_CONTROL_PLANE_BOOT_MODE` is not `first-boot`, optional extensions are described as prerequisites, or publishable guidance uses workstation-local absolute paths.'
+  "This environment does not authorize external substrates as AegisOps authority."
+)
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${doc_path}" "${phrase}" "customer-like rehearsal environment statement"
+done
+
+require_phrase "${runbook_path}" 'The customer-like rehearsal environment in `docs/deployment/customer-like-rehearsal-environment.md` is the reviewed disposable topology for replaying the first-boot to single-customer path before a pilot readiness decision.' "runbook customer-like rehearsal link"
+require_phrase "${profile_path}" 'The customer-like rehearsal environment in `docs/deployment/customer-like-rehearsal-environment.md` defines the disposable topology and preflight validation used to rehearse this profile without private customer context.' "single-customer profile customer-like rehearsal link"
+require_phrase "${smoke_path}" 'For Phase 37 rehearsal, run this bundle after `scripts/verify-customer-like-rehearsal-environment.sh --env-file <runtime-env-file>` passes for the disposable customer-like environment.' "runtime smoke customer-like rehearsal link"
+require_phrase "${handoff_path}" 'For Phase 37 customer-like rehearsal, include the verifier result from `scripts/verify-customer-like-rehearsal-environment.sh --env-file <runtime-env-file>` with the startup, smoke, backup-custody, and clean-state evidence.' "handoff customer-like rehearsal link"
+
+for forbidden in "requires OpenSearch" "requires n8n" "requires Shuffle" "requires ML shadow" "requires Kubernetes" "requires customer-private credential"; do
+  if grep -Fqi -- "${forbidden}" "${doc_path}"; then
+    echo "Forbidden customer-like rehearsal environment statement: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+if [[ -n "${env_file}" ]]; then
+  if [[ ! -f "${env_file}" ]]; then
+    echo "Missing rehearsal env file: ${env_file}" >&2
+    exit 1
+  fi
+
+  require_env_value AEGISOPS_CONTROL_PLANE_HOST
+  require_env_value AEGISOPS_CONTROL_PLANE_PORT
+  require_env_value AEGISOPS_CONTROL_PLANE_BOOT_MODE
+  require_env_value AEGISOPS_CONTROL_PLANE_LOG_LEVEL
+  require_env_value AEGISOPS_FIRST_BOOT_PROXY_PORT
+  require_env_value AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_TRUSTED_PROXY_CIDRS
+  require_env_value AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_TRUSTED_PROXY_CIDRS
+  require_env_value AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_PROXY_SERVICE_ACCOUNT
+  require_env_value AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVIEWED_IDENTITY_PROVIDER
+
+  if [[ "$(load_env_value AEGISOPS_CONTROL_PLANE_BOOT_MODE)" != "first-boot" ]]; then
+    echo "Invalid rehearsal boot mode: AEGISOPS_CONTROL_PLANE_BOOT_MODE must be first-boot" >&2
+    exit 1
+  fi
+
+  require_one_of "PostgreSQL DSN" \
+    AEGISOPS_CONTROL_PLANE_POSTGRES_DSN \
+    AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_FILE \
+    AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_OPENBAO_PATH
+  require_one_of "Wazuh ingest shared secret" \
+    AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE \
+    AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH
+  require_one_of "Wazuh ingest reverse-proxy secret" \
+    AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET_FILE \
+    AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET_OPENBAO_PATH
+  require_one_of "protected-surface reverse-proxy secret" \
+    AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET_FILE \
+    AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET_OPENBAO_PATH
+  require_one_of "admin bootstrap token" \
+    AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN_FILE \
+    AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN_OPENBAO_PATH
+  require_one_of "break-glass token" \
+    AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_FILE \
+    AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_OPENBAO_PATH
+
+  if uses_openbao_path; then
+    require_env_value AEGISOPS_OPENBAO_ADDRESS
+    require_one_of "OpenBao token" AEGISOPS_OPENBAO_TOKEN_FILE AEGISOPS_OPENBAO_TOKEN
+    require_env_value AEGISOPS_OPENBAO_KV_MOUNT
+  fi
+fi
+
+echo "Customer-like rehearsal environment is present and required rehearsal inputs fail closed when checked."

--- a/scripts/verify-customer-like-rehearsal-environment.sh
+++ b/scripts/verify-customer-like-rehearsal-environment.sh
@@ -103,7 +103,14 @@ is_placeholder_value() {
   local lowered
 
   lowered="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
-  [[ "${value}" == *"<"*">"* ]] || [[ "${lowered}" == *"todo"* ]] || [[ "${lowered}" == *"sample"* ]] || [[ "${lowered}" == *"fake"* ]] || [[ "${lowered}" == *"placeholder"* ]] || [[ "${lowered}" == *"change-me"* ]]
+  [[ "${value}" == *"<"*">"* ]] || \
+    [[ "${lowered}" == *"todo"* ]] || \
+    [[ "${lowered}" == *"sample"* ]] || \
+    [[ "${lowered}" == *"fake"* ]] || \
+    [[ "${lowered}" == *"placeholder"* ]] || \
+    [[ "${lowered}" == *"change-me"* ]] || \
+    [[ "${lowered}" == *"guess"* ]] || \
+    [[ "${lowered}" == *"unsigned"* ]]
 }
 
 require_env_value() {
@@ -235,6 +242,11 @@ for forbidden in "requires OpenSearch" "requires n8n" "requires Shuffle" "requir
     exit 1
   fi
 done
+
+if grep -Eq '(^|[^[:alnum:]_./-])(~[/\\]|/Users/[^[:space:])>]+|/home/[^[:space:])>]+|[A-Za-z]:\\Users\\[^[:space:])>]+)' "${doc_path}"; then
+  echo "Forbidden customer-like rehearsal environment statement: workstation-local absolute path detected" >&2
+  exit 1
+fi
 
 if [[ -n "${env_file}" ]]; then
   if [[ ! -f "${env_file}" ]]; then


### PR DESCRIPTION
## Summary
- Define the disposable customer-like rehearsal environment for the Phase 37 single-customer live rehearsal gate.
- Add a focused verifier that checks doc cross-links and fail-closed runtime env inputs.
- Cross-link the rehearsal environment from the runbook, single-customer profile, runtime smoke bundle, and operational evidence handoff pack.

## Verification
- `bash scripts/verify-customer-like-rehearsal-environment.sh`
- `bash scripts/test-verify-customer-like-rehearsal-environment.sh`
- `bash scripts/verify-single-customer-deployment-profile.sh`
- `bash scripts/test-verify-single-customer-deployment-profile.sh`
- `bash scripts/verify-phase-33-runtime-smoke-bundle.sh`
- `bash scripts/test-verify-phase-33-runtime-smoke-bundle.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`

Part of #775
Closes #776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a customer-like rehearsal environment guide describing disposable topology, required inputs/secrets, fail-closed preflight checks, operational inspection, rehearsal flow, and scope limits
  * Linked the new guide from the deployment profile and runbook; extended evidence-handoff guidance to require verifier output

* **New Features**
  * Added a fail-closed verifier for rehearsal environments
  * Added automated tests exercising verifier success and failure cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->