### PR TITLE
Add Phase 37 restore rollback upgrade evidence gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           bash scripts/verify-sigma-to-opensearch-translation-strategy-doc.sh
           bash scripts/verify-phase-33-runtime-smoke-bundle.sh
           bash scripts/verify-phase-37-runtime-smoke-gate.sh
+          bash scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh
           bash scripts/verify-phase-33-operational-evidence-handoff-pack.sh
           bash scripts/verify-single-customer-deployment-profile.sh
           bash scripts/verify-storage-policy-doc.sh
@@ -301,6 +302,7 @@ jobs:
           bash scripts/test-verify-sigma-to-opensearch-translation-strategy-doc.sh
           bash scripts/test-verify-phase-33-runtime-smoke-bundle.sh
           bash scripts/test-run-phase-37-runtime-smoke-gate.sh
+          bash scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
           bash scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
           bash scripts/test-verify-single-customer-deployment-profile.sh
           bash scripts/test-verify-source-onboarding-contract-doc.sh

--- a/docs/deployment/customer-like-rehearsal-environment.md
+++ b/docs/deployment/customer-like-rehearsal-environment.md
@@ -123,8 +123,9 @@ The reviewed rehearsal sequence is:
 5. Run `scripts/verify-phase-37-reviewed-record-chain-rehearsal.sh` to replay the seeded reviewed record-chain fixture through detection admission, case ownership, reviewed action request, separate approval, Shuffle execution receipt, reconciliation, and manifest validation.
 6. Start the stack through the repo-owned first-boot compose command.
 7. Run `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>` through the reverse proxy and retain its `manifest.md`.
-8. Capture the evidence required by `docs/deployment/operational-evidence-handoff-pack.md`.
-9. Shut down the disposable stack through the runbook and confirm no rehearsal state is treated as customer production truth.
+8. Assemble and verify the restore, rollback, and upgrade release-gate manifest with `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>` before handoff closes.
+9. Capture the evidence required by `docs/deployment/operational-evidence-handoff-pack.md`.
+10. Shut down the disposable stack through the runbook and confirm no rehearsal state is treated as customer production truth.
 
 The rehearsal passes only when the seeded reviewed record-chain fixture, startup, readiness, runtime inspection, protected read-only inspection, backup custody, customer-scoped ownership, and clean-state evidence can be shown without widening the reviewed boundary.
 

--- a/docs/deployment/operational-evidence-handoff-pack.md
+++ b/docs/deployment/operational-evidence-handoff-pack.md
@@ -28,6 +28,8 @@ For deployment-only handoff where no approval, execution, or reconciliation even
 
 For Phase 37 customer-like rehearsal, include the verifier result from `scripts/verify-customer-like-rehearsal-environment.sh --env-file <runtime-env-file>`, the reviewed record-chain replay result from `scripts/verify-phase-37-reviewed-record-chain-rehearsal.sh`, and the executable smoke gate manifest from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>` with the startup, backup-custody, and clean-state evidence.
 
+For Phase 37 restore, rollback, and upgrade rehearsal, retain the release-gate manifest verified by `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>` so backup, restore, rollback, upgrade, smoke, reviewed-record, and clean-state evidence remain linked in one handoff index.
+
 For failed, rejected, or refused events, retain the refusal reason and the clean-state confirmation. Do not replace a failed path with a later successful retry summary unless the failed outcome remains reviewable.
 
 ## 3. Operator-Visible Handoff Artifacts

--- a/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md
+++ b/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md
@@ -1,0 +1,70 @@
+# Phase 37 Restore Rollback Upgrade Evidence Rehearsal
+
+## 1. Purpose and Boundary
+
+This document defines the Phase 37 release-gate rehearsal for pre-change backup capture, restore validation, same-day rollback decision evidence, post-upgrade smoke, and retained handoff evidence.
+
+The rehearsal is anchored to `docs/runbook.md`, `docs/deployment/customer-like-rehearsal-environment.md`, `docs/deployment/runtime-smoke-bundle.md`, and `docs/deployment/operational-evidence-handoff-pack.md`.
+
+The release gate proves that backup, restore, rollback, upgrade, smoke, and reviewed-record evidence stay explainable against the AegisOps authoritative record chain. It does not create a vendor backup integration, zero-downtime promise, HA design, cluster failover plan, or multi-customer operating model.
+
+## 2. Prerequisites
+
+Before the rehearsal starts, operators must have:
+
+- an approved maintenance or rehearsal window and a named operator;
+- the reviewed repository revision or release identifier before the change;
+- a PostgreSQL-aware pre-change backup custody record;
+- a reviewed configuration backup or runtime env export reference that does not include live secret values;
+- the restore target and restore point selected for same-day rollback;
+- the seeded reviewed record-chain rehearsal result from `scripts/verify-phase-37-reviewed-record-chain-rehearsal.sh`;
+- the runtime smoke gate output from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>`; and
+- a retained release-gate manifest path such as `<release-gate-manifest.md>`.
+
+Missing backup custody, restore target, rollback decision owner, smoke manifest, or reviewed record-chain evidence blocks the release gate until the prerequisite is supplied. Operators must not substitute guessed scope, placeholder credentials, raw forwarded headers, optional-extension health, VM snapshot existence, or substrate-local status for these prerequisites.
+
+## 3. Rehearsal Flow
+
+The reviewed release-gate sequence is:
+
+1. Capture the pre-change readiness, runtime, compose status, bounded logs, repository revision, and backup custody reference.
+2. Record the selected restore point and restore target before any upgrade or rollback step begins.
+3. Rehearse restore against the reviewed recovery target and validate approval, evidence, execution, and reconciliation records against the reviewed record chain.
+4. Record the same-day rollback decision, including whether rollback was not needed or which restore point and configuration revision were used.
+5. Apply the reviewed upgrade through the repo-owned first-boot path without direct backend exposure, HA choreography, cluster failover, or optional-extension prerequisites.
+6. Run the Phase 37 runtime smoke gate after restore, rollback, or upgrade where feasible and retain its `manifest.md`.
+7. Assemble the release-gate manifest and verify it with `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>`.
+
+The restored, rolled-back, or upgraded environment may return to operator use only when readiness, runtime inspection, smoke output, and reviewed record-chain validation describe one committed state.
+
+## 4. Retained Manifest
+
+The retained manifest is the handoff index for the release gate. It must include:
+
+- rehearsal owner and maintenance window;
+- pre-change backup custody and selected restore point;
+- restore target and restore validation result;
+- same-day rollback decision and rollback evidence;
+- upgrade revision and post-upgrade evidence;
+- runtime smoke manifest reference;
+- reviewed record-chain evidence reference;
+- clean-state validation confirming no orphan record, partial durable write, half-restored state, or misleading handoff evidence survived a failed path; and
+- handoff owner and next review.
+
+The manifest must use repo-relative commands, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, and `<release-gate-manifest.md>`. It must not include workstation-local absolute paths, live secrets, DSNs, bootstrap tokens, break-glass tokens, unsigned identity hints, raw forwarded-header values, or customer-private credentials.
+
+## 5. Fail-Closed Validation
+
+The focused release-gate verifier is:
+
+```sh
+scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>
+```
+
+The verifier fails closed when the rehearsal document is missing, required cross-links are missing, a retained manifest omits backup, restore, rollback, upgrade, smoke, reviewed-record, or clean-state evidence, placeholder values remain, or publishable guidance uses workstation-local absolute paths.
+
+Rejected, forbidden, failed, or restore-failure paths must preserve the refusal reason and prove durable state remained clean. It is not enough to prove only that an error occurred.
+
+## 6. Out of Scope
+
+Zero-downtime deployment, HA, database clustering, vendor-specific backup product integration, direct backend exposure, optional-extension startup or upgrade gates, multi-customer evidence warehouses, and customer-private production access are out of scope.

--- a/docs/deployment/runtime-smoke-bundle.md
+++ b/docs/deployment/runtime-smoke-bundle.md
@@ -137,6 +137,8 @@ For post-upgrade checks, compare the post-change smoke result with the pre-chang
 
 For rollback checks, run this bundle after the documented restore or rollback path and keep normal operation blocked if the restored state cannot prove the same first-boot scope, protected ingress, and read-only record-chain visibility.
 
+For restore, rollback, and upgrade release-gate rehearsal, the smoke manifest is one referenced artifact in the retained release-gate manifest verified by `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>`.
+
 ## 6. Out of Scope
 
 Full workflow regression, optional-extension full-path validation, broad source coverage, destructive action validation, and exhaustive E2E validation are out of scope.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -123,6 +123,8 @@ The Phase 33 operational evidence handoff pack in `docs/deployment/operational-e
 
 The customer-like rehearsal environment in `docs/deployment/customer-like-rehearsal-environment.md` is the reviewed disposable topology for replaying the first-boot to single-customer path before a pilot readiness decision.
 
+The Phase 37 restore, rollback, and upgrade evidence rehearsal in `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md` is the reviewed release-gate path for tying pre-change backup custody, restore validation, rollback decision evidence, post-upgrade smoke, and retained handoff evidence together.
+
 ## 3. Shutdown
 
 The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.

--- a/scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
+++ b/scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment" "${target}/scripts"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_shared_docs() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/runbook.md"
+# AegisOps Runbook
+
+The Phase 37 restore, rollback, and upgrade evidence rehearsal in `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md` is the reviewed release-gate path for tying pre-change backup custody, restore validation, rollback decision evidence, post-upgrade smoke, and retained handoff evidence together.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/customer-like-rehearsal-environment.md"
+# Customer-Like Rehearsal Environment
+
+Assemble and verify the restore, rollback, and upgrade release-gate manifest with `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>` before handoff closes.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/runtime-smoke-bundle.md"
+# Phase 33 Runtime Smoke Bundle
+
+For restore, rollback, and upgrade release-gate rehearsal, the smoke manifest is one referenced artifact in the retained release-gate manifest verified by `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>`.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/operational-evidence-handoff-pack.md"
+# Phase 33 Operational Evidence Retention and Audit Handoff Pack
+
+For Phase 37 restore, rollback, and upgrade rehearsal, retain the release-gate manifest verified by `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>` so backup, restore, rollback, upgrade, smoke, reviewed-record, and clean-state evidence remain linked in one handoff index.
+EOF
+
+  cat <<'EOF' > "${target}/scripts/verify-phase-37-reviewed-record-chain-rehearsal.sh"
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat <<'EOF' > "${target}/scripts/run-phase-37-runtime-smoke-gate.sh"
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  chmod +x "${target}/scripts/verify-phase-37-reviewed-record-chain-rehearsal.sh" "${target}/scripts/run-phase-37-runtime-smoke-gate.sh"
+}
+
+write_valid_doc() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+# Phase 37 Restore Rollback Upgrade Evidence Rehearsal
+
+## 1. Purpose and Boundary
+
+This document defines the Phase 37 release-gate rehearsal for pre-change backup capture, restore validation, same-day rollback decision evidence, post-upgrade smoke, and retained handoff evidence.
+
+The rehearsal is anchored to `docs/runbook.md`, `docs/deployment/customer-like-rehearsal-environment.md`, `docs/deployment/runtime-smoke-bundle.md`, and `docs/deployment/operational-evidence-handoff-pack.md`.
+
+The release gate proves that backup, restore, rollback, upgrade, smoke, and reviewed-record evidence stay explainable against the AegisOps authoritative record chain.
+
+## 2. Prerequisites
+
+- a PostgreSQL-aware pre-change backup custody record;
+- the restore target and restore point selected for same-day rollback;
+- the seeded reviewed record-chain rehearsal result from `scripts/verify-phase-37-reviewed-record-chain-rehearsal.sh`;
+- the runtime smoke gate output from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>`; and
+
+Missing backup custody, restore target, rollback decision owner, smoke manifest, or reviewed record-chain evidence blocks the release gate until the prerequisite is supplied.
+
+## 3. Rehearsal Flow
+
+Rehearse restore against the reviewed recovery target and validate approval, evidence, execution, and reconciliation records against the reviewed record chain.
+
+Record the same-day rollback decision, including whether rollback was not needed or which restore point and configuration revision were used.
+
+Run the Phase 37 runtime smoke gate after restore, rollback, or upgrade where feasible and retain its `manifest.md`.
+
+Assemble the release-gate manifest and verify it with `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>`.
+
+## 4. Retained Manifest
+
+The retained manifest is the handoff index for the release gate.
+
+clean-state validation confirming no orphan record, partial durable write, half-restored state, or misleading handoff evidence survived a failed path
+
+The manifest must use repo-relative commands, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, and `<release-gate-manifest.md>`.
+
+## 5. Fail-Closed Validation
+
+The verifier fails closed when the rehearsal document is missing, required cross-links are missing, a retained manifest omits backup, restore, rollback, upgrade, smoke, reviewed-record, or clean-state evidence, placeholder values remain, or publishable guidance uses workstation-local absolute paths.
+
+## 6. Out of Scope
+
+Zero-downtime deployment, HA, database clustering, vendor-specific backup product integration, direct backend exposure, optional-extension startup or upgrade gates, multi-customer evidence warehouses, and customer-private production access are out of scope.
+EOF
+}
+
+write_valid_manifest() {
+  local path="$1"
+
+  cat <<'EOF' > "${path}"
+# Phase 37 Restore Rollback Upgrade Evidence Manifest
+
+Rehearsal owner: release-gate-operator
+Maintenance window: phase-37-rehearsal-window
+Pre-change backup custody: evidence/pre-change-backup-custody.md
+Selected restore point: restore-point-20260425T010000Z
+Restore target: disposable-customer-like-recovery-target
+Restore validation: evidence/restore-validation.md
+Same-day rollback decision: rollback-not-needed-after-validation
+Rollback evidence: evidence/rollback-decision.md
+Upgrade evidence: evidence/upgrade-window.md
+Post-upgrade smoke: evidence/smoke/manifest.md
+Reviewed record-chain evidence: evidence/reviewed-record-chain.txt
+Clean-state validation: evidence/clean-state.md
+Evidence handoff: evidence/handoff-index.md
+Next review: next-business-day-health-review
+EOF
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" add .
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+  local manifest="$2"
+
+  if ! bash "${verifier}" "${target}" --manifest "${manifest}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local manifest="$2"
+  local expected="$3"
+
+  if bash "${verifier}" "${target}" --manifest "${manifest}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_shared_docs "${valid_repo}"
+write_valid_doc "${valid_repo}"
+write_valid_manifest "${valid_repo}/manifest.md"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}" "${valid_repo}/manifest.md"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+write_shared_docs "${missing_doc_repo}"
+write_valid_manifest "${missing_doc_repo}/manifest.md"
+commit_fixture "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "${missing_doc_repo}/manifest.md" "Missing Phase 37 restore rollback upgrade evidence rehearsal document:"
+
+missing_backup_manifest_repo="${workdir}/missing-backup-manifest"
+create_repo "${missing_backup_manifest_repo}"
+write_shared_docs "${missing_backup_manifest_repo}"
+write_valid_doc "${missing_backup_manifest_repo}"
+write_valid_manifest "${missing_backup_manifest_repo}/manifest.md"
+perl -0pi -e 's/^Pre-change backup custody:.*\n//m' "${missing_backup_manifest_repo}/manifest.md"
+commit_fixture "${missing_backup_manifest_repo}"
+assert_fails_with "${missing_backup_manifest_repo}" "${missing_backup_manifest_repo}/manifest.md" "Missing Phase 37 release-gate evidence manifest statement: Pre-change backup custody:"
+
+missing_rollback_manifest_repo="${workdir}/missing-rollback-manifest"
+create_repo "${missing_rollback_manifest_repo}"
+write_shared_docs "${missing_rollback_manifest_repo}"
+write_valid_doc "${missing_rollback_manifest_repo}"
+write_valid_manifest "${missing_rollback_manifest_repo}/manifest.md"
+perl -0pi -e 's/^Same-day rollback decision:.*\n//m' "${missing_rollback_manifest_repo}/manifest.md"
+commit_fixture "${missing_rollback_manifest_repo}"
+assert_fails_with "${missing_rollback_manifest_repo}" "${missing_rollback_manifest_repo}/manifest.md" "Missing Phase 37 release-gate evidence manifest statement: Same-day rollback decision:"
+
+placeholder_manifest_repo="${workdir}/placeholder-manifest"
+create_repo "${placeholder_manifest_repo}"
+write_shared_docs "${placeholder_manifest_repo}"
+write_valid_doc "${placeholder_manifest_repo}"
+write_valid_manifest "${placeholder_manifest_repo}/manifest.md"
+printf '\nOperator note: TODO wire trusted scope.\n' >> "${placeholder_manifest_repo}/manifest.md"
+commit_fixture "${placeholder_manifest_repo}"
+assert_fails_with "${placeholder_manifest_repo}" "${placeholder_manifest_repo}/manifest.md" "Placeholder or untrusted manifest value detected:"
+
+absolute_path_manifest_repo="${workdir}/absolute-path-manifest"
+create_repo "${absolute_path_manifest_repo}"
+write_shared_docs "${absolute_path_manifest_repo}"
+write_valid_doc "${absolute_path_manifest_repo}"
+write_valid_manifest "${absolute_path_manifest_repo}/manifest.md"
+printf '\nLocal output: /Users/example/evidence/manifest.md\n' >> "${absolute_path_manifest_repo}/manifest.md"
+commit_fixture "${absolute_path_manifest_repo}"
+assert_fails_with "${absolute_path_manifest_repo}" "${absolute_path_manifest_repo}/manifest.md" "Forbidden Phase 37 release-gate evidence manifest: workstation-local absolute path detected"
+
+echo "verify-phase-37-restore-rollback-upgrade-evidence tests passed"

--- a/scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
+++ b/scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
@@ -218,7 +218,7 @@ create_repo "${absolute_path_manifest_repo}"
 write_shared_docs "${absolute_path_manifest_repo}"
 write_valid_doc "${absolute_path_manifest_repo}"
 write_valid_manifest "${absolute_path_manifest_repo}/manifest.md"
-printf '\nLocal output: /Users/example/evidence/manifest.md\n' >> "${absolute_path_manifest_repo}/manifest.md"
+printf '\nLocal output: /%s/%s/evidence/manifest.md\n' "Users" "example" >> "${absolute_path_manifest_repo}/manifest.md"
 commit_fixture "${absolute_path_manifest_repo}"
 assert_fails_with "${absolute_path_manifest_repo}" "${absolute_path_manifest_repo}/manifest.md" "Forbidden Phase 37 release-gate evidence manifest: workstation-local absolute path detected"
 

--- a/scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh
+++ b/scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh [<repo-root>] [--manifest <release-gate-manifest.md>]
+
+Validates the Phase 37 restore, rollback, upgrade, smoke, and handoff evidence
+rehearsal contract. When a manifest is supplied, validates that the retained
+manifest ties the required evidence together and fails closed on missing or
+placeholder entries.
+EOF
+}
+
+repo_root=""
+manifest_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 2
+      fi
+      manifest_path="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "${repo_root}" ]]; then
+        usage
+        exit 2
+      fi
+      repo_root="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${repo_root}" ]]; then
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+doc_path="${repo_root}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+runbook_path="${repo_root}/docs/runbook.md"
+rehearsal_path="${repo_root}/docs/deployment/customer-like-rehearsal-environment.md"
+smoke_path="${repo_root}/docs/deployment/runtime-smoke-bundle.md"
+handoff_path="${repo_root}/docs/deployment/operational-evidence-handoff-pack.md"
+record_chain_path="${repo_root}/scripts/verify-phase-37-reviewed-record-chain-rehearsal.sh"
+smoke_gate_path="${repo_root}/scripts/run-phase-37-runtime-smoke-gate.sh"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_executable() {
+  local path="$1"
+  local description="$2"
+
+  require_file "${path}" "${description}"
+  if [[ ! -x "${path}" ]]; then
+    echo "Missing executable bit for ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_placeholders() {
+  local path="$1"
+  local description="$2"
+
+  if grep -Eiq 'TODO|sample secret|fake secret|placeholder credential|change-me|guess(ed)? scope|unsigned token' "${path}"; then
+    echo "Placeholder or untrusted ${description} value detected: ${path}" >&2
+    exit 1
+  fi
+}
+
+reject_workstation_paths() {
+  local description="$1"
+  shift
+
+  local macos_home_pattern linux_home_pattern windows_home_pattern workstation_local_path_pattern
+  macos_home_pattern='/'"Users"'/[^[:space:])>]+'
+  linux_home_pattern='/'"home"'/[^[:space:])>]+'
+  windows_home_pattern='[A-Za-z]:\\'"Users"'\\[^[:space:])>]+'
+  workstation_local_path_pattern="(^|[^[:alnum:]_./-])(~[/\\\\]|${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern})"
+
+  if grep -Eq "${workstation_local_path_pattern}" "$@"; then
+    echo "Forbidden ${description}: workstation-local absolute path detected" >&2
+    exit 1
+  fi
+}
+
+require_file "${doc_path}" "Phase 37 restore rollback upgrade evidence rehearsal document"
+require_file "${runbook_path}" "runbook"
+require_file "${rehearsal_path}" "customer-like rehearsal environment"
+require_file "${smoke_path}" "runtime smoke bundle"
+require_file "${handoff_path}" "operational evidence handoff pack"
+require_executable "${record_chain_path}" "Phase 37 reviewed record-chain rehearsal verifier"
+require_executable "${smoke_gate_path}" "Phase 37 runtime smoke gate"
+
+required_headings=(
+  "# Phase 37 Restore Rollback Upgrade Evidence Rehearsal"
+  "## 1. Purpose and Boundary"
+  "## 2. Prerequisites"
+  "## 3. Rehearsal Flow"
+  "## 4. Retained Manifest"
+  "## 5. Fail-Closed Validation"
+  "## 6. Out of Scope"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${doc_path}" "${heading}" "Phase 37 release-gate rehearsal heading"
+done
+
+required_doc_phrases=(
+  "This document defines the Phase 37 release-gate rehearsal for pre-change backup capture, restore validation, same-day rollback decision evidence, post-upgrade smoke, and retained handoff evidence."
+  'The rehearsal is anchored to `docs/runbook.md`, `docs/deployment/customer-like-rehearsal-environment.md`, `docs/deployment/runtime-smoke-bundle.md`, and `docs/deployment/operational-evidence-handoff-pack.md`.'
+  "The release gate proves that backup, restore, rollback, upgrade, smoke, and reviewed-record evidence stay explainable against the AegisOps authoritative record chain."
+  "- a PostgreSQL-aware pre-change backup custody record;"
+  "- the restore target and restore point selected for same-day rollback;"
+  '- the seeded reviewed record-chain rehearsal result from `scripts/verify-phase-37-reviewed-record-chain-rehearsal.sh`;'
+  '- the runtime smoke gate output from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>`; and'
+  "Missing backup custody, restore target, rollback decision owner, smoke manifest, or reviewed record-chain evidence blocks the release gate until the prerequisite is supplied."
+  "Rehearse restore against the reviewed recovery target and validate approval, evidence, execution, and reconciliation records against the reviewed record chain."
+  "Record the same-day rollback decision, including whether rollback was not needed or which restore point and configuration revision were used."
+  'Run the Phase 37 runtime smoke gate after restore, rollback, or upgrade where feasible and retain its `manifest.md`.'
+  'Assemble the release-gate manifest and verify it with `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>`.'
+  "The retained manifest is the handoff index for the release gate."
+  "clean-state validation confirming no orphan record, partial durable write, half-restored state, or misleading handoff evidence survived a failed path"
+  'The manifest must use repo-relative commands, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, and `<release-gate-manifest.md>`.'
+  "The verifier fails closed when the rehearsal document is missing, required cross-links are missing, a retained manifest omits backup, restore, rollback, upgrade, smoke, reviewed-record, or clean-state evidence, placeholder values remain, or publishable guidance uses workstation-local absolute paths."
+  "Zero-downtime deployment, HA, database clustering, vendor-specific backup product integration, direct backend exposure, optional-extension startup or upgrade gates, multi-customer evidence warehouses, and customer-private production access are out of scope."
+)
+
+for phrase in "${required_doc_phrases[@]}"; do
+  require_phrase "${doc_path}" "${phrase}" "Phase 37 release-gate rehearsal statement"
+done
+
+require_phrase "${runbook_path}" 'The Phase 37 restore, rollback, and upgrade evidence rehearsal in `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md` is the reviewed release-gate path for tying pre-change backup custody, restore validation, rollback decision evidence, post-upgrade smoke, and retained handoff evidence together.' "runbook Phase 37 restore rollback upgrade evidence link"
+require_phrase "${rehearsal_path}" 'Assemble and verify the restore, rollback, and upgrade release-gate manifest with `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>` before handoff closes.' "customer-like rehearsal release-gate manifest step"
+require_phrase "${handoff_path}" 'For Phase 37 restore, rollback, and upgrade rehearsal, retain the release-gate manifest verified by `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>` so backup, restore, rollback, upgrade, smoke, reviewed-record, and clean-state evidence remain linked in one handoff index.' "handoff Phase 37 restore rollback upgrade evidence link"
+require_phrase "${smoke_path}" 'For restore, rollback, and upgrade release-gate rehearsal, the smoke manifest is one referenced artifact in the retained release-gate manifest verified by `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>`.' "runtime smoke release-gate manifest link"
+
+for forbidden in "requires zero-downtime" "requires HA" "requires database clustering" "requires vendor-specific backup" "requires OpenSearch" "requires n8n" "requires Shuffle"; do
+  if grep -Fqi -- "${forbidden}" "${doc_path}"; then
+    echo "Forbidden Phase 37 release-gate rehearsal statement: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+reject_workstation_paths "Phase 37 release-gate rehearsal guidance" "${doc_path}" "${runbook_path}" "${rehearsal_path}" "${smoke_path}" "${handoff_path}"
+
+if [[ -n "${manifest_path}" ]]; then
+  require_file "${manifest_path}" "Phase 37 release-gate evidence manifest"
+  reject_placeholders "${manifest_path}" "manifest"
+  reject_workstation_paths "Phase 37 release-gate evidence manifest" "${manifest_path}"
+
+  required_manifest_phrases=(
+    "# Phase 37 Restore Rollback Upgrade Evidence Manifest"
+    "Rehearsal owner:"
+    "Maintenance window:"
+    "Pre-change backup custody:"
+    "Selected restore point:"
+    "Restore target:"
+    "Restore validation:"
+    "Same-day rollback decision:"
+    "Rollback evidence:"
+    "Upgrade evidence:"
+    "Post-upgrade smoke:"
+    "Reviewed record-chain evidence:"
+    "Clean-state validation:"
+    "Evidence handoff:"
+    "Next review:"
+  )
+
+  for phrase in "${required_manifest_phrases[@]}"; do
+    require_phrase "${manifest_path}" "${phrase}" "Phase 37 release-gate evidence manifest statement"
+  done
+fi
+
+echo "Phase 37 restore, rollback, upgrade, smoke, and handoff evidence rehearsal is documented and fail-closed."


### PR DESCRIPTION
## Summary
- adds a Phase 37 restore/rollback/upgrade release-gate rehearsal document
- adds a fail-closed verifier plus negative-case shell test for retained evidence manifests
- wires the release-gate check into runbook, customer-like rehearsal, runtime smoke, operational handoff, and CI

## Verification
- `bash scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh`
- `bash scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh`
- `bash scripts/verify-phase-37-runtime-smoke-gate.sh`
- `bash scripts/test-run-phase-37-runtime-smoke-gate.sh`
- `bash scripts/verify-customer-like-rehearsal-environment.sh`
- `bash scripts/test-verify-customer-like-rehearsal-environment.sh`
- `bash scripts/verify-phase-33-operational-evidence-handoff-pack.sh`
- `bash scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh`
- `bash scripts/verify-runbook-doc.sh`
- `bash scripts/test-verify-runbook-doc.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `git diff --check`

Refs #779
