### PR TITLE
release: add secret cert and proxy custody checklist

### DIFF
--- a/docs/deployment/single-customer-profile.md
+++ b/docs/deployment/single-customer-profile.md
@@ -8,7 +8,7 @@ It packages the current first-boot runtime surface into the default reviewed dep
 
 The package is anchored to `docs/deployment/single-customer-release-bundle-inventory.md`, `docs/runbook.md`, `docs/smb-footprint-and-deployment-profile-baseline.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/storage-layout-and-mount-policy.md`, and `control-plane/deployment/first-boot/`.
 
-Before install, upgrade, rollback, or handoff, operators must read `docs/deployment/single-customer-release-bundle-inventory.md` as the reviewed versioned inventory for the single-customer launch package, including required artefacts, release binding, image tag expectations, optional-extension exclusions, and verifier ownership.
+Before install, upgrade, rollback, or handoff, operators must read `docs/deployment/single-customer-release-bundle-inventory.md` as the reviewed versioned inventory for the single-customer launch package, including required artefacts, release binding, image tag expectations, secret, certificate, and proxy custody checklist expectations, optional-extension exclusions, and verifier ownership.
 
 This package is operational guidance for the reviewed single-customer profile. It does not store customer-specific values, live secrets, DSNs, certificates, tokens, or vendor automation settings.
 

--- a/docs/deployment/single-customer-release-bundle-inventory.md
+++ b/docs/deployment/single-customer-release-bundle-inventory.md
@@ -30,6 +30,7 @@ This manifest is the first inventory operators read before install, upgrade, rol
 | First-boot entrypoint and migration bootstrap | Platform maintainers | `control-plane/deployment/first-boot/control-plane-entrypoint.sh` | Bound to the release revision and exercised during startup, upgrade, rollback, and restore restart | Runs runtime-config validation, PostgreSQL reachability proof, and migration bootstrap before readiness is accepted. |
 | Reverse-proxy artefacts | Platform maintainers | `proxy/nginx/nginx.conf`, `proxy/nginx/conf.d-first-boot/control-plane.conf` | Bound to the release revision and mounted by the first-boot compose surface | Preserves the reviewed reverse-proxy-first ingress boundary for health, readiness, runtime, protected read-only inspection, and Wazuh-facing intake. |
 | Migration artefacts | Control-plane maintainers | `postgres/control-plane/migrations/` | Bound to the same repository revision and copied into the reviewed first-boot image at `/opt/aegisops/postgres-migrations` | Keeps authoritative approval, evidence, execution, reconciliation, runtime, and readiness state aligned with the shipped control-plane schema. |
+| Secret, certificate, and proxy custody checklist | IT Operations, Information Systems Department | Section 2.1 of this manifest, `docs/runbook.md`, `docs/deployment/single-customer-profile.md`, and `control-plane/deployment/first-boot/bootstrap.env.sample` | Required before install, rotation, reload, restore, upgrade, or handoff treats the single-customer package as ready | Names custody owners, source references, fail-closed negative cases, reload and rotation checkpoints, and redacted evidence expectations for secrets, TLS, and the approved proxy boundary. |
 | Runbook | IT Operations, Information Systems Department | `docs/runbook.md` | Required operator procedure for the release revision | Gives startup, shutdown, restore, rollback, upgrade, secret rotation, daily health review, and handoff steps. |
 | Runtime smoke bundle | IT Operations, Information Systems Department | `docs/deployment/runtime-smoke-bundle.md` | Required post-deployment, post-upgrade, post-rollback, and handoff smoke reference | Proves startup status, readiness, protected read-only reachability, queue sanity, and first low-risk action preconditions through the approved boundary. |
 | Customer-like rehearsal preflight | IT Operations, Information Systems Department | `docs/deployment/customer-like-rehearsal-environment.md`, `scripts/verify-customer-like-rehearsal-environment.sh` | Required Phase 37 launch-gate precursor for the release revision | Proves the disposable customer-like topology and runtime env prerequisites before the release gate is accepted. |
@@ -38,6 +39,22 @@ This manifest is the first inventory operators read before install, upgrade, rol
 | Restore, rollback, and upgrade evidence rehearsal | IT Operations, Information Systems Department | `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md`, `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh` | Required release-gate evidence index for the release revision | Connects pre-change backup custody, restore validation, same-day rollback decision, post-upgrade smoke, reviewed-record evidence, and clean-state evidence. |
 | Operational evidence handoff pack | IT Operations, Information Systems Department | `docs/deployment/operational-evidence-handoff-pack.md` | Required retained audit handoff reference for the release revision | Defines the compact evidence package operators retain after deployment, upgrade, rollback, restore, approval, execution, reconciliation, and launch handoff. |
 | Release bundle inventory verifier | Platform maintainers | `scripts/verify-single-customer-release-bundle-inventory.sh`, `scripts/test-verify-single-customer-release-bundle-inventory.sh` | Required CI and local validation for release-bundle manifest changes | Fails closed when required bundle entries, cross-links, optional-extension exclusions, release bindings, or path-hygiene guarantees drift. |
+
+### 2.1 Secret, Certificate, and Proxy Custody Checklist
+
+Required custody bindings: PostgreSQL DSN, Wazuh ingest shared secret, Wazuh ingest reverse-proxy secret, protected-surface reverse-proxy secret, admin bootstrap token, break-glass token, ingress TLS certificate chain, ingress TLS private key, trusted proxy CIDR binding, protected-surface proxy service account, and optional OpenBao address, token, token file, KV mount, and secret paths when OpenBao is used.
+
+Each binding must name a custody owner, reviewed source reference, bounded consumer set, rotation or reload checkpoint, and redacted evidence location before release handoff can treat the binding as ready.
+
+Bootstrap and break-glass custody must name primary and backup custodians, document the exception trigger, and prove follow-up rotation before the environment returns to normal operation.
+
+Ingress TLS certificate custody must record certificate-chain owner, private-key custodian, expiry review horizon, reload evidence, and the approved reverse-proxy artefact revision without committing certificate material to Git.
+
+Reverse-proxy custody must prove that TLS termination and trusted-header normalization happen only at the approved ingress boundary, while the control-plane backend, PostgreSQL, OpenBao or mounted secret files, and raw secret material remain off the public front door.
+
+Missing, empty, placeholder, guessed, unsigned, sample, TODO, browser-state, raw forwarded-header, or customer-private custody values are not valid release evidence; install, rotation, reload, restore, upgrade, or handoff must remain failed closed until the reviewed source and owner are present.
+
+Custody change evidence must include the trigger, named operator, custody owner, approved source reference, affected binding, restart or reload result, readiness or refusal result through the reverse proxy, and handoff or operator health review reference.
 
 ## 3. Optional and Default-Off Extension Inventory
 
@@ -76,7 +93,7 @@ The focused release bundle inventory verifier is:
 scripts/verify-single-customer-release-bundle-inventory.sh
 ```
 
-The verifier fails closed when the release bundle manifest is missing, required launch bundle entries are absent, required release binding or handoff fields are stale, cross-links from deployment, runbook, runtime smoke, Phase 37 rehearsal, and evidence handoff surfaces are missing, optional extensions are promoted into mainline prerequisites, or publishable guidance uses workstation-local absolute paths.
+The verifier fails closed when the release bundle manifest is missing, required launch bundle or custody checklist entries are absent, required release binding or handoff fields are stale, cross-links from deployment, runbook, runtime smoke, Phase 37 rehearsal, and evidence handoff surfaces are missing, optional extensions are promoted into mainline prerequisites, direct backend or secret exposure is approved, proxy-boundary custody drifts, fail-closed custody language is removed, or publishable guidance uses workstation-local absolute paths.
 
 Negative validation for the verifier is:
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -10,7 +10,7 @@ It does not authorize environment-specific secrets in version control, optional-
 
 This document exists to define one reviewed startup and shutdown path that operators can rehearse without reconstructing the sequence from multiple phase notes.
 
-Before install, upgrade, rollback, restore, or launch handoff, operators must read the Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` to confirm the reviewed single-customer package, release identifier, repository revision, image tag expectations, required artefacts, and optional-extension exclusions.
+Before install, upgrade, rollback, restore, or launch handoff, operators must read the Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` to confirm the reviewed single-customer package, release identifier, repository revision, image tag expectations, secret, certificate, and proxy custody checklist expectations, required artefacts, and optional-extension exclusions.
 
 The reviewed procedure is limited to the current first-boot runtime floor:
 

--- a/scripts/test-verify-single-customer-release-bundle-inventory.sh
+++ b/scripts/test-verify-single-customer-release-bundle-inventory.sh
@@ -34,13 +34,13 @@ write_shared_files() {
   cat <<'EOF' > "${target}/docs/deployment/single-customer-profile.md"
 # Single-Customer Deployment Profile
 
-Before install, upgrade, rollback, or handoff, operators must read `docs/deployment/single-customer-release-bundle-inventory.md` as the reviewed versioned inventory for the single-customer launch package, including required artefacts, release binding, image tag expectations, optional-extension exclusions, and verifier ownership.
+Before install, upgrade, rollback, or handoff, operators must read `docs/deployment/single-customer-release-bundle-inventory.md` as the reviewed versioned inventory for the single-customer launch package, including required artefacts, release binding, image tag expectations, secret, certificate, and proxy custody checklist expectations, optional-extension exclusions, and verifier ownership.
 EOF
 
   cat <<'EOF' > "${target}/docs/runbook.md"
 # AegisOps Runbook
 
-Before install, upgrade, rollback, restore, or launch handoff, operators must read the Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` to confirm the reviewed single-customer package, release identifier, repository revision, image tag expectations, required artefacts, and optional-extension exclusions.
+Before install, upgrade, rollback, restore, or launch handoff, operators must read the Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` to confirm the reviewed single-customer package, release identifier, repository revision, image tag expectations, secret, certificate, and proxy custody checklist expectations, required artefacts, and optional-extension exclusions.
 EOF
 
   cat <<'EOF' > "${target}/docs/deployment/runtime-smoke-bundle.md"
@@ -177,6 +177,7 @@ This manifest is the first inventory operators read before install, upgrade, rol
 | First-boot entrypoint and migration bootstrap | Platform maintainers | `control-plane/deployment/first-boot/control-plane-entrypoint.sh` | Bound to the release revision and exercised during startup, upgrade, rollback, and restore restart | Runs runtime-config validation, PostgreSQL reachability proof, and migration bootstrap before readiness is accepted. |
 | Reverse-proxy artefacts | Platform maintainers | `proxy/nginx/nginx.conf`, `proxy/nginx/conf.d-first-boot/control-plane.conf` | Bound to the release revision and mounted by the first-boot compose surface | Preserves the reviewed reverse-proxy-first ingress boundary for health, readiness, runtime, protected read-only inspection, and Wazuh-facing intake. |
 | Migration artefacts | Control-plane maintainers | `postgres/control-plane/migrations/` | Bound to the same repository revision and copied into the reviewed first-boot image at `/opt/aegisops/postgres-migrations` | Keeps authoritative approval, evidence, execution, reconciliation, runtime, and readiness state aligned with the shipped control-plane schema. |
+| Secret, certificate, and proxy custody checklist | IT Operations, Information Systems Department | Section 2.1 of this manifest, `docs/runbook.md`, `docs/deployment/single-customer-profile.md`, and `control-plane/deployment/first-boot/bootstrap.env.sample` | Required before install, rotation, reload, restore, upgrade, or handoff treats the single-customer package as ready | Names custody owners, source references, fail-closed negative cases, reload and rotation checkpoints, and redacted evidence expectations for secrets, TLS, and the approved proxy boundary. |
 | Runbook | IT Operations, Information Systems Department | `docs/runbook.md` | Required operator procedure for the release revision | Gives startup, shutdown, restore, rollback, upgrade, secret rotation, daily health review, and handoff steps. |
 | Runtime smoke bundle | IT Operations, Information Systems Department | `docs/deployment/runtime-smoke-bundle.md` | Required post-deployment, post-upgrade, post-rollback, and handoff smoke reference | Proves startup status, readiness, protected read-only reachability, queue sanity, and first low-risk action preconditions through the approved boundary. |
 | Customer-like rehearsal preflight | IT Operations, Information Systems Department | `docs/deployment/customer-like-rehearsal-environment.md`, `scripts/verify-customer-like-rehearsal-environment.sh` | Required Phase 37 launch-gate precursor for the release revision | Proves the disposable customer-like topology and runtime env prerequisites before the release gate is accepted. |
@@ -185,6 +186,22 @@ This manifest is the first inventory operators read before install, upgrade, rol
 | Restore, rollback, and upgrade evidence rehearsal | IT Operations, Information Systems Department | `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md`, `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh` | Required release-gate evidence index for the release revision | Connects pre-change backup custody, restore validation, same-day rollback decision, post-upgrade smoke, reviewed-record evidence, and clean-state evidence. |
 | Operational evidence handoff pack | IT Operations, Information Systems Department | `docs/deployment/operational-evidence-handoff-pack.md` | Required retained audit handoff reference for the release revision | Defines the compact evidence package operators retain after deployment, upgrade, rollback, restore, approval, execution, reconciliation, and launch handoff. |
 | Release bundle inventory verifier | Platform maintainers | `scripts/verify-single-customer-release-bundle-inventory.sh`, `scripts/test-verify-single-customer-release-bundle-inventory.sh` | Required CI and local validation for release-bundle manifest changes | Fails closed when required bundle entries, cross-links, optional-extension exclusions, release bindings, or path-hygiene guarantees drift. |
+
+### 2.1 Secret, Certificate, and Proxy Custody Checklist
+
+Required custody bindings: PostgreSQL DSN, Wazuh ingest shared secret, Wazuh ingest reverse-proxy secret, protected-surface reverse-proxy secret, admin bootstrap token, break-glass token, ingress TLS certificate chain, ingress TLS private key, trusted proxy CIDR binding, protected-surface proxy service account, and optional OpenBao address, token, token file, KV mount, and secret paths when OpenBao is used.
+
+Each binding must name a custody owner, reviewed source reference, bounded consumer set, rotation or reload checkpoint, and redacted evidence location before release handoff can treat the binding as ready.
+
+Bootstrap and break-glass custody must name primary and backup custodians, document the exception trigger, and prove follow-up rotation before the environment returns to normal operation.
+
+Ingress TLS certificate custody must record certificate-chain owner, private-key custodian, expiry review horizon, reload evidence, and the approved reverse-proxy artefact revision without committing certificate material to Git.
+
+Reverse-proxy custody must prove that TLS termination and trusted-header normalization happen only at the approved ingress boundary, while the control-plane backend, PostgreSQL, OpenBao or mounted secret files, and raw secret material remain off the public front door.
+
+Missing, empty, placeholder, guessed, unsigned, sample, TODO, browser-state, raw forwarded-header, or customer-private custody values are not valid release evidence; install, rotation, reload, restore, upgrade, or handoff must remain failed closed until the reviewed source and owner are present.
+
+Custody change evidence must include the trigger, named operator, custody owner, approved source reference, affected binding, restart or reload result, readiness or refusal result through the reverse proxy, and handoff or operator health review reference.
 
 ## 3. Optional and Default-Off Extension Inventory
 
@@ -212,7 +229,7 @@ The release record must use repo-relative paths, documented env vars, and placeh
 
 ## 5. Verification
 
-The verifier fails closed when the release bundle manifest is missing, required launch bundle entries are absent, required release binding or handoff fields are stale, cross-links from deployment, runbook, runtime smoke, Phase 37 rehearsal, and evidence handoff surfaces are missing, optional extensions are promoted into mainline prerequisites, or publishable guidance uses workstation-local absolute paths.
+The verifier fails closed when the release bundle manifest is missing, required launch bundle or custody checklist entries are absent, required release binding or handoff fields are stale, cross-links from deployment, runbook, runtime smoke, Phase 37 rehearsal, and evidence handoff surfaces are missing, optional extensions are promoted into mainline prerequisites, direct backend or secret exposure is approved, proxy-boundary custody drifts, fail-closed custody language is removed, or publishable guidance uses workstation-local absolute paths.
 
 ## 6. Out of Scope
 
@@ -273,6 +290,38 @@ write_valid_manifest "${missing_smoke_entry_repo}"
 perl -0pi -e 's/^\| Runtime smoke bundle .*?\n//m' "${missing_smoke_entry_repo}/docs/deployment/single-customer-release-bundle-inventory.md"
 commit_fixture "${missing_smoke_entry_repo}"
 assert_fails_with "${missing_smoke_entry_repo}" "Missing single-customer release bundle inventory statement: | Runtime smoke bundle"
+
+missing_custody_entry_repo="${workdir}/missing-custody-entry"
+create_repo "${missing_custody_entry_repo}"
+write_shared_files "${missing_custody_entry_repo}"
+write_valid_manifest "${missing_custody_entry_repo}"
+perl -0pi -e 's/^\| Secret, certificate, and proxy custody checklist .*?\n//m' "${missing_custody_entry_repo}/docs/deployment/single-customer-release-bundle-inventory.md"
+commit_fixture "${missing_custody_entry_repo}"
+assert_fails_with "${missing_custody_entry_repo}" "Missing single-customer release bundle inventory statement: | Secret, certificate, and proxy custody checklist"
+
+missing_required_custody_bindings_repo="${workdir}/missing-required-custody-bindings"
+create_repo "${missing_required_custody_bindings_repo}"
+write_shared_files "${missing_required_custody_bindings_repo}"
+write_valid_manifest "${missing_required_custody_bindings_repo}"
+perl -0pi -e 's/^Required custody bindings: .*?\n\n//m' "${missing_required_custody_bindings_repo}/docs/deployment/single-customer-release-bundle-inventory.md"
+commit_fixture "${missing_required_custody_bindings_repo}"
+assert_fails_with "${missing_required_custody_bindings_repo}" "Missing single-customer release bundle inventory statement: Required custody bindings:"
+
+missing_tls_proxy_custody_repo="${workdir}/missing-tls-proxy-custody"
+create_repo "${missing_tls_proxy_custody_repo}"
+write_shared_files "${missing_tls_proxy_custody_repo}"
+write_valid_manifest "${missing_tls_proxy_custody_repo}"
+perl -0pi -e 's/^Reverse-proxy custody must prove .*?\n\n//m' "${missing_tls_proxy_custody_repo}/docs/deployment/single-customer-release-bundle-inventory.md"
+commit_fixture "${missing_tls_proxy_custody_repo}"
+assert_fails_with "${missing_tls_proxy_custody_repo}" "Missing single-customer release bundle inventory statement: Reverse-proxy custody must prove"
+
+missing_fail_closed_custody_repo="${workdir}/missing-fail-closed-custody"
+create_repo "${missing_fail_closed_custody_repo}"
+write_shared_files "${missing_fail_closed_custody_repo}"
+write_valid_manifest "${missing_fail_closed_custody_repo}"
+perl -0pi -e 's/^Missing, empty, placeholder, guessed, unsigned, sample, TODO, browser-state, raw forwarded-header, or customer-private custody values .*?\n\n//m' "${missing_fail_closed_custody_repo}/docs/deployment/single-customer-release-bundle-inventory.md"
+commit_fixture "${missing_fail_closed_custody_repo}"
+assert_fails_with "${missing_fail_closed_custody_repo}" "Missing single-customer release bundle inventory statement: Missing, empty, placeholder"
 
 missing_customer_like_verifier_repo="${workdir}/missing-customer-like-verifier"
 create_repo "${missing_customer_like_verifier_repo}"

--- a/scripts/verify-single-customer-release-bundle-inventory.sh
+++ b/scripts/verify-single-customer-release-bundle-inventory.sh
@@ -136,6 +136,7 @@ required_manifest_phrases=(
   '| First-boot entrypoint and migration bootstrap | Platform maintainers | `control-plane/deployment/first-boot/control-plane-entrypoint.sh` | Bound to the release revision and exercised during startup, upgrade, rollback, and restore restart |'
   '| Reverse-proxy artefacts | Platform maintainers | `proxy/nginx/nginx.conf`, `proxy/nginx/conf.d-first-boot/control-plane.conf` | Bound to the release revision and mounted by the first-boot compose surface |'
   '| Migration artefacts | Control-plane maintainers | `postgres/control-plane/migrations/` | Bound to the same repository revision and copied into the reviewed first-boot image at `/opt/aegisops/postgres-migrations` |'
+  '| Secret, certificate, and proxy custody checklist | IT Operations, Information Systems Department | Section 2.1 of this manifest, `docs/runbook.md`, `docs/deployment/single-customer-profile.md`, and `control-plane/deployment/first-boot/bootstrap.env.sample` | Required before install, rotation, reload, restore, upgrade, or handoff treats the single-customer package as ready |'
   '| Runbook | IT Operations, Information Systems Department | `docs/runbook.md` | Required operator procedure for the release revision |'
   '| Runtime smoke bundle | IT Operations, Information Systems Department | `docs/deployment/runtime-smoke-bundle.md` | Required post-deployment, post-upgrade, post-rollback, and handoff smoke reference |'
   '| Customer-like rehearsal preflight | IT Operations, Information Systems Department | `docs/deployment/customer-like-rehearsal-environment.md`, `scripts/verify-customer-like-rehearsal-environment.sh` | Required Phase 37 launch-gate precursor for the release revision |'
@@ -146,6 +147,13 @@ required_manifest_phrases=(
   '| Release bundle inventory verifier | Platform maintainers | `scripts/verify-single-customer-release-bundle-inventory.sh`, `scripts/test-verify-single-customer-release-bundle-inventory.sh` | Required CI and local validation for release-bundle manifest changes |'
   "Optional assistant, ML shadow, endpoint evidence, optional network evidence, external ticketing, OpenSearch, n8n, Shuffle, and isolated-executor paths are subordinate or default-off items only."
   "They are not mainline release prerequisites, startup prerequisites, readiness gates, smoke prerequisites, upgrade success gates, rollback success gates, restore success gates, or handoff blockers for this single-customer launch package."
+  "Required custody bindings: PostgreSQL DSN, Wazuh ingest shared secret, Wazuh ingest reverse-proxy secret, protected-surface reverse-proxy secret, admin bootstrap token, break-glass token, ingress TLS certificate chain, ingress TLS private key, trusted proxy CIDR binding, protected-surface proxy service account, and optional OpenBao address, token, token file, KV mount, and secret paths when OpenBao is used."
+  "Each binding must name a custody owner, reviewed source reference, bounded consumer set, rotation or reload checkpoint, and redacted evidence location before release handoff can treat the binding as ready."
+  "Bootstrap and break-glass custody must name primary and backup custodians, document the exception trigger, and prove follow-up rotation before the environment returns to normal operation."
+  "Ingress TLS certificate custody must record certificate-chain owner, private-key custodian, expiry review horizon, reload evidence, and the approved reverse-proxy artefact revision without committing certificate material to Git."
+  "Reverse-proxy custody must prove that TLS termination and trusted-header normalization happen only at the approved ingress boundary, while the control-plane backend, PostgreSQL, OpenBao or mounted secret files, and raw secret material remain off the public front door."
+  "Missing, empty, placeholder, guessed, unsigned, sample, TODO, browser-state, raw forwarded-header, or customer-private custody values are not valid release evidence; install, rotation, reload, restore, upgrade, or handoff must remain failed closed until the reviewed source and owner are present."
+  "Custody change evidence must include the trigger, named operator, custody owner, approved source reference, affected binding, restart or reload result, readiness or refusal result through the reverse proxy, and handoff or operator health review reference."
   "Operators must not infer optional-extension inclusion from repository directory presence, image availability, env sample comments, matching names, nearby notes, or external substrate health."
   '- release identifier in the form `aegisops-single-customer-<repository-revision>`;'
   "- repository revision or reviewed tag;"
@@ -159,7 +167,7 @@ required_manifest_phrases=(
   "- restore, rollback, and upgrade release-gate manifest reference;"
   "- clean-state validation confirming no orphan record, partial durable write, half-restored state, or misleading handoff evidence survived a failed path."
   'The release record must use repo-relative paths, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, `<release-gate-manifest.md>`, and `<repository-revision>`.'
-  "The verifier fails closed when the release bundle manifest is missing, required launch bundle entries are absent, required release binding or handoff fields are stale, cross-links from deployment, runbook, runtime smoke, Phase 37 rehearsal, and evidence handoff surfaces are missing, optional extensions are promoted into mainline prerequisites, or publishable guidance uses workstation-local absolute paths."
+  "The verifier fails closed when the release bundle manifest is missing, required launch bundle or custody checklist entries are absent, required release binding or handoff fields are stale, cross-links from deployment, runbook, runtime smoke, Phase 37 rehearsal, and evidence handoff surfaces are missing, optional extensions are promoted into mainline prerequisites, direct backend or secret exposure is approved, proxy-boundary custody drifts, fail-closed custody language is removed, or publishable guidance uses workstation-local absolute paths."
   "Package-manager distribution, hosted release channels, direct customer-private production access, zero-downtime deployment, HA, database clustering, multi-customer packaging, vendor-specific backup products, optional-service auto-installation, direct backend exposure, direct browser authority, direct substrate authority, and endpoint, network, assistant, ML, ticketing, OpenSearch, n8n, Shuffle, or isolated-executor paths as launch prerequisites are out of scope."
 )
 
@@ -167,8 +175,8 @@ for phrase in "${required_manifest_phrases[@]}"; do
   require_phrase "${manifest_path}" "${phrase}" "single-customer release bundle inventory statement"
 done
 
-require_phrase "${profile_path}" 'Before install, upgrade, rollback, or handoff, operators must read `docs/deployment/single-customer-release-bundle-inventory.md` as the reviewed versioned inventory for the single-customer launch package, including required artefacts, release binding, image tag expectations, optional-extension exclusions, and verifier ownership.' "single-customer profile release bundle inventory link"
-require_phrase "${runbook_path}" 'Before install, upgrade, rollback, restore, or launch handoff, operators must read the Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` to confirm the reviewed single-customer package, release identifier, repository revision, image tag expectations, required artefacts, and optional-extension exclusions.' "runbook release bundle inventory link"
+require_phrase "${profile_path}" 'Before install, upgrade, rollback, or handoff, operators must read `docs/deployment/single-customer-release-bundle-inventory.md` as the reviewed versioned inventory for the single-customer launch package, including required artefacts, release binding, image tag expectations, secret, certificate, and proxy custody checklist expectations, optional-extension exclusions, and verifier ownership.' "single-customer profile release bundle inventory link"
+require_phrase "${runbook_path}" 'Before install, upgrade, rollback, restore, or launch handoff, operators must read the Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` to confirm the reviewed single-customer package, release identifier, repository revision, image tag expectations, secret, certificate, and proxy custody checklist expectations, required artefacts, and optional-extension exclusions.' "runbook release bundle inventory link"
 require_phrase "${smoke_path}" 'For the Phase 38 single-customer launch package, the smoke result is one required handoff artefact in `docs/deployment/single-customer-release-bundle-inventory.md`; it proves the release-bound first-boot surface rather than optional-extension readiness.' "runtime smoke release bundle inventory link"
 require_phrase "${rehearsal_path}" 'The Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` treats this customer-like rehearsal preflight as required launch-gate evidence for the single-customer package.' "customer-like rehearsal release bundle inventory link"
 require_phrase "${restore_path}" 'The Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` uses this rehearsal as the required release-gate evidence index for restore, rollback, upgrade, smoke, reviewed-record, and clean-state handoff.' "restore rollback upgrade release bundle inventory link"
@@ -194,6 +202,20 @@ for forbidden in \
   "external ticketing is required for launch"; do
   if grep -Fqi -- "${forbidden}" "${manifest_path}"; then
     echo "Forbidden single-customer release bundle inventory statement: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+for forbidden in \
+  "browser state is custody authority" \
+  "raw forwarded headers are custody authority" \
+  "publish the control-plane backend port directly" \
+  "publish PostgreSQL directly" \
+  "commit TLS private keys" \
+  "sample secret is acceptable" \
+  "placeholder token is acceptable"; do
+  if grep -Fqi -- "${forbidden}" "${manifest_path}"; then
+    echo "Forbidden single-customer custody checklist statement: ${forbidden}" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
## Summary
- adds the Phase 38 secret, certificate, and proxy custody checklist to the single-customer release inventory
- enforces custody checklist sections, fail-closed values, and proxy boundary drift through the release bundle verifier
- cross-links custody expectations from the single-customer profile and runbook

## Verification
- bash scripts/verify-single-customer-release-bundle-inventory.sh
- bash scripts/test-verify-single-customer-release-bundle-inventory.sh
- bash scripts/verify-single-customer-deployment-profile.sh
- bash scripts/test-verify-single-customer-deployment-profile.sh
- bash scripts/verify-runbook-doc.sh
- bash scripts/test-verify-runbook-doc.sh
- bash scripts/verify-network-exposure-policy-doc.sh
- bash scripts/verify-storage-policy-doc.sh
- bash scripts/verify-publishable-path-hygiene.sh
- python3 -m unittest control-plane.tests.test_runtime_secret_boundary
- git diff --check

Closes #786