### PR TITLE
Release handoff evidence package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
           bash scripts/verify-phase-33-operational-evidence-handoff-pack.sh
           bash scripts/verify-single-customer-deployment-profile.sh
           bash scripts/verify-single-customer-release-bundle-inventory.sh
+          bash scripts/verify-release-handoff-evidence-package.sh
           bash scripts/verify-storage-policy-doc.sh
           bash scripts/verify-source-onboarding-contract-doc.sh
           bash scripts/verify-wazuh-rule-lifecycle-runbook.sh
@@ -308,6 +309,7 @@ jobs:
           bash scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
           bash scripts/test-verify-single-customer-deployment-profile.sh
           bash scripts/test-verify-single-customer-release-bundle-inventory.sh
+          bash scripts/test-verify-release-handoff-evidence-package.sh
           bash scripts/test-verify-source-onboarding-contract-doc.sh
           bash scripts/test-verify-wazuh-rule-lifecycle-runbook.sh
           bash scripts/test-verify-windows-source-onboarding-assets.sh

--- a/docs/deployment/customer-like-rehearsal-environment.md
+++ b/docs/deployment/customer-like-rehearsal-environment.md
@@ -10,6 +10,8 @@ It is anchored to `docs/deployment/single-customer-release-bundle-inventory.md`,
 
 The Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` treats this customer-like rehearsal preflight as required launch-gate evidence for the single-customer package.
 
+The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` records the install preflight and customer-like rehearsal result before launch handoff can close.
+
 The rehearsal environment must be disposable, customer-like, and free of private customer context. It must not add HA, Kubernetes, multi-customer packaging, customer-private credentials, direct backend exposure, optional extension requirements, or vendor-specific automation.
 
 ## 2. Disposable Topology

--- a/docs/deployment/operational-evidence-handoff-pack.md
+++ b/docs/deployment/operational-evidence-handoff-pack.md
@@ -12,6 +12,8 @@ The pack is anchored to `docs/deployment/single-customer-release-bundle-inventor
 
 For the Phase 38 single-customer launch package, `docs/deployment/single-customer-release-bundle-inventory.md` is the reviewed bundle manifest that names this handoff pack as required retained evidence guidance.
 
+For Phase 38 release handoff, use `docs/deployment/release-handoff-evidence-package.md` as the one launch or upgrade handoff index; this operational pack remains retained evidence guidance and does not become workflow authority.
+
 Use this pack when an operator needs a compact, reviewable evidence bundle after deployment, upgrade, restore, approval, execution, reconciliation review, rollback, or a planned handoff window.
 
 The pack may reference external substrate receipts, backup custody notes, or bounded logs, but those references remain evidence attached to reviewed AegisOps records. They do not create a parallel source of authority.

--- a/docs/deployment/release-handoff-evidence-manifest.template.md
+++ b/docs/deployment/release-handoff-evidence-manifest.template.md
@@ -1,0 +1,14 @@
+# Phase 38 Release Handoff Evidence Manifest
+
+Release readiness summary: <replace-with-reviewed-readiness-summary>
+Release bundle identifier: aegisops-single-customer-<repository-revision>
+Install preflight result: <replace-with-install-preflight-result-reference>
+Runtime smoke result: <replace-with-runtime-smoke-manifest-reference>
+Backup restore rollback upgrade rehearsal: <replace-with-release-gate-manifest-reference>
+Known limitations: <replace-with-reviewed-known-limitations-reference>
+Rollback instructions: <replace-with-reviewed-rollback-instructions-reference>
+Handoff owner: <replace-with-named-operator-or-maintainer>
+Next health review: <replace-with-next-business-review-reference>
+Authority boundary: AegisOps approval, evidence, execution, reconciliation, readiness, and recovery records remain authoritative; external records are subordinate context only.
+
+Use repo-relative paths, reviewed release identifiers, and redacted evidence references. Replace every placeholder before a handoff manifest is retained or verified.

--- a/docs/deployment/release-handoff-evidence-package.md
+++ b/docs/deployment/release-handoff-evidence-package.md
@@ -1,0 +1,65 @@
+# Phase 38 Release Handoff Evidence Package
+
+## 1. Purpose and Boundary
+
+This document defines the Phase 38 release handoff evidence package for a single-customer launch or reviewed upgrade.
+
+The package is a bounded repo-owned handoff index, not a new external archive platform, compliance framework, or workflow authority.
+
+AegisOps approval, evidence, execution, reconciliation, readiness, and recovery truth remains in the reviewed AegisOps records and release-gate evidence; downstream tickets, substrate receipts, and operator notes are subordinate context only.
+
+Use this package after the release bundle inventory, install preflight, runtime smoke, and restore, rollback, and upgrade evidence have been assembled for the same release identifier.
+
+## 2. Required Handoff Entries
+
+Every release handoff manifest must include release readiness summary, release bundle identifier, install preflight result, runtime smoke result, backup, restore, rollback, and upgrade rehearsal reference, known limitations, rollback instructions, handoff owner, and next health review.
+
+The release readiness summary must name the launch or upgrade decision, the reviewed repository revision or tag, the single-customer scope, and whether the package is ready, blocked, or accepted with documented limitations.
+
+The known limitations entry must be an explicit reviewed reference for the release window. Absence of a reviewed known-limitations entry blocks handoff because the next operator cannot distinguish "no known limitation" from an unreviewed package.
+
+Release notes and known limitations must point to the operator handoff record and the rollback decision record so a launch reviewer can see whether limitations block launch, normal operation, or rollback acceptance.
+
+The rollback instructions entry must point to the reviewed rollback path and the selected restore or configuration reference. It must not rely on memory, external ticket status, or substrate-local naming to infer the recovery target.
+
+## 3. Evidence Sources
+
+Install preflight evidence comes from `scripts/verify-single-customer-install-preflight.sh --env-file <runtime-env-file>`.
+
+Runtime smoke evidence comes from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>`.
+
+Restore, rollback, and upgrade evidence comes from `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>`.
+
+The release bundle identifier comes from `docs/deployment/single-customer-release-bundle-inventory.md` and must use the reviewed `aegisops-single-customer-<repository-revision>` format or a reviewed tag-bound equivalent.
+
+The operational handoff reference comes from `docs/deployment/operational-evidence-handoff-pack.md`, but this release package is the launch or upgrade handoff index for the current release window.
+
+## 4. Blocking Outcomes
+
+A failed install preflight, runtime smoke, restore validation, rollback rehearsal, upgrade evidence check, or missing known-limitation review blocks launch handoff and normal operation until the failed prerequisite is fixed or the refusal is retained as the handoff outcome.
+
+If the package records a failed, rejected, forbidden, or restore-failure path, it must include clean-state validation showing that no orphan record, partial durable write, half-restored state, or misleading handoff evidence survived the attempt.
+
+If external ticket records, backup notes, or substrate receipts disagree with AegisOps records or release-gate evidence, keep the AegisOps-owned record as authoritative and repair or annotate the downstream projection.
+
+## 5. Retention and Path Hygiene
+
+The package keeps the current launch or upgrade handoff, the linked release-gate manifest, the latest runtime smoke manifest, and the next health review expectation; it does not promise unlimited retention.
+
+The manifest must use repo-relative paths, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, `<release-gate-manifest.md>`, and `<release-handoff-manifest.md>`.
+
+Retained evidence must not include workstation-local absolute paths, live secrets, DSNs, customer credentials, bootstrap tokens, break-glass tokens, unsigned identity hints, raw forwarded-header values, or placeholder credentials as valid release evidence.
+
+## 6. Verification
+
+Verify a retained release handoff manifest with `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+
+The verifier fails closed when required handoff entries are missing, placeholder-only, sample, guessed, stale, workstation-local, or when required cross-links to Phase 37 smoke, restore, rollback, upgrade, release bundle, runbook, and operational handoff material are missing.
+
+Negative validation for the verifier is `scripts/test-verify-release-handoff-evidence-package.sh`.
+
+## 7. Out of Scope
+
+External archive platforms, unlimited retention promises, compliance-framework generalization, external ticket lifecycle authority, multi-customer evidence warehouses, direct backend exposure, optional-extension launch gates, and customer-private production access are out of scope.
+
+This package also does not authorize external tickets, downstream substrate lifecycle fields, browser state, raw forwarded headers, optional-extension health, or customer-private production access as release handoff authority.

--- a/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md
+++ b/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md
@@ -8,6 +8,8 @@ The rehearsal is anchored to `docs/deployment/single-customer-release-bundle-inv
 
 The Phase 38 release bundle inventory in `docs/deployment/single-customer-release-bundle-inventory.md` uses this rehearsal as the required release-gate evidence index for restore, rollback, upgrade, smoke, reviewed-record, and clean-state handoff.
 
+The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` consumes the verified restore, rollback, and upgrade release-gate manifest as the authoritative recovery evidence reference for the handoff window.
+
 The release gate proves that backup, restore, rollback, upgrade, smoke, and reviewed-record evidence stay explainable against the AegisOps authoritative record chain. It does not create a vendor backup integration, zero-downtime promise, HA design, cluster failover plan, or multi-customer operating model.
 
 ## 2. Prerequisites

--- a/docs/deployment/runtime-smoke-bundle.md
+++ b/docs/deployment/runtime-smoke-bundle.md
@@ -10,6 +10,8 @@ The bundle is anchored to `docs/deployment/single-customer-release-bundle-invent
 
 For the Phase 38 single-customer launch package, the smoke result is one required handoff artefact in `docs/deployment/single-customer-release-bundle-inventory.md`; it proves the release-bound first-boot surface rather than optional-extension readiness.
 
+The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` must retain the runtime smoke manifest reference for launch, upgrade, rollback, restore restart, and operator handoff readiness.
+
 The reviewed smoke path covers startup status, readiness, protected-surface reachability, operator-console read-only sanity, queue/read-only surface sanity, and first low-risk action preconditions.
 
 It does not require optional OpenSearch, n8n, Shuffle, endpoint evidence, optional network evidence, assistant, ML shadow, or isolated-executor extensions to be enabled.

--- a/docs/deployment/single-customer-release-bundle-inventory.md
+++ b/docs/deployment/single-customer-release-bundle-inventory.md
@@ -18,6 +18,8 @@ Bundle handoff owner: the named single-customer operator or maintainer who accep
 
 This manifest is the first inventory operators read before install, upgrade, rollback, or handoff. It is anchored to `docs/runbook.md`, `docs/deployment/single-customer-profile.md`, `docs/deployment/runtime-smoke-bundle.md`, `docs/deployment/customer-like-rehearsal-environment.md`, `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md`, `docs/deployment/operational-evidence-handoff-pack.md`, and `control-plane/deployment/first-boot/`.
 
+The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` is the Phase 38 handoff index that ties the release bundle identifier, install preflight result, runtime smoke, restore, rollback, upgrade, known limitations, rollback instructions, handoff owner, and next health review to one bounded record.
+
 ## 2. Required Launch Bundle Inventory
 
 | Bundle entry | Owner | Source path | Release binding | Handoff relevance |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -127,6 +127,8 @@ The customer-like rehearsal environment in `docs/deployment/customer-like-rehear
 
 The Phase 37 restore, rollback, and upgrade evidence rehearsal in `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md` is the reviewed release-gate path for tying pre-change backup custody, restore validation, rollback decision evidence, post-upgrade smoke, and retained handoff evidence together.
 
+Before launch, upgrade, rollback, restore, or operator handoff closes, assemble the Phase 38 release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` and verify its manifest with `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+
 ## 3. Shutdown
 
 The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.

--- a/scripts/test-verify-release-handoff-evidence-package.sh
+++ b/scripts/test-verify-release-handoff-evidence-package.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-release-handoff-evidence-package.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment" "${target}/scripts"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_shared_docs() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/runbook.md"
+# AegisOps Runbook
+
+Before launch, upgrade, rollback, restore, or operator handoff closes, assemble the Phase 38 release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` and verify its manifest with `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/single-customer-release-bundle-inventory.md"
+# Single-Customer Release Bundle Inventory
+
+The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` is the Phase 38 handoff index that ties the release bundle identifier, install preflight result, runtime smoke, restore, rollback, upgrade, known limitations, rollback instructions, handoff owner, and next health review to one bounded record.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/runtime-smoke-bundle.md"
+# Phase 33 Runtime Smoke Bundle
+
+The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` must retain the runtime smoke manifest reference for launch, upgrade, rollback, restore restart, and operator handoff readiness.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+# Phase 37 Restore Rollback Upgrade Evidence Rehearsal
+
+The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` consumes the verified restore, rollback, and upgrade release-gate manifest as the authoritative recovery evidence reference for the handoff window.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/operational-evidence-handoff-pack.md"
+# Phase 33 Operational Evidence Retention and Audit Handoff Pack
+
+For Phase 38 release handoff, use `docs/deployment/release-handoff-evidence-package.md` as the one launch or upgrade handoff index; this operational pack remains retained evidence guidance and does not become workflow authority.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/customer-like-rehearsal-environment.md"
+# Customer-Like Rehearsal Environment
+
+The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` records the install preflight and customer-like rehearsal result before launch handoff can close.
+EOF
+
+  cat <<'EOF' > "${target}/scripts/verify-single-customer-install-preflight.sh"
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat <<'EOF' > "${target}/scripts/run-phase-37-runtime-smoke-gate.sh"
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat <<'EOF' > "${target}/scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh"
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  chmod +x \
+    "${target}/scripts/verify-single-customer-install-preflight.sh" \
+    "${target}/scripts/run-phase-37-runtime-smoke-gate.sh" \
+    "${target}/scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh"
+}
+
+write_valid_package_doc() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/deployment/release-handoff-evidence-package.md"
+# Phase 38 Release Handoff Evidence Package
+
+## 1. Purpose and Boundary
+
+This document defines the Phase 38 release handoff evidence package for a single-customer launch or reviewed upgrade.
+
+The package is a bounded repo-owned handoff index, not a new external archive platform, compliance framework, or workflow authority.
+
+AegisOps approval, evidence, execution, reconciliation, readiness, and recovery truth remains in the reviewed AegisOps records and release-gate evidence; downstream tickets, substrate receipts, and operator notes are subordinate context only.
+
+## 2. Required Handoff Entries
+
+Every release handoff manifest must include release readiness summary, release bundle identifier, install preflight result, runtime smoke result, backup, restore, rollback, and upgrade rehearsal reference, known limitations, rollback instructions, handoff owner, and next health review.
+
+Release notes and known limitations must point to the operator handoff record and the rollback decision record so a launch reviewer can see whether limitations block launch, normal operation, or rollback acceptance.
+
+## 3. Evidence Sources
+
+Install preflight evidence comes from `scripts/verify-single-customer-install-preflight.sh --env-file <runtime-env-file>`.
+
+Runtime smoke evidence comes from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>`.
+
+Restore, rollback, and upgrade evidence comes from `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>`.
+
+## 4. Blocking Outcomes
+
+A failed install preflight, runtime smoke, restore validation, rollback rehearsal, upgrade evidence check, or missing known-limitation review blocks launch handoff and normal operation until the failed prerequisite is fixed or the refusal is retained as the handoff outcome.
+
+## 5. Retention and Path Hygiene
+
+The package keeps the current launch or upgrade handoff, the linked release-gate manifest, the latest runtime smoke manifest, and the next health review expectation; it does not promise unlimited retention.
+
+The manifest must use repo-relative paths, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, `<release-gate-manifest.md>`, and `<release-handoff-manifest.md>`.
+
+## 6. Verification
+
+Verify a retained release handoff manifest with `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+
+The verifier fails closed when required handoff entries are missing, placeholder-only, sample, guessed, stale, workstation-local, or when required cross-links to Phase 37 smoke, restore, rollback, upgrade, release bundle, runbook, and operational handoff material are missing.
+
+## 7. Out of Scope
+
+External archive platforms, unlimited retention promises, compliance-framework generalization, external ticket lifecycle authority, multi-customer evidence warehouses, direct backend exposure, optional-extension launch gates, and customer-private production access are out of scope.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/release-handoff-evidence-manifest.template.md"
+# Phase 38 Release Handoff Evidence Manifest
+
+Release readiness summary: <replace-with-reviewed-readiness-summary>
+Release bundle identifier: aegisops-single-customer-<repository-revision>
+Install preflight result: <replace-with-install-preflight-result-reference>
+Runtime smoke result: <replace-with-runtime-smoke-manifest-reference>
+Backup restore rollback upgrade rehearsal: <replace-with-release-gate-manifest-reference>
+Known limitations: <replace-with-reviewed-known-limitations-reference>
+Rollback instructions: <replace-with-reviewed-rollback-instructions-reference>
+Handoff owner: <replace-with-named-operator-or-maintainer>
+Next health review: <replace-with-next-business-review-reference>
+Authority boundary: AegisOps approval, evidence, execution, reconciliation, readiness, and recovery records remain authoritative; external records are subordinate context only.
+EOF
+}
+
+write_valid_manifest() {
+  local path="$1"
+
+  cat <<'EOF' > "${path}"
+# Phase 38 Release Handoff Evidence Manifest
+
+Release readiness summary: evidence/release-readiness-summary.md
+Release bundle identifier: aegisops-single-customer-3e831fd
+Install preflight result: evidence/install-preflight-result.md
+Runtime smoke result: evidence/runtime-smoke/manifest.md
+Backup restore rollback upgrade rehearsal: evidence/release-gate-manifest.md
+Known limitations: docs/releases/phase38-known-limitations.md
+Rollback instructions: docs/runbook.md#rollback
+Handoff owner: single-customer-operator
+Next health review: next-business-day-health-review
+Authority boundary: AegisOps approval, evidence, execution, reconciliation, readiness, and recovery records remain authoritative; external records are subordinate context only.
+EOF
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" add .
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+  local manifest="$2"
+
+  if ! bash "${verifier}" "${target}" --manifest "${manifest}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local manifest="$2"
+  local expected="$3"
+
+  if bash "${verifier}" "${target}" --manifest "${manifest}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_shared_docs "${valid_repo}"
+write_valid_package_doc "${valid_repo}"
+write_valid_manifest "${valid_repo}/manifest.md"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}" "${valid_repo}/manifest.md"
+
+for missing_entry in \
+  "Release readiness summary:" \
+  "Runtime smoke result:" \
+  "Rollback instructions:" \
+  "Known limitations:" \
+  "Next health review:"; do
+  missing_repo="${workdir}/missing-${missing_entry//[^A-Za-z0-9]/-}"
+  create_repo "${missing_repo}"
+  write_shared_docs "${missing_repo}"
+  write_valid_package_doc "${missing_repo}"
+  write_valid_manifest "${missing_repo}/manifest.md"
+  perl -0pi -e "s/^\\Q${missing_entry}\\E.*\\n//m" "${missing_repo}/manifest.md"
+  commit_fixture "${missing_repo}"
+  assert_fails_with "${missing_repo}" "${missing_repo}/manifest.md" "Missing Phase 38 release handoff manifest entry: ${missing_entry}"
+done
+
+missing_restore_repo="${workdir}/missing-restore-entry"
+create_repo "${missing_restore_repo}"
+write_shared_docs "${missing_restore_repo}"
+write_valid_package_doc "${missing_restore_repo}"
+write_valid_manifest "${missing_restore_repo}/manifest.md"
+perl -0pi -e 's/^Backup restore rollback upgrade rehearsal:.*\n//m' "${missing_restore_repo}/manifest.md"
+commit_fixture "${missing_restore_repo}"
+assert_fails_with "${missing_restore_repo}" "${missing_restore_repo}/manifest.md" "Missing Phase 38 release handoff manifest entry: Backup restore rollback upgrade rehearsal:"
+
+placeholder_repo="${workdir}/placeholder-manifest"
+create_repo "${placeholder_repo}"
+write_shared_docs "${placeholder_repo}"
+write_valid_package_doc "${placeholder_repo}"
+write_valid_manifest "${placeholder_repo}/manifest.md"
+printf '\nOperator note: TODO fill known limitations.\n' >> "${placeholder_repo}/manifest.md"
+commit_fixture "${placeholder_repo}"
+assert_fails_with "${placeholder_repo}" "${placeholder_repo}/manifest.md" "Placeholder or untrusted Phase 38 release handoff manifest value detected:"
+
+absolute_path_repo="${workdir}/absolute-path-manifest"
+create_repo "${absolute_path_repo}"
+write_shared_docs "${absolute_path_repo}"
+write_valid_package_doc "${absolute_path_repo}"
+write_valid_manifest "${absolute_path_repo}/manifest.md"
+printf '\nLocal evidence: /%s/%s/release-handoff/manifest.md\n' "Users" "example" >> "${absolute_path_repo}/manifest.md"
+commit_fixture "${absolute_path_repo}"
+assert_fails_with "${absolute_path_repo}" "${absolute_path_repo}/manifest.md" "Forbidden Phase 38 release handoff evidence manifest: workstation-local absolute path detected"
+
+missing_cross_link_repo="${workdir}/missing-cross-link"
+create_repo "${missing_cross_link_repo}"
+write_shared_docs "${missing_cross_link_repo}"
+write_valid_package_doc "${missing_cross_link_repo}"
+write_valid_manifest "${missing_cross_link_repo}/manifest.md"
+printf '# Phase 33 Runtime Smoke Bundle\n' > "${missing_cross_link_repo}/docs/deployment/runtime-smoke-bundle.md"
+commit_fixture "${missing_cross_link_repo}"
+assert_fails_with "${missing_cross_link_repo}" "${missing_cross_link_repo}/manifest.md" "Missing runtime smoke release handoff package link:"
+
+echo "verify-release-handoff-evidence-package tests passed"

--- a/scripts/verify-release-handoff-evidence-package.sh
+++ b/scripts/verify-release-handoff-evidence-package.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/verify-release-handoff-evidence-package.sh [<repo-root>] [--manifest <release-handoff-manifest.md>]
+
+Validates the Phase 38 release handoff evidence package. When a manifest is
+supplied, validates that the retained handoff index contains the required
+release readiness, preflight, smoke, recovery, limitation, rollback, owner, and
+next-review entries without placeholder or workstation-local values.
+EOF
+}
+
+repo_root=""
+manifest_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 2
+      fi
+      manifest_path="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "${repo_root}" ]]; then
+        usage
+        exit 2
+      fi
+      repo_root="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${repo_root}" ]]; then
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+doc_path="${repo_root}/docs/deployment/release-handoff-evidence-package.md"
+template_path="${repo_root}/docs/deployment/release-handoff-evidence-manifest.template.md"
+runbook_path="${repo_root}/docs/runbook.md"
+inventory_path="${repo_root}/docs/deployment/single-customer-release-bundle-inventory.md"
+smoke_path="${repo_root}/docs/deployment/runtime-smoke-bundle.md"
+restore_path="${repo_root}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+handoff_path="${repo_root}/docs/deployment/operational-evidence-handoff-pack.md"
+rehearsal_path="${repo_root}/docs/deployment/customer-like-rehearsal-environment.md"
+install_preflight_path="${repo_root}/scripts/verify-single-customer-install-preflight.sh"
+smoke_gate_path="${repo_root}/scripts/run-phase-37-runtime-smoke-gate.sh"
+restore_verifier_path="${repo_root}/scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_executable() {
+  local path="$1"
+  local description="$2"
+
+  require_file "${path}" "${description}"
+  if [[ ! -x "${path}" ]]; then
+    echo "Missing executable bit for ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_placeholders() {
+  local path="$1"
+  local description="$2"
+
+  if grep -Eiq 'TODO|sample secret|fake secret|placeholder credential|change-me|replace-with|guess(ed)? scope|unsigned token|<replace-[^>]+>' "${path}"; then
+    echo "Placeholder or untrusted ${description} value detected: ${path}" >&2
+    exit 1
+  fi
+}
+
+reject_workstation_paths() {
+  local description="$1"
+  shift
+
+  local macos_home_pattern linux_home_pattern windows_home_pattern workstation_local_path_pattern
+  macos_home_pattern='/'"Users"'/[^[:space:])>]+'
+  linux_home_pattern='/'"home"'/[^[:space:])>]+'
+  windows_home_pattern='[A-Za-z]:\\'"Users"'\\[^[:space:])>]+'
+  workstation_local_path_pattern="(^|[^[:alnum:]_./-])(~[/\\\\]|${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern})"
+
+  if grep -Eq "${workstation_local_path_pattern}" "$@"; then
+    echo "Forbidden ${description}: workstation-local absolute path detected" >&2
+    exit 1
+  fi
+}
+
+require_file "${doc_path}" "Phase 38 release handoff evidence package"
+require_file "${template_path}" "Phase 38 release handoff evidence manifest template"
+require_file "${runbook_path}" "runbook document"
+require_file "${inventory_path}" "single-customer release bundle inventory"
+require_file "${smoke_path}" "runtime smoke bundle"
+require_file "${restore_path}" "restore rollback upgrade evidence rehearsal"
+require_file "${handoff_path}" "operational evidence handoff pack"
+require_file "${rehearsal_path}" "customer-like rehearsal environment"
+require_executable "${install_preflight_path}" "single-customer install preflight verifier"
+require_executable "${smoke_gate_path}" "Phase 37 runtime smoke gate"
+require_executable "${restore_verifier_path}" "Phase 37 restore rollback upgrade evidence verifier"
+
+required_headings=(
+  "# Phase 38 Release Handoff Evidence Package"
+  "## 1. Purpose and Boundary"
+  "## 2. Required Handoff Entries"
+  "## 3. Evidence Sources"
+  "## 4. Blocking Outcomes"
+  "## 5. Retention and Path Hygiene"
+  "## 6. Verification"
+  "## 7. Out of Scope"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${doc_path}" "${heading}" "Phase 38 release handoff evidence package heading"
+done
+
+required_doc_phrases=(
+  "This document defines the Phase 38 release handoff evidence package for a single-customer launch or reviewed upgrade."
+  "The package is a bounded repo-owned handoff index, not a new external archive platform, compliance framework, or workflow authority."
+  "AegisOps approval, evidence, execution, reconciliation, readiness, and recovery truth remains in the reviewed AegisOps records and release-gate evidence; downstream tickets, substrate receipts, and operator notes are subordinate context only."
+  "Every release handoff manifest must include release readiness summary, release bundle identifier, install preflight result, runtime smoke result, backup, restore, rollback, and upgrade rehearsal reference, known limitations, rollback instructions, handoff owner, and next health review."
+  "Release notes and known limitations must point to the operator handoff record and the rollback decision record so a launch reviewer can see whether limitations block launch, normal operation, or rollback acceptance."
+  'Install preflight evidence comes from `scripts/verify-single-customer-install-preflight.sh --env-file <runtime-env-file>`.'
+  'Runtime smoke evidence comes from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>`.'
+  'Restore, rollback, and upgrade evidence comes from `scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh --manifest <release-gate-manifest.md>`.'
+  "A failed install preflight, runtime smoke, restore validation, rollback rehearsal, upgrade evidence check, or missing known-limitation review blocks launch handoff and normal operation until the failed prerequisite is fixed or the refusal is retained as the handoff outcome."
+  "The package keeps the current launch or upgrade handoff, the linked release-gate manifest, the latest runtime smoke manifest, and the next health review expectation; it does not promise unlimited retention."
+  'The manifest must use repo-relative paths, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, `<release-gate-manifest.md>`, and `<release-handoff-manifest.md>`.'
+  'Verify a retained release handoff manifest with `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.'
+  "The verifier fails closed when required handoff entries are missing, placeholder-only, sample, guessed, stale, workstation-local, or when required cross-links to Phase 37 smoke, restore, rollback, upgrade, release bundle, runbook, and operational handoff material are missing."
+  "External archive platforms, unlimited retention promises, compliance-framework generalization, external ticket lifecycle authority, multi-customer evidence warehouses, direct backend exposure, optional-extension launch gates, and customer-private production access are out of scope."
+)
+
+for phrase in "${required_doc_phrases[@]}"; do
+  require_phrase "${doc_path}" "${phrase}" "Phase 38 release handoff evidence package statement"
+done
+
+required_template_phrases=(
+  "# Phase 38 Release Handoff Evidence Manifest"
+  "Release readiness summary:"
+  "Release bundle identifier:"
+  "Install preflight result:"
+  "Runtime smoke result:"
+  "Backup restore rollback upgrade rehearsal:"
+  "Known limitations:"
+  "Rollback instructions:"
+  "Handoff owner:"
+  "Next health review:"
+  "Authority boundary: AegisOps approval, evidence, execution, reconciliation, readiness, and recovery records remain authoritative; external records are subordinate context only."
+)
+
+for phrase in "${required_template_phrases[@]}"; do
+  require_phrase "${template_path}" "${phrase}" "Phase 38 release handoff evidence manifest template entry"
+done
+
+require_phrase "${runbook_path}" 'Before launch, upgrade, rollback, restore, or operator handoff closes, assemble the Phase 38 release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` and verify its manifest with `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.' "runbook release handoff package link"
+require_phrase "${inventory_path}" 'The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` is the Phase 38 handoff index that ties the release bundle identifier, install preflight result, runtime smoke, restore, rollback, upgrade, known limitations, rollback instructions, handoff owner, and next health review to one bounded record.' "release bundle inventory release handoff package link"
+require_phrase "${smoke_path}" 'The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` must retain the runtime smoke manifest reference for launch, upgrade, rollback, restore restart, and operator handoff readiness.' "runtime smoke release handoff package link"
+require_phrase "${restore_path}" 'The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` consumes the verified restore, rollback, and upgrade release-gate manifest as the authoritative recovery evidence reference for the handoff window.' "restore rollback upgrade release handoff package link"
+require_phrase "${handoff_path}" 'For Phase 38 release handoff, use `docs/deployment/release-handoff-evidence-package.md` as the one launch or upgrade handoff index; this operational pack remains retained evidence guidance and does not become workflow authority.' "operational evidence release handoff package link"
+require_phrase "${rehearsal_path}" 'The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` records the install preflight and customer-like rehearsal result before launch handoff can close.' "customer-like rehearsal release handoff package link"
+
+for forbidden in \
+  "requires external archive platform" \
+  "requires unlimited retention" \
+  "external tickets are authoritative" \
+  "requires compliance framework" \
+  "requires optional extension" \
+  "requires direct backend exposure"; do
+  if grep -Fqi -- "${forbidden}" "${doc_path}"; then
+    echo "Forbidden Phase 38 release handoff package statement: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+reject_workstation_paths "Phase 38 release handoff evidence package guidance" \
+  "${doc_path}" \
+  "${template_path}" \
+  "${runbook_path}" \
+  "${inventory_path}" \
+  "${smoke_path}" \
+  "${restore_path}" \
+  "${handoff_path}" \
+  "${rehearsal_path}"
+
+if [[ -n "${manifest_path}" ]]; then
+  require_file "${manifest_path}" "Phase 38 release handoff evidence manifest"
+  reject_placeholders "${manifest_path}" "Phase 38 release handoff manifest"
+  reject_workstation_paths "Phase 38 release handoff evidence manifest" "${manifest_path}"
+
+  required_manifest_phrases=(
+    "# Phase 38 Release Handoff Evidence Manifest"
+    "Release readiness summary:"
+    "Release bundle identifier:"
+    "Install preflight result:"
+    "Runtime smoke result:"
+    "Backup restore rollback upgrade rehearsal:"
+    "Known limitations:"
+    "Rollback instructions:"
+    "Handoff owner:"
+    "Next health review:"
+    "Authority boundary: AegisOps approval, evidence, execution, reconciliation, readiness, and recovery records remain authoritative; external records are subordinate context only."
+  )
+
+  for phrase in "${required_manifest_phrases[@]}"; do
+    require_phrase "${manifest_path}" "${phrase}" "Phase 38 release handoff manifest entry"
+  done
+fi
+
+echo "Phase 38 release handoff evidence package is documented, cross-linked, and fail-closed."


### PR DESCRIPTION
## Summary
- define the Phase 38 release handoff evidence package and manifest template
- add fail-closed validation for required handoff manifest entries, placeholders, workstation-local paths, and stale cross-links
- wire the new verifier into CI and cross-link Phase 37 smoke/restore evidence, release inventory, runbook, rehearsal, and operational handoff docs

## Verification
- bash scripts/test-verify-release-handoff-evidence-package.sh
- bash scripts/verify-release-handoff-evidence-package.sh
- bash scripts/verify-phase-37-runtime-smoke-gate.sh
- bash scripts/test-run-phase-37-runtime-smoke-gate.sh
- bash scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh
- bash scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
- bash scripts/verify-phase-33-operational-evidence-handoff-pack.sh
- bash scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
- bash scripts/verify-single-customer-release-bundle-inventory.sh
- bash scripts/test-verify-single-customer-release-bundle-inventory.sh
- bash scripts/verify-publishable-path-hygiene.sh
- git diff --check

Part of #784
Closes #788