### PR TITLE
Harden action receipt validation

### DIFF
--- a/control-plane/aegisops_control_plane/action_receipt_validation.py
+++ b/control-plane/aegisops_control_plane/action_receipt_validation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+_PLACEHOLDER_RECEIPT_VALUES = frozenset(
+    (
+        "<set-me>",
+        "<todo>",
+        "placeholder",
+        "sample",
+        "tbd",
+        "todo",
+    )
+)
+
+
+class MissingReceiptValueError(ValueError):
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(
+            f"adapter receipt missing required '{field_name}' attribute"
+        )
+
+
+def require_receipt_string_value(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise MissingReceiptValueError(field_name)
+
+    normalized_value = value.strip()
+    if (
+        normalized_value == ""
+        or normalized_value.lower() in _PLACEHOLDER_RECEIPT_VALUES
+    ):
+        raise MissingReceiptValueError(field_name)
+
+    return value

--- a/control-plane/aegisops_control_plane/execution_coordinator_delegation.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator_delegation.py
@@ -4,6 +4,10 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Mapping
 
+from .action_receipt_validation import (
+    MissingReceiptValueError,
+    require_receipt_string_value,
+)
 from .execution_coordinator import (
     ExecutionCoordinatorServiceDependencies,
     _PHASE26_REVIEWED_COORDINATION_TARGET_TYPES,
@@ -397,12 +401,13 @@ class ApprovedActionDelegationCoordinator:
 
     @staticmethod
     def _require_receipt_string_attribute(receipt: object, field_name: str) -> str:
-        value = getattr(receipt, field_name, None)
-        if not isinstance(value, str) or value.strip() == "":
-            raise ValueError(
-                f"adapter receipt missing required '{field_name}' attribute"
+        try:
+            return require_receipt_string_value(
+                getattr(receipt, field_name, None),
+                field_name,
             )
-        return value
+        except MissingReceiptValueError as exc:
+            raise ValueError(str(exc)) from exc
 
     def _mark_dispatch_failure(
         self,

--- a/control-plane/aegisops_control_plane/execution_coordinator_reconciliation.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator_reconciliation.py
@@ -5,6 +5,10 @@ from datetime import datetime
 import logging
 from typing import Mapping
 
+from .action_receipt_validation import (
+    MissingReceiptValueError,
+    require_receipt_string_value,
+)
 from .execution_coordinator import ExecutionCoordinatorServiceDependencies
 from .models import (
     ActionExecutionRecord,
@@ -480,41 +484,31 @@ class ActionExecutionReconciliationCoordinator:
                 if not isinstance(payload_hash, str):
                     raise ValueError("observed execution must include string payload_hash")
             if require_coordination_receipt_identifiers:
-                if (
-                    not isinstance(coordination_reference_id, str)
-                    or not coordination_reference_id.strip()
-                ):
-                    raise ValueError(
-                        "observed execution must include string coordination_reference_id"
+                try:
+                    coordination_reference_id = require_receipt_string_value(
+                        coordination_reference_id,
+                        "coordination_reference_id",
                     )
-                if (
-                    not isinstance(coordination_target_type, str)
-                    or not coordination_target_type.strip()
-                ):
-                    raise ValueError(
-                        "observed execution must include string coordination_target_type"
+                    coordination_target_type = require_receipt_string_value(
+                        coordination_target_type,
+                        "coordination_target_type",
                     )
-                if (
-                    not isinstance(external_receipt_id, str)
-                    or not external_receipt_id.strip()
-                ):
-                    raise ValueError(
-                        "observed execution must include string external_receipt_id"
+                    external_receipt_id = require_receipt_string_value(
+                        external_receipt_id,
+                        "external_receipt_id",
                     )
-                if (
-                    not isinstance(coordination_target_id, str)
-                    or not coordination_target_id.strip()
-                ):
-                    raise ValueError(
-                        "observed execution must include string coordination_target_id"
+                    coordination_target_id = require_receipt_string_value(
+                        coordination_target_id,
+                        "coordination_target_id",
                     )
-                if (
-                    not isinstance(ticket_reference_url, str)
-                    or not ticket_reference_url.strip()
-                ):
-                    raise ValueError(
-                        "observed execution must include string ticket_reference_url"
+                    ticket_reference_url = require_receipt_string_value(
+                        ticket_reference_url,
+                        "ticket_reference_url",
                     )
+                except MissingReceiptValueError as exc:
+                    raise ValueError(
+                        f"observed execution must include string {exc.field_name}"
+                    ) from exc
             normalized.append(
                 {
                     "execution_run_id": execution_run_id,

--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -208,6 +208,103 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
             executions[0].provenance["dispatch_failure"]["error"],
             "adapter receipt missing required 'external_receipt_id' attribute",
         )
+
+    def test_service_fail_closes_when_create_tracking_ticket_receipt_uses_placeholder_identifier(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = support.datetime(2026, 4, 18, 1, 30, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 1, 35, tzinfo=support.timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-placeholder-receipt-001",
+            "alert_id": "alert-tracking-placeholder-receipt-001",
+            "finding_id": "finding-tracking-placeholder-receipt-001",
+            "coordination_reference_id": "coord-ref-placeholder-receipt-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = support._phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-placeholder-receipt-001",
+            alert_id="alert-tracking-placeholder-receipt-001",
+            finding_id="finding-tracking-placeholder-receipt-001",
+            coordination_reference_id="coord-ref-placeholder-receipt-001",
+        )
+        payload_hash = support._approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            support.ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-placeholder-receipt-001",
+                action_request_id="action-request-create-ticket-placeholder-receipt-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            support.ActionRequestRecord(
+                action_request_id="action-request-create-ticket-placeholder-receipt-001",
+                approval_decision_id="approval-create-ticket-placeholder-receipt-001",
+                case_id="case-tracking-placeholder-receipt-001",
+                alert_id="alert-tracking-placeholder-receipt-001",
+                finding_id="finding-tracking-placeholder-receipt-001",
+                idempotency_key="idempotency-create-ticket-placeholder-receipt-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        original_dispatch = type(service._shuffle).dispatch_approved_action
+
+        def dispatch_with_placeholder_external_receipt_id(
+            adapter: object,
+            **kwargs: object,
+        ) -> object:
+            receipt = original_dispatch(adapter, **kwargs)
+            return support.replace(receipt, external_receipt_id="<set-me>")
+
+        with support.mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=dispatch_with_placeholder_external_receipt_id,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "adapter receipt missing required 'external_receipt_id' attribute",
+            ):
+                service.delegate_approved_action_to_shuffle(
+                    action_request_id="action-request-create-ticket-placeholder-receipt-001",
+                    approved_payload=approved_payload,
+                    delegated_at=delegated_at,
+                    delegation_issuer="control-plane-service",
+                )
+
+        executions = store.list(support.ActionExecutionRecord)
+        self.assertEqual(len(executions), 1)
+        self.assertEqual(executions[0].lifecycle_state, "failed")
+        self.assertEqual(
+            executions[0].provenance["dispatch_failure"]["error"],
+            "adapter receipt missing required 'external_receipt_id' attribute",
+        )
+
     def test_service_fail_closes_when_create_tracking_ticket_receipt_binding_drifts(
         self,
     ) -> None:
@@ -885,6 +982,60 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
                     tzinfo=support.timezone.utc,
                 ),
             )
+
+        self.assertEqual(store.list(support.ReconciliationRecord), ())
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "observed execution must include string external_receipt_id",
+        ):
+            service.reconcile_action_execution(
+                action_request_id="action-request-create-ticket-blank-receipt-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                observed_executions=(
+                    {
+                        "execution_run_id": "shuffle-run-placeholder-receipt-001",
+                        "execution_surface_id": "shuffle",
+                        "idempotency_key": "idempotency-create-ticket-blank-receipt-001",
+                        "observed_at": support.datetime(
+                            2026,
+                            4,
+                            18,
+                            4,
+                            46,
+                            tzinfo=support.timezone.utc,
+                        ),
+                        "approval_decision_id": "approval-create-ticket-blank-receipt-001",
+                        "delegation_id": "delegation-placeholder-receipt-001",
+                        "payload_hash": payload_hash,
+                        "coordination_reference_id": "coord-ref-blank-receipt-001",
+                        "coordination_target_type": "zammad",
+                        "external_receipt_id": "<set-me>",
+                        "coordination_target_id": "zammad-ticket-placeholder-receipt-001",
+                        "ticket_reference_url": "https://tickets.example.test/#ticket/zammad-ticket-placeholder-receipt-001",
+                        "status": "success",
+                    },
+                ),
+                compared_at=support.datetime(
+                    2026,
+                    4,
+                    18,
+                    4,
+                    46,
+                    tzinfo=support.timezone.utc,
+                ),
+                stale_after=support.datetime(
+                    2026,
+                    4,
+                    18,
+                    5,
+                    0,
+                    tzinfo=support.timezone.utc,
+                ),
+            )
+
+        self.assertEqual(store.list(support.ReconciliationRecord), ())
     def test_service_records_execution_correlation_mismatch_states_separately(self) -> None:
         store, _ = support.make_store()
         service = support.AegisOpsControlPlaneService(


### PR DESCRIPTION
## Summary
- add shared receipt string validation for action delegation and reconciliation observed receipts
- reject placeholder receipt identifiers before they become execution provenance or reconciliation input
- cover create_tracking_ticket placeholder receipt fail-closed paths

## Tests
- python3 -m unittest control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py control-plane/tests/test_service_persistence_action_reconciliation_reconciliation.py control-plane/tests/test_service_persistence_action_reconciliation_delegation.py
- python3 -m unittest control-plane/tests/test_phase37_reviewed_record_chain_rehearsal.py
- scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
- scripts/test-verify-release-handoff-evidence-package.sh
- bash scripts/test-verify-phase-20-low-risk-action-boundary.sh
- bash scripts/test-verify-phase-26-ticket-coordination-validation.sh
- python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_service_internal_boundaries_docs.py control-plane/tests/test_maintainability_decomposition_thresholds_docs.py
- git diff --check

Part of #793. Addresses #796.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for receipt data to reject placeholder and dummy values as missing required fields, improving error detection for incomplete configurations.

* **Bug Fixes**
  * Centralized receipt validation logic across the system for consistent error handling.

* **Tests**
  * Added test coverage for placeholder value rejection in receipt validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->