### PR TITLE
Add GitHub audit activation candidate

### DIFF
--- a/control-plane/tests/test_github_audit_detector_activation_candidate_docs.py
+++ b/control-plane/tests/test_github_audit_detector_activation_candidate_docs.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CANDIDATE_DIR = (
+    REPO_ROOT
+    / "docs"
+    / "source-families"
+    / "github-audit"
+    / "detector-activation-candidates"
+)
+FIXTURE_PATH = REPO_ROOT / "control-plane" / "tests" / "fixtures" / "wazuh" / "github-audit-alert.json"
+VERIFIER_PATH = REPO_ROOT / "scripts" / "verify-github-audit-detector-activation-candidate.sh"
+
+
+class GitHubAuditDetectorActivationCandidateDocsTests(unittest.TestCase):
+    def test_single_github_audit_activation_candidate_is_reviewable_and_bounded(self) -> None:
+        self.assertTrue(CANDIDATE_DIR.exists(), f"missing candidate directory: {CANDIDATE_DIR}")
+        candidates = sorted(CANDIDATE_DIR.glob("*.md"))
+        self.assertEqual(
+            [path.name for path in candidates],
+            ["repository-admin-membership-change.md"],
+        )
+
+        text = candidates[0].read_text(encoding="utf-8")
+
+        for term in (
+            "Lifecycle state: `candidate`",
+            "Candidate scope: GitHub audit repository administrator membership changes",
+            "Candidate Rule Review Criteria",
+            "Fixture And Parser Evidence",
+            "`control-plane/tests/fixtures/wazuh/github-audit-alert.json`",
+            "`decoder.name` is `github_audit`",
+            "`data.audit_action` is `member.added`",
+            "`data.privilege.permission` is `admin`",
+            "Staging Activation Expectations",
+            "False-Positive Review Expectations",
+            "Rollback Expectations",
+            "GitHub audit remains source evidence only",
+            "does not authorize direct GitHub API actioning",
+            "does not make GitHub the authority for AegisOps case state, approval state, action state, execution state, or reconciliation outcomes",
+        ):
+            self.assertIn(term, text)
+
+    def test_candidate_fixture_preserves_required_parser_and_privilege_evidence(self) -> None:
+        fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+        self.assertEqual(fixture["decoder"]["name"], "github_audit")
+        self.assertEqual(fixture["rule"]["id"], "github-audit-privilege-change")
+        self.assertEqual(fixture["rule"]["description"], "GitHub audit repository privilege change")
+        self.assertEqual(fixture["data"]["source_family"], "github_audit")
+        self.assertEqual(fixture["data"]["audit_action"], "member.added")
+        self.assertEqual(fixture["data"]["privilege"]["change_type"], "membership_change")
+        self.assertEqual(fixture["data"]["privilege"]["scope"], "repository_admin")
+        self.assertEqual(fixture["data"]["privilege"]["permission"], "admin")
+        self.assertEqual(fixture["data"]["privilege"]["role"], "maintainer")
+        self.assertEqual(fixture["data"]["repository"]["full_name"], "TommyKammy/AegisOps")
+        self.assertEqual(fixture["manager"]["name"], "wazuh-manager-github-1")
+        self.assertEqual(fixture["data"]["request_id"], "GH-REQ-0001")
+
+    def test_candidate_verifier_is_available_for_source_family_review(self) -> None:
+        self.assertTrue(VERIFIER_PATH.exists(), f"missing verifier: {VERIFIER_PATH}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source-families/github-audit/detector-activation-candidates/repository-admin-membership-change.md
+++ b/docs/source-families/github-audit/detector-activation-candidates/repository-admin-membership-change.md
@@ -1,0 +1,84 @@
+# GitHub Audit Repository Admin Membership Change Candidate
+
+Lifecycle state: `candidate`
+
+Candidate scope: GitHub audit repository administrator membership changes.
+
+This candidate covers the reviewed GitHub audit signal where a repository membership or team membership event grants administrator-level repository access. The current fixture-backed example is `member.added` with `data.privilege.scope` set to `repository_admin` and `data.privilege.permission` set to `admin`.
+
+The candidate exists to make one detector activation path reviewable from the existing detection-ready source-family package. It is not a detector catalog, direct GitHub remediation path, GitHub-owned workflow truth, or production activation approval.
+
+## Candidate Rule Review Criteria
+
+Reviewers may consider this candidate only when all of the following are true:
+
+- source family is GitHub audit admitted through the reviewed Wazuh-backed intake boundary;
+- `decoder.name` is `github_audit`;
+- `rule.id` is `github-audit-privilege-change`;
+- `data.source_family` is `github_audit`;
+- `data.audit_action` is `member.added`;
+- `data.privilege.change_type` is `membership_change`;
+- `data.privilege.scope` is `repository_admin`;
+- `data.privilege.permission` is `admin`;
+- actor identity, target identity, repository context, organization context, request context, Wazuh rule metadata, Wazuh manager identity, location, and timestamp remain present and reviewable; and
+- missing, malformed, placeholder, or inferred provenance keeps the candidate blocked rather than treated as detector-ready.
+
+The rule must not infer repository, organization, account, issue, or environment linkage from naming conventions, path shape, comments, or nearby metadata alone. It requires the explicit GitHub audit fields preserved by the reviewed Wazuh fixture and onboarding package.
+
+## Fixture And Parser Evidence
+
+Fixture and parser evidence is anchored to `control-plane/tests/fixtures/wazuh/github-audit-alert.json`.
+
+The reviewed fixture proves that:
+
+- `decoder.name` is `github_audit`;
+- `data.audit_action` is `member.added`;
+- `data.privilege.permission` is `admin`;
+- Wazuh manager identity is `wazuh-manager-github-1`;
+- rule identity is `github-audit-privilege-change`;
+- repository context is `TommyKammy/AegisOps`;
+- organization context is `TommyKammy`;
+- actor identity is `octocat`;
+- target identity is `security-reviews`; and
+- request context is `GH-REQ-0001`.
+
+This evidence is sufficient for candidate review only. Parser changes, rule metadata changes, source field changes, or provenance changes require fixture refresh and renewed review before the candidate can move toward staging.
+
+## Staging Activation Expectations
+
+Staging activation expectations are:
+
+- keep lifecycle state at `candidate` until rule review, rollout review, fixture review, expected-volume review, and false-positive review are recorded;
+- validate the candidate against the reviewed GitHub audit fixture and any separately approved staging replay corpus before production activation is considered;
+- use staging only to observe candidate behavior in a controlled validation environment or test index;
+- record expected alert volume, expected benign administrative cases, reviewer ownership, next-review date, and rollback owner before moving beyond candidate review; and
+- keep AegisOps alert, case, approval, action, execution, and reconciliation state authoritative inside the control plane.
+
+This document does not approve active OpenSearch detector deployment, live Wazuh rule rollout, GitHub API credentials, direct GitHub mutation, automated response, or production write-capable behavior.
+
+## False-Positive Review Expectations
+
+False-positive review expectations must cover routine repository administration, approved maintainer activity, access review cleanup, automation identity behavior, scheduled change windows, onboarding or offboarding work, and expected team membership maintenance.
+
+The reviewer must record whether the event is benign, suspicious, deferred, or still ambiguous. A benign conclusion requires explicit linkage to reviewed AegisOps records, an approved change-management path, or read-oriented GitHub audit evidence. Familiar actor, team, repository, workflow, or organization names are not enough to suppress the candidate.
+
+If the false-positive explanation depends on missing parser evidence, missing Wazuh provenance, raw forwarded identity, placeholder credentials, or inferred scope linkage, the candidate remains blocked.
+
+## Rollback Expectations
+
+Rollback expectations are:
+
+- disable or withdraw the candidate activation if staged behavior produces unacceptable false positives, source drift, parser drift, missing provenance, or analyst load outside the reviewed expectation;
+- restore the last reviewed fixture, rule metadata, or candidate state when parser or Wazuh rule changes invalidate the evidence package;
+- move the lifecycle state back to `candidate` or `draft` until refreshed evidence is reviewed; and
+- preserve a reviewable record of the rollback reason, affected fixture evidence, owner, and follow-up.
+
+Rollback is a content and validation reset path. It does not authorize direct GitHub API actioning, repository mutation, destructive response, or undocumented production hotfixes.
+
+## Source Evidence Boundary
+
+GitHub audit remains source evidence only.
+
+This candidate does not authorize direct GitHub API actioning, source-side mutation, GitHub credentials, GitHub-owned case authority, GitHub-owned approval state, GitHub-owned action state, GitHub-owned execution state, GitHub-owned reconciliation truth, or autonomous remediation.
+
+It also does not make GitHub the authority for AegisOps case state, approval state, action state, execution state, or reconciliation outcomes.

--- a/docs/source-families/github-audit/onboarding-package.md
+++ b/docs/source-families/github-audit/onboarding-package.md
@@ -100,6 +100,8 @@ Detector-Use Approval and Limits: GitHub audit is approved as a detection-ready 
 
 Detector activation still requires separate rule review, rollout review, and Wazuh rule lifecycle validation.
 
+The only currently documented activation candidate for this package is `docs/source-families/github-audit/detector-activation-candidates/repository-admin-membership-change.md`.
+
 Approved detector-use prerequisites:
 
 - source family is GitHub audit through the Wazuh-backed intake boundary;

--- a/scripts/verify-github-audit-detector-activation-candidate.sh
+++ b/scripts/verify-github-audit-detector-activation-candidate.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+candidate_dir="${repo_root}/docs/source-families/github-audit/detector-activation-candidates"
+candidate_doc="${candidate_dir}/repository-admin-membership-change.md"
+fixture_path="${repo_root}/control-plane/tests/fixtures/wazuh/github-audit-alert.json"
+profile_test="${repo_root}/control-plane/tests/test_github_audit_detector_activation_candidate_docs.py"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_contains() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "${expected}" "${file_path}"; then
+    echo "Missing required text in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_single_candidate() {
+  local count
+
+  count="$(find "${candidate_dir}" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d '[:space:]')"
+  if [[ "${count}" != "1" ]]; then
+    echo "Expected exactly one GitHub audit detector activation candidate, found ${count}." >&2
+    exit 1
+  fi
+}
+
+require_json_value() {
+  local json_path="$1"
+  local dotted_path="$2"
+  local expected="$3"
+
+  if ! python3 - "${json_path}" "${dotted_path}" "${expected}" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+current = payload
+for part in sys.argv[2].split("."):
+    current = current[part]
+
+if str(current) != sys.argv[3]:
+    raise SystemExit(1)
+PY
+  then
+    echo "Fixture ${json_path} does not preserve ${dotted_path}=${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${candidate_doc}" "Missing GitHub audit detector activation candidate"
+require_file "${fixture_path}" "Missing GitHub audit fixture evidence"
+require_file "${profile_test}" "Missing GitHub audit detector activation candidate unittest"
+require_single_candidate
+
+required_candidate_text=(
+  'Lifecycle state: `candidate`'
+  "Candidate scope: GitHub audit repository administrator membership changes."
+  "Candidate Rule Review Criteria"
+  "Fixture And Parser Evidence"
+  '`control-plane/tests/fixtures/wazuh/github-audit-alert.json`'
+  '`decoder.name` is `github_audit`'
+  '`data.audit_action` is `member.added`'
+  '`data.privilege.permission` is `admin`'
+  "Staging Activation Expectations"
+  "False-Positive Review Expectations"
+  "Rollback Expectations"
+  "GitHub audit remains source evidence only."
+  "does not authorize direct GitHub API actioning"
+  "does not make GitHub the authority for AegisOps case state, approval state, action state, execution state, or reconciliation outcomes"
+)
+
+for expected in "${required_candidate_text[@]}"; do
+  require_contains "${candidate_doc}" "${expected}"
+done
+
+require_json_value "${fixture_path}" "decoder.name" "github_audit"
+require_json_value "${fixture_path}" "rule.id" "github-audit-privilege-change"
+require_json_value "${fixture_path}" "rule.description" "GitHub audit repository privilege change"
+require_json_value "${fixture_path}" "data.source_family" "github_audit"
+require_json_value "${fixture_path}" "data.audit_action" "member.added"
+require_json_value "${fixture_path}" "data.privilege.change_type" "membership_change"
+require_json_value "${fixture_path}" "data.privilege.scope" "repository_admin"
+require_json_value "${fixture_path}" "data.privilege.permission" "admin"
+require_json_value "${fixture_path}" "data.privilege.role" "maintainer"
+require_json_value "${fixture_path}" "manager.name" "wazuh-manager-github-1"
+require_json_value "${fixture_path}" "data.request_id" "GH-REQ-0001"
+
+echo "GitHub audit detector activation candidate remains fixture-backed, bounded, and source-evidence only."


### PR DESCRIPTION
## Summary
- Adds one bounded GitHub audit detector activation candidate for repository administrator membership changes.
- Links the candidate from the GitHub audit onboarding package.
- Adds fixture-backed unittest coverage and a verifier that keeps the candidate source-evidence only.

Part of #802
Closes #803

## Verification
- python3 -m unittest control-plane/tests/test_github_audit_detector_activation_candidate_docs.py
- python3 -m unittest control-plane/tests/test_github_audit_source_profile_docs.py control-plane/tests/test_github_audit_detector_activation_candidate_docs.py
- bash scripts/verify-github-audit-detector-activation-candidate.sh
- bash scripts/verify-phase-34-identity-rich-detection-ready-family.sh
- bash scripts/verify-publishable-path-hygiene.sh
- python3 -m unittest control-plane/tests/test_service_persistence_ingest_case_lifecycle.py -k github_audit_fixture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced GitHub audit detector activation candidate for repository admin membership changes, including lifecycle phases, reviewer eligibility, staging validation, and rollback procedures.
  * Updated onboarding documentation to reference the new detector candidate.

* **Tests**
  * Added test suite to validate consistency between detector documentation, fixture data, and verification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->