### PR TITLE
Add Entra ID detector activation candidate

### DIFF
--- a/control-plane/tests/test_entra_id_detector_activation_candidate_docs.py
+++ b/control-plane/tests/test_entra_id_detector_activation_candidate_docs.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CANDIDATE_DIR = (
+    REPO_ROOT
+    / "docs"
+    / "source-families"
+    / "entra-id"
+    / "detector-activation-candidates"
+)
+FIXTURE_PATH = REPO_ROOT / "control-plane" / "tests" / "fixtures" / "wazuh" / "entra-id-alert.json"
+VERIFIER_PATH = REPO_ROOT / "scripts" / "verify-entra-id-detector-activation-candidate.sh"
+
+
+class EntraIdDetectorActivationCandidateDocsTests(unittest.TestCase):
+    def test_single_entra_id_activation_candidate_is_reviewable_and_bounded(self) -> None:
+        self.assertTrue(CANDIDATE_DIR.exists(), f"missing candidate directory: {CANDIDATE_DIR}")
+        candidates = sorted(CANDIDATE_DIR.glob("*.md"))
+        self.assertEqual(
+            [path.name for path in candidates],
+            ["privileged-role-assignment.md"],
+        )
+
+        text = candidates[0].read_text(encoding="utf-8")
+
+        for term in (
+            "Lifecycle state: `candidate`",
+            "Candidate scope: Entra ID privileged directory role assignments",
+            "Candidate Rule Review Criteria",
+            "Fixture And Parser Evidence",
+            "`control-plane/tests/fixtures/wazuh/entra-id-alert.json`",
+            "`decoder.name` is `entra_id`",
+            "`data.audit_action` is `Add member to role`",
+            "`data.privilege.scope` is `directory_role`",
+            "`data.privilege.permission` is `Global Administrator`",
+            "Staging Activation Expectations",
+            "False-Positive Review Expectations",
+            "Rollback And Disable Procedure",
+            "Entra ID remains source evidence only",
+            "does not authorize direct Entra ID actioning",
+            "does not make Entra ID the authority for AegisOps case state, approval state, action state, execution state, or reconciliation outcomes",
+        ):
+            self.assertIn(term, text)
+
+    def test_candidate_fixture_preserves_required_parser_and_privilege_evidence(self) -> None:
+        fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+        self.assertEqual(fixture["decoder"]["name"], "entra_id")
+        self.assertEqual(fixture["rule"]["id"], "entra-id-role-assignment")
+        self.assertEqual(fixture["rule"]["description"], "Entra ID privileged role assignment")
+        self.assertEqual(fixture["data"]["source_family"], "entra_id")
+        self.assertEqual(fixture["data"]["audit_action"], "Add member to role")
+        self.assertEqual(fixture["data"]["operation"], "Add member to role")
+        self.assertEqual(fixture["data"]["record_type"], "Entra ID audit")
+        self.assertEqual(fixture["data"]["privilege"]["change_type"], "role_assignment")
+        self.assertEqual(fixture["data"]["privilege"]["scope"], "directory_role")
+        self.assertEqual(fixture["data"]["privilege"]["permission"], "Global Administrator")
+        self.assertEqual(fixture["data"]["privilege"]["role"], "Privileged Role Administrator")
+        self.assertEqual(fixture["data"]["tenant"]["id"], "tenant-001")
+        self.assertEqual(fixture["data"]["actor"]["id"], "spn-operations")
+        self.assertEqual(fixture["data"]["target"]["id"], "role-global-admin")
+        self.assertEqual(fixture["manager"]["name"], "wazuh-manager-entra-1")
+        self.assertEqual(fixture["data"]["correlation_id"], "entra-corr-0001")
+        self.assertEqual(fixture["data"]["request_id"], "ENTRA-REQ-0001")
+
+    def test_candidate_verifier_is_available_for_source_family_review(self) -> None:
+        self.assertTrue(VERIFIER_PATH.exists(), f"missing verifier: {VERIFIER_PATH}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source-families/entra-id/detector-activation-candidates/privileged-role-assignment.md
+++ b/docs/source-families/entra-id/detector-activation-candidates/privileged-role-assignment.md
@@ -1,0 +1,90 @@
+# Entra ID Privileged Role Assignment Candidate
+
+Lifecycle state: `candidate`
+
+Candidate scope: Entra ID privileged directory role assignments.
+
+This candidate covers the reviewed Entra ID signal where an audit record shows a privileged directory role assignment. The current fixture-backed example is `Add member to role` with `data.privilege.scope` set to `directory_role` and `data.privilege.permission` set to `Global Administrator`.
+
+The candidate exists to make one detector activation path reviewable from the existing detection-ready Entra ID source-family package. It is not a detector catalog, direct Entra ID remediation path, Entra ID-owned workflow truth, Microsoft 365 audit uplift, or production activation approval.
+
+## Candidate Rule Review Criteria
+
+Reviewers may consider this candidate only when all of the following are true:
+
+- source family is Entra ID admitted through the reviewed Wazuh-backed intake boundary;
+- `decoder.name` is `entra_id`;
+- `rule.id` is `entra-id-role-assignment`;
+- `data.source_family` is `entra_id`;
+- `data.audit_action` is `Add member to role`;
+- `data.operation` is `Add member to role`;
+- `data.record_type` is `Entra ID audit`;
+- `data.privilege.change_type` is `role_assignment`;
+- `data.privilege.scope` is `directory_role`;
+- `data.privilege.permission` is `Global Administrator`;
+- tenant context, actor identity, target role identity, app or service-principal context, authentication context, request context, Wazuh rule metadata, Wazuh manager identity, location, and timestamp remain present and reviewable; and
+- missing, malformed, placeholder, or inferred provenance keeps the candidate blocked rather than treated as detector-ready.
+
+The rule must not infer tenant, directory role, actor, target, account, issue, or environment linkage from naming conventions, path shape, comments, or nearby metadata alone. It requires the explicit Entra ID audit fields preserved by the reviewed Wazuh fixture and onboarding package.
+
+## Fixture And Parser Evidence
+
+Fixture and parser evidence is anchored to `control-plane/tests/fixtures/wazuh/entra-id-alert.json`.
+
+The reviewed fixture proves that:
+
+- `decoder.name` is `entra_id`;
+- `data.audit_action` is `Add member to role`;
+- `data.operation` is `Add member to role`;
+- `data.record_type` is `Entra ID audit`;
+- `data.privilege.scope` is `directory_role`;
+- `data.privilege.permission` is `Global Administrator`;
+- Wazuh manager identity is `wazuh-manager-entra-1`;
+- rule identity is `entra-id-role-assignment`;
+- tenant identity is `tenant-001`;
+- actor identity is `spn-operations`;
+- target role identity is `role-global-admin`;
+- correlation context is `entra-corr-0001`; and
+- request context is `ENTRA-REQ-0001`.
+
+This evidence is sufficient for candidate review only. Parser changes, rule metadata changes, source field changes, tenant or directory-object mapping changes, timestamp changes, or provenance changes require fixture refresh and renewed review before the candidate can move toward staging.
+
+## Staging Activation Expectations
+
+Staging activation expectations are:
+
+- keep lifecycle state at `candidate` until rule review, rollout review, fixture review, expected-volume review, and false-positive review are recorded;
+- validate the candidate against the reviewed Entra ID fixture and any separately approved staging replay corpus before production activation is considered;
+- use staging only to observe candidate behavior in a controlled validation environment or test index;
+- record expected alert volume, expected benign administrative cases, reviewer ownership, next-review date, rollback owner, and disable owner before moving beyond candidate review; and
+- keep AegisOps alert, case, approval, action, execution, and reconciliation state authoritative inside the control plane.
+
+This document does not approve active OpenSearch detector deployment, live Wazuh rule rollout, Entra ID API credentials, direct directory mutation, automated response, Microsoft 365 audit detector activation, or production write-capable behavior.
+
+## False-Positive Review Expectations
+
+False-positive review expectations must cover routine directory administration, approved identity operations, reviewed service identity behavior, privileged role assignment maintenance, scheduled change windows, emergency access procedure review, and expected automation-path maintenance.
+
+The reviewer must record whether the event is benign, suspicious, deferred, or still ambiguous. A benign conclusion requires explicit linkage to reviewed AegisOps records, an approved change-management path, or read-oriented Entra ID audit evidence. Familiar actor, tenant, role, app, service principal, or target names are not enough to suppress the candidate.
+
+If the false-positive explanation depends on missing parser evidence, missing Wazuh provenance, raw forwarded identity, placeholder credentials, sample secrets, unsigned tokens, or inferred scope linkage, the candidate remains blocked.
+
+## Rollback And Disable Procedure
+
+Rollback and disable expectations are:
+
+- disable or withdraw the candidate activation if staged behavior produces unacceptable false positives, source drift, parser drift, missing provenance, missing tenant context, or analyst load outside the reviewed expectation;
+- restore the last reviewed fixture, rule metadata, or candidate state when parser or Wazuh rule changes invalidate the evidence package;
+- move the lifecycle state back to `candidate` or `draft` until refreshed evidence is reviewed;
+- keep the Entra ID onboarding package as source-family evidence only unless a separate review approves a new detector candidate; and
+- preserve a reviewable record of the disable reason, rollback reason, affected fixture evidence, owner, and follow-up.
+
+Rollback is a content and validation reset path. It does not authorize direct Entra ID actioning, directory mutation, credential reset, destructive response, or undocumented production hotfixes.
+
+## Source Evidence Boundary
+
+Entra ID remains source evidence only.
+
+This candidate does not authorize direct Entra ID actioning, directory mutation, source-side credentials, credential changes, Entra ID-owned case authority, Entra ID-owned approval state, Entra ID-owned action state, Entra ID-owned execution state, Entra ID-owned reconciliation truth, Microsoft 365 audit silent uplift, or autonomous remediation.
+
+It also does not make Entra ID the authority for AegisOps case state, approval state, action state, execution state, or reconciliation outcomes.

--- a/scripts/verify-entra-id-detector-activation-candidate.sh
+++ b/scripts/verify-entra-id-detector-activation-candidate.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+candidate_dir="${repo_root}/docs/source-families/entra-id/detector-activation-candidates"
+candidate_doc="${candidate_dir}/privileged-role-assignment.md"
+fixture_path="${repo_root}/control-plane/tests/fixtures/wazuh/entra-id-alert.json"
+profile_test="${repo_root}/control-plane/tests/test_entra_id_detector_activation_candidate_docs.py"
+microsoft_onboarding_doc="${repo_root}/docs/source-families/microsoft-365-audit/onboarding-package.md"
+
+require_file() {
+  local path="$1"
+  local message="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${message}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_contains() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "${expected}" "${file_path}"; then
+    echo "Missing required text in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+require_single_candidate() {
+  local count
+
+  count="$(find "${candidate_dir}" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d '[:space:]')"
+  if [[ "${count}" != "1" ]]; then
+    echo "Expected exactly one Entra ID detector activation candidate, found ${count}." >&2
+    exit 1
+  fi
+}
+
+require_json_value() {
+  local json_path="$1"
+  local dotted_path="$2"
+  local expected="$3"
+
+  if ! python3 - "${json_path}" "${dotted_path}" "${expected}" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+current = payload
+for part in sys.argv[2].split("."):
+    current = current[part]
+
+if str(current) != sys.argv[3]:
+    raise SystemExit(1)
+PY
+  then
+    echo "Fixture ${json_path} does not preserve ${dotted_path}=${expected}" >&2
+    exit 1
+  fi
+}
+
+require_file "${candidate_doc}" "Missing Entra ID detector activation candidate"
+require_file "${fixture_path}" "Missing Entra ID fixture evidence"
+require_file "${profile_test}" "Missing Entra ID detector activation candidate unittest"
+require_file "${microsoft_onboarding_doc}" "Missing Microsoft 365 audit onboarding package"
+require_single_candidate
+
+required_candidate_text=(
+  'Lifecycle state: `candidate`'
+  "Candidate scope: Entra ID privileged directory role assignments."
+  "Candidate Rule Review Criteria"
+  "Fixture And Parser Evidence"
+  '`control-plane/tests/fixtures/wazuh/entra-id-alert.json`'
+  '`decoder.name` is `entra_id`'
+  '`data.audit_action` is `Add member to role`'
+  '`data.privilege.scope` is `directory_role`'
+  '`data.privilege.permission` is `Global Administrator`'
+  "Staging Activation Expectations"
+  "False-Positive Review Expectations"
+  "Rollback And Disable Procedure"
+  "Entra ID remains source evidence only."
+  "does not authorize direct Entra ID actioning"
+  "does not make Entra ID the authority for AegisOps case state, approval state, action state, execution state, or reconciliation outcomes"
+)
+
+for expected in "${required_candidate_text[@]}"; do
+  require_contains "${candidate_doc}" "${expected}"
+done
+
+require_contains "${microsoft_onboarding_doc}" 'Readiness state: `schema-reviewed`'
+if grep -Fqx -- 'Readiness state: `detection-ready`' "${microsoft_onboarding_doc}" >/dev/null; then
+  echo "Microsoft 365 audit must not be silently uplifted by the Entra ID detector candidate." >&2
+  exit 1
+fi
+
+require_json_value "${fixture_path}" "decoder.name" "entra_id"
+require_json_value "${fixture_path}" "rule.id" "entra-id-role-assignment"
+require_json_value "${fixture_path}" "rule.description" "Entra ID privileged role assignment"
+require_json_value "${fixture_path}" "data.source_family" "entra_id"
+require_json_value "${fixture_path}" "data.audit_action" "Add member to role"
+require_json_value "${fixture_path}" "data.operation" "Add member to role"
+require_json_value "${fixture_path}" "data.record_type" "Entra ID audit"
+require_json_value "${fixture_path}" "data.privilege.change_type" "role_assignment"
+require_json_value "${fixture_path}" "data.privilege.scope" "directory_role"
+require_json_value "${fixture_path}" "data.privilege.permission" "Global Administrator"
+require_json_value "${fixture_path}" "data.privilege.role" "Privileged Role Administrator"
+require_json_value "${fixture_path}" "data.tenant.id" "tenant-001"
+require_json_value "${fixture_path}" "data.actor.id" "spn-operations"
+require_json_value "${fixture_path}" "data.target.id" "role-global-admin"
+require_json_value "${fixture_path}" "manager.name" "wazuh-manager-entra-1"
+require_json_value "${fixture_path}" "data.correlation_id" "entra-corr-0001"
+require_json_value "${fixture_path}" "data.request_id" "ENTRA-REQ-0001"
+
+echo "Entra ID detector activation candidate remains fixture-backed, bounded, and source-evidence only."

--- a/scripts/verify-entra-id-detector-activation-candidate.sh
+++ b/scripts/verify-entra-id-detector-activation-candidate.sh
@@ -93,9 +93,14 @@ for expected in "${required_candidate_text[@]}"; do
   require_contains "${candidate_doc}" "${expected}"
 done
 
-require_contains "${microsoft_onboarding_doc}" 'Readiness state: `schema-reviewed`'
-if grep -Eq -- '^[[:space:]]*Readiness state:[[:space:]]*`detection-ready`[[:space:]]*$' "${microsoft_onboarding_doc}"; then
-  echo "Microsoft 365 audit must not be silently uplifted by the Entra ID detector candidate." >&2
+readiness_line_count="$(grep -Ec -- '^[[:space:]]*Readiness state:' "${microsoft_onboarding_doc}" || true)"
+if [[ "${readiness_line_count}" != "1" ]]; then
+  echo "Microsoft 365 audit onboarding package must contain exactly one readiness state line." >&2
+  exit 1
+fi
+
+if ! grep -Eq -- '^[[:space:]]*Readiness state:[[:space:]]*`schema-reviewed`[[:space:]]*$' "${microsoft_onboarding_doc}"; then
+  echo "Microsoft 365 audit onboarding package must remain exactly at readiness state \`schema-reviewed\`." >&2
   exit 1
 fi
 

--- a/scripts/verify-entra-id-detector-activation-candidate.sh
+++ b/scripts/verify-entra-id-detector-activation-candidate.sh
@@ -94,7 +94,7 @@ for expected in "${required_candidate_text[@]}"; do
 done
 
 require_contains "${microsoft_onboarding_doc}" 'Readiness state: `schema-reviewed`'
-if grep -Fqx -- 'Readiness state: `detection-ready`' "${microsoft_onboarding_doc}" >/dev/null; then
+if grep -Eq -- '^[[:space:]]*Readiness state:[[:space:]]*`detection-ready`[[:space:]]*$' "${microsoft_onboarding_doc}"; then
   echo "Microsoft 365 audit must not be silently uplifted by the Entra ID detector candidate." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Adds one bounded Entra ID detector activation candidate for privileged directory role assignments.
- Adds a focused unittest and verifier for the candidate doc, fixture parser/provenance evidence, Microsoft 365 audit non-uplift, and source-evidence-only boundary.
- Leaves Entra ID as source evidence only; no runtime detector deployment or directory actioning is introduced.

## Verification
- `python3 -m unittest control-plane/tests/test_entra_id_detector_activation_candidate_docs.py`
- `scripts/verify-entra-id-detector-activation-candidate.sh`
- `scripts/verify-phase-34-identity-rich-detection-ready-family.sh`
- `python3 -m unittest control-plane/tests/test_phase14_identity_rich_source_profile_docs.py control-plane/tests/test_github_audit_detector_activation_candidate_docs.py control-plane/tests/test_entra_id_detector_activation_candidate_docs.py`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `git diff --check`

Part of #802.
Closes #804.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for an Entra ID privileged role-assignment detection candidate with reviewer criteria, staging expectations, false-positive handling, and activation/rollback gates.

* **Tests**
  * Added unit tests that validate the candidate documentation, required sections, and preservation of key fixture evidence fields.

* **New Features**
  * Added an automated verification tool to assert candidate conformance, fixture integrity, and onboarding readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->