### PR TITLE
Operations: Wazuh rule lifecycle and rollback gate

### DIFF
--- a/docs/wazuh-rule-lifecycle-runbook.md
+++ b/docs/wazuh-rule-lifecycle-runbook.md
@@ -89,7 +89,27 @@ If `wazuh-logtest` output does not preserve the reviewed rule metadata or accoun
 
 If the rule only validates with ad hoc field rewrites, undocumented parser assumptions, or missing provenance, onboarding is not complete.
 
-## 6. Rollout, Fixture Review, and Rollback
+## 6. Phase 40 Detector Activation Gate
+
+Phase 40 detector activation must remain a reviewed AegisOps release-gate decision, not a Wazuh-owned workflow transition.
+
+Staging activation is allowed only after rule review, fixture review, expected-volume review, false-positive review, rollback owner, disable owner, and next-review date are recorded.
+
+Staging activation is a controlled observation step for candidate detector behavior. It may use reviewed replay data, a controlled validation environment, or a test index, but it must not be treated as production activation, AegisOps workflow authority, or a live executor wiring approval.
+
+Before a candidate moves from staging to activation review, the reviewer must confirm:
+
+- the Wazuh rule identity, source family, parser assumptions, and reviewed fixture set are explicit;
+- the candidate has a named reviewer, activation owner, disable owner, rollback owner, and next-review date;
+- expected alert volume, expected benign cases, false-positive review notes, and analyst load expectations are recorded;
+- the detector evidence handoff path names the AegisOps-owned alert, case, reconciliation, and release-gate evidence records that will carry the operational truth; and
+- rollback can restore the last reviewed rule revision and fixture set without relying on Wazuh as the authority for downstream workflow state.
+
+Activation evidence must identify the candidate rule, reviewed fixture set, staging validation result, reviewer, activation window, expected alert volume, and release-gate evidence record.
+
+The gate must fail closed when provenance, scope, reviewer, owner, fixture, validation, false-positive, disable, rollback, or release-gate evidence is missing, malformed, placeholder, or inferred.
+
+## 7. Rollout, Disable, and Rollback
 
 Controlled rollout review must happen only after the `wazuh-logtest` result, fixture updates, and local tests all agree on the intended alert behavior.
 
@@ -102,6 +122,45 @@ Before any separate activation decision, reviewers should confirm:
 
 Rollback means disabling or reverting the custom rule, restoring the last reviewed rule revision, and withdrawing any dependent fixture or workflow assumptions until validation is rerun.
 
+Disable evidence must identify the disabled rule or candidate, disable owner, disable reason, affected fixture or parser evidence, operator notification path, and follow-up review.
+
+Rollback evidence must identify the last reviewed rule revision, restored fixture set, rollback owner, rollback reason, validation rerun result, and AegisOps release-gate evidence record.
+
 If rollback is required, reviewers should also record whether the previous fixture set must be restored, whether any adapter logic depends on the reverted rule shape, and whether analyst-facing expectations need to move back to `staging` or `candidate`.
 
 Rollback must remain non-destructive and reviewable. It is a documentation, rule-set, fixture, and validation reset path rather than an approval for live destructive response or undocumented hotfixes.
+
+## 8. False-Positive Handling
+
+False-positive handling must keep benign, suspicious, deferred, and ambiguous outcomes tied to AegisOps-owned alert, case, approval, action, execution, or reconciliation records.
+
+The false-positive review must record the specific benign explanation, reviewed evidence source, affected rule or candidate, reviewer, follow-up owner, and whether the candidate remains in staging, moves toward activation review, returns to `candidate`, or is disabled.
+
+A benign conclusion requires explicit linkage to an AegisOps-owned record, approved change-management path, or reviewed read-only source evidence. Familiar actor names, hostnames, repository names, tenant names, Wazuh manager labels, expected-looking groups, comments, or nearby metadata are not enough to suppress a candidate or declare the signal safe.
+
+If false-positive review depends on missing parser evidence, missing Wazuh provenance, raw forwarded identity, placeholder credentials, sample secrets, unsigned tokens, TODO values, or inferred tenant, repository, account, issue, or environment linkage, the candidate remains blocked until the prerequisite is supplied.
+
+## 9. Detector Evidence Handoff
+
+Detector evidence handoff must land in AegisOps-owned records and the retained release-gate evidence package before activation is treated as complete.
+
+The handoff package must name:
+
+- the Wazuh candidate rule and source-family package;
+- the reviewed fixture set and validation command result;
+- the AegisOps alert, case, or reconciliation record identifiers that received detector evidence;
+- the reviewer, activation owner, disable owner, rollback owner, and next-review date;
+- the false-positive review disposition and expected alert volume; and
+- the release-gate evidence record that binds activation, disable, and rollback evidence to the current repository revision.
+
+The handoff is evidence custody only. It does not let Wazuh decide case truth, approval truth, execution truth, reconciliation truth, or release readiness.
+
+## 10. Authority Boundary
+
+Wazuh remains detection substrate only and is not the authority for AegisOps alert lifecycle, case state, approval state, action state, execution state, reconciliation outcome, or release-gate truth.
+
+Wazuh may provide analytic signal evidence, rule metadata, parser output, and source provenance for AegisOps review. AegisOps-owned records remain authoritative for workflow state, analyst disposition, approval decisions, action delegation, execution reconciliation, release-gate acceptance, disable decisions, and rollback completion.
+
+Operators must not infer activation success, disable completion, rollback completion, case closure, approval state, or reconciliation outcome from Wazuh rule state, alert count, source names, manager labels, or detector status alone.
+
+When Wazuh substrate evidence and AegisOps-owned records disagree, repair the derived substrate-facing projection or block the gate for review. Do not redefine AegisOps workflow truth around Wazuh status.

--- a/scripts/test-verify-wazuh-rollback-evidence-gate.sh
+++ b/scripts/test-verify-wazuh-rollback-evidence-gate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-wazuh-rollback-evidence-gate.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+}
+
+write_doc() {
+  local target="$1"
+  local doc_content="$2"
+
+  printf '%s\n' "${doc_content}" >"${target}/docs/wazuh-rule-lifecycle-runbook.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected rollback evidence verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected rollback evidence verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_doc "${valid_repo}" '# Wazuh Rule Lifecycle and Validation Runbook
+
+Activation evidence must identify the candidate rule, reviewed fixture set, staging validation result, reviewer, activation window, expected alert volume, and release-gate evidence record.
+Disable evidence must identify the disabled rule or candidate, disable owner, disable reason, affected fixture or parser evidence, operator notification path, and follow-up review.
+Rollback evidence must identify the last reviewed rule revision, restored fixture set, rollback owner, rollback reason, validation rerun result, and AegisOps release-gate evidence record.
+Detector evidence handoff must land in AegisOps-owned records and the retained release-gate evidence package before activation is treated as complete.
+the release-gate evidence record that binds activation, disable, and rollback evidence to the current repository revision.
+The gate must fail closed when provenance, scope, reviewer, owner, fixture, validation, false-positive, disable, rollback, or release-gate evidence is missing, malformed, placeholder, or inferred.
+Operators must not infer activation success, disable completion, rollback completion, case closure, approval state, or reconciliation outcome from Wazuh rule state, alert count, source names, manager labels, or detector status alone.'
+assert_passes "${valid_repo}"
+
+missing_rollback_repo="${workdir}/missing-rollback"
+create_repo "${missing_rollback_repo}"
+write_doc "${missing_rollback_repo}" '# Wazuh Rule Lifecycle and Validation Runbook
+
+Activation evidence must identify the candidate rule, reviewed fixture set, staging validation result, reviewer, activation window, expected alert volume, and release-gate evidence record.
+Disable evidence must identify the disabled rule or candidate, disable owner, disable reason, affected fixture or parser evidence, operator notification path, and follow-up review.
+Detector evidence handoff must land in AegisOps-owned records and the retained release-gate evidence package before activation is treated as complete.
+the release-gate evidence record that binds activation, disable, and rollback evidence to the current repository revision.
+The gate must fail closed when provenance, scope, reviewer, owner, fixture, validation, false-positive, disable, rollback, or release-gate evidence is missing, malformed, placeholder, or inferred.
+Operators must not infer activation success, disable completion, rollback completion, case closure, approval state, or reconciliation outcome from Wazuh rule state, alert count, source names, manager labels, or detector status alone.'
+assert_fails_with "${missing_rollback_repo}" "Missing Wazuh rollback evidence gate text"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo "${missing_doc_repo}"
+assert_fails_with "${missing_doc_repo}" "Missing Wazuh rule lifecycle runbook:"
+
+echo "verify-wazuh-rollback-evidence-gate tests passed"

--- a/scripts/test-verify-wazuh-rule-lifecycle-runbook.sh
+++ b/scripts/test-verify-wazuh-rule-lifecycle-runbook.sh
@@ -96,9 +96,35 @@ The local validation sequence is: prepare representative input logs, run `wazuh-
 
 If `wazuh-logtest` output does not preserve the reviewed rule metadata or accountable source identity needed by AegisOps, the rule must return to `draft` or `candidate` rather than moving forward on analyst workflow assumptions.
 
-## 6. Rollout, Fixture Review, and Rollback
+## 6. Phase 40 Detector Activation Gate
 
-Rollback means disabling or reverting the custom rule, restoring the last reviewed rule revision, and withdrawing any dependent fixture or workflow assumptions until validation is rerun.'
+Phase 40 detector activation must remain a reviewed AegisOps release-gate decision, not a Wazuh-owned workflow transition.
+
+Staging activation is allowed only after rule review, fixture review, expected-volume review, false-positive review, rollback owner, disable owner, and next-review date are recorded.
+
+Activation evidence must identify the candidate rule, reviewed fixture set, staging validation result, reviewer, activation window, expected alert volume, and release-gate evidence record.
+
+The gate must fail closed when provenance, scope, reviewer, owner, fixture, validation, false-positive, disable, rollback, or release-gate evidence is missing, malformed, placeholder, or inferred.
+
+## 7. Rollout, Disable, and Rollback
+
+Rollback means disabling or reverting the custom rule, restoring the last reviewed rule revision, and withdrawing any dependent fixture or workflow assumptions until validation is rerun.
+
+Disable evidence must identify the disabled rule or candidate, disable owner, disable reason, affected fixture or parser evidence, operator notification path, and follow-up review.
+
+Rollback evidence must identify the last reviewed rule revision, restored fixture set, rollback owner, rollback reason, validation rerun result, and AegisOps release-gate evidence record.
+
+## 8. False-Positive Handling
+
+False-positive handling must keep benign, suspicious, deferred, and ambiguous outcomes tied to AegisOps-owned alert, case, approval, action, execution, or reconciliation records.
+
+## 9. Detector Evidence Handoff
+
+Detector evidence handoff must land in AegisOps-owned records and the retained release-gate evidence package before activation is treated as complete.
+
+## 10. Authority Boundary
+
+Wazuh remains detection substrate only and is not the authority for AegisOps alert lifecycle, case state, approval state, action state, execution state, reconciliation outcome, or release-gate truth.'
 commit_fixture "${valid_repo}"
 assert_passes "${valid_repo}"
 
@@ -135,10 +161,76 @@ At minimum, the fixture-backed review path must keep `control-plane/tests/test_w
 
 ## 5. `wazuh-logtest` Validation Runbook
 
+## 6. Phase 40 Detector Activation Gate
+
+Phase 40 detector activation must remain a reviewed AegisOps release-gate decision, not a Wazuh-owned workflow transition.
+
+Staging activation is allowed only after rule review, fixture review, expected-volume review, false-positive review, rollback owner, disable owner, and next-review date are recorded.
+
+Activation evidence must identify the candidate rule, reviewed fixture set, staging validation result, reviewer, activation window, expected alert volume, and release-gate evidence record.
+
+The gate must fail closed when provenance, scope, reviewer, owner, fixture, validation, false-positive, disable, rollback, or release-gate evidence is missing, malformed, placeholder, or inferred.
+
+## 7. Rollout, Disable, and Rollback
+
+Rollback means disabling or reverting the custom rule, restoring the last reviewed rule revision, and withdrawing any dependent fixture or workflow assumptions until validation is rerun.
+
+Disable evidence must identify the disabled rule or candidate, disable owner, disable reason, affected fixture or parser evidence, operator notification path, and follow-up review.
+
+Rollback evidence must identify the last reviewed rule revision, restored fixture set, rollback owner, rollback reason, validation rerun result, and AegisOps release-gate evidence record.
+
+## 8. False-Positive Handling
+
+False-positive handling must keep benign, suspicious, deferred, and ambiguous outcomes tied to AegisOps-owned alert, case, approval, action, execution, or reconciliation records.
+
+## 9. Detector Evidence Handoff
+
+Detector evidence handoff must land in AegisOps-owned records and the retained release-gate evidence package before activation is treated as complete.
+
+## 10. Authority Boundary
+
+Wazuh remains detection substrate only and is not the authority for AegisOps alert lifecycle, case state, approval state, action state, execution state, reconciliation outcome, or release-gate truth.'
+commit_fixture "${missing_logtest_repo}"
+assert_fails_with "${missing_logtest_repo}" 'Missing Wazuh rule lifecycle runbook statement: Use `wazuh-logtest` before staging or downstream workflow review so rule authors can confirm that the candidate event produces the expected Wazuh rule metadata and alert shape.'
+
+missing_phase40_repo="${workdir}/missing-phase40"
+create_repo "${missing_phase40_repo}"
+write_doc "${missing_phase40_repo}" '# Wazuh Rule Lifecycle and Validation Runbook
+
+## 1. Purpose
+
+This runbook defines the reviewed lifecycle for Wazuh rules that AegisOps relies on during the current Phase 12 design and implementation slice.
+
+It supplements `docs/detection-lifecycle-and-rule-qa-framework.md`, `docs/source-onboarding-contract.md`, `docs/wazuh-alert-ingest-contract.md`, and `docs/secops-business-hours-operating-model.md`.
+
+## 2. Scope and Non-Goals
+
+This runbook does not authorize live Wazuh automation changes, broad source-family rollout, or destructive response actions.
+
+## 3. Rule Lifecycle Within AegisOps
+
+A Wazuh rule change must not be treated as an isolated substrate tweak.
+
+## 4. Custom-Rule Onboarding Path for Phase 12
+
+For AegisOps, a custom-rule change is admissible only when the resulting Wazuh alert shape still satisfies the reviewed Wazuh ingest contract, especially `id`, `timestamp`, `rule.id`, `rule.level`, `rule.description`, accountable source identity, and full raw payload preservation.
+
+Phase 12 implementers must update or add fixture coverage under `control-plane/tests/fixtures/wazuh/` whenever a custom rule introduces a new reviewed alert shape, source-identity branch, or provenance expectation.
+
+At minimum, the fixture-backed review path must keep `control-plane/tests/test_wazuh_adapter.py`, `control-plane/tests/test_service_persistence_assistant_advisory.py`, and `control-plane/tests/test_service_persistence_ingest_case_lifecycle.py` aligned with the reviewed rule behavior before downstream workflow logic can rely on it.
+
+## 5. `wazuh-logtest` Validation Runbook
+
+Use `wazuh-logtest` before staging or downstream workflow review so rule authors can confirm that the candidate event produces the expected Wazuh rule metadata and alert shape.
+
+The local validation sequence is: prepare representative input logs, run `wazuh-logtest`, compare the resulting alert fields against `docs/wazuh-alert-ingest-contract.md`, then refresh Phase 12 fixtures and adapter tests before treating the rule as onboarding-ready.
+
+If `wazuh-logtest` output does not preserve the reviewed rule metadata or accountable source identity needed by AegisOps, the rule must return to `draft` or `candidate` rather than moving forward on analyst workflow assumptions.
+
 ## 6. Rollout, Fixture Review, and Rollback
 
 Rollback means disabling or reverting the custom rule, restoring the last reviewed rule revision, and withdrawing any dependent fixture or workflow assumptions until validation is rerun.'
-commit_fixture "${missing_logtest_repo}"
-assert_fails_with "${missing_logtest_repo}" 'Missing Wazuh rule lifecycle runbook statement: Use `wazuh-logtest` before staging or downstream workflow review so rule authors can confirm that the candidate event produces the expected Wazuh rule metadata and alert shape.'
+commit_fixture "${missing_phase40_repo}"
+assert_fails_with "${missing_phase40_repo}" "Missing Wazuh rule lifecycle runbook heading: ## 6. Phase 40 Detector Activation Gate"
 
 echo "verify-wazuh-rule-lifecycle-runbook tests passed"

--- a/scripts/verify-wazuh-rollback-evidence-gate.sh
+++ b/scripts/verify-wazuh-rollback-evidence-gate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+runbook_path="${repo_root}/docs/wazuh-rule-lifecycle-runbook.md"
+
+require_contains() {
+  local file_path="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "${expected}" "${file_path}"; then
+    echo "Missing Wazuh rollback evidence gate text in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -f "${runbook_path}" ]]; then
+  echo "Missing Wazuh rule lifecycle runbook: ${runbook_path}" >&2
+  exit 1
+fi
+
+required_evidence_text=(
+  "Activation evidence must identify the candidate rule, reviewed fixture set, staging validation result, reviewer, activation window, expected alert volume, and release-gate evidence record."
+  "Disable evidence must identify the disabled rule or candidate, disable owner, disable reason, affected fixture or parser evidence, operator notification path, and follow-up review."
+  "Rollback evidence must identify the last reviewed rule revision, restored fixture set, rollback owner, rollback reason, validation rerun result, and AegisOps release-gate evidence record."
+  "Detector evidence handoff must land in AegisOps-owned records and the retained release-gate evidence package before activation is treated as complete."
+  "the release-gate evidence record that binds activation, disable, and rollback evidence to the current repository revision."
+  "The gate must fail closed when provenance, scope, reviewer, owner, fixture, validation, false-positive, disable, rollback, or release-gate evidence is missing, malformed, placeholder, or inferred."
+  "Operators must not infer activation success, disable completion, rollback completion, case closure, approval state, or reconciliation outcome from Wazuh rule state, alert count, source names, manager labels, or detector status alone."
+)
+
+for expected in "${required_evidence_text[@]}"; do
+  require_contains "${runbook_path}" "${expected}"
+done
+
+echo "Wazuh rollback evidence gate preserves activation, disable, rollback, handoff, and authority-boundary evidence."

--- a/scripts/verify-wazuh-rule-lifecycle-runbook.sh
+++ b/scripts/verify-wazuh-rule-lifecycle-runbook.sh
@@ -12,7 +12,11 @@ required_headings=(
   "## 3. Rule Lifecycle Within AegisOps"
   "## 4. Custom-Rule Onboarding Path for Phase 12"
   '## 5. `wazuh-logtest` Validation Runbook'
-  "## 6. Rollout, Fixture Review, and Rollback"
+  "## 6. Phase 40 Detector Activation Gate"
+  "## 7. Rollout, Disable, and Rollback"
+  "## 8. False-Positive Handling"
+  "## 9. Detector Evidence Handoff"
+  "## 10. Authority Boundary"
 )
 
 required_phrases=(
@@ -27,6 +31,15 @@ required_phrases=(
   'If `wazuh-logtest` output does not preserve the reviewed rule metadata or accountable source identity needed by AegisOps, the rule must return to `draft` or `candidate` rather than moving forward on analyst workflow assumptions.'
   "Rollback means disabling or reverting the custom rule, restoring the last reviewed rule revision, and withdrawing any dependent fixture or workflow assumptions until validation is rerun."
   "This runbook does not authorize live Wazuh automation changes, broad source-family rollout, or destructive response actions."
+  "Phase 40 detector activation must remain a reviewed AegisOps release-gate decision, not a Wazuh-owned workflow transition."
+  "Staging activation is allowed only after rule review, fixture review, expected-volume review, false-positive review, rollback owner, disable owner, and next-review date are recorded."
+  "Activation evidence must identify the candidate rule, reviewed fixture set, staging validation result, reviewer, activation window, expected alert volume, and release-gate evidence record."
+  "Disable evidence must identify the disabled rule or candidate, disable owner, disable reason, affected fixture or parser evidence, operator notification path, and follow-up review."
+  "Rollback evidence must identify the last reviewed rule revision, restored fixture set, rollback owner, rollback reason, validation rerun result, and AegisOps release-gate evidence record."
+  "False-positive handling must keep benign, suspicious, deferred, and ambiguous outcomes tied to AegisOps-owned alert, case, approval, action, execution, or reconciliation records."
+  "Detector evidence handoff must land in AegisOps-owned records and the retained release-gate evidence package before activation is treated as complete."
+  "Wazuh remains detection substrate only and is not the authority for AegisOps alert lifecycle, case state, approval state, action state, execution state, reconciliation outcome, or release-gate truth."
+  "The gate must fail closed when provenance, scope, reviewer, owner, fixture, validation, false-positive, disable, rollback, or release-gate evidence is missing, malformed, placeholder, or inferred."
 )
 
 if [[ ! -f "${doc_path}" ]]; then


### PR DESCRIPTION
## Summary
- expands the Wazuh rule lifecycle runbook with Phase 40 staging activation, rollout, disable, rollback, false-positive, detector evidence handoff, and authority-boundary gates
- tightens the existing Wazuh runbook verifier so missing Phase 40 activation and rollback requirements fail closed
- adds a dedicated Wazuh rollback evidence gate verifier and focused verifier test

## Verification
- `./scripts/test-verify-wazuh-rule-lifecycle-runbook.sh`
- `./scripts/test-verify-wazuh-rollback-evidence-gate.sh`
- `bash scripts/verify-wazuh-rule-lifecycle-runbook.sh && bash scripts/verify-wazuh-rollback-evidence-gate.sh && bash scripts/verify-phase-12-wazuh-ci-validation.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `python3 -m unittest control-plane.tests.test_phase14_identity_rich_source_profile_docs`
- `bash scripts/verify-entra-id-detector-activation-candidate.sh && bash scripts/verify-github-audit-detector-activation-candidate.sh`

Closes #805
Part of #802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced rule lifecycle documentation with stricter activation controls and phase-based gating procedures.
  * Added comprehensive evidence requirements for rule activation, disablement, and rollback operations.
  * New authority boundary and false-positive handling guidelines.

* **Tests**
  * Added verification tests to validate compliance with rule lifecycle documentation standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->