### PR TITLE
Docs: detector activation evidence handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           bash scripts/verify-control-plane-state-model-doc.sh
           bash scripts/verify-automation-substrate-contract-doc.sh
           bash scripts/verify-control-plane-schema-skeleton.sh
+          bash scripts/verify-detector-activation-evidence-handoff.sh
           bash scripts/verify-detection-lifecycle-and-rule-qa-framework.sh
           bash scripts/verify-documentation-ownership-map.sh
           bash scripts/verify-secops-domain-model-doc.sh
@@ -287,6 +288,7 @@ jobs:
           bash scripts/test-verify-automation-substrate-contract-doc.sh
           bash scripts/test-verify-control-plane-state-model-doc.sh
           bash scripts/test-verify-control-plane-schema-skeleton.sh
+          bash scripts/test-verify-detector-activation-evidence-handoff.sh
           bash scripts/test-verify-detection-lifecycle-and-rule-qa-framework.sh
           bash scripts/test-verify-positive-smb-value-proposition.sh
           bash scripts/run-ci-phase-contract.sh all-shell-tests

--- a/docs/detector-activation-evidence-handoff.md
+++ b/docs/detector-activation-evidence-handoff.md
@@ -1,0 +1,51 @@
+# Detector Activation Evidence Handoff Manifest
+
+## 1. Purpose and Boundary
+
+The detector activation evidence handoff is a compact review package for Phase 40 detector activation, disable, and rollback decisions.
+
+The manifest is evidence custody only; AegisOps-owned alert, case, evidence, reconciliation, and release-gate records remain authoritative.
+
+It must not become a compliance archive platform, unlimited detector history system, external ticket authority, or optional-extension prerequisite.
+
+The package keeps rule review evidence, fixture and parser evidence, activation evidence, rollback evidence, alert or case admission sanity, and known limitations visible to operators, maintainers, and auditors without turning detector activation into a parallel archive or workflow authority.
+
+## 2. Manifest Fields
+
+| Field | Required evidence | Authority boundary |
+| --- | --- | --- |
+| Rule review evidence | Candidate rule identifier, lifecycle state, source-family package, reviewer, rule intent, source scope, expected alert volume, expected benign cases, false-positive review, next-review date, and activation owner. | Rule review evidence gates activation but does not make the detector source authoritative for case or workflow truth. |
+| Fixture and parser evidence | Reviewed fixture paths, parser or decoder identity, validation command result, source field coverage, timestamp quality, provenance evidence, and the exact fixture set used for review. | Fixture evidence proves the admitted alert shape only; parser drift or fixture drift blocks activation until refreshed review is recorded. |
+| Activation evidence | Activation window, reviewer sign-off, activation owner, disable owner, rollback owner, release-gate evidence record, repository revision, and the AegisOps alert, case, evidence, or reconciliation identifiers that received detector evidence. | Activation is accepted only through AegisOps-owned records and release-gate evidence, not through Wazuh, OpenSearch, GitHub, Entra ID, or ticket status alone. |
+| Rollback and disable evidence | Disable reason, rollback reason, restored rule revision, restored fixture set, validation rerun result, operator notification path, follow-up owner, and release-gate evidence record. | Rollback is a non-destructive content, rule-set, fixture, and validation reset path; it does not authorize direct source-side mutation or undocumented hotfixes. |
+| Alert or case admission sanity | AegisOps alert, case, evidence, or reconciliation identifiers, admission result, reviewed linkage to the source-family record, and clean-state outcome for failed or rejected paths. | Case admission remains control-plane-owned and must fail closed when provenance, scope, linkage, or snapshot consistency is missing. |
+| Known limitations | Deferred detector behavior, unsupported source fields, parser gaps, expected false-positive limits, retention limit, optional-extension non-requirements, and follow-up owner. | Limitations preserve review context without creating an unlimited history system or expanding detector authority. |
+
+## 3. Required Review Questions
+
+- Does the handoff name the exact candidate rule, source-family package, fixture set, validation command result, reviewer, activation owner, disable owner, rollback owner, and next-review date?
+- Does the handoff cite AegisOps-owned alert, case, evidence, reconciliation, or release-gate records for activation and rollback evidence?
+- Did rule review evidence preserve the intended analytic scope, false-positive expectations, expected alert volume, and known limitations without inferring scope from names or nearby metadata?
+- Did fixture and parser evidence prove the reviewed alert shape, timestamp quality, source-family field coverage, and Wazuh provenance used for detector review?
+- Did alert or case admission preserve explicit reviewed linkage, fail closed on missing provenance or scope, and leave no orphan record, partial durable write, or half-admitted case after rejected paths?
+- Does rollback or disable evidence identify the restored rule revision, restored fixture set, validation rerun result, owner, notification path, and follow-up without approving direct source-side mutation?
+
+## 4. Source-Family Alignment
+
+GitHub audit and Entra ID runbooks must point detector activation review to this manifest before a candidate moves beyond staging review.
+
+Source-family runbooks must keep detector handoff subordinate to AegisOps-owned records. GitHub audit, Entra ID, Wazuh, OpenSearch, and external ticket fields may provide evidence, but they do not own case state, approval state, action state, execution state, reconciliation truth, release readiness, or rollback completion.
+
+If source-family evidence is missing parser coverage, missing provenance, placeholder credentials, inferred tenant or repository linkage, unsigned identity hints, raw forwarded identity, or mixed-snapshot admission evidence, the handoff remains blocked until the prerequisite is supplied or the rejected path is preserved as the reviewed outcome.
+
+## 5. Validation
+
+Run `scripts/verify-detector-activation-evidence-handoff.sh` after changing this manifest, the GitHub audit runbook, the Entra ID runbook, or detector activation candidate evidence.
+
+Focused validation for a handoff package should also include the source-family candidate verifier, the fixture or parser test named by the candidate, and the control-plane case admission sanity check that proves rejected paths leave durable state clean.
+
+## 6. Out of Scope
+
+Unlimited detector history retention, compliance archive platform design, external ticket authority, direct GitHub API actioning, direct Entra ID actioning, optional-extension startup gates, and source-owned workflow truth are out of scope.
+
+This manifest does not require external ticket systems, optional extensions, customer-private credentials, live detector credentials, direct source-side mutation, source-side enforcement, or a long-term detector archive before a reviewed AegisOps handoff can close.

--- a/docs/source-families/entra-id/analyst-triage-runbook.md
+++ b/docs/source-families/entra-id/analyst-triage-runbook.md
@@ -113,7 +113,19 @@ Any new reviewed Entra ID rule shape, provenance expectation, or identity branch
 
 The analyst triage record should note whether the current fixture set still explains the alert clearly, whether the event remains compatible with the control-plane-first analyst workflow, and whether a new fixture or mapping update is required.
 
-## 11. Baseline Alignment Notes
+## 11. Detector Activation Handoff Alignment
+
+Detector activation evidence handoff must use `docs/detector-activation-evidence-handoff.md` as the manifest for rule review evidence, fixture and parser evidence, activation evidence, rollback evidence, alert or case admission sanity, and known limitations.
+
+The handoff must cite AegisOps-owned alert, case, evidence, reconciliation, or release-gate records; source-family output, Wazuh status, OpenSearch status, GitHub status, Entra ID status, and external ticket fields are evidence only.
+
+Missing provenance, missing parser evidence, missing reviewer ownership, inferred scope linkage, placeholder credentials, or mixed-snapshot admission evidence blocks activation handoff until the prerequisite is supplied.
+
+The Entra ID handoff must preserve the reviewed tenant, directory-object, actor, target role, app or service-principal, authentication, correlation, request, and privilege context from the source-family package and fixture before a candidate moves beyond staging review.
+
+It must not promote Entra ID portal state, tenant names, role names, app names, service-principal names, Microsoft 365 audit status, or external ticket references into handoff authority for case admission, activation, disable, or rollback completion.
+
+## 12. Baseline Alignment Notes
 
 This runbook remains aligned with `docs/source-onboarding-contract.md`, `docs/detection-lifecycle-and-rule-qa-framework.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
 

--- a/docs/source-families/entra-id/detector-activation-candidates/privileged-role-assignment.md
+++ b/docs/source-families/entra-id/detector-activation-candidates/privileged-role-assignment.md
@@ -61,6 +61,10 @@ Staging activation expectations are:
 
 This document does not approve active OpenSearch detector deployment, live Wazuh rule rollout, Entra ID API credentials, direct directory mutation, automated response, Microsoft 365 audit detector activation, or production write-capable behavior.
 
+Activation handoff must follow `docs/detector-activation-evidence-handoff.md` before this candidate moves beyond staging review.
+
+The handoff must retain rule review evidence, fixture and parser evidence, activation evidence, rollback evidence, alert or case admission sanity, and known limitations while keeping Entra ID evidence subordinate to AegisOps-owned records.
+
 ## False-Positive Review Expectations
 
 False-positive review expectations must cover routine directory administration, approved identity operations, reviewed service identity behavior, privileged role assignment maintenance, scheduled change windows, emergency access procedure review, and expected automation-path maintenance.

--- a/docs/source-families/github-audit/analyst-triage-runbook.md
+++ b/docs/source-families/github-audit/analyst-triage-runbook.md
@@ -111,7 +111,19 @@ Any new reviewed GitHub audit rule shape, provenance expectation, or identity br
 
 The analyst triage record should note whether the current fixture set still explains the alert clearly, whether the event remains compatible with the control-plane-first analyst workflow, and whether a new fixture or mapping update is required.
 
-## 11. Baseline Alignment Notes
+## 11. Detector Activation Handoff Alignment
+
+Detector activation evidence handoff must use `docs/detector-activation-evidence-handoff.md` as the manifest for rule review evidence, fixture and parser evidence, activation evidence, rollback evidence, alert or case admission sanity, and known limitations.
+
+The handoff must cite AegisOps-owned alert, case, evidence, reconciliation, or release-gate records; source-family output, Wazuh status, OpenSearch status, GitHub status, Entra ID status, and external ticket fields are evidence only.
+
+Missing provenance, missing parser evidence, missing reviewer ownership, inferred scope linkage, placeholder credentials, or mixed-snapshot admission evidence blocks activation handoff until the prerequisite is supplied.
+
+The GitHub audit handoff must preserve the reviewed repository, organization, actor, target, request, and privilege context from the source-family package and fixture before a candidate moves beyond staging review.
+
+It must not promote GitHub tickets, GitHub UI state, repository names, team names, workflow names, or external ticket references into handoff authority for case admission, activation, disable, or rollback completion.
+
+## 12. Baseline Alignment Notes
 
 This runbook remains aligned with `docs/source-onboarding-contract.md`, `docs/detection-lifecycle-and-rule-qa-framework.md`, `docs/wazuh-rule-lifecycle-runbook.md`, and `docs/secops-business-hours-operating-model.md`.
 

--- a/docs/source-families/github-audit/detector-activation-candidates/repository-admin-membership-change.md
+++ b/docs/source-families/github-audit/detector-activation-candidates/repository-admin-membership-change.md
@@ -56,6 +56,10 @@ Staging activation expectations are:
 
 This document does not approve active OpenSearch detector deployment, live Wazuh rule rollout, GitHub API credentials, direct GitHub mutation, automated response, or production write-capable behavior.
 
+Activation handoff must follow `docs/detector-activation-evidence-handoff.md` before this candidate moves beyond staging review.
+
+The handoff must retain rule review evidence, fixture and parser evidence, activation evidence, rollback evidence, alert or case admission sanity, and known limitations while keeping GitHub audit evidence subordinate to AegisOps-owned records.
+
 ## False-Positive Review Expectations
 
 False-positive review expectations must cover routine repository administration, approved maintainer activity, access review cleanup, automation identity behavior, scheduled change windows, onboarding or offboarding work, and expected team membership maintenance.

--- a/docs/wazuh-rule-lifecycle-runbook.md
+++ b/docs/wazuh-rule-lifecycle-runbook.md
@@ -144,6 +144,8 @@ If false-positive review depends on missing parser evidence, missing Wazuh prove
 
 Detector evidence handoff must land in AegisOps-owned records and the retained release-gate evidence package before activation is treated as complete.
 
+`docs/detector-activation-evidence-handoff.md` is the reviewed detector activation evidence handoff manifest for Phase 40 activation, disable, rollback, alert or case admission sanity, and known limitations.
+
 The handoff package must name:
 
 - the Wazuh candidate rule and source-family package;

--- a/scripts/test-verify-detector-activation-evidence-handoff.sh
+++ b/scripts/test-verify-detector-activation-evidence-handoff.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-detector-activation-evidence-handoff.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p \
+    "${target}/docs/source-families/github-audit/detector-activation-candidates" \
+    "${target}/docs/source-families/entra-id/detector-activation-candidates"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_valid_docs() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/detector-activation-evidence-handoff.md"
+# Detector Activation Evidence Handoff Manifest
+
+The detector activation evidence handoff is a compact review package for Phase 40 detector activation, disable, and rollback decisions.
+
+The manifest is evidence custody only; AegisOps-owned alert, case, evidence, reconciliation, and release-gate records remain authoritative.
+
+It must not become a compliance archive platform, unlimited detector history system, external ticket authority, or optional-extension prerequisite.
+
+## 2. Manifest Fields
+
+| Field | Required evidence | Authority boundary |
+| --- | --- | --- |
+| Rule review evidence | Candidate rule identifier, lifecycle state, source-family package, reviewer, rule intent, source scope, expected alert volume, expected benign cases, false-positive review, next-review date, and activation owner. | Rule review evidence gates activation but does not make the detector source authoritative for case or workflow truth. |
+| Fixture and parser evidence | Reviewed fixture paths, parser or decoder identity, validation command result, source field coverage, timestamp quality, provenance evidence, and the exact fixture set used for review. | Fixture evidence proves the admitted alert shape only; parser drift or fixture drift blocks activation until refreshed review is recorded. |
+| Activation evidence | Activation window, reviewer sign-off, activation owner, disable owner, rollback owner, release-gate evidence record, repository revision, and the AegisOps alert, case, evidence, or reconciliation identifiers that received detector evidence. | Activation is accepted only through AegisOps-owned records and release-gate evidence, not through Wazuh, OpenSearch, GitHub, Entra ID, or ticket status alone. |
+| Rollback and disable evidence | Disable reason, rollback reason, restored rule revision, restored fixture set, validation rerun result, operator notification path, follow-up owner, and release-gate evidence record. | Rollback is a non-destructive content, rule-set, fixture, and validation reset path; it does not authorize direct source-side mutation or undocumented hotfixes. |
+| Alert or case admission sanity | AegisOps alert, case, evidence, or reconciliation identifiers, admission result, reviewed linkage to the source-family record, and clean-state outcome for failed or rejected paths. | Case admission remains control-plane-owned and must fail closed when provenance, scope, linkage, or snapshot consistency is missing. |
+| Known limitations | Deferred detector behavior, unsupported source fields, parser gaps, expected false-positive limits, retention limit, optional-extension non-requirements, and follow-up owner. | Limitations preserve review context without creating an unlimited history system or expanding detector authority. |
+
+## 3. Required Review Questions
+
+- Does the handoff name the exact candidate rule, source-family package, fixture set, validation command result, reviewer, activation owner, disable owner, rollback owner, and next-review date?
+- Does the handoff cite AegisOps-owned alert, case, evidence, reconciliation, or release-gate records for activation and rollback evidence?
+- Did alert or case admission preserve explicit reviewed linkage, fail closed on missing provenance or scope, and leave no orphan record, partial durable write, or half-admitted case after rejected paths?
+
+## 4. Source-Family Alignment
+
+GitHub audit and Entra ID runbooks must point detector activation review to this manifest before a candidate moves beyond staging review.
+
+## 5. Validation
+
+Run `scripts/verify-detector-activation-evidence-handoff.sh` after changing this manifest, the GitHub audit runbook, the Entra ID runbook, or detector activation candidate evidence.
+
+## 6. Out of Scope
+
+Unlimited detector history retention, compliance archive platform design, external ticket authority, direct GitHub API actioning, direct Entra ID actioning, optional-extension startup gates, and source-owned workflow truth are out of scope.
+EOF
+
+  cat <<'EOF' > "${target}/docs/wazuh-rule-lifecycle-runbook.md"
+# Wazuh Rule Lifecycle and Validation Runbook
+
+`docs/detector-activation-evidence-handoff.md` is the reviewed detector activation evidence handoff manifest for Phase 40 activation, disable, rollback, alert or case admission sanity, and known limitations.
+EOF
+
+  for family in github-audit entra-id; do
+    mkdir -p "${target}/docs/source-families/${family}"
+    cat <<'EOF' > "${target}/docs/source-families/${family}/analyst-triage-runbook.md"
+# Analyst Triage Runbook
+
+Detector activation evidence handoff must use `docs/detector-activation-evidence-handoff.md` as the manifest for rule review evidence, fixture and parser evidence, activation evidence, rollback evidence, alert or case admission sanity, and known limitations.
+
+The handoff must cite AegisOps-owned alert, case, evidence, reconciliation, or release-gate records; source-family output, Wazuh status, OpenSearch status, GitHub status, Entra ID status, and external ticket fields are evidence only.
+
+Missing provenance, missing parser evidence, missing reviewer ownership, inferred scope linkage, placeholder credentials, or mixed-snapshot admission evidence blocks activation handoff until the prerequisite is supplied.
+EOF
+  done
+
+  cat <<'EOF' > "${target}/docs/source-families/github-audit/detector-activation-candidates/repository-admin-membership-change.md"
+# GitHub Audit Repository Admin Membership Change Candidate
+
+Activation handoff must follow `docs/detector-activation-evidence-handoff.md` before this candidate moves beyond staging review.
+EOF
+
+  cat <<'EOF' > "${target}/docs/source-families/entra-id/detector-activation-candidates/privileged-role-assignment.md"
+# Entra ID Privileged Role Assignment Candidate
+
+Activation handoff must follow `docs/detector-activation-evidence-handoff.md` before this candidate moves beyond staging review.
+EOF
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" add .
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_valid_docs "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_manifest_repo="${workdir}/missing-manifest"
+create_repo "${missing_manifest_repo}"
+write_valid_docs "${missing_manifest_repo}"
+rm "${missing_manifest_repo}/docs/detector-activation-evidence-handoff.md"
+commit_fixture "${missing_manifest_repo}"
+assert_fails_with "${missing_manifest_repo}" "Missing detector activation evidence handoff manifest:"
+
+missing_alignment_repo="${workdir}/missing-alignment"
+create_repo "${missing_alignment_repo}"
+write_valid_docs "${missing_alignment_repo}"
+printf '# GitHub Audit Analyst Triage Runbook\n' > "${missing_alignment_repo}/docs/source-families/github-audit/analyst-triage-runbook.md"
+commit_fixture "${missing_alignment_repo}"
+assert_fails_with "${missing_alignment_repo}" "Missing GitHub audit detector handoff alignment:"
+
+missing_case_sanity_repo="${workdir}/missing-case-sanity"
+create_repo "${missing_case_sanity_repo}"
+write_valid_docs "${missing_case_sanity_repo}"
+perl -0pi -e 's/\| Alert or case admission sanity \| AegisOps alert, case, evidence, or reconciliation identifiers, admission result, reviewed linkage to the source-family record, and clean-state outcome for failed or rejected paths\. \| Case admission remains control-plane-owned and must fail closed when provenance, scope, linkage, or snapshot consistency is missing\. \|\n//' "${missing_case_sanity_repo}/docs/detector-activation-evidence-handoff.md"
+commit_fixture "${missing_case_sanity_repo}"
+assert_fails_with "${missing_case_sanity_repo}" "Missing detector activation evidence handoff manifest statement: | Alert or case admission sanity |"
+
+forbidden_authority_repo="${workdir}/forbidden-authority"
+create_repo "${forbidden_authority_repo}"
+write_valid_docs "${forbidden_authority_repo}"
+printf '\nDirect GitHub API actioning is approved for activation handoff.\n' >> "${forbidden_authority_repo}/docs/detector-activation-evidence-handoff.md"
+commit_fixture "${forbidden_authority_repo}"
+assert_fails_with "${forbidden_authority_repo}" "Forbidden GitHub authority statement: direct GitHub API actioning is approved"
+
+echo "verify-detector-activation-evidence-handoff tests passed"

--- a/scripts/verify-detector-activation-evidence-handoff.sh
+++ b/scripts/verify-detector-activation-evidence-handoff.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+manifest_doc="${repo_root}/docs/detector-activation-evidence-handoff.md"
+wazuh_runbook="${repo_root}/docs/wazuh-rule-lifecycle-runbook.md"
+github_runbook="${repo_root}/docs/source-families/github-audit/analyst-triage-runbook.md"
+entra_runbook="${repo_root}/docs/source-families/entra-id/analyst-triage-runbook.md"
+github_candidate="${repo_root}/docs/source-families/github-audit/detector-activation-candidates/repository-admin-membership-change.md"
+entra_candidate="${repo_root}/docs/source-families/entra-id/detector-activation-candidates/privileged-role-assignment.md"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+require_absent_case_insensitive() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if grep -Fqi -- "${phrase}" "${path}"; then
+    echo "Forbidden ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+require_file "${manifest_doc}" "detector activation evidence handoff manifest"
+require_file "${wazuh_runbook}" "Wazuh rule lifecycle runbook"
+require_file "${github_runbook}" "GitHub audit analyst triage runbook"
+require_file "${entra_runbook}" "Entra ID analyst triage runbook"
+require_file "${github_candidate}" "GitHub audit detector activation candidate"
+require_file "${entra_candidate}" "Entra ID detector activation candidate"
+
+required_manifest_text=(
+  "# Detector Activation Evidence Handoff Manifest"
+  "The detector activation evidence handoff is a compact review package for Phase 40 detector activation, disable, and rollback decisions."
+  "The manifest is evidence custody only; AegisOps-owned alert, case, evidence, reconciliation, and release-gate records remain authoritative."
+  "It must not become a compliance archive platform, unlimited detector history system, external ticket authority, or optional-extension prerequisite."
+  "## 2. Manifest Fields"
+  "| Field | Required evidence | Authority boundary |"
+  "| Rule review evidence | Candidate rule identifier, lifecycle state, source-family package, reviewer, rule intent, source scope, expected alert volume, expected benign cases, false-positive review, next-review date, and activation owner. | Rule review evidence gates activation but does not make the detector source authoritative for case or workflow truth. |"
+  "| Fixture and parser evidence | Reviewed fixture paths, parser or decoder identity, validation command result, source field coverage, timestamp quality, provenance evidence, and the exact fixture set used for review. | Fixture evidence proves the admitted alert shape only; parser drift or fixture drift blocks activation until refreshed review is recorded. |"
+  "| Activation evidence | Activation window, reviewer sign-off, activation owner, disable owner, rollback owner, release-gate evidence record, repository revision, and the AegisOps alert, case, evidence, or reconciliation identifiers that received detector evidence. | Activation is accepted only through AegisOps-owned records and release-gate evidence, not through Wazuh, OpenSearch, GitHub, Entra ID, or ticket status alone. |"
+  "| Rollback and disable evidence | Disable reason, rollback reason, restored rule revision, restored fixture set, validation rerun result, operator notification path, follow-up owner, and release-gate evidence record. | Rollback is a non-destructive content, rule-set, fixture, and validation reset path; it does not authorize direct source-side mutation or undocumented hotfixes. |"
+  "| Alert or case admission sanity | AegisOps alert, case, evidence, or reconciliation identifiers, admission result, reviewed linkage to the source-family record, and clean-state outcome for failed or rejected paths. | Case admission remains control-plane-owned and must fail closed when provenance, scope, linkage, or snapshot consistency is missing. |"
+  "| Known limitations | Deferred detector behavior, unsupported source fields, parser gaps, expected false-positive limits, retention limit, optional-extension non-requirements, and follow-up owner. | Limitations preserve review context without creating an unlimited history system or expanding detector authority. |"
+  "## 3. Required Review Questions"
+  "- Does the handoff name the exact candidate rule, source-family package, fixture set, validation command result, reviewer, activation owner, disable owner, rollback owner, and next-review date?"
+  "- Does the handoff cite AegisOps-owned alert, case, evidence, reconciliation, or release-gate records for activation and rollback evidence?"
+  "- Did alert or case admission preserve explicit reviewed linkage, fail closed on missing provenance or scope, and leave no orphan record, partial durable write, or half-admitted case after rejected paths?"
+  "## 4. Source-Family Alignment"
+  "GitHub audit and Entra ID runbooks must point detector activation review to this manifest before a candidate moves beyond staging review."
+  "## 5. Validation"
+  'Run `scripts/verify-detector-activation-evidence-handoff.sh` after changing this manifest, the GitHub audit runbook, the Entra ID runbook, or detector activation candidate evidence.'
+  "## 6. Out of Scope"
+  "Unlimited detector history retention, compliance archive platform design, external ticket authority, direct GitHub API actioning, direct Entra ID actioning, optional-extension startup gates, and source-owned workflow truth are out of scope."
+)
+
+for phrase in "${required_manifest_text[@]}"; do
+  require_phrase "${manifest_doc}" "${phrase}" "detector activation evidence handoff manifest statement"
+done
+
+required_alignment_text=(
+  'Detector activation evidence handoff must use `docs/detector-activation-evidence-handoff.md` as the manifest for rule review evidence, fixture and parser evidence, activation evidence, rollback evidence, alert or case admission sanity, and known limitations.'
+  "The handoff must cite AegisOps-owned alert, case, evidence, reconciliation, or release-gate records; source-family output, Wazuh status, OpenSearch status, GitHub status, Entra ID status, and external ticket fields are evidence only."
+  "Missing provenance, missing parser evidence, missing reviewer ownership, inferred scope linkage, placeholder credentials, or mixed-snapshot admission evidence blocks activation handoff until the prerequisite is supplied."
+)
+
+for phrase in "${required_alignment_text[@]}"; do
+  require_phrase "${github_runbook}" "${phrase}" "GitHub audit detector handoff alignment"
+  require_phrase "${entra_runbook}" "${phrase}" "Entra ID detector handoff alignment"
+done
+
+require_phrase "${wazuh_runbook}" '`docs/detector-activation-evidence-handoff.md` is the reviewed detector activation evidence handoff manifest for Phase 40 activation, disable, rollback, alert or case admission sanity, and known limitations.' "Wazuh runbook detector handoff manifest link"
+require_phrase "${github_candidate}" 'Activation handoff must follow `docs/detector-activation-evidence-handoff.md` before this candidate moves beyond staging review.' "GitHub candidate detector handoff link"
+require_phrase "${entra_candidate}" 'Activation handoff must follow `docs/detector-activation-evidence-handoff.md` before this candidate moves beyond staging review.' "Entra ID candidate detector handoff link"
+
+for path in "${manifest_doc}" "${github_runbook}" "${entra_runbook}" "${github_candidate}" "${entra_candidate}"; do
+  require_absent_case_insensitive "${path}" "requires unlimited retention" "detector handoff boundary statement"
+  require_absent_case_insensitive "${path}" "optional extension prerequisite" "detector handoff prerequisite statement"
+  require_absent_case_insensitive "${path}" "direct GitHub API actioning is approved" "GitHub authority statement"
+  require_absent_case_insensitive "${path}" "direct Entra ID actioning is approved" "Entra ID authority statement"
+done
+
+echo "Detector activation evidence handoff manifest and source-family runbook alignment are present and bounded."


### PR DESCRIPTION
## Summary
- Add the Phase 40 detector activation evidence handoff manifest covering rule review, fixture/parser evidence, activation, rollback, case admission sanity, and limitations.
- Align GitHub audit and Entra ID runbooks plus detector candidates to the manifest while keeping source systems subordinate to AegisOps-owned records.
- Add a focused verifier, shell regression test, and CI wiring.

## Verification
- `bash scripts/verify-detector-activation-evidence-handoff.sh`
- `bash scripts/test-verify-detector-activation-evidence-handoff.sh`
- `bash scripts/verify-github-audit-detector-activation-candidate.sh && bash scripts/verify-entra-id-detector-activation-candidate.sh`
- `bash scripts/verify-wazuh-rule-lifecycle-runbook.sh`
- `python3 -m unittest control-plane.tests.test_github_audit_detector_activation_candidate_docs control-plane.tests.test_entra_id_detector_activation_candidate_docs`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash scripts/test-verify-publishable-path-hygiene.sh`

Part of #802
Closes #806
