### PR TITLE
Operations: define Zammad live pilot boundary

### DIFF
--- a/control-plane/tests/test_issue812_zammad_live_pilot_boundary_docs.py
+++ b/control-plane/tests/test_issue812_zammad_live_pilot_boundary_docs.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Issue812ZammadLivePilotBoundaryDocsTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected document at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_zammad_live_pilot_boundary_doc_defines_scope_and_non_authority(
+        self,
+    ) -> None:
+        text = self._read("docs/operations-zammad-live-pilot-boundary.md")
+
+        for term in (
+            "# Operations Zammad-First Live Pilot Boundary and Credential Custody",
+            "Zammad is the only approved live coordination substrate for the first pilot.",
+            "GLPI remains a documented fallback only after a separate reviewed change rejects Zammad for the pilot.",
+            "The pilot is link-first and coordination-only.",
+            "AegisOps remains authoritative for case, action, approval, execution, and reconciliation records.",
+            "Ticket state, SLA state, comments, assignee, queue, priority, escalation, or closure in Zammad must not become AegisOps case, action, approval, execution, or reconciliation authority.",
+            "multi-ITSM abstraction",
+            "bidirectional sync",
+            "ticket-system authority",
+        ):
+            self.assertIn(term, text)
+
+    def test_zammad_live_pilot_boundary_doc_defines_credential_custody(
+        self,
+    ) -> None:
+        text = self._read("docs/operations-zammad-live-pilot-boundary.md")
+
+        for term in (
+            "## 3. Credential Custody and Rotation",
+            "Zammad live-pilot credentials must resolve only from the reviewed managed-secret boundary.",
+            "`AEGISOPS_ZAMMAD_BASE_URL`",
+            "`AEGISOPS_ZAMMAD_TOKEN_FILE`",
+            "`AEGISOPS_ZAMMAD_OPENBAO_PATH`",
+            "No Zammad credential, bearer token, API key, session cookie, customer secret, or environment-specific endpoint credential may be committed to Git",
+            "Placeholder, sample, fake, TODO, unsigned, empty, stale, or human-mailbox credentials are invalid.",
+            "Rotation must be documented before pilot activation, after suspected exposure, after custodian or scope change, and after any break-glass use.",
+            "If the reviewed secret source is unavailable, unreadable, empty, stale, or only placeholder-backed, the pilot remains unavailable and fails closed.",
+        ):
+            self.assertIn(term, text)
+
+    def test_zammad_live_pilot_boundary_doc_defines_endpoint_and_degraded_behavior(
+        self,
+    ) -> None:
+        text = self._read("docs/operations-zammad-live-pilot-boundary.md")
+
+        for term in (
+            "## 4. Endpoint and Proxy Assumptions",
+            "Zammad access for the pilot must use the reviewed outbound integration path and the documented endpoint in `AEGISOPS_ZAMMAD_BASE_URL`.",
+            "Operators must not trust raw `X-Forwarded-*`, `Forwarded`, host, proto, tenant, or user identity hints from Zammad",
+            "The AegisOps backend and operator UI must not expose a direct inbound Zammad webhook authority path for this pilot.",
+            "## 5. Unavailable and Degraded Operator Behavior",
+            "unavailable",
+            "degraded",
+            "When Zammad is unavailable or credentials fail custody validation, operators may continue AegisOps case review, approval, execution, and reconciliation from AegisOps records.",
+            "Operators must not infer ticket existence, approval, execution, reconciliation, closure, or customer notification from a missing, stale, unreachable, or mismatched Zammad record.",
+            "No failed Zammad write, stale read, timeout, proxy failure, auth failure, or degraded ticket payload may create an orphan AegisOps authority record or mark an AegisOps lifecycle step complete.",
+        ):
+            self.assertIn(term, text)
+
+    def test_zammad_live_pilot_verifier_is_present_and_passes(self) -> None:
+        verifier = REPO_ROOT / "scripts" / "verify-zammad-live-pilot-boundary.sh"
+
+        self.assertTrue(verifier.exists(), f"expected verifier at {verifier}")
+
+        result = subprocess.run(
+            ["bash", str(verifier), str(REPO_ROOT)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"verifier failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_issue812_zammad_live_pilot_boundary_docs.py
+++ b/control-plane/tests/test_issue812_zammad_live_pilot_boundary_docs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+import shutil
 import subprocess
 import unittest
 
@@ -63,8 +64,9 @@ class Issue812ZammadLivePilotBoundaryDocsTests(unittest.TestCase):
             "Operators must not trust raw `X-Forwarded-*`, `Forwarded`, host, proto, tenant, or user identity hints from Zammad",
             "The AegisOps backend and operator UI must not expose a direct inbound Zammad webhook authority path for this pilot.",
             "## 5. Unavailable and Degraded Operator Behavior",
-            "unavailable",
-            "degraded",
+            "`available`",
+            "`degraded`",
+            "`unavailable`",
             "When Zammad is unavailable or credentials fail custody validation, operators may continue AegisOps case review, approval, execution, and reconciliation from AegisOps records.",
             "Operators must not infer ticket existence, approval, execution, reconciliation, closure, or customer notification from a missing, stale, unreachable, or mismatched Zammad record.",
             "No failed Zammad write, stale read, timeout, proxy failure, auth failure, or degraded ticket payload may create an orphan AegisOps authority record or mark an AegisOps lifecycle step complete.",
@@ -76,8 +78,10 @@ class Issue812ZammadLivePilotBoundaryDocsTests(unittest.TestCase):
 
         self.assertTrue(verifier.exists(), f"expected verifier at {verifier}")
 
+        bash_path = shutil.which("bash")
+        self.assertIsNotNone(bash_path, "bash executable not found in PATH")
         result = subprocess.run(
-            ["bash", str(verifier), str(REPO_ROOT)],
+            [bash_path, str(verifier), str(REPO_ROOT)],
             check=False,
             capture_output=True,
             text=True,

--- a/docs/operations-zammad-live-pilot-boundary.md
+++ b/docs/operations-zammad-live-pilot-boundary.md
@@ -1,0 +1,98 @@
+# Operations Zammad-First Live Pilot Boundary and Credential Custody
+
+## 1. Purpose
+
+This document defines the first live coordination-substrate pilot boundary for AegisOps operations.
+
+It supplements `docs/phase-26-first-coordination-substrate-and-non-authoritative-ticket-boundary.md`, `docs/auth-baseline.md`, `docs/network-exposure-and-access-path-policy.md`, and `docs/runbook.md` by narrowing the first live coordination path to one substrate and by recording the credential, endpoint, unavailable, and degraded-state posture required before that path can be activated.
+
+This document defines policy and verification expectations only. It does not provision Zammad, mint credentials, create a bidirectional synchronization service, authorize ticket-system workflow truth, or store live secrets.
+
+## 2. Pilot Scope and Non-Authority Boundary
+
+Zammad is the only approved live coordination substrate for the first pilot.
+
+GLPI remains a documented fallback only after a separate reviewed change rejects Zammad for the pilot.
+
+The pilot is link-first and coordination-only. AegisOps may record a reviewed Zammad ticket pointer, ticket URL, external receipt, and bounded operator-facing coordination status when those values are explicitly bound to the authoritative AegisOps case or action-review record.
+
+AegisOps remains authoritative for case, action, approval, execution, and reconciliation records.
+
+Ticket state, SLA state, comments, assignee, queue, priority, escalation, or closure in Zammad must not become AegisOps case, action, approval, execution, or reconciliation authority.
+
+The following are out of scope for this pilot:
+
+- multi-ITSM abstraction;
+- bidirectional sync;
+- ticket-system authority;
+- ticket-driven case creation;
+- ticket-driven approval or execution dispatch;
+- ticket-driven reconciliation or case closure;
+- background ticket polling as lifecycle truth; and
+- direct promotion of Zammad workflow state into AegisOps-owned records.
+
+## 3. Credential Custody and Rotation
+
+Zammad live-pilot credentials must resolve only from the reviewed managed-secret boundary.
+
+The approved runtime bindings are:
+
+- `AEGISOPS_ZAMMAD_BASE_URL` for the reviewed Zammad endpoint URL;
+- `AEGISOPS_ZAMMAD_TOKEN_FILE` for a mounted secret-file token reference; and
+- `AEGISOPS_ZAMMAD_OPENBAO_PATH` for a managed-secret reference when OpenBao is the reviewed backend.
+
+At least one reviewed secret reference, either `AEGISOPS_ZAMMAD_TOKEN_FILE` or `AEGISOPS_ZAMMAD_OPENBAO_PATH`, must be present before live Zammad access is enabled. The resolved value must be non-empty, current, and scoped only to the pilot coordination action family.
+
+No Zammad credential, bearer token, API key, session cookie, customer secret, or environment-specific endpoint credential may be committed to Git, copied into issue text, stored in fixtures, or embedded in operator prompts.
+
+Placeholder, sample, fake, TODO, unsigned, empty, stale, or human-mailbox credentials are invalid.
+
+The credential owner is the Platform Administrator role defined in `docs/auth-baseline.md`. Operators may request pilot activation or report degraded status, but they must not substitute a personal Zammad session, mailbox-backed credential, browser state, copied token, or prior cached secret read for the reviewed source.
+
+Rotation must be documented before pilot activation, after suspected exposure, after custodian or scope change, and after any break-glass use.
+
+The rotation record must include the AegisOps release or repository revision, named custodian, secret source reference, affected consumer set, activation time, reload or restart checkpoint, redacted verification evidence, and follow-up owner for any degraded or unavailable outcome.
+
+If the reviewed secret source is unavailable, unreadable, empty, stale, or only placeholder-backed, the pilot remains unavailable and fails closed.
+
+## 4. Endpoint and Proxy Assumptions
+
+Zammad access for the pilot must use the reviewed outbound integration path and the documented endpoint in `AEGISOPS_ZAMMAD_BASE_URL`.
+
+The endpoint must identify one reviewed Zammad tenant or instance. Operators must not infer tenant, customer, queue, or case linkage from hostname shape, ticket number shape, free text, labels, comments, or nearby issue metadata.
+
+Operators must not trust raw `X-Forwarded-*`, `Forwarded`, host, proto, tenant, or user identity hints from Zammad unless a later reviewed proxy boundary has already authenticated and normalized those signals.
+
+The AegisOps backend and operator UI must not expose a direct inbound Zammad webhook authority path for this pilot.
+
+If a future webhook or callback path is reviewed, it must be treated as non-authoritative coordination context until a separate boundary proves authentication, replay protection, tenant binding, and explicit linkage to the authoritative AegisOps record.
+
+Endpoint failures, proxy failures, TLS failures, authorization failures, DNS failures, schema drift, or mismatched ticket identifiers must remain visible as coordination-path health signals. They must not silently downgrade into success, cached truth, or ticket-system authority.
+
+## 5. Unavailable and Degraded Operator Behavior
+
+The pilot has three operator-visible states:
+
+- `available`: the reviewed endpoint and credential source validated for the current bounded operation, and returned coordination context is explicitly bound to the AegisOps record.
+- `degraded`: AegisOps authoritative records remain usable, but the Zammad coordination path is stale, partially unavailable, slow, missing optional fields, or returns a non-authoritative mismatch that must be visible.
+- `unavailable`: the endpoint, credential source, proxy path, token custody validation, or explicit AegisOps linkage is missing or failed.
+
+When Zammad is unavailable or credentials fail custody validation, operators may continue AegisOps case review, approval, execution, and reconciliation from AegisOps records.
+
+When Zammad is degraded, operators may inspect the last verified coordination reference only if the UI or report labels it as non-authoritative and stale or partial. They must repair the coordination path or keep it degraded; they must not treat degraded Zammad context as approval, execution, reconciliation, or case truth.
+
+Operators must not infer ticket existence, approval, execution, reconciliation, closure, or customer notification from a missing, stale, unreachable, or mismatched Zammad record.
+
+No failed Zammad write, stale read, timeout, proxy failure, auth failure, or degraded ticket payload may create an orphan AegisOps authority record or mark an AegisOps lifecycle step complete.
+
+Unavailable or degraded pilot behavior is testable by verifying that missing credential source, placeholder credential source, unreachable endpoint, stale ticket read, mismatched ticket identifier, and missing explicit AegisOps linkage all preserve AegisOps authority and expose the coordination gap.
+
+## 6. Verification Expectations
+
+Before the pilot is treated as ready, run:
+
+- `bash scripts/verify-zammad-live-pilot-boundary.sh`;
+- `python3 -m unittest control-plane.tests.test_issue812_zammad_live_pilot_boundary_docs`; and
+- a live or rehearsed credential-custody checklist that proves the configured `AEGISOPS_ZAMMAD_TOKEN_FILE` or `AEGISOPS_ZAMMAD_OPENBAO_PATH` resolves through the reviewed managed-secret boundary without exposing the secret value.
+
+The verifier fails closed when this document stops naming Zammad as the single first pilot substrate, weakens credential custody, omits endpoint or proxy assumptions, omits unavailable or degraded behavior, introduces placeholder or fake credential acceptance, introduces workstation-local path guidance, or promotes the external ticket system to case, action, approval, execution, or reconciliation authority.

--- a/scripts/test-verify-zammad-live-pilot-boundary.sh
+++ b/scripts/test-verify-zammad-live-pilot-boundary.sh
@@ -37,12 +37,12 @@ bash "${fixture_repo}/scripts/verify-zammad-live-pilot-boundary.sh" "${fixture_r
 
 missing_degraded_repo="${workdir}/missing-degraded"
 cp -R "${source_repo}" "${missing_degraded_repo}"
-perl -0pi -e 's/- `degraded`: AegisOps authoritative records remain usable, but the Zammad coordination path is stale, partially unavailable, slow, missing optional fields, or returns a non-authoritative mismatch that must be visible\.\n//' "${missing_degraded_repo}/docs/operations-zammad-live-pilot-boundary.md"
+perl -0pi -e 's/`degraded`//' "${missing_degraded_repo}/docs/operations-zammad-live-pilot-boundary.md"
 assert_fails_with "${missing_degraded_repo}" 'Missing Zammad live pilot boundary statement: `degraded`'
 
 missing_unavailable_repo="${workdir}/missing-unavailable"
 cp -R "${source_repo}" "${missing_unavailable_repo}"
-perl -0pi -e 's/If the reviewed secret source is unavailable, unreadable, empty, stale, or only placeholder-backed, the pilot remains unavailable and fails closed\.\n//' "${missing_unavailable_repo}/docs/operations-zammad-live-pilot-boundary.md"
+perl -0pi -e 's/pilot remains unavailable//' "${missing_unavailable_repo}/docs/operations-zammad-live-pilot-boundary.md"
 assert_fails_with "${missing_unavailable_repo}" "Missing Zammad live pilot boundary statement: If the reviewed secret source is unavailable, unreadable, empty, stale, or only placeholder-backed, the pilot remains unavailable and fails closed."
 
 authority_drift_repo="${workdir}/authority-drift"

--- a/scripts/test-verify-zammad-live-pilot-boundary.sh
+++ b/scripts/test-verify-zammad-live-pilot-boundary.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source_repo="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+fixture_repo="${workdir}/repo"
+cp -R "${source_repo}" "${fixture_repo}"
+
+assert_fails_with() {
+  local repo="$1"
+  local expected="$2"
+  local output
+
+  set +e
+  output="$(bash "${repo}/scripts/verify-zammad-live-pilot-boundary.sh" "${repo}" 2>&1)"
+  local status=$?
+  set -e
+
+  if [[ ${status} -eq 0 ]]; then
+    echo "Expected verifier to fail, but it passed." >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" <<<"${output}"; then
+    echo "Verifier failed with unexpected output." >&2
+    echo "Expected: ${expected}" >&2
+    echo "Actual:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+}
+
+bash "${fixture_repo}/scripts/verify-zammad-live-pilot-boundary.sh" "${fixture_repo}"
+
+missing_degraded_repo="${workdir}/missing-degraded"
+cp -R "${source_repo}" "${missing_degraded_repo}"
+perl -0pi -e 's/- `degraded`: AegisOps authoritative records remain usable, but the Zammad coordination path is stale, partially unavailable, slow, missing optional fields, or returns a non-authoritative mismatch that must be visible\.\n//' "${missing_degraded_repo}/docs/operations-zammad-live-pilot-boundary.md"
+assert_fails_with "${missing_degraded_repo}" 'Missing Zammad live pilot boundary statement: `degraded`'
+
+missing_unavailable_repo="${workdir}/missing-unavailable"
+cp -R "${source_repo}" "${missing_unavailable_repo}"
+perl -0pi -e 's/If the reviewed secret source is unavailable, unreadable, empty, stale, or only placeholder-backed, the pilot remains unavailable and fails closed\.\n//' "${missing_unavailable_repo}/docs/operations-zammad-live-pilot-boundary.md"
+assert_fails_with "${missing_unavailable_repo}" "Missing Zammad live pilot boundary statement: If the reviewed secret source is unavailable, unreadable, empty, stale, or only placeholder-backed, the pilot remains unavailable and fails closed."
+
+authority_drift_repo="${workdir}/authority-drift"
+cp -R "${source_repo}" "${authority_drift_repo}"
+printf '\nZammad is authoritative for closure.\n' >>"${authority_drift_repo}/docs/operations-zammad-live-pilot-boundary.md"
+assert_fails_with "${authority_drift_repo}" "Forbidden Zammad live pilot boundary statement: Zammad is authoritative"
+
+placeholder_acceptance_repo="${workdir}/placeholder-acceptance"
+cp -R "${source_repo}" "${placeholder_acceptance_repo}"
+printf '\nplaceholder credentials are valid during bootstrap.\n' >>"${placeholder_acceptance_repo}/docs/operations-zammad-live-pilot-boundary.md"
+assert_fails_with "${placeholder_acceptance_repo}" "Forbidden Zammad live pilot boundary statement: placeholder credentials are valid"
+
+echo "Zammad live pilot boundary verifier negative checks passed."

--- a/scripts/verify-zammad-live-pilot-boundary.sh
+++ b/scripts/verify-zammad-live-pilot-boundary.sh
@@ -117,6 +117,11 @@ for forbidden in \
   reject_phrase "${doc_path}" "${forbidden}" "Zammad live pilot boundary statement"
 done
 
-reject_regex "${doc_path}" '(^|[^[:alnum:]_./-])(~[/\\]|/Users/[^[:space:])>]+|/home/[^[:space:])>]+|[A-Za-z]:\\Users\\[^[:space:])>]+)' "workstation-local absolute path"
+macos_home_pattern='/'"Users"'/[^[:space:])>]+'
+linux_home_pattern='/'"home"'/[^[:space:])>]+'
+windows_home_pattern='[A-Za-z]:\\'"Users"'\\[^[:space:])>]+'
+workstation_local_path_pattern="(^|[^[:alnum:]_./-])(~[/\\\\]|${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern})"
+
+reject_regex "${doc_path}" "${workstation_local_path_pattern}" "workstation-local absolute path"
 
 echo "Zammad live pilot boundary document, credential custody posture, and degraded-state expectations are present."

--- a/scripts/verify-zammad-live-pilot-boundary.sh
+++ b/scripts/verify-zammad-live-pilot-boundary.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/operations-zammad-live-pilot-boundary.md"
+test_path="${repo_root}/control-plane/tests/test_issue812_zammad_live_pilot_boundary_docs.py"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if grep -Fqi -- "${phrase}" "${path}"; then
+    echo "Forbidden ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_regex() {
+  local path="$1"
+  local regex="$2"
+  local description="$3"
+
+  if grep -Eiq -- "${regex}" "${path}"; then
+    echo "Forbidden ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_file "${doc_path}" "Zammad live pilot boundary document"
+require_file "${test_path}" "issue 812 Zammad live pilot docs unittest"
+
+required_headings=(
+  "# Operations Zammad-First Live Pilot Boundary and Credential Custody"
+  "## 1. Purpose"
+  "## 2. Pilot Scope and Non-Authority Boundary"
+  "## 3. Credential Custody and Rotation"
+  "## 4. Endpoint and Proxy Assumptions"
+  "## 5. Unavailable and Degraded Operator Behavior"
+  "## 6. Verification Expectations"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${doc_path}" "${heading}" "Zammad live pilot boundary heading"
+done
+
+required_phrases=(
+  "Zammad is the only approved live coordination substrate for the first pilot."
+  "GLPI remains a documented fallback only after a separate reviewed change rejects Zammad for the pilot."
+  "The pilot is link-first and coordination-only."
+  "AegisOps remains authoritative for case, action, approval, execution, and reconciliation records."
+  "Ticket state, SLA state, comments, assignee, queue, priority, escalation, or closure in Zammad must not become AegisOps case, action, approval, execution, or reconciliation authority."
+  "multi-ITSM abstraction"
+  "bidirectional sync"
+  "ticket-system authority"
+  "Zammad live-pilot credentials must resolve only from the reviewed managed-secret boundary."
+  "\`AEGISOPS_ZAMMAD_BASE_URL\`"
+  "\`AEGISOPS_ZAMMAD_TOKEN_FILE\`"
+  "\`AEGISOPS_ZAMMAD_OPENBAO_PATH\`"
+  "No Zammad credential, bearer token, API key, session cookie, customer secret, or environment-specific endpoint credential may be committed to Git"
+  "Placeholder, sample, fake, TODO, unsigned, empty, stale, or human-mailbox credentials are invalid."
+  "Rotation must be documented before pilot activation, after suspected exposure, after custodian or scope change, and after any break-glass use."
+  "If the reviewed secret source is unavailable, unreadable, empty, stale, or only placeholder-backed, the pilot remains unavailable and fails closed."
+  "Zammad access for the pilot must use the reviewed outbound integration path and the documented endpoint in \`AEGISOPS_ZAMMAD_BASE_URL\`."
+  "Operators must not trust raw \`X-Forwarded-*\`, \`Forwarded\`, host, proto, tenant, or user identity hints from Zammad"
+  "The AegisOps backend and operator UI must not expose a direct inbound Zammad webhook authority path for this pilot."
+  "\`available\`"
+  "\`degraded\`"
+  "\`unavailable\`"
+  "When Zammad is unavailable or credentials fail custody validation, operators may continue AegisOps case review, approval, execution, and reconciliation from AegisOps records."
+  "Operators must not infer ticket existence, approval, execution, reconciliation, closure, or customer notification from a missing, stale, unreachable, or mismatched Zammad record."
+  "No failed Zammad write, stale read, timeout, proxy failure, auth failure, or degraded ticket payload may create an orphan AegisOps authority record or mark an AegisOps lifecycle step complete."
+  "missing credential source, placeholder credential source, unreachable endpoint, stale ticket read, mismatched ticket identifier, and missing explicit AegisOps linkage"
+  "bash scripts/verify-zammad-live-pilot-boundary.sh"
+  "python3 -m unittest control-plane.tests.test_issue812_zammad_live_pilot_boundary_docs"
+)
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${doc_path}" "${phrase}" "Zammad live pilot boundary statement"
+done
+
+for forbidden in \
+  "ticket system is authoritative" \
+  "tickets are authoritative" \
+  "Zammad is authoritative" \
+  "ticket-driven approval is approved" \
+  "ticket-driven execution is approved" \
+  "bidirectional sync is approved" \
+  "multi-ITSM abstraction is approved" \
+  "placeholder credentials are valid" \
+  "fake credentials are valid" \
+  "sample credentials are valid" \
+  "use a personal Zammad session" \
+  "trust raw forwarded headers"; do
+  reject_phrase "${doc_path}" "${forbidden}" "Zammad live pilot boundary statement"
+done
+
+reject_regex "${doc_path}" '(^|[^[:alnum:]_./-])(~[/\\]|/Users/[^[:space:])>]+|/home/[^[:space:])>]+|[A-Za-z]:\\Users\\[^[:space:])>]+)' "workstation-local absolute path"
+
+echo "Zammad live pilot boundary document, credential custody posture, and degraded-state expectations are present."


### PR DESCRIPTION
## Summary
- define the Zammad-first live pilot boundary and non-authoritative ticket posture
- document credential custody, rotation, endpoint/proxy assumptions, and unavailable/degraded behavior
- add focused unittest plus shell verifier and negative verifier fixtures

## Verification
- python3 -m unittest control-plane.tests.test_issue812_zammad_live_pilot_boundary_docs
- bash scripts/verify-zammad-live-pilot-boundary.sh
- bash scripts/test-verify-zammad-live-pilot-boundary.sh
- bash scripts/test-verify-publishable-path-hygiene.sh
- python3 -m unittest control-plane.tests.test_phase26_coordination_substrate_boundary_docs control-plane.tests.test_issue812_zammad_live_pilot_boundary_docs
- bash scripts/verify-phase-26-ticket-coordination-validation.sh

Part of #811.
Closes #812.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Zammad Live Pilot operational boundaries documentation specifying credential management, rotation requirements, endpoint assumptions, and fail-closed operator behavior.

* **Tests**
  * Added test module and automated verification to validate operational boundary compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->