### PR TITLE
test: cover duplicate create ticket receipt reuse

### DIFF
--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -116,6 +116,122 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
                 "ticket_reference_url"
             ].startswith("https://tickets.example.test/#ticket/zammad-ticket-delegation-")
         )
+
+    def test_service_reuses_create_tracking_ticket_receipt_on_duplicate_delegation(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = support.datetime(2026, 4, 18, 1, 8, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 1, 13, tzinfo=support.timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-duplicate-delegation-001",
+            "alert_id": "alert-tracking-duplicate-delegation-001",
+            "finding_id": "finding-tracking-duplicate-delegation-001",
+            "coordination_reference_id": "coord-ref-duplicate-delegation-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = support._phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-duplicate-delegation-001",
+            alert_id="alert-tracking-duplicate-delegation-001",
+            finding_id="finding-tracking-duplicate-delegation-001",
+            coordination_reference_id="coord-ref-duplicate-delegation-001",
+        )
+        payload_hash = support._approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            support.ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-duplicate-delegation-001",
+                action_request_id="action-request-create-ticket-duplicate-delegation-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            support.ActionRequestRecord(
+                action_request_id="action-request-create-ticket-duplicate-delegation-001",
+                approval_decision_id="approval-create-ticket-duplicate-delegation-001",
+                case_id="case-tracking-duplicate-delegation-001",
+                alert_id="alert-tracking-duplicate-delegation-001",
+                finding_id="finding-tracking-duplicate-delegation-001",
+                idempotency_key="idempotency-create-ticket-duplicate-delegation-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        original_dispatch = type(service._shuffle).dispatch_approved_action
+        dispatch_calls = 0
+
+        def counted_dispatch(adapter: object, **kwargs: object) -> object:
+            nonlocal dispatch_calls
+            dispatch_calls += 1
+            return original_dispatch(adapter, **kwargs)
+
+        with support.mock.patch.object(
+            type(service._shuffle),
+            "dispatch_approved_action",
+            autospec=True,
+            side_effect=counted_dispatch,
+        ):
+            first_execution = service.delegate_approved_action_to_shuffle(
+                action_request_id=(
+                    "action-request-create-ticket-duplicate-delegation-001"
+                ),
+                approved_payload=approved_payload,
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+                evidence_ids=("evidence-create-ticket-duplicate-delegation-001",),
+            )
+            duplicate_execution = service.delegate_approved_action_to_shuffle(
+                action_request_id=(
+                    "action-request-create-ticket-duplicate-delegation-001"
+                ),
+                approved_payload=approved_payload,
+                delegated_at=delegated_at + support.timedelta(minutes=1),
+                delegation_issuer="control-plane-service",
+                evidence_ids=("evidence-create-ticket-duplicate-delegation-001",),
+            )
+
+        self.assertEqual(dispatch_calls, 1)
+        self.assertEqual(duplicate_execution, first_execution)
+        self.assertEqual(store.list(support.ActionExecutionRecord), (first_execution,))
+        self.assertEqual(
+            duplicate_execution.provenance["downstream_binding"],
+            first_execution.provenance["downstream_binding"],
+        )
+        self.assertEqual(
+            duplicate_execution.provenance["downstream_binding"][
+                "coordination_reference_id"
+            ],
+            "coord-ref-duplicate-delegation-001",
+        )
+        self.assertEqual(
+            duplicate_execution.provenance["downstream_binding"][
+                "external_receipt_id"
+            ],
+            first_execution.provenance["downstream_binding"]["external_receipt_id"],
+        )
+
     def test_service_fail_closes_when_create_tracking_ticket_receipt_omits_external_receipt_id(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- Add a focused create_tracking_ticket receipt-binding regression for duplicate delegation
- Assert the duplicate path reuses the persisted downstream receipt context and does not dispatch another ticket create attempt

## Verification
- python3 -m unittest control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
- python3 -m unittest control-plane.tests.test_phase26_end_to_end_validation control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket
- git diff --check

Part of #811
Depends on #812
Closes #813