### PR TITLE
Expose degraded coordination receipt mismatches

### DIFF
--- a/control-plane/aegisops_control_plane/action_receipt_validation.py
+++ b/control-plane/aegisops_control_plane/action_receipt_validation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 
 _PLACEHOLDER_RECEIPT_VALUES = frozenset(
     (
@@ -32,4 +34,12 @@ def require_receipt_string_value(value: object, field_name: str) -> str:
     ):
         raise MissingReceiptValueError(field_name)
 
+    return value
+
+
+def require_receipt_https_url_value(value: object, field_name: str) -> str:
+    normalized_value = require_receipt_string_value(value, field_name).strip()
+    parsed_value = urlparse(normalized_value)
+    if parsed_value.scheme != "https" or not parsed_value.netloc:
+        raise MissingReceiptValueError(field_name)
     return value

--- a/control-plane/aegisops_control_plane/action_receipt_validation.py
+++ b/control-plane/aegisops_control_plane/action_receipt_validation.py
@@ -42,4 +42,4 @@ def require_receipt_https_url_value(value: object, field_name: str) -> str:
     parsed_value = urlparse(normalized_value)
     if parsed_value.scheme != "https" or not parsed_value.netloc:
         raise MissingReceiptValueError(field_name)
-    return value
+    return normalized_value

--- a/control-plane/aegisops_control_plane/execution_coordinator_delegation.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator_delegation.py
@@ -6,6 +6,7 @@ from typing import Mapping
 
 from .action_receipt_validation import (
     MissingReceiptValueError,
+    require_receipt_https_url_value,
     require_receipt_string_value,
 )
 from .execution_coordinator import (
@@ -340,7 +341,7 @@ class ApprovedActionDelegationCoordinator:
                 )
             self._require_receipt_string_attribute(receipt, "external_receipt_id")
             self._require_receipt_string_attribute(receipt, "coordination_target_id")
-            self._require_receipt_string_attribute(receipt, "ticket_reference_url")
+            self._require_receipt_https_url_attribute(receipt, "ticket_reference_url")
 
     def _finalized_execution_provenance(
         self,
@@ -391,7 +392,7 @@ class ApprovedActionDelegationCoordinator:
                             receipt,
                             "coordination_target_id",
                         ),
-                        "ticket_reference_url": self._require_receipt_string_attribute(
+                        "ticket_reference_url": self._require_receipt_https_url_attribute(
                             receipt,
                             "ticket_reference_url",
                         ),
@@ -403,6 +404,16 @@ class ApprovedActionDelegationCoordinator:
     def _require_receipt_string_attribute(receipt: object, field_name: str) -> str:
         try:
             return require_receipt_string_value(
+                getattr(receipt, field_name, None),
+                field_name,
+            )
+        except MissingReceiptValueError as exc:
+            raise ValueError(str(exc)) from exc
+
+    @staticmethod
+    def _require_receipt_https_url_attribute(receipt: object, field_name: str) -> str:
+        try:
+            return require_receipt_https_url_value(
                 getattr(receipt, field_name, None),
                 field_name,
             )

--- a/control-plane/aegisops_control_plane/execution_coordinator_reconciliation.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator_reconciliation.py
@@ -7,6 +7,7 @@ from typing import Mapping
 
 from .action_receipt_validation import (
     MissingReceiptValueError,
+    require_receipt_https_url_value,
     require_receipt_string_value,
 )
 from .execution_coordinator import ExecutionCoordinatorServiceDependencies
@@ -70,6 +71,9 @@ class ActionExecutionReconciliationCoordinator:
             execution["execution_run_id"] for execution in normalized_executions
         )
         unique_execution_run_ids = tuple(dict.fromkeys(linked_execution_run_ids))
+        has_duplicate_observations = len(linked_execution_run_ids) != len(
+            unique_execution_run_ids
+        )
         latest_execution = normalized_executions[-1] if normalized_executions else None
         authoritative_execution = self._find_authoritative_action_execution(
             action_request_id=action_request.action_request_id,
@@ -154,6 +158,12 @@ class ActionExecutionReconciliationCoordinator:
                 ingest_disposition = "stale"
                 lifecycle_state = "stale"
                 mismatch_summary = "stale downstream execution observation requires refresh"
+            elif has_duplicate_observations and require_coordination_receipt_identifiers:
+                ingest_disposition = "duplicate"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "duplicate coordination receipts observed for one approved request"
+                )
             elif len(unique_execution_run_ids) > 1:
                 ingest_disposition = "duplicate"
                 lifecycle_state = "mismatched"
@@ -501,7 +511,7 @@ class ActionExecutionReconciliationCoordinator:
                         coordination_target_id,
                         "coordination_target_id",
                     )
-                    ticket_reference_url = require_receipt_string_value(
+                    ticket_reference_url = require_receipt_https_url_value(
                         ticket_reference_url,
                         "ticket_reference_url",
                     )

--- a/control-plane/tests/test_action_receipt_validation.py
+++ b/control-plane/tests/test_action_receipt_validation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+# ruff: noqa: E402
+
+import pathlib
+import sys
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from aegisops_control_plane.action_receipt_validation import (
+    MissingReceiptValueError,
+    require_receipt_https_url_value,
+)
+
+
+class ActionReceiptValidationTests(unittest.TestCase):
+    def test_https_url_value_returns_normalized_url_without_surrounding_whitespace(
+        self,
+    ) -> None:
+        self.assertEqual(
+            require_receipt_https_url_value(
+                " https://tickets.example.test/#ticket/4242 ",
+                "ticket_reference_url",
+            ),
+            "https://tickets.example.test/#ticket/4242",
+        )
+
+    def test_https_url_value_rejects_non_https_url(self) -> None:
+        with self.assertRaises(MissingReceiptValueError):
+            require_receipt_https_url_value(
+                "http://tickets.example.test/#ticket/4242",
+                "ticket_reference_url",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -871,6 +871,129 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
             reconciliation.subject_linkage["external_receipt_ids"],
             (downstream_binding["external_receipt_id"],),
         )
+
+    def test_service_marks_duplicate_create_tracking_ticket_receipts_degraded(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = support.datetime(2026, 4, 18, 4, 16, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 4, 18, 4, 21, tzinfo=support.timezone.utc)
+        compared_at = support.datetime(2026, 4, 18, 4, 26, tzinfo=support.timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-duplicate-receipt-001",
+            "alert_id": "alert-tracking-duplicate-receipt-001",
+            "finding_id": "finding-tracking-duplicate-receipt-001",
+            "coordination_reference_id": "coord-ref-duplicate-receipt-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = support._phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-duplicate-receipt-001",
+            alert_id="alert-tracking-duplicate-receipt-001",
+            finding_id="finding-tracking-duplicate-receipt-001",
+            coordination_reference_id="coord-ref-duplicate-receipt-001",
+        )
+        payload_hash = support._approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            support.ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-duplicate-receipt-001",
+                action_request_id="action-request-create-ticket-duplicate-receipt-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            support.ActionRequestRecord(
+                action_request_id="action-request-create-ticket-duplicate-receipt-001",
+                approval_decision_id="approval-create-ticket-duplicate-receipt-001",
+                case_id="case-tracking-duplicate-receipt-001",
+                alert_id="alert-tracking-duplicate-receipt-001",
+                finding_id="finding-tracking-duplicate-receipt-001",
+                idempotency_key="idempotency-create-ticket-duplicate-receipt-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-create-ticket-duplicate-receipt-001",
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        observed_execution = {
+            "execution_run_id": execution.execution_run_id,
+            "execution_surface_id": "shuffle",
+            "idempotency_key": "idempotency-create-ticket-duplicate-receipt-001",
+            "approval_decision_id": execution.approval_decision_id,
+            "delegation_id": execution.delegation_id,
+            "payload_hash": execution.payload_hash,
+            "coordination_reference_id": downstream_binding["coordination_reference_id"],
+            "coordination_target_type": downstream_binding["coordination_target_type"],
+            "external_receipt_id": downstream_binding["external_receipt_id"],
+            "coordination_target_id": downstream_binding["coordination_target_id"],
+            "ticket_reference_url": downstream_binding["ticket_reference_url"],
+            "status": "success",
+        }
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id="action-request-create-ticket-duplicate-receipt-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    **observed_execution,
+                    "observed_at": compared_at,
+                },
+                {
+                    **observed_execution,
+                    "observed_at": compared_at + support.timedelta(seconds=30),
+                },
+            ),
+            compared_at=compared_at + support.timedelta(minutes=1),
+            stale_after=support.datetime(
+                2026,
+                4,
+                18,
+                4,
+                45,
+                tzinfo=support.timezone.utc,
+            ),
+        )
+
+        stored_execution = service.get_record(
+            support.ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertEqual(reconciliation.ingest_disposition, "duplicate")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertEqual(
+            reconciliation.mismatch_summary,
+            "duplicate coordination receipts observed for one approved request",
+        )
+        self.assertEqual(stored_execution.lifecycle_state, "queued")
+
     def test_service_fail_closes_when_create_tracking_ticket_receipt_has_no_authoritative_execution(
         self,
     ) -> None:
@@ -1152,6 +1275,59 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
             )
 
         self.assertEqual(store.list(support.ReconciliationRecord), ())
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "observed execution must include string ticket_reference_url",
+        ):
+            service.reconcile_action_execution(
+                action_request_id="action-request-create-ticket-blank-receipt-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                observed_executions=(
+                    {
+                        "execution_run_id": "shuffle-run-unreachable-url-001",
+                        "execution_surface_id": "shuffle",
+                        "idempotency_key": "idempotency-create-ticket-blank-receipt-001",
+                        "observed_at": support.datetime(
+                            2026,
+                            4,
+                            18,
+                            4,
+                            47,
+                            tzinfo=support.timezone.utc,
+                        ),
+                        "approval_decision_id": "approval-create-ticket-blank-receipt-001",
+                        "delegation_id": "delegation-unreachable-url-001",
+                        "payload_hash": payload_hash,
+                        "coordination_reference_id": "coord-ref-blank-receipt-001",
+                        "coordination_target_type": "zammad",
+                        "external_receipt_id": "external-receipt-unreachable-url-001",
+                        "coordination_target_id": "zammad-ticket-unreachable-url-001",
+                        "ticket_reference_url": "http://tickets.example.test/#ticket/zammad-ticket-unreachable-url-001",
+                        "status": "success",
+                    },
+                ),
+                compared_at=support.datetime(
+                    2026,
+                    4,
+                    18,
+                    4,
+                    47,
+                    tzinfo=support.timezone.utc,
+                ),
+                stale_after=support.datetime(
+                    2026,
+                    4,
+                    18,
+                    5,
+                    0,
+                    tzinfo=support.timezone.utc,
+                ),
+            )
+
+        self.assertEqual(store.list(support.ReconciliationRecord), ())
+
     def test_service_records_execution_correlation_mismatch_states_separately(self) -> None:
         store, _ = support.make_store()
         service = support.AegisOpsControlPlaneService(


### PR DESCRIPTION
## Summary
- mark duplicate same-run create-ticket coordination receipts as degraded reconciliation mismatches
- fail closed on malformed or non-HTTPS coordination ticket receipt URLs before reconciliation persists
- add focused regression coverage for duplicate receipts and invalid ticket URLs

## Verification
- python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket
- python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_service_persistence_action_reconciliation_reconciliation control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket
- git diff --check

Closes #814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced HTTPS-only validation for ticket reference receipt fields, including trimming/normalization and rejection of non-HTTPS values.
  * Added duplicate receipt detection to identify and classify duplicate coordination receipts during execution reconciliation.

* **Tests**
  * Expanded tests to cover HTTPS receipt validation (including normalization and rejection cases).
  * Added tests verifying duplicate receipt detection and its resulting classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->