### PR TITLE
Issue #820: Add live assistant trace governance evidence

### DIFF
--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -550,6 +550,7 @@ def _build_assistant_advisory_output(
         "candidate_recommendations": tuple(candidate_recommendations),
         "citations": citations,
         "uncertainty_flags": _dedupe_strings(tuple(uncertainty_flags)),
+        "reviewed_context_conflicts": context_conflicts,
     }
 
 

--- a/control-plane/aegisops_control_plane/live_assistant_workflow.py
+++ b/control-plane/aegisops_control_plane/live_assistant_workflow.py
@@ -378,13 +378,20 @@ class LiveAssistantWorkflowCoordinator:
                 "status": workflow_snapshot.status,
             },
         }
-        subject_linkage.update(
-            self._provider_operability_linkage(
-                adapter=adapter,
-                provider_result=provider_result,
-                workflow_snapshot=workflow_snapshot,
-            )
+        provider_operability_linkage = self._provider_operability_linkage(
+            adapter=adapter,
+            provider_result=provider_result,
+            workflow_snapshot=workflow_snapshot,
         )
+        subject_linkage.update(provider_operability_linkage)
+        trace_governance = self._trace_governance_evidence(
+            context_snapshot=context_snapshot,
+            workflow_snapshot=workflow_snapshot,
+            provider_result=provider_result,
+            provider_operability_linkage=provider_operability_linkage,
+            adapter=adapter,
+        )
+        subject_linkage["trace_governance"] = trace_governance
         build_ai_trace_record = getattr(adapter, "build_ai_trace_record", None)
         ai_trace_record: AITraceRecord | None = None
         if provider_result is not None and callable(build_ai_trace_record):
@@ -458,6 +465,7 @@ class LiveAssistantWorkflowCoordinator:
                 "review_lifecycle_state": "under_review",
                 "subject_linkage": canonical_subject_linkage,
                 "reviewed_input_refs": reviewed_input_refs,
+                "trace_governance": trace_governance,
             }
         )
 
@@ -468,6 +476,110 @@ class LiveAssistantWorkflowCoordinator:
             lifecycle_state="under_review",
             assistant_advisory_draft=advisory_draft,
         )
+
+    def _trace_governance_evidence(
+        self,
+        *,
+        context_snapshot: object,
+        workflow_snapshot: Any,
+        provider_result: AssistantProviderResult | AssistantProviderFailure | None,
+        provider_operability_linkage: dict[str, object],
+        adapter: object,
+    ) -> dict[str, object]:
+        advisory_output = dict(getattr(context_snapshot, "advisory_output"))
+        unresolved_reasons = tuple(workflow_snapshot.unresolved_reasons)
+        provider_response_provenance = (
+            dict(provider_result.response_provenance)
+            if provider_result is not None
+            else {}
+        )
+        provider_model_version = provider_response_provenance.get("model_version")
+        if (
+            not isinstance(provider_model_version, str)
+            or not provider_model_version.strip()
+        ):
+            provider_model_version = None
+
+        citation_failure_state = self._citation_failure_state(
+            unresolved_reasons=unresolved_reasons,
+            advisory_output=advisory_output,
+            workflow_status=workflow_snapshot.status,
+        )
+        return {
+            "prompt_version_evidence": {
+                "prompt_version": (
+                    provider_result.prompt_version
+                    if provider_result is not None
+                    else self._adapter_identity(
+                        adapter,
+                        "_prompt_version",
+                        self._workflow_prompt_versions[workflow_snapshot.workflow_task],
+                    )
+                ),
+                "workflow_family": workflow_snapshot.workflow_family,
+                "workflow_task": workflow_snapshot.workflow_task,
+                "source": "configured_live_assistant_prompt_manifest",
+            },
+            "model_provider_evidence": {
+                "provider_identity": provider_operability_linkage["provider_identity"],
+                "model_identity": provider_operability_linkage[
+                    "provider_model_identity"
+                ],
+                "provider_status": provider_operability_linkage["provider_status"],
+                "provider_model_version": provider_model_version,
+            },
+            "citation_state": {
+                "completeness": (
+                    "complete" if citation_failure_state is None else "incomplete"
+                ),
+                "failure_state": citation_failure_state,
+                "citation_count": len(tuple(workflow_snapshot.citations)),
+                "unresolved_reasons": unresolved_reasons,
+            },
+            "reviewed_context_conflicts": self._reviewed_context_conflicts(
+                advisory_output
+            ),
+            "authority_mode": "advisory_only",
+        }
+
+    @staticmethod
+    def _reviewed_context_conflicts(
+        advisory_output: dict[str, object],
+    ) -> tuple[str, ...]:
+        raw_conflicts = advisory_output.get("reviewed_context_conflicts")
+        if not isinstance(raw_conflicts, (list, tuple)):
+            return ()
+        conflicts: list[str] = []
+        for conflict in raw_conflicts:
+            if not isinstance(conflict, str):
+                continue
+            normalized_conflict = conflict.strip()
+            if normalized_conflict and normalized_conflict not in conflicts:
+                conflicts.append(normalized_conflict)
+        return tuple(conflicts)
+
+    @staticmethod
+    def _citation_failure_state(
+        *,
+        unresolved_reasons: tuple[str, ...],
+        advisory_output: dict[str, object],
+        workflow_status: str,
+    ) -> str | None:
+        raw_uncertainty_flags = advisory_output.get("uncertainty_flags", ())
+        uncertainty_flags = (
+            tuple(str(flag) for flag in raw_uncertainty_flags)
+            if isinstance(raw_uncertainty_flags, (list, tuple, set))
+            else ()
+        )
+        if any("citation" in reason.casefold() for reason in unresolved_reasons):
+            return "missing_supporting_citations"
+        if "missing_supporting_citations" in uncertainty_flags:
+            return "missing_supporting_citations"
+        if "missing_evidence_citation" in uncertainty_flags:
+            return "missing_evidence_citation"
+        if workflow_status != "ready":
+            return "unresolved"
+        return None
 
     @staticmethod
     def _adapter_identity(
@@ -685,5 +797,6 @@ class LiveAssistantWorkflowCoordinator:
                 "linked_reconciliation_ids": getattr(
                     context_snapshot, "linked_reconciliation_ids"
                 ),
+                "trace_governance": ai_trace_record.subject_linkage["trace_governance"],
             },
         )

--- a/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
@@ -161,6 +161,30 @@ class Phase24LiveAssistantFeedbackLoopValidationTests(ServicePersistenceTestBase
             ai_trace.assistant_advisory_draft["subject_linkage"]["recommendation_ids"],
             (recommendation.recommendation_id,),
         )
+        trace_governance = ai_trace.subject_linkage["trace_governance"]
+        self.assertEqual(
+            trace_governance["prompt_version_evidence"]["prompt_version"],
+            "phase24-case-summary-v1",
+        )
+        self.assertEqual(
+            trace_governance["model_provider_evidence"],
+            {
+                "provider_identity": "openai",
+                "model_identity": "gpt-5.4",
+                "provider_status": "ready",
+                "provider_model_version": "model-version-2026-04-17",
+            },
+        )
+        self.assertEqual(
+            trace_governance["citation_state"]["completeness"],
+            "complete",
+        )
+        self.assertIsNone(trace_governance["citation_state"]["failure_state"])
+        self.assertEqual(trace_governance["authority_mode"], "advisory_only")
+        self.assertEqual(
+            recommendation.assistant_advisory_draft["trace_governance"],
+            trace_governance,
+        )
         self.assertEqual(recommendation.ai_trace_id, ai_trace.ai_trace_id)
         self.assertEqual(recommendation.case_id, promoted_case.case_id)
         self.assertEqual(recommendation.alert_id, promoted_case.alert_id)
@@ -391,12 +415,16 @@ class Phase24LiveAssistantFeedbackLoopValidationTests(ServicePersistenceTestBase
                     "citations": (promoted_case.case_id,),
                 },
                 "uncertainty_flags": ("missing_supporting_citations",),
+                "reviewed_context_conflicts": ("triage.disposition",),
             },
         )
         expected_citations = _phase24_live_assistant_citations_from_context(
             unresolved_context
         )
         service._assistant_provider_adapter = mock.Mock()
+        service._assistant_provider_adapter._provider_identity = "openai"
+        service._assistant_provider_adapter._model_identity = "gpt-5.4"
+        service._assistant_provider_adapter._prompt_version = "phase24-case-summary-v1"
 
         with mock.patch.object(
             service,
@@ -424,6 +452,63 @@ class Phase24LiveAssistantFeedbackLoopValidationTests(ServicePersistenceTestBase
         self.assertEqual(
             ai_trace.assistant_advisory_draft["summary"],
             expected_summary,
+        )
+        trace_governance = ai_trace.subject_linkage["trace_governance"]
+        self.assertEqual(
+            trace_governance["prompt_version_evidence"]["prompt_version"],
+            "phase24-case-summary-v1",
+        )
+        self.assertEqual(
+            trace_governance["prompt_version_evidence"]["workflow_family"],
+            "first_live_assistant_summary_family",
+        )
+        self.assertEqual(
+            trace_governance["prompt_version_evidence"]["workflow_task"],
+            "case_summary",
+        )
+        self.assertEqual(
+            trace_governance["prompt_version_evidence"]["source"],
+            "configured_live_assistant_prompt_manifest",
+        )
+        self.assertEqual(
+            trace_governance["model_provider_evidence"]["provider_identity"],
+            "openai",
+        )
+        self.assertEqual(
+            trace_governance["model_provider_evidence"]["model_identity"],
+            "gpt-5.4",
+        )
+        self.assertEqual(
+            trace_governance["model_provider_evidence"]["provider_status"],
+            "not_requested",
+        )
+        self.assertIsNone(
+            trace_governance["model_provider_evidence"]["provider_model_version"]
+        )
+        self.assertEqual(
+            trace_governance["citation_state"]["completeness"],
+            "incomplete",
+        )
+        self.assertEqual(
+            trace_governance["citation_state"]["failure_state"],
+            "missing_supporting_citations",
+        )
+        self.assertEqual(
+            trace_governance["citation_state"]["citation_count"],
+            len(expected_citations),
+        )
+        self.assertEqual(
+            trace_governance["citation_state"]["unresolved_reasons"],
+            ("required citations are missing",),
+        )
+        self.assertEqual(
+            trace_governance["reviewed_context_conflicts"],
+            ("triage.disposition",),
+        )
+        self.assertEqual(trace_governance["authority_mode"], "advisory_only")
+        self.assertEqual(
+            ai_trace.assistant_advisory_draft["trace_governance"],
+            ai_trace.subject_linkage["trace_governance"],
         )
 
         recommendations = store.list(RecommendationRecord)


### PR DESCRIPTION
## Summary
- Add persisted live-assistant `trace_governance` evidence to AI trace subject linkage and advisory drafts.
- Retain prompt version, workflow, provider/model/version, citation completeness/failure state, reviewed-context conflict markers, and advisory-only authority mode.
- Surface `reviewed_context_conflicts` in advisory output so conflict evidence can be copied into trace review artifacts.

## Verification
- `python3 -m unittest control-plane.tests.test_phase24_live_assistant_validation`
- `python3 -m py_compile control-plane/aegisops_control_plane/live_assistant_workflow.py control-plane/aegisops_control_plane/assistant_context.py`
- `bash scripts/test-verify-publishable-path-hygiene.sh`

Part of #818
Closes #820
