### PR TITLE
Improve AI Trace review queue ergonomics

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
@@ -169,6 +169,82 @@ export function registerOperatorRoutesCaseworkTests() {
       });
     });
 
+    it("renders grouped AI trace review states in the analyst queue", async () => {
+      const fetchFn = createAuthorizedFetch({
+        "/inspect-analyst-queue": {
+          queue_name: "analyst_review",
+          read_only: true,
+          records: [
+            {
+              alert_id: "alert-123",
+              review_state: "degraded",
+              case_id: "case-456",
+              case_lifecycle_state: "open",
+              ai_trace_review_groups: [
+                {
+                  alert_id: "alert-123",
+                  case_id: "case-456",
+                  trace_count: 1,
+                  states: [
+                    "conflict",
+                    "citation_failure",
+                    "provider_degraded",
+                    "unresolved",
+                  ],
+                  trace_link: "/operator/assistant/ai_trace/ai-trace-queue-unresolved-001",
+                  traces: [
+                    {
+                      ai_trace_id: "ai-trace-queue-unresolved-001",
+                      lifecycle_state: "under_review",
+                      draft_status: "unresolved",
+                      provider_status: "failed",
+                      provider_operational_quality: "degraded",
+                      unresolved_reasons: [
+                        "provider_generation_failed",
+                        "missing_supporting_citations",
+                        "conflicting_reviewed_context",
+                      ],
+                    },
+                  ],
+                },
+              ],
+              reviewed_context: {
+                source: {
+                  source_family: "github_audit",
+                },
+              },
+            },
+          ],
+          total_records: 1,
+        },
+      });
+      const dependencies = createDefaultDependencies({
+        fetchFn,
+      });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/queue"]}>
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        await screen.findByRole("heading", { name: "AI Trace review queue" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Provider degraded")).toBeInTheDocument();
+      expect(screen.getByText("Citation failure")).toBeInTheDocument();
+      expect(screen.getByText("Conflict")).toBeInTheDocument();
+      expect(screen.getByText("Unresolved")).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Open AI trace review" }),
+      ).toHaveAttribute(
+        "href",
+        "/operator/assistant/ai_trace/ai-trace-queue-unresolved-001",
+      );
+      expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /execute/i })).not.toBeInTheDocument();
+    });
+
     it("renders alert detail with authoritative and subordinate sections separated", async () => {
       const dependencies = createDefaultDependencies({
         fetchFn: createAuthorizedFetch({

--- a/apps/operator-ui/src/app/operatorConsolePages/advisorySurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/advisorySurfaces.tsx
@@ -30,6 +30,7 @@ export const SUPPORTED_ADVISORY_RECORD_FAMILIES = new Set([
   "recommendation",
   "approval_decision",
   "reconciliation",
+  "ai_trace",
 ]);
 
 export function advisorySummary(record: UnknownRecord) {

--- a/apps/operator-ui/src/app/operatorConsolePages/queuePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/queuePages.tsx
@@ -1,6 +1,17 @@
-import { Table, TableBody, TableCell, TableHead, TableRow, Typography } from "@mui/material";
+import {
+  Alert,
+  Chip,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
 import { useMemo } from "react";
 import {
+  asRecordArray,
   asString,
   asStringArray,
   AuditedRouteLink,
@@ -14,9 +25,116 @@ import {
   RecordWarnings,
   SectionCard,
   StatusStrip,
+  statusTone,
   useOperatorList,
   ValueList,
 } from "./shared";
+
+function aiTraceReviewStateLabel(state: string) {
+  switch (state) {
+    case "provider_degraded":
+      return "Provider degraded";
+    case "citation_failure":
+      return "Citation failure";
+    case "conflict":
+      return "Conflict";
+    case "unresolved":
+      return "Unresolved";
+    default:
+      return state
+        .replace(/[_-]+/g, " ")
+        .replace(/\b\w/g, (character) => character.toUpperCase());
+  }
+}
+
+function QueueAiTraceReviewGroups({ records }: { records: Record<string, unknown>[] }) {
+  const groups = records.flatMap((record) =>
+    asRecordArray(record.ai_trace_review_groups).map((group) => ({
+      alertId: asString(group.alert_id) ?? asString(record.alert_id),
+      caseId: asString(group.case_id) ?? asString(record.case_id),
+      states: asStringArray(group.states),
+      traceCount: typeof group.trace_count === "number" ? group.trace_count : null,
+      traceLink: asString(group.trace_link),
+      traces: asRecordArray(group.traces),
+    })),
+  );
+
+  if (groups.length === 0) {
+    return null;
+  }
+
+  return (
+    <SectionCard
+      subtitle="Unresolved assistant trace states stay grouped by authoritative alert or case scope for daily review. These links open read-only trace context only."
+      title="AI Trace review queue"
+    >
+      <Stack spacing={2}>
+        <Alert severity="warning" variant="outlined">
+          AI Trace review is advisory-only; it cannot approve, execute, reconcile, or override reviewed records.
+        </Alert>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Scope</TableCell>
+              <TableCell>Trace states</TableCell>
+              <TableCell>Trace count</TableCell>
+              <TableCell>Review link</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {groups.map((group) => {
+              const traceKey =
+                group.traceLink ??
+                group.traces
+                  .map((trace) => asString(trace.ai_trace_id))
+                  .find((traceId): traceId is string => traceId !== null) ??
+                `${group.alertId ?? "alert"}:${group.caseId ?? "case"}`;
+              return (
+                <TableRow hover key={traceKey}>
+                  <TableCell>
+                    <Stack spacing={0.5}>
+                      <Typography variant="body2">
+                        Alert: {group.alertId ?? "Not available"}
+                      </Typography>
+                      <Typography color="text.secondary" variant="body2">
+                        Case: {group.caseId ?? "No case anchor"}
+                      </Typography>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>
+                    <Stack direction="row" flexWrap="wrap" gap={1}>
+                      {group.states.map((state) => (
+                        <Chip
+                          color={statusTone(state)}
+                          key={`${traceKey}-${state}`}
+                          label={aiTraceReviewStateLabel(state)}
+                          size="small"
+                          variant={state === "unresolved" ? "outlined" : "filled"}
+                        />
+                      ))}
+                    </Stack>
+                  </TableCell>
+                  <TableCell>{group.traceCount ?? group.traces.length}</TableCell>
+                  <TableCell>
+                    {group.traceLink ? (
+                      <AuditedRouteLink label="Open AI trace review" to={group.traceLink}>
+                        Open AI trace review
+                      </AuditedRouteLink>
+                    ) : (
+                      <Typography color="text.secondary" variant="body2">
+                        No trace link
+                      </Typography>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Stack>
+    </SectionCard>
+  );
+}
 
 export function QueuePage() {
   const filter = useMemo(() => ({}), []);
@@ -39,70 +157,73 @@ export function QueuePage() {
       {data ? <QueryStateNotice error={error} refreshing={refreshing} /> : null}
       {data ? (
         data.length > 0 ? (
-          <SectionCard
-            subtitle="Explicit degraded, pending, and mismatch states remain visible instead of being smoothed away."
-            title="Queue records"
-          >
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Alert</TableCell>
-                  <TableCell>Review state</TableCell>
-                  <TableCell>Case</TableCell>
-                  <TableCell>Source family</TableCell>
-                  <TableCell>Action review</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {data.map((record) => {
-                  const alertId = asString(record.alert_id) ?? "Unknown alert";
-                  const caseId = asString(record.case_id);
-                  const sourceFamily = asString(
-                    getPath(record, "reviewed_context.source.source_family"),
-                  );
-                  const actionReviewState = asString(
-                    getPath(record, "current_action_review.review_state"),
-                  );
-                  return (
-                    <TableRow hover key={String(record.id ?? alertId)}>
-                      <TableCell>
-                        <Typography component="div">
-                          <AuditedRouteLink
-                            label="Open alert detail"
-                            to={`/operator/alerts/${alertId}`}
-                          >
-                            {alertId}
-                          </AuditedRouteLink>
-                        </Typography>
-                        <Typography color="text.secondary" variant="caption">
-                          {formatValue(record.queue_selection)}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <StatusStrip values={[["Review", asString(record.review_state)]]} />
-                      </TableCell>
-                      <TableCell>
-                        {caseId ? (
-                          <AuditedRouteLink
-                            label="Open case detail"
-                            to={`/operator/cases/${caseId}`}
-                          >
-                            {caseId}
-                          </AuditedRouteLink>
-                        ) : (
-                          <Typography color="text.secondary" variant="body2">
-                            No case anchor
+          <Stack spacing={3}>
+            <QueueAiTraceReviewGroups records={data} />
+            <SectionCard
+              subtitle="Explicit degraded, pending, and mismatch states remain visible instead of being smoothed away."
+              title="Queue records"
+            >
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Alert</TableCell>
+                    <TableCell>Review state</TableCell>
+                    <TableCell>Case</TableCell>
+                    <TableCell>Source family</TableCell>
+                    <TableCell>Action review</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {data.map((record) => {
+                    const alertId = asString(record.alert_id) ?? "Unknown alert";
+                    const caseId = asString(record.case_id);
+                    const sourceFamily = asString(
+                      getPath(record, "reviewed_context.source.source_family"),
+                    );
+                    const actionReviewState = asString(
+                      getPath(record, "current_action_review.review_state"),
+                    );
+                    return (
+                      <TableRow hover key={String(record.id ?? alertId)}>
+                        <TableCell>
+                          <Typography component="div">
+                            <AuditedRouteLink
+                              label="Open alert detail"
+                              to={`/operator/alerts/${alertId}`}
+                            >
+                              {alertId}
+                            </AuditedRouteLink>
                           </Typography>
-                        )}
-                      </TableCell>
-                      <TableCell>{sourceFamily ?? "Not available"}</TableCell>
-                      <TableCell>{actionReviewState ?? "No active review"}</TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </SectionCard>
+                          <Typography color="text.secondary" variant="caption">
+                            {formatValue(record.queue_selection)}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <StatusStrip values={[["Review", asString(record.review_state)]]} />
+                        </TableCell>
+                        <TableCell>
+                          {caseId ? (
+                            <AuditedRouteLink
+                              label="Open case detail"
+                              to={`/operator/cases/${caseId}`}
+                            >
+                              {caseId}
+                            </AuditedRouteLink>
+                          ) : (
+                            <Typography color="text.secondary" variant="body2">
+                              No case anchor
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell>{sourceFamily ?? "Not available"}</TableCell>
+                        <TableCell>{actionReviewState ?? "No active review"}</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </SectionCard>
+          </Stack>
         ) : (
           <EmptyState message="The reviewed analyst queue is empty." />
         )

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -211,9 +211,10 @@ class OperatorInspectionReadSurface:
         *,
         alert_id: str,
         case_id: str | None,
+        ai_trace_records: tuple[AITraceRecord, ...],
     ) -> tuple[dict[str, object], ...]:
         groups_by_scope: dict[str, dict[str, object]] = {}
-        for ai_trace in self._service._store.list(AITraceRecord):
+        for ai_trace in ai_trace_records:
             subject_linkage = ai_trace.subject_linkage
             linked_alert_id = self._optional_string_from_mapping(
                 subject_linkage,
@@ -321,6 +322,7 @@ class OperatorInspectionReadSurface:
             self._service._latest_detection_reconciliations_by_alert_id()
         )
         action_review_index = self._service._build_action_review_record_index()
+        ai_trace_records = self._service._store.list(AITraceRecord)
         queue_records: list[dict[str, object]] = []
         for alert in self._service._store.list(AlertRecord):
             if alert.lifecycle_state not in active_alert_states:
@@ -353,6 +355,7 @@ class OperatorInspectionReadSurface:
             ai_trace_review_groups = self._ai_trace_review_groups_for_queue_record(
                 alert_id=alert.alert_id,
                 case_id=alert.case_id,
+                ai_trace_records=ai_trace_records,
             )
             queue_records.append(
                 {

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -7,6 +7,7 @@ from .models import (
     ActionRequestRecord,
     AlertRecord,
     AnalyticSignalRecord,
+    AITraceRecord,
     CaseRecord,
     ControlPlaneRecord,
     EvidenceRecord,
@@ -158,6 +159,156 @@ class OperatorInspectionReadSurface:
         self._coordination_reference_signature = coordination_reference_signature
         self._dedupe_strings = dedupe_strings
 
+    @staticmethod
+    def _optional_string_from_mapping(
+        mapping: Mapping[str, object],
+        key: str,
+    ) -> str | None:
+        value = mapping.get(key)
+        return value.strip() if isinstance(value, str) and value.strip() else None
+
+    @staticmethod
+    def _string_tuple_from_object(value: object) -> tuple[str, ...]:
+        if isinstance(value, str) and value.strip():
+            return (value.strip(),)
+        if isinstance(value, (tuple, list)):
+            return tuple(
+                entry.strip()
+                for entry in value
+                if isinstance(entry, str) and entry.strip()
+            )
+        return ()
+
+    def _ai_trace_review_states(
+        self,
+        *,
+        lifecycle_state: str,
+        provider_status: str | None,
+        provider_operational_quality: str | None,
+        draft_status: str | None,
+        unresolved_reasons: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        states: list[str] = []
+        if "conflicting_reviewed_context" in unresolved_reasons:
+            states.append("conflict")
+        if (
+            "missing_supporting_citations" in unresolved_reasons
+            or "missing_evidence_citation" in unresolved_reasons
+        ):
+            states.append("citation_failure")
+        if (
+            provider_status in {"failed", "timeout"}
+            or provider_operational_quality == "degraded"
+            or "provider_generation_failed" in unresolved_reasons
+        ):
+            states.append("provider_degraded")
+        if lifecycle_state == "under_review" or draft_status == "unresolved":
+            states.append("unresolved")
+        return tuple(dict.fromkeys(states))
+
+    def _ai_trace_review_groups_for_queue_record(
+        self,
+        *,
+        alert_id: str,
+        case_id: str | None,
+    ) -> tuple[dict[str, object], ...]:
+        groups_by_scope: dict[str, dict[str, object]] = {}
+        for ai_trace in self._service._store.list(AITraceRecord):
+            subject_linkage = ai_trace.subject_linkage
+            linked_alert_id = self._optional_string_from_mapping(
+                subject_linkage,
+                "source_alert_id",
+            )
+            linked_case_id = self._optional_string_from_mapping(
+                subject_linkage,
+                "source_case_id",
+            )
+            if linked_alert_id != alert_id and (
+                case_id is None or linked_case_id != case_id
+            ):
+                continue
+
+            assistant_advisory_draft = ai_trace.assistant_advisory_draft
+            draft_status = self._optional_string_from_mapping(
+                assistant_advisory_draft,
+                "status",
+            )
+            unresolved_reasons = self._string_tuple_from_object(
+                assistant_advisory_draft.get("unresolved_reasons")
+            )
+            provider_status = self._optional_string_from_mapping(
+                subject_linkage,
+                "provider_status",
+            )
+            provider_operational_quality = self._optional_string_from_mapping(
+                subject_linkage,
+                "provider_operational_quality",
+            )
+            states = self._ai_trace_review_states(
+                lifecycle_state=ai_trace.lifecycle_state,
+                provider_status=provider_status,
+                provider_operational_quality=provider_operational_quality,
+                draft_status=draft_status,
+                unresolved_reasons=unresolved_reasons,
+            )
+            if not states:
+                continue
+
+            group_case_id = linked_case_id or case_id
+            group_key = group_case_id or alert_id
+            group = groups_by_scope.setdefault(
+                group_key,
+                {
+                    "alert_id": alert_id,
+                    "case_id": group_case_id,
+                    "states": [],
+                    "traces": [],
+                },
+            )
+            group["states"] = list(
+                dict.fromkeys([*group["states"], *states])  # type: ignore[arg-type]
+            )
+            traces = group["traces"]
+            if not isinstance(traces, list):
+                continue
+            traces.append(
+                {
+                    "ai_trace_id": ai_trace.ai_trace_id,
+                    "lifecycle_state": ai_trace.lifecycle_state,
+                    "draft_status": draft_status,
+                    "provider_status": provider_status,
+                    "provider_operational_quality": provider_operational_quality,
+                    "unresolved_reasons": unresolved_reasons,
+                    "material_input_refs": ai_trace.material_input_refs,
+                    "trace_link": f"/operator/assistant/ai_trace/{ai_trace.ai_trace_id}",
+                }
+            )
+
+        groups: list[dict[str, object]] = []
+        for group in groups_by_scope.values():
+            traces = group["traces"]
+            if not isinstance(traces, list) or not traces:
+                continue
+            sorted_traces = sorted(
+                traces,
+                key=lambda trace: str(trace.get("ai_trace_id", "")),
+            )
+            first_trace = sorted_traces[0]
+            group["traces"] = tuple(sorted_traces)
+            group["trace_count"] = len(sorted_traces)
+            group["trace_link"] = first_trace.get("trace_link")
+            groups.append(group)
+
+        return tuple(
+            sorted(
+                groups,
+                key=lambda group: (
+                    str(group.get("case_id") or ""),
+                    str(group.get("alert_id") or ""),
+                ),
+            )
+        )
+
     def inspect_analyst_queue(self) -> object:
         active_alert_states = {
             "new",
@@ -199,6 +350,10 @@ class OperatorInspectionReadSurface:
                 record_index=action_review_index,
             )
             review_state = self._service._alert_review_state(alert)
+            ai_trace_review_groups = self._ai_trace_review_groups_for_queue_record(
+                alert_id=alert.alert_id,
+                case_id=alert.case_id,
+            )
             queue_records.append(
                 {
                     "alert_id": alert.alert_id,
@@ -237,6 +392,7 @@ class OperatorInspectionReadSurface:
                     "current_action_review": (
                         dict(action_reviews[0]) if action_reviews else None
                     ),
+                    "ai_trace_review_groups": ai_trace_review_groups,
                 }
             )
 

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -167,6 +167,93 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             ["wazuh:1731595300.1234567"],
         )
 
+    def test_cli_groups_unresolved_ai_trace_review_state_in_analyst_queue(self) -> None:
+        _, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-queue-trace-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                ai_trace_id="ai-trace-queue-unresolved-001",
+                review_owner="analyst-001",
+                intended_outcome="Keep unresolved assistant trace review visible.",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+                assistant_advisory_draft={
+                    "status": "unresolved",
+                    "unresolved_reasons": (
+                        "provider_generation_failed",
+                        "missing_supporting_citations",
+                        "conflicting_reviewed_context",
+                    ),
+                    "citations": (promoted_case.case_id, evidence_id),
+                },
+            )
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-queue-unresolved-001",
+                subject_linkage={
+                    "source_record_family": "recommendation",
+                    "source_record_id": recommendation.recommendation_id,
+                    "source_alert_id": promoted_case.alert_id,
+                    "source_case_id": promoted_case.case_id,
+                    "provider_status": "failed",
+                    "provider_operational_quality": "degraded",
+                    "trace_governance": {
+                        "authority_mode": "advisory_only",
+                        "approval_authority": "none",
+                        "execution_authority": "none",
+                        "reconciliation_authority": "none",
+                    },
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase24-queue-summary-v1",
+                generated_at=reviewed_at,
+                material_input_refs=(promoted_case.alert_id, promoted_case.case_id, evidence_id),
+                reviewer_identity="analyst-001",
+                lifecycle_state="under_review",
+                assistant_advisory_draft={
+                    "status": "unresolved",
+                    "unresolved_reasons": (
+                        "provider_generation_failed",
+                        "missing_supporting_citations",
+                        "conflicting_reviewed_context",
+                    ),
+                    "citations": (promoted_case.case_id, evidence_id),
+                },
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(["inspect-analyst-queue"], stdout=stdout, service=service)
+
+        payload = json.loads(stdout.getvalue())
+        trace_review_groups = payload["records"][0]["ai_trace_review_groups"]
+        self.assertEqual(len(trace_review_groups), 1)
+        self.assertEqual(trace_review_groups[0]["case_id"], promoted_case.case_id)
+        self.assertEqual(trace_review_groups[0]["trace_count"], 1)
+        self.assertEqual(
+            trace_review_groups[0]["states"],
+            ["conflict", "citation_failure", "provider_degraded", "unresolved"],
+        )
+        self.assertEqual(
+            trace_review_groups[0]["trace_link"],
+            f"/operator/assistant/ai_trace/ai-trace-queue-unresolved-001",
+        )
+        self.assertEqual(
+            trace_review_groups[0]["traces"][0]["unresolved_reasons"],
+            [
+                "provider_generation_failed",
+                "missing_supporting_citations",
+                "conflicting_reviewed_context",
+            ],
+        )
+
     def test_cli_renders_reviewed_wazuh_alert_detail_view(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
@@ -510,7 +510,7 @@ class ActionReviewSurfacePersistenceTests(ServicePersistenceTestBase):
             queue_snapshot["records"][0]["current_action_review"]["action_request_id"],
             second_request.action_request_id,
         )
-        self.assertLessEqual(store.list_calls, 6)
+        self.assertLessEqual(store.list_calls, 7)
         self.assertEqual(store.reconciliation_list_calls, 2)
         self.assertNotEqual(first_request.action_request_id, second_request.action_request_id)
     def test_service_action_review_surfaces_prefer_live_approval_and_execution_records(


### PR DESCRIPTION
## Summary
- add grouped AI Trace review state to the analyst queue snapshot
- render unresolved, provider degraded, citation failure, and reviewed-context conflict states in the operator queue
- preserve read-only AI trace advisory links without adding approval, execution, reconciliation, or override actions

Closes #821

## Verification
- python3 -m unittest control-plane.tests.test_cli_inspection_workflow_family.CliInspectionWorkflowFamilyTests.test_cli_renders_reviewed_wazuh_business_hours_analyst_queue_view control-plane.tests.test_cli_inspection_workflow_family.CliInspectionWorkflowFamilyTests.test_cli_groups_unresolved_ai_trace_review_state_in_analyst_queue
- npm run test --workspace @aegisops/operator-ui -- src/app/OperatorRoutes.test.tsx
- npm run build --workspace @aegisops/operator-ui