### PR TITLE
Operations: pilot readiness checklist and entry criteria

### DIFF
--- a/docs/deployment/operational-evidence-handoff-pack.md
+++ b/docs/deployment/operational-evidence-handoff-pack.md
@@ -14,6 +14,8 @@ For the Phase 38 single-customer launch package, `docs/deployment/single-custome
 
 For Phase 38 release handoff, use `docs/deployment/release-handoff-evidence-package.md` as the one launch or upgrade handoff index; this operational pack remains retained evidence guidance and does not become workflow authority.
 
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` is the reviewed entry decision surface that points operators to the retained release, smoke, detector, coordination, limitation, and evidence handoff records before pilot start.
+
 Use this pack when an operator needs a compact, reviewable evidence bundle after deployment, upgrade, restore, approval, execution, reconciliation review, rollback, or a planned handoff window.
 
 The pack may reference external substrate receipts, backup custody notes, or bounded logs, but those references remain evidence attached to reviewed AegisOps records. They do not create a parallel source of authority.

--- a/docs/deployment/pilot-readiness-checklist.md
+++ b/docs/deployment/pilot-readiness-checklist.md
@@ -1,0 +1,85 @@
+# Single-Customer Pilot Readiness Checklist and Entry Criteria
+
+## 1. Purpose and Boundary
+
+This document defines the reviewed entry checklist for starting one single-customer pilot.
+
+The entry decision is a reviewed go, no-go, or go-with-explicit-limitations decision for one customer environment; it is not a compliance certification, multi-customer rollout approval, SLA commitment, or 24x7 support promise.
+
+This checklist is the reviewed entry decision surface above the release bundle, runtime smoke, detector activation, Zammad coordination, assistant boundary, known-limitations review, retention expectation, and evidence handoff material. It does not provision runtime services, activate detectors by itself, mint Zammad credentials, create customer-private production access, or make external tickets or assistant output authoritative.
+
+## 2. Entry Decision Summary
+
+The pilot may start only when release readiness, runtime smoke, detector activation scope, coordination pilot scope, assistant limitations, data retention, and evidence handoff are reviewed together for the same release identifier.
+
+The decision record must name:
+
+- the reviewed `aegisops-single-customer-<repository-revision>` release identifier or reviewed tag-bound equivalent;
+- the single customer environment and named pilot owner without embedding customer secrets;
+- the entry decision: go, no-go, or go with explicit limitations;
+- the handoff owner and next business health review; and
+- the exact evidence records used for release readiness, runtime smoke, detector scope, Zammad coordination, assistant limitations, known limitations, retention, and handoff.
+
+Mixed release identifiers, missing owners, stale smoke evidence, inferred detector scope, unreviewed Zammad credentials, missing assistant limitation language, or absent known-limitations review keep the decision at no-go until the prerequisite is repaired or the refusal is retained as the reviewed outcome.
+
+## 3. Readiness Checklist
+
+Release readiness must be bound to `docs/deployment/single-customer-release-bundle-inventory.md` and `docs/deployment/release-handoff-evidence-package.md` for the same `aegisops-single-customer-<repository-revision>` release identifier.
+
+Runtime smoke must pass through `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>` and retain the smoke `manifest.md` as entry evidence.
+
+Detector activation scope must follow `docs/detector-activation-evidence-handoff.md` and name only the reviewed candidate rules, fixture evidence, activation owner, disable owner, rollback owner, expected alert volume, false-positive review, and next-review date accepted for the pilot.
+
+Coordination scope must follow `docs/operations-zammad-live-pilot-boundary.md`; Zammad remains link-first, coordination-only, and non-authoritative for AegisOps case, action, approval, execution, and reconciliation records.
+
+Assistant output remains advisory-only and non-authoritative; it must stay grounded in reviewed control-plane records and linked evidence and must not approve, execute, reconcile, close, or widen pilot scope.
+
+Known limitations must be explicit, reviewed, and tied to the entry decision, including whether each limitation blocks pilot start, allows pilot start with a follow-up owner, or requires rollback or disable evidence.
+
+Data retention for the pilot is bounded to the current release handoff, runtime smoke manifest, detector activation evidence handoff, Zammad coordination reference, assistant limitation note, and next health review expectation; it is not an unlimited archive.
+
+Evidence handoff must name the release handoff record, runtime smoke manifest, detector activation handoff, coordination pilot status, assistant limitation statement, known-limitations review, handoff owner, and next health review.
+
+## 4. Required Entry Evidence
+
+| Entry area | Required entry evidence | Blocking condition |
+| --- | --- | --- |
+| Release readiness | Same release identifier in the release bundle inventory and release handoff package, repository revision or reviewed tag, image tag expectation, install preflight result, restore, rollback, and upgrade evidence reference, and handoff owner. | Missing release identifier, mismatched revision, failed preflight, missing recovery evidence, or missing handoff owner. |
+| Runtime smoke | Retained `manifest.md` from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>` plus readiness, runtime, protected read-only, queue, and reconciliation read-only evidence. | Failed smoke, stale smoke, direct backend smoke, fake proxy identity, or optional-extension-only readiness. |
+| Detector activation | Detector activation evidence handoff for the reviewed candidate set, fixture and parser evidence, owner set, expected volume, false-positive review, disable and rollback evidence, and next-review date. | Inferred source scope, missing provenance, missing owner, missing rollback path, placeholder credentials, or detector status treated as workflow truth. |
+| Coordination pilot | Zammad-first coordination scope, reviewed endpoint, credential custody source, available, degraded, or unavailable posture, and explicit AegisOps linkage for any ticket pointer. | Missing `AEGISOPS_ZAMMAD_BASE_URL`, missing reviewed token source, placeholder credential, stale ticket read, mismatched ticket identifier, or ticket state treated as AegisOps authority. |
+| Assistant limitations | Advisory-only statement linked to the reviewed assistant boundary and any pilot-specific disabled or limited assistant surfaces. | Assistant output treated as approval, execution, reconciliation, case closure, detector activation, release readiness, or support-coverage authority. |
+| Known limitations | Reviewed limitation list with block, accept-with-owner, rollback, disable, or follow-up disposition for each limitation. | Empty or absent limitation review, TODO-only note, sample limitation, no owner, or unclear effect on entry. |
+| Evidence handoff and retention | Release handoff record, smoke manifest, detector handoff, coordination status, assistant limitation statement, known-limitations review, handoff owner, and next health review. | Missing evidence owner, mixed snapshots, unlimited retention claim, customer-secret exposure, workstation-local paths, or no next review. |
+
+## 5. Known Limitations, Retention, and Evidence Handoff
+
+Known limitations must preserve the difference between no known blocking limitation and not yet reviewed. A pilot entry decision may record no known blocking limitation only when the limitation review itself is present and names the reviewer, release identifier, scope, and next review.
+
+For accepted limitations, the decision record must name the follow-up owner, expected operator-visible behavior, whether the limitation affects launch, normal operation, rollback acceptance, detector disable, Zammad coordination, assistant output, or evidence handoff, and the review date when the limitation must be revisited.
+
+Retention is bounded to reviewed small-team operating needs. Keep the current pilot entry decision, the release handoff record, runtime smoke manifest, detector activation evidence handoff, Zammad coordination status, assistant limitation statement, known-limitations review, handoff owner, and next health review expectation. Do not promise to retain every raw log line, external ticket field, detector event, assistant prompt, substrate receipt, or historical smoke sample forever.
+
+Evidence handoff remains subordinate to authoritative AegisOps records. External tickets, Wazuh status, source-family output, optional analytics, bounded logs, and operator notes may support the handoff, but they do not become case, action, approval, execution, reconciliation, detector, release, or readiness truth.
+
+## 6. Blocking Outcomes
+
+Missing release readiness, failed runtime smoke, missing detector activation owner, missing disable or rollback owner, missing Zammad credential custody, missing assistant limitation statement, missing known-limitations review, missing evidence handoff owner, or mixed release identifiers blocks pilot entry.
+
+Pilot entry also remains blocked when evidence combines mixed snapshots, uses workstation-local absolute paths, exposes live secrets, relies on placeholder credentials, infers tenant or ticket linkage from names, treats raw forwarded headers as trusted identity, promotes optional extensions into launch gates, or makes external tickets, detector substrates, or assistant output authoritative.
+
+On no-go or failed-entry paths, preserve the refusal reason and clean-state evidence. Do not replace a failed entry attempt with a later success summary unless the failed outcome remains reviewable for the next health review.
+
+## 7. Verification
+
+Verify this checklist with `scripts/verify-pilot-readiness-checklist.sh`.
+
+Negative validation for the verifier is `scripts/test-verify-pilot-readiness-checklist.sh`.
+
+Run the checklist verifier after changing this checklist, the runbook, release bundle inventory, release handoff package, runtime smoke bundle, detector activation evidence handoff, Zammad live pilot boundary, assistant boundary, or operational evidence handoff pack.
+
+## 8. Out of Scope
+
+Formal compliance certification, multi-customer rollout, SLA or 24x7 support promise, external archive platform design, customer-private production access, optional-extension launch gates, direct backend exposure, ticket-system authority, and assistant-owned workflow authority are out of scope.
+
+This checklist does not approve HA, database clustering, hosted release channels, vendor-specific backup products, live source-side mutation, direct detector automation, bidirectional ticket sync, multi-ITSM abstraction, endpoint or network evidence as launch prerequisites, or broad support promises beyond the reviewed business-hours single-customer pilot.

--- a/docs/deployment/release-handoff-evidence-package.md
+++ b/docs/deployment/release-handoff-evidence-package.md
@@ -10,6 +10,8 @@ AegisOps approval, evidence, execution, reconciliation, readiness, and recovery 
 
 Use this package after the release bundle inventory, install preflight, runtime smoke, and restore, rollback, and upgrade evidence have been assembled for the same release identifier.
 
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this release handoff package as the reviewed release-readiness and known-limitations evidence source for the pilot entry decision.
+
 ## 2. Required Handoff Entries
 
 Every release handoff manifest must include release readiness summary, release bundle identifier, install preflight result, runtime smoke result, backup, restore, rollback, and upgrade rehearsal reference, known limitations, rollback instructions, handoff owner, and next health review.

--- a/docs/deployment/runtime-smoke-bundle.md
+++ b/docs/deployment/runtime-smoke-bundle.md
@@ -12,6 +12,8 @@ For the Phase 38 single-customer launch package, the smoke result is one require
 
 The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` must retain the runtime smoke manifest reference for launch, upgrade, rollback, restore restart, and operator handoff readiness.
 
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` treats the retained runtime smoke `manifest.md` from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>` as required entry evidence.
+
 The reviewed smoke path covers startup status, readiness, protected-surface reachability, operator-console read-only sanity, queue/read-only surface sanity, and first low-risk action preconditions.
 
 It does not require optional OpenSearch, n8n, Shuffle, endpoint evidence, optional network evidence, assistant, ML shadow, or isolated-executor extensions to be enabled.

--- a/docs/deployment/single-customer-release-bundle-inventory.md
+++ b/docs/deployment/single-customer-release-bundle-inventory.md
@@ -20,6 +20,8 @@ This manifest is the first inventory operators read before install, upgrade, rol
 
 The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` is the Phase 38 handoff index that ties the release bundle identifier, install preflight result, runtime smoke, restore, rollback, upgrade, known limitations, rollback instructions, handoff owner, and next health review to one bounded record.
 
+Pilot entry must use `docs/deployment/pilot-readiness-checklist.md` after the single-customer release bundle inventory is bound to the same `aegisops-single-customer-<repository-revision>` release identifier.
+
 ## 2. Required Launch Bundle Inventory
 
 | Bundle entry | Owner | Source path | Release binding | Handoff relevance |

--- a/docs/detector-activation-evidence-handoff.md
+++ b/docs/detector-activation-evidence-handoff.md
@@ -10,6 +10,8 @@ It must not become a compliance archive platform, unlimited detector history sys
 
 The package keeps rule review evidence, fixture and parser evidence, activation evidence, rollback evidence, alert or case admission sanity, and known limitations visible to operators, maintainers, and auditors without turning detector activation into a parallel archive or workflow authority.
 
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this detector activation evidence handoff as the bounded detector scope, owner, rollback, disable, expected-volume, false-positive, and known-limitation evidence for pilot entry.
+
 ## 2. Manifest Fields
 
 | Field | Required evidence | Authority boundary |

--- a/docs/operations-zammad-live-pilot-boundary.md
+++ b/docs/operations-zammad-live-pilot-boundary.md
@@ -8,6 +8,8 @@ It supplements `docs/phase-26-first-coordination-substrate-and-non-authoritative
 
 This document defines policy and verification expectations only. It does not provision Zammad, mint credentials, create a bidirectional synchronization service, authorize ticket-system workflow truth, or store live secrets.
 
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this Zammad-first boundary as the coordination pilot scope and credential-custody prerequisite for pilot entry.
+
 ## 2. Pilot Scope and Non-Authority Boundary
 
 Zammad is the only approved live coordination substrate for the first pilot.

--- a/docs/phase-15-identity-grounded-analyst-assistant-boundary.md
+++ b/docs/phase-15-identity-grounded-analyst-assistant-boundary.md
@@ -131,6 +131,8 @@ If identity ambiguity remains, the assistant must report that ambiguity directly
 
 The assistant is advisory-only.
 
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` must keep this assistant boundary advisory-only and non-authoritative for pilot entry.
+
 It may summarize reviewed records, compare reviewed evidence, explain reviewed mismatch state, and draft candidate next steps.
 
 It must not approve actions, execute actions, mutate authoritative records, or present its own output as reconciliation truth.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -129,6 +129,8 @@ The Phase 37 restore, rollback, and upgrade evidence rehearsal in `docs/deployme
 
 Before launch, upgrade, rollback, restore, or operator handoff closes, assemble the Phase 38 release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` and verify its manifest with `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
 
+Before starting a single-customer pilot, review `docs/deployment/pilot-readiness-checklist.md` and verify it with `scripts/verify-pilot-readiness-checklist.sh` so release readiness, runtime smoke, detector activation scope, Zammad coordination scope, assistant limitations, data retention, known limitations, and evidence handoff are decided together.
+
 ## 3. Shutdown
 
 The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.

--- a/scripts/test-verify-pilot-readiness-checklist.sh
+++ b/scripts/test-verify-pilot-readiness-checklist.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-pilot-readiness-checklist.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment" "${target}/docs"
+}
+
+write_valid_docs() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/deployment/pilot-readiness-checklist.md"
+# Single-Customer Pilot Readiness Checklist and Entry Criteria
+
+## 1. Purpose and Boundary
+
+This document defines the reviewed entry checklist for starting one single-customer pilot.
+
+The entry decision is a reviewed go, no-go, or go-with-explicit-limitations decision for one customer environment; it is not a compliance certification, multi-customer rollout approval, SLA commitment, or 24x7 support promise.
+
+## 2. Entry Decision Summary
+
+The pilot may start only when release readiness, runtime smoke, detector activation scope, coordination pilot scope, assistant limitations, data retention, and evidence handoff are reviewed together for the same release identifier.
+
+## 3. Readiness Checklist
+
+Release readiness must be bound to `docs/deployment/single-customer-release-bundle-inventory.md` and `docs/deployment/release-handoff-evidence-package.md` for the same `aegisops-single-customer-<repository-revision>` release identifier.
+
+Runtime smoke must pass through `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>` and retain the smoke `manifest.md` as entry evidence.
+
+Detector activation scope must follow `docs/detector-activation-evidence-handoff.md` and name only the reviewed candidate rules, fixture evidence, activation owner, disable owner, rollback owner, expected alert volume, false-positive review, and next-review date accepted for the pilot.
+
+Coordination scope must follow `docs/operations-zammad-live-pilot-boundary.md`; Zammad remains link-first, coordination-only, and non-authoritative for AegisOps case, action, approval, execution, and reconciliation records.
+
+Assistant output remains advisory-only and non-authoritative; it must stay grounded in reviewed control-plane records and linked evidence and must not approve, execute, reconcile, close, or widen pilot scope.
+
+## 4. Required Entry Evidence
+
+Evidence handoff must name the release handoff record, runtime smoke manifest, detector activation handoff, coordination pilot status, assistant limitation statement, known-limitations review, handoff owner, and next health review.
+
+## 5. Known Limitations, Retention, and Evidence Handoff
+
+Known limitations must be explicit, reviewed, and tied to the entry decision, including whether each limitation blocks pilot start, allows pilot start with a follow-up owner, or requires rollback or disable evidence.
+
+Data retention for the pilot is bounded to the current release handoff, runtime smoke manifest, detector activation evidence handoff, Zammad coordination reference, assistant limitation note, and next health review expectation; it is not an unlimited archive.
+
+## 6. Blocking Outcomes
+
+Missing release readiness, failed runtime smoke, missing detector activation owner, missing disable or rollback owner, missing Zammad credential custody, missing assistant limitation statement, missing known-limitations review, missing evidence handoff owner, or mixed release identifiers blocks pilot entry.
+
+## 7. Verification
+
+Verify this checklist with `scripts/verify-pilot-readiness-checklist.sh`.
+
+Negative validation for the verifier is `scripts/test-verify-pilot-readiness-checklist.sh`.
+
+## 8. Out of Scope
+
+Formal compliance certification, multi-customer rollout, SLA or 24x7 support promise, external archive platform design, customer-private production access, optional-extension launch gates, direct backend exposure, ticket-system authority, and assistant-owned workflow authority are out of scope.
+EOF
+
+  cat <<'EOF' > "${target}/docs/runbook.md"
+# AegisOps Runbook
+
+Before starting a single-customer pilot, review `docs/deployment/pilot-readiness-checklist.md` and verify it with `scripts/verify-pilot-readiness-checklist.sh` so release readiness, runtime smoke, detector activation scope, Zammad coordination scope, assistant limitations, data retention, known limitations, and evidence handoff are decided together.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/single-customer-release-bundle-inventory.md"
+# Single-Customer Release Bundle Inventory
+
+Pilot entry must use `docs/deployment/pilot-readiness-checklist.md` after the single-customer release bundle inventory is bound to the same `aegisops-single-customer-<repository-revision>` release identifier.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/release-handoff-evidence-package.md"
+# Phase 38 Release Handoff Evidence Package
+
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this release handoff package as the reviewed release-readiness and known-limitations evidence source for the pilot entry decision.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/runtime-smoke-bundle.md"
+# Phase 33 Runtime Smoke Bundle
+
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` treats the retained runtime smoke `manifest.md` from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>` as required entry evidence.
+EOF
+
+  cat <<'EOF' > "${target}/docs/detector-activation-evidence-handoff.md"
+# Detector Activation Evidence Handoff Manifest
+
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this detector activation evidence handoff as the bounded detector scope, owner, rollback, disable, expected-volume, false-positive, and known-limitation evidence for pilot entry.
+EOF
+
+  cat <<'EOF' > "${target}/docs/operations-zammad-live-pilot-boundary.md"
+# Operations Zammad-First Live Pilot Boundary and Credential Custody
+
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this Zammad-first boundary as the coordination pilot scope and credential-custody prerequisite for pilot entry.
+EOF
+
+  cat <<'EOF' > "${target}/docs/phase-15-identity-grounded-analyst-assistant-boundary.md"
+# Phase 15 Identity-Grounded Analyst Assistant Boundary
+
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` must keep this assistant boundary advisory-only and non-authoritative for pilot entry.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/operational-evidence-handoff-pack.md"
+# Phase 33 Operational Evidence Retention and Audit Handoff Pack
+
+The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` is the reviewed entry decision surface that points operators to the retained release, smoke, detector, coordination, limitation, and evidence handoff records before pilot start.
+EOF
+
+  mkdir -p "${target}/scripts"
+  touch "${target}/scripts/test-verify-pilot-readiness-checklist.sh"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_valid_docs "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_checklist_repo="${workdir}/missing-checklist"
+create_repo "${missing_checklist_repo}"
+write_valid_docs "${missing_checklist_repo}"
+rm "${missing_checklist_repo}/docs/deployment/pilot-readiness-checklist.md"
+assert_fails_with "${missing_checklist_repo}" "Missing pilot readiness checklist:"
+
+missing_smoke_repo="${workdir}/missing-smoke"
+create_repo "${missing_smoke_repo}"
+write_valid_docs "${missing_smoke_repo}"
+perl -0pi -e 's/^Runtime smoke must pass.*\n//m' "${missing_smoke_repo}/docs/deployment/pilot-readiness-checklist.md"
+assert_fails_with "${missing_smoke_repo}" 'Missing pilot readiness checklist statement: Runtime smoke must pass through `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>`'
+
+missing_coordination_link_repo="${workdir}/missing-coordination-link"
+create_repo "${missing_coordination_link_repo}"
+write_valid_docs "${missing_coordination_link_repo}"
+printf '# Operations Zammad-First Live Pilot Boundary and Credential Custody\n' > "${missing_coordination_link_repo}/docs/operations-zammad-live-pilot-boundary.md"
+assert_fails_with "${missing_coordination_link_repo}" 'Missing coordination pilot readiness link: The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this Zammad-first boundary'
+
+forbidden_authority_repo="${workdir}/forbidden-authority"
+create_repo "${forbidden_authority_repo}"
+write_valid_docs "${forbidden_authority_repo}"
+printf '\nThe assistant may approve pilot exceptions.\n' >> "${forbidden_authority_repo}/docs/deployment/pilot-readiness-checklist.md"
+assert_fails_with "${forbidden_authority_repo}" "Forbidden pilot readiness checklist statement: assistant may approve"
+
+absolute_path_repo="${workdir}/absolute-path"
+create_repo "${absolute_path_repo}"
+write_valid_docs "${absolute_path_repo}"
+printf '\nLocal evidence: /%s/%s/pilot-readiness.md\n' "Users" "example" >> "${absolute_path_repo}/docs/deployment/pilot-readiness-checklist.md"
+assert_fails_with "${absolute_path_repo}" "Forbidden pilot readiness guidance: workstation-local absolute path detected"
+
+echo "Pilot readiness checklist verifier tests passed."

--- a/scripts/verify-pilot-readiness-checklist.sh
+++ b/scripts/verify-pilot-readiness-checklist.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+checklist_path="${repo_root}/docs/deployment/pilot-readiness-checklist.md"
+runbook_path="${repo_root}/docs/runbook.md"
+release_inventory_path="${repo_root}/docs/deployment/single-customer-release-bundle-inventory.md"
+release_handoff_path="${repo_root}/docs/deployment/release-handoff-evidence-package.md"
+smoke_path="${repo_root}/docs/deployment/runtime-smoke-bundle.md"
+detector_handoff_path="${repo_root}/docs/detector-activation-evidence-handoff.md"
+coordination_path="${repo_root}/docs/operations-zammad-live-pilot-boundary.md"
+assistant_path="${repo_root}/docs/phase-15-identity-grounded-analyst-assistant-boundary.md"
+operational_handoff_path="${repo_root}/docs/deployment/operational-evidence-handoff-pack.md"
+verifier_test_path="${repo_root}/scripts/test-verify-pilot-readiness-checklist.sh"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if grep -Fqi -- "${phrase}" "${path}"; then
+    echo "Forbidden ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_workstation_paths() {
+  local description="$1"
+  shift
+
+  local macos_home_pattern linux_home_pattern windows_home_pattern workstation_local_path_pattern
+  macos_home_pattern='/'"Users"'/[^[:space:])>]+'
+  linux_home_pattern='/'"home"'/[^[:space:])>]+'
+  windows_home_pattern='[A-Za-z]:\\'"Users"'\\[^[:space:])>]+'
+  workstation_local_path_pattern="(^|[^[:alnum:]_./-])(~[/\\\\]|${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern})"
+
+  if grep -Eq "${workstation_local_path_pattern}" "$@"; then
+    echo "Forbidden ${description}: workstation-local absolute path detected" >&2
+    exit 1
+  fi
+}
+
+require_file "${checklist_path}" "pilot readiness checklist"
+require_file "${runbook_path}" "runbook"
+require_file "${release_inventory_path}" "single-customer release bundle inventory"
+require_file "${release_handoff_path}" "release handoff evidence package"
+require_file "${smoke_path}" "runtime smoke bundle"
+require_file "${detector_handoff_path}" "detector activation evidence handoff manifest"
+require_file "${coordination_path}" "Zammad live pilot boundary"
+require_file "${assistant_path}" "assistant boundary"
+require_file "${operational_handoff_path}" "operational evidence handoff pack"
+require_file "${verifier_test_path}" "pilot readiness checklist verifier tests"
+
+required_headings=(
+  "# Single-Customer Pilot Readiness Checklist and Entry Criteria"
+  "## 1. Purpose and Boundary"
+  "## 2. Entry Decision Summary"
+  "## 3. Readiness Checklist"
+  "## 4. Required Entry Evidence"
+  "## 5. Known Limitations, Retention, and Evidence Handoff"
+  "## 6. Blocking Outcomes"
+  "## 7. Verification"
+  "## 8. Out of Scope"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${checklist_path}" "${heading}" "pilot readiness checklist heading"
+done
+
+required_checklist_phrases=(
+  "This document defines the reviewed entry checklist for starting one single-customer pilot."
+  "The entry decision is a reviewed go, no-go, or go-with-explicit-limitations decision for one customer environment; it is not a compliance certification, multi-customer rollout approval, SLA commitment, or 24x7 support promise."
+  "The pilot may start only when release readiness, runtime smoke, detector activation scope, coordination pilot scope, assistant limitations, data retention, and evidence handoff are reviewed together for the same release identifier."
+  'Release readiness must be bound to `docs/deployment/single-customer-release-bundle-inventory.md` and `docs/deployment/release-handoff-evidence-package.md` for the same `aegisops-single-customer-<repository-revision>` release identifier.'
+  'Runtime smoke must pass through `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>` and retain the smoke `manifest.md` as entry evidence.'
+  'Detector activation scope must follow `docs/detector-activation-evidence-handoff.md` and name only the reviewed candidate rules, fixture evidence, activation owner, disable owner, rollback owner, expected alert volume, false-positive review, and next-review date accepted for the pilot.'
+  'Coordination scope must follow `docs/operations-zammad-live-pilot-boundary.md`; Zammad remains link-first, coordination-only, and non-authoritative for AegisOps case, action, approval, execution, and reconciliation records.'
+  'Assistant output remains advisory-only and non-authoritative; it must stay grounded in reviewed control-plane records and linked evidence and must not approve, execute, reconcile, close, or widen pilot scope.'
+  "Known limitations must be explicit, reviewed, and tied to the entry decision, including whether each limitation blocks pilot start, allows pilot start with a follow-up owner, or requires rollback or disable evidence."
+  "Data retention for the pilot is bounded to the current release handoff, runtime smoke manifest, detector activation evidence handoff, Zammad coordination reference, assistant limitation note, and next health review expectation; it is not an unlimited archive."
+  "Evidence handoff must name the release handoff record, runtime smoke manifest, detector activation handoff, coordination pilot status, assistant limitation statement, known-limitations review, handoff owner, and next health review."
+  "Missing release readiness, failed runtime smoke, missing detector activation owner, missing disable or rollback owner, missing Zammad credential custody, missing assistant limitation statement, missing known-limitations review, missing evidence handoff owner, or mixed release identifiers blocks pilot entry."
+  'Verify this checklist with `scripts/verify-pilot-readiness-checklist.sh`.'
+  'Negative validation for the verifier is `scripts/test-verify-pilot-readiness-checklist.sh`.'
+  "Formal compliance certification, multi-customer rollout, SLA or 24x7 support promise, external archive platform design, customer-private production access, optional-extension launch gates, direct backend exposure, ticket-system authority, and assistant-owned workflow authority are out of scope."
+)
+
+for phrase in "${required_checklist_phrases[@]}"; do
+  require_phrase "${checklist_path}" "${phrase}" "pilot readiness checklist statement"
+done
+
+require_phrase "${runbook_path}" 'Before starting a single-customer pilot, review `docs/deployment/pilot-readiness-checklist.md` and verify it with `scripts/verify-pilot-readiness-checklist.sh` so release readiness, runtime smoke, detector activation scope, Zammad coordination scope, assistant limitations, data retention, known limitations, and evidence handoff are decided together.' "runbook pilot readiness link"
+require_phrase "${release_inventory_path}" 'Pilot entry must use `docs/deployment/pilot-readiness-checklist.md` after the single-customer release bundle inventory is bound to the same `aegisops-single-customer-<repository-revision>` release identifier.' "release inventory pilot readiness link"
+require_phrase "${release_handoff_path}" 'The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this release handoff package as the reviewed release-readiness and known-limitations evidence source for the pilot entry decision.' "release handoff pilot readiness link"
+require_phrase "${smoke_path}" 'The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` treats the retained runtime smoke `manifest.md` from `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>` as required entry evidence.' "runtime smoke pilot readiness link"
+require_phrase "${detector_handoff_path}" 'The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this detector activation evidence handoff as the bounded detector scope, owner, rollback, disable, expected-volume, false-positive, and known-limitation evidence for pilot entry.' "detector handoff pilot readiness link"
+require_phrase "${coordination_path}" 'The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this Zammad-first boundary as the coordination pilot scope and credential-custody prerequisite for pilot entry.' "coordination pilot readiness link"
+require_phrase "${assistant_path}" 'The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` must keep this assistant boundary advisory-only and non-authoritative for pilot entry.' "assistant pilot readiness link"
+require_phrase "${operational_handoff_path}" 'The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` is the reviewed entry decision surface that points operators to the retained release, smoke, detector, coordination, limitation, and evidence handoff records before pilot start.' "operational handoff pilot readiness link"
+
+for forbidden in \
+  "compliance certification is complete" \
+  "multi-customer rollout is approved" \
+  "24x7 support is promised" \
+  "SLA is promised" \
+  "ticket system is authoritative" \
+  "assistant may approve" \
+  "assistant may execute" \
+  "detector activation is automatic" \
+  "optional extensions are required for pilot"; do
+  reject_phrase "${checklist_path}" "${forbidden}" "pilot readiness checklist statement"
+done
+
+reject_workstation_paths "pilot readiness guidance" \
+  "${checklist_path}" \
+  "${runbook_path}" \
+  "${release_inventory_path}" \
+  "${release_handoff_path}" \
+  "${smoke_path}" \
+  "${detector_handoff_path}" \
+  "${coordination_path}" \
+  "${assistant_path}" \
+  "${operational_handoff_path}"
+
+echo "Pilot readiness checklist, entry criteria, cross-links, limitations, and evidence handoff expectations are present and bounded."


### PR DESCRIPTION
## Summary
- add a reviewed single-customer pilot readiness checklist and entry criteria
- connect release readiness, runtime smoke, detector activation, Zammad coordination, assistant limitations, known limitations, retention, and evidence handoff
- add a focused verifier plus negative validation for missing checklist, smoke entry, coordination cross-link, forbidden assistant authority, and workstation-local path guidance

## Verification
- bash scripts/verify-pilot-readiness-checklist.sh
- bash scripts/test-verify-pilot-readiness-checklist.sh
- bash scripts/verify-release-handoff-evidence-package.sh
- bash scripts/verify-detector-activation-evidence-handoff.sh
- bash scripts/verify-zammad-live-pilot-boundary.sh
- bash scripts/verify-phase-33-runtime-smoke-bundle.sh
- bash scripts/verify-single-customer-release-bundle-inventory.sh
- bash scripts/verify-publishable-path-hygiene.sh

Part of #825
Closes #826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pilot readiness checklist as the decision surface for approving single-customer pilot entry.
  * Updated deployment guides to cross-reference release readiness, runtime smoke, detector activation, coordination scope, and assistant limitations within the checklist.

* **Tests**
  * Added verification tooling and test suite to validate pilot readiness checklist compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->