### PR TITLE
Add pilot support playbook and break-glass rehearsal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           bash scripts/verify-postgres-compose-skeleton.sh
           bash scripts/verify-publishable-path-hygiene.sh
           bash scripts/verify-proxy-compose-skeleton.sh
+          bash scripts/verify-support-playbook-break-glass-rehearsal.sh
           bash scripts/verify-response-action-safety-model-doc.sh
           bash scripts/verify-requirements-baseline-control-plane-thesis.sh
           bash scripts/verify-readme-and-repository-structure-control-plane-thesis.sh
@@ -309,6 +310,7 @@ jobs:
           bash scripts/test-verify-single-customer-install-preflight.sh
           bash scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
           bash scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
+          bash scripts/test-verify-support-playbook-break-glass-rehearsal.sh
           bash scripts/test-verify-single-customer-deployment-profile.sh
           bash scripts/test-verify-single-customer-release-bundle-inventory.sh
           bash scripts/test-verify-release-handoff-evidence-package.sh

--- a/docs/deployment/operational-evidence-handoff-pack.md
+++ b/docs/deployment/operational-evidence-handoff-pack.md
@@ -18,6 +18,8 @@ The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` 
 
 Use this pack when an operator needs a compact, reviewable evidence bundle after deployment, upgrade, restore, approval, execution, reconciliation review, rollback, or a planned handoff window.
 
+Support playbook evidence from `docs/deployment/support-playbook-break-glass-rehearsal.md` may be retained in this handoff pack only as operator-readable evidence attached to reviewed AegisOps records.
+
 The pack may reference external substrate receipts, backup custody notes, or bounded logs, but those references remain evidence attached to reviewed AegisOps records. They do not create a parallel source of authority.
 
 ## 2. Retained Evidence Categories

--- a/docs/deployment/pilot-readiness-checklist.md
+++ b/docs/deployment/pilot-readiness-checklist.md
@@ -40,6 +40,8 @@ Data retention for the pilot is bounded to the current release handoff, runtime 
 
 Evidence handoff must name the release handoff record, runtime smoke manifest, detector activation handoff, coordination pilot status, assistant limitation statement, known-limitations review, handoff owner, and next health review.
 
+The support playbook in `docs/deployment/support-playbook-break-glass-rehearsal.md` is the reviewed pilot degradation and break-glass rehearsal reference; pilot entry remains blocked if support expectations would require 24x7 coverage, customer-specific support terms, or emergency authority bypass.
+
 ## 4. Required Entry Evidence
 
 | Entry area | Required entry evidence | Blocking condition |

--- a/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md
+++ b/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md
@@ -12,6 +12,8 @@ The release handoff evidence package in `docs/deployment/release-handoff-evidenc
 
 The release gate proves that backup, restore, rollback, upgrade, smoke, and reviewed-record evidence stay explainable against the AegisOps authoritative record chain. It does not create a vendor backup integration, zero-downtime promise, HA design, cluster failover plan, or multi-customer operating model.
 
+Support escalation from `docs/deployment/support-playbook-break-glass-rehearsal.md` must route rollback and restore decisions back to this release-gate rehearsal and retain refusal reason plus clean-state evidence for failed paths.
+
 ## 2. Prerequisites
 
 Before the rehearsal starts, operators must have:

--- a/docs/deployment/support-playbook-break-glass-rehearsal.md
+++ b/docs/deployment/support-playbook-break-glass-rehearsal.md
@@ -1,0 +1,83 @@
+# Support Playbook and Break-Glass Rehearsal
+
+## 1. Purpose and Boundary
+
+This playbook tells maintainers and operators what to inspect when the single-customer pilot degrades without creating emergency authority bypass.
+
+The reviewed operating posture remains business-hours, operator-led, and subordinate to AegisOps authoritative records.
+
+The playbook covers source, detector, coordination, assistant, runtime, rollback, and restore degradation for the reviewed single-customer pilot.
+
+It does not create 24x7 on-call coverage, a customer-specific support contract, direct backend access, direct substrate authority, or emergency authority bypass.
+
+## 2. Common Pilot Failure Modes
+
+| Failure mode | Inspect first | Do not infer |
+| --- | --- | --- |
+| Source degradation | Source-family evidence, ingest custody, replay or fixture proof, source timestamp, and AegisOps linkage. | Tenant, customer, alert, case, or evidence linkage from names, path shape, comments, or nearby metadata. |
+| Detector degradation | Detector activation handoff, candidate rule identifier, fixture evidence, expected volume, false-positive review, disable owner, rollback owner, and next review. | Detector output as case, approval, execution, reconciliation, or rollback truth. |
+| Coordination degradation | Zammad boundary, endpoint, reviewed token source, reachability, and explicit AegisOps linkage. | Ticket state, comments, assignee, queue, priority, SLA, escalation, or closure as AegisOps authority. |
+| Assistant degradation | Assistant citations, reviewed record ids, linked evidence ids, uncertainty flags, and limited surfaces. | Advisory text as approval, execution, reconciliation, closure, detector activation, or support-coverage authority. |
+| Runtime degradation | Reverse-proxy health, readiness, runtime inspection, compose state, bounded logs, env contract, and migration bootstrap. | Direct backend health, optional-extension health, raw forwarded headers, or partial container state as readiness. |
+| Rollback degradation | Rollback decision owner, selected restore point, backup custody, before-and-after revisions, smoke result, and clean-state proof. | A clean retry summary as proof that the failed path disappeared. |
+| Restore degradation | Backup provenance, restore point, empty target expectation, readiness, record-chain validation, and clean-state proof. | Exception text alone as durable-state proof. |
+
+## 3. Degraded Path Handling
+
+Source handling: inspect the reviewed source-family evidence, ingest custody, replay or fixture proof, source timestamp, and explicit linkage to the AegisOps alert, case, or evidence record before widening source scope.
+
+Detector handling: inspect the detector activation evidence handoff, candidate rule identifier, fixture and parser evidence, expected volume, false-positive review, disable owner, rollback owner, and next-review date before trusting detector output.
+
+Coordination handling: inspect `docs/operations-zammad-live-pilot-boundary.md`, `AEGISOPS_ZAMMAD_BASE_URL`, the reviewed token source reference, endpoint reachability, and explicit AegisOps linkage before treating a ticket pointer as usable coordination context.
+
+Assistant handling: inspect the assistant boundary, citations, reviewed record ids, linked evidence ids, uncertainty flags, and disabled or limited assistant surfaces before relying on an advisory summary.
+
+Runtime handling: inspect the reverse-proxy health, readiness, runtime inspection, compose status, bounded logs, runtime env contract, and migration bootstrap evidence before admitting normal operator use.
+
+Rollback handling: inspect the same-day rollback decision owner, selected restore point, pre-change backup custody, before-and-after repository revision, smoke result, and clean-state evidence before closing the maintenance window.
+
+Restore handling: inspect backup provenance, selected restore point, empty restore target expectation, post-restore readiness, record-chain validation, and clean-state proof before returning to service.
+
+## 4. Break-Glass Custody and Rehearsal
+
+Break-glass custody is a documented recovery exception, not an alternate approval path, permanent operator shortcut, or way to bypass reviewed AegisOps authority.
+
+A break-glass rehearsal must name the trigger, primary custodian, backup custodian, approving reviewer, bounded access window, affected runtime binding, redacted evidence location, rotation follow-up owner, and return-to-normal confirmation.
+
+Missing, placeholder, sample, TODO, unsigned, browser-state, raw forwarded-header, or personal-session credentials keep break-glass blocked until the reviewed custody source is repaired.
+
+Break-glass use must not approve, execute, reconcile, close, activate detectors, mark tickets authoritative, or change rollback acceptance without the reviewed AegisOps record and reviewer path.
+
+After break-glass use, operators must rotate or invalidate the affected secret, capture reload or restart evidence, run the relevant readiness or refusal check, and retain the follow-up owner before normal operation resumes.
+
+## 5. Rollback and Restore Escalation
+
+Rollback and restore escalation must stay cross-linked to `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md`, `docs/deployment/operational-evidence-handoff-pack.md`, and `docs/runbook.md`.
+
+Escalate to rollback when runtime, detector, coordination, assistant, or evidence drift cannot be corrected inside the reviewed maintenance or health-review window without widening scope.
+
+Escalate to restore when authoritative approval, evidence, execution, or reconciliation records are missing, orphaned, partially restored, mixed-snapshot, or no longer attributable to the selected restore point.
+
+Rejected, forbidden, failed, rollback, or restore-failure paths must retain the refusal reason and clean-state proof; it is not enough to record that an exception occurred.
+
+## 6. Evidence Collection Expectations
+
+Evidence collection must remain operator-readable and compact: record the event, named operator, affected path, authoritative AegisOps record ids, repository revision or release identifier, command or inspection output, refusal reason when present, clean-state proof, follow-up owner, and next review.
+
+Use repo-relative commands, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, `<release-gate-manifest.md>`, and `<support-evidence-note.md>`.
+
+Operator-readable support evidence may live as a maintenance note, retained handoff entry, ticket comment, or reviewed runbook entry when it preserves the required fields and links back to authoritative AegisOps records.
+
+Evidence must not include live secrets, DSNs, bootstrap tokens, break-glass tokens, private keys, customer credentials, raw forwarded-header values, unsigned identity hints, or workstation-local absolute paths.
+
+## 7. Verification
+
+Verify this playbook with `scripts/verify-support-playbook-break-glass-rehearsal.sh`.
+
+Negative validation for the verifier is `scripts/test-verify-support-playbook-break-glass-rehearsal.sh`.
+
+Run the verifier after changing this playbook, the runbook, pilot readiness checklist, restore rollback upgrade evidence rehearsal, or operational evidence handoff pack.
+
+## 8. Out of Scope
+
+Formal SLA support, 24x7 support coverage, direct customer-private production access, customer-specific paid support terms, emergency authority bypass, direct backend exposure, direct substrate authority, ticket-system authority, detector-owned workflow truth, assistant-owned workflow truth, and optional-extension launch gates are out of scope.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -131,6 +131,8 @@ Before launch, upgrade, rollback, restore, or operator handoff closes, assemble 
 
 Before starting a single-customer pilot, review `docs/deployment/pilot-readiness-checklist.md` and verify it with `scripts/verify-pilot-readiness-checklist.sh` so release readiness, runtime smoke, detector activation scope, Zammad coordination scope, assistant limitations, data retention, known limitations, and evidence handoff are decided together.
 
+For pilot support degradation, break-glass rehearsal, and operator-readable evidence expectations, use `docs/deployment/support-playbook-break-glass-rehearsal.md` and verify it with `scripts/verify-support-playbook-break-glass-rehearsal.sh`.
+
 ## 3. Shutdown
 
 The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.

--- a/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-support-playbook-break-glass-rehearsal.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment" "${target}/scripts"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+}
+
+write_shared_files() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/runbook.md"
+# AegisOps Runbook
+
+For pilot support degradation, break-glass rehearsal, and operator-readable evidence expectations, use `docs/deployment/support-playbook-break-glass-rehearsal.md` and verify it with `scripts/verify-support-playbook-break-glass-rehearsal.sh`.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/pilot-readiness-checklist.md"
+# Single-Customer Pilot Readiness Checklist and Entry Criteria
+
+The support playbook in `docs/deployment/support-playbook-break-glass-rehearsal.md` is the reviewed pilot degradation and break-glass rehearsal reference; pilot entry remains blocked if support expectations would require 24x7 coverage, customer-specific support terms, or emergency authority bypass.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+# Phase 37 Restore Rollback Upgrade Evidence Rehearsal
+
+Support escalation from `docs/deployment/support-playbook-break-glass-rehearsal.md` must route rollback and restore decisions back to this release-gate rehearsal and retain refusal reason plus clean-state evidence for failed paths.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/operational-evidence-handoff-pack.md"
+# Phase 33 Operational Evidence Retention and Audit Handoff Pack
+
+Support playbook evidence from `docs/deployment/support-playbook-break-glass-rehearsal.md` may be retained in this handoff pack only as operator-readable evidence attached to reviewed AegisOps records.
+EOF
+
+  touch "${target}/scripts/test-verify-support-playbook-break-glass-rehearsal.sh"
+}
+
+write_valid_playbook() {
+  local target="$1"
+
+  cat <<'EOF' > "${target}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+# Support Playbook and Break-Glass Rehearsal
+
+## 1. Purpose and Boundary
+
+This playbook tells maintainers and operators what to inspect when the single-customer pilot degrades without creating emergency authority bypass.
+
+The reviewed operating posture remains business-hours, operator-led, and subordinate to AegisOps authoritative records.
+
+The playbook covers source, detector, coordination, assistant, runtime, rollback, and restore degradation for the reviewed single-customer pilot.
+
+It does not create 24x7 on-call coverage, a customer-specific support contract, direct backend access, direct substrate authority, or emergency authority bypass.
+
+## 2. Common Pilot Failure Modes
+
+| Failure mode | Inspect first | Do not infer |
+| --- | --- | --- |
+| Source degradation | Source-family evidence, ingest custody, replay or fixture proof, source timestamp, and AegisOps linkage. | Tenant, customer, alert, case, or evidence linkage from names or path shape. |
+| Detector degradation | Detector activation handoff, candidate rule identifier, fixture evidence, expected volume, false-positive review, disable owner, rollback owner, and next review. | Detector output as case, approval, execution, or rollback truth. |
+| Coordination degradation | Zammad boundary, endpoint, reviewed token source, reachability, and explicit AegisOps linkage. | Ticket state, comments, assignee, or closure as AegisOps authority. |
+| Assistant degradation | Assistant citations, reviewed record ids, linked evidence ids, uncertainty flags, and limited surfaces. | Advisory text as approval, execution, reconciliation, or closure. |
+| Runtime degradation | Reverse-proxy health, readiness, runtime inspection, compose state, bounded logs, env contract, and migration bootstrap. | Direct backend health, optional-extension health, or partial container state as readiness. |
+| Rollback degradation | Rollback decision owner, selected restore point, backup custody, revisions, smoke result, and clean-state proof. | A clean retry summary as proof that the failed path disappeared. |
+| Restore degradation | Backup provenance, restore point, empty target expectation, readiness, record-chain validation, and clean-state proof. | Exception text alone as durable-state proof. |
+
+## 3. Degraded Path Handling
+
+Source handling: inspect the reviewed source-family evidence, ingest custody, replay or fixture proof, source timestamp, and explicit linkage to the AegisOps alert, case, or evidence record before widening source scope.
+
+Detector handling: inspect the detector activation evidence handoff, candidate rule identifier, fixture and parser evidence, expected volume, false-positive review, disable owner, rollback owner, and next-review date before trusting detector output.
+
+Coordination handling: inspect `docs/operations-zammad-live-pilot-boundary.md`, `AEGISOPS_ZAMMAD_BASE_URL`, the reviewed token source reference, endpoint reachability, and explicit AegisOps linkage before treating a ticket pointer as usable coordination context.
+
+Assistant handling: inspect the assistant boundary, citations, reviewed record ids, linked evidence ids, uncertainty flags, and disabled or limited assistant surfaces before relying on an advisory summary.
+
+Runtime handling: inspect the reverse-proxy health, readiness, runtime inspection, compose status, bounded logs, runtime env contract, and migration bootstrap evidence before admitting normal operator use.
+
+Rollback handling: inspect the same-day rollback decision owner, selected restore point, pre-change backup custody, before-and-after repository revision, smoke result, and clean-state evidence before closing the maintenance window.
+
+Restore handling: inspect backup provenance, selected restore point, empty restore target expectation, post-restore readiness, record-chain validation, and clean-state proof before returning to service.
+
+## 4. Break-Glass Custody and Rehearsal
+
+Break-glass custody is a documented recovery exception, not an alternate approval path, permanent operator shortcut, or way to bypass reviewed AegisOps authority.
+
+A break-glass rehearsal must name the trigger, primary custodian, backup custodian, approving reviewer, bounded access window, affected runtime binding, redacted evidence location, rotation follow-up owner, and return-to-normal confirmation.
+
+Missing, placeholder, sample, TODO, unsigned, browser-state, raw forwarded-header, or personal-session credentials keep break-glass blocked until the reviewed custody source is repaired.
+
+Break-glass use must not approve, execute, reconcile, close, activate detectors, mark tickets authoritative, or change rollback acceptance without the reviewed AegisOps record and reviewer path.
+
+After break-glass use, operators must rotate or invalidate the affected secret, capture reload or restart evidence, run the relevant readiness or refusal check, and retain the follow-up owner before normal operation resumes.
+
+## 5. Rollback and Restore Escalation
+
+Rollback and restore escalation must stay cross-linked to `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md`, `docs/deployment/operational-evidence-handoff-pack.md`, and `docs/runbook.md`.
+
+Escalate to rollback when runtime, detector, coordination, assistant, or evidence drift cannot be corrected inside the reviewed maintenance or health-review window without widening scope.
+
+Escalate to restore when authoritative approval, evidence, execution, or reconciliation records are missing, orphaned, partially restored, mixed-snapshot, or no longer attributable to the selected restore point.
+
+Rejected, forbidden, failed, rollback, or restore-failure paths must retain the refusal reason and clean-state proof; it is not enough to record that an exception occurred.
+
+## 6. Evidence Collection Expectations
+
+Evidence collection must remain operator-readable and compact: record the event, named operator, affected path, authoritative AegisOps record ids, repository revision or release identifier, command or inspection output, refusal reason when present, clean-state proof, follow-up owner, and next review.
+
+Use repo-relative commands, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, `<release-gate-manifest.md>`, and `<support-evidence-note.md>`.
+
+## 7. Verification
+
+Verify this playbook with `scripts/verify-support-playbook-break-glass-rehearsal.sh`.
+
+Negative validation for the verifier is `scripts/test-verify-support-playbook-break-glass-rehearsal.sh`.
+
+## 8. Out of Scope
+
+Formal SLA support, 24x7 support coverage, direct customer-private production access, customer-specific paid support terms, emergency authority bypass, direct backend exposure, direct substrate authority, ticket-system authority, detector-owned workflow truth, assistant-owned workflow truth, and optional-extension launch gates are out of scope.
+EOF
+}
+
+commit_fixture() {
+  local target="$1"
+
+  git -C "${target}" add .
+  git -C "${target}" commit --allow-empty -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_shared_files "${valid_repo}"
+write_valid_playbook "${valid_repo}"
+commit_fixture "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_playbook_repo="${workdir}/missing-playbook"
+create_repo "${missing_playbook_repo}"
+write_shared_files "${missing_playbook_repo}"
+commit_fixture "${missing_playbook_repo}"
+assert_fails_with "${missing_playbook_repo}" "Missing support playbook and break-glass rehearsal:"
+
+missing_detector_repo="${workdir}/missing-detector"
+create_repo "${missing_detector_repo}"
+write_shared_files "${missing_detector_repo}"
+write_valid_playbook "${missing_detector_repo}"
+perl -0pi -e 's/^Detector handling: .*?\n\n//m' "${missing_detector_repo}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+commit_fixture "${missing_detector_repo}"
+assert_fails_with "${missing_detector_repo}" "Missing support playbook statement: Detector handling:"
+
+missing_break_glass_repo="${workdir}/missing-break-glass"
+create_repo "${missing_break_glass_repo}"
+write_shared_files "${missing_break_glass_repo}"
+write_valid_playbook "${missing_break_glass_repo}"
+perl -0pi -e 's/^Break-glass custody is .*?\n\n//m' "${missing_break_glass_repo}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+commit_fixture "${missing_break_glass_repo}"
+assert_fails_with "${missing_break_glass_repo}" "Missing support playbook statement: Break-glass custody is"
+
+missing_restore_link_repo="${workdir}/missing-restore-link"
+create_repo "${missing_restore_link_repo}"
+write_shared_files "${missing_restore_link_repo}"
+write_valid_playbook "${missing_restore_link_repo}"
+printf '# Phase 37 Restore Rollback Upgrade Evidence Rehearsal\n' > "${missing_restore_link_repo}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+commit_fixture "${missing_restore_link_repo}"
+assert_fails_with "${missing_restore_link_repo}" "Missing restore rehearsal support playbook link:"
+
+forbidden_bypass_repo="${workdir}/forbidden-bypass"
+create_repo "${forbidden_bypass_repo}"
+write_shared_files "${forbidden_bypass_repo}"
+write_valid_playbook "${forbidden_bypass_repo}"
+cat <<'EOF' >> "${forbidden_bypass_repo}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+
+Emergency authority bypass is approved for unrecoverable incidents.
+EOF
+commit_fixture "${forbidden_bypass_repo}"
+assert_fails_with "${forbidden_bypass_repo}" "Forbidden support playbook statement: emergency authority bypass is approved"
+
+workstation_path_repo="${workdir}/workstation-path"
+create_repo "${workstation_path_repo}"
+write_shared_files "${workstation_path_repo}"
+write_valid_playbook "${workstation_path_repo}"
+cat <<'EOF' >> "${workstation_path_repo}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+
+Use /Users/example/private/support-note.md for local evidence.
+EOF
+commit_fixture "${workstation_path_repo}"
+assert_fails_with "${workstation_path_repo}" "Forbidden support playbook guidance: workstation-local absolute path detected"
+
+echo "Support playbook and break-glass rehearsal verifier tests passed."

--- a/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
@@ -275,6 +275,7 @@ done
 
 assert_rejects_workstation_path "$(printf '%sUsers/example/private/support-note.md' '/')"
 assert_rejects_workstation_path "$(printf 'C:%sUsers%sexample%sprivate%ssupport-note.md' '/' '/' '/' '/')"
+assert_rejects_workstation_path "$(printf 'C:%sUSERS%sexample%sprivate%ssupport-note.md' '/' '/' '/' '/')"
 assert_rejects_workstation_path "$(printf 'C:%bUsers%bexample%bprivate%bsupport-note.md' '\\' '\\' '\\' '\\')"
 
 echo "Support playbook and break-glass rehearsal verifier tests passed."

--- a/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
@@ -279,7 +279,7 @@ for forbidden_phrase in \
   assert_rejects_forbidden_playbook_phrase "${forbidden_phrase}"
 done
 
-assert_rejects_workstation_path "$(printf '~%ssupport-note.md' '/')"
+assert_rejects_workstation_path "$(printf '~%sexample%sprivate%ssupport-note.md' '/' '/' '/')"
 assert_rejects_workstation_path "$(printf '%shome%sexample%sprivate%ssupport-note.md' '/' '/' '/' '/')"
 assert_rejects_workstation_path "$(printf '%sUsers/example/private/support-note.md' '/')"
 assert_rejects_workstation_path "$(printf 'C:%sUsers%sexample%sprivate%ssupport-note.md' '/' '/' '/' '/')"

--- a/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
@@ -189,6 +189,27 @@ assert_rejects_forbidden_playbook_phrase() {
   assert_fails_with "${target}" "Forbidden support playbook statement: ${phrase}"
 }
 
+workstation_path_case_index=0
+
+assert_rejects_workstation_path() {
+  local path_fragment="$1"
+  local target
+
+  workstation_path_case_index=$((workstation_path_case_index + 1))
+  target="${workdir}/workstation-path-${workstation_path_case_index}"
+
+  create_repo "${target}"
+  write_shared_files "${target}"
+  write_valid_playbook "${target}"
+  {
+    printf '\n'
+    printf 'Use %s for local evidence.\n' "${path_fragment}"
+  } >> "${target}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+
+  commit_fixture "${target}"
+  assert_fails_with "${target}" "Forbidden support playbook guidance: workstation-local absolute path detected"
+}
+
 valid_repo="${workdir}/valid"
 create_repo "${valid_repo}"
 write_shared_files "${valid_repo}"
@@ -252,16 +273,8 @@ for forbidden_phrase in \
   assert_rejects_forbidden_playbook_phrase "${forbidden_phrase}"
 done
 
-workstation_path_repo="${workdir}/workstation-path"
-create_repo "${workstation_path_repo}"
-write_shared_files "${workstation_path_repo}"
-write_valid_playbook "${workstation_path_repo}"
-{
-  printf '\n'
-  printf 'Use %sUsers/example/private/support-note.md for local evidence.\n' '/'
-} >> "${workstation_path_repo}/docs/deployment/support-playbook-break-glass-rehearsal.md"
-
-commit_fixture "${workstation_path_repo}"
-assert_fails_with "${workstation_path_repo}" "Forbidden support playbook guidance: workstation-local absolute path detected"
+assert_rejects_workstation_path "$(printf '%sUsers/example/private/support-note.md' '/')"
+assert_rejects_workstation_path "$(printf 'C:%sUsers%sexample%sprivate%ssupport-note.md' '/' '/' '/' '/')"
+assert_rejects_workstation_path "$(printf 'C:%bUsers%bexample%bprivate%bsupport-note.md' '\\' '\\' '\\' '\\')"
 
 echo "Support playbook and break-glass rehearsal verifier tests passed."

--- a/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
@@ -248,6 +248,9 @@ commit_fixture "${missing_restore_link_repo}"
 assert_fails_with "${missing_restore_link_repo}" "Missing restore rehearsal support playbook link:"
 
 for forbidden_phrase in \
+  "24x7 on-call is provided" \
+  "SLA support is provided" \
+  "customer-specific support contract is provided" \
   "emergency authority bypass is approved" \
   "break-glass may approve" \
   "break-glass may execute" \
@@ -269,10 +272,15 @@ for forbidden_phrase in \
   "detector activation is approved by break-glass" \
   "assistant output is authoritative" \
   "rollback acceptance is approved" \
-  "rollback acceptance is authoritative"; do
+  "rollback acceptance is authoritative" \
+  "direct backend access is approved" \
+  "personal session credential is acceptable" \
+  "placeholder credential is acceptable"; do
   assert_rejects_forbidden_playbook_phrase "${forbidden_phrase}"
 done
 
+assert_rejects_workstation_path "$(printf '~%ssupport-note.md' '/')"
+assert_rejects_workstation_path "$(printf '%shome%sexample%sprivate%ssupport-note.md' '/' '/' '/' '/')"
 assert_rejects_workstation_path "$(printf '%sUsers/example/private/support-note.md' '/')"
 assert_rejects_workstation_path "$(printf 'C:%sUsers%sexample%sprivate%ssupport-note.md' '/' '/' '/' '/')"
 assert_rejects_workstation_path "$(printf 'C:%sUSERS%sexample%sprivate%ssupport-note.md' '/' '/' '/' '/')"

--- a/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
@@ -221,10 +221,11 @@ workstation_path_repo="${workdir}/workstation-path"
 create_repo "${workstation_path_repo}"
 write_shared_files "${workstation_path_repo}"
 write_valid_playbook "${workstation_path_repo}"
-cat <<'EOF' >> "${workstation_path_repo}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+{
+  printf '\n'
+  printf 'Use %sUsers/example/private/support-note.md for local evidence.\n' '/'
+} >> "${workstation_path_repo}/docs/deployment/support-playbook-break-glass-rehearsal.md"
 
-Use /Users/example/private/support-note.md for local evidence.
-EOF
 commit_fixture "${workstation_path_repo}"
 assert_fails_with "${workstation_path_repo}" "Forbidden support playbook guidance: workstation-local absolute path detected"
 

--- a/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
@@ -169,6 +169,26 @@ assert_fails_with() {
   fi
 }
 
+forbidden_phrase_case_index=0
+
+assert_rejects_forbidden_playbook_phrase() {
+  local phrase="$1"
+  local target
+
+  forbidden_phrase_case_index=$((forbidden_phrase_case_index + 1))
+  target="${workdir}/forbidden-playbook-phrase-${forbidden_phrase_case_index}"
+
+  create_repo "${target}"
+  write_shared_files "${target}"
+  write_valid_playbook "${target}"
+  {
+    printf '\n'
+    printf '%s.\n' "${phrase}"
+  } >> "${target}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+  commit_fixture "${target}"
+  assert_fails_with "${target}" "Forbidden support playbook statement: ${phrase}"
+}
+
 valid_repo="${workdir}/valid"
 create_repo "${valid_repo}"
 write_shared_files "${valid_repo}"
@@ -206,16 +226,31 @@ printf '# Phase 37 Restore Rollback Upgrade Evidence Rehearsal\n' > "${missing_r
 commit_fixture "${missing_restore_link_repo}"
 assert_fails_with "${missing_restore_link_repo}" "Missing restore rehearsal support playbook link:"
 
-forbidden_bypass_repo="${workdir}/forbidden-bypass"
-create_repo "${forbidden_bypass_repo}"
-write_shared_files "${forbidden_bypass_repo}"
-write_valid_playbook "${forbidden_bypass_repo}"
-cat <<'EOF' >> "${forbidden_bypass_repo}/docs/deployment/support-playbook-break-glass-rehearsal.md"
-
-Emergency authority bypass is approved for unrecoverable incidents.
-EOF
-commit_fixture "${forbidden_bypass_repo}"
-assert_fails_with "${forbidden_bypass_repo}" "Forbidden support playbook statement: emergency authority bypass is approved"
+for forbidden_phrase in \
+  "emergency authority bypass is approved" \
+  "break-glass may approve" \
+  "break-glass may execute" \
+  "break-glass may reconcile" \
+  "break-glass may close" \
+  "break-glass may close tickets" \
+  "break-glass may activate detectors" \
+  "break-glass may deactivate detectors" \
+  "break-glass may enable detectors" \
+  "break-glass may mark tickets authoritative" \
+  "break-glass may mark ticket state authoritative" \
+  "break-glass may change rollback acceptance" \
+  "break-glass may approve rollback acceptance" \
+  "break-glass may override rollback acceptance" \
+  "ticket state is authoritative" \
+  "tickets are authoritative" \
+  "mark ticket state authoritative" \
+  "detector output is authoritative" \
+  "detector activation is approved by break-glass" \
+  "assistant output is authoritative" \
+  "rollback acceptance is approved" \
+  "rollback acceptance is authoritative"; do
+  assert_rejects_forbidden_playbook_phrase "${forbidden_phrase}"
+done
 
 workstation_path_repo="${workdir}/workstation-path"
 create_repo "${workstation_path_repo}"

--- a/scripts/verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/verify-support-playbook-break-glass-rehearsal.sh
@@ -49,7 +49,7 @@ reject_workstation_paths() {
   local macos_home_pattern linux_home_pattern windows_home_pattern workstation_local_path_pattern
   macos_home_pattern='/'"Users"'/[^[:space:])>]+'
   linux_home_pattern='/'"home"'/[^[:space:])>]+'
-  windows_home_pattern='[A-Za-z]:\\'"Users"'\\[^[:space:])>]+'
+  windows_home_pattern='[A-Za-z]:[\\/][Uu]sers[\\/][^[:space:])>]+'
   workstation_local_path_pattern="(^|[^[:alnum:]_./-])(~[/\\\\]|${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern})"
 
   if grep -Eq "${workstation_local_path_pattern}" "$@"; then

--- a/scripts/verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/verify-support-playbook-break-glass-rehearsal.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+playbook_path="${repo_root}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+runbook_path="${repo_root}/docs/runbook.md"
+pilot_readiness_path="${repo_root}/docs/deployment/pilot-readiness-checklist.md"
+restore_path="${repo_root}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+handoff_path="${repo_root}/docs/deployment/operational-evidence-handoff-pack.md"
+verifier_test_path="${repo_root}/scripts/test-verify-support-playbook-break-glass-rehearsal.sh"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if grep -Fqi -- "${phrase}" "${path}"; then
+    echo "Forbidden ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_workstation_paths() {
+  local description="$1"
+  shift
+
+  local macos_home_pattern linux_home_pattern windows_home_pattern workstation_local_path_pattern
+  macos_home_pattern='/'"Users"'/[^[:space:])>]+'
+  linux_home_pattern='/'"home"'/[^[:space:])>]+'
+  windows_home_pattern='[A-Za-z]:\\'"Users"'\\[^[:space:])>]+'
+  workstation_local_path_pattern="(^|[^[:alnum:]_./-])(~[/\\\\]|${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern})"
+
+  if grep -Eq "${workstation_local_path_pattern}" "$@"; then
+    echo "Forbidden ${description}: workstation-local absolute path detected" >&2
+    exit 1
+  fi
+}
+
+require_file "${playbook_path}" "support playbook and break-glass rehearsal"
+require_file "${runbook_path}" "runbook"
+require_file "${pilot_readiness_path}" "pilot readiness checklist"
+require_file "${restore_path}" "restore rollback upgrade evidence rehearsal"
+require_file "${handoff_path}" "operational evidence handoff pack"
+require_file "${verifier_test_path}" "support playbook verifier tests"
+
+required_headings=(
+  "# Support Playbook and Break-Glass Rehearsal"
+  "## 1. Purpose and Boundary"
+  "## 2. Common Pilot Failure Modes"
+  "## 3. Degraded Path Handling"
+  "## 4. Break-Glass Custody and Rehearsal"
+  "## 5. Rollback and Restore Escalation"
+  "## 6. Evidence Collection Expectations"
+  "## 7. Verification"
+  "## 8. Out of Scope"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${playbook_path}" "${heading}" "support playbook heading"
+done
+
+required_playbook_phrases=(
+  "This playbook tells maintainers and operators what to inspect when the single-customer pilot degrades without creating emergency authority bypass."
+  "The reviewed operating posture remains business-hours, operator-led, and subordinate to AegisOps authoritative records."
+  "The playbook covers source, detector, coordination, assistant, runtime, rollback, and restore degradation for the reviewed single-customer pilot."
+  "It does not create 24x7 on-call coverage, a customer-specific support contract, direct backend access, direct substrate authority, or emergency authority bypass."
+  "| Source degradation |"
+  "| Detector degradation |"
+  "| Coordination degradation |"
+  "| Assistant degradation |"
+  "| Runtime degradation |"
+  "| Rollback degradation |"
+  "| Restore degradation |"
+  "Source handling: inspect the reviewed source-family evidence, ingest custody, replay or fixture proof, source timestamp, and explicit linkage to the AegisOps alert, case, or evidence record before widening source scope."
+  "Detector handling: inspect the detector activation evidence handoff, candidate rule identifier, fixture and parser evidence, expected volume, false-positive review, disable owner, rollback owner, and next-review date before trusting detector output."
+  'Coordination handling: inspect `docs/operations-zammad-live-pilot-boundary.md`, `AEGISOPS_ZAMMAD_BASE_URL`, the reviewed token source reference, endpoint reachability, and explicit AegisOps linkage before treating a ticket pointer as usable coordination context.'
+  "Assistant handling: inspect the assistant boundary, citations, reviewed record ids, linked evidence ids, uncertainty flags, and disabled or limited assistant surfaces before relying on an advisory summary."
+  "Runtime handling: inspect the reverse-proxy health, readiness, runtime inspection, compose status, bounded logs, runtime env contract, and migration bootstrap evidence before admitting normal operator use."
+  "Rollback handling: inspect the same-day rollback decision owner, selected restore point, pre-change backup custody, before-and-after repository revision, smoke result, and clean-state evidence before closing the maintenance window."
+  "Restore handling: inspect backup provenance, selected restore point, empty restore target expectation, post-restore readiness, record-chain validation, and clean-state proof before returning to service."
+  "Break-glass custody is a documented recovery exception, not an alternate approval path, permanent operator shortcut, or way to bypass reviewed AegisOps authority."
+  "A break-glass rehearsal must name the trigger, primary custodian, backup custodian, approving reviewer, bounded access window, affected runtime binding, redacted evidence location, rotation follow-up owner, and return-to-normal confirmation."
+  "Missing, placeholder, sample, TODO, unsigned, browser-state, raw forwarded-header, or personal-session credentials keep break-glass blocked until the reviewed custody source is repaired."
+  "Break-glass use must not approve, execute, reconcile, close, activate detectors, mark tickets authoritative, or change rollback acceptance without the reviewed AegisOps record and reviewer path."
+  "After break-glass use, operators must rotate or invalidate the affected secret, capture reload or restart evidence, run the relevant readiness or refusal check, and retain the follow-up owner before normal operation resumes."
+  'Rollback and restore escalation must stay cross-linked to `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md`, `docs/deployment/operational-evidence-handoff-pack.md`, and `docs/runbook.md`.'
+  "Escalate to rollback when runtime, detector, coordination, assistant, or evidence drift cannot be corrected inside the reviewed maintenance or health-review window without widening scope."
+  "Escalate to restore when authoritative approval, evidence, execution, or reconciliation records are missing, orphaned, partially restored, mixed-snapshot, or no longer attributable to the selected restore point."
+  "Rejected, forbidden, failed, rollback, or restore-failure paths must retain the refusal reason and clean-state proof; it is not enough to record that an exception occurred."
+  "Evidence collection must remain operator-readable and compact: record the event, named operator, affected path, authoritative AegisOps record ids, repository revision or release identifier, command or inspection output, refusal reason when present, clean-state proof, follow-up owner, and next review."
+  'Use repo-relative commands, documented env vars, and placeholders such as `<runtime-env-file>`, `<evidence-dir>`, `<release-gate-manifest.md>`, and `<support-evidence-note.md>`.'
+  'Verify this playbook with `scripts/verify-support-playbook-break-glass-rehearsal.sh`.'
+  'Negative validation for the verifier is `scripts/test-verify-support-playbook-break-glass-rehearsal.sh`.'
+)
+
+for phrase in "${required_playbook_phrases[@]}"; do
+  require_phrase "${playbook_path}" "${phrase}" "support playbook statement"
+done
+
+require_phrase "${runbook_path}" 'For pilot support degradation, break-glass rehearsal, and operator-readable evidence expectations, use `docs/deployment/support-playbook-break-glass-rehearsal.md` and verify it with `scripts/verify-support-playbook-break-glass-rehearsal.sh`.' "runbook support playbook link"
+require_phrase "${pilot_readiness_path}" 'The support playbook in `docs/deployment/support-playbook-break-glass-rehearsal.md` is the reviewed pilot degradation and break-glass rehearsal reference; pilot entry remains blocked if support expectations would require 24x7 coverage, customer-specific support terms, or emergency authority bypass.' "pilot readiness support playbook link"
+require_phrase "${restore_path}" 'Support escalation from `docs/deployment/support-playbook-break-glass-rehearsal.md` must route rollback and restore decisions back to this release-gate rehearsal and retain refusal reason plus clean-state evidence for failed paths.' "restore rehearsal support playbook link"
+require_phrase "${handoff_path}" 'Support playbook evidence from `docs/deployment/support-playbook-break-glass-rehearsal.md` may be retained in this handoff pack only as operator-readable evidence attached to reviewed AegisOps records.' "operational handoff support playbook link"
+
+for forbidden in \
+  "24x7 on-call is provided" \
+  "SLA support is provided" \
+  "customer-specific support contract is provided" \
+  "emergency authority bypass is approved" \
+  "break-glass may approve" \
+  "break-glass may execute" \
+  "break-glass may reconcile" \
+  "ticket state is authoritative" \
+  "detector output is authoritative" \
+  "assistant output is authoritative" \
+  "direct backend access is approved" \
+  "personal session credential is acceptable" \
+  "placeholder credential is acceptable"; do
+  reject_phrase "${playbook_path}" "${forbidden}" "support playbook statement"
+done
+
+reject_workstation_paths "support playbook guidance" \
+  "${playbook_path}" \
+  "${runbook_path}" \
+  "${pilot_readiness_path}" \
+  "${restore_path}" \
+  "${handoff_path}"
+
+echo "Support playbook, break-glass rehearsal, escalation cross-links, and evidence expectations are present and bounded."

--- a/scripts/verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/verify-support-playbook-break-glass-rehearsal.sh
@@ -49,7 +49,7 @@ reject_workstation_paths() {
   local macos_home_pattern linux_home_pattern windows_home_pattern workstation_local_path_pattern
   macos_home_pattern='/'"Users"'/[^[:space:])>]+'
   linux_home_pattern='/'"home"'/[^[:space:])>]+'
-  windows_home_pattern='[A-Za-z]:[\\/][Uu]sers[\\/][^[:space:])>]+'
+  windows_home_pattern='[A-Za-z]:[\\/][Uu][Ss][Ee][Rr][Ss][\\/][^[:space:])>]+'
   workstation_local_path_pattern="(^|[^[:alnum:]_./-])(~[/\\\\]|${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern})"
 
   if grep -Eq "${workstation_local_path_pattern}" "$@"; then

--- a/scripts/verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/verify-support-playbook-break-glass-rehearsal.sh
@@ -129,12 +129,27 @@ for forbidden in \
   "SLA support is provided" \
   "customer-specific support contract is provided" \
   "emergency authority bypass is approved" \
+  "break-glass may approve rollback acceptance" \
   "break-glass may approve" \
   "break-glass may execute" \
   "break-glass may reconcile" \
+  "break-glass may close tickets" \
+  "break-glass may close" \
+  "break-glass may activate detectors" \
+  "break-glass may deactivate detectors" \
+  "break-glass may enable detectors" \
+  "break-glass may mark tickets authoritative" \
+  "break-glass may mark ticket state authoritative" \
+  "break-glass may change rollback acceptance" \
+  "break-glass may override rollback acceptance" \
   "ticket state is authoritative" \
+  "tickets are authoritative" \
+  "mark ticket state authoritative" \
   "detector output is authoritative" \
+  "detector activation is approved by break-glass" \
   "assistant output is authoritative" \
+  "rollback acceptance is approved" \
+  "rollback acceptance is authoritative" \
   "direct backend access is approved" \
   "personal session credential is acceptable" \
   "placeholder credential is acceptable"; do


### PR DESCRIPTION
## Summary
- add the pilot support playbook covering source, detector, coordination, assistant, runtime, rollback, and restore degradation
- document break-glass custody and rehearsal expectations without emergency authority bypass
- add fail-closed verifier coverage and cross-links from runbook, pilot readiness, restore rehearsal, and operational handoff docs

## Verification
- bash scripts/test-verify-support-playbook-break-glass-rehearsal.sh
- bash scripts/verify-support-playbook-break-glass-rehearsal.sh
- bash scripts/verify-publishable-path-hygiene.sh
- bash scripts/verify-pilot-readiness-checklist.sh
- bash scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh
- bash scripts/verify-phase-33-operational-evidence-handoff-pack.sh
- bash scripts/verify-runbook-doc.sh

Part of #825
Closes #828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive break-glass support playbook with rehearsal procedures, prohibited uses, required metadata, cross-linked escalation steps, evidence-handling rules, and pre-pilot guidance updates

* **Chores**
  * Integrated automated verification into CI to ensure the playbook and related docs meet required structure, links, and content constraints

* **Tests**
  * Added verification tests covering positive/negative scenarios, forbidden phrasing, and workstation-path restrictions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->