### PR TITLE
Add pilot pause rollback exit criteria

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           bash scripts/verify-parameter-category-docs.sh
           bash scripts/verify-parameter-config-files.sh
           bash scripts/run-ci-phase-contract.sh all-verifiers
+          bash scripts/verify-pilot-pause-rollback-exit-criteria.sh
           bash scripts/verify-positive-smb-value-proposition.sh
           bash scripts/verify-postgres-compose-skeleton.sh
           bash scripts/verify-publishable-path-hygiene.sh
@@ -311,6 +312,7 @@ jobs:
           bash scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
           bash scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
           bash scripts/test-verify-support-playbook-break-glass-rehearsal.sh
+          bash scripts/test-verify-pilot-pause-rollback-exit-criteria.sh
           bash scripts/test-verify-single-customer-deployment-profile.sh
           bash scripts/test-verify-single-customer-release-bundle-inventory.sh
           bash scripts/test-verify-release-handoff-evidence-package.sh

--- a/docs/deployment/operational-evidence-handoff-pack.md
+++ b/docs/deployment/operational-evidence-handoff-pack.md
@@ -22,6 +22,8 @@ Operator training and handoff for the pilot uses `docs/deployment/operator-train
 
 Support playbook evidence from `docs/deployment/support-playbook-break-glass-rehearsal.md` may be retained in this handoff pack only as operator-readable evidence attached to reviewed AegisOps records.
 
+Pilot pause, rollback, continue, and exit evidence must use `docs/deployment/pilot-pause-rollback-exit-criteria.md` as the reviewed operator/support decision surface for unresolved limitations and next-roadmap input capture.
+
 The pack may reference external substrate receipts, backup custody notes, or bounded logs, but those references remain evidence attached to reviewed AegisOps records. They do not create a parallel source of authority.
 
 ## 2. Retained Evidence Categories

--- a/docs/deployment/operator-training-handoff-packet.md
+++ b/docs/deployment/operator-training-handoff-packet.md
@@ -10,6 +10,8 @@ Use it before pilot handoff, during operator shadowing, and when a daily owner n
 
 Verify the packet with `scripts/verify-operator-training-handoff-packet.sh`.
 
+For pilot pause, rollback, continue, or exit signoff, operators must use `docs/deployment/pilot-pause-rollback-exit-criteria.md` after completing the queue, case, action-review, reviewed-record, non-authority, and evidence handoff walkthrough.
+
 ## 2. Daily Queue, Case, and Action-Review Path
 
 Daily work starts from the AegisOps queue, not from Wazuh, OpenSearch, Zammad, Shuffle, n8n, or assistant output.

--- a/docs/deployment/pilot-pause-rollback-exit-criteria.md
+++ b/docs/deployment/pilot-pause-rollback-exit-criteria.md
@@ -1,0 +1,97 @@
+# Pilot Pause, Rollback, and Exit Criteria
+
+## 1. Purpose and Boundary
+
+This document defines reviewed pause, rollback, continue, exit, unresolved-limitation, and next-roadmap capture criteria for the single-customer pilot.
+
+The decision surface is operational and reviewable. It is not a customer commercial terms sheet, public launch checklist, SLA acceptance record, multi-customer rollout gate, or multi-tenant expansion plan.
+
+Pilot pause, rollback, continue, and exit decisions remain subordinate to AegisOps authoritative records, the pilot readiness decision, support playbook evidence, operator handoff evidence, and the restore, rollback, and upgrade release-gate rehearsal.
+
+## 2. Decision Record
+
+Every pilot health review that considers pause, rollback, continue, or exit must record:
+
+- the reviewed release identifier or repository revision;
+- the named pilot owner, operator, support reviewer, and handoff owner;
+- the linked pilot readiness decision, support evidence note, operator handoff entry, runtime smoke manifest, rollback evidence record, known-limitation review, and next health review;
+- the decision: continue, pause, rollback, exit-success, exit-no-go, or capture-next-roadmap-input; and
+- the refusal reason and clean-state evidence when the decision is pause, rollback, exit-no-go, rejected, forbidden, or failed.
+
+The decision must use directly linked AegisOps records and retained evidence. Operators must not infer customer, tenant, ticket, detector, assistant, release, or rollback linkage from naming conventions, nearby notes, ticket state, assistant output, raw forwarded headers, or substrate-local status.
+
+## 3. Pilot Pause Criteria
+
+Pause the pilot and keep normal operator use blocked when any of the following are true:
+
+- release readiness, runtime smoke, detector activation scope, Zammad coordination scope, assistant limitation, known-limitation, support, or handoff evidence is missing, stale, mixed across release identifiers, or only partially trusted;
+- a runtime, detector, coordination, assistant, evidence, or support degradation cannot be corrected inside the reviewed business-hours health-review window without widening pilot scope;
+- support expectations would require 24x7 coverage, customer-specific paid support terms, emergency authority bypass, direct backend access, or customer-private secret exposure;
+- an unresolved limitation affects launch, normal operation, rollback acceptance, detector disable, Zammad coordination, assistant output, evidence handoff, or operator training and lacks an owner, disposition, review date, or clean-state proof; or
+- the operator cannot explain the queue, case, action-review, approval, execution, reconciliation, evidence handoff, and next-owner path from directly linked reviewed records.
+
+Pause is a reviewed hold state, not a silent success, informal support escalation, commercial renegotiation, or permission to keep operating with guessed prerequisites.
+
+## 4. Rollback Criteria
+
+Escalate to rollback when the pilot cannot continue or pause safely on the current release because runtime, detector, coordination, assistant, support, evidence, or handoff drift would leave reviewed records ambiguous or untrustworthy.
+
+Rollback must align with `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md` and retain:
+
+- same-day rollback decision owner;
+- selected restore point and restore target;
+- pre-change backup custody and reviewed configuration reference;
+- before-and-after repository revision or release identifier;
+- runtime smoke result after rollback where feasible;
+- reviewed record-chain evidence;
+- refusal reason for failed, rejected, forbidden, or restore-failure paths; and
+- clean-state proof that no orphan record, partial durable write, half-restored state, or misleading handoff evidence survived the attempt.
+
+Rollback does not authorize direct source-side mutation, vendor-specific backup product dependency, HA choreography, direct backend exposure, optional-extension launch gates, ticket-system authority, assistant-owned workflow decisions, or customer-private production access.
+
+## 5. Exit and Success Criteria
+
+Exit-success is allowed only when the reviewed pilot record shows that the single-customer operating path stayed bounded and trustworthy for the reviewed pilot window.
+
+The exit-success decision must name:
+
+- the reviewed release identifier or repository revision;
+- release readiness and runtime smoke evidence;
+- detector activation, disable, rollback, expected-volume, false-positive, and next-review evidence for the accepted detector scope;
+- Zammad coordination posture and credential custody without treating tickets as AegisOps authority;
+- assistant advisory-only limitation evidence;
+- known limitations with dispositions, owners, and review dates;
+- operator and support signoff that the queue, case, action-review, reviewed-record, non-authority, pause, rollback, and evidence handoff paths are understood; and
+- the next roadmap input record, if any, without changing Phase 43 scope.
+
+Exit-no-go is required when the pilot cannot prove those criteria, when rollback or clean-state evidence is missing after a failed path, or when the outcome would depend on customer commercial terms, public launch readiness, multi-customer rollout assumptions, or multi-tenant expansion criteria.
+
+## 6. Unresolved Limitations and Next-Roadmap Input
+
+Unresolved limitations must be handled as reviewed records with a disposition of block, accept-with-owner, rollback, disable, support-follow-up, or capture-next-roadmap-input.
+
+Each unresolved limitation must name the operator-visible behavior, affected surface, owner, next review, evidence link, and whether it changes pilot pause, rollback, continue, or exit status.
+
+Next-roadmap input may capture candidate follow-up work from the pilot, but it must remain separate from Phase 43 acceptance. Captured input must not turn customer commercial terms, public launch checklist items, multi-customer rollout requirements, multi-tenant expansion criteria, optional-extension launch gates, or broad support promises into current pilot scope.
+
+## 7. Operator and Support Signoff Checklist
+
+Before continuing after a pause, accepting rollback completion, or recording exit-success, operator and support signoff must confirm:
+
+- the support playbook was reviewed for degradation and break-glass handling;
+- the operator training packet was reviewed for queue, case, action-review, reviewed-record, non-authority, and evidence handoff practice;
+- the pilot owner, support reviewer, operator, handoff owner, next health review, and any follow-up owner are named;
+- failed, rejected, forbidden, rollback, restore, pause, and no-go paths retain refusal reason plus clean-state proof; and
+- no signoff relies on workstation-local absolute paths, live secrets, placeholder credentials, raw forwarded headers, ticket authority, assistant authority, optional-extension health, or inferred scope.
+
+## 8. Verification
+
+Verify this criteria document with `scripts/verify-pilot-pause-rollback-exit-criteria.sh`.
+
+Negative validation for the verifier is `scripts/test-verify-pilot-pause-rollback-exit-criteria.sh`.
+
+Run the verifier after changing this document, the runbook, pilot readiness checklist, support playbook, operator training packet, release handoff package, operational evidence handoff pack, or restore rollback upgrade evidence rehearsal.
+
+## 9. Out of Scope
+
+Customer commercial terms, formal SLA commitments, public launch checklist ownership, hosted release channels, multi-customer rollout, multi-tenant expansion criteria, direct customer-private production access, direct backend exposure, optional-extension launch gates, ticket-system authority, assistant-owned workflow authority, and broad support promises beyond the reviewed business-hours single-customer pilot are out of scope.

--- a/docs/deployment/pilot-readiness-checklist.md
+++ b/docs/deployment/pilot-readiness-checklist.md
@@ -10,6 +10,8 @@ This checklist is the reviewed entry decision surface above the release bundle, 
 
 Operator training and handoff for the pilot must use `docs/deployment/operator-training-handoff-packet.md` and verify it with `scripts/verify-operator-training-handoff-packet.sh` before treating the pilot operator handoff as ready.
 
+Pilot pause, rollback, and exit decisions must use `docs/deployment/pilot-pause-rollback-exit-criteria.md`; entry readiness alone is not exit-success, rollback acceptance, or permission to continue after a paused or degraded pilot.
+
 ## 2. Entry Decision Summary
 
 The pilot may start only when release readiness, runtime smoke, detector activation scope, coordination pilot scope, assistant limitations, data retention, and evidence handoff are reviewed together for the same release identifier.

--- a/docs/deployment/release-handoff-evidence-package.md
+++ b/docs/deployment/release-handoff-evidence-package.md
@@ -12,6 +12,8 @@ Use this package after the release bundle inventory, install preflight, runtime 
 
 The pilot readiness checklist in `docs/deployment/pilot-readiness-checklist.md` consumes this release handoff package as the reviewed release-readiness and known-limitations evidence source for the pilot entry decision.
 
+Pilot exit-success, exit-no-go, pause, continue, and rollback decisions must point to `docs/deployment/pilot-pause-rollback-exit-criteria.md` instead of treating release handoff alone as pilot success.
+
 ## 2. Required Handoff Entries
 
 Every release handoff manifest must include release readiness summary, release bundle identifier, install preflight result, runtime smoke result, backup, restore, rollback, and upgrade rehearsal reference, known limitations, rollback instructions, handoff owner, and next health review.

--- a/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md
+++ b/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md
@@ -14,6 +14,8 @@ The release gate proves that backup, restore, rollback, upgrade, smoke, and revi
 
 Support escalation from `docs/deployment/support-playbook-break-glass-rehearsal.md` must route rollback and restore decisions back to this release-gate rehearsal and retain refusal reason plus clean-state evidence for failed paths.
 
+Pilot rollback acceptance must stay aligned to `docs/deployment/pilot-pause-rollback-exit-criteria.md`; a same-day rollback decision is not accepted for pilot continuation or exit until operator/support signoff, refusal reason when applicable, and clean-state evidence are retained.
+
 ## 2. Prerequisites
 
 Before the rehearsal starts, operators must have:

--- a/docs/deployment/support-playbook-break-glass-rehearsal.md
+++ b/docs/deployment/support-playbook-break-glass-rehearsal.md
@@ -10,6 +10,8 @@ The playbook covers source, detector, coordination, assistant, runtime, rollback
 
 It does not create 24x7 on-call coverage, a customer-specific support contract, direct backend access, direct substrate authority, or emergency authority bypass.
 
+Pilot pause, rollback, and exit decisions must use `docs/deployment/pilot-pause-rollback-exit-criteria.md` so support degradation, break-glass evidence, rollback escalation, unresolved limitations, and next-roadmap input remain reviewed and bounded.
+
 ## 2. Common Pilot Failure Modes
 
 | Failure mode | Inspect first | Do not infer |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -133,6 +133,8 @@ Before starting a single-customer pilot, review `docs/deployment/pilot-readiness
 
 For pilot support degradation, break-glass rehearsal, and operator-readable evidence expectations, use `docs/deployment/support-playbook-break-glass-rehearsal.md` and verify it with `scripts/verify-support-playbook-break-glass-rehearsal.sh`.
 
+Before continuing, pausing, rolling back, or exiting a single-customer pilot, review `docs/deployment/pilot-pause-rollback-exit-criteria.md` and verify it with `scripts/verify-pilot-pause-rollback-exit-criteria.sh` so pause criteria, rollback criteria, exit criteria, unresolved limitations, next-roadmap input, and operator/support signoff remain bounded to Phase 43.
+
 ## 3. Shutdown
 
 The reviewed shutdown path exists to return the platform to a clean, operator-confirmed safe state without leaving ambiguous runtime ownership or half-stopped ingress.

--- a/scripts/test-verify-pilot-pause-rollback-exit-criteria.sh
+++ b/scripts/test-verify-pilot-pause-rollback-exit-criteria.sh
@@ -131,6 +131,12 @@ write_valid_docs "${forbidden_scope_repo}"
 printf '\nThe public launch checklist is approved by pilot exit.\n' >> "${forbidden_scope_repo}/docs/deployment/pilot-pause-rollback-exit-criteria.md"
 assert_fails_with "${forbidden_scope_repo}" "Forbidden pilot pause rollback exit criteria statement: public launch checklist is approved"
 
+forbidden_runbook_scope_repo="${workdir}/forbidden-runbook-scope"
+create_repo "${forbidden_runbook_scope_repo}"
+write_valid_docs "${forbidden_runbook_scope_repo}"
+printf '\nThe multi-tenant expansion is approved by pilot exit.\n' >> "${forbidden_runbook_scope_repo}/docs/runbook.md"
+assert_fails_with "${forbidden_runbook_scope_repo}" "Forbidden pilot pause rollback exit criteria statement: multi-tenant expansion is approved"
+
 absolute_path_repo="${workdir}/absolute-path"
 create_repo "${absolute_path_repo}"
 write_valid_docs "${absolute_path_repo}"

--- a/scripts/test-verify-pilot-pause-rollback-exit-criteria.sh
+++ b/scripts/test-verify-pilot-pause-rollback-exit-criteria.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-pilot-pause-rollback-exit-criteria.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment"
+}
+
+write_valid_docs() {
+  local target="$1"
+
+  cp "${repo_root}/docs/deployment/pilot-pause-rollback-exit-criteria.md" "${target}/docs/deployment/pilot-pause-rollback-exit-criteria.md"
+
+  cat <<'EOF' > "${target}/docs/runbook.md"
+# AegisOps Runbook
+
+Before continuing, pausing, rolling back, or exiting a single-customer pilot, review `docs/deployment/pilot-pause-rollback-exit-criteria.md` and verify it with `scripts/verify-pilot-pause-rollback-exit-criteria.sh` so pause criteria, rollback criteria, exit criteria, unresolved limitations, next-roadmap input, and operator/support signoff remain bounded to Phase 43.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/pilot-readiness-checklist.md"
+# Single-Customer Pilot Readiness Checklist and Entry Criteria
+
+Pilot pause, rollback, and exit decisions must use `docs/deployment/pilot-pause-rollback-exit-criteria.md`; entry readiness alone is not exit-success, rollback acceptance, or permission to continue after a paused or degraded pilot.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+# Support Playbook and Break-Glass Rehearsal
+
+Pilot pause, rollback, and exit decisions must use `docs/deployment/pilot-pause-rollback-exit-criteria.md` so support degradation, break-glass evidence, rollback escalation, unresolved limitations, and next-roadmap input remain reviewed and bounded.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/operator-training-handoff-packet.md"
+# Operator Training and Handoff Packet
+
+For pilot pause, rollback, continue, or exit signoff, operators must use `docs/deployment/pilot-pause-rollback-exit-criteria.md` after completing the queue, case, action-review, reviewed-record, non-authority, and evidence handoff walkthrough.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/release-handoff-evidence-package.md"
+# Phase 38 Release Handoff Evidence Package
+
+Pilot exit-success, exit-no-go, pause, continue, and rollback decisions must point to `docs/deployment/pilot-pause-rollback-exit-criteria.md` instead of treating release handoff alone as pilot success.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/operational-evidence-handoff-pack.md"
+# Phase 33 Operational Evidence Retention and Audit Handoff Pack
+
+Pilot pause, rollback, continue, and exit evidence must use `docs/deployment/pilot-pause-rollback-exit-criteria.md` as the reviewed operator/support decision surface for unresolved limitations and next-roadmap input capture.
+EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+# Phase 37 Restore Rollback Upgrade Evidence Rehearsal
+
+Pilot rollback acceptance must stay aligned to `docs/deployment/pilot-pause-rollback-exit-criteria.md`; a same-day rollback decision is not accepted for pilot continuation or exit until operator/support signoff, refusal reason when applicable, and clean-state evidence are retained.
+EOF
+
+  mkdir -p "${target}/scripts"
+  touch "${target}/scripts/test-verify-pilot-pause-rollback-exit-criteria.sh"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo "${valid_repo}"
+write_valid_docs "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_criteria_repo="${workdir}/missing-criteria"
+create_repo "${missing_criteria_repo}"
+write_valid_docs "${missing_criteria_repo}"
+rm "${missing_criteria_repo}/docs/deployment/pilot-pause-rollback-exit-criteria.md"
+assert_fails_with "${missing_criteria_repo}" "Missing pilot pause rollback exit criteria document:"
+
+missing_pause_repo="${workdir}/missing-pause"
+create_repo "${missing_pause_repo}"
+write_valid_docs "${missing_pause_repo}"
+perl -0pi -e 's/^Pause the pilot and keep normal operator use blocked when any of the following are true:\n//m' "${missing_pause_repo}/docs/deployment/pilot-pause-rollback-exit-criteria.md"
+assert_fails_with "${missing_pause_repo}" "Missing pilot pause rollback exit criteria statement: Pause the pilot and keep normal operator use blocked"
+
+missing_rollback_alignment_repo="${workdir}/missing-rollback-alignment"
+create_repo "${missing_rollback_alignment_repo}"
+write_valid_docs "${missing_rollback_alignment_repo}"
+printf '# Phase 37 Restore Rollback Upgrade Evidence Rehearsal\n' > "${missing_rollback_alignment_repo}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+assert_fails_with "${missing_rollback_alignment_repo}" 'Missing restore rollback rehearsal pause rollback exit criteria link: Pilot rollback acceptance must stay aligned to `docs/deployment/pilot-pause-rollback-exit-criteria.md`'
+
+missing_signoff_repo="${workdir}/missing-signoff"
+create_repo "${missing_signoff_repo}"
+write_valid_docs "${missing_signoff_repo}"
+perl -0pi -e 's/^Before continuing after a pause, accepting rollback completion, or recording exit-success, operator and support signoff must confirm:\n//m' "${missing_signoff_repo}/docs/deployment/pilot-pause-rollback-exit-criteria.md"
+assert_fails_with "${missing_signoff_repo}" "Missing pilot pause rollback exit criteria statement: Before continuing after a pause, accepting rollback completion, or recording exit-success"
+
+forbidden_scope_repo="${workdir}/forbidden-scope"
+create_repo "${forbidden_scope_repo}"
+write_valid_docs "${forbidden_scope_repo}"
+printf '\nThe public launch checklist is approved by pilot exit.\n' >> "${forbidden_scope_repo}/docs/deployment/pilot-pause-rollback-exit-criteria.md"
+assert_fails_with "${forbidden_scope_repo}" "Forbidden pilot pause rollback exit criteria statement: public launch checklist is approved"
+
+absolute_path_repo="${workdir}/absolute-path"
+create_repo "${absolute_path_repo}"
+write_valid_docs "${absolute_path_repo}"
+printf '\nLocal evidence: /%s/%s/pilot-exit.md\n' "Users" "example" >> "${absolute_path_repo}/docs/deployment/pilot-pause-rollback-exit-criteria.md"
+assert_fails_with "${absolute_path_repo}" "Forbidden pilot pause rollback exit guidance: workstation-local absolute path detected"
+
+echo "Pilot pause rollback exit criteria verifier tests passed."

--- a/scripts/verify-pilot-pause-rollback-exit-criteria.sh
+++ b/scripts/verify-pilot-pause-rollback-exit-criteria.sh
@@ -130,6 +130,7 @@ require_phrase "${restore_path}" 'Pilot rollback acceptance must stay aligned to
 
 for doc_path in \
   "${criteria_path}" \
+  "${runbook_path}" \
   "${pilot_checklist_path}" \
   "${support_path}" \
   "${operator_packet_path}" \

--- a/scripts/verify-pilot-pause-rollback-exit-criteria.sh
+++ b/scripts/verify-pilot-pause-rollback-exit-criteria.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+criteria_path="${repo_root}/docs/deployment/pilot-pause-rollback-exit-criteria.md"
+runbook_path="${repo_root}/docs/runbook.md"
+pilot_checklist_path="${repo_root}/docs/deployment/pilot-readiness-checklist.md"
+support_path="${repo_root}/docs/deployment/support-playbook-break-glass-rehearsal.md"
+operator_packet_path="${repo_root}/docs/deployment/operator-training-handoff-packet.md"
+release_handoff_path="${repo_root}/docs/deployment/release-handoff-evidence-package.md"
+operational_handoff_path="${repo_root}/docs/deployment/operational-evidence-handoff-pack.md"
+restore_path="${repo_root}/docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md"
+verifier_test_path="${repo_root}/scripts/test-verify-pilot-pause-rollback-exit-criteria.sh"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if grep -Fqi -- "${phrase}" "${path}"; then
+    echo "Forbidden ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_workstation_paths() {
+  local description="$1"
+  shift
+
+  local macos_home_pattern linux_home_pattern windows_home_pattern workstation_local_path_pattern
+  macos_home_pattern='/'"Users"'/[^[:space:])>]+'
+  linux_home_pattern='/'"home"'/[^[:space:])>]+'
+  windows_home_pattern='[A-Za-z]:\\'"Users"'\\[^[:space:])>]+'
+  workstation_local_path_pattern="(^|[^[:alnum:]_./-])(~[/\\\\]|${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern})"
+
+  if grep -Eq "${workstation_local_path_pattern}" "$@"; then
+    echo "Forbidden ${description}: workstation-local absolute path detected" >&2
+    exit 1
+  fi
+}
+
+require_file "${criteria_path}" "pilot pause rollback exit criteria document"
+require_file "${runbook_path}" "runbook"
+require_file "${pilot_checklist_path}" "pilot readiness checklist"
+require_file "${support_path}" "support playbook"
+require_file "${operator_packet_path}" "operator training packet"
+require_file "${release_handoff_path}" "release handoff package"
+require_file "${operational_handoff_path}" "operational evidence handoff pack"
+require_file "${restore_path}" "restore rollback upgrade evidence rehearsal"
+require_file "${verifier_test_path}" "pilot pause rollback exit criteria verifier tests"
+
+required_headings=(
+  "# Pilot Pause, Rollback, and Exit Criteria"
+  "## 1. Purpose and Boundary"
+  "## 2. Decision Record"
+  "## 3. Pilot Pause Criteria"
+  "## 4. Rollback Criteria"
+  "## 5. Exit and Success Criteria"
+  "## 6. Unresolved Limitations and Next-Roadmap Input"
+  "## 7. Operator and Support Signoff Checklist"
+  "## 8. Verification"
+  "## 9. Out of Scope"
+)
+
+for heading in "${required_headings[@]}"; do
+  require_phrase "${criteria_path}" "${heading}" "pilot pause rollback exit criteria heading"
+done
+
+required_criteria_phrases=(
+  "This document defines reviewed pause, rollback, continue, exit, unresolved-limitation, and next-roadmap capture criteria for the single-customer pilot."
+  "The decision surface is operational and reviewable. It is not a customer commercial terms sheet, public launch checklist, SLA acceptance record, multi-customer rollout gate, or multi-tenant expansion plan."
+  "Pilot pause, rollback, continue, and exit decisions remain subordinate to AegisOps authoritative records, the pilot readiness decision, support playbook evidence, operator handoff evidence, and the restore, rollback, and upgrade release-gate rehearsal."
+  "the decision: continue, pause, rollback, exit-success, exit-no-go, or capture-next-roadmap-input; and"
+  "The decision must use directly linked AegisOps records and retained evidence."
+  "Pause the pilot and keep normal operator use blocked when any of the following are true:"
+  "support expectations would require 24x7 coverage, customer-specific paid support terms, emergency authority bypass, direct backend access, or customer-private secret exposure;"
+  "Pause is a reviewed hold state, not a silent success, informal support escalation, commercial renegotiation, or permission to keep operating with guessed prerequisites."
+  "Escalate to rollback when the pilot cannot continue or pause safely on the current release because runtime, detector, coordination, assistant, support, evidence, or handoff drift would leave reviewed records ambiguous or untrustworthy."
+  'Rollback must align with `docs/deployment/restore-rollback-upgrade-evidence-rehearsal.md` and retain:'
+  "clean-state proof that no orphan record, partial durable write, half-restored state, or misleading handoff evidence survived the attempt."
+  "Rollback does not authorize direct source-side mutation, vendor-specific backup product dependency, HA choreography, direct backend exposure, optional-extension launch gates, ticket-system authority, assistant-owned workflow decisions, or customer-private production access."
+  "Exit-success is allowed only when the reviewed pilot record shows that the single-customer operating path stayed bounded and trustworthy for the reviewed pilot window."
+  "operator and support signoff that the queue, case, action-review, reviewed-record, non-authority, pause, rollback, and evidence handoff paths are understood; and"
+  "Exit-no-go is required when the pilot cannot prove those criteria, when rollback or clean-state evidence is missing after a failed path, or when the outcome would depend on customer commercial terms, public launch readiness, multi-customer rollout assumptions, or multi-tenant expansion criteria."
+  "Unresolved limitations must be handled as reviewed records with a disposition of block, accept-with-owner, rollback, disable, support-follow-up, or capture-next-roadmap-input."
+  "Next-roadmap input may capture candidate follow-up work from the pilot, but it must remain separate from Phase 43 acceptance."
+  "Captured input must not turn customer commercial terms, public launch checklist items, multi-customer rollout requirements, multi-tenant expansion criteria, optional-extension launch gates, or broad support promises into current pilot scope."
+  "Before continuing after a pause, accepting rollback completion, or recording exit-success, operator and support signoff must confirm:"
+  "the support playbook was reviewed for degradation and break-glass handling;"
+  "the operator training packet was reviewed for queue, case, action-review, reviewed-record, non-authority, and evidence handoff practice;"
+  "no signoff relies on workstation-local absolute paths, live secrets, placeholder credentials, raw forwarded headers, ticket authority, assistant authority, optional-extension health, or inferred scope."
+  'Verify this criteria document with `scripts/verify-pilot-pause-rollback-exit-criteria.sh`.'
+  'Negative validation for the verifier is `scripts/test-verify-pilot-pause-rollback-exit-criteria.sh`.'
+  "Customer commercial terms, formal SLA commitments, public launch checklist ownership, hosted release channels, multi-customer rollout, multi-tenant expansion criteria, direct customer-private production access, direct backend exposure, optional-extension launch gates, ticket-system authority, assistant-owned workflow authority, and broad support promises beyond the reviewed business-hours single-customer pilot are out of scope."
+)
+
+for phrase in "${required_criteria_phrases[@]}"; do
+  require_phrase "${criteria_path}" "${phrase}" "pilot pause rollback exit criteria statement"
+done
+
+require_phrase "${runbook_path}" 'Before continuing, pausing, rolling back, or exiting a single-customer pilot, review `docs/deployment/pilot-pause-rollback-exit-criteria.md` and verify it with `scripts/verify-pilot-pause-rollback-exit-criteria.sh` so pause criteria, rollback criteria, exit criteria, unresolved limitations, next-roadmap input, and operator/support signoff remain bounded to Phase 43.' "runbook pilot pause rollback exit criteria link"
+require_phrase "${pilot_checklist_path}" 'Pilot pause, rollback, and exit decisions must use `docs/deployment/pilot-pause-rollback-exit-criteria.md`; entry readiness alone is not exit-success, rollback acceptance, or permission to continue after a paused or degraded pilot.' "pilot readiness pause rollback exit criteria link"
+require_phrase "${support_path}" 'Pilot pause, rollback, and exit decisions must use `docs/deployment/pilot-pause-rollback-exit-criteria.md` so support degradation, break-glass evidence, rollback escalation, unresolved limitations, and next-roadmap input remain reviewed and bounded.' "support playbook pause rollback exit criteria link"
+require_phrase "${operator_packet_path}" 'For pilot pause, rollback, continue, or exit signoff, operators must use `docs/deployment/pilot-pause-rollback-exit-criteria.md` after completing the queue, case, action-review, reviewed-record, non-authority, and evidence handoff walkthrough.' "operator training pause rollback exit criteria link"
+require_phrase "${release_handoff_path}" 'Pilot exit-success, exit-no-go, pause, continue, and rollback decisions must point to `docs/deployment/pilot-pause-rollback-exit-criteria.md` instead of treating release handoff alone as pilot success.' "release handoff pause rollback exit criteria link"
+require_phrase "${operational_handoff_path}" 'Pilot pause, rollback, continue, and exit evidence must use `docs/deployment/pilot-pause-rollback-exit-criteria.md` as the reviewed operator/support decision surface for unresolved limitations and next-roadmap input capture.' "operational handoff pause rollback exit criteria link"
+require_phrase "${restore_path}" 'Pilot rollback acceptance must stay aligned to `docs/deployment/pilot-pause-rollback-exit-criteria.md`; a same-day rollback decision is not accepted for pilot continuation or exit until operator/support signoff, refusal reason when applicable, and clean-state evidence are retained.' "restore rollback rehearsal pause rollback exit criteria link"
+
+for doc_path in \
+  "${criteria_path}" \
+  "${pilot_checklist_path}" \
+  "${support_path}" \
+  "${operator_packet_path}" \
+  "${release_handoff_path}" \
+  "${operational_handoff_path}" \
+  "${restore_path}"; do
+  for forbidden in \
+    "customer commercial terms are approved" \
+    "public launch checklist is approved" \
+    "multi-tenant expansion is approved" \
+    "multi-customer rollout is approved" \
+    "24x7 support is promised" \
+    "SLA is promised" \
+    "ticket status is authoritative" \
+    "assistant may approve" \
+    "assistant may execute"; do
+    reject_phrase "${doc_path}" "${forbidden}" "pilot pause rollback exit criteria statement"
+  done
+done
+
+reject_workstation_paths "pilot pause rollback exit guidance" \
+  "${criteria_path}" \
+  "${runbook_path}" \
+  "${pilot_checklist_path}" \
+  "${support_path}" \
+  "${operator_packet_path}" \
+  "${release_handoff_path}" \
+  "${operational_handoff_path}" \
+  "${restore_path}"
+
+echo "Pilot pause, rollback, exit, unresolved limitation, next-roadmap, and operator/support signoff criteria are present and bounded."


### PR DESCRIPTION
## Summary
- add reviewed pilot pause, rollback, exit, unresolved-limitation, and next-roadmap criteria
- add focused verifier plus negative tests and wire them into CI
- cross-link the criteria from runbook, pilot readiness, support, operator handoff, release handoff, operational handoff, and rollback rehearsal docs

## Verification
- bash scripts/verify-pilot-pause-rollback-exit-criteria.sh
- bash scripts/test-verify-pilot-pause-rollback-exit-criteria.sh
- bash scripts/verify-pilot-readiness-checklist.sh && bash scripts/test-verify-pilot-readiness-checklist.sh
- bash scripts/verify-support-playbook-break-glass-rehearsal.sh && bash scripts/test-verify-support-playbook-break-glass-rehearsal.sh
- bash scripts/verify-operator-training-handoff-packet.sh && bash scripts/test-verify-operator-training-handoff-packet.sh
- bash scripts/verify-phase-37-restore-rollback-upgrade-evidence.sh && bash scripts/test-verify-phase-37-restore-rollback-upgrade-evidence.sh
- bash scripts/verify-release-handoff-evidence-package.sh && bash scripts/test-verify-release-handoff-evidence-package.sh
- bash scripts/verify-phase-33-operational-evidence-handoff-pack.sh && bash scripts/test-verify-phase-33-operational-evidence-handoff-pack.sh
- bash scripts/verify-runbook-doc.sh && bash scripts/test-verify-runbook-doc.sh
- bash scripts/verify-publishable-path-hygiene.sh
- git diff --check

Closes #827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new governance criteria for pilot pause, rollback, and exit decisions
  * Updated deployment procedures and operator training materials to enforce the new criteria throughout pilot lifecycle management

* **Tests**
  * Added verification scripts to validate compliance with updated pilot governance requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->