### PR TITLE
Expose reviewed first-boot operator reads

### DIFF
--- a/control-plane/deployment/first-boot/docker-compose.yml
+++ b/control-plane/deployment/first-boot/docker-compose.yml
@@ -67,4 +67,4 @@ services:
       - ../../../proxy/nginx/conf.d-first-boot:/etc/nginx/conf.d:ro
       - /srv/aegisops/proxy-certs-placeholder:/etc/nginx/certs:ro
     # approved reverse-proxy boundary only; backend services remain internal
-    # reviewed user-facing route implementation is limited to health, readiness, and runtime inspection
+    # reviewed route implementation is limited to health, readiness, runtime, and protected read-only operator inspection

--- a/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
+++ b/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
@@ -119,23 +119,43 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
             "location = /inspect-reconciliation-status {",
             "proxy_pass http://aegisops_control_plane/inspect-reconciliation-status;",
             "location = /inspect-analyst-queue {",
-            "proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;",
             "location = /inspect-alert-detail {",
-            "proxy_pass http://aegisops_control_plane/inspect-alert-detail$is_args$args;",
             "location = /inspect-case-detail {",
-            "proxy_pass http://aegisops_control_plane/inspect-case-detail$is_args$args;",
             "location = /inspect-action-review {",
-            "proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;",
             "location = /inspect-advisory-output {",
-            "proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;",
             "location = /operator/queue {",
-            "proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;",
         )
         for term in reviewed_routes:
             self.assertIn(term, text)
 
+        read_only_route_targets = {
+            "/inspect-analyst-queue": (
+                "proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;"
+            ),
+            "/inspect-alert-detail": (
+                "proxy_pass http://aegisops_control_plane/inspect-alert-detail$is_args$args;"
+            ),
+            "/inspect-case-detail": (
+                "proxy_pass http://aegisops_control_plane/inspect-case-detail$is_args$args;"
+            ),
+            "/inspect-action-review": (
+                "proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;"
+            ),
+            "/inspect-advisory-output": (
+                "proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;"
+            ),
+            "/operator/queue": (
+                "proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;"
+            ),
+        }
+        for route, target in read_only_route_targets.items():
+            block = self._nginx_location_block(text, route)
+            self.assertIn("limit_except GET { deny all; }", block)
+            self.assertIn(target, block)
+
         for forbidden in (
             "render-recommendation-draft",
+            "/inspect-assistant-context",
             "/operator/promote-alert-to-case",
             "/operator/record-case-observation",
             "/operator/record-action-approval-decision",
@@ -150,6 +170,16 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
             compose_text,
             "control-plane",
         )
+
+    @staticmethod
+    def _nginx_location_block(config_text: str, route: str) -> str:
+        match = re.search(
+            rf"(?ms)^  location = {re.escape(route)} \{{\n(.*?)(?=^  \}})",
+            config_text,
+        )
+        if match is None:
+            raise AssertionError(f"expected first-boot proxy location block for {route}")
+        return match.group(1)
 
     @staticmethod
     def _service_block(compose_text: str, service_name: str) -> str:

--- a/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
+++ b/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
@@ -150,7 +150,7 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
         }
         for route, target in read_only_route_targets.items():
             block = self._nginx_location_block(text, route)
-            self.assertIn("limit_except GET { deny all; }", block)
+            self.assertIn("limit_except GET HEAD { deny all; }", block)
             self.assertIn(target, block)
 
         for forbidden in (

--- a/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
+++ b/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
@@ -105,7 +105,7 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
         self.assertTrue(proxy_config.exists(), f"expected first-boot proxy config at {proxy_config}")
 
         text = proxy_config.read_text(encoding="utf-8")
-        for term in (
+        reviewed_routes = (
             "upstream aegisops_control_plane {",
             "server control-plane:8080;",
             "location = /healthz {",
@@ -118,13 +118,29 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
             "proxy_pass http://aegisops_control_plane/inspect-records$is_args$args;",
             "location = /inspect-reconciliation-status {",
             "proxy_pass http://aegisops_control_plane/inspect-reconciliation-status;",
-        ):
+            "location = /inspect-analyst-queue {",
+            "proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;",
+            "location = /inspect-alert-detail {",
+            "proxy_pass http://aegisops_control_plane/inspect-alert-detail$is_args$args;",
+            "location = /inspect-case-detail {",
+            "proxy_pass http://aegisops_control_plane/inspect-case-detail$is_args$args;",
+            "location = /inspect-action-review {",
+            "proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;",
+            "location = /inspect-advisory-output {",
+            "proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;",
+            "location = /operator/queue {",
+            "proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;",
+        )
+        for term in reviewed_routes:
             self.assertIn(term, text)
 
         for forbidden in (
-            "inspect-assistant-context",
-            "inspect-advisory-output",
             "render-recommendation-draft",
+            "/operator/promote-alert-to-case",
+            "/operator/record-case-observation",
+            "/operator/record-action-approval-decision",
+            "/operator/create-reviewed-action-request",
+            "/admin/bootstrap",
         ):
             self.assertNotIn(forbidden, text)
 

--- a/docs/deployment/runtime-smoke-bundle.md
+++ b/docs/deployment/runtime-smoke-bundle.md
@@ -92,10 +92,28 @@ Confirm protected runtime inspection through the reviewed proxy and trusted oper
 curl -fsS <trusted-platform-admin-proxy-auth-headers> http://127.0.0.1:<proxy-port>/runtime
 ```
 
+Confirm the reviewed analyst queue read surface through the protected boundary:
+
+```sh
+curl -fsS <trusted-operator-read-only-proxy-auth-headers> http://127.0.0.1:<proxy-port>/inspect-analyst-queue
+```
+
+Confirm the reviewed `/operator/queue` route reaches the same backend-authoritative queue read surface:
+
+```sh
+curl -fsS <trusted-operator-read-only-proxy-auth-headers> http://127.0.0.1:<proxy-port>/operator/queue
+```
+
 Confirm read-only alert visibility through the reviewed proxy:
 
 ```sh
 curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-records?family=alerts"
+```
+
+Confirm reviewed alert detail visibility through the reviewed proxy:
+
+```sh
+curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-alert-detail?alert_id=<reviewed-alert-id>"
 ```
 
 Confirm read-only case visibility through the reviewed proxy:
@@ -104,10 +122,28 @@ Confirm read-only case visibility through the reviewed proxy:
 curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-records?family=cases"
 ```
 
+Confirm reviewed case detail visibility through the reviewed proxy:
+
+```sh
+curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-case-detail?case_id=<reviewed-case-id>"
+```
+
 Confirm action-review records are inspectable without creating a new request:
 
 ```sh
 curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-records?family=action_requests"
+```
+
+Confirm the reviewed action-review detail surface remains read-only:
+
+```sh
+curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-action-review?action_request_id=<reviewed-action-request-id>"
+```
+
+Confirm the assistant advisory read surface stays subordinate to the reviewed record:
+
+```sh
+curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-advisory-output?family=case&record_id=<reviewed-case-id>"
 ```
 
 Confirm reconciliation status remains readable from the protected mainline surface:

--- a/proxy/nginx/conf.d-first-boot/control-plane.conf
+++ b/proxy/nginx/conf.d-first-boot/control-plane.conf
@@ -32,6 +32,30 @@ server {
     proxy_pass http://aegisops_control_plane/inspect-reconciliation-status;
   }
 
+  location = /inspect-analyst-queue {
+    proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
+  }
+
+  location = /inspect-alert-detail {
+    proxy_pass http://aegisops_control_plane/inspect-alert-detail$is_args$args;
+  }
+
+  location = /inspect-case-detail {
+    proxy_pass http://aegisops_control_plane/inspect-case-detail$is_args$args;
+  }
+
+  location = /inspect-action-review {
+    proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;
+  }
+
+  location = /inspect-advisory-output {
+    proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;
+  }
+
+  location = /operator/queue {
+    proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
+  }
+
   location / {
     return 404;
   }

--- a/proxy/nginx/conf.d-first-boot/control-plane.conf
+++ b/proxy/nginx/conf.d-first-boot/control-plane.conf
@@ -33,32 +33,32 @@ server {
   }
 
   location = /inspect-analyst-queue {
-    limit_except GET { deny all; }
+    limit_except GET HEAD { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
   }
 
   location = /inspect-alert-detail {
-    limit_except GET { deny all; }
+    limit_except GET HEAD { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-alert-detail$is_args$args;
   }
 
   location = /inspect-case-detail {
-    limit_except GET { deny all; }
+    limit_except GET HEAD { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-case-detail$is_args$args;
   }
 
   location = /inspect-action-review {
-    limit_except GET { deny all; }
+    limit_except GET HEAD { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;
   }
 
   location = /inspect-advisory-output {
-    limit_except GET { deny all; }
+    limit_except GET HEAD { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;
   }
 
   location = /operator/queue {
-    limit_except GET { deny all; }
+    limit_except GET HEAD { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
   }
 

--- a/proxy/nginx/conf.d-first-boot/control-plane.conf
+++ b/proxy/nginx/conf.d-first-boot/control-plane.conf
@@ -33,26 +33,32 @@ server {
   }
 
   location = /inspect-analyst-queue {
+    limit_except GET { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
   }
 
   location = /inspect-alert-detail {
+    limit_except GET { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-alert-detail$is_args$args;
   }
 
   location = /inspect-case-detail {
+    limit_except GET { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-case-detail$is_args$args;
   }
 
   location = /inspect-action-review {
+    limit_except GET { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;
   }
 
   location = /inspect-advisory-output {
+    limit_except GET { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;
   }
 
   location = /operator/queue {
+    limit_except GET { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
   }
 

--- a/scripts/test-verify-phase-33-runtime-smoke-bundle.sh
+++ b/scripts/test-verify-phase-33-runtime-smoke-bundle.sh
@@ -48,6 +48,18 @@ location = /inspect-records {
 }
 location = /inspect-reconciliation-status {
 }
+location = /inspect-analyst-queue {
+}
+location = /inspect-alert-detail {
+}
+location = /inspect-case-detail {
+}
+location = /inspect-action-review {
+}
+location = /inspect-advisory-output {
+}
+location = /operator/queue {
+}
 EOF
 }
 
@@ -113,11 +125,23 @@ Use a reviewed `analyst`, `approver`, or `platform_admin` role for `<trusted-ope
 
 Use `curl -fsS <trusted-platform-admin-proxy-auth-headers> http://127.0.0.1:<proxy-port>/runtime`.
 
+Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> http://127.0.0.1:<proxy-port>/inspect-analyst-queue`.
+
+Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> http://127.0.0.1:<proxy-port>/operator/queue`.
+
 Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-records?family=alerts"`.
+
+Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-alert-detail?alert_id=<reviewed-alert-id>"`.
 
 Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-records?family=cases"`.
 
+Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-case-detail?case_id=<reviewed-case-id>"`.
+
 Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-records?family=action_requests"`.
+
+Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-action-review?action_request_id=<reviewed-action-request-id>"`.
+
+Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-advisory-output?family=case&record_id=<reviewed-case-id>"`.
 
 Use `curl -fsS <trusted-operator-read-only-proxy-auth-headers> http://127.0.0.1:<proxy-port>/inspect-reconciliation-status`.
 

--- a/scripts/test-verify-phase-33-runtime-smoke-bundle.sh
+++ b/scripts/test-verify-phase-33-runtime-smoke-bundle.sh
@@ -54,27 +54,27 @@ location = /inspect-reconciliation-status {
   proxy_pass http://aegisops_control_plane/inspect-reconciliation-status;
 }
 location = /inspect-analyst-queue {
-  limit_except GET { deny all; }
+  limit_except GET HEAD { deny all; }
   proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
 }
 location = /inspect-alert-detail {
-  limit_except GET { deny all; }
+  limit_except GET HEAD { deny all; }
   proxy_pass http://aegisops_control_plane/inspect-alert-detail$is_args$args;
 }
 location = /inspect-case-detail {
-  limit_except GET { deny all; }
+  limit_except GET HEAD { deny all; }
   proxy_pass http://aegisops_control_plane/inspect-case-detail$is_args$args;
 }
 location = /inspect-action-review {
-  limit_except GET { deny all; }
+  limit_except GET HEAD { deny all; }
   proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;
 }
 location = /inspect-advisory-output {
-  limit_except GET { deny all; }
+  limit_except GET HEAD { deny all; }
   proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;
 }
 location = /operator/queue {
-  limit_except GET { deny all; }
+  limit_except GET HEAD { deny all; }
   proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
 }
 EOF

--- a/scripts/test-verify-phase-33-runtime-smoke-bundle.sh
+++ b/scripts/test-verify-phase-33-runtime-smoke-bundle.sh
@@ -39,26 +39,43 @@ EOF
 
   cat <<'EOF' > "${target}/proxy/nginx/conf.d-first-boot/control-plane.conf"
 location = /healthz {
+  proxy_pass http://aegisops_control_plane/healthz;
 }
 location = /readyz {
+  proxy_pass http://aegisops_control_plane/readyz;
 }
 location = /runtime {
+  proxy_pass http://aegisops_control_plane/runtime;
 }
 location = /inspect-records {
+  proxy_pass http://aegisops_control_plane/inspect-records$is_args$args;
 }
 location = /inspect-reconciliation-status {
+  proxy_pass http://aegisops_control_plane/inspect-reconciliation-status;
 }
 location = /inspect-analyst-queue {
+  limit_except GET { deny all; }
+  proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
 }
 location = /inspect-alert-detail {
+  limit_except GET { deny all; }
+  proxy_pass http://aegisops_control_plane/inspect-alert-detail$is_args$args;
 }
 location = /inspect-case-detail {
+  limit_except GET { deny all; }
+  proxy_pass http://aegisops_control_plane/inspect-case-detail$is_args$args;
 }
 location = /inspect-action-review {
+  limit_except GET { deny all; }
+  proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;
 }
 location = /inspect-advisory-output {
+  limit_except GET { deny all; }
+  proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;
 }
 location = /operator/queue {
+  limit_except GET { deny all; }
+  proxy_pass http://aegisops_control_plane/inspect-analyst-queue$is_args$args;
 }
 EOF
 }
@@ -253,9 +270,17 @@ missing_proxy_route_repo="${workdir}/missing-proxy-route"
 create_repo "${missing_proxy_route_repo}"
 write_shared_docs "${missing_proxy_route_repo}"
 write_valid_bundle "${missing_proxy_route_repo}"
-perl -0pi -e 's/location = \/inspect-reconciliation-status \{\n\}\n//' "${missing_proxy_route_repo}/proxy/nginx/conf.d-first-boot/control-plane.conf"
+perl -0pi -e 's/location = \/inspect-reconciliation-status \{\n  proxy_pass http:\/\/aegisops_control_plane\/inspect-reconciliation-status;\n\}\n//' "${missing_proxy_route_repo}/proxy/nginx/conf.d-first-boot/control-plane.conf"
 commit_fixture "${missing_proxy_route_repo}"
 assert_fails_with "${missing_proxy_route_repo}" "Missing first-boot proxy smoke route: location = /inspect-reconciliation-status"
+
+miswired_proxy_route_repo="${workdir}/miswired-proxy-route"
+create_repo "${miswired_proxy_route_repo}"
+write_shared_docs "${miswired_proxy_route_repo}"
+write_valid_bundle "${miswired_proxy_route_repo}"
+perl -0pi -e 's/proxy_pass http:\/\/aegisops_control_plane\/inspect-action-review\$is_args\$args;/proxy_pass http:\/\/aegisops_control_plane\/inspect-records\$is_args\$args;/' "${miswired_proxy_route_repo}/proxy/nginx/conf.d-first-boot/control-plane.conf"
+commit_fixture "${miswired_proxy_route_repo}"
+assert_fails_with "${miswired_proxy_route_repo}" 'Missing first-boot proxy smoke route: proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;'
 
 forbidden_low_risk_write_repo="${workdir}/forbidden-low-risk-write"
 create_repo "${forbidden_low_risk_write_repo}"

--- a/scripts/verify-phase-16-first-boot-contract.sh
+++ b/scripts/verify-phase-16-first-boot-contract.sh
@@ -196,7 +196,7 @@ compose_lines=(
   '    # reviewed image-backed first-boot control-plane runtime only'
   '    # optional extensions remain out of scope for this first-boot path'
   '    # do not add OpenSearch, n8n, analyst-assistant UI, or executor services here'
-  '    # reviewed user-facing route implementation is limited to health, readiness, and runtime inspection'
+  '    # reviewed route implementation is limited to health, readiness, runtime, and protected read-only operator inspection'
 )
 for line in "${compose_lines[@]}"; do
   require_fixed_string "${compose_file}" "${line}"

--- a/scripts/verify-phase-33-runtime-smoke-bundle.sh
+++ b/scripts/verify-phase-33-runtime-smoke-bundle.sh
@@ -98,19 +98,30 @@ done
 require_phrase "${runbook_path}" 'The Phase 33 runtime smoke bundle in `docs/deployment/runtime-smoke-bundle.md` is the reviewed post-deployment and post-upgrade handoff check for this runbook.' "runbook Phase 33 smoke bundle link"
 require_phrase "${profile_path}" 'Post-upgrade smoke checks are the reviewed runtime smoke bundle in `docs/deployment/runtime-smoke-bundle.md`:' "single-customer profile Phase 33 smoke bundle link"
 
-for proxy_path_fragment in \
-  "/healthz" \
-  "/readyz" \
-  "/runtime" \
-  "/inspect-records" \
-  "/inspect-reconciliation-status" \
-  "/inspect-analyst-queue" \
-  "/inspect-alert-detail" \
-  "/inspect-case-detail" \
-  "/inspect-action-review" \
-  "/inspect-advisory-output" \
-  "/operator/queue"; do
-  require_phrase "${proxy_path}" "location = ${proxy_path_fragment}" "first-boot proxy smoke route"
+for required_proxy_line in \
+  "location = /healthz {" \
+  "proxy_pass http://aegisops_control_plane/healthz;" \
+  "location = /readyz {" \
+  "proxy_pass http://aegisops_control_plane/readyz;" \
+  "location = /runtime {" \
+  "proxy_pass http://aegisops_control_plane/runtime;" \
+  "location = /inspect-records {" \
+  "proxy_pass http://aegisops_control_plane/inspect-records\$is_args\$args;" \
+  "location = /inspect-reconciliation-status {" \
+  "proxy_pass http://aegisops_control_plane/inspect-reconciliation-status;" \
+  "location = /inspect-analyst-queue {" \
+  "proxy_pass http://aegisops_control_plane/inspect-analyst-queue\$is_args\$args;" \
+  "location = /inspect-alert-detail {" \
+  "proxy_pass http://aegisops_control_plane/inspect-alert-detail\$is_args\$args;" \
+  "location = /inspect-case-detail {" \
+  "proxy_pass http://aegisops_control_plane/inspect-case-detail\$is_args\$args;" \
+  "location = /inspect-action-review {" \
+  "proxy_pass http://aegisops_control_plane/inspect-action-review\$is_args\$args;" \
+  "location = /inspect-advisory-output {" \
+  "proxy_pass http://aegisops_control_plane/inspect-advisory-output\$is_args\$args;" \
+  "location = /operator/queue {" \
+  "proxy_pass http://aegisops_control_plane/inspect-analyst-queue\$is_args\$args;"; do
+  require_phrase "${proxy_path}" "${required_proxy_line}" "first-boot proxy smoke route"
 done
 
 for forbidden in "requires OpenSearch" "requires n8n" "requires Shuffle" "requires ML shadow" "execute the low-risk action" "POST /operator/create-reviewed-action-request"; do

--- a/scripts/verify-phase-33-runtime-smoke-bundle.sh
+++ b/scripts/verify-phase-33-runtime-smoke-bundle.sh
@@ -74,9 +74,15 @@ required_phrases=(
   'Use a reviewed `platform_admin` role for `<trusted-platform-admin-proxy-auth-headers>` because `/runtime` is platform-admin protected.'
   'Use a reviewed `analyst`, `approver`, or `platform_admin` role for `<trusted-operator-read-only-proxy-auth-headers>` because the read-only inspection routes accept those operator roles.'
   'curl -fsS <trusted-platform-admin-proxy-auth-headers> http://127.0.0.1:<proxy-port>/runtime'
+  'curl -fsS <trusted-operator-read-only-proxy-auth-headers> http://127.0.0.1:<proxy-port>/inspect-analyst-queue'
+  'curl -fsS <trusted-operator-read-only-proxy-auth-headers> http://127.0.0.1:<proxy-port>/operator/queue'
   'curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-records?family=alerts"'
+  'curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-alert-detail?alert_id=<reviewed-alert-id>"'
   'curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-records?family=cases"'
+  'curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-case-detail?case_id=<reviewed-case-id>"'
   'curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-records?family=action_requests"'
+  'curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-action-review?action_request_id=<reviewed-action-request-id>"'
+  'curl -fsS <trusted-operator-read-only-proxy-auth-headers> "http://127.0.0.1:<proxy-port>/inspect-advisory-output?family=case&record_id=<reviewed-case-id>"'
   'curl -fsS <trusted-operator-read-only-proxy-auth-headers> http://127.0.0.1:<proxy-port>/inspect-reconciliation-status'
   'Confirm the operator console can render `/operator/queue` or the configured operator-console base path with the same reviewed backend session, then keep the check read-only.'
   "Confirm the first candidate low-risk action remains in precondition review only: a reviewed alert or case is selected, an allowed low-risk action type is identified, approver ownership is known, and no action request, approval decision, delegation, executor dispatch, or reconciliation write is performed by this smoke bundle."
@@ -92,7 +98,18 @@ done
 require_phrase "${runbook_path}" 'The Phase 33 runtime smoke bundle in `docs/deployment/runtime-smoke-bundle.md` is the reviewed post-deployment and post-upgrade handoff check for this runbook.' "runbook Phase 33 smoke bundle link"
 require_phrase "${profile_path}" 'Post-upgrade smoke checks are the reviewed runtime smoke bundle in `docs/deployment/runtime-smoke-bundle.md`:' "single-customer profile Phase 33 smoke bundle link"
 
-for proxy_path_fragment in "/healthz" "/readyz" "/runtime" "/inspect-records" "/inspect-reconciliation-status"; do
+for proxy_path_fragment in \
+  "/healthz" \
+  "/readyz" \
+  "/runtime" \
+  "/inspect-records" \
+  "/inspect-reconciliation-status" \
+  "/inspect-analyst-queue" \
+  "/inspect-alert-detail" \
+  "/inspect-case-detail" \
+  "/inspect-action-review" \
+  "/inspect-advisory-output" \
+  "/operator/queue"; do
   require_phrase "${proxy_path}" "location = ${proxy_path_fragment}" "first-boot proxy smoke route"
 done
 


### PR DESCRIPTION
## Summary
- Expose reviewed protected read-only operator surfaces through the first-boot proxy: queue, alert detail, case detail, action review, advisory output, reconciliation, and `/operator/queue`.
- Keep write/admin routes absent from the first-boot proxy surface.
- Align Phase 33 runtime smoke docs/verifier and Phase 16 first-boot route-scope wording with the proxy route list.

## Verification
- `python3 -m unittest control-plane.tests.test_phase17_first_boot_runtime_artifacts.Phase17FirstBootRuntimeArtifactTests.test_first_boot_proxy_routes_reviewed_runtime_surfaces_to_control_plane`
- `python3 -m unittest control-plane.tests.test_phase17_first_boot_runtime_artifacts`
- `python3 -m unittest control-plane.tests.test_phase16_first_boot_verifier`
- `bash scripts/verify-phase-33-runtime-smoke-bundle.sh`
- `bash scripts/test-verify-phase-33-runtime-smoke-bundle.sh`
- `bash scripts/verify-phase-16-first-boot-contract.sh`
- `bash scripts/verify-phase-37-runtime-smoke-gate.sh`
- `python3 -m unittest control-plane.tests.test_publishable_path_hygiene`
- `node dist/index.js issue-lint 835 --config supervisor.config.aegisops.coderabbit.json` from the supervisor checkout: `execution_ready=yes`, `missing_required=none`, `metadata_errors=none`

Live runtime smoke gate was not run because it requires a running first-boot stack plus untracked runtime env/secrets.

Closes #835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded protected read-only operator inspection endpoints: analyst queue visibility, alert/case/action detail inspection, and advisory output validation are now available.

* **Tests**
  * First-boot proxy route verification enhanced with expanded endpoint coverage and stricter control-plane exposure expectations.

* **Documentation**
  * Deployment documentation updated with verification commands for new protected read-only inspection endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->