### PR TITLE
Normalize first-boot proxy identity headers

### DIFF
--- a/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
+++ b/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
@@ -164,6 +164,52 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, text)
 
+    def test_first_boot_proxy_normalizes_protected_identity_headers(self) -> None:
+        proxy_config = REPO_ROOT / "proxy" / "nginx" / "conf.d-first-boot" / "control-plane.conf"
+        self.assertTrue(proxy_config.exists(), f"expected first-boot proxy config at {proxy_config}")
+
+        text = proxy_config.read_text(encoding="utf-8")
+        protected_identity_headers = (
+            "X-AegisOps-Proxy-Secret",
+            "X-AegisOps-Proxy-Service-Account",
+            "X-AegisOps-Authenticated-IdP",
+            "X-AegisOps-Authenticated-Subject",
+            "X-AegisOps-Authenticated-Identity",
+            "X-AegisOps-Authenticated-Role",
+        )
+
+        for header in protected_identity_headers:
+            self.assertIn(
+                f'proxy_set_header {header} "";',
+                text,
+                f"first-boot proxy must strip caller-supplied {header}",
+            )
+            nginx_client_header_var = "$http_" + header.lower().replace("-", "_")
+            self.assertNotIn(
+                nginx_client_header_var,
+                text,
+                f"first-boot proxy must not pass caller-supplied {header} through",
+            )
+
+        for route in (
+            "/runtime",
+            "/inspect-records",
+            "/inspect-reconciliation-status",
+            "/inspect-analyst-queue",
+            "/inspect-alert-detail",
+            "/inspect-case-detail",
+            "/inspect-action-review",
+            "/inspect-advisory-output",
+            "/operator/queue",
+        ):
+            block = self._nginx_location_block(text, route)
+            for header in protected_identity_headers:
+                self.assertNotIn(
+                    f"proxy_set_header {header} $http_",
+                    block,
+                    f"{route} must not override normalization with caller-supplied {header}",
+                )
+
     @staticmethod
     def _control_plane_service_block(compose_text: str) -> str:
         return Phase17FirstBootRuntimeArtifactTests._service_block(

--- a/proxy/nginx/conf.d-first-boot/control-plane.conf
+++ b/proxy/nginx/conf.d-first-boot/control-plane.conf
@@ -11,6 +11,15 @@ server {
   proxy_set_header Host $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
+  # The first-boot proxy does not yet have a reviewed authenticated identity
+  # source. Strip protected AegisOps identity headers from external callers so
+  # backend authorization stays authoritative and fails closed.
+  proxy_set_header X-AegisOps-Proxy-Secret "";
+  proxy_set_header X-AegisOps-Proxy-Service-Account "";
+  proxy_set_header X-AegisOps-Authenticated-IdP "";
+  proxy_set_header X-AegisOps-Authenticated-Subject "";
+  proxy_set_header X-AegisOps-Authenticated-Identity "";
+  proxy_set_header X-AegisOps-Authenticated-Role "";
 
   location = /healthz {
     proxy_pass http://aegisops_control_plane/healthz;


### PR DESCRIPTION
## Summary
- Strip caller-supplied protected `X-AegisOps-*` identity headers at the first-boot nginx proxy boundary.
- Add a focused first-boot proxy regression test covering the protected identity headers used by backend auth.

## Verification
- `python3 -m unittest control-plane/tests/test_phase17_first_boot_runtime_artifacts.py`
- `python3 -m unittest control-plane/tests/test_phase21_runtime_auth_validation.py`
- `python3 -m unittest control-plane/tests/test_phase17_boot_path_validation.py`
- `bash scripts/verify-phase-16-first-boot-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node dist/index.js issue-lint 836 --config supervisor.config.aegisops.coderabbit.json` -> `execution_ready=yes`, `missing_required=none`, `metadata_errors=none`

Closes #836
