### PR TITLE
Phase 44.5: activate operator-ui CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,31 @@ jobs:
       - name: Run control-plane runtime unit tests
         run: python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
 
+  operator-ui:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Run operator UI merge-gate checks
+        run: |
+          npm ci
+          npm run typecheck --workspace @aegisops/operator-ui
+          npm run test --workspace @aegisops/operator-ui
+          npm run build --workspace @aegisops/operator-ui
+
   focused-shell-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -320,3 +345,6 @@ jobs:
           bash scripts/test-verify-wazuh-rule-lifecycle-runbook.sh
           bash scripts/test-verify-windows-source-onboarding-assets.sh
           bash scripts/test-verify-ci-phase-29-workflow-coverage.sh
+
+      - name: Run operator UI workflow coverage guard
+        run: bash scripts/test-verify-ci-operator-ui-workflow-coverage.sh

--- a/apps/operator-ui/package.json
+++ b/apps/operator-ui/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit && vite build",
     "test": "vitest run",
     "test:e2e": "playwright test"

--- a/apps/operator-ui/src/app/OperatorRoutes.controlPlane.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.controlPlane.testSuite.tsx
@@ -298,7 +298,6 @@ export function registerOperatorRoutesControlPlaneTests() {
     });
 
     it("records bounded case observations, leads, and recommendations from case detail", async () => {
-      const user = userEvent.setup();
       let caseDetailPayload: Record<string, unknown> = {
         case_id: "case-456",
         case_record: {
@@ -430,17 +429,21 @@ export function registerOperatorRoutesControlPlaneTests() {
       });
       const observationCard = observationSection.closest(".MuiCard-root");
       expect(observationCard).not.toBeNull();
-      await user.type(
+      fireEvent.change(
         within(observationCard as HTMLElement).getByRole("textbox", {
           name: "Observed at",
         }),
-        "2026-04-22T00:00",
+        { target: { value: "2026-04-22T00:00" } },
       );
-      await user.type(
+      fireEvent.change(
         within(observationCard as HTMLElement).getByRole("textbox", {
           name: "Scope statement",
         }),
-        "Observed repository permission change requires tracked review.",
+        {
+          target: {
+            value: "Observed repository permission change requires tracked review.",
+          },
+        },
       );
       const supportingEvidenceField = within(observationCard as HTMLElement).getByRole(
         "textbox",
@@ -448,10 +451,11 @@ export function registerOperatorRoutesControlPlaneTests() {
           name: "Supporting evidence ids",
         },
       );
-      await user.clear(supportingEvidenceField);
-      await user.type(supportingEvidenceField, "evidence-123, evidence-456");
-      await user.click(within(observationCard as HTMLElement).getByRole("checkbox"));
-      await user.click(
+      fireEvent.change(supportingEvidenceField, {
+        target: { value: "evidence-123, evidence-456" },
+      });
+      fireEvent.click(within(observationCard as HTMLElement).getByRole("checkbox"));
+      fireEvent.click(
         within(observationCard as HTMLElement).getByRole("button", { name: "Record observation" }),
       );
       await waitFor(() => {
@@ -467,20 +471,24 @@ export function registerOperatorRoutesControlPlaneTests() {
       const leadSection = screen.getByRole("heading", { name: "Record case lead" });
       const leadCard = leadSection.closest(".MuiCard-root");
       expect(leadCard).not.toBeNull();
-      await user.type(
+      fireEvent.change(
         within(leadCard as HTMLElement).getByRole("textbox", {
           name: "Observation id",
         }),
-        "observation-123",
+        { target: { value: "observation-123" } },
       );
-      await user.type(
+      fireEvent.change(
         within(leadCard as HTMLElement).getByRole("textbox", {
           name: "Triage rationale",
         }),
-        "Privilege-impacting change needs durable follow-up.",
+        {
+          target: {
+            value: "Privilege-impacting change needs durable follow-up.",
+          },
+        },
       );
-      await user.click(within(leadCard as HTMLElement).getByRole("checkbox"));
-      await user.click(
+      fireEvent.click(within(leadCard as HTMLElement).getByRole("checkbox"));
+      fireEvent.click(
         within(leadCard as HTMLElement).getByRole("button", { name: "Record lead" }),
       );
       await waitFor(() => {
@@ -498,20 +506,24 @@ export function registerOperatorRoutesControlPlaneTests() {
       });
       const recommendationCard = recommendationSection.closest(".MuiCard-root");
       expect(recommendationCard).not.toBeNull();
-      await user.type(
+      fireEvent.change(
         within(recommendationCard as HTMLElement).getByRole("textbox", {
           name: "Lead id",
         }),
-        "lead-123",
+        { target: { value: "lead-123" } },
       );
-      await user.type(
+      fireEvent.change(
         within(recommendationCard as HTMLElement).getByRole("textbox", {
           name: "Intended outcome",
         }),
-        "Review repository owner change evidence before approval.",
+        {
+          target: {
+            value: "Review repository owner change evidence before approval.",
+          },
+        },
       );
-      await user.click(within(recommendationCard as HTMLElement).getByRole("checkbox"));
-      await user.click(
+      fireEvent.click(within(recommendationCard as HTMLElement).getByRole("checkbox"));
+      fireEvent.click(
         within(recommendationCard as HTMLElement).getByRole("button", {
           name: "Record recommendation",
         }),

--- a/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
@@ -46,6 +46,46 @@ function setTextboxValue(name: string, value: string) {
   });
 }
 
+function renderCaseworkResetHarness() {
+  return renderWithTaskActionProviders(
+    <CaseworkCardsHarness
+      actionRequestId="action-request-456"
+      actionRequestState="pending_approval"
+      approvalState="pending"
+      caseId="case-456"
+      decisionRationale="Pending review"
+      expiresAt="2026-05-01T00:00:00Z"
+      linkedEvidenceIds={["evidence-123"]}
+      linkedLeadIds={["lead-123"]}
+      linkedObservationIds={["observation-123"]}
+      linkedRecommendationIds={["recommendation-123"]}
+    />,
+  );
+}
+
+function rerenderCaseworkResetHarness(rerender: ReturnType<typeof render>["rerender"]) {
+  rerender(
+    <AdminContext dataProvider={testDataProvider}>
+      <TaskActionClientProvider
+        client={createOperatorTaskActionClient({ fetchFn: vi.fn<typeof fetch>() })}
+      >
+        <CaseworkCardsHarness
+          actionRequestId="action-request-789"
+          actionRequestState="granted"
+          approvalState="approved"
+          caseId="case-789"
+          decisionRationale="Already granted"
+          expiresAt="2026-06-01T00:00:00Z"
+          linkedEvidenceIds={["evidence-789"]}
+          linkedLeadIds={["lead-789"]}
+          linkedObservationIds={["observation-789"]}
+          linkedRecommendationIds={["recommendation-789"]}
+        />
+      </TaskActionClientProvider>
+    </AdminContext>,
+  );
+}
+
 function PromoteAlertCardHarness({
   alertId,
   currentCaseId,
@@ -222,20 +262,7 @@ describe("caseworkActionCards", () => {
   });
 
   it("resets observation, lead, and recommendation drafts when the bound case id changes", async () => {
-    const { rerender } = renderWithTaskActionProviders(
-      <CaseworkCardsHarness
-        actionRequestId="action-request-456"
-        actionRequestState="pending_approval"
-        approvalState="pending"
-        caseId="case-456"
-        decisionRationale="Pending review"
-        expiresAt="2026-05-01T00:00:00Z"
-        linkedEvidenceIds={["evidence-123"]}
-        linkedLeadIds={["lead-123"]}
-        linkedObservationIds={["observation-123"]}
-        linkedRecommendationIds={["recommendation-123"]}
-      />,
-    );
+    const { rerender } = renderCaseworkResetHarness();
 
     setTextboxValue("Observed at", "2026");
     setTextboxValue("Scope statement", "scope");
@@ -245,42 +272,8 @@ describe("caseworkActionCards", () => {
     setTextboxValue("Lead id", "stale-lead");
     setTextboxValue("Intended outcome", "stale-outcome");
     setTextboxValue("Recommendation id", "stale-recommendation");
-    setTextboxValue("Recipient identity", "owner-stale@example.com");
-    setTextboxValue("Message intent", "stale-intent");
-    setTextboxValue("Escalation reason", "stale-escalation");
-    setTextboxValue("Expires at", "2026-05");
-    setTextboxValue("Action request id override", "stale-request");
-    setTextboxValue("Decided at", "2026-04");
-    setTextboxValue("Decision rationale", "stale-decision-rationale");
-    setTextboxValue("Fallback at", "2026-04");
-    setTextboxValue("Reason", "stale-reason");
-    setTextboxValue("Action taken", "stale-action");
-    setTextboxValue("Verification evidence ids", "stale-evidence-list");
-    setTextboxValue("Residual uncertainty", "stale-uncertainty");
-    setTextboxValue("Escalated at", "2026-04");
-    setTextboxValue("Escalated to", "stale-manager");
-    setTextboxValue("Note", "stale-note");
 
-    rerender(
-      <AdminContext dataProvider={testDataProvider}>
-        <TaskActionClientProvider
-          client={createOperatorTaskActionClient({ fetchFn: vi.fn<typeof fetch>() })}
-        >
-          <CaseworkCardsHarness
-            actionRequestId="action-request-789"
-            actionRequestState="granted"
-            approvalState="approved"
-            caseId="case-789"
-            decisionRationale="Already granted"
-            expiresAt="2026-06-01T00:00:00Z"
-            linkedEvidenceIds={["evidence-789"]}
-            linkedLeadIds={["lead-789"]}
-            linkedObservationIds={["observation-789"]}
-            linkedRecommendationIds={["recommendation-789"]}
-          />
-        </TaskActionClientProvider>
-      </AdminContext>,
-    );
+    rerenderCaseworkResetHarness(rerender);
 
     expect(screen.getByRole("textbox", { name: "Observed at" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Scope statement" })).toHaveValue("");
@@ -294,6 +287,24 @@ describe("caseworkActionCards", () => {
     expect(screen.getByRole("textbox", { name: "Recommendation id" })).toHaveValue(
       "recommendation-789",
     );
+    expect(screen.getByText("Known observation ids: observation-789")).toBeInTheDocument();
+    expect(screen.getByText("Known lead ids: lead-789")).toBeInTheDocument();
+    expect(screen.getByText("Known recommendation ids: recommendation-789")).toBeInTheDocument();
+  }, 15000);
+
+  it("resets action request and approval drafts when the bound case id changes", async () => {
+    const { rerender } = renderCaseworkResetHarness();
+
+    setTextboxValue("Recipient identity", "owner-stale@example.com");
+    setTextboxValue("Message intent", "stale-intent");
+    setTextboxValue("Escalation reason", "stale-escalation");
+    setTextboxValue("Expires at", "2026-05");
+    setTextboxValue("Action request id override", "stale-request");
+    setTextboxValue("Decided at", "2026-04");
+    setTextboxValue("Decision rationale", "stale-decision-rationale");
+
+    rerenderCaseworkResetHarness(rerender);
+
     expect(screen.getByRole("textbox", { name: "Recipient identity" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Message intent" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Escalation reason" })).toHaveValue("");
@@ -303,6 +314,22 @@ describe("caseworkActionCards", () => {
     expect(screen.getByRole("textbox", { name: "Decision rationale" })).toHaveValue(
       "Already granted",
     );
+  }, 15000);
+
+  it("resets manual follow-up drafts when the bound case id changes", async () => {
+    const { rerender } = renderCaseworkResetHarness();
+
+    setTextboxValue("Fallback at", "2026-04");
+    setTextboxValue("Reason", "stale-reason");
+    setTextboxValue("Action taken", "stale-action");
+    setTextboxValue("Verification evidence ids", "stale-evidence-list");
+    setTextboxValue("Residual uncertainty", "stale-uncertainty");
+    setTextboxValue("Escalated at", "2026-04");
+    setTextboxValue("Escalated to", "stale-manager");
+    setTextboxValue("Note", "stale-note");
+
+    rerenderCaseworkResetHarness(rerender);
+
     expect(screen.getByRole("textbox", { name: "Fallback at" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Reason" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Action taken" })).toHaveValue("");
@@ -313,8 +340,5 @@ describe("caseworkActionCards", () => {
     expect(screen.getByRole("textbox", { name: "Escalated at" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Escalated to" })).toHaveValue("");
     expect(screen.getByRole("textbox", { name: "Note" })).toHaveValue("");
-    expect(screen.getByText("Known observation ids: observation-789")).toBeInTheDocument();
-    expect(screen.getByText("Known lead ids: lead-789")).toBeInTheDocument();
-    expect(screen.getByText("Known recommendation ids: recommendation-789")).toBeInTheDocument();
   }, 15000);
 });

--- a/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
+++ b/apps/operator-ui/src/taskActions/caseworkActionCards.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AdminContext } from "react-admin";
 import type { ReactNode } from "react";
@@ -38,6 +38,12 @@ function renderWithTaskActionProviders(ui: ReactNode) {
       </TaskActionClientProvider>
     </AdminContext>,
   );
+}
+
+function setTextboxValue(name: string, value: string) {
+  fireEvent.change(screen.getByRole("textbox", { name }), {
+    target: { value },
+  });
 }
 
 function PromoteAlertCardHarness({
@@ -216,7 +222,6 @@ describe("caseworkActionCards", () => {
   });
 
   it("resets observation, lead, and recommendation drafts when the bound case id changes", async () => {
-    const user = userEvent.setup();
     const { rerender } = renderWithTaskActionProviders(
       <CaseworkCardsHarness
         actionRequestId="action-request-456"
@@ -232,72 +237,29 @@ describe("caseworkActionCards", () => {
       />,
     );
 
-    await user.type(screen.getByRole("textbox", { name: "Observed at" }), "2026");
-    await user.type(screen.getByRole("textbox", { name: "Scope statement" }), "scope");
-    await user.clear(screen.getByRole("textbox", { name: "Supporting evidence ids" }));
-    await user.type(
-      screen.getByRole("textbox", { name: "Supporting evidence ids" }),
-      "stale-evidence",
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: "Observation id" }),
-      "stale-observation",
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: "Triage rationale" }),
-      "stale-rationale",
-    );
-    await user.type(screen.getByRole("textbox", { name: "Lead id" }), "stale-lead");
-    await user.type(
-      screen.getByRole("textbox", { name: "Intended outcome" }),
-      "stale-outcome",
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: "Recommendation id" }),
-      "stale-recommendation",
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: "Recipient identity" }),
-      "owner-stale@example.com",
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: "Message intent" }),
-      "stale-intent",
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: "Escalation reason" }),
-      "stale-escalation",
-    );
-    await user.type(screen.getByRole("textbox", { name: "Expires at" }), "2026-05");
-    await user.type(
-      screen.getByRole("textbox", { name: "Action request id override" }),
-      "stale-request",
-    );
-    await user.type(screen.getByRole("textbox", { name: "Decided at" }), "2026-04");
-    await user.type(
-      screen.getByRole("textbox", { name: "Decision rationale" }),
-      "stale-decision-rationale",
-    );
-    await user.type(screen.getByRole("textbox", { name: "Fallback at" }), "2026-04");
-    await user.type(screen.getByRole("textbox", { name: "Reason" }), "stale-reason");
-    await user.type(
-      screen.getByRole("textbox", { name: "Action taken" }),
-      "stale-action",
-    );
-    await user.clear(
-      screen.getByRole("textbox", { name: "Verification evidence ids" }),
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: "Verification evidence ids" }),
-      "stale-evidence-list",
-    );
-    await user.type(
-      screen.getByRole("textbox", { name: "Residual uncertainty" }),
-      "stale-uncertainty",
-    );
-    await user.type(screen.getByRole("textbox", { name: "Escalated at" }), "2026-04");
-    await user.type(screen.getByRole("textbox", { name: "Escalated to" }), "stale-manager");
-    await user.type(screen.getByRole("textbox", { name: "Note" }), "stale-note");
+    setTextboxValue("Observed at", "2026");
+    setTextboxValue("Scope statement", "scope");
+    setTextboxValue("Supporting evidence ids", "stale-evidence");
+    setTextboxValue("Observation id", "stale-observation");
+    setTextboxValue("Triage rationale", "stale-rationale");
+    setTextboxValue("Lead id", "stale-lead");
+    setTextboxValue("Intended outcome", "stale-outcome");
+    setTextboxValue("Recommendation id", "stale-recommendation");
+    setTextboxValue("Recipient identity", "owner-stale@example.com");
+    setTextboxValue("Message intent", "stale-intent");
+    setTextboxValue("Escalation reason", "stale-escalation");
+    setTextboxValue("Expires at", "2026-05");
+    setTextboxValue("Action request id override", "stale-request");
+    setTextboxValue("Decided at", "2026-04");
+    setTextboxValue("Decision rationale", "stale-decision-rationale");
+    setTextboxValue("Fallback at", "2026-04");
+    setTextboxValue("Reason", "stale-reason");
+    setTextboxValue("Action taken", "stale-action");
+    setTextboxValue("Verification evidence ids", "stale-evidence-list");
+    setTextboxValue("Residual uncertainty", "stale-uncertainty");
+    setTextboxValue("Escalated at", "2026-04");
+    setTextboxValue("Escalated to", "stale-manager");
+    setTextboxValue("Note", "stale-note");
 
     rerender(
       <AdminContext dataProvider={testDataProvider}>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "build": "npm run build --workspace @aegisops/operator-ui",
-    "test": "npm run test --workspace @aegisops/operator-ui"
+    "test": "npm run test --workspace @aegisops/operator-ui",
+    "typecheck": "npm run typecheck --workspace @aegisops/operator-ui"
   }
 }

--- a/scripts/test-verify-ci-operator-ui-workflow-coverage.sh
+++ b/scripts/test-verify-ci-operator-ui-workflow-coverage.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+workflow_path="${repo_root}/.github/workflows/ci.yml"
+
+operator_ui_step_name="Run operator UI merge-gate checks"
+operator_ui_commands=(
+  "npm ci"
+  "npm run typecheck --workspace @aegisops/operator-ui"
+  "npm run test --workspace @aegisops/operator-ui"
+  "npm run build --workspace @aegisops/operator-ui"
+)
+
+self_guard_step_name="Run operator UI workflow coverage guard"
+self_guard_command="bash scripts/test-verify-ci-operator-ui-workflow-coverage.sh"
+
+if [[ ! -f "${workflow_path}" ]]; then
+  echo "Missing CI workflow: ${workflow_path}" >&2
+  exit 1
+fi
+
+. "${repo_root}/scripts/ci-workflow-phase-helper.sh"
+
+active_run_commands="$(collect_active_run_commands)"
+operator_ui_step_commands="$(extract_step_run_commands "${operator_ui_step_name}")"
+
+if [[ -z "${operator_ui_step_commands}" ]]; then
+  echo "Missing dedicated operator UI merge-gate step in CI workflow: ${operator_ui_step_name}" >&2
+  exit 1
+fi
+
+for command in "${operator_ui_commands[@]}"; do
+  if ! grep -Fqx -- "${command}" <<<"${operator_ui_step_commands}" >/dev/null; then
+    echo "Missing operator UI merge-gate command in dedicated CI step: ${command}" >&2
+    exit 1
+  fi
+done
+
+self_guard_step_commands="$(extract_step_run_commands "${self_guard_step_name}")"
+if [[ -z "${self_guard_step_commands}" ]]; then
+  echo "Missing dedicated operator UI workflow coverage guard step in CI workflow: ${self_guard_step_name}" >&2
+  exit 1
+fi
+
+if ! grep -Fqx -- "${self_guard_command}" <<<"${self_guard_step_commands}" >/dev/null; then
+  echo "Dedicated operator UI workflow coverage guard step must run exactly: ${self_guard_command}" >&2
+  printf 'Found commands:\n%s\n' "${self_guard_step_commands}" >&2
+  exit 1
+fi
+
+if ! grep -Fqx -- "${self_guard_command}" <<<"${active_run_commands}" >/dev/null; then
+  echo "Missing operator UI workflow coverage guard command in CI workflow: ${self_guard_command}" >&2
+  exit 1
+fi
+
+echo "CI workflow includes the required operator UI install, typecheck, test, build, and workflow guard commands."


### PR DESCRIPTION
## Summary
- add the operator-ui workspace install/typecheck/test/build commands to the main CI merge gate
- add a focused workflow coverage guard so CI fails if the operator-ui gate is removed
- expose an explicit operator-ui typecheck npm script for local/CI parity

## Verification
- bash scripts/test-verify-ci-operator-ui-workflow-coverage.sh
- npm ci
- npm run typecheck --workspace @aegisops/operator-ui
- npm run test --workspace @aegisops/operator-ui
- npm run build --workspace @aegisops/operator-ui
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml parsed"'
- actionlint v1.7.12 .github/workflows/ci.yml
- bash scripts/test-verify-ci-publishable-path-hygiene.sh && bash scripts/verify-publishable-path-hygiene.sh
- node dist/index.js issue-lint 838 --config supervisor.config.aegisops.coderabbit.json