### PR TITLE
Phase 46.1 approval role matrix runbook

### DIFF
--- a/docs/deployment/operator-training-handoff-packet.md
+++ b/docs/deployment/operator-training-handoff-packet.md
@@ -46,6 +46,8 @@ If any segment is missing, stale, mixed across release identifiers, or only impl
 
 ## 4. Approval, Execution, and Reconciliation Split
 
+The approval role matrix in `docs/runbook.md` is the reviewed handoff reference for approver, fallback approver, platform admin, operator, and support owner responsibilities.
+
 Approval answers whether a specific AegisOps action request is allowed for the reviewed scope.
 
 Execution answers what the approved execution surface actually attempted or refused and which receipt or correlation identifier came back.
@@ -53,6 +55,8 @@ Execution answers what the approved execution surface actually attempted or refu
 Reconciliation answers whether authoritative AegisOps review accepted, rejected, or escalated the observed execution against the approved intent.
 
 Execution success is not reconciliation success, and a ticket closure is neither execution success nor reconciliation success.
+
+Denied approvals, approval timeouts, fallback approver use, and break-glass closeout must be explained from the AegisOps approval record and directly linked evidence before the operator handoff treats the path as blocked, escalated, or returned to normal.
 
 When explaining this split to the next operator, use three separate sentences: who approved what, what surface attempted or refused it, and what reconciliation decided or still needs. Do not summarize the three surfaces as one green, done, or closed state unless the reviewed reconciliation record itself supports that terminal outcome.
 
@@ -95,6 +99,7 @@ Use repo-relative commands and placeholders in handoff notes, such as `scripts/v
 - Can the operator explain the queue item, case detail, action-review detail, approval, execution, reconciliation, and handoff path without using external ticket status as authority?
 - Can the operator point to the exact reviewed record identifiers that make up the record chain?
 - Can the operator explain why approval, execution, and reconciliation are separate decisions?
+- Can the operator point to the runbook approval role matrix and explain denial, timeout, fallback approver, and break-glass closeout evidence without widening authority?
 - Can the operator state that external tickets and assistant output are non-authoritative?
 - Can the operator assemble the evidence handoff with repo-relative commands, placeholders, and no workstation-local absolute paths?
 

--- a/docs/deployment/support-playbook-break-glass-rehearsal.md
+++ b/docs/deployment/support-playbook-break-glass-rehearsal.md
@@ -21,6 +21,7 @@ Pilot pause, rollback, and exit decisions must use `docs/deployment/pilot-pause-
 | Coordination degradation | Zammad boundary, endpoint, reviewed token source, reachability, and explicit AegisOps linkage. | Ticket state, comments, assignee, queue, priority, SLA, escalation, or closure as AegisOps authority. |
 | Assistant degradation | Assistant citations, reviewed record ids, linked evidence ids, uncertainty flags, and limited surfaces. | Advisory text as approval, execution, reconciliation, closure, detector activation, or support-coverage authority. |
 | Runtime degradation | Reverse-proxy health, readiness, runtime inspection, compose state, bounded logs, env contract, and migration bootstrap. | Direct backend health, optional-extension health, raw forwarded headers, or partial container state as readiness. |
+| Approval handling degradation | AegisOps action request, approval decision record, approver or fallback approver name, denial or timeout reason, unchanged scope, linked evidence, and break-glass closeout evidence when relevant. | Ticket comments, support notes, downstream receipts, browser state, or break-glass custody as approval, execution, reconciliation, or closure authority. |
 | Rollback degradation | Rollback decision owner, selected restore point, backup custody, before-and-after revisions, smoke result, and clean-state proof. | A clean retry summary as proof that the failed path disappeared. |
 | Restore degradation | Backup provenance, restore point, empty target expectation, readiness, record-chain validation, and clean-state proof. | Exception text alone as durable-state proof. |
 
@@ -35,6 +36,8 @@ Coordination handling: inspect `docs/operations-zammad-live-pilot-boundary.md`, 
 Assistant handling: inspect the assistant boundary, citations, reviewed record ids, linked evidence ids, uncertainty flags, and disabled or limited assistant surfaces before relying on an advisory summary.
 
 Runtime handling: inspect the reverse-proxy health, readiness, runtime inspection, compose status, bounded logs, runtime env contract, and migration bootstrap evidence before admitting normal operator use.
+
+Approval handling: inspect `docs/runbook.md`, the AegisOps action request, approval decision record, approver or fallback approver name, denial or timeout reason, unchanged action scope, directly linked evidence, and any break-glass closeout proof before treating approval handling as complete or escalation-ready.
 
 Rollback handling: inspect the same-day rollback decision owner, selected restore point, pre-change backup custody, before-and-after repository revision, smoke result, and clean-state evidence before closing the maintenance window.
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -361,12 +361,37 @@ The approved baseline requires explicit approval for SOAR workflows that perform
 
 Approval handling procedures must preserve human review, auditability, and the separation between detection and execution.
 
-Future approval guidance should describe:
+### 6.1 Approval Role Matrix
 
-- who may approve which categories of actions,
-- how approval decisions are recorded,
-- how rejected or expired approvals are handled, and
-- how operators verify that unapproved actions were not executed.
+| Role | Reviewed responsibility |
+| --- | --- |
+| Approver | Reviews the exact AegisOps action request, linked case, requested scope, evidence, risk, and expiry window before recording approve or deny on the AegisOps approval decision record. |
+| Fallback approver | Acts only when the primary approver is unavailable or the approval window would otherwise expire, and must preserve the fallback reason, time window, and same scope limits as the original request. |
+| Platform admin | Maintains reviewed identity, role binding, runtime, and secret-custody plumbing, but does not approve an action unless separately named as the approver for that request. |
+| Operator | Prepares the action request, evidence bundle, and routing note, then waits for the reviewed approval outcome instead of self-approving, executing, or treating a ticket comment as approval. |
+| Support owner | Coordinates degradation, denial, timeout, fallback, or break-glass follow-up evidence and next-owner handoff, but does not approve, execute, reconcile, or redefine AegisOps workflow truth. |
+
+These roles are named responsibilities inside the existing AegisOps approval model. They do not create new role classes, new authority sources, customer-specific support authority, or external-ticket-driven workflow truth.
+
+### 6.2 Denial, Timeout, Fallback, and Break-Glass Closeout
+
+A denied approval keeps the action request blocked from execution, records the denial reason on the AegisOps approval decision record, and preserves any external ticket or support note only as subordinate coordination context.
+
+An approval timeout or expired approval window keeps execution blocked until a new reviewed request is created or the documented fallback approver path records the same scope, reason, and evidence in AegisOps.
+
+Fallback approval handling requires a named fallback approver, the reason the primary approver could not decide inside the reviewed window, the unchanged action scope, and evidence that the fallback did not widen authority.
+
+Break-glass closeout is a recovery closeout path only: it must document trigger, custodian, approving reviewer, bounded access window, affected binding, rotation or invalidation evidence, readiness or refusal check, clean-state proof, and return-to-normal owner without converting break-glass use into approval, execution, or reconciliation authority.
+
+If denial, timeout, fallback, or break-glass evidence is missing, malformed, mixed across scopes, or only present in an external ticket comment, operators must leave execution blocked and preserve the refusal or unresolved state for the next owner.
+
+### 6.3 Approval Evidence and Authority Boundary
+
+Approval truth remains the AegisOps approval decision record; external ticket comments, assistant output, browser state, downstream execution receipts, optional evidence, or support notes must not approve, deny, expire, supersede, execute, or reconcile an action.
+
+Approval, execution, and reconciliation evidence must stay visibly separated: the approval record says whether the exact request is allowed, the execution record says what was attempted or refused, and the reconciliation record says whether the observed outcome matches the approved intent.
+
+Operator handoff must include the action request identifier, approval decision identifier, approver or fallback approver name, decision outcome, denial or timeout reason when applicable, approval window, linked evidence identifiers, and any break-glass closeout evidence needed to prove return to the normal reviewed path.
 
 This section must remain consistent with the business-hours-oriented operating model and must not imply unrestricted autonomous response.
 

--- a/scripts/test-verify-operator-training-handoff-packet.sh
+++ b/scripts/test-verify-operator-training-handoff-packet.sh
@@ -88,6 +88,8 @@ Operators must follow explicit record identifiers such as `alert_id`, `case_id`,
 
 ## 4. Approval, Execution, and Reconciliation Split
 
+The approval role matrix in `docs/runbook.md` is the reviewed handoff reference for approver, fallback approver, platform admin, operator, and support owner responsibilities.
+
 Approval answers whether a specific AegisOps action request is allowed for the reviewed scope.
 
 Execution answers what the approved execution surface actually attempted or refused and which receipt or correlation identifier came back.
@@ -95,6 +97,8 @@ Execution answers what the approved execution surface actually attempted or refu
 Reconciliation answers whether authoritative AegisOps review accepted, rejected, or escalated the observed execution against the approved intent.
 
 Execution success is not reconciliation success, and a ticket closure is neither execution success nor reconciliation success.
+
+Denied approvals, approval timeouts, fallback approver use, and break-glass closeout must be explained from the AegisOps approval record and directly linked evidence before the operator handoff treats the path as blocked, escalated, or returned to normal.
 
 ## 5. External Ticket Non-Authority
 
@@ -121,6 +125,7 @@ For failed, rejected, forbidden, rollback, restore, or no-go paths, the handoff 
 - Can the operator explain the queue item, case detail, action-review detail, approval, execution, reconciliation, and handoff path without using external ticket status as authority?
 - Can the operator point to the exact reviewed record identifiers that make up the record chain?
 - Can the operator explain why approval, execution, and reconciliation are separate decisions?
+- Can the operator point to the runbook approval role matrix and explain denial, timeout, fallback approver, and break-glass closeout evidence without widening authority?
 - Can the operator state that external tickets and assistant output are non-authoritative?
 - Can the operator assemble the evidence handoff with repo-relative commands, placeholders, and no workstation-local absolute paths?
 

--- a/scripts/test-verify-runbook-doc.sh
+++ b/scripts/test-verify-runbook-doc.sh
@@ -140,7 +140,37 @@ Bootstrap and break-glass material are recovery exceptions only.
 
 After any break-glass use, operators must rotate the exposed bootstrap or break-glass material before the environment returns to normal operation and must preserve evidence showing the exception was closed.
 
-## 6. Approval Handling"""
+## 6. Approval Handling
+
+The approved baseline requires explicit approval for SOAR workflows that perform write or destructive actions by default.
+
+Approval handling procedures must preserve human review, auditability, and the separation between detection and execution.
+
+### 6.1 Approval Role Matrix
+
+| Role | Reviewed responsibility |
+| --- | --- |
+| Approver | Reviews the exact AegisOps action request, linked case, requested scope, evidence, risk, and expiry window before recording approve or deny on the AegisOps approval decision record. |
+| Fallback approver | Acts only when the primary approver is unavailable or the approval window would otherwise expire, and must preserve the fallback reason, time window, and same scope limits as the original request. |
+| Platform admin | Maintains reviewed identity, role binding, runtime, and secret-custody plumbing, but does not approve an action unless separately named as the approver for that request. |
+| Operator | Prepares the action request, evidence bundle, and routing note, then waits for the reviewed approval outcome instead of self-approving, executing, or treating a ticket comment as approval. |
+| Support owner | Coordinates degradation, denial, timeout, fallback, or break-glass follow-up evidence and next-owner handoff, but does not approve, execute, reconcile, or redefine AegisOps workflow truth. |
+
+### 6.2 Denial, Timeout, Fallback, and Break-Glass Closeout
+
+A denied approval keeps the action request blocked from execution, records the denial reason on the AegisOps approval decision record, and preserves any external ticket or support note only as subordinate coordination context.
+
+An approval timeout or expired approval window keeps execution blocked until a new reviewed request is created or the documented fallback approver path records the same scope, reason, and evidence in AegisOps.
+
+Fallback approval handling requires a named fallback approver, the reason the primary approver could not decide inside the reviewed window, the unchanged action scope, and evidence that the fallback did not widen authority.
+
+Break-glass closeout is a recovery closeout path only: it must document trigger, custodian, approving reviewer, bounded access window, affected binding, rotation or invalidation evidence, readiness or refusal check, clean-state proof, and return-to-normal owner without converting break-glass use into approval, execution, or reconciliation authority.
+
+### 6.3 Approval Evidence and Authority Boundary
+
+Approval truth remains the AegisOps approval decision record; external ticket comments, assistant output, browser state, downstream execution receipts, optional evidence, or support notes must not approve, deny, expire, supersede, execute, or reconcile an action.
+
+Approval, execution, and reconciliation evidence must stay visibly separated: the approval record says whether the exact request is allowed, the execution record says what was attempted or refused, and the reconciliation record says whether the observed outcome matches the approved intent."""
 if "## 5. Secret Rotation and Break-Glass Custody" not in text:
     text = text.replace(old_heading, new_block)
 text = text.replace("## 6. Validation", "## 7. Validation")

--- a/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/test-verify-support-playbook-break-glass-rehearsal.sh
@@ -77,6 +77,7 @@ It does not create 24x7 on-call coverage, a customer-specific support contract, 
 | Coordination degradation | Zammad boundary, endpoint, reviewed token source, reachability, and explicit AegisOps linkage. | Ticket state, comments, assignee, or closure as AegisOps authority. |
 | Assistant degradation | Assistant citations, reviewed record ids, linked evidence ids, uncertainty flags, and limited surfaces. | Advisory text as approval, execution, reconciliation, or closure. |
 | Runtime degradation | Reverse-proxy health, readiness, runtime inspection, compose state, bounded logs, env contract, and migration bootstrap. | Direct backend health, optional-extension health, or partial container state as readiness. |
+| Approval handling degradation | AegisOps action request, approval decision record, approver or fallback approver name, denial or timeout reason, unchanged scope, linked evidence, and break-glass closeout evidence when relevant. | Ticket comments, support notes, downstream receipts, browser state, or break-glass custody as approval, execution, reconciliation, or closure authority. |
 | Rollback degradation | Rollback decision owner, selected restore point, backup custody, revisions, smoke result, and clean-state proof. | A clean retry summary as proof that the failed path disappeared. |
 | Restore degradation | Backup provenance, restore point, empty target expectation, readiness, record-chain validation, and clean-state proof. | Exception text alone as durable-state proof. |
 
@@ -91,6 +92,8 @@ Coordination handling: inspect `docs/operations-zammad-live-pilot-boundary.md`, 
 Assistant handling: inspect the assistant boundary, citations, reviewed record ids, linked evidence ids, uncertainty flags, and disabled or limited assistant surfaces before relying on an advisory summary.
 
 Runtime handling: inspect the reverse-proxy health, readiness, runtime inspection, compose status, bounded logs, runtime env contract, and migration bootstrap evidence before admitting normal operator use.
+
+Approval handling: inspect `docs/runbook.md`, the AegisOps action request, approval decision record, approver or fallback approver name, denial or timeout reason, unchanged action scope, directly linked evidence, and any break-glass closeout proof before treating approval handling as complete or escalation-ready.
 
 Rollback handling: inspect the same-day rollback decision owner, selected restore point, pre-change backup custody, before-and-after repository revision, smoke result, and clean-state evidence before closing the maintenance window.
 

--- a/scripts/verify-operator-training-handoff-packet.sh
+++ b/scripts/verify-operator-training-handoff-packet.sh
@@ -91,10 +91,12 @@ required_packet_phrases=(
   "Action review is the reviewed family that keeps the action request, approval decision, execution receipt, and reconciliation outcome visible without collapsing them into one status badge."
   "The reviewed record chain is the authoritative sequence of AegisOps-owned records that explains why work entered the queue, what case owns it, what evidence supports it, what action was requested, who approved or rejected it, what execution surface reported, and how reconciliation closed or escalated the outcome."
   'Operators must follow explicit record identifiers such as `alert_id`, `case_id`, `evidence_id`, `action_request_id`, `approval_decision_id`, `action_execution_id`, and `reconciliation_id` instead of inferring linkage from names, ticket titles, dashboard order, or nearby notes.'
+  'The approval role matrix in `docs/runbook.md` is the reviewed handoff reference for approver, fallback approver, platform admin, operator, and support owner responsibilities.'
   "Approval answers whether a specific AegisOps action request is allowed for the reviewed scope."
   "Execution answers what the approved execution surface actually attempted or refused and which receipt or correlation identifier came back."
   "Reconciliation answers whether authoritative AegisOps review accepted, rejected, or escalated the observed execution against the approved intent."
   "Execution success is not reconciliation success, and a ticket closure is neither execution success nor reconciliation success."
+  "Denied approvals, approval timeouts, fallback approver use, and break-glass closeout must be explained from the AegisOps approval record and directly linked evidence before the operator handoff treats the path as blocked, escalated, or returned to normal."
   "External tickets are coordination references only; they may carry ticket identifiers, URLs, comments, or assignee context, but they do not own AegisOps case, approval, execution, or reconciliation truth."
   "If an external ticket disagrees with the AegisOps reviewed record chain, operators keep the AegisOps record authoritative and preserve the disagreement for review."
   "Assistant output is advisory-only and must remain grounded in reviewed AegisOps records and linked evidence."
@@ -105,6 +107,7 @@ required_packet_phrases=(
   "- Can the operator explain the queue item, case detail, action-review detail, approval, execution, reconciliation, and handoff path without using external ticket status as authority?"
   "- Can the operator point to the exact reviewed record identifiers that make up the record chain?"
   "- Can the operator explain why approval, execution, and reconciliation are separate decisions?"
+  "- Can the operator point to the runbook approval role matrix and explain denial, timeout, fallback approver, and break-glass closeout evidence without widening authority?"
   "- Can the operator state that external tickets and assistant output are non-authoritative?"
   "- Can the operator assemble the evidence handoff with repo-relative commands, placeholders, and no workstation-local absolute paths?"
   "Generic SOC curriculum, broad SIEM or SOAR administration, assistant prompt engineering, multi-customer operating model, compliance certification, and ticket-system workflow ownership are out of scope."

--- a/scripts/verify-runbook-doc.sh
+++ b/scripts/verify-runbook-doc.sh
@@ -24,6 +24,9 @@ required_headings=(
   "### 5.2 Reviewed Secret Rotation Checklist"
   "### 5.3 Bootstrap Token and Break-Glass Custody Checklist"
   "## 6. Approval Handling"
+  "### 6.1 Approval Role Matrix"
+  "### 6.2 Denial, Timeout, Fallback, and Break-Glass Closeout"
+  "### 6.3 Approval Evidence and Authority Boundary"
   "## 7. Validation"
   "### 7.1 Selected Slice and Preconditions"
   "### 7.2 Analyst Validation Path"
@@ -96,6 +99,17 @@ required_phrases=(
   "After any break-glass use, operators must rotate the exposed bootstrap or break-glass material before the environment returns to normal operation and must preserve evidence showing the exception was closed."
   "The approved baseline requires explicit approval for SOAR workflows that perform write or destructive actions by default."
   "Approval handling procedures must preserve human review, auditability, and the separation between detection and execution."
+  "| Approver | Reviews the exact AegisOps action request, linked case, requested scope, evidence, risk, and expiry window before recording approve or deny on the AegisOps approval decision record. |"
+  "| Fallback approver | Acts only when the primary approver is unavailable or the approval window would otherwise expire, and must preserve the fallback reason, time window, and same scope limits as the original request. |"
+  "| Platform admin | Maintains reviewed identity, role binding, runtime, and secret-custody plumbing, but does not approve an action unless separately named as the approver for that request. |"
+  "| Operator | Prepares the action request, evidence bundle, and routing note, then waits for the reviewed approval outcome instead of self-approving, executing, or treating a ticket comment as approval. |"
+  "| Support owner | Coordinates degradation, denial, timeout, fallback, or break-glass follow-up evidence and next-owner handoff, but does not approve, execute, reconcile, or redefine AegisOps workflow truth. |"
+  "A denied approval keeps the action request blocked from execution, records the denial reason on the AegisOps approval decision record, and preserves any external ticket or support note only as subordinate coordination context."
+  "An approval timeout or expired approval window keeps execution blocked until a new reviewed request is created or the documented fallback approver path records the same scope, reason, and evidence in AegisOps."
+  "Fallback approval handling requires a named fallback approver, the reason the primary approver could not decide inside the reviewed window, the unchanged action scope, and evidence that the fallback did not widen authority."
+  "Break-glass closeout is a recovery closeout path only: it must document trigger, custodian, approving reviewer, bounded access window, affected binding, rotation or invalidation evidence, readiness or refusal check, clean-state proof, and return-to-normal owner without converting break-glass use into approval, execution, or reconciliation authority."
+  "Approval truth remains the AegisOps approval decision record; external ticket comments, assistant output, browser state, downstream execution receipts, optional evidence, or support notes must not approve, deny, expire, supersede, execute, or reconcile an action."
+  "Approval, execution, and reconciliation evidence must stay visibly separated: the approval record says whether the exact request is allowed, the execution record says what was attempted or refused, and the reconciliation record says whether the observed outcome matches the approved intent."
   "Validation steps must be documented and repeatable before this runbook can be treated as an operational procedure beyond the reviewed startup and shutdown path."
   "The operator health review contract is the reviewed business-hours cadence for deciding whether the mainline path is ready, safely degraded, or escalation-bound."
   'Each business day, operators must review `curl -fsS http://127.0.0.1:<proxy-port>/readyz`, `curl -fsS http://127.0.0.1:<proxy-port>/runtime`, the reviewed queue and alert surfaces, and any explicit degraded-state markers before treating the platform as ready for normal work.'
@@ -129,6 +143,7 @@ forbidden_phrases=(
   "Detailed startup steps are intentionally deferred until implementation artifacts and validation procedures exist."
   "Detailed shutdown steps are intentionally deferred until implementation artifacts and validation procedures exist."
   "Detailed restore steps are intentionally deferred until implementation artifacts and validation procedures exist."
+  "Future approval guidance should describe:"
 )
 
 if [[ ! -f "${doc_path}" ]]; then

--- a/scripts/verify-support-playbook-break-glass-rehearsal.sh
+++ b/scripts/verify-support-playbook-break-glass-rehearsal.sh
@@ -91,6 +91,7 @@ required_playbook_phrases=(
   "| Coordination degradation |"
   "| Assistant degradation |"
   "| Runtime degradation |"
+  "| Approval handling degradation |"
   "| Rollback degradation |"
   "| Restore degradation |"
   "Source handling: inspect the reviewed source-family evidence, ingest custody, replay or fixture proof, source timestamp, and explicit linkage to the AegisOps alert, case, or evidence record before widening source scope."
@@ -98,6 +99,7 @@ required_playbook_phrases=(
   'Coordination handling: inspect `docs/operations-zammad-live-pilot-boundary.md`, `AEGISOPS_ZAMMAD_BASE_URL`, the reviewed token source reference, endpoint reachability, and explicit AegisOps linkage before treating a ticket pointer as usable coordination context.'
   "Assistant handling: inspect the assistant boundary, citations, reviewed record ids, linked evidence ids, uncertainty flags, and disabled or limited assistant surfaces before relying on an advisory summary."
   "Runtime handling: inspect the reverse-proxy health, readiness, runtime inspection, compose status, bounded logs, runtime env contract, and migration bootstrap evidence before admitting normal operator use."
+  'Approval handling: inspect `docs/runbook.md`, the AegisOps action request, approval decision record, approver or fallback approver name, denial or timeout reason, unchanged action scope, directly linked evidence, and any break-glass closeout proof before treating approval handling as complete or escalation-ready.'
   "Rollback handling: inspect the same-day rollback decision owner, selected restore point, pre-change backup custody, before-and-after repository revision, smoke result, and clean-state evidence before closing the maintenance window."
   "Restore handling: inspect backup provenance, selected restore point, empty restore target expectation, post-restore readiness, record-chain validation, and clean-state proof before returning to service."
   "Break-glass custody is a documented recovery exception, not an alternate approval path, permanent operator shortcut, or way to bypass reviewed AegisOps authority."


### PR DESCRIPTION
## Summary
- publish the approval role matrix in the runbook for approver, fallback approver, platform admin, operator, and support owner responsibilities
- document denial, timeout, fallback, and break-glass closeout handling while preserving AegisOps approval authority
- link operator training and support playbook guidance to the approval matrix and tighten focused verifiers/self-tests

## Verification
- bash scripts/verify-runbook-doc.sh
- bash scripts/verify-operator-training-handoff-packet.sh
- bash scripts/verify-support-playbook-break-glass-rehearsal.sh
- bash scripts/test-verify-runbook-doc.sh
- bash scripts/test-verify-operator-training-handoff-packet.sh
- bash scripts/test-verify-support-playbook-break-glass-rehearsal.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node dist/index.js issue-lint 846 --config supervisor.config.aegisops.coderabbit.json (from <codex-supervisor-root>)

Closes #846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced approval handling procedures with explicit role responsibilities and evidence linkage requirements
  * Added break-glass rehearsal failure modes and validation guidance
  * Clarified authority boundaries between approval, execution, and reconciliation workflows
  * Expanded operator training materials and deployment playbooks

* **Tests**
  * Updated verification scripts to validate new approval documentation requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->