### PR TITLE
Phase 47.1: Extract action lifecycle write routing

### DIFF
--- a/control-plane/aegisops_control_plane/action_lifecycle_write_coordinator.py
+++ b/control-plane/aegisops_control_plane/action_lifecycle_write_coordinator.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping, Protocol
+
+from .models import (
+    ActionExecutionRecord,
+    ActionRequestRecord,
+    ApprovalDecisionRecord,
+    ReconciliationRecord,
+)
+
+
+class ActionLifecycleWriteCoordinatorServiceDependencies(Protocol):
+    _action_review_write_surface: object
+    _execution_coordinator: object
+
+
+class ActionLifecycleWriteCoordinator:
+    """Coordinates action lifecycle writes behind the public service facade."""
+
+    def __init__(
+        self,
+        service: ActionLifecycleWriteCoordinatorServiceDependencies,
+    ) -> None:
+        self._service = service
+
+    def create_reviewed_action_request_from_advisory(
+        self,
+        *,
+        record_family: str,
+        record_id: str,
+        requester_identity: str,
+        recipient_identity: str,
+        message_intent: str,
+        escalation_reason: str,
+        expires_at: datetime,
+        action_request_id: str | None = None,
+    ) -> ActionRequestRecord:
+        return self._service._execution_coordinator.create_reviewed_action_request_from_advisory(
+            record_family=record_family,
+            record_id=record_id,
+            requester_identity=requester_identity,
+            recipient_identity=recipient_identity,
+            message_intent=message_intent,
+            escalation_reason=escalation_reason,
+            expires_at=expires_at,
+            action_request_id=action_request_id,
+        )
+
+    def create_reviewed_tracking_ticket_request_from_advisory(
+        self,
+        *,
+        record_family: str,
+        record_id: str,
+        requester_identity: str,
+        coordination_reference_id: str,
+        coordination_target_type: str,
+        ticket_title: str,
+        ticket_description: str,
+        expires_at: datetime,
+        ticket_severity: str = "medium",
+        action_request_id: str | None = None,
+    ) -> ActionRequestRecord:
+        return self._service._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory(
+            record_family=record_family,
+            record_id=record_id,
+            requester_identity=requester_identity,
+            coordination_reference_id=coordination_reference_id,
+            coordination_target_type=coordination_target_type,
+            ticket_title=ticket_title,
+            ticket_description=ticket_description,
+            expires_at=expires_at,
+            ticket_severity=ticket_severity,
+            action_request_id=action_request_id,
+        )
+
+    def record_action_approval_decision(
+        self,
+        *,
+        action_request_id: str,
+        approver_identity: str,
+        authenticated_approver_identity: str | None = None,
+        decision: str,
+        decision_rationale: str,
+        decided_at: datetime,
+        approval_decision_id: str | None = None,
+    ) -> ApprovalDecisionRecord:
+        return self._service._action_review_write_surface.record_action_approval_decision(
+            action_request_id=action_request_id,
+            approver_identity=approver_identity,
+            authenticated_approver_identity=authenticated_approver_identity,
+            decision=decision,
+            decision_rationale=decision_rationale,
+            decided_at=decided_at,
+            approval_decision_id=approval_decision_id,
+        )
+
+    def delegate_approved_action_to_shuffle(
+        self,
+        *,
+        action_request_id: str,
+        approved_payload: Mapping[str, object],
+        delegated_at: datetime,
+        delegation_issuer: str,
+        evidence_ids: tuple[str, ...] = (),
+    ) -> ActionExecutionRecord:
+        return self._service._execution_coordinator.delegate_approved_action_to_shuffle(
+            action_request_id=action_request_id,
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer=delegation_issuer,
+            evidence_ids=evidence_ids,
+        )
+
+    def delegate_approved_action_to_isolated_executor(
+        self,
+        *,
+        action_request_id: str,
+        approved_payload: Mapping[str, object],
+        delegated_at: datetime,
+        delegation_issuer: str,
+        evidence_ids: tuple[str, ...] = (),
+    ) -> ActionExecutionRecord:
+        return self._service._execution_coordinator.delegate_approved_action_to_isolated_executor(
+            action_request_id=action_request_id,
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer=delegation_issuer,
+            evidence_ids=evidence_ids,
+        )
+
+    def reconcile_action_execution(
+        self,
+        *,
+        action_request_id: str,
+        execution_surface_type: str,
+        execution_surface_id: str,
+        observed_executions: tuple[Mapping[str, object], ...],
+        compared_at: datetime,
+        stale_after: datetime,
+    ) -> ReconciliationRecord:
+        return self._service._execution_coordinator.reconcile_action_execution(
+            action_request_id=action_request_id,
+            execution_surface_type=execution_surface_type,
+            execution_surface_id=execution_surface_id,
+            observed_executions=observed_executions,
+            compared_at=compared_at,
+            stale_after=stale_after,
+        )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -30,6 +30,7 @@ from .assistant_provider import (
     AssistantProviderResult,
     AssistantProviderTransport,
 )
+from .action_lifecycle_write_coordinator import ActionLifecycleWriteCoordinator
 from .action_review_write_surface import ActionReviewWriteSurface
 from .case_workflow import CaseWorkflowService
 from .config import OpenBaoKVv2SecretTransport, RuntimeConfig
@@ -1384,6 +1385,7 @@ class AegisOpsControlPlaneService:
             normalize_admission_provenance=_normalize_admission_provenance,
         )
         self._execution_coordinator = ExecutionCoordinator(self)
+        self._action_lifecycle_write_coordinator = ActionLifecycleWriteCoordinator(self)
         self._endpoint_evidence_pack_adapter = EndpointEvidencePackAdapter()
         self._misp_context_adapter = MispContextAdapter(
             enabled=config.misp_enrichment_enabled
@@ -2059,7 +2061,7 @@ class AegisOpsControlPlaneService:
         delegation_issuer: str,
         evidence_ids: tuple[str, ...] = (),
     ) -> ActionExecutionRecord:
-        return self._execution_coordinator.delegate_approved_action_to_shuffle(
+        return self._action_lifecycle_write_coordinator.delegate_approved_action_to_shuffle(
             action_request_id=action_request_id,
             approved_payload=approved_payload,
             delegated_at=delegated_at,
@@ -2076,7 +2078,7 @@ class AegisOpsControlPlaneService:
         delegation_issuer: str,
         evidence_ids: tuple[str, ...] = (),
     ) -> ActionExecutionRecord:
-        return self._execution_coordinator.delegate_approved_action_to_isolated_executor(
+        return self._action_lifecycle_write_coordinator.delegate_approved_action_to_isolated_executor(
             action_request_id=action_request_id,
             approved_payload=approved_payload,
             delegated_at=delegated_at,
@@ -4588,7 +4590,7 @@ class AegisOpsControlPlaneService:
         expires_at: datetime,
         action_request_id: str | None = None,
     ) -> ActionRequestRecord:
-        return self._execution_coordinator.create_reviewed_action_request_from_advisory(
+        return self._action_lifecycle_write_coordinator.create_reviewed_action_request_from_advisory(
             record_family=record_family,
             record_id=record_id,
             requester_identity=requester_identity,
@@ -4613,7 +4615,7 @@ class AegisOpsControlPlaneService:
         ticket_severity: str = "medium",
         action_request_id: str | None = None,
     ) -> ActionRequestRecord:
-        return self._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory(
+        return self._action_lifecycle_write_coordinator.create_reviewed_tracking_ticket_request_from_advisory(
             record_family=record_family,
             record_id=record_id,
             requester_identity=requester_identity,
@@ -4677,7 +4679,7 @@ class AegisOpsControlPlaneService:
         decided_at: datetime,
         approval_decision_id: str | None = None,
     ) -> ApprovalDecisionRecord:
-        return self._action_review_write_surface.record_action_approval_decision(
+        return self._action_lifecycle_write_coordinator.record_action_approval_decision(
             action_request_id=action_request_id,
             approver_identity=approver_identity,
             authenticated_approver_identity=authenticated_approver_identity,
@@ -5509,7 +5511,7 @@ class AegisOpsControlPlaneService:
         compared_at: datetime,
         stale_after: datetime,
     ) -> ReconciliationRecord:
-        return self._execution_coordinator.reconcile_action_execution(
+        return self._action_lifecycle_write_coordinator.reconcile_action_execution(
             action_request_id=action_request_id,
             execution_surface_type=execution_surface_type,
             execution_surface_id=execution_surface_id,

--- a/control-plane/tests/test_execution_coordinator_boundary.py
+++ b/control-plane/tests/test_execution_coordinator_boundary.py
@@ -12,6 +12,9 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
 from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.action_lifecycle_write_coordinator import (
+    ActionLifecycleWriteCoordinator,
+)
 from aegisops_control_plane.execution_coordinator import ExecutionCoordinator
 from aegisops_control_plane.service import AegisOpsControlPlaneService
 from postgres_test_support import make_store
@@ -35,6 +38,325 @@ class ExecutionCoordinatorBoundaryTests(unittest.TestCase):
         self.assertTrue(
             hasattr(service, "_execution_coordinator"),
             "expected AegisOpsControlPlaneService to compose a dedicated execution coordinator",
+        )
+
+    def test_service_initializes_dedicated_action_lifecycle_write_coordinator(
+        self,
+    ) -> None:
+        service = self._build_service()
+
+        self.assertTrue(
+            hasattr(service, "_action_lifecycle_write_coordinator"),
+            "expected AegisOpsControlPlaneService to compose a dedicated action lifecycle write coordinator",
+        )
+
+    def test_service_routes_action_lifecycle_write_entrypoints_through_coordinator(
+        self,
+    ) -> None:
+        service = self._build_service()
+        coordinator = mock.Mock()
+        action_request_result = object()
+        tracking_ticket_result = object()
+        approval_result = object()
+        shuffle_result = object()
+        isolated_result = object()
+        reconciliation_result = object()
+        coordinator.create_reviewed_action_request_from_advisory.return_value = (
+            action_request_result
+        )
+        coordinator.create_reviewed_tracking_ticket_request_from_advisory.return_value = (
+            tracking_ticket_result
+        )
+        coordinator.record_action_approval_decision.return_value = approval_result
+        coordinator.delegate_approved_action_to_shuffle.return_value = shuffle_result
+        coordinator.delegate_approved_action_to_isolated_executor.return_value = (
+            isolated_result
+        )
+        coordinator.reconcile_action_execution.return_value = reconciliation_result
+        service._action_lifecycle_write_coordinator = coordinator
+        expires_at = datetime(2026, 4, 15, 0, 0, tzinfo=timezone.utc)
+        decided_at = datetime(2026, 4, 15, 0, 30, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 15, 1, 0, tzinfo=timezone.utc)
+        compared_at = datetime(2026, 4, 15, 2, 0, tzinfo=timezone.utc)
+        stale_after = datetime(2026, 4, 15, 3, 0, tzinfo=timezone.utc)
+        observed_executions = (
+            {
+                "execution_run_id": "shuffle-run-001",
+                "execution_surface_id": "shuffle",
+                "idempotency_key": "idem-001",
+                "approval_decision_id": "approval-001",
+                "delegation_id": "delegation-001",
+                "payload_hash": "payload-001",
+                "observed_at": compared_at,
+            },
+        )
+
+        self.assertIs(
+            service.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id="recommendation-001",
+                requester_identity="analyst-001",
+                recipient_identity="owner-001",
+                message_intent="notify",
+                escalation_reason="bounded reason",
+                expires_at=expires_at,
+                action_request_id="action-request-001",
+            ),
+            action_request_result,
+        )
+        self.assertIs(
+            service.create_reviewed_tracking_ticket_request_from_advisory(
+                record_family="recommendation",
+                record_id="recommendation-002",
+                requester_identity="analyst-001",
+                coordination_reference_id="case-001",
+                coordination_target_type="zammad",
+                ticket_title="Review bounded case",
+                ticket_description="Open a link-first coordination ticket.",
+                expires_at=expires_at,
+                ticket_severity="medium",
+                action_request_id="action-request-002",
+            ),
+            tracking_ticket_result,
+        )
+        self.assertIs(
+            service.record_action_approval_decision(
+                action_request_id="action-request-001",
+                approver_identity="approver-001",
+                authenticated_approver_identity="approver-001",
+                decision="grant",
+                decision_rationale="Reviewed action remains bounded.",
+                decided_at=decided_at,
+                approval_decision_id="approval-001",
+            ),
+            approval_result,
+        )
+        self.assertIs(
+            service.delegate_approved_action_to_shuffle(
+                action_request_id="action-request-001",
+                approved_payload={"action": "notify"},
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+                evidence_ids=("evidence-001",),
+            ),
+            shuffle_result,
+        )
+        self.assertIs(
+            service.delegate_approved_action_to_isolated_executor(
+                action_request_id="action-request-002",
+                approved_payload={"action": "notify"},
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+                evidence_ids=("evidence-002",),
+            ),
+            isolated_result,
+        )
+        self.assertIs(
+            service.reconcile_action_execution(
+                action_request_id="action-request-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                observed_executions=observed_executions,
+                compared_at=compared_at,
+                stale_after=stale_after,
+            ),
+            reconciliation_result,
+        )
+
+        coordinator.create_reviewed_action_request_from_advisory.assert_called_once_with(
+            record_family="recommendation",
+            record_id="recommendation-001",
+            requester_identity="analyst-001",
+            recipient_identity="owner-001",
+            message_intent="notify",
+            escalation_reason="bounded reason",
+            expires_at=expires_at,
+            action_request_id="action-request-001",
+        )
+        coordinator.create_reviewed_tracking_ticket_request_from_advisory.assert_called_once_with(
+            record_family="recommendation",
+            record_id="recommendation-002",
+            requester_identity="analyst-001",
+            coordination_reference_id="case-001",
+            coordination_target_type="zammad",
+            ticket_title="Review bounded case",
+            ticket_description="Open a link-first coordination ticket.",
+            expires_at=expires_at,
+            ticket_severity="medium",
+            action_request_id="action-request-002",
+        )
+        coordinator.record_action_approval_decision.assert_called_once_with(
+            action_request_id="action-request-001",
+            approver_identity="approver-001",
+            authenticated_approver_identity="approver-001",
+            decision="grant",
+            decision_rationale="Reviewed action remains bounded.",
+            decided_at=decided_at,
+            approval_decision_id="approval-001",
+        )
+        coordinator.delegate_approved_action_to_shuffle.assert_called_once_with(
+            action_request_id="action-request-001",
+            approved_payload={"action": "notify"},
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-001",),
+        )
+        coordinator.delegate_approved_action_to_isolated_executor.assert_called_once_with(
+            action_request_id="action-request-002",
+            approved_payload={"action": "notify"},
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-002",),
+        )
+        coordinator.reconcile_action_execution.assert_called_once_with(
+            action_request_id="action-request-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=observed_executions,
+            compared_at=compared_at,
+            stale_after=stale_after,
+        )
+
+    def test_action_lifecycle_write_coordinator_preserves_internal_boundaries(
+        self,
+    ) -> None:
+        service = mock.Mock()
+        coordinator = ActionLifecycleWriteCoordinator(service)
+        service._execution_coordinator = mock.Mock()
+        service._action_review_write_surface = mock.Mock()
+        action_request_result = object()
+        tracking_ticket_result = object()
+        approval_result = object()
+        shuffle_result = object()
+        isolated_result = object()
+        reconciliation_result = object()
+        service._execution_coordinator.create_reviewed_action_request_from_advisory.return_value = (
+            action_request_result
+        )
+        service._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory.return_value = (
+            tracking_ticket_result
+        )
+        service._action_review_write_surface.record_action_approval_decision.return_value = (
+            approval_result
+        )
+        service._execution_coordinator.delegate_approved_action_to_shuffle.return_value = (
+            shuffle_result
+        )
+        service._execution_coordinator.delegate_approved_action_to_isolated_executor.return_value = (
+            isolated_result
+        )
+        service._execution_coordinator.reconcile_action_execution.return_value = (
+            reconciliation_result
+        )
+        expires_at = datetime(2026, 4, 15, 0, 0, tzinfo=timezone.utc)
+        decided_at = datetime(2026, 4, 15, 0, 30, tzinfo=timezone.utc)
+        delegated_at = datetime(2026, 4, 15, 1, 0, tzinfo=timezone.utc)
+        compared_at = datetime(2026, 4, 15, 2, 0, tzinfo=timezone.utc)
+        stale_after = datetime(2026, 4, 15, 3, 0, tzinfo=timezone.utc)
+        observed_executions = (
+            {
+                "execution_run_id": "shuffle-run-001",
+                "execution_surface_id": "shuffle",
+                "idempotency_key": "idem-001",
+                "approval_decision_id": "approval-001",
+                "delegation_id": "delegation-001",
+                "payload_hash": "payload-001",
+                "observed_at": compared_at,
+            },
+        )
+
+        self.assertIs(
+            coordinator.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id="recommendation-001",
+                requester_identity="analyst-001",
+                recipient_identity="owner-001",
+                message_intent="notify",
+                escalation_reason="bounded reason",
+                expires_at=expires_at,
+                action_request_id="action-request-001",
+            ),
+            action_request_result,
+        )
+        self.assertIs(
+            coordinator.create_reviewed_tracking_ticket_request_from_advisory(
+                record_family="recommendation",
+                record_id="recommendation-002",
+                requester_identity="analyst-001",
+                coordination_reference_id="case-001",
+                coordination_target_type="zammad",
+                ticket_title="Review bounded case",
+                ticket_description="Open a link-first coordination ticket.",
+                expires_at=expires_at,
+                ticket_severity="medium",
+                action_request_id="action-request-002",
+            ),
+            tracking_ticket_result,
+        )
+        self.assertIs(
+            coordinator.record_action_approval_decision(
+                action_request_id="action-request-001",
+                approver_identity="approver-001",
+                authenticated_approver_identity="approver-001",
+                decision="grant",
+                decision_rationale="Reviewed action remains bounded.",
+                decided_at=decided_at,
+                approval_decision_id="approval-001",
+            ),
+            approval_result,
+        )
+        self.assertIs(
+            coordinator.delegate_approved_action_to_shuffle(
+                action_request_id="action-request-001",
+                approved_payload={"action": "notify"},
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+                evidence_ids=("evidence-001",),
+            ),
+            shuffle_result,
+        )
+        self.assertIs(
+            coordinator.delegate_approved_action_to_isolated_executor(
+                action_request_id="action-request-002",
+                approved_payload={"action": "notify"},
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+                evidence_ids=("evidence-002",),
+            ),
+            isolated_result,
+        )
+        self.assertIs(
+            coordinator.reconcile_action_execution(
+                action_request_id="action-request-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                observed_executions=observed_executions,
+                compared_at=compared_at,
+                stale_after=stale_after,
+            ),
+            reconciliation_result,
+        )
+
+        service._action_review_write_surface.record_action_approval_decision.assert_called_once()
+        self.assertEqual(
+            service._execution_coordinator.create_reviewed_action_request_from_advisory.call_count,
+            1,
+        )
+        self.assertEqual(
+            service._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory.call_count,
+            1,
+        )
+        self.assertEqual(
+            service._execution_coordinator.delegate_approved_action_to_shuffle.call_count,
+            1,
+        )
+        self.assertEqual(
+            service._execution_coordinator.delegate_approved_action_to_isolated_executor.call_count,
+            1,
+        )
+        self.assertEqual(
+            service._execution_coordinator.reconcile_action_execution.call_count,
+            1,
         )
 
     def test_service_delegates_reviewed_action_request_creation_to_execution_coordinator(

--- a/control-plane/tests/test_execution_coordinator_boundary.py
+++ b/control-plane/tests/test_execution_coordinator_boundary.py
@@ -337,26 +337,58 @@ class ExecutionCoordinatorBoundaryTests(unittest.TestCase):
             reconciliation_result,
         )
 
-        service._action_review_write_surface.record_action_approval_decision.assert_called_once()
-        self.assertEqual(
-            service._execution_coordinator.create_reviewed_action_request_from_advisory.call_count,
-            1,
+        service._execution_coordinator.create_reviewed_action_request_from_advisory.assert_called_once_with(
+            record_family="recommendation",
+            record_id="recommendation-001",
+            requester_identity="analyst-001",
+            recipient_identity="owner-001",
+            message_intent="notify",
+            escalation_reason="bounded reason",
+            expires_at=expires_at,
+            action_request_id="action-request-001",
         )
-        self.assertEqual(
-            service._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory.call_count,
-            1,
+        service._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory.assert_called_once_with(
+            record_family="recommendation",
+            record_id="recommendation-002",
+            requester_identity="analyst-001",
+            coordination_reference_id="case-001",
+            coordination_target_type="zammad",
+            ticket_title="Review bounded case",
+            ticket_description="Open a link-first coordination ticket.",
+            expires_at=expires_at,
+            ticket_severity="medium",
+            action_request_id="action-request-002",
         )
-        self.assertEqual(
-            service._execution_coordinator.delegate_approved_action_to_shuffle.call_count,
-            1,
+        service._action_review_write_surface.record_action_approval_decision.assert_called_once_with(
+            action_request_id="action-request-001",
+            approver_identity="approver-001",
+            authenticated_approver_identity="approver-001",
+            decision="grant",
+            decision_rationale="Reviewed action remains bounded.",
+            decided_at=decided_at,
+            approval_decision_id="approval-001",
         )
-        self.assertEqual(
-            service._execution_coordinator.delegate_approved_action_to_isolated_executor.call_count,
-            1,
+        service._execution_coordinator.delegate_approved_action_to_shuffle.assert_called_once_with(
+            action_request_id="action-request-001",
+            approved_payload={"action": "notify"},
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-001",),
         )
-        self.assertEqual(
-            service._execution_coordinator.reconcile_action_execution.call_count,
-            1,
+        service._execution_coordinator.delegate_approved_action_to_isolated_executor.assert_called_once_with(
+            action_request_id="action-request-002",
+            approved_payload={"action": "notify"},
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-002",),
+        )
+        service._execution_coordinator.reconcile_action_execution.assert_called_once_with(
+            action_request_id="action-request-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=observed_executions,
+            compared_at=compared_at,
+            stale_after=stale_after,
         )
 
     def test_service_delegates_reviewed_action_request_creation_to_execution_coordinator(

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -93,6 +93,9 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             self.assertIn(term, action_tests)
 
         for term in (
+            "test_service_initializes_dedicated_action_lifecycle_write_coordinator",
+            "test_service_routes_action_lifecycle_write_entrypoints_through_coordinator",
+            "test_action_lifecycle_write_coordinator_preserves_internal_boundaries",
             "test_service_initializes_dedicated_execution_coordinator",
             "test_service_delegates_reviewed_action_request_creation_to_execution_coordinator",
             "test_service_delegates_shuffle_and_isolated_executor_flows_to_execution_coordinator",


### PR DESCRIPTION
## Summary
- Add `ActionLifecycleWriteCoordinator` as the service facade routing boundary for action request, approval, delegation, and reconciliation writes.
- Keep existing execution and action-review collaborators as the underlying enforcement boundaries.
- Add focused boundary tests plus regression guard coverage for the extracted lifecycle write coordinator.

## Verification
- `python3 -m unittest control-plane.tests.test_execution_coordinator_boundary`
- `python3 -m unittest control-plane.tests.test_action_review_write_boundary`
- `python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation`
- `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket control-plane.tests.test_service_persistence_action_reconciliation_delegation control-plane.tests.test_service_persistence_action_reconciliation_reconciliation control-plane.tests.test_service_persistence_action_reconciliation_review_surfaces control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests`
- `python3 -m unittest control-plane.tests.test_execution_coordinator_boundary control-plane.tests.test_action_review_write_boundary control-plane.tests.test_service_boundary_refactor_regression_validation control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket control-plane.tests.test_service_persistence_action_reconciliation_delegation control-plane.tests.test_service_persistence_action_reconciliation_reconciliation control-plane.tests.test_service_persistence_action_reconciliation_review_surfaces control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests`
- `python3 -m unittest control-plane.tests.test_maintainability_decomposition_thresholds_docs`
- `python3 -m py_compile control-plane/aegisops_control_plane/action_lifecycle_write_coordinator.py control-plane/aegisops_control_plane/service.py control-plane/tests/test_execution_coordinator_boundary.py control-plane/tests/test_service_boundary_refactor_regression_validation.py`
- `git diff --check`
- `node dist/index.js issue-lint 849 --config supervisor.config.aegisops.coderabbit.json`

Closes #849


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a dedicated coordinator service to consolidate action-lifecycle write operations (request creation, approval recording, delegation, reconciliation), improving separation of concerns and consistency of lifecycle handling.
* **Tests**
  * Expanded unit and boundary tests to cover the new coordinator pathways and preserve regression validation for action-lifecycle write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->