### PR TITLE
Phase 47.2: Extract readiness runtime status coordination

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
@@ -54,7 +54,9 @@ export function registerOperatorRoutesCaseworkTests() {
         expect(screen.getByRole("heading", { name: "Readiness" })).toBeInTheDocument();
       });
 
-      expect(screen.getByText("Route: /operator/readiness")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText("Route: /operator/readiness")).toBeInTheDocument();
+      });
     });
 
     it("renders the reviewed queue route from backend-authoritative queue records", async () => {

--- a/control-plane/aegisops_control_plane/http_surface.py
+++ b/control-plane/aegisops_control_plane/http_surface.py
@@ -31,6 +31,7 @@ from .http_protected_surface import (
     require_reviewed_proxy_identity_match,
 )
 from .http_runtime_surface import runtime_read_response
+from .readiness_contracts import resolve_readyz_runtime_status
 from .service import AegisOpsControlPlaneService
 
 
@@ -79,13 +80,14 @@ def build_handler_class(
                 return
 
             if request_path == "/readyz":
+                readiness_payload = service.inspect_readiness_diagnostics().to_dict()
+                runtime_status = resolve_readyz_runtime_status(readiness_payload)
                 self._write_json(
-                    HTTPStatus.OK,
-                    {
-                        "service_name": runtime_snapshot["service_name"],
-                        "status": "ready",
-                        "persistence_mode": runtime_snapshot["persistence_mode"],
-                    },
+                    runtime_status.http_status,
+                    runtime_status.to_readyz_payload(
+                        service_name=str(runtime_snapshot["service_name"]),
+                        persistence_mode=str(runtime_snapshot["persistence_mode"]),
+                    ),
                 )
                 return
 

--- a/control-plane/aegisops_control_plane/readiness_contracts.py
+++ b/control-plane/aegisops_control_plane/readiness_contracts.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from http import HTTPStatus
+from typing import Mapping
 
 from .models import (
     ActionExecutionRecord,
@@ -38,7 +40,82 @@ class ReadinessReviewPathRecords:
     reconciliations: tuple[ReconciliationRecord, ...]
 
 
+@dataclass(frozen=True)
+class ReadinessRuntimeStatus:
+    status: str
+    readiness_source: str
+    http_status: HTTPStatus
+    admits_runtime_traffic: bool
+
+    def to_readyz_payload(
+        self,
+        *,
+        service_name: str,
+        persistence_mode: str,
+    ) -> dict[str, object]:
+        return {
+            "service_name": service_name,
+            "status": self.status,
+            "readiness_source": self.readiness_source,
+            "admits_runtime_traffic": self.admits_runtime_traffic,
+            "persistence_mode": persistence_mode,
+        }
+
+
+def resolve_current_readiness_runtime_status(
+    *,
+    startup_ready: bool,
+    reconciliation_lifecycle_counts: Mapping[str, int],
+    review_path_health_overall_state: str | None = None,
+) -> ReadinessRuntimeStatus:
+    if not startup_ready:
+        status = "failing_closed"
+    elif reconciliation_lifecycle_counts.get("stale", 0):
+        status = "stale"
+    elif reconciliation_lifecycle_counts.get("mismatched", 0):
+        status = "degraded"
+    elif review_path_health_overall_state in {"degraded", "failed"}:
+        status = "degraded"
+    else:
+        status = "ready"
+
+    admits_runtime_traffic = status == "ready"
+    return ReadinessRuntimeStatus(
+        status=status,
+        readiness_source="current_dependency_status",
+        http_status=(
+            HTTPStatus.OK
+            if admits_runtime_traffic
+            else HTTPStatus.SERVICE_UNAVAILABLE
+        ),
+        admits_runtime_traffic=admits_runtime_traffic,
+    )
+
+
+def resolve_readyz_runtime_status(
+    readiness_payload: Mapping[str, object],
+) -> ReadinessRuntimeStatus:
+    raw_status = readiness_payload.get("status")
+    status = (
+        raw_status if isinstance(raw_status, str) and raw_status else "failing_closed"
+    )
+    admits_runtime_traffic = status == "ready"
+    return ReadinessRuntimeStatus(
+        status=status,
+        readiness_source="current_dependency_status",
+        http_status=(
+            HTTPStatus.OK
+            if admits_runtime_traffic
+            else HTTPStatus.SERVICE_UNAVAILABLE
+        ),
+        admits_runtime_traffic=admits_runtime_traffic,
+    )
+
+
 __all__ = [
     "ReadinessDiagnosticsAggregates",
     "ReadinessReviewPathRecords",
+    "ReadinessRuntimeStatus",
+    "resolve_current_readiness_runtime_status",
+    "resolve_readyz_runtime_status",
 ]

--- a/control-plane/aegisops_control_plane/readiness_contracts.py
+++ b/control-plane/aegisops_control_plane/readiness_contracts.py
@@ -9,6 +9,10 @@ from .models import (
     ReconciliationRecord,
 )
 
+_READINESS_RUNTIME_STATUSES = frozenset(
+    {"ready", "degraded", "stale", "failing_closed"}
+)
+
 
 @dataclass(frozen=True)
 class ReadinessDiagnosticsAggregates:
@@ -97,7 +101,9 @@ def resolve_readyz_runtime_status(
 ) -> ReadinessRuntimeStatus:
     raw_status = readiness_payload.get("status")
     status = (
-        raw_status if isinstance(raw_status, str) and raw_status else "failing_closed"
+        raw_status
+        if isinstance(raw_status, str) and raw_status in _READINESS_RUNTIME_STATUSES
+        else "failing_closed"
     )
     admits_runtime_traffic = status == "ready"
     return ReadinessRuntimeStatus(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -65,6 +65,7 @@ from .operator_inspection import OperatorInspectionReadSurface
 from .readiness_contracts import (
     ReadinessDiagnosticsAggregates,
     ReadinessReviewPathRecords,
+    resolve_current_readiness_runtime_status,
 )
 from .restore_readiness import RestoreReadinessService
 from .runtime_boundary import RuntimeBoundaryService, _is_missing_runtime_binding
@@ -660,15 +661,11 @@ def _derive_readiness_status(
     reconciliation_lifecycle_counts: Mapping[str, int],
     review_path_health_overall_state: str | None = None,
 ) -> str:
-    if not startup_ready:
-        return "failing_closed"
-    if reconciliation_lifecycle_counts.get("stale", 0):
-        return "stale"
-    if reconciliation_lifecycle_counts.get("mismatched", 0):
-        return "degraded"
-    if review_path_health_overall_state in {"degraded", "failed"}:
-        return "degraded"
-    return "ready"
+    return resolve_current_readiness_runtime_status(
+        startup_ready=startup_ready,
+        reconciliation_lifecycle_counts=reconciliation_lifecycle_counts,
+        review_path_health_overall_state=review_path_health_overall_state,
+    ).status
 
 
 RECORD_TYPES_BY_FAMILY: dict[str, Type[ControlPlaneRecord]] = {

--- a/control-plane/tests/test_runtime_skeleton.py
+++ b/control-plane/tests/test_runtime_skeleton.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import threading
 import unittest
+from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler
 from unittest import mock
 from urllib import error, request
@@ -251,6 +252,19 @@ class RuntimeSkeletonTests(unittest.TestCase):
         self.assertEqual(payload["status"], "degraded")
         self.assertEqual(payload["readiness_source"], "current_dependency_status")
         service.inspect_readiness_diagnostics.assert_called_once_with()
+
+    def test_readyz_runtime_status_fails_closed_for_unknown_status(self) -> None:
+        from aegisops_control_plane.readiness_contracts import (
+            resolve_readyz_runtime_status,
+        )
+
+        runtime_status = resolve_readyz_runtime_status(
+            {"status": "shadow-ready", "readiness_source": "current_dependency_status"}
+        )
+
+        self.assertEqual(runtime_status.status, "failing_closed")
+        self.assertEqual(runtime_status.http_status, HTTPStatus.SERVICE_UNAVAILABLE)
+        self.assertFalse(runtime_status.admits_runtime_traffic)
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_runtime_skeleton.py
+++ b/control-plane/tests/test_runtime_skeleton.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
 import pathlib
 import sys
 import tempfile
+import threading
 import unittest
 from http.server import BaseHTTPRequestHandler
+from unittest import mock
+from urllib import error, request
 
 
 CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -198,6 +202,55 @@ class RuntimeSkeletonTests(unittest.TestCase):
         )
 
         self.assertTrue(issubclass(handler_class, BaseHTTPRequestHandler))
+
+    def test_readyz_uses_current_readiness_diagnostics_status(self) -> None:
+        from http.server import ThreadingHTTPServer
+
+        from aegisops_control_plane import http_surface
+
+        readiness_snapshot = mock.Mock()
+        readiness_snapshot.to_dict.return_value = {
+            "read_only": True,
+            "booted": True,
+            "status": "degraded",
+            "startup": {"startup_ready": True},
+            "shutdown": {"shutdown_ready": False},
+            "metrics": {
+                "review_path_health": {"overall_state": "degraded"},
+                "optional_extensions": {"overall_state": "degraded"},
+            },
+            "latest_reconciliation": None,
+        }
+        service = mock.Mock()
+        service.inspect_readiness_diagnostics.return_value = readiness_snapshot
+
+        handler_class = http_surface.build_handler_class(
+            service=service,
+            runtime_snapshot={
+                "service_name": "aegisops-control-plane",
+                "persistence_mode": "postgresql",
+            },
+            stderr=sys.stderr,
+        )
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler_class)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with self.assertRaises(error.HTTPError) as raised:
+                request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                    f"http://127.0.0.1:{server.server_port}/readyz",
+                    timeout=2,
+                )
+            payload = json.loads(raised.exception.read().decode("utf-8"))
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        self.assertEqual(raised.exception.code, 503)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertEqual(payload["readiness_source"], "current_dependency_status")
+        service.inspect_readiness_diagnostics.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/docs/deployment/runtime-smoke-bundle.md
+++ b/docs/deployment/runtime-smoke-bundle.md
@@ -72,6 +72,8 @@ Confirm readiness through the reviewed reverse proxy:
 curl -fsS http://127.0.0.1:<proxy-port>/readyz
 ```
 
+`/readyz` is the reviewed current dependency readiness source for this smoke bundle. It reflects the current control-plane readiness diagnostics status, admits runtime traffic only when that status is `ready`, and returns refusal for `degraded`, `stale`, or `failing_closed` status instead of treating admitted startup state or optional-extension posture as sufficient.
+
 For protected surfaces, substitute `<trusted-platform-admin-proxy-auth-headers>` or `<trusted-operator-read-only-proxy-auth-headers>` with the reviewed proxy session header arguments. Those arguments must come from the trusted proxy or equivalent reviewed operator session, not from sample, fake, or operator-invented values.
 
 The protected header set is:
@@ -157,7 +159,7 @@ If a command returns an authentication refusal, readiness refusal, route refusal
 ## 4. Handoff Checklist
 
 - Startup status: the repo-owned compose stack shows the expected first-boot services and the bounded logs do not contain unresolved runtime-config, PostgreSQL reachability, migration, or reverse-proxy admission failures.
-- Readiness: `/healthz` and `/readyz` succeed through the approved reverse proxy, and readiness is not inferred from container existence alone.
+- Readiness: `/healthz` and `/readyz` succeed through the approved reverse proxy, and readiness is not inferred from container existence, admitted startup state alone, or optional-extension health.
 - Protected surface: `/runtime` succeeds only through the reviewed trusted-proxy or equivalent operator boundary, and missing or fake authentication remains blocked.
 - Runtime scope: `/runtime` still describes the reviewed first-boot and single-customer surface rather than optional-extension, HA, multi-customer, or direct-backend expansion.
 - Queue/read-only sanity: alert, case, action-request, and reconciliation inspection commands return bounded read-only data or an explicit empty state from the protected mainline surface.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -96,6 +96,8 @@ The minimum startup evidence set is:
 - the reverse-proxy readiness result from `curl -fsS http://127.0.0.1:<proxy-port>/readyz`; and
 - the runtime inspection snapshot from `curl -fsS http://127.0.0.1:<proxy-port>/runtime`.
 
+The `/readyz` result is the current dependency readiness source, not just an admitted-startup marker. It is expected to refuse normal traffic when the current readiness diagnostics status is `degraded`, `stale`, or `failing_closed`; optional-extension degradation remains subordinate and cannot be used to make `/readyz` ready.
+
 Evidence capture must record whether any startup step initially failed, what was corrected, and whether the final ready state was achieved without changing the approved boundary or adding new prerequisites.
 
 Operators must redact or omit secret material from saved evidence.
@@ -107,6 +109,7 @@ The platform may be treated as ready for the reviewed operational baseline only 
 - the control-plane service has not failed closed on missing runtime config, missing migration assets, PostgreSQL connection failure, partial migration application, or readiness-proof failure;
 - `/healthz` succeeds through the reverse proxy;
 - `/readyz` succeeds through the reverse proxy, proving required bootstrap state, PostgreSQL reachability, and the expected reviewed schema state;
+- `/readyz` reflects current dependency status from the readiness diagnostics contract and is not inferred from optional-extension health or startup admission alone;
 - `/runtime` shows the reviewed first-boot surface rather than an expanded optional-extension claim;
 - the operator can confirm the startup remained limited to the control-plane, PostgreSQL, reverse proxy, and reviewed Wazuh-facing first-boot boundary; and
 - optional extensions, if shown at all, remain explicitly subordinate and non-blocking rather than being inferred as part of mainline readiness.


### PR DESCRIPTION
## Summary
- Add a bounded readiness runtime status contract for current dependency status semantics.
- Route /readyz through current readiness diagnostics instead of a static boot-snapshot ready payload.
- Clarify runtime smoke and runbook readiness semantics while keeping optional extensions subordinate.

## Verification
- python3 -m unittest control-plane/tests/test_runtime_skeleton.py
- python3 -m unittest control-plane/tests/test_phase21_runtime_auth_validation.py -k readiness
- python3 -m unittest control-plane/tests/test_phase27_day2_runtime_contract.py -k readiness
- python3 -m unittest control-plane/tests/test_cli_inspection_runtime_surface.py -k readiness
- python3 -m unittest control-plane/tests/test_service_persistence_restore_readiness.py -k readiness
- bash scripts/verify-runbook-doc.sh && bash scripts/verify-phase-33-runtime-smoke-bundle.sh
- git diff --check
- python3 -m py_compile control-plane/aegisops_control_plane/readiness_contracts.py control-plane/aegisops_control_plane/http_surface.py control-plane/aegisops_control_plane/service.py
- node dist/index.js issue-lint 850 --config supervisor.config.aegisops.coderabbit.json

Part of #848
Closes #850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced readiness diagnostics with dynamic runtime status evaluation and reporting.

* **Bug Fixes**
  * `/readyz` now returns appropriate HTTP status when degraded, stale, or failing instead of always success.

* **Documentation**
  * Clarified `/readyz` semantics and tightened traffic admission checklist.

* **Tests**
  * Added `/readyz` endpoint tests for multiple readiness states and updated UI test to wait for readiness route rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->