### PR TITLE
Phase 47.3: Extract external evidence intake coordination

### DIFF
--- a/control-plane/aegisops_control_plane/external_evidence_boundary.py
+++ b/control-plane/aegisops_control_plane/external_evidence_boundary.py
@@ -22,6 +22,7 @@ class ExternalEvidenceBoundaryServiceDependencies(Protocol):
     _store: object
     _endpoint_evidence_pack_adapter: object
     _misp_context_adapter: object
+    _osquery_host_context_adapter: object
 
     def _build_lifecycle_transition_records(
         self,
@@ -103,6 +104,122 @@ class ExternalEvidenceBoundary:
 
     def __init__(self, service: ExternalEvidenceBoundaryServiceDependencies) -> None:
         self._service = service
+
+    def attach_osquery_host_context(
+        self,
+        *,
+        case_id: str,
+        host_identifier: str,
+        query_name: str,
+        query_sql: str,
+        result_kind: str,
+        rows: tuple[Mapping[str, object], ...],
+        collected_at: datetime,
+        reviewed_by: str,
+        source_id: str,
+        collection_path: str,
+        query_context: Mapping[str, object] | None = None,
+        evidence_id: str | None = None,
+        observation_scope_statement: str | None = None,
+        observation_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ObservationRecord | None]:
+        case_id = self._service._require_non_empty_string(case_id, "case_id")
+        normalized_scope_statement = self._service._normalize_optional_string(
+            observation_scope_statement,
+            "observation_scope_statement",
+        )
+        if normalized_scope_statement is None and observation_id is not None:
+            raise ValueError(
+                "observation_id requires observation_scope_statement for osquery attachment"
+            )
+        with self._service._store.transaction(isolation_level="SERIALIZABLE"):
+            case = self._service._require_reviewed_operator_case(case_id)
+            authoritative_host_identifier = self._service._require_case_host_identifier(
+                case
+            )
+            attachment = self._service._osquery_host_context_adapter.build_attachment(
+                case_id=case.case_id,
+                alert_id=case.alert_id,
+                authoritative_host_identifier=authoritative_host_identifier,
+                host_identifier=host_identifier,
+                query_name=query_name,
+                query_sql=query_sql,
+                result_kind=result_kind,
+                rows=rows,
+                collected_at=collected_at,
+                reviewed_by=reviewed_by,
+                source_id=source_id,
+                collection_path=collection_path,
+                query_context=query_context,
+            )
+            resolved_evidence_id = self._service._resolve_new_record_identifier(
+                EvidenceRecord,
+                evidence_id,
+                "evidence_id",
+                "evidence",
+            )
+            evidence = self._service.persist_record(
+                EvidenceRecord(
+                    evidence_id=resolved_evidence_id,
+                    source_record_id=attachment.source_record_id,
+                    alert_id=case.alert_id,
+                    case_id=case.case_id,
+                    source_system=attachment.source_system,
+                    collector_identity=attachment.collector_identity,
+                    acquired_at=attachment.acquired_at,
+                    derivation_relationship=attachment.derivation_relationship,
+                    lifecycle_state="linked",
+                    provenance=attachment.provenance,
+                    content=attachment.content,
+                )
+            )
+            current_case = self._service._require_reviewed_operator_case(case.case_id)
+            merged_case_evidence_ids = self._service._merge_linked_ids(
+                current_case.evidence_ids,
+                evidence.evidence_id,
+            )
+            if merged_case_evidence_ids != current_case.evidence_ids:
+                self._service.persist_record(
+                    replace(
+                        current_case,
+                        evidence_ids=merged_case_evidence_ids,
+                    )
+                )
+
+            observation: ObservationRecord | None = None
+            if normalized_scope_statement is not None:
+                resolved_observation_id = self._service._resolve_new_record_identifier(
+                    ObservationRecord,
+                    observation_id,
+                    "observation_id",
+                    "observation",
+                )
+                observation = self._service.persist_record(
+                    ObservationRecord(
+                        observation_id=resolved_observation_id,
+                        hunt_id=None,
+                        hunt_run_id=None,
+                        alert_id=current_case.alert_id,
+                        case_id=current_case.case_id,
+                        supporting_evidence_ids=(evidence.evidence_id,),
+                        author_identity=self._service._require_non_empty_string(
+                            reviewed_by,
+                            "reviewed_by",
+                        ),
+                        observed_at=self._service._require_aware_datetime(
+                            collected_at,
+                            "collected_at",
+                        ),
+                        scope_statement=normalized_scope_statement,
+                        lifecycle_state="confirmed",
+                        provenance=attachment.observation_provenance,
+                        content={
+                            **attachment.observation_content,
+                            "host_context_evidence_id": evidence.evidence_id,
+                        },
+                    )
+                )
+            return evidence, observation
 
     def attach_misp_context(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -4264,101 +4264,22 @@ class AegisOpsControlPlaneService:
         observation_scope_statement: str | None = None,
         observation_id: str | None = None,
     ) -> tuple[EvidenceRecord, ObservationRecord | None]:
-        case_id = self._require_non_empty_string(case_id, "case_id")
-        normalized_scope_statement = self._normalize_optional_string(
-            observation_scope_statement,
-            "observation_scope_statement",
+        return self._external_evidence_boundary.attach_osquery_host_context(
+            case_id=case_id,
+            host_identifier=host_identifier,
+            query_name=query_name,
+            query_sql=query_sql,
+            result_kind=result_kind,
+            rows=rows,
+            collected_at=collected_at,
+            reviewed_by=reviewed_by,
+            source_id=source_id,
+            collection_path=collection_path,
+            query_context=query_context,
+            evidence_id=evidence_id,
+            observation_scope_statement=observation_scope_statement,
+            observation_id=observation_id,
         )
-        if normalized_scope_statement is None and observation_id is not None:
-            raise ValueError(
-                "observation_id requires observation_scope_statement for osquery attachment"
-            )
-        with self._store.transaction(isolation_level="SERIALIZABLE"):
-            case = self._require_reviewed_operator_case(case_id)
-            authoritative_host_identifier = self._require_case_host_identifier(case)
-            attachment = self._osquery_host_context_adapter.build_attachment(
-                case_id=case.case_id,
-                alert_id=case.alert_id,
-                authoritative_host_identifier=authoritative_host_identifier,
-                host_identifier=host_identifier,
-                query_name=query_name,
-                query_sql=query_sql,
-                result_kind=result_kind,
-                rows=rows,
-                collected_at=collected_at,
-                reviewed_by=reviewed_by,
-                source_id=source_id,
-                collection_path=collection_path,
-                query_context=query_context,
-            )
-            resolved_evidence_id = self._resolve_new_record_identifier(
-                EvidenceRecord,
-                evidence_id,
-                "evidence_id",
-                "evidence",
-            )
-            evidence = self.persist_record(
-                EvidenceRecord(
-                    evidence_id=resolved_evidence_id,
-                    source_record_id=attachment.source_record_id,
-                    alert_id=case.alert_id,
-                    case_id=case.case_id,
-                    source_system=attachment.source_system,
-                    collector_identity=attachment.collector_identity,
-                    acquired_at=attachment.acquired_at,
-                    derivation_relationship=attachment.derivation_relationship,
-                    lifecycle_state="linked",
-                    provenance=attachment.provenance,
-                    content=attachment.content,
-                )
-            )
-            current_case = self._require_reviewed_operator_case(case.case_id)
-            merged_case_evidence_ids = self._merge_linked_ids(
-                current_case.evidence_ids,
-                evidence.evidence_id,
-            )
-            if merged_case_evidence_ids != current_case.evidence_ids:
-                self.persist_record(
-                    replace(
-                        current_case,
-                        evidence_ids=merged_case_evidence_ids,
-                    )
-                )
-
-            observation: ObservationRecord | None = None
-            if normalized_scope_statement is not None:
-                resolved_observation_id = self._resolve_new_record_identifier(
-                    ObservationRecord,
-                    observation_id,
-                    "observation_id",
-                    "observation",
-                )
-                observation = self.persist_record(
-                    ObservationRecord(
-                        observation_id=resolved_observation_id,
-                        hunt_id=None,
-                        hunt_run_id=None,
-                        alert_id=current_case.alert_id,
-                        case_id=current_case.case_id,
-                        supporting_evidence_ids=(evidence.evidence_id,),
-                        author_identity=self._require_non_empty_string(
-                            reviewed_by,
-                            "reviewed_by",
-                        ),
-                        observed_at=self._require_aware_datetime(
-                            collected_at,
-                            "collected_at",
-                        ),
-                        scope_statement=normalized_scope_statement,
-                        lifecycle_state="confirmed",
-                        provenance=attachment.observation_provenance,
-                        content={
-                            **attachment.observation_content,
-                            "host_context_evidence_id": evidence.evidence_id,
-                        },
-                    )
-                )
-            return evidence, observation
 
     def attach_misp_context(
         self,

--- a/control-plane/tests/test_phase28_external_evidence_boundary_refactor.py
+++ b/control-plane/tests/test_phase28_external_evidence_boundary_refactor.py
@@ -93,6 +93,74 @@ class Phase28ExternalEvidenceBoundaryRefactorTests(unittest.TestCase):
             },
         )
 
+    def test_attach_osquery_host_context_delegates_to_external_evidence_boundary(
+        self,
+    ) -> None:
+        service = self._build_service()
+        collected_at = datetime(2026, 4, 18, 0, 0, tzinfo=timezone.utc)
+        rows = (
+            {
+                "pid": "123",
+                "name": "sshd",
+                "path": "/usr/sbin/sshd",
+            },
+        )
+        query_context = {"pack": "osquery-defense", "platform": "linux"}
+        sentinel = (object(), object())
+        observed: dict[str, object] = {}
+
+        def fake_attach_osquery_host_context(**kwargs: object) -> tuple[object, object]:
+            observed.update(kwargs)
+            return sentinel
+
+        service._external_evidence_boundary.attach_osquery_host_context = (
+            fake_attach_osquery_host_context
+        )
+
+        result = service.attach_osquery_host_context(
+            case_id="case-001",
+            host_identifier="host-001",
+            query_name="running_processes",
+            query_sql="SELECT pid, name, path FROM processes;",
+            result_kind="process",
+            rows=rows,
+            collected_at=collected_at,
+            reviewed_by="analyst-001",
+            source_id="query-result-001",
+            collection_path="pack/osquery-defense/processes/running_processes",
+            query_context=query_context,
+            evidence_id="evidence-osquery-001",
+            observation_scope_statement=(
+                "Observed reviewed osquery host context on the explicitly scoped host."
+            ),
+            observation_id="observation-osquery-001",
+        )
+
+        self.assertIs(result, sentinel)
+        self.assertEqual(
+            observed,
+            {
+                "case_id": "case-001",
+                "host_identifier": "host-001",
+                "query_name": "running_processes",
+                "query_sql": "SELECT pid, name, path FROM processes;",
+                "result_kind": "process",
+                "rows": rows,
+                "collected_at": collected_at,
+                "reviewed_by": "analyst-001",
+                "source_id": "query-result-001",
+                "collection_path": (
+                    "pack/osquery-defense/processes/running_processes"
+                ),
+                "query_context": query_context,
+                "evidence_id": "evidence-osquery-001",
+                "observation_scope_statement": (
+                    "Observed reviewed osquery host context on the explicitly scoped host."
+                ),
+                "observation_id": "observation-osquery-001",
+            },
+        )
+
     def test_create_endpoint_request_delegates_to_external_evidence_boundary(self) -> None:
         service = self._build_service()
         expires_at = datetime.now(timezone.utc) + timedelta(hours=1)


### PR DESCRIPTION
## Summary
- Move osquery host-context intake coordination out of the service facade and into `ExternalEvidenceBoundary`.
- Keep the public `attach_osquery_host_context` service method as a thin wrapper, matching the existing MISP and endpoint evidence delegation pattern.
- Add a focused delegation regression test proving osquery intake is coordinated through the external evidence boundary.

Closes #851

## Verification
- `python3 -m unittest control-plane/tests/test_phase28_external_evidence_boundary_refactor.py`
- `python3 -m unittest control-plane/tests/test_phase25_osquery_host_context_validation.py`
- `python3 -m unittest control-plane/tests/test_phase28_misp_enrichment_validation.py`
- `python3 -m unittest control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py`
- `python3 -m unittest control-plane/tests/test_publishable_path_hygiene.py control-plane/tests/test_service_boundary_refactor_regression_validation.py`
- `git diff --check`
- `node dist/index.js issue-lint 851 --config supervisor.config.aegisops.json` from `<codex-supervisor-root>`: `execution_ready=yes`, `missing_required=none`, `metadata_errors=none`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for attaching osquery host-context evidence to cases with automatic observation recording and evidence linking.

* **Refactor**
  * Reorganized internal evidence processing logic to improve separation of concerns and code maintainability.

* **Tests**
  * Added validation tests ensuring evidence attachment operations work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->