### PR TITLE
Phase 47.4: Extract assistant advisory coordinator

### DIFF
--- a/control-plane/aegisops_control_plane/assistant_advisory.py
+++ b/control-plane/aegisops_control_plane/assistant_advisory.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .models import AITraceRecord, RecommendationRecord
+
+
+class AssistantAdvisoryAssembler(Protocol):
+    def inspect_advisory_output(self, record_family: str, record_id: str) -> Any:
+        ...
+
+    def render_recommendation_draft(self, record_family: str, record_id: str) -> Any:
+        ...
+
+    def attach_assistant_advisory_draft(
+        self,
+        record_family: str,
+        record_id: str,
+    ) -> RecommendationRecord | AITraceRecord:
+        ...
+
+
+class AssistantAdvisoryCoordinator:
+    """Coordinates advisory-only assembly behind the service API."""
+
+    def __init__(self, assembler: AssistantAdvisoryAssembler) -> None:
+        self._assembler = assembler
+
+    def inspect_advisory_output(self, record_family: str, record_id: str) -> Any:
+        return self._assembler.inspect_advisory_output(record_family, record_id)
+
+    def render_recommendation_draft(self, record_family: str, record_id: str) -> Any:
+        return self._assembler.render_recommendation_draft(record_family, record_id)
+
+    def attach_assistant_advisory_draft(
+        self,
+        record_family: str,
+        record_id: str,
+    ) -> RecommendationRecord | AITraceRecord:
+        return self._assembler.attach_assistant_advisory_draft(record_family, record_id)

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -30,6 +30,7 @@ from .assistant_provider import (
     AssistantProviderResult,
     AssistantProviderTransport,
 )
+from .assistant_advisory import AssistantAdvisoryCoordinator
 from .action_lifecycle_write_coordinator import ActionLifecycleWriteCoordinator
 from .action_review_write_surface import ActionReviewWriteSurface
 from .case_workflow import CaseWorkflowService
@@ -1337,6 +1338,9 @@ class AegisOpsControlPlaneService:
             recommendation_draft_snapshot_from_context=(
                 _recommendation_draft_snapshot_from_context
             ),
+        )
+        self._assistant_advisory_coordinator = AssistantAdvisoryCoordinator(
+            self._assistant_context_assembler
         )
         self._live_assistant_workflow_coordinator = LiveAssistantWorkflowCoordinator(
             self,
@@ -4464,7 +4468,7 @@ class AegisOpsControlPlaneService:
         record_family: str,
         record_id: str,
     ) -> AdvisoryInspectionSnapshot:
-        return self._assistant_context_assembler.inspect_advisory_output(
+        return self._assistant_advisory_coordinator.inspect_advisory_output(
             record_family,
             record_id,
         )
@@ -4474,7 +4478,7 @@ class AegisOpsControlPlaneService:
         record_family: str,
         record_id: str,
     ) -> RecommendationDraftSnapshot:
-        return self._assistant_context_assembler.render_recommendation_draft(
+        return self._assistant_advisory_coordinator.render_recommendation_draft(
             record_family,
             record_id,
         )
@@ -4676,7 +4680,7 @@ class AegisOpsControlPlaneService:
         record_family: str,
         record_id: str,
     ) -> RecommendationRecord | AITraceRecord:
-        return self._assistant_context_assembler.attach_assistant_advisory_draft(
+        return self._assistant_advisory_coordinator.attach_assistant_advisory_draft(
             record_family,
             record_id,
         )

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -53,7 +53,8 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             self.assertIn(term, workflow_and_cli_tests)
 
         for term in (
-            "test_service_delegates_assistant_context_and_advisory_rendering_to_assembler",
+            "test_service_delegates_assistant_context_to_assembler_and_advisory_to_coordinator",
+            "test_assistant_advisory_coordinator_exposes_no_authority_bearing_methods",
             "test_service_routes_reviewed_slice_checks_through_policy_module",
             "test_service_rejects_case_scoped_advisory_reads_without_linked_case",
         ):

--- a/control-plane/tests/test_service_persistence_assistant_advisory.py
+++ b/control-plane/tests/test_service_persistence_assistant_advisory.py
@@ -32,10 +32,38 @@ from _service_persistence_support import (
     timedelta,
     timezone,
 )
+from aegisops_control_plane.assistant_advisory import AssistantAdvisoryCoordinator
 
 
 class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
-    def test_service_delegates_assistant_context_and_advisory_rendering_to_assembler(
+    def test_assistant_advisory_coordinator_exposes_no_authority_bearing_methods(
+        self,
+    ) -> None:
+        coordinator = AssistantAdvisoryCoordinator(mock.Mock())
+        public_methods = {
+            name
+            for name in dir(coordinator)
+            if not name.startswith("_") and callable(getattr(coordinator, name))
+        }
+
+        self.assertEqual(
+            public_methods,
+            {
+                "attach_assistant_advisory_draft",
+                "inspect_advisory_output",
+                "render_recommendation_draft",
+            },
+        )
+        authority_terms = ("approval", "execution", "reconciliation", "closure")
+        self.assertFalse(
+            any(
+                authority_term in method_name
+                for method_name in public_methods
+                for authority_term in authority_terms
+            )
+        )
+
+    def test_service_delegates_assistant_context_to_assembler_and_advisory_to_coordinator(
         self,
     ) -> None:
         store, _ = make_store()
@@ -47,13 +75,14 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
         service._assistant_context_assembler.inspect_assistant_context.return_value = (
             mock.sentinel.assistant_context_snapshot
         )
-        service._assistant_context_assembler.inspect_advisory_output.return_value = (
+        service._assistant_advisory_coordinator = mock.Mock()
+        service._assistant_advisory_coordinator.inspect_advisory_output.return_value = (
             mock.sentinel.advisory_output_snapshot
         )
-        service._assistant_context_assembler.render_recommendation_draft.return_value = (
+        service._assistant_advisory_coordinator.render_recommendation_draft.return_value = (
             mock.sentinel.recommendation_draft_snapshot
         )
-        service._assistant_context_assembler.attach_assistant_advisory_draft.return_value = (
+        service._assistant_advisory_coordinator.attach_assistant_advisory_draft.return_value = (
             mock.sentinel.attached_advisory_draft_record
         )
 
@@ -80,16 +109,19 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
             "case",
             "case-delegated-001",
         )
-        service._assistant_context_assembler.inspect_advisory_output.assert_called_once_with(
+        service._assistant_context_assembler.inspect_advisory_output.assert_not_called()
+        service._assistant_context_assembler.render_recommendation_draft.assert_not_called()
+        service._assistant_context_assembler.attach_assistant_advisory_draft.assert_not_called()
+        service._assistant_advisory_coordinator.inspect_advisory_output.assert_called_once_with(
             "case",
             "case-delegated-001",
         )
-        service._assistant_context_assembler.render_recommendation_draft.assert_called_once_with(
+        service._assistant_advisory_coordinator.render_recommendation_draft.assert_called_once_with(
             "case",
             "case-delegated-001",
         )
         (
-            service._assistant_context_assembler.attach_assistant_advisory_draft
+            service._assistant_advisory_coordinator.attach_assistant_advisory_draft
             .assert_called_once_with(
                 "recommendation",
                 "recommendation-delegated-001",


### PR DESCRIPTION
## Summary
- Add `AssistantAdvisoryCoordinator` as the service-facing owner for advisory inspection, recommendation draft rendering, and advisory draft attachment.
- Keep raw assistant context assembly on `AssistantContextAssembler` while routing advisory service methods through the coordinator.
- Tighten boundary regression tests so the coordinator exposes no approval, execution, reconciliation, or closure methods.

## Verification
- `uv run --with pytest python -m pytest control-plane/tests/test_service_persistence_assistant_advisory.py -q`
- `uv run --with pytest python -m pytest control-plane/tests/test_phase15_identity_grounded_analyst_assistant_boundary_docs.py control-plane/tests/test_phase24_live_assistant_workflow_docs.py control-plane/tests/test_phase24_live_assistant_validation.py control-plane/tests/test_phase24_live_assistant_surface_validation.py control-plane/tests/test_phase24_live_assistant_fallback_validation.py control-plane/tests/test_phase24_live_assistant_provider_validation.py control-plane/tests/test_phase24_live_assistant_adversarial_validation.py control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py -q`
- `uv run --with pytest python -m pytest control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_service_internal_boundaries_docs.py control-plane/tests/test_execution_coordinator_boundary.py control-plane/tests/test_operator_inspection_boundary.py -q`
- `node <codex-supervisor-root>/dist/index.js issue-lint 852 --config <codex-supervisor-root>/supervisor.config.aegisops.coderabbit.json`

Closes #852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advisory coordination system to the control plane, enabling structured handling of advisory operations, recommendation drafting, and advisory attachment.

* **Tests**
  * Updated test suite to validate advisory coordination functionality and verify that advisory-related operations maintain appropriate security boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->