### PR TITLE
Phase 47.5: Add maintainability hotspot verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           bash scripts/verify-documentation-ownership-map.sh
           bash scripts/verify-secops-domain-model-doc.sh
           bash scripts/verify-ingest-compose-skeleton.sh
+          bash scripts/verify-maintainability-hotspots.sh
           bash scripts/verify-naming-conventions-doc.sh
           bash scripts/verify-network-exposure-policy-doc.sh
           bash scripts/verify-n8n-compose-skeleton.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,7 @@ jobs:
           bash scripts/test-verify-control-plane-schema-skeleton.sh
           bash scripts/test-verify-detector-activation-evidence-handoff.sh
           bash scripts/test-verify-detection-lifecycle-and-rule-qa-framework.sh
+          bash scripts/test-verify-maintainability-hotspots.sh
           bash scripts/test-verify-positive-smb-value-proposition.sh
           bash scripts/run-ci-phase-contract.sh all-shell-tests
           bash scripts/test-verify-ci-phase-contract-runner.sh

--- a/control-plane/tests/test_maintainability_decomposition_thresholds_docs.py
+++ b/control-plane/tests/test_maintainability_decomposition_thresholds_docs.py
@@ -36,6 +36,9 @@ class MaintainabilityDecompositionThresholdsDocsTests(unittest.TestCase):
             "`control-plane/aegisops_control_plane/restore_readiness.py`",
             "A hotspot should move to backlog creation when",
             "A hotspot can stay in place for the current issue only when",
+            "How To Interpret Verifier Output",
+            "`scripts/verify-maintainability-hotspots.sh`",
+            "`docs/maintainability-hotspot-baseline.txt`",
             "backlog trigger",
             "decomposition threshold",
         ):
@@ -57,6 +60,10 @@ class MaintainabilityDecompositionThresholdsDocsTests(unittest.TestCase):
         text = self._read("docs/documentation-ownership-map.md")
         self.assertIn(
             "| `docs/maintainability-decomposition-thresholds.md` | Maintainability decomposition thresholds and backlog triggers | IT Operations, Information Systems Department |",
+            text,
+        )
+        self.assertIn(
+            "| `docs/maintainability-hotspot-baseline.txt` | Reviewed maintainability hotspot verifier baseline | IT Operations, Information Systems Department |",
             text,
         )
 

--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -39,6 +39,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/control-plane-state-model.md` | Control-plane state and reconciliation baseline | IT Operations, Information Systems Department |
 | `docs/control-plane-runtime-service-boundary.md` | Live control-plane runtime service boundary and repository placement baseline | IT Operations, Information Systems Department |
 | `docs/maintainability-decomposition-thresholds.md` | Maintainability decomposition thresholds and backlog triggers | IT Operations, Information Systems Department |
+| `docs/maintainability-hotspot-baseline.txt` | Reviewed maintainability hotspot verifier baseline | IT Operations, Information Systems Department |
 | `docs/phase-16-release-state-and-first-boot-scope.md` | Approved Phase 16 release-state, first-boot runtime boundary, and definition of done | IT Operations, Information Systems Department |
 | `docs/phase-16-release-state-and-first-boot-validation.md` | Review record for the approved Phase 16 first-boot scope and bootability target | IT Operations, Information Systems Department |
 | `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md` | Concrete Phase 17 first-boot runtime config contract and boot command expectations | IT Operations, Information Systems Department |

--- a/docs/maintainability-decomposition-thresholds.md
+++ b/docs/maintainability-decomposition-thresholds.md
@@ -192,3 +192,20 @@ Future roadmap planning should cite this document when deciding whether a hotspo
 Pull-request review should cite this document when a supposedly narrow change is actually landing on a module that already crossed the decomposition threshold.
 
 If a reviewer can point to the threshold rule and the backlog triggers above, the repo should prefer explicit backlog creation over "one more change" reasoning.
+
+## 9. How To Interpret Verifier Output
+
+The maintainability hotspot verifier is `scripts/verify-maintainability-hotspots.sh`.
+Its focused regression test is `scripts/test-verify-maintainability-hotspots.sh`.
+
+The verifier is a responsibility-growth guard, not a line-count-only gate.
+It reports a candidate only when a tracked control-plane Python module is both large enough to be review-heavy and carries several responsibility signals such as runtime or auth boundary handling, operator surfaces, casework mutation, assistant or advisory assembly, action or reconciliation governance, readiness or restore behavior, and source or evidence admission.
+
+Known current candidates are recorded in `docs/maintainability-hotspot-baseline.txt`.
+If the verifier reports only known baseline entries, maintainers should treat the output as a reminder that those files remain reviewed hotspots and should not absorb unrelated responsibility growth without a decomposition decision.
+
+If the verifier fails with a new candidate, reviewers should use the threshold rule above before extending the file further.
+The expected response is either a narrow justification that the current change stays inside one cohesive responsibility or a follow-up maintainability backlog that preserves public behavior while extracting the next coherent cluster.
+
+If the verifier fails because a baseline entry is stale, update the baseline only after confirming the listed file no longer crosses the responsibility-growth threshold.
+That stale-baseline failure is a cleanup prompt, not permission to redefine the threshold around a summary field or convenience projection.

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,0 +1,3 @@
+# Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
+# One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
+control-plane/aegisops_control_plane/service.py

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -50,7 +50,7 @@ append_repeated_lines() {
   local prefix="$3"
   local count="$4"
 
-  for index in $(seq 1 "${count}"); do
+  for ((index = 1; index <= count; index++)); do
     printf '    %s_%03d = %03d\n' "${prefix}" "${index}" "${index}" >>"${target}/${path}"
   done
 }

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -141,6 +141,24 @@ if ! grep -F "control-plane/aegisops_control_plane/new_facade.py" "${fail_stderr
   exit 1
 fi
 
+nested_hotspot_repo="${workdir}/nested-hotspot"
+create_repo \
+  "${nested_hotspot_repo}" \
+  "control-plane/aegisops_control_plane/facades/operator_facade.py" "class OperatorFacade:
+    def expand(self):
+        auth_principal = 'trusted-runtime-boundary'
+        operator_detail_snapshot = {'principal': auth_principal}
+        case_lifecycle_transition = operator_detail_snapshot
+        assistant_advisory_recommendation = case_lifecycle_transition
+        action_approval_reconciliation = assistant_advisory_recommendation
+        restore_readiness_export = action_approval_reconciliation
+        evidence_ingest_admission = restore_readiness_export
+        return evidence_ingest_admission"
+append_repeated_lines "${nested_hotspot_repo}" "control-plane/aegisops_control_plane/facades/operator_facade.py" "mixed_line" 950
+git -C "${nested_hotspot_repo}" add .
+git -C "${nested_hotspot_repo}" commit -q -m "nested hotspot"
+assert_fails_with "${nested_hotspot_repo}" "control-plane/aegisops_control_plane/facades/operator_facade.py"
+
 missing_doc_repo="${workdir}/missing-doc"
 create_repo \
   "${missing_doc_repo}" \

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-maintainability-hotspots.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo() {
+  local target="$1"
+  shift
+
+  mkdir -p "${target}"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+
+  mkdir -p "${target}/docs" "${target}/control-plane/aegisops_control_plane"
+  printf '%s\n' \
+    "# AegisOps Maintainability Decomposition Thresholds and Backlog Triggers" \
+    "" \
+    "## How To Interpret Verifier Output" \
+    "" \
+    "Verifier candidates are review prompts for responsibility growth, not automatic refactor instructions." \
+    >"${target}/docs/maintainability-decomposition-thresholds.md"
+
+  while (($#)); do
+    local path="$1"
+    local content="$2"
+    shift 2
+
+    mkdir -p "${target}/$(dirname "${path}")"
+    printf '%s\n' "${content}" >"${target}/${path}"
+  done
+
+  git -C "${target}" add .
+  git -C "${target}" commit -q -m "fixture"
+}
+
+append_repeated_lines() {
+  local target="$1"
+  local path="$2"
+  local prefix="$3"
+  local count="$4"
+
+  for index in $(seq 1 "${count}"); do
+    printf '    %s_%03d = %03d\n' "${prefix}" "${index}" "${index}" >>"${target}/${path}"
+  done
+}
+
+assert_passes() {
+  local target="$1"
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+single_responsibility_repo="${workdir}/single-responsibility"
+create_repo \
+  "${single_responsibility_repo}" \
+  "control-plane/aegisops_control_plane/report_projection.py" "class ReportProjection:
+    def render_summary(self):
+        status = 'ready'
+        snapshot = {'status': status}
+        return snapshot"
+append_repeated_lines "${single_responsibility_repo}" "control-plane/aegisops_control_plane/report_projection.py" "projection_line" 950
+git -C "${single_responsibility_repo}" add .
+git -C "${single_responsibility_repo}" commit -q -m "large single responsibility"
+assert_passes "${single_responsibility_repo}"
+
+baseline_repo="${workdir}/baseline"
+create_repo \
+  "${baseline_repo}" \
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py" \
+  "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
+    def describe_runtime(self):
+        auth_principal = 'trusted-runtime-boundary'
+        queue_status = {'operator': auth_principal}
+        case_transition = queue_status
+        assistant_recommendation = case_transition
+        action_reconciliation = assistant_recommendation
+        restore_backup_export = action_reconciliation
+        evidence_admission = restore_backup_export
+        return evidence_admission"
+append_repeated_lines "${baseline_repo}" "control-plane/aegisops_control_plane/service.py" "mixed_line" 950
+git -C "${baseline_repo}" add .
+git -C "${baseline_repo}" commit -q -m "known hotspot baseline"
+assert_passes "${baseline_repo}"
+if ! grep -F "Known maintainability hotspot baseline remains present" "${pass_stdout}" >/dev/null; then
+  echo "Expected pass output to report the known baseline hotspot." >&2
+  cat "${pass_stdout}" >&2
+  exit 1
+fi
+
+new_hotspot_repo="${workdir}/new-hotspot"
+create_repo \
+  "${new_hotspot_repo}" \
+  "control-plane/aegisops_control_plane/new_facade.py" "class NewFacade:
+    def expand(self):
+        auth_principal = 'trusted-runtime-boundary'
+        operator_detail_snapshot = {'principal': auth_principal}
+        case_lifecycle_transition = operator_detail_snapshot
+        assistant_advisory_recommendation = case_lifecycle_transition
+        action_approval_reconciliation = assistant_advisory_recommendation
+        restore_readiness_export = action_approval_reconciliation
+        evidence_ingest_admission = restore_readiness_export
+        return evidence_ingest_admission"
+append_repeated_lines "${new_hotspot_repo}" "control-plane/aegisops_control_plane/new_facade.py" "mixed_line" 950
+git -C "${new_hotspot_repo}" add .
+git -C "${new_hotspot_repo}" commit -q -m "new hotspot"
+assert_fails_with "${new_hotspot_repo}" "docs/maintainability-decomposition-thresholds.md"
+if ! grep -F "control-plane/aegisops_control_plane/new_facade.py" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to name the hotspot candidate." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
+
+missing_doc_repo="${workdir}/missing-doc"
+create_repo \
+  "${missing_doc_repo}" \
+  "control-plane/aegisops_control_plane/small.py" "class Small:
+    pass"
+rm "${missing_doc_repo}/docs/maintainability-decomposition-thresholds.md"
+git -C "${missing_doc_repo}" add -A
+git -C "${missing_doc_repo}" commit -q -m "missing doc"
+assert_fails_with "${missing_doc_repo}" "Missing maintainability decomposition threshold document"
+
+echo "verify-maintainability-hotspots tests passed"

--- a/scripts/verify-documentation-ownership-map.sh
+++ b/scripts/verify-documentation-ownership-map.sh
@@ -27,6 +27,7 @@ required_phrases=(
   '| `docs/response-action-safety-model.md` | Response action safety and approval binding baseline | IT Operations, Information Systems Department |'
   '| `docs/automation-substrate-contract.md` | Approved automation delegation contract baseline | IT Operations, Information Systems Department |'
   '| `docs/control-plane-state-model.md` | Control-plane state and reconciliation baseline | IT Operations, Information Systems Department |'
+  '| `docs/maintainability-hotspot-baseline.txt` | Reviewed maintainability hotspot verifier baseline | IT Operations, Information Systems Department |'
   '| `docs/retention-evidence-and-replay-readiness-baseline.md` | Retention, evidence lifecycle, and replay readiness baseline | IT Operations, Information Systems Department |'
   '| `docs/adr/` | Architecture Decision Records (ADRs) | IT Operations, Information Systems Department |'
   '| `docs/parameters/` | Parameter documentation | IT Operations, Information Systems Department |'

--- a/scripts/verify-maintainability-hotspots.sh
+++ b/scripts/verify-maintainability-hotspots.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tool_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${tool_root}}"
+threshold_doc="docs/maintainability-decomposition-thresholds.md"
+baseline_file="docs/maintainability-hotspot-baseline.txt"
+
+if ! git -C "${repo_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not a Git working tree: ${repo_root}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${repo_root}/${threshold_doc}" ]]; then
+  echo "Missing maintainability decomposition threshold document: ${threshold_doc}" >&2
+  exit 1
+fi
+
+if ! grep -Eq "^## .*How To Interpret Verifier Output" "${repo_root}/${threshold_doc}"; then
+  echo "Maintainability threshold document must explain verifier output: ${threshold_doc}" >&2
+  exit 1
+fi
+
+export AEGISOPS_REPO_ROOT="${repo_root}"
+export AEGISOPS_MAINTAINABILITY_BASELINE="${baseline_file}"
+export AEGISOPS_MAINTAINABILITY_DOC="${threshold_doc}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+repo_root = pathlib.Path(os.environ["AEGISOPS_REPO_ROOT"])
+baseline_path = repo_root / os.environ["AEGISOPS_MAINTAINABILITY_BASELINE"]
+threshold_doc = os.environ["AEGISOPS_MAINTAINABILITY_DOC"]
+
+minimum_effective_lines = int(os.environ.get("AEGISOPS_MAINTAINABILITY_MIN_EFFECTIVE_LINES", "900"))
+minimum_signals = int(os.environ.get("AEGISOPS_MAINTAINABILITY_MIN_SIGNALS", "4"))
+
+signal_patterns: dict[str, re.Pattern[str]] = {
+    "runtime/auth boundary": re.compile(r"(auth|principal|runtime|boundary|tenant|scope)", re.I),
+    "operator surface": re.compile(r"(operator|queue|detail|projection|inspect|summary|snapshot|status)", re.I),
+    "casework mutation": re.compile(r"(case|triage|promot|lifecycle|transition|mutation)", re.I),
+    "assistant/advisory assembly": re.compile(r"(assistant|advisory|recommendation|citation)", re.I),
+    "action/reconciliation governance": re.compile(r"(action|approval|execution|reconciliation|delegat)", re.I),
+    "readiness/restore/export": re.compile(r"(readiness|backup|restore|export|shutdown|startup)", re.I),
+    "source/evidence admission": re.compile(r"(evidence|ingest|source|detector|alert|admission)", re.I),
+}
+
+required_boundary_signals = {
+    "runtime/auth boundary",
+    "operator surface",
+    "action/reconciliation governance",
+}
+
+
+def tracked_python_files() -> list[str]:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "ls-files",
+            "--",
+            "control-plane/aegisops_control_plane/*.py",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.endswith(".py")]
+
+
+def read_baseline() -> set[str]:
+    if not baseline_path.exists():
+        return set()
+
+    entries: set[str] = set()
+    for line in baseline_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        entries.add(stripped.split()[0])
+    return entries
+
+
+def effective_line_count(text: str) -> int:
+    count = 0
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            count += 1
+    return count
+
+
+def candidate_for(relative_path: str) -> tuple[str, int, tuple[str, ...]] | None:
+    path = repo_root / relative_path
+    text = path.read_text(encoding="utf-8", errors="replace")
+    facade_like = (
+        pathlib.Path(relative_path).name == "service.py"
+        or "facade" in relative_path.lower()
+        or re.search(r"^class\s+\w*(Service|Facade)\b", text, re.M) is not None
+    )
+    if not facade_like:
+        return None
+
+    effective_lines = effective_line_count(text)
+    present_signals = tuple(
+        signal_name
+        for signal_name, pattern in signal_patterns.items()
+        if pattern.search(text)
+    )
+
+    if effective_lines < minimum_effective_lines:
+        return None
+    if len(present_signals) < minimum_signals:
+        return None
+    if not required_boundary_signals.intersection(present_signals):
+        return None
+
+    return (relative_path, effective_lines, present_signals)
+
+
+baseline_entries = read_baseline()
+candidates = [candidate for relative_path in tracked_python_files() if (candidate := candidate_for(relative_path))]
+candidate_paths = {relative_path for relative_path, _, _ in candidates}
+
+unknown_candidates = [candidate for candidate in candidates if candidate[0] not in baseline_entries]
+stale_baseline_entries = sorted(baseline_entries - candidate_paths)
+
+if unknown_candidates:
+    print(
+        "Maintainability hotspot candidates exceeded the reviewed baseline.",
+        file=sys.stderr,
+    )
+    print(
+        f"Review {threshold_doc} before extending these files or open a decomposition backlog.",
+        file=sys.stderr,
+    )
+    for relative_path, effective_lines, signals in unknown_candidates:
+        print(
+            f"- {relative_path}: effective_lines={effective_lines}, signals={', '.join(signals)}",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+
+if stale_baseline_entries:
+    print(
+        "Maintainability hotspot baseline contains entries that no longer match candidates.",
+        file=sys.stderr,
+    )
+    for relative_path in stale_baseline_entries:
+        print(f"- {relative_path}", file=sys.stderr)
+    print(f"Update {baseline_path.relative_to(repo_root)} after confirming the hotspot was decomposed.", file=sys.stderr)
+    sys.exit(1)
+
+if candidates:
+    print("Known maintainability hotspot baseline remains present:")
+    for relative_path, effective_lines, signals in candidates:
+        print(
+            f"- {relative_path}: effective_lines={effective_lines}, signals={len(signals)}; see {threshold_doc}"
+        )
+else:
+    print(f"No maintainability hotspot candidates found. See {threshold_doc}.")
+PY

--- a/scripts/verify-maintainability-hotspots.sh
+++ b/scripts/verify-maintainability-hotspots.sh
@@ -90,6 +90,7 @@ def read_baseline() -> set[str]:
 
 
 def effective_line_count(text: str) -> int:
+    """Return maintained non-comment lines; docstrings intentionally count."""
     count = 0
     for line in text.splitlines():
         stripped = line.strip()

--- a/scripts/verify-maintainability-hotspots.sh
+++ b/scripts/verify-maintainability-hotspots.sh
@@ -67,7 +67,7 @@ def tracked_python_files() -> list[str]:
             str(repo_root),
             "ls-files",
             "--",
-            "control-plane/aegisops_control_plane/*.py",
+            ":(glob)control-plane/aegisops_control_plane/**/*.py",
         ],
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary
- add a facade-focused maintainability hotspot verifier that combines size, responsibility signals, and a reviewed baseline
- add fixture-based positive/negative verifier tests and document how maintainers should interpret output
- wire the verifier into docs-and-skeleton CI and track the baseline artifact in documentation ownership

## Verification
- bash scripts/test-verify-maintainability-hotspots.sh
- bash scripts/verify-maintainability-hotspots.sh
- python3 -m unittest control-plane.tests.test_maintainability_decomposition_thresholds_docs
- bash scripts/verify-documentation-ownership-map.sh
- sed -n '34,92p' .github/workflows/ci.yml | sed 's/^          //' | bash\n- node dist/index.js issue-lint 853 --config supervisor.config.aegisops.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on interpreting maintainability-hotspot verifier output and how to respond to failures.
  * Established a documented baseline artifact for known maintainability hotspots and updated the documentation ownership map.

* **Tests**
  * Added comprehensive test coverage exercising multiple verifier scenarios, including baseline, new-hotspot, nested, and missing-doc cases.

* **Chores**
  * CI now runs the maintainability-hotspot verification and its tests alongside existing documentation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->