### PR TITLE
Phase 45.1 queue priority projection fields

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
@@ -70,6 +70,12 @@ export function registerOperatorRoutesCaseworkTests() {
               review_state: "degraded",
               case_id: "case-456",
               case_lifecycle_state: "open",
+              owner: "analyst-review-001",
+              age_seconds: 3600,
+              age_bucket: "fresh",
+              severity: "high",
+              last_activity_at: "2026-04-26T22:16:17Z",
+              next_action: "Review the queue projection before any approval-bound response.",
               accountable_source_identities: [
                 "manager:wazuh-manager-github-1",
               ],
@@ -106,6 +112,14 @@ export function registerOperatorRoutesCaseworkTests() {
       await waitFor(() => {
         expect(screen.getByText("alert-123")).toBeInTheDocument();
         expect(screen.getAllByText(/Review: degraded/i).length).toBeGreaterThan(0);
+        expect(screen.getByText("analyst-review-001")).toBeInTheDocument();
+        expect(screen.getByText("fresh")).toBeInTheDocument();
+        expect(screen.getByText("high")).toBeInTheDocument();
+        expect(screen.getByText("2026-04-26T22:16:17Z")).toBeInTheDocument();
+        expect(
+          screen.getAllByText("Review the queue projection before any approval-bound response.")
+            .length,
+        ).toBeGreaterThan(0);
         expect(
           screen.getByText(/Primary review surface/i),
         ).toBeInTheDocument();

--- a/apps/operator-ui/src/app/operatorConsolePages/queuePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/queuePages.tsx
@@ -168,9 +168,13 @@ export function QueuePage() {
                   <TableRow>
                     <TableCell>Alert</TableCell>
                     <TableCell>Review state</TableCell>
+                    <TableCell>Owner</TableCell>
+                    <TableCell>Severity</TableCell>
+                    <TableCell>Age</TableCell>
                     <TableCell>Case</TableCell>
                     <TableCell>Source family</TableCell>
                     <TableCell>Action review</TableCell>
+                    <TableCell>Next action</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -183,6 +187,10 @@ export function QueuePage() {
                     const actionReviewState = asString(
                       getPath(record, "current_action_review.review_state"),
                     );
+                    const owner = asString(record.owner);
+                    const severity = asString(record.severity);
+                    const ageBucket = asString(record.age_bucket);
+                    const nextAction = asString(record.next_action);
                     return (
                       <TableRow hover key={String(record.id ?? alertId)}>
                         <TableCell>
@@ -201,6 +209,9 @@ export function QueuePage() {
                         <TableCell>
                           <StatusStrip values={[["Review", asString(record.review_state)]]} />
                         </TableCell>
+                        <TableCell>{owner ?? "Unassigned"}</TableCell>
+                        <TableCell>{severity ?? "Not available"}</TableCell>
+                        <TableCell>{ageBucket ?? "Not available"}</TableCell>
                         <TableCell>
                           {caseId ? (
                             <AuditedRouteLink
@@ -217,6 +228,7 @@ export function QueuePage() {
                         </TableCell>
                         <TableCell>{sourceFamily ?? "Not available"}</TableCell>
                         <TableCell>{actionReviewState ?? "No active review"}</TableCell>
+                        <TableCell>{nextAction ?? "Review queue record"}</TableCell>
                       </TableRow>
                     );
                   })}
@@ -240,12 +252,17 @@ export function QueuePage() {
               ["Review", asString(record.review_state)],
               ["Case", asString(record.case_lifecycle_state)],
               ["Escalation", asString(record.escalation_boundary)],
+              ["Owner", asString(record.owner)],
+              ["Severity", asString(record.severity)],
+              ["Age", asString(record.age_bucket)],
               ["Action review", asString(getPath(record, "current_action_review.review_state"))],
             ]}
           />
           <RecordWarnings record={record} />
           <ValueList
             entries={[
+              ["Last activity", record.last_activity_at],
+              ["Next action", record.next_action],
               ["Accountable identities", asStringArray(record.accountable_source_identities)],
               ["Subordinate detection ids", asStringArray(record.substrate_detection_record_ids)],
               ["Correlation key", record.correlation_key],

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -347,33 +347,19 @@ class OperatorInspectionReadSurface:
 
         return "medium"
 
-    def _latest_transition_at(
-        self,
-        *,
-        alert_id: str,
-        case_id: str | None,
-    ) -> datetime | None:
-        candidate_subjects = {("alert", alert_id)}
-        if case_id is not None:
-            candidate_subjects.add(("case", case_id))
-        transitions = [
-            transition.transitioned_at
-            for transition in self._service._store.list(LifecycleTransitionRecord)
-            if (
-                transition.subject_record_family,
-                transition.subject_record_id,
-            )
-            in candidate_subjects
-        ]
-        return max(transitions) if transitions else None
-
     def _queue_owner(
         self,
         *,
         alert_id: str,
         case_id: str | None,
         reviewed_context: Mapping[str, object],
+        action_reviews: tuple[dict[str, object], ...],
     ) -> str | None:
+        if action_reviews:
+            requester_identity = action_reviews[0].get("requester_identity")
+            if isinstance(requester_identity, str) and requester_identity.strip():
+                return requester_identity.strip()
+
         recommendations = [
             recommendation
             for recommendation in self._service._store.list(RecommendationRecord)
@@ -391,7 +377,8 @@ class OperatorInspectionReadSurface:
         leads = [
             lead
             for lead in self._service._store.list(LeadRecord)
-            if lead.alert_id == alert_id or (case_id is not None and lead.case_id == case_id)
+            if lead.alert_id == alert_id
+            or (case_id is not None and lead.case_id == case_id)
         ]
         if leads:
             latest_lead = sorted(
@@ -496,17 +483,7 @@ class OperatorInspectionReadSurface:
                 if first_seen_at is not None
                 else 0
             )
-            last_activity_at = max(
-                candidate
-                for candidate in (
-                    reconciliation.last_seen_at,
-                    self._latest_transition_at(
-                        alert_id=alert.alert_id,
-                        case_id=alert.case_id,
-                    ),
-                )
-                if candidate is not None
-            )
+            last_activity_at = reconciliation.last_seen_at or first_seen_at
             owner_reviewed_context = (
                 case_record.reviewed_context if case_record is not None else alert.reviewed_context
             )
@@ -549,6 +526,7 @@ class OperatorInspectionReadSurface:
                         alert_id=alert.alert_id,
                         case_id=alert.case_id,
                         reviewed_context=owner_reviewed_context,
+                        action_reviews=action_reviews,
                     ),
                     "age_seconds": age_seconds,
                     "age_bucket": self._queue_age_bucket(age_seconds),

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -14,6 +14,7 @@ from .models import (
     LifecycleTransitionRecord,
     ObservationRecord,
     LeadRecord,
+    RecommendationRecord,
     ReconciliationRecord,
 )
 
@@ -310,6 +311,137 @@ class OperatorInspectionReadSurface:
             )
         )
 
+    @staticmethod
+    def _queue_age_bucket(age_seconds: int) -> str:
+        if age_seconds >= 24 * 60 * 60:
+            return "stale"
+        return "fresh"
+
+    @staticmethod
+    def _queue_severity_from_reviewed_context(
+        reviewed_context: Mapping[str, object],
+    ) -> str:
+        provenance = reviewed_context.get("provenance")
+        rule_level = (
+            provenance.get("rule_level")
+            if isinstance(provenance, Mapping)
+            else None
+        )
+        if isinstance(rule_level, int):
+            if rule_level >= 12:
+                return "critical"
+            if rule_level >= 7:
+                return "high"
+            if rule_level >= 4:
+                return "medium"
+            return "low"
+
+        explicit_severity = reviewed_context.get("severity")
+        if isinstance(explicit_severity, str) and explicit_severity in {
+            "low",
+            "medium",
+            "high",
+            "critical",
+        }:
+            return explicit_severity
+
+        return "medium"
+
+    def _latest_transition_at(
+        self,
+        *,
+        alert_id: str,
+        case_id: str | None,
+    ) -> datetime | None:
+        candidate_subjects = {("alert", alert_id)}
+        if case_id is not None:
+            candidate_subjects.add(("case", case_id))
+        transitions = [
+            transition.transitioned_at
+            for transition in self._service._store.list(LifecycleTransitionRecord)
+            if (
+                transition.subject_record_family,
+                transition.subject_record_id,
+            )
+            in candidate_subjects
+        ]
+        return max(transitions) if transitions else None
+
+    def _queue_owner(
+        self,
+        *,
+        alert_id: str,
+        case_id: str | None,
+        reviewed_context: Mapping[str, object],
+    ) -> str | None:
+        recommendations = [
+            recommendation
+            for recommendation in self._service._store.list(RecommendationRecord)
+            if recommendation.alert_id == alert_id
+            or (case_id is not None and recommendation.case_id == case_id)
+        ]
+        if recommendations:
+            latest_recommendation = sorted(
+                recommendations,
+                key=lambda recommendation: recommendation.recommendation_id,
+                reverse=True,
+            )[0]
+            return latest_recommendation.review_owner
+
+        leads = [
+            lead
+            for lead in self._service._store.list(LeadRecord)
+            if lead.alert_id == alert_id or (case_id is not None and lead.case_id == case_id)
+        ]
+        if leads:
+            latest_lead = sorted(
+                leads,
+                key=lambda lead: lead.lead_id,
+                reverse=True,
+            )[0]
+            return latest_lead.triage_owner
+
+        handoff = reviewed_context.get("handoff")
+        if isinstance(handoff, Mapping):
+            handoff_owner = handoff.get("handoff_owner")
+            if isinstance(handoff_owner, str) and handoff_owner.strip():
+                return handoff_owner.strip()
+
+        return None
+
+    def _queue_next_action(
+        self,
+        *,
+        alert_id: str,
+        case_id: str | None,
+        review_state: str,
+        action_reviews: tuple[dict[str, object], ...],
+    ) -> str:
+        if action_reviews:
+            next_expected_action = action_reviews[0].get("next_expected_action")
+            if isinstance(next_expected_action, str) and next_expected_action.strip():
+                return next_expected_action.strip()
+
+        recommendations = [
+            recommendation
+            for recommendation in self._service._store.list(RecommendationRecord)
+            if recommendation.alert_id == alert_id
+            or (case_id is not None and recommendation.case_id == case_id)
+        ]
+        if recommendations:
+            latest_recommendation = sorted(
+                recommendations,
+                key=lambda recommendation: recommendation.recommendation_id,
+                reverse=True,
+            )[0]
+            return latest_recommendation.intended_outcome
+
+        if case_id is None:
+            return "Promote alert to case"
+        if review_state == "case_required":
+            return "Review linked case"
+        return "Review queue record"
+
     def inspect_analyst_queue(self) -> object:
         active_alert_states = {
             "new",
@@ -357,6 +489,27 @@ class OperatorInspectionReadSurface:
                 case_id=alert.case_id,
                 ai_trace_records=ai_trace_records,
             )
+            now = datetime.now(timezone.utc)
+            first_seen_at = reconciliation.first_seen_at
+            age_seconds = (
+                max(0, int((now - first_seen_at).total_seconds()))
+                if first_seen_at is not None
+                else 0
+            )
+            last_activity_at = max(
+                candidate
+                for candidate in (
+                    reconciliation.last_seen_at,
+                    self._latest_transition_at(
+                        alert_id=alert.alert_id,
+                        case_id=alert.case_id,
+                    ),
+                )
+                if candidate is not None
+            )
+            owner_reviewed_context = (
+                case_record.reviewed_context if case_record is not None else alert.reviewed_context
+            )
             queue_records.append(
                 {
                     "alert_id": alert.alert_id,
@@ -392,6 +545,23 @@ class OperatorInspectionReadSurface:
                     "correlation_key": reconciliation.correlation_key,
                     "first_seen_at": reconciliation.first_seen_at,
                     "last_seen_at": reconciliation.last_seen_at,
+                    "owner": self._queue_owner(
+                        alert_id=alert.alert_id,
+                        case_id=alert.case_id,
+                        reviewed_context=owner_reviewed_context,
+                    ),
+                    "age_seconds": age_seconds,
+                    "age_bucket": self._queue_age_bucket(age_seconds),
+                    "severity": self._queue_severity_from_reviewed_context(
+                        alert.reviewed_context,
+                    ),
+                    "last_activity_at": last_activity_at,
+                    "next_action": self._queue_next_action(
+                        alert_id=alert.alert_id,
+                        case_id=alert.case_id,
+                        review_state=review_state,
+                        action_reviews=action_reviews,
+                    ),
                     "current_action_review": (
                         dict(action_reviews[0]) if action_reviews else None
                     ),

--- a/control-plane/tests/test_operator_inspection_boundary.py
+++ b/control-plane/tests/test_operator_inspection_boundary.py
@@ -4,15 +4,21 @@ import pathlib
 import sys
 import unittest
 from unittest import mock
+from copy import deepcopy
+from datetime import datetime, timezone
 
 
 CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))
 
 from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.service import AegisOpsControlPlaneService
 from postgres_test_support import make_store
+from support.fixtures import load_wazuh_fixture
 
 
 class OperatorInspectionBoundaryTests(unittest.TestCase):
@@ -23,8 +29,28 @@ class OperatorInspectionBoundaryTests(unittest.TestCase):
                 host="127.0.0.1",
                 port=0,
                 postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",
             ),
             store=store,
+        )
+
+    def _ingest_queue_fixture(
+        self,
+        service: AegisOpsControlPlaneService,
+        *,
+        timestamp: datetime,
+        native_id: str,
+    ):
+        alert = deepcopy(load_wazuh_fixture("github-audit-alert.json"))
+        alert["id"] = native_id
+        alert["timestamp"] = timestamp.isoformat()
+        return service.ingest_wazuh_alert(
+            raw_alert=alert,
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="127.0.0.1",
         )
 
     def test_service_initializes_dedicated_operator_inspection_read_surface(
@@ -67,6 +93,71 @@ class OperatorInspectionBoundaryTests(unittest.TestCase):
         inspection_read_surface.inspect_case_detail.assert_called_once_with(
             "case-inspection-001"
         )
+
+    def test_analyst_queue_projection_includes_backend_derived_daily_priority_fields(
+        self,
+    ) -> None:
+        service = self._build_service()
+        observed_at = datetime.now(timezone.utc).replace(microsecond=0)
+        admitted = self._ingest_queue_fixture(
+            service,
+            timestamp=observed_at,
+            native_id="queue-projection-normal-001",
+        )
+        promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-queue-001",
+            triage_rationale="Keep daily queue ownership derived from AegisOps lead records.",
+        )
+        service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            lead_id=lead.lead_id,
+            review_owner="analyst-review-001",
+            intended_outcome="Review the queue projection before any approval-bound response.",
+        )
+
+        snapshot = service.inspect_analyst_queue()
+
+        self.assertEqual(snapshot.total_records, 1)
+        record = snapshot.records[0]
+        self.assertEqual(record["owner"], "analyst-review-001")
+        self.assertGreaterEqual(record["age_seconds"], 0)
+        self.assertEqual(record["age_bucket"], "fresh")
+        self.assertEqual(record["severity"], "high")
+        self.assertGreaterEqual(record["last_activity_at"], observed_at)
+        self.assertEqual(
+            record["next_action"],
+            "Review the queue projection before any approval-bound response.",
+        )
+
+    def test_analyst_queue_projection_keeps_empty_stale_and_missing_owner_states_visible(
+        self,
+    ) -> None:
+        empty_service = self._build_service()
+        empty_snapshot = empty_service.inspect_analyst_queue()
+        self.assertEqual(empty_snapshot.total_records, 0)
+        self.assertEqual(empty_snapshot.records, ())
+
+        service = self._build_service()
+        stale_at = datetime(2026, 4, 1, 9, 30, tzinfo=timezone.utc)
+        admitted = self._ingest_queue_fixture(
+            service,
+            timestamp=stale_at,
+            native_id="queue-projection-stale-001",
+        )
+
+        snapshot = service.inspect_analyst_queue()
+
+        self.assertEqual(snapshot.total_records, 1)
+        record = snapshot.records[0]
+        self.assertEqual(record["alert_id"], admitted.alert.alert_id)
+        self.assertIsNone(record["owner"])
+        self.assertGreaterEqual(record["age_seconds"], 24 * 60 * 60)
+        self.assertEqual(record["age_bucket"], "stale")
+        self.assertEqual(record["severity"], "high")
+        self.assertGreaterEqual(record["last_activity_at"], stale_at)
+        self.assertEqual(record["next_action"], "Promote alert to case")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add backend-derived analyst queue priority fields for owner, age, severity, last activity, and next action
- render those fields in the operator queue table and queue summary
- add focused backend and operator-ui regression coverage for normal, empty, stale, and missing-owner queue states

Part of #859
Depends on #834
Closes #860

## Verification
- python3 -m unittest control-plane/tests/test_operator_inspection_boundary.py -v
- npm test -- --run src/app/OperatorRoutes.test.tsx (from apps/operator-ui)
- npm run typecheck --workspace @aegisops/operator-ui
- node dist/index.js issue-lint 860 --config supervisor.config.aegisops.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue table now displays additional columns: Owner, Severity, Age, and Next action
  * Queue summary section enhanced with ownership, severity, and timing information for better visibility and decision-making

<!-- end of auto-generated comment: release notes by coderabbit.ai -->