### PR TITLE
Phase 45.2: Add operator queue degraded-state lanes

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
@@ -185,6 +185,87 @@ export function registerOperatorRoutesCaseworkTests() {
       });
     });
 
+    it("renders mismatch, stale receipt, degraded extension, action-required, and clean queue lanes", async () => {
+      const fetchFn = createAuthorizedFetch({
+        "/inspect-analyst-queue": {
+          queue_name: "analyst_review",
+          read_only: true,
+          lane_counts: {
+            action_required: 1,
+            reconciliation_mismatch: 1,
+            stale_receipt: 1,
+            optional_extension_degraded: 1,
+            clean: 1,
+          },
+          records: [
+            {
+              alert_id: "alert-lanes-mismatch",
+              review_state: "new",
+              queue_lanes: [
+                "action_required",
+                "reconciliation_mismatch",
+                "stale_receipt",
+                "optional_extension_degraded",
+              ],
+              queue_lane_details: {
+                reconciliation_mismatch: {
+                  state: "mismatched",
+                  summary: "stale downstream execution observation requires refresh",
+                },
+                stale_receipt: {
+                  state: "stale",
+                  summary: "stale downstream execution observation requires refresh",
+                },
+                optional_extension_degraded: {
+                  endpoint_evidence: {
+                    readiness: "degraded",
+                    reason: "receipt_lag_requires_review",
+                  },
+                },
+              },
+            },
+            {
+              alert_id: "alert-lanes-clean",
+              review_state: "triaged",
+              queue_lanes: ["clean"],
+            },
+          ],
+          total_records: 2,
+        },
+      });
+      const dependencies = createDefaultDependencies({
+        fetchFn,
+      });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/queue"]}>
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Queue lanes" })).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Action required: 1")).toBeInTheDocument();
+      expect(screen.getByText("Reconciliation mismatch: 1")).toBeInTheDocument();
+      expect(screen.getByText("Stale receipt: 1")).toBeInTheDocument();
+      expect(screen.getByText("Optional extension degraded: 1")).toBeInTheDocument();
+      expect(screen.getByText("Clean: 1")).toBeInTheDocument();
+      expect(screen.getByText("alert-lanes-mismatch")).toBeInTheDocument();
+      expect(screen.getAllByText("Reconciliation mismatch").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Stale receipt").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Optional extension degraded").length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText("stale downstream execution observation requires refresh").length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText("endpoint evidence: receipt lag requires review").length,
+      ).toBeGreaterThan(0);
+      expect(screen.getByText("alert-lanes-clean")).toBeInTheDocument();
+      expect(screen.getAllByText("Clean").length).toBeGreaterThan(0);
+    });
+
     it("renders grouped AI trace review states in the analyst queue", async () => {
       const fetchFn = createAuthorizedFetch({
         "/inspect-analyst-queue": {

--- a/apps/operator-ui/src/app/operatorConsolePages/queuePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/queuePages.tsx
@@ -11,9 +11,11 @@ import {
 } from "@mui/material";
 import { useMemo } from "react";
 import {
+  asRecord,
   asRecordArray,
   asString,
   asStringArray,
+  formatLabel,
   AuditedRouteLink,
   EmptyState,
   ErrorState,
@@ -29,6 +31,14 @@ import {
   useOperatorList,
   ValueList,
 } from "./shared";
+
+const QUEUE_LANE_LABELS: Record<string, string> = {
+  action_required: "Action required",
+  reconciliation_mismatch: "Reconciliation mismatch",
+  stale_receipt: "Stale receipt",
+  optional_extension_degraded: "Optional extension degraded",
+  clean: "Clean",
+};
 
 function aiTraceReviewStateLabel(state: string) {
   switch (state) {
@@ -136,6 +146,94 @@ function QueueAiTraceReviewGroups({ records }: { records: Record<string, unknown
   );
 }
 
+function queueLaneLabel(lane: string) {
+  return QUEUE_LANE_LABELS[lane] ?? formatLabel(lane);
+}
+
+function QueueLaneSummary({ records }: { records: Record<string, unknown>[] }) {
+  const counts = Object.keys(QUEUE_LANE_LABELS).map((lane) => {
+    const count = records.filter((record) =>
+      asStringArray(record.queue_lanes).includes(lane),
+    ).length;
+    return [lane, count] as const;
+  });
+
+  return (
+    <SectionCard
+      subtitle="These lanes make mismatch and degraded state visible for review without making receipts or optional extensions authoritative."
+      title="Queue lanes"
+    >
+      <Stack direction="row" flexWrap="wrap" gap={1}>
+        {counts.map(([lane, count]) => (
+          <Chip
+            color={statusTone(lane)}
+            key={lane}
+            label={`${queueLaneLabel(lane)}: ${count}`}
+            size="small"
+            variant={count > 0 ? "filled" : "outlined"}
+          />
+        ))}
+      </Stack>
+    </SectionCard>
+  );
+}
+
+function QueueLaneDetails({ record }: { record: Record<string, unknown> }) {
+  const lanes = asStringArray(record.queue_lanes);
+  const details = asRecord(record.queue_lane_details);
+  const degradedExtensions = asRecord(details?.optional_extension_degraded);
+  const reconciliationMismatch = asRecord(details?.reconciliation_mismatch);
+  const staleReceipt = asRecord(details?.stale_receipt);
+  const detailLines: string[] = [];
+
+  const mismatchSummary = asString(reconciliationMismatch?.summary);
+  if (mismatchSummary) {
+    detailLines.push(mismatchSummary);
+  }
+
+  const staleSummary = asString(staleReceipt?.summary);
+  if (staleSummary && staleSummary !== mismatchSummary) {
+    detailLines.push(staleSummary);
+  }
+
+  if (degradedExtensions) {
+    for (const [extensionName, extensionState] of Object.entries(degradedExtensions)) {
+      const extensionRecord = asRecord(extensionState);
+      const reason = asString(extensionRecord?.reason);
+      if (reason) {
+        detailLines.push(
+          `${formatLabel(extensionName).toLowerCase()}: ${reason.replace(/_/g, " ")}`,
+        );
+      }
+    }
+  }
+
+  if (lanes.length === 0 && detailLines.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={0.75}>
+      <Stack direction="row" flexWrap="wrap" gap={1}>
+        {lanes.map((lane) => (
+          <Chip
+            color={statusTone(lane)}
+            key={lane}
+            label={queueLaneLabel(lane)}
+            size="small"
+            variant={lane === "clean" ? "outlined" : "filled"}
+          />
+        ))}
+      </Stack>
+      {detailLines.map((line) => (
+        <Typography color="text.secondary" key={line} variant="caption">
+          {line}
+        </Typography>
+      ))}
+    </Stack>
+  );
+}
+
 export function QueuePage() {
   const filter = useMemo(() => ({}), []);
   const sort = useMemo(
@@ -158,6 +256,7 @@ export function QueuePage() {
       {data ? (
         data.length > 0 ? (
           <Stack spacing={3}>
+            <QueueLaneSummary records={data} />
             <QueueAiTraceReviewGroups records={data} />
             <SectionCard
               subtitle="Explicit degraded, pending, and mismatch states remain visible instead of being smoothed away."
@@ -174,6 +273,7 @@ export function QueuePage() {
                     <TableCell>Case</TableCell>
                     <TableCell>Source family</TableCell>
                     <TableCell>Action review</TableCell>
+                    <TableCell>Lanes</TableCell>
                     <TableCell>Next action</TableCell>
                   </TableRow>
                 </TableHead>
@@ -228,6 +328,9 @@ export function QueuePage() {
                         </TableCell>
                         <TableCell>{sourceFamily ?? "Not available"}</TableCell>
                         <TableCell>{actionReviewState ?? "No active review"}</TableCell>
+                        <TableCell>
+                          <QueueLaneDetails record={record} />
+                        </TableCell>
                         <TableCell>{nextAction ?? "Review queue record"}</TableCell>
                       </TableRow>
                     );
@@ -258,6 +361,7 @@ export function QueuePage() {
               ["Action review", asString(getPath(record, "current_action_review.review_state"))],
             ]}
           />
+          <QueueLaneDetails record={record} />
           <RecordWarnings record={record} />
           <ValueList
             entries={[

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -600,7 +600,7 @@ class OperatorInspectionReadSurface:
                 if "action_required" not in lanes:
                     lanes.append("action_required")
 
-        if reconciliation.lifecycle_state not in {"matched"}:
+        if reconciliation.lifecycle_state == "mismatched":
             lanes.append("reconciliation_mismatch")
             details["reconciliation_mismatch"] = {
                 "state": reconciliation.lifecycle_state,

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -607,14 +607,23 @@ class OperatorInspectionReadSurface:
                 "summary": reconciliation.mismatch_summary,
             }
 
-        if (
-            reconciliation.ingest_disposition == "stale"
-            or reconciliation.lifecycle_state == "stale"
-            or "stale downstream execution observation" in reconciliation.mismatch_summary
-        ):
+        stale_downstream_observed = (
+            "stale downstream execution observation" in reconciliation.mismatch_summary
+        )
+        stale_receipt_state = None
+        if reconciliation.lifecycle_state == "stale":
+            stale_receipt_state = reconciliation.lifecycle_state
+        elif stale_downstream_observed:
+            stale_receipt_state = "stale_downstream_observed"
+        elif reconciliation.ingest_disposition == "stale":
+            stale_receipt_state = reconciliation.ingest_disposition
+
+        if stale_receipt_state is not None:
             lanes.append("stale_receipt")
             details["stale_receipt"] = {
-                "state": reconciliation.ingest_disposition,
+                "state": stale_receipt_state,
+                "lifecycle_state": reconciliation.lifecycle_state,
+                "ingest_disposition": reconciliation.ingest_disposition,
                 "summary": reconciliation.mismatch_summary,
             }
 

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -22,6 +22,15 @@ from .models import (
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
 
 
+_QUEUE_LANES = (
+    "action_required",
+    "reconciliation_mismatch",
+    "stale_receipt",
+    "optional_extension_degraded",
+    "clean",
+)
+
+
 class InspectionStore(Protocol):
     def get(self, record_type: Type[RecordT], record_id: str) -> RecordT | None:
         ...
@@ -476,6 +485,12 @@ class OperatorInspectionReadSurface:
                 case_id=alert.case_id,
                 ai_trace_records=ai_trace_records,
             )
+            queue_lanes, queue_lane_details = self._queue_lanes_for_record(
+                alert=alert,
+                reconciliation=reconciliation,
+                review_state=review_state,
+                action_reviews=action_reviews,
+            )
             now = datetime.now(timezone.utc)
             first_seen_at = reconciliation.first_seen_at
             age_seconds = (
@@ -540,6 +555,8 @@ class OperatorInspectionReadSurface:
                         review_state=review_state,
                         action_reviews=action_reviews,
                     ),
+                    "queue_lanes": queue_lanes,
+                    "queue_lane_details": queue_lane_details,
                     "current_action_review": (
                         dict(action_reviews[0]) if action_reviews else None
                     ),
@@ -559,8 +576,87 @@ class OperatorInspectionReadSurface:
             read_only=True,
             queue_name="analyst_review",
             total_records=len(queue_records),
+            lane_counts=self._queue_lane_counts(queue_records),
             records=tuple(queue_records),
         )
+
+    def _queue_lanes_for_record(
+        self,
+        *,
+        alert: AlertRecord,
+        reconciliation: ReconciliationRecord,
+        review_state: str,
+        action_reviews: tuple[dict[str, object], ...],
+    ) -> tuple[tuple[str, ...], dict[str, object]]:
+        lanes: list[str] = []
+        details: dict[str, object] = {}
+
+        if review_state in {"pending_review", "case_required", "investigating", "degraded"}:
+            lanes.append("action_required")
+
+        if action_reviews:
+            current_review_state = action_reviews[0].get("review_state")
+            if current_review_state not in {None, "approved", "completed", "matched"}:
+                if "action_required" not in lanes:
+                    lanes.append("action_required")
+
+        if reconciliation.lifecycle_state not in {"matched"}:
+            lanes.append("reconciliation_mismatch")
+            details["reconciliation_mismatch"] = {
+                "state": reconciliation.lifecycle_state,
+                "summary": reconciliation.mismatch_summary,
+            }
+
+        if (
+            reconciliation.ingest_disposition == "stale"
+            or reconciliation.lifecycle_state == "stale"
+            or "stale downstream execution observation" in reconciliation.mismatch_summary
+        ):
+            lanes.append("stale_receipt")
+            details["stale_receipt"] = {
+                "state": reconciliation.ingest_disposition,
+                "summary": reconciliation.mismatch_summary,
+            }
+
+        degraded_optional_extensions = self._degraded_optional_extensions(alert.reviewed_context)
+        if degraded_optional_extensions:
+            lanes.append("optional_extension_degraded")
+            details["optional_extension_degraded"] = degraded_optional_extensions
+
+        if not lanes:
+            lanes.append("clean")
+
+        return tuple(lanes), details
+
+    @staticmethod
+    def _degraded_optional_extensions(
+        reviewed_context: Mapping[str, object],
+    ) -> dict[str, object]:
+        optional_extensions = reviewed_context.get("optional_extensions")
+        if not isinstance(optional_extensions, Mapping):
+            return {}
+
+        degraded_extensions: dict[str, object] = {}
+        for extension_name, extension_state in optional_extensions.items():
+            if not isinstance(extension_state, Mapping):
+                continue
+            if extension_state.get("readiness") == "degraded":
+                degraded_extensions[str(extension_name)] = dict(extension_state)
+        return degraded_extensions
+
+    @staticmethod
+    def _queue_lane_counts(
+        queue_records: list[dict[str, object]],
+    ) -> dict[str, int]:
+        lane_counts = {lane: 0 for lane in _QUEUE_LANES}
+        for record in queue_records:
+            queue_lanes = record.get("queue_lanes")
+            if not isinstance(queue_lanes, tuple):
+                continue
+            for lane in queue_lanes:
+                if isinstance(lane, str) and lane in lane_counts:
+                    lane_counts[lane] += 1
+        return lane_counts
 
     def inspect_alert_detail(self, alert_id: str) -> object:
         alert_id = self._service._require_non_empty_string(alert_id, "alert_id")

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -296,6 +296,7 @@ class AnalystQueueSnapshot:
     read_only: bool
     queue_name: str
     total_records: int
+    lane_counts: dict[str, int]
     records: tuple[dict[str, object], ...]
 
     def to_dict(self) -> dict[str, object]:
@@ -304,6 +305,7 @@ class AnalystQueueSnapshot:
                 "read_only": self.read_only,
                 "queue_name": self.queue_name,
                 "total_records": self.total_records,
+                "lane_counts": self.lane_counts,
                 "records": self.records,
             }
         )

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -3694,6 +3694,68 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         )
         self.assertEqual(queue_view.records[1]["queue_lanes"], ("clean",))
 
+    def test_service_does_not_mark_pending_reconciliation_as_mismatch_lane(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops"
+            ),
+            store=store,
+        )
+        seen_at = support.datetime(2026, 4, 5, 12, 20, tzinfo=support.timezone.utc)
+
+        service.persist_record(
+            AlertRecord(
+                alert_id="alert-queue-pending-reconciliation",
+                finding_id="finding-queue-pending-reconciliation",
+                analytic_signal_id="signal-queue-pending-reconciliation",
+                case_id=None,
+                lifecycle_state="triaged",
+            )
+        )
+        service.persist_record(
+            support.ReconciliationRecord(
+                reconciliation_id="reconciliation-queue-pending",
+                subject_linkage={
+                    "alert_ids": ("alert-queue-pending-reconciliation",),
+                    "analytic_signal_ids": ("signal-queue-pending-reconciliation",),
+                    "substrate_detection_record_ids": ("wazuh:queue-pending",),
+                    "source_systems": ("wazuh",),
+                },
+                alert_id="alert-queue-pending-reconciliation",
+                finding_id="finding-queue-pending-reconciliation",
+                analytic_signal_id="signal-queue-pending-reconciliation",
+                execution_run_id="execution-run-queue-pending",
+                linked_execution_run_ids=("execution-run-queue-pending",),
+                correlation_key="wazuh:queue-pending",
+                first_seen_at=seen_at,
+                last_seen_at=seen_at,
+                ingest_disposition="created",
+                mismatch_summary="reconciliation pending downstream receipt review",
+                compared_at=seen_at,
+                lifecycle_state="pending",
+            )
+        )
+
+        queue_view = service.inspect_analyst_queue()
+
+        self.assertEqual(queue_view.total_records, 1)
+        record = queue_view.records[0]
+        self.assertEqual(record["queue_lanes"], ("clean",))
+        self.assertNotIn("reconciliation_mismatch", record["queue_lane_details"])
+        self.assertEqual(
+            queue_view.to_dict()["lane_counts"],
+            {
+                "action_required": 0,
+                "reconciliation_mismatch": 0,
+                "stale_receipt": 0,
+                "optional_extension_degraded": 0,
+                "clean": 1,
+            },
+        )
+
     def test_service_rejects_schema_invalid_records_before_they_are_inspectable(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -3562,12 +3562,14 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
     def test_service_marks_queue_lanes_for_mismatch_stale_and_degraded_context(
         self,
     ) -> None:
-        store, _ = make_store()
-        service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops"
+            ),
             store=store,
         )
-        seen_at = datetime(2026, 4, 5, 12, 15, tzinfo=timezone.utc)
+        seen_at = support.datetime(2026, 4, 5, 12, 15, tzinfo=support.timezone.utc)
 
         service.persist_record(
             AlertRecord(
@@ -3587,7 +3589,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             )
         )
         service.persist_record(
-            ReconciliationRecord(
+            support.ReconciliationRecord(
                 reconciliation_id="reconciliation-queue-lanes",
                 subject_linkage={
                     "alert_ids": ("alert-queue-lanes",),
@@ -3603,7 +3605,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
                 correlation_key="wazuh:queue-lanes",
                 first_seen_at=seen_at,
                 last_seen_at=seen_at,
-                ingest_disposition="stale",
+                ingest_disposition="created",
                 mismatch_summary="stale downstream execution observation requires refresh",
                 compared_at=seen_at,
                 lifecycle_state="mismatched",
@@ -3619,7 +3621,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             )
         )
         service.persist_record(
-            ReconciliationRecord(
+            support.ReconciliationRecord(
                 reconciliation_id="reconciliation-queue-clean",
                 subject_linkage={
                     "alert_ids": ("alert-queue-clean",),
@@ -3665,7 +3667,9 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(
             record["queue_lane_details"]["stale_receipt"],
             {
-                "state": "stale",
+                "state": "stale_downstream_observed",
+                "lifecycle_state": "mismatched",
+                "ingest_disposition": "created",
                 "summary": "stale downstream execution observation requires refresh",
             },
         )

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -3559,6 +3559,137 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             ("alert-known-last-seen", "alert-unknown-last-seen"),
         )
 
+    def test_service_marks_queue_lanes_for_mismatch_stale_and_degraded_context(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        seen_at = datetime(2026, 4, 5, 12, 15, tzinfo=timezone.utc)
+
+        service.persist_record(
+            AlertRecord(
+                alert_id="alert-queue-lanes",
+                finding_id="finding-queue-lanes",
+                analytic_signal_id="signal-queue-lanes",
+                case_id=None,
+                lifecycle_state="new",
+                reviewed_context={
+                    "optional_extensions": {
+                        "endpoint_evidence": {
+                            "readiness": "degraded",
+                            "reason": "receipt_lag_requires_review",
+                        }
+                    }
+                },
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-queue-lanes",
+                subject_linkage={
+                    "alert_ids": ("alert-queue-lanes",),
+                    "analytic_signal_ids": ("signal-queue-lanes",),
+                    "substrate_detection_record_ids": ("wazuh:queue-lanes",),
+                    "source_systems": ("wazuh",),
+                },
+                alert_id="alert-queue-lanes",
+                finding_id="finding-queue-lanes",
+                analytic_signal_id="signal-queue-lanes",
+                execution_run_id="execution-run-queue-lanes",
+                linked_execution_run_ids=("execution-run-queue-lanes",),
+                correlation_key="wazuh:queue-lanes",
+                first_seen_at=seen_at,
+                last_seen_at=seen_at,
+                ingest_disposition="stale",
+                mismatch_summary="stale downstream execution observation requires refresh",
+                compared_at=seen_at,
+                lifecycle_state="mismatched",
+            )
+        )
+        service.persist_record(
+            AlertRecord(
+                alert_id="alert-queue-clean",
+                finding_id="finding-queue-clean",
+                analytic_signal_id="signal-queue-clean",
+                case_id=None,
+                lifecycle_state="triaged",
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-queue-clean",
+                subject_linkage={
+                    "alert_ids": ("alert-queue-clean",),
+                    "analytic_signal_ids": ("signal-queue-clean",),
+                    "substrate_detection_record_ids": ("wazuh:queue-clean",),
+                    "source_systems": ("wazuh",),
+                },
+                alert_id="alert-queue-clean",
+                finding_id="finding-queue-clean",
+                analytic_signal_id="signal-queue-clean",
+                execution_run_id=None,
+                linked_execution_run_ids=(),
+                correlation_key="wazuh:queue-clean",
+                first_seen_at=seen_at - timedelta(minutes=5),
+                last_seen_at=seen_at - timedelta(minutes=5),
+                ingest_disposition="created",
+                mismatch_summary="matched upstream signal into alert lifecycle",
+                compared_at=seen_at,
+                lifecycle_state="matched",
+            )
+        )
+
+        queue_view = service.inspect_analyst_queue()
+
+        self.assertEqual(queue_view.total_records, 2)
+        record = queue_view.records[0]
+        self.assertEqual(
+            record["queue_lanes"],
+            (
+                "action_required",
+                "reconciliation_mismatch",
+                "stale_receipt",
+                "optional_extension_degraded",
+            ),
+        )
+        self.assertEqual(
+            record["queue_lane_details"]["reconciliation_mismatch"],
+            {
+                "state": "mismatched",
+                "summary": "stale downstream execution observation requires refresh",
+            },
+        )
+        self.assertEqual(
+            record["queue_lane_details"]["stale_receipt"],
+            {
+                "state": "stale",
+                "summary": "stale downstream execution observation requires refresh",
+            },
+        )
+        self.assertEqual(
+            record["queue_lane_details"]["optional_extension_degraded"],
+            {
+                "endpoint_evidence": {
+                    "readiness": "degraded",
+                    "reason": "receipt_lag_requires_review",
+                }
+            },
+        )
+        self.assertEqual(
+            queue_view.to_dict()["lane_counts"],
+            {
+                "action_required": 1,
+                "reconciliation_mismatch": 1,
+                "stale_receipt": 1,
+                "optional_extension_degraded": 1,
+                "clean": 1,
+            },
+        )
+        self.assertEqual(queue_view.records[1]["queue_lanes"], ("clean",))
+
     def test_service_rejects_schema_invalid_records_before_they_are_inspectable(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -406,6 +406,8 @@ The operator health review contract is the reviewed business-hours cadence for d
 
 Each business day, operators must review `curl -fsS http://127.0.0.1:<proxy-port>/readyz`, `curl -fsS http://127.0.0.1:<proxy-port>/runtime`, the reviewed queue and alert surfaces, and any explicit degraded-state markers before treating the platform as ready for normal work.
 
+The reviewed queue lanes for action-required, reconciliation mismatch, stale receipt, optional-extension degraded, and clean states are visibility aids for this review. They do not make optional extension health, downstream receipts, or browser-rendered state authoritative for workflow closure.
+
 The daily review must classify each degraded condition as safe for continued business-hours inspection, requiring same-day follow-up, or requiring escalation before normal operation continues.
 
 Daily review should cover these operator-owned questions in one pass:


### PR DESCRIPTION
## Summary
- add backend operator queue lane projection for action-required, reconciliation mismatch, stale receipt, optional-extension degraded, and clean states
- render queue lane summary/detail chips in the operator UI without making receipts or optional extensions authoritative
- update the daily health review runbook and add focused backend/UI regression coverage

## Verification
- python3 -m unittest control-plane.tests.test_service_persistence_ingest_case_lifecycle
- python3 -m unittest control-plane.tests.test_operator_inspection_boundary control-plane.tests.test_phase30f_operator_ui_validation
- python3 -m unittest control-plane.tests.test_phase32_secret_rotation_runbook_docs control-plane.tests.test_phase27_day2_hardening_validation
- npm --prefix apps/operator-ui run typecheck
- npm --prefix apps/operator-ui test
- bash scripts/verify-runbook-doc.sh
- node dist/index.js issue-lint 861 --config supervisor.config.aegisops.coderabbit.json

Part of #859. Depends on #860. Closes #861.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue page now shows lane-aware view: per-record lane classification, status chips, detailed lane summaries, a new "Lanes" column, and aggregated lane counts for analyst queues.

* **Tests**
  * Added UI and backend tests validating lane assignment, per-record lane details, and aggregated lane counts.

* **Documentation**
  * Runbook clarifies reviewed lane states are non-authoritative for workflow closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->