### PR TITLE
Phase 45.3: Replace operator placeholder drilldowns

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
@@ -293,6 +293,14 @@ export function registerOperatorRoutesAuthAndShellTests() {
       "href",
       expect.stringContaining("/reviewed-operator/queue"),
     );
+    expect(screen.getByRole("menuitem", { name: "Alerts" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/reviewed-operator/alerts"),
+    );
+    expect(screen.getByRole("menuitem", { name: "Cases" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/reviewed-operator/cases"),
+    );
     expect(screen.getByRole("menuitem", { name: "Action Review" })).toHaveAttribute(
       "href",
       expect.stringContaining("/reviewed-operator/action-review"),

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.testSuite.tsx
@@ -342,6 +342,154 @@ export function registerOperatorRoutesCaseworkTests() {
       expect(screen.queryByRole("button", { name: /execute/i })).not.toBeInTheDocument();
     });
 
+    it("renders the alert drilldown index instead of the placeholder alert page", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-analyst-queue": {
+            queue_name: "analyst_review",
+            read_only: true,
+            records: [
+              {
+                alert_id: "alert-index-001",
+                review_state: "degraded",
+                case_id: "case-index-001",
+                case_lifecycle_state: "open",
+                reviewed_context: {
+                  source: {
+                    source_family: "github_audit",
+                  },
+                },
+                external_ticket_reference: {
+                  status: "missing_anchor",
+                },
+              },
+            ],
+            total_records: 1,
+          },
+        }),
+      });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/alerts"]}>
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        await screen.findByRole("heading", { name: "Alerts" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/This route exists so later adapter and page work can land/i),
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "alert-index-001" })).toHaveAttribute(
+        "href",
+        "/operator/alerts/alert-index-001",
+      );
+      expect(screen.getByRole("link", { name: "case-index-001" })).toHaveAttribute(
+        "href",
+        "/operator/cases/case-index-001",
+      );
+      expect(screen.getByText("github_audit")).toBeInTheDocument();
+      expect(screen.getByText("degraded")).toBeInTheDocument();
+      expect(screen.getByText("Review state remains degraded.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Non-authoritative coordination reference is missing_anchor."),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /promote/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /record/i })).not.toBeInTheDocument();
+    });
+
+    it("renders an empty read-only case drilldown index instead of the placeholder case page", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-analyst-queue": {
+            queue_name: "analyst_review",
+            read_only: true,
+            records: [
+              {
+                alert_id: "alert-without-case",
+                review_state: "new",
+                reviewed_context: {
+                  source: {
+                    source_family: "wazuh",
+                  },
+                },
+              },
+            ],
+            total_records: 1,
+          },
+        }),
+      });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/cases"]}>
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        await screen.findByRole("heading", { name: "Cases" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/This route exists so later adapter and page work can land/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText("No case anchors are currently visible in the analyst queue."),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Back to queue" })).toHaveAttribute(
+        "href",
+        "/operator/queue",
+      );
+      expect(screen.queryByRole("button", { name: /record observation/i })).not.toBeInTheDocument();
+    });
+
+    it("renders provenance landing as a bounded record-chain index", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-analyst-queue": {
+            queue_name: "analyst_review",
+            read_only: true,
+            records: [
+              {
+                alert_id: "alert-prov-001",
+                review_state: "triaged",
+                case_id: "case-prov-001",
+                reviewed_context: {
+                  source: {
+                    source_family: "microsoft_365_audit",
+                  },
+                },
+              },
+            ],
+            total_records: 1,
+          },
+        }),
+      });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/provenance/cases"]}>
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        await screen.findByRole("heading", { name: "Provenance" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/This route exists so later adapter and page work can land/i),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("Record-chain drilldown index")).toBeInTheDocument();
+      expect(screen.getByText("case-prov-001")).toBeInTheDocument();
+      expect(screen.getByText("alert-prov-001")).toBeInTheDocument();
+      expect(screen.getByText("microsoft_365_audit")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Open provenance" })).toHaveAttribute(
+        "href",
+        "/operator/provenance/cases/case-prov-001",
+      );
+      expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /execute/i })).not.toBeInTheDocument();
+    });
+
     it("renders alert detail with authoritative and subordinate sections separated", async () => {
       const dependencies = createDefaultDependencies({
         fetchFn: createAuthorizedFetch({

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -147,12 +147,12 @@ function OperatorMenu({
       <Menu.Item
         leftIcon={<WarningAmberOutlinedIcon />}
         primaryText="Alerts"
-        to={buildOperatorShellPath(basePath, "queue")}
+        to={buildOperatorShellPath(basePath, "alerts")}
       />
       <Menu.Item
         leftIcon={<InsightsOutlinedIcon />}
         primaryText="Cases"
-        to={buildOperatorShellPath(basePath, "queue")}
+        to={buildOperatorShellPath(basePath, "cases")}
       />
       <Menu.Item
         leftIcon={<LinkOutlinedIcon />}

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -67,10 +67,16 @@ const AssistantAdvisoryPage =
   lazyOperatorConsolePage("AssistantAdvisoryPage") as unknown as typeof import("./operatorConsolePages").AssistantAdvisoryPage;
 const AlertDetailPage =
   lazyOperatorConsolePage("AlertDetailPage") as unknown as typeof import("./operatorConsolePages").AlertDetailPage;
+const AlertIndexPage =
+  lazyOperatorConsolePage("AlertIndexPage") as unknown as typeof import("./operatorConsolePages").AlertIndexPage;
 const CaseDetailPage =
   lazyOperatorConsolePage("CaseDetailPage") as unknown as typeof import("./operatorConsolePages").CaseDetailPage;
+const CaseIndexPage =
+  lazyOperatorConsolePage("CaseIndexPage") as unknown as typeof import("./operatorConsolePages").CaseIndexPage;
 const ProvenancePage =
   lazyOperatorConsolePage("ProvenancePage") as unknown as typeof import("./operatorConsolePages").ProvenancePage;
+const ProvenanceIndexPage =
+  lazyOperatorConsolePage("ProvenanceIndexPage") as unknown as typeof import("./operatorConsolePages").ProvenanceIndexPage;
 const QueuePage =
   lazyOperatorConsolePage("QueuePage") as unknown as typeof import("./operatorConsolePages").QueuePage;
 const ReadinessPage =
@@ -324,29 +330,6 @@ function UnsupportedOperatorRoutePage() {
   );
 }
 
-function PlaceholderPage({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  return (
-    <Stack spacing={2} sx={{ p: 3 }}>
-      <Typography component="h1" variant="h4">
-        {title}
-      </Typography>
-      <Typography color="text.secondary" variant="body1">
-        {description}
-      </Typography>
-      <Typography variant="body2">
-        This route exists so later adapter and page work can land without
-        replacing the approved auth boundary.
-      </Typography>
-    </Stack>
-  );
-}
-
 function DeferredPageFallback() {
   return (
     <Stack
@@ -402,14 +385,18 @@ function OperatorShellContent({
         <Routes>
           <Route element={<OverviewPage operatorRoles={operatorRoles} />} index />
           <Route element={<QueuePage />} path="queue" />
+          <Route element={<AlertIndexPage />} path="alerts" />
           <Route
             element={<AlertDetailPage operatorIdentity={operatorIdentity} />}
             path="alerts/:alertId"
           />
+          <Route element={<CaseIndexPage />} path="cases" />
           <Route
             element={<CaseDetailPage operatorIdentity={operatorIdentity} />}
             path="cases/:caseId"
           />
+          <Route element={<ProvenanceIndexPage />} path="provenance" />
+          <Route element={<ProvenanceIndexPage />} path="provenance/:family" />
           <Route element={<ProvenancePage />} path="provenance/:family/:recordId" />
           <Route element={<ReadinessPage />} path="readiness" />
           <Route element={<ReconciliationPage />} path="reconciliation" />
@@ -449,33 +436,6 @@ function OperatorShellContent({
               )
             }
             path="action-review/:actionRequestId"
-          />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Use the queue as the primary route into alert detail."
-                title="Alerts"
-              />
-            }
-            path="alerts"
-          />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Use the queue or linked alert detail to open a specific case."
-                title="Cases"
-              />
-            }
-            path="cases"
-          />
-          <Route
-            element={
-              <PlaceholderPage
-                description="Open provenance from alert or case detail so the page stays anchored to an authoritative record."
-                title="Provenance"
-              />
-            }
-            path="provenance/*"
           />
           <Route element={<UnsupportedOperatorRoutePage />} path="*" />
         </Routes>

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -1,5 +1,13 @@
 export { QueuePage } from "./operatorConsolePages/queuePages";
-export { AlertDetailPage, CaseDetailPage } from "./operatorConsolePages/caseworkPages";
+export {
+  AlertDetailPage,
+  CaseDetailPage,
+} from "./operatorConsolePages/caseworkPages";
+export {
+  AlertIndexPage,
+  CaseIndexPage,
+  ProvenanceIndexPage,
+} from "./operatorConsolePages/drilldownIndexPages";
 export { ActionReviewPage } from "./operatorConsolePages/actionReviewPages";
 export { AssistantAdvisoryPage } from "./operatorConsolePages/assistantPages";
 export {

--- a/apps/operator-ui/src/app/operatorConsolePages/drilldownIndexPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/drilldownIndexPages.tsx
@@ -1,0 +1,392 @@
+import {
+  Alert,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import {
+  asString,
+  asStringArray,
+  AuditedRouteButton,
+  AuditedRouteLink,
+  EmptyState,
+  ErrorState,
+  formatValue,
+  getPath,
+  LoadingState,
+  PageFrame,
+  QueryStateNotice,
+  RecordWarnings,
+  SectionCard,
+  StatusStrip,
+  type UnknownRecord,
+  useOperatorList,
+} from "./shared";
+
+const QUEUE_SORT = {
+  field: "last_seen_at",
+  order: "DESC" as const,
+};
+
+function sourceFamily(record: UnknownRecord) {
+  return asString(getPath(record, "reviewed_context.source.source_family"));
+}
+
+function caseLifecycle(record: UnknownRecord) {
+  return asString(record.case_lifecycle_state) ?? asString(getPath(record, "case_record.lifecycle_state"));
+}
+
+function ReviewedQueueLink() {
+  return (
+    <AuditedRouteButton label="Back to queue" to="/operator/queue">
+      Back to queue
+    </AuditedRouteButton>
+  );
+}
+
+function AlertIndexTable({ records }: { records: UnknownRecord[] }) {
+  if (records.length === 0) {
+    return <EmptyState message="No alert records are currently visible in the analyst queue." />;
+  }
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>Alert</TableCell>
+          <TableCell>Review</TableCell>
+          <TableCell>Case anchor</TableCell>
+          <TableCell>Source family</TableCell>
+          <TableCell>Provenance</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {records.map((record) => {
+          const alertId = asString(record.alert_id);
+          const caseId = asString(record.case_id);
+
+          return (
+            <TableRow key={alertId ?? String(record.id)} hover>
+              <TableCell>
+                {alertId ? (
+                  <AuditedRouteLink label="Open alert detail" to={`/operator/alerts/${alertId}`}>
+                    {alertId}
+                  </AuditedRouteLink>
+                ) : (
+                  formatValue(alertId)
+                )}
+              </TableCell>
+              <TableCell>{formatValue(record.review_state)}</TableCell>
+              <TableCell>
+                {caseId ? (
+                  <AuditedRouteLink label="Open case detail" to={`/operator/cases/${caseId}`}>
+                    {caseId}
+                  </AuditedRouteLink>
+                ) : (
+                  "No case anchor"
+                )}
+              </TableCell>
+              <TableCell>{formatValue(sourceFamily(record))}</TableCell>
+              <TableCell>
+                {alertId ? (
+                  <AuditedRouteLink
+                    label="Open alert provenance"
+                    to={`/operator/provenance/alerts/${alertId}`}
+                  >
+                    Open provenance
+                  </AuditedRouteLink>
+                ) : (
+                  "Unavailable"
+                )}
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function AlertIndexPage() {
+  const filter = useMemo(() => ({}), []);
+  const { data, error, loading, refreshing } = useOperatorList(
+    "queue",
+    filter,
+    QUEUE_SORT,
+  );
+
+  return (
+    <PageFrame
+      subtitle="Read-only alert drilldown starts from backend-authoritative queue records and keeps cases, provenance, and subordinate context as linked inspection surfaces."
+      title="Alerts"
+    >
+      {loading && !data ? <LoadingState label="Loading alert drilldown index" /> : null}
+      {error && !data ? <ErrorState error={error} /> : null}
+      {data ? (
+        <Stack spacing={3}>
+          <QueryStateNotice error={error} refreshing={refreshing} />
+          <SectionCard
+            subtitle="The queue record is the bounded selection surface. Open a detail page to inspect the full authoritative alert record chain."
+            title="Alert drilldown index"
+          >
+            <Stack spacing={2}>
+              <Alert severity="info" variant="outlined">
+                This page is read-only and cannot promote, approve, execute, reconcile, or edit downstream tickets.
+              </Alert>
+              <AlertIndexTable records={data} />
+            </Stack>
+          </SectionCard>
+          {data.map((record) => (
+            <RecordWarnings key={`warning-${String(record.id)}`} record={record} />
+          ))}
+          <ReviewedQueueLink />
+        </Stack>
+      ) : null}
+    </PageFrame>
+  );
+}
+
+function uniqueCaseRecords(records: UnknownRecord[]) {
+  const cases = new Map<string, UnknownRecord>();
+
+  for (const record of records) {
+    const caseId = asString(record.case_id);
+    if (!caseId || cases.has(caseId)) {
+      continue;
+    }
+
+    cases.set(caseId, record);
+  }
+
+  return Array.from(cases.values());
+}
+
+function CaseIndexTable({ records }: { records: UnknownRecord[] }) {
+  const cases = uniqueCaseRecords(records);
+
+  if (cases.length === 0) {
+    return <EmptyState message="No case anchors are currently visible in the analyst queue." />;
+  }
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>Case</TableCell>
+          <TableCell>Lifecycle</TableCell>
+          <TableCell>Linked alert</TableCell>
+          <TableCell>Source family</TableCell>
+          <TableCell>Provenance</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {cases.map((record) => {
+          const caseId = asString(record.case_id);
+          const alertId = asString(record.alert_id);
+
+          return (
+            <TableRow key={caseId ?? String(record.id)} hover>
+              <TableCell>
+                {caseId ? (
+                  <AuditedRouteLink label="Open case detail" to={`/operator/cases/${caseId}`}>
+                    {caseId}
+                  </AuditedRouteLink>
+                ) : (
+                  formatValue(caseId)
+                )}
+              </TableCell>
+              <TableCell>{formatValue(caseLifecycle(record))}</TableCell>
+              <TableCell>
+                {alertId ? (
+                  <AuditedRouteLink label="Open alert detail" to={`/operator/alerts/${alertId}`}>
+                    {alertId}
+                  </AuditedRouteLink>
+                ) : (
+                  "Unavailable"
+                )}
+              </TableCell>
+              <TableCell>{formatValue(sourceFamily(record))}</TableCell>
+              <TableCell>
+                {caseId ? (
+                  <AuditedRouteLink
+                    label="Open case provenance"
+                    to={`/operator/provenance/cases/${caseId}`}
+                  >
+                    Open provenance
+                  </AuditedRouteLink>
+                ) : (
+                  "Unavailable"
+                )}
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function CaseIndexPage() {
+  const filter = useMemo(() => ({}), []);
+  const { data, error, loading, refreshing } = useOperatorList(
+    "queue",
+    filter,
+    QUEUE_SORT,
+  );
+
+  return (
+    <PageFrame
+      subtitle="Read-only case drilldown starts from case anchors already present in the authoritative analyst queue projection."
+      title="Cases"
+    >
+      {loading && !data ? <LoadingState label="Loading case drilldown index" /> : null}
+      {error && !data ? <ErrorState error={error} /> : null}
+      {data ? (
+        <Stack spacing={3}>
+          <QueryStateNotice error={error} refreshing={refreshing} />
+          <SectionCard
+            subtitle="Cases listed here are selected only from explicit queue case anchors; sibling or naming-derived cases are not inferred."
+            title="Case drilldown index"
+          >
+            <Stack spacing={2}>
+              <Alert severity="info" variant="outlined">
+                This page is read-only and cannot record observations, leads, recommendations, approvals, executions, or ticket edits.
+              </Alert>
+              <CaseIndexTable records={data} />
+            </Stack>
+          </SectionCard>
+          <ReviewedQueueLink />
+        </Stack>
+      ) : null}
+    </PageFrame>
+  );
+}
+
+function ProvenanceIndexTable({
+  family,
+  records,
+}: {
+  family: "alerts" | "cases";
+  records: UnknownRecord[];
+}) {
+  const visibleRecords =
+    family === "cases" ? uniqueCaseRecords(records) : records;
+
+  if (visibleRecords.length === 0) {
+    return (
+      <EmptyState
+        message={`No ${family === "cases" ? "case anchors" : "alert records"} are currently visible for provenance drilldown.`}
+      />
+    );
+  }
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>Authoritative record</TableCell>
+          <TableCell>Linked context</TableCell>
+          <TableCell>Source family</TableCell>
+          <TableCell>Provenance drilldown</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {visibleRecords.map((record) => {
+          const alertId = asString(record.alert_id);
+          const caseId = asString(record.case_id);
+          const recordId = family === "cases" ? caseId : alertId;
+          const linkedContext =
+            family === "cases" ? alertId : caseId ?? asStringArray(record.linked_case_ids).join(", ");
+
+          return (
+            <TableRow key={`${family}-${recordId ?? String(record.id)}`} hover>
+              <TableCell>{formatValue(recordId)}</TableCell>
+              <TableCell>{formatValue(linkedContext)}</TableCell>
+              <TableCell>{formatValue(sourceFamily(record))}</TableCell>
+              <TableCell>
+                {recordId ? (
+                  <AuditedRouteLink
+                    label="Open provenance detail"
+                    to={`/operator/provenance/${family}/${recordId}`}
+                  >
+                    Open provenance
+                  </AuditedRouteLink>
+                ) : (
+                  "Unavailable"
+                )}
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function ProvenanceIndexPage() {
+  const params = useParams();
+  const family = asString(params.family);
+  const selectedFamily = family === "cases" ? "cases" : "alerts";
+  const filter = useMemo(() => ({}), []);
+  const { data, error, loading, refreshing } = useOperatorList(
+    "queue",
+    filter,
+    QUEUE_SORT,
+  );
+
+  return (
+    <PageFrame
+      subtitle="Read-only provenance drilldown starts from explicitly linked queue records and opens bounded record-chain pages for alert or case anchors."
+      title="Provenance"
+    >
+      {family !== null && family !== "alerts" && family !== "cases" ? (
+        <ErrorState
+          error={
+            new Error(
+              "Unsupported provenance route. Use alerts or cases with an authoritative identifier.",
+            )
+          }
+        />
+      ) : null}
+      {loading && !data ? <LoadingState label="Loading provenance drilldown index" /> : null}
+      {error && !data ? <ErrorState error={error} /> : null}
+      {data && (family === null || family === "alerts" || family === "cases") ? (
+        <Stack spacing={3}>
+          <QueryStateNotice error={error} refreshing={refreshing} />
+          <SectionCard
+            subtitle="Choose an explicit alert or case anchor before inspecting provenance. The page does not infer lineage from names, neighbors, or sibling records."
+            title="Record-chain drilldown index"
+          >
+            <Stack spacing={2}>
+              <StatusStrip
+                values={[
+                  ["Family", selectedFamily],
+                  ["Read mode", "read-only"],
+                ]}
+              />
+              <Stack direction="row" gap={1}>
+                <AuditedRouteButton label="Show alert provenance" to="/operator/provenance/alerts">
+                  Alert provenance
+                </AuditedRouteButton>
+                <AuditedRouteButton label="Show case provenance" to="/operator/provenance/cases">
+                  Case provenance
+                </AuditedRouteButton>
+              </Stack>
+              <Typography color="text.secondary" variant="body2">
+                Missing optional evidence remains unavailable rather than being promoted into authoritative record truth.
+              </Typography>
+              <ProvenanceIndexTable family={selectedFamily} records={data} />
+            </Stack>
+          </SectionCard>
+          <ReviewedQueueLink />
+        </Stack>
+      ) : null}
+    </PageFrame>
+  );
+}

--- a/control-plane/tests/test_phase31_operator_ui_validation.py
+++ b/control-plane/tests/test_phase31_operator_ui_validation.py
@@ -123,9 +123,9 @@ class Phase31OperatorUiValidationTests(unittest.TestCase):
             'to={buildOperatorShellPath(basePath, "forbidden")}',
             'path="assistant/:recordFamily/:recordId"',
             'path="action-review/:actionRequestId"',
+            'path="provenance/:family"',
             'path="*"',
             "Unsupported operator route",
-            "Open provenance from alert or case detail so the page stays anchored to an authoritative record.",
         ):
             self.assertIn(term, operator_shell)
 


### PR DESCRIPTION
## Summary
- Replaces placeholder alert, case, and provenance landing routes with queue-backed read-only drilldown indexes.
- Keeps authoritative queue anchors primary while linking to bounded alert, case, and provenance detail pages.
- Adds route tests for degraded alert index, empty case index, and provenance record-chain index behavior.

Part of #859.
Closes #862.

## Verification
- npm run typecheck --workspace @aegisops/operator-ui
- npm test --workspace @aegisops/operator-ui
- npm run build --workspace @aegisops/operator-ui
- node dist/index.js issue-lint 862 --config <aegisops-coderabbit-supervisor-config>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated index pages for Alerts, Cases, and Provenance in the operator console, showing read-only drilldown tables, status/empty-state notices, provenance links, and navigation to relevant detail views.

* **Tests**
  * Expanded UI test coverage to validate the new index pages, drilldown content, navigation link targets, empty-state behavior, and role-based read-only scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->