### PR TITLE
Phase 45.4: Align operator training docs with UI paths

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.controlPlane.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.controlPlane.testSuite.tsx
@@ -870,7 +870,7 @@ export function registerOperatorRoutesControlPlaneTests() {
           }),
         );
       });
-    }, 10000);
+    }, 20000);
 
     it("creates reviewed tracking-ticket action requests from case detail", async () => {
       let caseDetailPayload: Record<string, unknown> = {

--- a/docs/deployment/operator-training-handoff-packet.md
+++ b/docs/deployment/operator-training-handoff-packet.md
@@ -76,6 +76,8 @@ The assistant must not approve, execute, reconcile, close a case, widen pilot sc
 
 Use assistant summaries only as cited decision support. If citations are missing, identity context is ambiguous, optional enrichment conflicts with reviewed records, or the output asserts authority it does not have, keep the item unresolved and return to the reviewed record chain.
 
+Optional evidence, downstream substrate receipts, browser state, and external tickets are subordinate context only; they may support the handoff but cannot override the reviewed AegisOps record chain.
+
 ## 7. Evidence Handoff Walkthrough
 
 A handoff starts by naming the reviewed event, operator, release or repository revision when runtime state changed, customer-scoped reference without secrets, and the directly linked AegisOps record identifiers.

--- a/scripts/test-verify-operator-training-handoff-packet.sh
+++ b/scripts/test-verify-operator-training-handoff-packet.sh
@@ -112,6 +112,8 @@ Assistant output is advisory-only and must remain grounded in reviewed AegisOps 
 
 The assistant must not approve, execute, reconcile, close a case, widen pilot scope, or replace missing evidence with generated text.
 
+Optional evidence, downstream substrate receipts, browser state, and external tickets are subordinate context only; they may support the handoff but cannot override the reviewed AegisOps record chain.
+
 ## 7. Evidence Handoff Walkthrough
 
 A handoff starts by naming the reviewed event, operator, release or repository revision when runtime state changed, customer-scoped reference without secrets, and the directly linked AegisOps record identifiers.
@@ -196,6 +198,14 @@ write_valid_packet "${missing_non_authority_repo}"
 perl -0pi -e 's/External tickets are coordination references only; they may carry ticket identifiers, URLs, comments, or assignee context, but they do not own AegisOps case, approval, execution, or reconciliation truth\.\n//' "${missing_non_authority_repo}/docs/deployment/operator-training-handoff-packet.md"
 commit_fixture "${missing_non_authority_repo}"
 assert_fails_with "${missing_non_authority_repo}" "Missing operator training packet statement: External tickets are coordination references only"
+
+missing_subordinate_context_repo="${workdir}/missing-subordinate-context"
+create_repo "${missing_subordinate_context_repo}"
+write_shared_docs "${missing_subordinate_context_repo}"
+write_valid_packet "${missing_subordinate_context_repo}"
+perl -0pi -e 's/Optional evidence, downstream substrate receipts, browser state, and external tickets are subordinate context only; they may support the handoff but cannot override the reviewed AegisOps record chain\.\n//' "${missing_subordinate_context_repo}/docs/deployment/operator-training-handoff-packet.md"
+commit_fixture "${missing_subordinate_context_repo}"
+assert_fails_with "${missing_subordinate_context_repo}" "Missing operator training packet statement: Optional evidence, downstream substrate receipts, browser state, and external tickets are subordinate context only"
 
 forbidden_authority_repo="${workdir}/forbidden-authority"
 create_repo "${forbidden_authority_repo}"

--- a/scripts/verify-operator-training-handoff-packet.sh
+++ b/scripts/verify-operator-training-handoff-packet.sh
@@ -101,6 +101,7 @@ required_packet_phrases=(
   "If an external ticket disagrees with the AegisOps reviewed record chain, operators keep the AegisOps record authoritative and preserve the disagreement for review."
   "Assistant output is advisory-only and must remain grounded in reviewed AegisOps records and linked evidence."
   "The assistant must not approve, execute, reconcile, close a case, widen pilot scope, or replace missing evidence with generated text."
+  "Optional evidence, downstream substrate receipts, browser state, and external tickets are subordinate context only; they may support the handoff but cannot override the reviewed AegisOps record chain."
   "A handoff starts by naming the reviewed event, operator, release or repository revision when runtime state changed, customer-scoped reference without secrets, and the directly linked AegisOps record identifiers."
   "The handoff must include the release handoff record, runtime smoke manifest when relevant, detector activation handoff when relevant, external coordination reference when present, assistant limitation statement when assistant output was used, known-limitations review, handoff owner, and next health review or queue owner."
   "For failed, rejected, forbidden, rollback, restore, or no-go paths, the handoff must preserve the refusal reason and clean-state evidence instead of overwriting the failed attempt with a later success summary."


### PR DESCRIPTION
## Summary
- Tighten the operator training handoff verifier to require subordinate-context guidance for optional evidence, downstream substrate receipts, browser state, and external tickets.
- Update the operator training packet with that authority-boundary language.
- Add a negative verifier regression case for removing the subordinate-context statement.
- Stabilize the long action-request/manual-follow-up operator UI test timeout after CI hit the existing 10s cap.

## Verification
- `bash scripts/verify-operator-training-handoff-packet.sh`
- `bash scripts/test-verify-operator-training-handoff-packet.sh`
- `bash scripts/verify-pilot-readiness-checklist.sh`
- `npm run test --workspace @aegisops/operator-ui -- src/app/OperatorRoutes.test.tsx -t "creates reviewed action requests and records manual follow-up notes from case detail"`
- `npm run test --workspace @aegisops/operator-ui`
- `npm run typecheck --workspace @aegisops/operator-ui`
- `npm run build --workspace @aegisops/operator-ui`
- `node dist/index.js issue-lint 863 --config supervisor.config.aegisops.coderabbit.json` from `<codex-supervisor-root>`

Closes #863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the authority hierarchy in the operator training handoff packet: optional supporting artifacts including downstream substrate receipts, browser state, and external tickets are subordinate to the reviewed AegisOps record chain and cannot override it. Validation mechanisms have been enhanced to ensure this requirement is properly maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->