### PR TITLE
Phase 46.3: Harden reconciliation closeout detail

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.actionReview.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.actionReview.testSuite.tsx
@@ -292,6 +292,25 @@ export function registerOperatorRoutesActionReviewTests() {
                   execution_run_id: "shuffle-run-789",
                   linked_execution_run_ids: ["shuffle-run-789"],
                 },
+                reconciliation_detail: {
+                  authority: "aegisops_reconciliation_record",
+                  expected_aegisops_state: "matched",
+                  authoritative_aegisops_state: "mismatched",
+                  received_receipt: {
+                    ingest_disposition: "mismatch",
+                    execution_run_id: "shuffle-run-789",
+                    linked_execution_run_ids: ["shuffle-run-789"],
+                    correlation_key: "coord-ref-789",
+                  },
+                  closeout_evidence: {
+                    reconciliation_id: "recon-789",
+                    compared_at: "2026-04-27T09:00:00Z",
+                    mismatch_summary:
+                      "receipt payload disagrees with the reconciled ticket state",
+                  },
+                  action_required: true,
+                  next_step: "review_mismatch_before_closeout",
+                },
                 coordination_ticket_outcome: {
                   authority: "authoritative_aegisops_review",
                   status: "mismatch",
@@ -364,6 +383,14 @@ export function registerOperatorRoutesActionReviewTests() {
       expect(screen.getByText("Coordination visibility")).toBeInTheDocument();
       expect(screen.getAllByText("action-execution-789").length).toBeGreaterThan(0);
       expect(screen.getAllByText("shuffle-run-789").length).toBeGreaterThan(0);
+      expect(screen.getByText("Expected AegisOps state")).toBeInTheDocument();
+      expect(screen.getAllByText("matched").length).toBeGreaterThan(0);
+      expect(screen.getByText("Authoritative AegisOps state")).toBeInTheDocument();
+      expect(screen.getAllByText("mismatched").length).toBeGreaterThan(0);
+      expect(screen.getByText("Received receipt ingest")).toBeInTheDocument();
+      expect(screen.getByText("review_mismatch_before_closeout")).toBeInTheDocument();
+      expect(screen.getByText("Closeout compared at")).toBeInTheDocument();
+      expect(screen.getByText("2026-04-27T09:00:00Z")).toBeInTheDocument();
       expect(
         screen.getAllByText(
           "receipt payload disagrees with the reconciled ticket state",

--- a/apps/operator-ui/src/app/operatorConsolePages/actionReviewSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/actionReviewSurfaces.tsx
@@ -126,9 +126,19 @@ export function ReconciliationVisibilitySection({
 }: {
   actionReview: UnknownRecord | null;
 }) {
+  const reconciliationDetail = asRecord(actionReview?.reconciliation_detail);
+  const receivedReceipt = asRecord(reconciliationDetail?.received_receipt);
+  const closeoutEvidence = asRecord(reconciliationDetail?.closeout_evidence);
   const mismatchInspection = asRecord(actionReview?.mismatch_inspection);
   const reconciliationState = asString(actionReview?.reconciliation_state);
   const mismatchSummary = asString(mismatchInspection?.mismatch_summary);
+  const closeoutSummary = asString(closeoutEvidence?.mismatch_summary);
+  const actionRequired =
+    reconciliationDetail?.action_required === true
+      ? "yes"
+      : reconciliationDetail?.action_required === false
+        ? "no"
+        : null;
 
   return (
     <SectionCard
@@ -140,6 +150,8 @@ export function ReconciliationVisibilitySection({
           values={[
             ["Reconciliation", reconciliationState],
             ["Ingest", asString(mismatchInspection?.ingest_disposition)],
+            ["Action required", actionRequired],
+            ["Next step", asString(reconciliationDetail?.next_step)],
           ]}
         />
         {mismatchInspection ? (
@@ -150,12 +162,26 @@ export function ReconciliationVisibilitySection({
         ) : null}
         {!mismatchInspection && !asString(actionReview?.reconciliation_id) ? (
           <Alert severity="warning" variant="outlined">
-            No authoritative reconciliation record is visible for this reviewed request yet.
+            {closeoutSummary ??
+              "No authoritative reconciliation record is visible for this reviewed request yet."}
           </Alert>
         ) : null}
         <ValueList
           entries={[
             ["Reconciliation id", asString(actionReview?.reconciliation_id)],
+            [
+              "Expected AegisOps state",
+              asString(reconciliationDetail?.expected_aegisops_state),
+            ],
+            [
+              "Authoritative AegisOps state",
+              asString(reconciliationDetail?.authoritative_aegisops_state),
+            ],
+            ["Received receipt ingest", asString(receivedReceipt?.ingest_disposition)],
+            ["Received receipt run", asString(receivedReceipt?.execution_run_id)],
+            ["Closeout action required", actionRequired],
+            ["Closeout next step", asString(reconciliationDetail?.next_step)],
+            ["Closeout compared at", asString(closeoutEvidence?.compared_at)],
             ["Mismatch summary", mismatchSummary],
             ["Correlation key", asString(mismatchInspection?.correlation_key)],
             ["Observed execution run", asString(mismatchInspection?.execution_run_id)],

--- a/control-plane/aegisops_control_plane/action_review_projection.py
+++ b/control-plane/aegisops_control_plane/action_review_projection.py
@@ -319,6 +319,7 @@ def build_action_review_chain_snapshot(
         reconciliation=reconciliation,
     )
     mismatch_inspection = action_review_mismatch_inspection(reconciliation)
+    reconciliation_detail = action_review_reconciliation_detail(reconciliation)
     replacement_action_request = service._replacement_action_request(
         action_request,
         record_index=record_index,
@@ -394,6 +395,7 @@ def build_action_review_chain_snapshot(
             else action_request.policy_evaluation.get("execution_surface_id")
         ),
         "timeline": timeline,
+        "reconciliation_detail": reconciliation_detail,
         "mismatch_inspection": mismatch_inspection,
         "action_execution_id": (
             action_execution.action_execution_id if action_execution is not None else None
@@ -726,6 +728,72 @@ def action_review_mismatch_inspection(
         "first_seen_at": reconciliation.first_seen_at,
         "last_seen_at": reconciliation.last_seen_at,
         "compared_at": reconciliation.compared_at,
+    }
+
+
+def action_review_reconciliation_detail(
+    reconciliation: ReconciliationRecord | None,
+) -> dict[str, object]:
+    if reconciliation is None:
+        return {
+            "authority": "aegisops_reconciliation_record",
+            "expected_aegisops_state": "matched",
+            "authoritative_aegisops_state": "missing",
+            "received_receipt": {
+                "ingest_disposition": "missing",
+                "execution_run_id": None,
+                "linked_execution_run_ids": (),
+                "correlation_key": None,
+                "first_seen_at": None,
+                "last_seen_at": None,
+            },
+            "closeout_evidence": {
+                "reconciliation_id": None,
+                "compared_at": None,
+                "mismatch_summary": (
+                    "No authoritative reconciliation record is visible for this "
+                    "reviewed request yet."
+                ),
+            },
+            "action_required": True,
+            "next_step": "obtain_authoritative_receipt_before_closeout",
+        }
+
+    action_required = reconciliation.lifecycle_state != "matched"
+    if reconciliation.lifecycle_state == "matched":
+        next_step = "record_closeout_evidence"
+    elif (
+        reconciliation.lifecycle_state == "stale"
+        or reconciliation.ingest_disposition == "stale"
+    ):
+        next_step = "refresh_downstream_receipt_before_closeout"
+    elif (
+        reconciliation.lifecycle_state == "mismatched"
+        or reconciliation.ingest_disposition == "mismatch"
+    ):
+        next_step = "review_mismatch_before_closeout"
+    else:
+        next_step = "obtain_authoritative_receipt_before_closeout"
+
+    return {
+        "authority": "aegisops_reconciliation_record",
+        "expected_aegisops_state": "matched",
+        "authoritative_aegisops_state": reconciliation.lifecycle_state,
+        "received_receipt": {
+            "ingest_disposition": reconciliation.ingest_disposition,
+            "execution_run_id": reconciliation.execution_run_id,
+            "linked_execution_run_ids": reconciliation.linked_execution_run_ids,
+            "correlation_key": reconciliation.correlation_key,
+            "first_seen_at": reconciliation.first_seen_at,
+            "last_seen_at": reconciliation.last_seen_at,
+        },
+        "closeout_evidence": {
+            "reconciliation_id": reconciliation.reconciliation_id,
+            "compared_at": reconciliation.compared_at,
+            "mismatch_summary": reconciliation.mismatch_summary,
+        },
+        "action_required": action_required,
+        "next_step": next_step,
     }
 
 

--- a/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
@@ -30,6 +30,111 @@ from _service_persistence_support import (
 )
 
 class ActionReviewSurfacePersistenceTests(ServicePersistenceTestBase):
+    def test_action_review_reconciliation_detail_names_expected_received_and_closeout_guidance(
+        self,
+    ) -> None:
+        compared_at = datetime(2026, 4, 27, 9, 0, tzinfo=timezone.utc)
+        mismatch_detail = action_review_projection.action_review_reconciliation_detail(
+            support.ReconciliationRecord(
+                reconciliation_id="reconciliation-detail-mismatch-001",
+                subject_linkage={
+                    "action_request_ids": ("action-request-detail-mismatch-001",),
+                    "action_execution_ids": ("action-execution-detail-mismatch-001",),
+                },
+                alert_id="alert-detail-mismatch-001",
+                finding_id="finding-detail-mismatch-001",
+                analytic_signal_id=None,
+                execution_run_id="execution-run-observed-mismatch-001",
+                linked_execution_run_ids=("execution-run-observed-mismatch-001",),
+                correlation_key="correlation-detail-mismatch-001",
+                first_seen_at=compared_at - timedelta(minutes=5),
+                last_seen_at=compared_at - timedelta(minutes=1),
+                ingest_disposition="mismatch",
+                mismatch_summary="receipt payload disagrees with AegisOps expected ticket state",
+                compared_at=compared_at,
+                lifecycle_state="mismatched",
+            )
+        )
+        stale_detail = action_review_projection.action_review_reconciliation_detail(
+            support.ReconciliationRecord(
+                reconciliation_id="reconciliation-detail-stale-001",
+                subject_linkage={
+                    "action_request_ids": ("action-request-detail-stale-001",),
+                    "action_execution_ids": ("action-execution-detail-stale-001",),
+                },
+                alert_id="alert-detail-stale-001",
+                finding_id="finding-detail-stale-001",
+                analytic_signal_id=None,
+                execution_run_id="execution-run-observed-stale-001",
+                linked_execution_run_ids=("execution-run-observed-stale-001",),
+                correlation_key="correlation-detail-stale-001",
+                first_seen_at=compared_at - timedelta(minutes=10),
+                last_seen_at=compared_at - timedelta(minutes=9),
+                ingest_disposition="stale",
+                mismatch_summary="receipt is older than the reviewed action state",
+                compared_at=compared_at,
+                lifecycle_state="stale",
+            )
+        )
+        matched_detail = action_review_projection.action_review_reconciliation_detail(
+            support.ReconciliationRecord(
+                reconciliation_id="reconciliation-detail-matched-001",
+                subject_linkage={
+                    "action_request_ids": ("action-request-detail-matched-001",),
+                    "action_execution_ids": ("action-execution-detail-matched-001",),
+                },
+                alert_id="alert-detail-matched-001",
+                finding_id="finding-detail-matched-001",
+                analytic_signal_id=None,
+                execution_run_id="execution-run-observed-matched-001",
+                linked_execution_run_ids=("execution-run-observed-matched-001",),
+                correlation_key="correlation-detail-matched-001",
+                first_seen_at=compared_at - timedelta(minutes=3),
+                last_seen_at=compared_at - timedelta(minutes=1),
+                ingest_disposition="matched",
+                mismatch_summary="receipt matches the reviewed action state",
+                compared_at=compared_at,
+                lifecycle_state="matched",
+            )
+        )
+        missing_detail = action_review_projection.action_review_reconciliation_detail(None)
+
+        self.assertEqual(
+            mismatch_detail["expected_aegisops_state"],
+            "matched",
+        )
+        self.assertEqual(
+            mismatch_detail["authoritative_aegisops_state"],
+            "mismatched",
+        )
+        self.assertEqual(
+            mismatch_detail["received_receipt"]["ingest_disposition"],
+            "mismatch",
+        )
+        self.assertTrue(mismatch_detail["action_required"])
+        self.assertEqual(
+            mismatch_detail["next_step"],
+            "review_mismatch_before_closeout",
+        )
+        self.assertEqual(
+            mismatch_detail["closeout_evidence"]["reconciliation_id"],
+            "reconciliation-detail-mismatch-001",
+        )
+
+        self.assertEqual(
+            stale_detail["next_step"],
+            "refresh_downstream_receipt_before_closeout",
+        )
+        self.assertTrue(stale_detail["action_required"])
+        self.assertEqual(matched_detail["next_step"], "record_closeout_evidence")
+        self.assertFalse(matched_detail["action_required"])
+        self.assertEqual(missing_detail["authoritative_aegisops_state"], "missing")
+        self.assertEqual(
+            missing_detail["next_step"],
+            "obtain_authoritative_receipt_before_closeout",
+        )
+        self.assertTrue(missing_detail["action_required"])
+
     def test_service_inspect_action_review_detail_anchors_selected_and_current_review(
         self,
     ) -> None:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -396,6 +396,8 @@ Approval, execution, and reconciliation evidence must stay visibly separated: th
 
 Operator handoff must include the action request identifier, approval decision identifier, approver or fallback approver name, decision outcome, denial or timeout reason when applicable, approval window, linked evidence identifiers, and any break-glass closeout evidence needed to prove return to the normal reviewed path.
 
+Reconciliation closeout must name the expected AegisOps state separately from the received substrate receipt. A matched reconciliation may be closed only with the AegisOps reconciliation identifier, comparison time, execution receipt reference, and linked evidence retained as closeout evidence. A mismatched reconciliation remains open until an operator reviews the mismatch summary against the approved action scope and records the corrected AegisOps outcome. A stale or missing receipt remains action-required until a fresh authoritative receipt is obtained or the missing receipt is explicitly escalated; external ticket closure, downstream receipt text, or support comments must not be used as AegisOps closure.
+
 This section must remain consistent with the business-hours-oriented operating model and must not imply unrestricted autonomous response.
 
 ## 7. Validation


### PR DESCRIPTION
## Summary
- Add an action-review reconciliation detail projection that separates expected AegisOps state from the received substrate receipt.
- Surface action-required closeout guidance and evidence fields in the operator UI.
- Document matched, mismatched, stale, and missing receipt closeout rules in the runbook.

## Verification
- python3 -m unittest control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
- npm run typecheck --workspace @aegisops/operator-ui
- npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx -t "renders execution receipt, reconciliation mismatch, and coordination visibility on action-review detail"
- node dist/index.js issue-lint 865 --config supervisor.config.aegisops.json
- git diff --check

Refs #865