### PR TITLE
Refactor Zammad verifier self-test fixtures

### DIFF
--- a/scripts/test-verify-zammad-live-pilot-boundary.sh
+++ b/scripts/test-verify-zammad-live-pilot-boundary.sh
@@ -6,8 +6,23 @@ source_repo="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 workdir="$(mktemp -d)"
 trap 'rm -rf "${workdir}"' EXIT
 
-fixture_repo="${workdir}/repo"
-cp -R "${source_repo}" "${fixture_repo}"
+create_fixture_repo() {
+  local repo="$1"
+
+  mkdir -p \
+    "${repo}/control-plane/tests/fixtures/zammad" \
+    "${repo}/docs" \
+    "${repo}/scripts"
+
+  cp "${source_repo}/scripts/verify-zammad-live-pilot-boundary.sh" \
+    "${repo}/scripts/verify-zammad-live-pilot-boundary.sh"
+  cp "${source_repo}/docs/operations-zammad-live-pilot-boundary.md" \
+    "${repo}/docs/operations-zammad-live-pilot-boundary.md"
+  cp "${source_repo}/control-plane/tests/test_issue812_zammad_live_pilot_boundary_docs.py" \
+    "${repo}/control-plane/tests/test_issue812_zammad_live_pilot_boundary_docs.py"
+  cp "${source_repo}/control-plane/tests/fixtures/zammad/non-authority-coordination-rehearsal.json" \
+    "${repo}/control-plane/tests/fixtures/zammad/non-authority-coordination-rehearsal.json"
+}
 
 assert_fails_with() {
   local repo="$1"
@@ -33,25 +48,27 @@ assert_fails_with() {
   fi
 }
 
+fixture_repo="${workdir}/repo"
+create_fixture_repo "${fixture_repo}"
 bash "${fixture_repo}/scripts/verify-zammad-live-pilot-boundary.sh" "${fixture_repo}"
 
 missing_degraded_repo="${workdir}/missing-degraded"
-cp -R "${source_repo}" "${missing_degraded_repo}"
+create_fixture_repo "${missing_degraded_repo}"
 perl -0pi -e 's/`degraded`//' "${missing_degraded_repo}/docs/operations-zammad-live-pilot-boundary.md"
 assert_fails_with "${missing_degraded_repo}" 'Missing Zammad live pilot boundary statement: `degraded`'
 
 missing_unavailable_repo="${workdir}/missing-unavailable"
-cp -R "${source_repo}" "${missing_unavailable_repo}"
+create_fixture_repo "${missing_unavailable_repo}"
 perl -0pi -e 's/pilot remains unavailable//' "${missing_unavailable_repo}/docs/operations-zammad-live-pilot-boundary.md"
 assert_fails_with "${missing_unavailable_repo}" "Missing Zammad live pilot boundary statement: If the reviewed secret source is unavailable, unreadable, empty, stale, or only placeholder-backed, the pilot remains unavailable and fails closed."
 
 missing_rehearsal_fixture_repo="${workdir}/missing-rehearsal-fixture"
-cp -R "${source_repo}" "${missing_rehearsal_fixture_repo}"
+create_fixture_repo "${missing_rehearsal_fixture_repo}"
 rm "${missing_rehearsal_fixture_repo}/control-plane/tests/fixtures/zammad/non-authority-coordination-rehearsal.json"
 assert_fails_with "${missing_rehearsal_fixture_repo}" "Missing Zammad non-authority coordination rehearsal fixture:"
 
 fixture_authority_drift_repo="${workdir}/fixture-authority-drift"
-cp -R "${source_repo}" "${fixture_authority_drift_repo}"
+create_fixture_repo "${fixture_authority_drift_repo}"
 python3 - "${fixture_authority_drift_repo}/control-plane/tests/fixtures/zammad/non-authority-coordination-rehearsal.json" <<'PY'
 import json
 import pathlib
@@ -65,12 +82,12 @@ PY
 assert_fails_with "${fixture_authority_drift_repo}" "degraded scenario promotes ticket state authority"
 
 authority_drift_repo="${workdir}/authority-drift"
-cp -R "${source_repo}" "${authority_drift_repo}"
+create_fixture_repo "${authority_drift_repo}"
 printf '\nZammad is authoritative for closure.\n' >>"${authority_drift_repo}/docs/operations-zammad-live-pilot-boundary.md"
 assert_fails_with "${authority_drift_repo}" "Forbidden Zammad live pilot boundary statement: Zammad is authoritative"
 
 placeholder_acceptance_repo="${workdir}/placeholder-acceptance"
-cp -R "${source_repo}" "${placeholder_acceptance_repo}"
+create_fixture_repo "${placeholder_acceptance_repo}"
 printf '\nplaceholder credentials are valid during bootstrap.\n' >>"${placeholder_acceptance_repo}/docs/operations-zammad-live-pilot-boundary.md"
 assert_fails_with "${placeholder_acceptance_repo}" "Forbidden Zammad live pilot boundary statement: placeholder credentials are valid"
 


### PR DESCRIPTION
## Summary
- replace repeated full-checkout copies in the Zammad boundary verifier self-test with minimal temporary fixture repos
- preserve the existing positive verifier run and all negative fail-closed scenarios
- keep explicit source-repo argument support covered by local verification

## Verification
- bash scripts/verify-zammad-live-pilot-boundary.sh
- bash scripts/test-verify-zammad-live-pilot-boundary.sh
- bash -c '! bash -x scripts/test-verify-zammad-live-pilot-boundary.sh 2>&1 | grep -F "cp -R"'
- tmpdir=$(mktemp -d); cd "$tmpdir"; bash <repo>/scripts/test-verify-zammad-live-pilot-boundary.sh <repo>; rc=$?; rm -rf "$tmpdir"; exit $rc
- git diff --check
- node dist/index.js issue-lint 875 --config supervisor.config.aegisops.coderabbit.json
- node dist/index.js issue-lint 875 --config supervisor.config.aegisops.json

Closes #875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Optimized test fixture setup to streamline fixture creation and reduce unnecessary file copying during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->