### PR TITLE
Add redacted release handoff exemplar

### DIFF
--- a/docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md
+++ b/docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md
@@ -1,0 +1,29 @@
+# Phase 38 Release Handoff Evidence Manifest - Filled Redacted Single-Customer Pilot Example
+
+This filled exemplar shows the expected retained packet shape for one single-customer pilot release. It is intentionally redacted and contains no customer secrets, customer-private payloads, raw customer logs, workstation-local paths, live credentials, bootstrap tokens, or private ticket content.
+
+Release readiness summary: Pilot release accepted for one redacted customer environment after reviewed preflight, smoke, restore, rollback, upgrade, and known-limitations evidence all referenced the same release identifier. AegisOps control-plane records and release-gate evidence remain the workflow truth for the launch decision.
+
+Release bundle identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+
+Install preflight result: docs/deployment/evidence-examples/single-customer-pilot/install-preflight-result.redacted.md records PASS for `scripts/verify-single-customer-install-preflight.sh --env-file <runtime-env-file>`. The retained result confirms required runtime env shape, secret-source references, reverse-proxy expectation, and startup prerequisites without storing secret values.
+
+Runtime smoke result: docs/deployment/evidence-examples/single-customer-pilot/runtime-smoke/manifest.md records PASS for `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>`. The smoke manifest covers readiness, protected read-only reachability, queue sanity, and first low-risk action preconditions for this release identifier.
+
+Backup restore rollback upgrade rehearsal: docs/deployment/evidence-examples/single-customer-pilot/release-gate-manifest.md records backup custody, selected restore point, restore validation, same-day rollback-not-needed decision, post-upgrade smoke, reviewed record-chain evidence, and clean-state validation for the same release identifier.
+
+Known limitations: docs/deployment/evidence-examples/single-customer-pilot/known-limitations.redacted.md records accepted limitations, non-blocking follow-up owners, and rollback acceptance criteria. The reviewed limitation set does not approve direct backend access, optional-extension launch gates, external ticket authority, or assistant-owned workflow action.
+
+Rollback instructions: docs/runbook.md#43-rollback-and-restore references the reviewed rollback path and selected restore point for this release identifier. Recovery target selection comes from the release-gate manifest, not from memory, ticket status, substrate-local names, or inferred environment naming.
+
+Handoff owner: pilot-owner-redacted, IT Operations, Information Systems Department.
+
+Next health review: 2026-04-28 business-day health review, queue review, and backup-drift check owned by pilot-owner-redacted. The follow-up review must confirm queue state, readiness state, backup job outcome, known-limitation follow-ups, and whether any refused or missing evidence still blocks broader rollout.
+
+Refused or missing evidence handling: Customer-private raw log payloads, credential screenshots, browser session captures, raw forwarded-header values, unsigned identity hints, and ticket-private conversation exports were refused for the retained packet. The packet retains redacted evidence summaries, AegisOps record identifiers, release-gate references, and clean-state validation instead of substituting private data or treating absence as success.
+
+Missing evidence outcome: A customer-private payload request is marked refused and non-substitutable. If later review requires the payload, pilot expansion remains blocked until an approved redacted evidence source is retained; the current handoff does not infer success from the missing artifact.
+
+Subordinate context only: Wazuh alert references, Shuffle execution receipts, Zammad ticket links, assistant notes, ML shadow observations, downstream receipts, optional endpoint evidence, optional network evidence, and optional extension health are retained as context only. They do not own release readiness, case state, approval, execution, reconciliation, restore, rollback, pilot entry, or handoff truth.
+
+Authority boundary: AegisOps approval, evidence, execution, reconciliation, readiness, and recovery records remain authoritative; external records are subordinate context only.

--- a/scripts/test-verify-release-handoff-evidence-package.sh
+++ b/scripts/test-verify-release-handoff-evidence-package.sh
@@ -145,6 +145,23 @@ Handoff owner: <replace-with-named-operator-or-maintainer>
 Next health review: <replace-with-next-business-review-reference>
 Authority boundary: AegisOps approval, evidence, execution, reconciliation, readiness, and recovery records remain authoritative; external records are subordinate context only.
 EOF
+
+  cat <<'EOF' > "${target}/docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md"
+# Phase 38 Release Handoff Evidence Manifest - Filled Redacted Single-Customer Pilot Example
+
+Release readiness summary: Pilot release accepted for one redacted customer environment after reviewed preflight, smoke, restore, rollback, upgrade, and known-limitations evidence all referenced the same release identifier.
+Release bundle identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+Install preflight result: docs/deployment/evidence-examples/single-customer-pilot/install-preflight-result.redacted.md records PASS for the reviewed runtime env shape with secret values omitted.
+Runtime smoke result: docs/deployment/evidence-examples/single-customer-pilot/runtime-smoke/manifest.md records PASS for readiness, protected read-only reachability, queue sanity, and first low-risk action preconditions.
+Backup restore rollback upgrade rehearsal: docs/deployment/evidence-examples/single-customer-pilot/release-gate-manifest.md records backup custody, restore validation, rollback-not-needed decision, post-upgrade smoke, and clean-state evidence.
+Known limitations: docs/deployment/evidence-examples/single-customer-pilot/known-limitations.redacted.md records accepted limitations, non-blocking follow-up owners, and rollback acceptance criteria.
+Rollback instructions: docs/runbook.md#43-rollback-and-restore references the reviewed rollback path and selected restore point for this release identifier.
+Handoff owner: pilot-owner-redacted, IT Operations, Information Systems Department.
+Next health review: 2026-04-28 business-day health review, queue review, and backup-drift check owned by pilot-owner-redacted.
+Refused or missing evidence handling: Customer-private raw log payloads and live credential screenshots were refused for the retained packet; the packet retains redacted evidence summaries and clean-state validation instead of substituting private data.
+Subordinate context only: Wazuh alert references, Shuffle execution receipts, Zammad ticket links, assistant notes, ML shadow observations, downstream receipts, and optional evidence fields are retained as context only and do not own release readiness, case state, approval, execution, reconciliation, restore, rollback, or handoff truth.
+Authority boundary: AegisOps approval, evidence, execution, reconciliation, readiness, and recovery records remain authoritative; external records are subordinate context only.
+EOF
 }
 
 write_valid_manifest() {
@@ -208,6 +225,15 @@ write_valid_package_doc "${valid_repo}"
 write_valid_manifest "${valid_repo}/manifest.md"
 commit_fixture "${valid_repo}"
 assert_passes "${valid_repo}" "${valid_repo}/manifest.md"
+
+missing_exemplar_repo="${workdir}/missing-exemplar"
+create_repo "${missing_exemplar_repo}"
+write_shared_docs "${missing_exemplar_repo}"
+write_valid_package_doc "${missing_exemplar_repo}"
+write_valid_manifest "${missing_exemplar_repo}/manifest.md"
+rm "${missing_exemplar_repo}/docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md"
+commit_fixture "${missing_exemplar_repo}"
+assert_fails_with "${missing_exemplar_repo}" "${missing_exemplar_repo}/manifest.md" "Missing Phase 38 filled redacted release handoff evidence exemplar:"
 
 for missing_entry in \
   "Release readiness summary:" \

--- a/scripts/verify-release-handoff-evidence-package.sh
+++ b/scripts/verify-release-handoff-evidence-package.sh
@@ -47,6 +47,7 @@ fi
 
 doc_path="${repo_root}/docs/deployment/release-handoff-evidence-package.md"
 template_path="${repo_root}/docs/deployment/release-handoff-evidence-manifest.template.md"
+exemplar_path="${repo_root}/docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md"
 runbook_path="${repo_root}/docs/runbook.md"
 inventory_path="${repo_root}/docs/deployment/single-customer-release-bundle-inventory.md"
 smoke_path="${repo_root}/docs/deployment/runtime-smoke-bundle.md"
@@ -117,6 +118,7 @@ reject_workstation_paths() {
 
 require_file "${doc_path}" "Phase 38 release handoff evidence package"
 require_file "${template_path}" "Phase 38 release handoff evidence manifest template"
+require_file "${exemplar_path}" "Phase 38 filled redacted release handoff evidence exemplar"
 require_file "${runbook_path}" "runbook document"
 require_file "${inventory_path}" "single-customer release bundle inventory"
 require_file "${smoke_path}" "runtime smoke bundle"
@@ -181,6 +183,28 @@ for phrase in "${required_template_phrases[@]}"; do
   require_phrase "${template_path}" "${phrase}" "Phase 38 release handoff evidence manifest template entry"
 done
 
+required_exemplar_phrases=(
+  "# Phase 38 Release Handoff Evidence Manifest - Filled Redacted Single-Customer Pilot Example"
+  "Release readiness summary:"
+  "Release bundle identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5"
+  "Install preflight result:"
+  "Runtime smoke result:"
+  "Backup restore rollback upgrade rehearsal:"
+  "Known limitations:"
+  "Rollback instructions:"
+  "Handoff owner:"
+  "Next health review:"
+  "Refused or missing evidence handling:"
+  "Subordinate context only:"
+  "Authority boundary: AegisOps approval, evidence, execution, reconciliation, readiness, and recovery records remain authoritative; external records are subordinate context only."
+)
+
+for phrase in "${required_exemplar_phrases[@]}"; do
+  require_phrase "${exemplar_path}" "${phrase}" "Phase 38 filled redacted release handoff exemplar entry"
+done
+
+reject_placeholders "${exemplar_path}" "Phase 38 filled redacted release handoff exemplar"
+
 require_phrase "${runbook_path}" 'Before launch, upgrade, rollback, restore, or operator handoff closes, assemble the Phase 38 release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` and verify its manifest with `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.' "runbook release handoff package link"
 require_phrase "${inventory_path}" 'The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` is the Phase 38 handoff index that ties the release bundle identifier, install preflight result, runtime smoke, restore, rollback, upgrade, known limitations, rollback instructions, handoff owner, and next health review to one bounded record.' "release bundle inventory release handoff package link"
 require_phrase "${smoke_path}" 'The release handoff evidence package in `docs/deployment/release-handoff-evidence-package.md` must retain the runtime smoke manifest reference for launch, upgrade, rollback, restore restart, and operator handoff readiness.' "runtime smoke release handoff package link"
@@ -204,6 +228,7 @@ done
 reject_workstation_paths "Phase 38 release handoff evidence package guidance" \
   "${doc_path}" \
   "${template_path}" \
+  "${exemplar_path}" \
   "${runbook_path}" \
   "${inventory_path}" \
   "${smoke_path}" \


### PR DESCRIPTION
## Summary
- Add a filled redacted single-customer pilot release handoff evidence exemplar.
- Wire the release handoff verifier to require the exemplar and reject placeholder/workstation-local exemplar content.
- Add verifier fixture coverage for the exemplar and a missing-exemplar failure path.

## Verification
- bash scripts/verify-release-handoff-evidence-package.sh
- bash scripts/test-verify-release-handoff-evidence-package.sh
- bash scripts/verify-pilot-readiness-checklist.sh
- node dist/index.js issue-lint 879 --config supervisor.config.aegisops.coderabbit.json

Closes #879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example release-handoff evidence manifest for single-customer pilot releases with guidance on required evidence references and handoff ownership.

* **Tests**
  * Added validation test for the release-handoff evidence manifest to ensure all required components are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->