### PR TITLE
Add pilot go/no-go packet verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           bash scripts/verify-single-customer-deployment-profile.sh
           bash scripts/verify-single-customer-release-bundle-inventory.sh
           bash scripts/verify-release-handoff-evidence-package.sh
+          bash scripts/verify-pilot-go-no-go-decision-packet.sh
           bash scripts/verify-storage-policy-doc.sh
           bash scripts/verify-source-onboarding-contract-doc.sh
           bash scripts/verify-wazuh-rule-lifecycle-runbook.sh
@@ -343,6 +344,7 @@ jobs:
           bash scripts/test-verify-single-customer-deployment-profile.sh
           bash scripts/test-verify-single-customer-release-bundle-inventory.sh
           bash scripts/test-verify-release-handoff-evidence-package.sh
+          bash scripts/test-verify-pilot-go-no-go-decision-packet.sh
           bash scripts/test-verify-source-onboarding-contract-doc.sh
           bash scripts/test-verify-wazuh-rule-lifecycle-runbook.sh
           bash scripts/test-verify-windows-source-onboarding-assets.sh

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-assistant-limitation.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-assistant-limitation.md
@@ -1,0 +1,17 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+Decision status: go-with-explicit-limitations
+Pilot customer scope: redacted single-customer pilot environment
+Pilot owner: pilot-owner-redacted.
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Evidence handoff owner: pilot-owner-redacted.
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Refused evidence: private payloads are refused.
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-assistant-limitation.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-assistant-limitation.md
@@ -10,7 +10,7 @@ Detector activation evidence: docs/deployment/detector-activation-evidence.singl
 Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Refused evidence: private payloads are refused.
 Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-detector-activation.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-detector-activation.md
@@ -1,0 +1,17 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+Decision status: go-with-explicit-limitations
+Pilot customer scope: redacted single-customer pilot environment
+Pilot owner: pilot-owner-redacted.
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Evidence handoff owner: pilot-owner-redacted.
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Refused evidence: private payloads are refused.
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-known-limitations.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-known-limitations.md
@@ -1,0 +1,17 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+Decision status: go-with-explicit-limitations
+Pilot customer scope: redacted single-customer pilot environment
+Pilot owner: pilot-owner-redacted.
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Evidence handoff owner: pilot-owner-redacted.
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Refused evidence: private payloads are refused.
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-known-limitations.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-known-limitations.md
@@ -10,7 +10,7 @@ Detector activation evidence: docs/deployment/detector-activation-evidence.singl
 Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Refused evidence: private payloads are refused.
 Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-next-health-review.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-next-health-review.md
@@ -1,0 +1,17 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+Decision status: go-with-explicit-limitations
+Pilot customer scope: redacted single-customer pilot environment
+Pilot owner: pilot-owner-redacted.
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Evidence handoff owner: pilot-owner-redacted.
+Refused evidence: private payloads are refused.
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-next-health-review.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-next-health-review.md
@@ -11,7 +11,7 @@ Known limitations review: docs/deployment/known-limitations-retention-decision-t
 Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Refused evidence: private payloads are refused.
 Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
 Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-owner.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-owner.md
@@ -1,0 +1,17 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+Decision status: go-with-explicit-limitations
+Pilot customer scope: redacted single-customer pilot environment
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Evidence handoff owner: pilot-owner-redacted.
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Refused evidence: private payloads are refused.
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-owner.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-owner.md
@@ -10,7 +10,7 @@ Known limitations review: docs/deployment/known-limitations-retention-decision-t
 Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Refused evidence: private payloads are refused.
 Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-release-handoff.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-release-handoff.md
@@ -1,0 +1,31 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+
+Decision status: go-with-explicit-limitations
+
+Pilot customer scope: redacted single-customer pilot environment
+
+Pilot owner: pilot-owner-redacted.
+
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Evidence handoff owner: pilot-owner-redacted.
+
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Refused evidence: private payloads are refused.
+
+Verification: Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`, `scripts/verify-pilot-readiness-checklist.sh`, and `scripts/verify-pilot-go-no-go-decision-packet.sh --packet <pilot-go-no-go-packet.md>`.
+
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-release-handoff.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-release-handoff.md
@@ -20,7 +20,7 @@ Zammad/non-authority posture: Zammad remains coordination-only for aegisops-sing
 
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-retention-decision.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-retention-decision.md
@@ -1,0 +1,17 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+Decision status: go-with-explicit-limitations
+Pilot customer scope: redacted single-customer pilot environment
+Pilot owner: pilot-owner-redacted.
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Evidence handoff owner: pilot-owner-redacted.
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Refused evidence: private payloads are refused.
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-retention-decision.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-retention-decision.md
@@ -10,7 +10,7 @@ Detector activation evidence: docs/deployment/detector-activation-evidence.singl
 Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Refused evidence: private payloads are refused.
 Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-zammad-non-authority.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-zammad-non-authority.md
@@ -10,7 +10,7 @@ Detector activation evidence: docs/deployment/detector-activation-evidence.singl
 Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 Refused evidence: private payloads are refused.
 Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-zammad-non-authority.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/missing-zammad-non-authority.md
@@ -1,0 +1,17 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+Decision status: go-with-explicit-limitations
+Pilot customer scope: redacted single-customer pilot environment
+Pilot owner: pilot-owner-redacted.
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Evidence handoff owner: pilot-owner-redacted.
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+Refused evidence: private payloads are refused.
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/mixed-release-identifier.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/mixed-release-identifier.md
@@ -1,0 +1,33 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+
+Decision status: go-with-explicit-limitations
+
+Pilot customer scope: redacted single-customer pilot environment
+
+Pilot owner: pilot-owner-redacted.
+
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-deadbee. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Evidence handoff owner: pilot-owner-redacted.
+
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Refused evidence: private payloads are refused.
+
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
+
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/mixed-release-identifier.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/mixed-release-identifier.md
@@ -22,7 +22,7 @@ Zammad/non-authority posture: Zammad remains coordination-only for aegisops-sing
 
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/owner-not-release-bound.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/owner-not-release-bound.md
@@ -1,17 +1,33 @@
 # Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
 
 This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+
 Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+
 Decision status: go-with-explicit-limitations
+
 Pilot customer scope: redacted single-customer pilot environment
+
 Pilot owner: pilot-owner-redacted.
+
 Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+
 Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
 Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
 Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
-Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Evidence handoff owner: pilot-owner-redacted owns the retained packet.
+
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
 Refused evidence: private payloads are refused.
+
 Verification: Run `scripts/verify-pilot-readiness-checklist.sh`.
+
 Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/secret-looking-value.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/secret-looking-value.md
@@ -1,0 +1,33 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+
+Decision status: go-with-explicit-limitations
+
+Pilot customer scope: redacted single-customer pilot environment
+
+Pilot owner: pilot-owner-redacted.
+
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5. __SECRET_LOOKING_VALUE__
+
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Evidence handoff owner: pilot-owner-redacted.
+
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Refused evidence: private payloads are refused.
+
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh` for `docs/deployment/pilot-readiness-checklist.md`.
+
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/secret-looking-value.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/secret-looking-value.md
@@ -22,7 +22,7 @@ Zammad/non-authority posture: Zammad remains coordination-only for aegisops-sing
 
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/workstation-local-path.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/workstation-local-path.md
@@ -1,0 +1,33 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release.
+
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+
+Decision status: go-with-explicit-limitations
+
+Pilot customer scope: redacted single-customer pilot environment
+
+Pilot owner: pilot-owner-redacted.
+
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Local copy: __WORKSTATION_LOCAL_PATH__. Run `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md for aegisops-single-customer-pilot-2026-04-27-c4527e5. Run `scripts/verify-detector-activation-evidence-handoff.sh`.
+
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Zammad/non-authority posture: Zammad remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Evidence handoff owner: pilot-owner-redacted.
+
+Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
+
+Refused evidence: private payloads are refused.
+
+Verification: Run `scripts/verify-pilot-readiness-checklist.sh` for `docs/deployment/pilot-readiness-checklist.md`.
+
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth.

--- a/docs/deployment/fixtures/pilot-go-no-go-decision-packet/workstation-local-path.md
+++ b/docs/deployment/fixtures/pilot-go-no-go-decision-packet/workstation-local-path.md
@@ -22,7 +22,7 @@ Zammad/non-authority posture: Zammad remains coordination-only for aegisops-sing
 
 Assistant limitation posture: assistant output remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 
-Evidence handoff owner: pilot-owner-redacted.
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 
 Next health review: 2026-04-28 for aegisops-single-customer-pilot-2026-04-27-c4527e5.
 

--- a/docs/deployment/pilot-go-no-go-decision-packet.single-customer-pilot.example.md
+++ b/docs/deployment/pilot-go-no-go-decision-packet.single-customer-pilot.example.md
@@ -1,0 +1,33 @@
+# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example
+
+This packet is the reviewed pilot go/no-go decision surface for one single-customer release. It is intentionally redacted and contains no customer secrets, customer-private payloads, raw customer logs, workstation-local paths, live credentials, bootstrap tokens, or private ticket content.
+
+Release identifier: aegisops-single-customer-pilot-2026-04-27-c4527e5
+
+Decision status: go-with-explicit-limitations
+
+Pilot customer scope: redacted single-customer pilot environment
+
+Pilot owner: pilot-owner-redacted, IT Operations, Information Systems Department.
+
+Release handoff evidence: docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md records reviewed release readiness, install preflight, runtime smoke, restore, rollback, upgrade, known limitations, rollback instructions, handoff owner, and next health review for aegisops-single-customer-pilot-2026-04-27-c4527e5. Validate the retained release handoff with `scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>`.
+
+Detector activation evidence: docs/deployment/detector-activation-evidence.single-customer-pilot.example.md records the reviewed GitHub audit detector scope, fixture evidence, parser evidence, activation owner, disable owner, rollback owner, false-positive review, expected volume, AegisOps record linkage, and next review for aegisops-single-customer-pilot-2026-04-27-c4527e5. Validate detector handoff with `scripts/verify-detector-activation-evidence-handoff.sh`.
+
+Known limitations review: docs/deployment/known-limitations-retention-decision-template.md is the completed review surface for aegisops-single-customer-pilot-2026-04-27-c4527e5. The reviewed limitations are accepted with owners and revisit dates; no unreviewed limitation is treated as "no known limitation."
+
+Retention decision: docs/deployment/known-limitations-retention-decision-template.md records bounded retention for aegisops-single-customer-pilot-2026-04-27-c4527e5 covering the release handoff, runtime smoke manifest, detector activation evidence handoff, Zammad coordination status, assistant limitation statement, known-limitation review, refused evidence, handoff owner, and next health review.
+
+Zammad/non-authority posture: docs/operations-zammad-live-pilot-boundary.md remains coordination-only for aegisops-single-customer-pilot-2026-04-27-c4527e5. Zammad links, ticket reads, credential custody notes, and rehearsal evidence are subordinate context and do not own AegisOps case, approval, execution, reconciliation, release, readiness, or go/no-go truth.
+
+Assistant limitation posture: docs/phase-15-identity-grounded-analyst-assistant-boundary.md remains advisory-only for aegisops-single-customer-pilot-2026-04-27-c4527e5. Assistant output may summarize reviewed control-plane records and linked evidence but does not approve, execute, reconcile, close, widen detector scope, or decide pilot entry.
+
+Evidence handoff owner: pilot-owner-redacted owns the retained packet for aegisops-single-customer-pilot-2026-04-27-c4527e5 and must preserve the go/no-go outcome, refused evidence, limitation owners, and next health review expectation.
+
+Next health review: 2026-04-28 business-day health review for aegisops-single-customer-pilot-2026-04-27-c4527e5 must review queue state, readiness state, backup job outcome, detector false-positive behavior, known-limitation follow-ups, Zammad coordination posture, assistant limitation posture, and any refused evidence that still blocks broader rollout.
+
+Refused evidence: Customer-private raw log payloads, credential screenshots, browser session captures, raw forwarded-header values, unsigned identity hints, and ticket-private conversation exports are refused for this packet. The packet retains redacted evidence summaries, AegisOps record identifiers, release-gate references, and clean-state validation instead of substituting private data or treating absence as success.
+
+Verification: Run `scripts/verify-pilot-go-no-go-decision-packet.sh --packet <pilot-go-no-go-packet.md>`, `scripts/verify-pilot-readiness-checklist.sh` for `docs/deployment/pilot-readiness-checklist.md`, `scripts/verify-release-handoff-evidence-package.sh`, and `scripts/verify-detector-activation-evidence-handoff.sh` before treating this packet as reviewed.
+
+Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth. Wazuh, Shuffle, Zammad, assistant output, ML shadow observations, downstream receipts, optional endpoint evidence, optional network evidence, and optional extension health are subordinate context only.

--- a/docs/deployment/pilot-readiness-checklist.md
+++ b/docs/deployment/pilot-readiness-checklist.md
@@ -92,6 +92,10 @@ Verify this checklist with `scripts/verify-pilot-readiness-checklist.sh`.
 
 Negative validation for the verifier is `scripts/test-verify-pilot-readiness-checklist.sh`.
 
+Verify a retained pilot go/no-go decision packet with `scripts/verify-pilot-go-no-go-decision-packet.sh --packet <pilot-go-no-go-packet.md>`.
+
+Negative validation for the go/no-go packet verifier is `scripts/test-verify-pilot-go-no-go-decision-packet.sh`.
+
 Run the checklist verifier after changing this checklist, the runbook, release bundle inventory, release handoff package, runtime smoke bundle, detector activation evidence handoff, Zammad live pilot boundary, assistant boundary, or operational evidence handoff pack.
 
 ## 8. Out of Scope

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -134,6 +134,8 @@ Before launch, upgrade, rollback, restore, or operator handoff closes, assemble 
 
 Before starting a single-customer pilot, review `docs/deployment/pilot-readiness-checklist.md` and verify it with `scripts/verify-pilot-readiness-checklist.sh` so release readiness, runtime smoke, detector activation scope, Zammad coordination scope, assistant limitations, data retention, known limitations, and evidence handoff are decided together.
 
+Before a pilot launch decision is treated as reviewed, verify the retained go/no-go packet with `scripts/verify-pilot-go-no-go-decision-packet.sh --packet <pilot-go-no-go-packet.md>` so release handoff, detector activation, known limitations, retention, Zammad/non-authority posture, assistant limitations, owner, and next health review evidence bind to one release identifier.
+
 For pilot support degradation, break-glass rehearsal, and operator-readable evidence expectations, use `docs/deployment/support-playbook-break-glass-rehearsal.md` and verify it with `scripts/verify-support-playbook-break-glass-rehearsal.sh`.
 
 Before continuing, pausing, rolling back, or exiting a single-customer pilot, review `docs/deployment/pilot-pause-rollback-exit-criteria.md` and verify it with `scripts/verify-pilot-pause-rollback-exit-criteria.sh` so pause criteria, rollback criteria, exit criteria, unresolved limitations, next-roadmap input, and operator/support signoff remain bounded to Phase 43.

--- a/scripts/test-verify-pilot-go-no-go-decision-packet.sh
+++ b/scripts/test-verify-pilot-go-no-go-decision-packet.sh
@@ -44,6 +44,7 @@ assert_fails_with() {
 assert_passes "${positive_packet}"
 assert_fails_with "${fixture_dir}/missing-release-handoff.md" "Missing pilot go/no-go decision packet entry: Release handoff evidence:"
 assert_fails_with "${fixture_dir}/mixed-release-identifier.md" "Mixed pilot go/no-go release identifiers:"
+assert_fails_with "${fixture_dir}/owner-not-release-bound.md" "Missing evidence handoff owner: Evidence handoff owner: must reference aegisops-single-customer-pilot-2026-04-27-c4527e5"
 
 workstation_path_packet="${workdir}/workstation-local-path.md"
 cp "${fixture_dir}/workstation-local-path.md" "${workstation_path_packet}"

--- a/scripts/test-verify-pilot-go-no-go-decision-packet.sh
+++ b/scripts/test-verify-pilot-go-no-go-decision-packet.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-pilot-go-no-go-decision-packet.sh"
+fixture_dir="${repo_root}/docs/deployment/fixtures/pilot-go-no-go-decision-packet"
+positive_packet="${repo_root}/docs/deployment/pilot-go-no-go-decision-packet.single-customer-pilot.example.md"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local packet="$1"
+
+  if ! bash "${verifier}" --packet "${packet}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${packet}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local packet="$1"
+  local expected="$2"
+
+  if bash "${verifier}" --packet "${packet}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${packet}" >&2
+    exit 1
+  fi
+
+  if ! grep -F -- "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_passes "${positive_packet}"
+assert_fails_with "${fixture_dir}/missing-release-handoff.md" "Missing pilot go/no-go decision packet entry: Release handoff evidence:"
+assert_fails_with "${fixture_dir}/mixed-release-identifier.md" "Mixed pilot go/no-go release identifiers:"
+
+workstation_path_packet="${workdir}/workstation-local-path.md"
+cp "${fixture_dir}/workstation-local-path.md" "${workstation_path_packet}"
+workstation_path="$(printf '/%s/%s/pilot/packet.md' "Users" "example")"
+perl -0pi -e "s#__WORKSTATION_LOCAL_PATH__#${workstation_path}#g" "${workstation_path_packet}"
+assert_fails_with "${workstation_path_packet}" "Forbidden pilot go/no-go decision packet: workstation-local absolute path detected"
+
+secret_value_packet="${workdir}/secret-looking-value.md"
+cp "${fixture_dir}/secret-looking-value.md" "${secret_value_packet}"
+secret_value="$(printf '%s=%s' "token" "abc123")"
+perl -0pi -e "s#__SECRET_LOOKING_VALUE__#${secret_value}#g" "${secret_value_packet}"
+assert_fails_with "${secret_value_packet}" "Secret-looking pilot go/no-go decision packet value detected:"
+
+for required_fixture in \
+  missing-detector-activation.md \
+  missing-known-limitations.md \
+  missing-retention-decision.md \
+  missing-zammad-non-authority.md \
+  missing-assistant-limitation.md \
+  missing-owner.md \
+  missing-next-health-review.md; do
+  assert_fails_with "${fixture_dir}/${required_fixture}" "Missing pilot go/no-go decision packet entry:"
+done
+
+echo "Pilot go/no-go decision packet verifier tests passed."

--- a/scripts/verify-pilot-go-no-go-decision-packet.sh
+++ b/scripts/verify-pilot-go-no-go-decision-packet.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/verify-pilot-go-no-go-decision-packet.sh [<repo-root>] [--packet <pilot-go-no-go-packet.md>]
+
+Validates a redacted single-customer pilot go/no-go decision packet. The packet
+must bind release handoff, detector activation, known limitations, retention,
+Zammad/non-authority posture, assistant limitation posture, owner, and next
+health review evidence to one release identifier.
+EOF
+}
+
+repo_root=""
+packet_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --packet)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 2
+      fi
+      packet_path="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "${repo_root}" ]]; then
+        usage
+        exit 2
+      fi
+      repo_root="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${repo_root}" ]]; then
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+if [[ -z "${packet_path}" ]]; then
+  packet_path="${repo_root}/docs/deployment/pilot-go-no-go-decision-packet.single-customer-pilot.example.md"
+fi
+
+checklist_path="${repo_root}/docs/deployment/pilot-readiness-checklist.md"
+runbook_path="${repo_root}/docs/runbook.md"
+verifier_test_path="${repo_root}/scripts/test-verify-pilot-go-no-go-decision-packet.sh"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${description}: ${path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_phrase() {
+  local path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if grep -Fqi -- "${phrase}" "${path}"; then
+    echo "Forbidden ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+reject_workstation_paths() {
+  local description="$1"
+  shift
+
+  local macos_home_pattern linux_home_pattern windows_home_pattern workstation_local_path_pattern
+  macos_home_pattern='/'"Users"'/[^[:space:])>]+'
+  linux_home_pattern='/'"home"'/[^[:space:])>]+'
+  windows_home_pattern='[A-Za-z]:\\'"Users"'\\[^[:space:])>]+'
+  workstation_local_path_pattern="(^|[^[:alnum:]_./-])(~[/\\\\]|${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern})"
+
+  if grep -Eq "${workstation_local_path_pattern}" "$@"; then
+    echo "Forbidden ${description}: workstation-local absolute path detected" >&2
+    exit 1
+  fi
+}
+
+reject_secret_looking_values() {
+  local path="$1"
+  local description="$2"
+
+  if grep -Eiq '(secret|token|password|passwd|api[_-]?key|access[_-]?key|private[_-]?key)[[:space:]]*[:=][[:space:]]*[^<[:space:]][^[:space:]]*|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|Bearer[[:space:]]+[A-Za-z0-9._~+/-]+' "${path}"; then
+    echo "Secret-looking ${description} value detected: ${path}" >&2
+    exit 1
+  fi
+}
+
+extract_release_identifier() {
+  local path="$1"
+
+  grep -Eo 'aegisops-single-customer-[A-Za-z0-9_-]+' "${path}" | LC_ALL=C sort -u
+}
+
+require_label_contains_release() {
+  local label="$1"
+  local description="$2"
+
+  if ! grep -F -- "${label}" "${packet_path}" | grep -F -- "${release_identifier}" >/dev/null; then
+    echo "Missing ${description}: ${label} must reference ${release_identifier}" >&2
+    exit 1
+  fi
+}
+
+require_file "${packet_path}" "pilot go/no-go decision packet"
+require_file "${checklist_path}" "pilot readiness checklist"
+require_file "${runbook_path}" "runbook"
+require_file "${verifier_test_path}" "pilot go/no-go decision packet verifier tests"
+
+release_identifiers=()
+while IFS= read -r release_identifier_entry; do
+  release_identifiers+=("${release_identifier_entry}")
+done < <(extract_release_identifier "${packet_path}")
+if [[ "${#release_identifiers[@]}" -eq 0 ]]; then
+  echo "Missing pilot go/no-go release identifier: expected aegisops-single-customer-<repository-revision> or reviewed tag-bound equivalent" >&2
+  exit 1
+fi
+
+if [[ "${#release_identifiers[@]}" -gt 1 ]]; then
+  echo "Mixed pilot go/no-go release identifiers: ${release_identifiers[*]}" >&2
+  exit 1
+fi
+
+release_identifier="${release_identifiers[0]}"
+
+required_packet_phrases=(
+  "# Pilot Go/No-Go Decision Packet - Filled Redacted Single-Customer Pilot Example"
+  "This packet is the reviewed pilot go/no-go decision surface for one single-customer release."
+  "Decision status: go-with-explicit-limitations"
+  "Pilot customer scope: redacted single-customer pilot environment"
+  "Pilot owner:"
+  "Release handoff evidence:"
+  "Detector activation evidence:"
+  "Known limitations review:"
+  "Retention decision:"
+  "Zammad/non-authority posture:"
+  "Assistant limitation posture:"
+  "Evidence handoff owner:"
+  "Next health review:"
+  "Refused evidence:"
+  "Verification:"
+  "Authority boundary: AegisOps control-plane records remain authoritative for approval, evidence, execution, reconciliation, readiness, release, pilot entry, and go/no-go truth."
+)
+
+for phrase in "${required_packet_phrases[@]}"; do
+  require_phrase "${packet_path}" "${phrase}" "pilot go/no-go decision packet entry"
+done
+
+require_label_contains_release "Release identifier:" "pilot release identifier"
+require_label_contains_release "Release handoff evidence:" "release handoff evidence"
+require_label_contains_release "Detector activation evidence:" "detector activation evidence"
+require_label_contains_release "Known limitations review:" "known limitations review"
+require_label_contains_release "Retention decision:" "retention decision"
+require_label_contains_release "Zammad/non-authority posture:" "Zammad non-authority posture"
+require_label_contains_release "Assistant limitation posture:" "assistant limitation posture"
+require_label_contains_release "Next health review:" "next health review"
+
+required_reference_phrases=(
+  "docs/deployment/release-handoff-evidence-manifest.single-customer-pilot.example.md"
+  "docs/deployment/detector-activation-evidence.single-customer-pilot.example.md"
+  "docs/deployment/known-limitations-retention-decision-template.md"
+  "docs/deployment/pilot-readiness-checklist.md"
+  "scripts/verify-release-handoff-evidence-package.sh --manifest <release-handoff-manifest.md>"
+  "scripts/verify-detector-activation-evidence-handoff.sh"
+  "scripts/verify-pilot-readiness-checklist.sh"
+)
+
+for phrase in "${required_reference_phrases[@]}"; do
+  require_phrase "${packet_path}" "${phrase}" "pilot go/no-go decision packet reference"
+done
+
+for forbidden in \
+  "ticket system is authoritative" \
+  "Zammad is authoritative" \
+  "assistant may approve" \
+  "assistant may execute" \
+  "assistant may reconcile" \
+  "detector status is authoritative" \
+  "compliance certification is complete" \
+  "multi-customer rollout is approved" \
+  "24x7 support is promised" \
+  "SLA is promised" \
+  "unlimited retention is approved"; do
+  reject_phrase "${packet_path}" "${forbidden}" "pilot go/no-go decision packet statement"
+done
+
+reject_workstation_paths "pilot go/no-go decision packet" "${packet_path}"
+reject_secret_looking_values "${packet_path}" "pilot go/no-go decision packet"
+
+require_phrase "${checklist_path}" 'Verify a retained pilot go/no-go decision packet with `scripts/verify-pilot-go-no-go-decision-packet.sh --packet <pilot-go-no-go-packet.md>`.' "pilot readiness checklist go/no-go verifier link"
+require_phrase "${checklist_path}" 'Negative validation for the go/no-go packet verifier is `scripts/test-verify-pilot-go-no-go-decision-packet.sh`.' "pilot readiness checklist go/no-go verifier test link"
+require_phrase "${runbook_path}" 'Before a pilot launch decision is treated as reviewed, verify the retained go/no-go packet with `scripts/verify-pilot-go-no-go-decision-packet.sh --packet <pilot-go-no-go-packet.md>` so release handoff, detector activation, known limitations, retention, Zammad/non-authority posture, assistant limitations, owner, and next health review evidence bind to one release identifier.' "runbook pilot go/no-go verifier link"
+
+reject_workstation_paths "pilot go/no-go verifier guidance" "${checklist_path}" "${runbook_path}"
+
+echo "Pilot go/no-go decision packet is complete, redacted, bounded, and bound to ${release_identifier}."

--- a/scripts/verify-pilot-go-no-go-decision-packet.sh
+++ b/scripts/verify-pilot-go-no-go-decision-packet.sh
@@ -178,6 +178,7 @@ require_label_contains_release "Known limitations review:" "known limitations re
 require_label_contains_release "Retention decision:" "retention decision"
 require_label_contains_release "Zammad/non-authority posture:" "Zammad non-authority posture"
 require_label_contains_release "Assistant limitation posture:" "assistant limitation posture"
+require_label_contains_release "Evidence handoff owner:" "evidence handoff owner"
 require_label_contains_release "Next health review:" "next health review"
 
 required_reference_phrases=(


### PR DESCRIPTION
## Summary
- add a deterministic pilot go/no-go decision packet verifier for the Phase 48 evidence packet
- add a redacted positive packet exemplar and negative fixtures for missing sections, mixed release IDs, workstation-local paths, and secret-looking values
- wire the verifier into CI plus the pilot readiness checklist and runbook

## Verification
- bash scripts/verify-pilot-go-no-go-decision-packet.sh
- bash scripts/test-verify-pilot-go-no-go-decision-packet.sh
- bash scripts/verify-pilot-readiness-checklist.sh
- bash scripts/test-verify-pilot-readiness-checklist.sh
- bash scripts/verify-release-handoff-evidence-package.sh
- bash scripts/test-verify-release-handoff-evidence-package.sh
- bash scripts/verify-detector-activation-evidence-handoff.sh
- bash scripts/test-verify-detector-activation-evidence-handoff.sh
- bash scripts/verify-publishable-path-hygiene.sh
- git diff --check
- node dist/index.js issue-lint 882 --config supervisor.config.aegisops.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pilot go/no-go decision packet verifier and accompanying automated test suite.

* **Documentation**
  * Added comprehensive pilot go/no-go decision packet fixtures and an example packet.
  * Updated the pilot readiness checklist and runbook to require verifier-based validation and single-release binding of packet metadata (release, evidence, ownership, next health review).

* **Chores**
  * Integrated the new verifier into CI verification and focused test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->