### PR TITLE
Phase 48.5.1: Add Phase 44 pilot ingress docs

### DIFF
--- a/control-plane/tests/test_phase44_pilot_ingress_operator_surface_docs.py
+++ b/control-plane/tests/test_phase44_pilot_ingress_operator_surface_docs.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase44PilotIngressOperatorSurfaceDocsTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected file at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_phase44_boundary_doc_defines_closed_pilot_ingress_contract(self) -> None:
+        text = self._read(
+            "docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md"
+        )
+
+        for term in (
+            "AegisOps Phase 44 Pilot Ingress and Operator Surface Closure Boundary",
+            "In Scope",
+            "Out of Scope",
+            "Fail-Closed Conditions",
+            "first-boot proxy operator surface",
+            "protected identity header normalization",
+            "backend and operator-ui role canonicalization",
+            "runtime smoke ingress evidence",
+            "operator-ui CI gate",
+            "AegisOps backend records remain authoritative",
+            "operator UI and proxy evidence do not become workflow truth",
+            "direct backend exposure",
+            "Browser state, operator UI state, external tickets, assistant output, and downstream receipts remain subordinate context",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase44_validation_doc_records_verifier_references_and_no_behavior_change(
+        self,
+    ) -> None:
+        text = self._read(
+            "docs/phase-44-pilot-ingress-and-operator-surface-closure-validation.md"
+        )
+
+        for term in (
+            "Phase 44 Pilot Ingress and Operator Surface Closure Validation",
+            "Validation status: PASS",
+            "docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md",
+            "control-plane/deployment/first-boot/docker-compose.yml",
+            "proxy/nginx/conf.d-first-boot/control-plane.conf",
+            "control-plane/tests/test_phase17_first_boot_runtime_artifacts.py",
+            "control-plane/tests/test_phase21_runtime_auth_validation.py",
+            "apps/operator-ui/src/auth/session.test.ts",
+            "scripts/run-phase-37-runtime-smoke-gate.sh",
+            "scripts/test-verify-ci-operator-ui-workflow-coverage.sh",
+            "bash scripts/verify-architecture-runbook-validation.sh",
+            "python3 -m unittest control-plane.tests.test_phase44_pilot_ingress_operator_surface_docs",
+            "node <codex-supervisor-root>/dist/index.js issue-lint 889 --config <supervisor-config-path>",
+            "No runtime behavior, operator UI behavior, or authority posture changes are introduced by this validation document.",
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md
+++ b/docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md
@@ -123,7 +123,7 @@ Phase 44 must fail closed when any prerequisite boundary signal is missing, malf
 
 Blocking conditions include:
 
-- the first-boot proxy route set is missing required reviewed routes or exposes write-capable or administrative routes outside the reviewed boundary;
+- the first-boot proxy route set is missing reviewed routes required by this boundary or exposes write-capable or administrative routes outside the reviewed boundary;
 - caller-supplied protected identity headers can pass through the first-boot proxy as trusted values;
 - the protected-surface runtime lacks reviewed proxy CIDRs, proxy secret, proxy service account, or reviewed identity-provider binding when non-loopback protected-surface access is configured;
 - protected-surface requests bypass the reviewed proxy peer boundary, omit HTTPS, use the wrong proxy credential, use the wrong proxy service account, omit reviewed identity provider, subject, identity, or role attribution, or present an unauthorized role;

--- a/docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md
+++ b/docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md
@@ -1,0 +1,165 @@
+# AegisOps Phase 44 Pilot Ingress and Operator Surface Closure Boundary
+
+## 1. Purpose
+
+This document defines the reviewed Phase 44 pilot ingress and operator surface closure boundary.
+
+It retroactively closes the Phase 44 contract around the first-boot proxy operator surface, protected identity header normalization, backend and operator-ui role canonicalization, runtime smoke ingress evidence, and the operator-ui CI gate.
+
+It supplements `docs/phase-16-release-state-and-first-boot-scope.md`, `docs/phase-17-runtime-config-contract-and-boot-command-expectations.md`, `docs/phase-19-thin-operator-surface-and-daily-analyst-workflow.md`, `docs/phase-31-product-grade-hardening-boundary.md`, `docs/deployment/runtime-smoke-bundle.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/runbook.md`, and `docs/architecture.md`.
+
+This document describes the closed Phase 44 ingress and operator surface contract only. It does not change runtime behavior, operator UI behavior, route exposure, identity posture, role posture, or workflow authority.
+
+## 2. In Scope
+
+Phase 44 closes one narrow pilot ingress and operator surface contract:
+
+- the repo-owned first-boot proxy remains the reviewed operator ingress surface for health, readiness, runtime inspection, read-only operator inspection, and the bounded operator queue path;
+- protected identity headers are stripped or normalized at the reviewed proxy boundary before backend authorization evaluates them;
+- backend protected-surface authentication remains the enforcement boundary for reviewed identity provider, subject, identity, role, proxy secret, proxy service account, HTTPS, and trusted peer signals;
+- backend and operator-ui role canonicalization stay aligned around reviewed roles such as `analyst`, `approver`, and `platform_admin`;
+- runtime smoke ingress evidence remains a bounded proof that the reviewed proxy path can reach protected runtime and operator inspection routes without performing write-capable workflow actions; and
+- the operator-ui CI gate remains the reviewed frontend quality gate for typecheck, tests, and build before the operator surface is treated as pilot-ready.
+
+The Phase 44 boundary is an ingress and validation closure. It records that the pilot path is understandable from repo-owned artifacts without promoting browser state, proxy logs, smoke output, assistant output, tickets, or downstream receipts into workflow truth.
+
+## 3. Out of Scope
+
+Phase 44 does not authorize:
+
+- new proxy routes or runtime endpoints;
+- new operator UI features;
+- a new role model or production RBAC design;
+- direct backend exposure;
+- production identity-provider rollout beyond the reviewed protected-surface contract;
+- browser-owned authorization, lifecycle, approval, execution, reconciliation, or audit truth;
+- write-capable operator workflow expansion;
+- optional extension promotion into the mainline pilot ingress path; or
+- treating Browser state, operator UI state, external tickets, assistant output, and downstream receipts as workflow truth.
+
+Direct backend exposure remains outside the reviewed pilot path. Operators and verifiers must use the reviewed proxy boundary and repo-owned commands rather than bypassing the proxy to make a failing ingress path appear healthy.
+
+## 4. First-Boot Proxy Operator Surface
+
+The reviewed first-boot proxy operator surface is anchored in `control-plane/deployment/first-boot/docker-compose.yml` and `proxy/nginx/conf.d-first-boot/control-plane.conf`.
+
+The proxy surface may expose only the reviewed first-boot and operator-inspection route families needed for the pilot closure:
+
+- `/healthz`;
+- `/readyz`;
+- `/runtime`;
+- `/inspect-records`;
+- `/inspect-reconciliation-status`;
+- `/inspect-analyst-queue`;
+- `/inspect-alert-detail`;
+- `/inspect-case-detail`;
+- `/inspect-action-review`;
+- `/inspect-advisory-output`; and
+- `/operator/queue`.
+
+The read-only inspection routes and queue alias must keep their read-only method posture. The proxy must not expose operator write routes, administrative bootstrap routes, or direct backend internals as part of Phase 44.
+
+## 5. Protected Identity Header Normalization
+
+Protected identity header normalization happens at the reviewed proxy boundary before the backend evaluates protected-surface authorization.
+
+The reviewed protected header family is:
+
+- `X-AegisOps-Proxy-Secret`;
+- `X-AegisOps-Proxy-Service-Account`;
+- `X-AegisOps-Authenticated-IdP`;
+- `X-AegisOps-Authenticated-Subject`;
+- `X-AegisOps-Authenticated-Identity`; and
+- `X-AegisOps-Authenticated-Role`.
+
+The first-boot proxy must strip caller-supplied values for this header family until a reviewed authenticated identity source is wired into the boundary. The backend must then fail closed when required proxy, provider, subject, identity, role, peer, HTTPS, or credential signals are absent, malformed, placeholder-like, or inconsistent with the reviewed runtime config.
+
+Raw `X-Forwarded-*`, `Forwarded`, host, proto, tenant, user-id, role, and identity hints are not trusted unless the reviewed proxy and identity-provider boundary has authenticated, normalized, and bound them to the request.
+
+## 6. Role Canonicalization
+
+Backend and operator-ui role canonicalization must remain explicit and aligned.
+
+The backend receives canonical protected-surface roles and checks them against endpoint-specific allowed roles. The operator UI normalizes reviewed session role claims into lower-case canonical role names and filters them against the configured reviewed role set.
+
+The reviewed pilot role family remains:
+
+- `analyst`;
+- `approver`; and
+- `platform_admin`.
+
+Missing roles, malformed role arrays, unreviewed role names, placeholder values, or role claims that are present only in client-controlled state must fail closed as unauthenticated, forbidden, or invalid-session behavior according to the applicable boundary.
+
+The operator UI may render role-aware navigation and page posture as convenience behavior, but backend authorization remains authoritative for protected reads and any later write-capable workflow action.
+
+## 7. Runtime Smoke Ingress Evidence
+
+Runtime smoke ingress evidence is bounded evidence around the reviewed proxy path.
+
+The reviewed evidence path is `scripts/run-phase-37-runtime-smoke-gate.sh --env-file <runtime-env-file> --evidence-dir <evidence-dir>`.
+
+That gate captures startup status, bounded logs, health, readiness, protected runtime inspection, read-only operator queue ingress, read-only detail ingress, and first low-risk action preconditions. It intentionally does not create reviewed action requests, approval decisions, delegation dispatches, executor writes, or reconciliation writes.
+
+Runtime smoke output is evidence that the reviewed ingress path is reachable and retains the expected read-only posture. It is not workflow truth and must not override AegisOps backend records.
+
+## 8. Operator-UI CI Gate
+
+The operator-ui CI gate is the reviewed frontend gate for the pilot operator surface.
+
+The CI workflow and verifier references are:
+
+- `.github/workflows/ci.yml`;
+- `scripts/test-verify-ci-operator-ui-workflow-coverage.sh`;
+- `apps/operator-ui/src/auth/session.test.ts`;
+- `apps/operator-ui/src/app/OperatorRoutes.test.tsx`;
+- `apps/operator-ui/e2e/operator-workflows.spec.ts`; and
+- `apps/operator-ui/playwright.config.ts`.
+
+The gate proves the operator UI can typecheck, run its focused tests, and build against the reviewed session and route contract. It does not make the browser the authority for identity, role, record lifecycle, approval, execution, reconciliation, or audit truth.
+
+## 9. Fail-Closed Conditions
+
+Phase 44 must fail closed when any prerequisite boundary signal is missing, malformed, placeholder-like, or only partially trusted.
+
+Blocking conditions include:
+
+- the first-boot proxy route set is missing required reviewed routes or exposes write-capable or administrative routes outside the reviewed boundary;
+- caller-supplied protected identity headers can pass through the first-boot proxy as trusted values;
+- the protected-surface runtime lacks reviewed proxy CIDRs, proxy secret, proxy service account, or reviewed identity-provider binding when non-loopback protected-surface access is configured;
+- protected-surface requests bypass the reviewed proxy peer boundary, omit HTTPS, use the wrong proxy credential, use the wrong proxy service account, omit reviewed identity provider, subject, identity, or role attribution, or present an unauthorized role;
+- placeholder credentials such as `<set-me>` are accepted as runtime credentials;
+- operator-ui session parsing treats malformed claims, empty roles, or unreviewed roles as valid access;
+- runtime smoke evidence is captured through direct backend exposure rather than the reviewed proxy path; or
+- operator UI, browser state, proxy evidence, tickets, assistant output, or downstream receipts are used as workflow truth instead of subordinate context.
+
+When one of these conditions appears, the correct outcome is rejection, blocked readiness, forbidden access, invalid-session behavior, or an explicit follow-up. The system must not infer success from naming conventions, path shape, cached browser state, proxy reachability alone, or nearby metadata.
+
+## 10. Authority Boundary Notes
+
+AegisOps backend records remain authoritative for alert, case, evidence, recommendation, approval, action intent, execution receipt, reconciliation, lifecycle, readiness, and audit truth.
+
+The first-boot proxy is an ingress and normalization boundary, not a workflow authority.
+
+The operator UI is a thin client and subordinate surface, not a system of record.
+
+Runtime smoke evidence proves bounded route reachability and expected read-only posture, not the truth of operational casework or workflow completion.
+
+operator UI and proxy evidence do not become workflow truth.
+
+Browser state, operator UI state, external tickets, assistant output, and downstream receipts remain subordinate context unless a reviewed AegisOps backend record explicitly binds them into the authoritative record chain.
+
+Proxy logs, runtime smoke output, and optional substrate state remain subordinate context under the same rule.
+
+## 11. Validation Expectations
+
+Validation must remain documentation and boundary focused.
+
+At minimum, validation should prove:
+
+- the Phase 44 boundary and validation docs exist;
+- the docs name in-scope, out-of-scope, fail-closed conditions, verifier references, and authority boundary notes;
+- the first-boot proxy route and protected identity header normalization tests remain the evidence anchor for ingress closure;
+- backend protected-surface auth tests remain the enforcement anchor for identity, role, proxy, and placeholder fail-closed behavior;
+- operator-ui session tests remain the role canonicalization anchor;
+- runtime smoke gate references remain repo-relative and use `<runtime-env-file>` and `<evidence-dir>` placeholders; and
+- no runtime or UI behavior change is included.

--- a/docs/phase-44-pilot-ingress-and-operator-surface-closure-validation.md
+++ b/docs/phase-44-pilot-ingress-and-operator-surface-closure-validation.md
@@ -1,0 +1,68 @@
+# Phase 44 Pilot Ingress and Operator Surface Closure Validation
+
+- Validation status: PASS
+- Reviewed on: 2026-04-28
+- Scope: confirm that the Phase 44 pilot ingress and operator surface closure is documented as a repo-owned contract without changing runtime behavior, operator UI behavior, or authority posture.
+- Reviewed sources: `docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md`, `control-plane/deployment/first-boot/docker-compose.yml`, `proxy/nginx/conf.d-first-boot/control-plane.conf`, `control-plane/tests/test_phase17_first_boot_runtime_artifacts.py`, `control-plane/tests/test_phase21_runtime_auth_validation.py`, `apps/operator-ui/src/auth/session.ts`, `apps/operator-ui/src/auth/session.test.ts`, `apps/operator-ui/src/app/OperatorRoutes.test.tsx`, `apps/operator-ui/e2e/operator-workflows.spec.ts`, `scripts/run-phase-37-runtime-smoke-gate.sh`, `scripts/test-verify-ci-operator-ui-workflow-coverage.sh`, `.github/workflows/ci.yml`
+
+## Verdict
+
+Phase 44 is closed as a documentation-only pilot ingress and operator surface contract.
+
+The reviewed first-boot proxy remains the only pilot operator ingress surface for the documented route families. Protected identity headers remain normalized at the proxy boundary before backend protected-surface authorization evaluates proxy, provider, subject, identity, role, HTTPS, and trusted-peer signals.
+
+Backend and operator-ui role canonicalization remain aligned around reviewed canonical roles while backend authorization remains the enforcement boundary.
+
+Runtime smoke ingress evidence remains a bounded proof of proxy-reached runtime and operator inspection paths. It does not perform write-capable workflow actions and does not become workflow truth.
+
+The operator-ui CI gate remains the frontend quality gate for the reviewed thin-client surface. It does not move authority from backend records into browser state.
+
+No runtime behavior, operator UI behavior, or authority posture changes are introduced by this validation document.
+
+## Locked Behaviors
+
+- first-boot operator ingress remains anchored to `control-plane/deployment/first-boot/docker-compose.yml` and `proxy/nginx/conf.d-first-boot/control-plane.conf`
+- protected identity header normalization strips caller-supplied protected AegisOps identity headers at the reviewed proxy boundary
+- backend protected-surface auth fails closed for missing, malformed, placeholder, untrusted, or unauthorized proxy and identity signals
+- backend and operator-ui role canonicalization keep `analyst`, `approver`, and `platform_admin` as reviewed canonical role names
+- runtime smoke ingress evidence uses the reviewed proxy path and remains read-only for operator inspection
+- operator-ui CI proves typecheck, tests, and build for the browser surface without promoting the browser to workflow authority
+- AegisOps backend records remain authoritative over operator UI, proxy evidence, external tickets, assistant output, downstream receipts, and optional substrate state
+
+## Evidence
+
+`docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md` defines the in-scope and out-of-scope boundary, fail-closed conditions, verifier references, and authority notes for the closed Phase 44 pilot ingress contract.
+
+`control-plane/deployment/first-boot/docker-compose.yml` preserves the repo-owned first-boot control-plane, PostgreSQL, and proxy composition used by the reviewed ingress path.
+
+`proxy/nginx/conf.d-first-boot/control-plane.conf` preserves the first-boot proxy route set and strips protected AegisOps identity headers before traffic reaches the backend.
+
+`control-plane/tests/test_phase17_first_boot_runtime_artifacts.py` locks the first-boot proxy route posture and protected identity header normalization behavior. The test proves caller-supplied protected identity headers are stripped and not passed through as trusted inputs.
+
+`control-plane/tests/test_phase21_runtime_auth_validation.py` locks backend protected-surface authentication behavior. The suite covers reviewed proxy peer, HTTPS, proxy secret, proxy service account, reviewed identity provider, subject, identity, role, allowed-role, and placeholder credential fail-closed behavior.
+
+`apps/operator-ui/src/auth/session.ts` and `apps/operator-ui/src/auth/session.test.ts` lock operator-ui role canonicalization and invalid-session handling. The UI normalizes reviewed role claims into canonical lower-case names and rejects malformed or unreviewed claims instead of treating client state as authority.
+
+`scripts/run-phase-37-runtime-smoke-gate.sh` captures runtime smoke ingress evidence through the reviewed proxy path using `--env-file <runtime-env-file>` and `--evidence-dir <evidence-dir>`. The evidence manifest records protected runtime inspection, readiness, startup status, bounded logs, read-only operator ingress, and first low-risk action preconditions without performing a workflow write.
+
+`scripts/test-verify-ci-operator-ui-workflow-coverage.sh` and `.github/workflows/ci.yml` keep the operator-ui CI gate explicit with `npm run typecheck --workspace @aegisops/operator-ui`, `npm run test --workspace @aegisops/operator-ui`, and `npm run build --workspace @aegisops/operator-ui`.
+
+## Validation Commands
+
+- `python3 -m unittest control-plane.tests.test_phase44_pilot_ingress_operator_surface_docs`
+- `python3 -m unittest control-plane.tests.test_phase17_first_boot_runtime_artifacts`
+- `python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation`
+- `npm --prefix apps/operator-ui test -- --run src/auth/session.test.ts`
+- `bash scripts/verify-architecture-runbook-validation.sh`
+- `bash scripts/test-verify-ci-publishable-path-hygiene.sh`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 889 --config <supervisor-config-path>`
+
+## Non-Expansion Notes
+
+Phase 44 validation is intentionally retroactive and documentation-only.
+
+It does not add proxy routes, runtime routes, backend authorization behavior, operator UI features, role names, production RBAC behavior, workflow writes, or deployment requirements.
+
+The reviewed command references use repo-relative paths, documented environment placeholders, and explicit `<codex-supervisor-root>` and `<supervisor-config-path>` placeholders instead of workstation-local absolute paths.
+
+Operator UI and proxy evidence do not become workflow truth. Browser state, operator UI state, external tickets, assistant output, downstream receipts, runtime smoke output, and optional substrate state remain subordinate context unless a reviewed AegisOps backend record explicitly binds them into the authoritative record chain.


### PR DESCRIPTION
## Summary
- Add the Phase 44 pilot ingress/operator surface closure boundary doc.
- Add the matching Phase 44 validation doc with repo-relative verifier references and authority notes.
- Add a focused docs regression test for the Phase 44 doc pair.

## Verification
- python3 -m unittest control-plane.tests.test_phase44_pilot_ingress_operator_surface_docs
- python3 -m unittest control-plane.tests.test_phase17_first_boot_runtime_artifacts
- python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation
- npm --prefix apps/operator-ui test -- --run src/auth/session.test.ts
- bash scripts/verify-architecture-runbook-validation.sh
- bash scripts/test-verify-ci-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 889 --config <supervisor-config-path>

Closes #889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 44 pilot ingress and operator-surface closure and validation docs that record the closed ingress/operator contract, allowed routes/roles, fail-closed auth expectations, bounded inspection evidence, CI validation references, and affirmation of no runtime/UI behavior changes.

* **Tests**
  * Added tests that verify the new Phase 44 documents exist and contain the required contract and validation wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->