### PR TITLE
Phase 48.5.4: Add Phase 47 decomposition docs

### DIFF
--- a/control-plane/tests/test_phase47_responsibility_decomposition_docs.py
+++ b/control-plane/tests/test_phase47_responsibility_decomposition_docs.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase47ResponsibilityDecompositionDocsTests(unittest.TestCase):
+    @staticmethod
+    def _read(relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected file at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def test_phase47_boundary_doc_defines_decomposition_contract(self) -> None:
+        text = self._read(
+            "docs/phase-47-control-plane-responsibility-decomposition-boundary.md"
+        )
+
+        for term in (
+            "AegisOps Phase 47 Control-Plane Responsibility Decomposition Boundary",
+            "In Scope",
+            "Out of Scope",
+            "Fail-Closed Conditions",
+            "action lifecycle write routing",
+            "readiness runtime status coordination",
+            "external evidence coordination",
+            "assistant advisory coordination",
+            "maintainability hotspot verifier",
+            "AegisOpsControlPlaneService",
+            "Phase 49.0",
+            "AegisOps control-plane records remain authoritative",
+            "`service.py` remains a reviewed maintainability hotspot",
+        ):
+            self.assertIn(term, text)
+
+    def test_phase47_validation_doc_records_verifier_references_and_no_readiness_claim(
+        self,
+    ) -> None:
+        text = self._read(
+            "docs/phase-47-control-plane-responsibility-decomposition-validation.md"
+        )
+
+        for term in (
+            "Phase 47 Control-Plane Responsibility Decomposition Validation",
+            "Validation status: PASS",
+            "docs/phase-47-control-plane-responsibility-decomposition-boundary.md",
+            "docs/control-plane-service-internal-boundaries.md",
+            "docs/maintainability-decomposition-thresholds.md",
+            "docs/maintainability-hotspot-baseline.txt",
+            "control-plane/aegisops_control_plane/action_lifecycle_write_coordinator.py",
+            "control-plane/aegisops_control_plane/readiness_contracts.py",
+            "control-plane/aegisops_control_plane/external_evidence_boundary.py",
+            "control-plane/aegisops_control_plane/assistant_advisory.py",
+            "bash scripts/verify-maintainability-hotspots.sh",
+            "python3 -m unittest control-plane/tests/test_phase47_responsibility_decomposition_docs.py",
+            "node <codex-supervisor-root>/dist/index.js issue-lint 888 --config <supervisor-config-path>",
+            "No runtime behavior, authority posture, or commercial readiness claim is introduced by this validation document.",
+            "Phase 49.0 owns the remaining service.py responsibility concentration follow-up.",
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-47-control-plane-responsibility-decomposition-boundary.md
+++ b/docs/phase-47-control-plane-responsibility-decomposition-boundary.md
@@ -1,0 +1,157 @@
+# AegisOps Phase 47 Control-Plane Responsibility Decomposition Boundary
+
+## 1. Purpose
+
+This document defines the reviewed Phase 47 control-plane responsibility decomposition boundary.
+
+It retroactively closes the Phase 47 contract around behavior-preserving coordinator extractions, readiness contract isolation, external evidence coordination, assistant advisory coordination, and the maintainability hotspot verifier.
+
+It supplements `docs/control-plane-service-internal-boundaries.md`, `docs/maintainability-decomposition-thresholds.md`, `docs/maintainability-hotspot-baseline.txt`, `docs/control-plane-runtime-service-boundary.md`, `docs/response-action-safety-model.md`, `docs/control-plane-state-model.md`, and `docs/architecture.md`.
+
+This document describes the closed Phase 47 decomposition contract only. It does not change runtime behavior, authority posture, action behavior, evidence authority, assistant authority, readiness behavior, public facade signatures, or deployment posture.
+
+## 2. In Scope
+
+Phase 47 closes one narrow control-plane maintainability contract:
+
+- action lifecycle write routing stays delegated through `control-plane/aegisops_control_plane/action_lifecycle_write_coordinator.py`;
+- readiness runtime status coordination keeps shared readiness DTO and status-resolution ownership in `control-plane/aegisops_control_plane/readiness_contracts.py`;
+- external evidence coordination stays delegated through `control-plane/aegisops_control_plane/external_evidence_boundary.py`;
+- assistant advisory coordination stays delegated through `control-plane/aegisops_control_plane/assistant_advisory.py` and the existing assistant context assembler;
+- focused coordinator and boundary tests remain the executable proof that public `AegisOpsControlPlaneService` entrypoints preserve the reviewed behavior; and
+- the maintainability hotspot verifier remains the guard that records `control-plane/aegisops_control_plane/service.py` as a known reviewed hotspot instead of pretending the hotspot is solved.
+
+Phase 47 is a behavior-preserving decomposition closure. It records that selected responsibilities moved behind narrower collaborators while AegisOps control-plane records remain authoritative and the public facade remains stable for reviewed callers.
+
+## 3. Out of Scope
+
+Phase 47 does not authorize:
+
+- Phase 49.0 service decomposition;
+- new coordinator extraction beyond the implementation already landed before this documentation closure;
+- new runtime behavior, HTTP routes, CLI commands, action types, evidence sources, assistant capabilities, approval paths, execution paths, reconciliation outcomes, readiness states, or deployment paths;
+- treating assistants, optional evidence, external tickets, downstream receipts, browser state, source substrates, forwarded headers, placeholder credentials, or operator-facing projections as authority;
+- changing maintainability thresholds or hotspot baselines without an explicit verifier-backed rationale; or
+- claiming commercial readiness, completed third-stage service decomposition, or elimination of `service.py` responsibility concentration.
+
+`service.py` remains a reviewed maintainability hotspot. Further concentration reduction belongs to Phase 49.0, not to this Phase 47 documentation closure.
+
+## 4. Action Lifecycle Write Routing
+
+Action lifecycle write routing is anchored in `control-plane/aegisops_control_plane/action_lifecycle_write_coordinator.py`.
+
+`AegisOpsControlPlaneService` remains the public facade for action lifecycle writes, but the write routing behind these facade entrypoints is owned by the coordinator. The reviewed delegation covers action request creation from assistant advisory context, tracking-ticket action requests, approval decision recording, delegation binding, and reconciliation write coordination.
+
+The coordinator extraction must preserve the existing fail-closed authority model:
+
+- action requests remain bound to explicit AegisOps record identifiers, reviewed payloads, approval scope, and expiry constraints;
+- approval decisions do not become execution or reconciliation truth;
+- execution receipts do not become reconciliation truth;
+- downstream tickets, comments, receipts, assistant summaries, or substrate status do not replace AegisOps action records; and
+- missing, malformed, placeholder-like, stale, or mismatched approval, execution, provenance, payload, or scope signals keep the write path blocked or unresolved.
+
+The public facade may forward to the coordinator, but it must not infer successful action lifecycle state from naming conventions, path shape, nearby metadata, external ticket state, or subordinate context.
+
+## 5. Readiness Runtime Status Coordination
+
+Readiness runtime status coordination is anchored in `control-plane/aegisops_control_plane/readiness_contracts.py`.
+
+The readiness contract extraction keeps shared readiness aggregate DTOs and runtime status resolution in one explicit module so runtime surfaces and readiness collaborators do not reach through persistence adapter internals for status semantics.
+
+Readiness status remains derived from AegisOps-owned runtime, readiness, backup, restore, restore-drill, and lifecycle facts. Operator-facing readiness text, HTTP response shape, dashboard display, or optional substrate health is a projection over those facts, not an independent source of truth.
+
+If readiness inputs are missing, malformed, mixed across snapshots, stale, or contradictory, the reviewed posture is degraded, blocked, unavailable, or explicit follow-up. Phase 47 does not allow readiness success to be inferred from summary text, a successful HTTP render, optional extension availability, or a downstream substrate response.
+
+## 6. External Evidence Coordination
+
+External evidence coordination is anchored in `control-plane/aegisops_control_plane/external_evidence_boundary.py`.
+
+The extraction keeps MISP, osquery, and endpoint evidence request handling behind a boundary that preserves AegisOps evidence authority. External evidence may enrich a reviewed record only when the AegisOps record chain explicitly binds the evidence subject, source, provenance, and linked case or alert context.
+
+External evidence remains subordinate context. Optional evidence, enrichment payloads, endpoint artifacts, ticket references, source-substrate metadata, and downstream receipts do not become alert, case, approval, execution, reconciliation, readiness, or audit truth.
+
+When evidence provenance, source identity, subject linkage, tenant or repository binding, credential custody, or record linkage is absent or only partially trusted, the boundary must fail closed by rejecting the write, keeping the evidence unresolved, or surfacing a follow-up instead of accepting guessed context.
+
+## 7. Assistant Advisory Coordination
+
+Assistant advisory coordination is anchored in `control-plane/aegisops_control_plane/assistant_advisory.py` and the existing `AssistantContextAssembler`.
+
+The coordinator exposes advisory-only operations for inspected advisory output, recommendation draft rendering, and assistant advisory draft attachment. It must not expose approval, execution, reconciliation, case closure, readiness, credential, or production write authority.
+
+Assistant output remains subordinate to reviewed AegisOps records and linked evidence. The coordinator may assemble citation-grounded context and advisory drafts, but it must preserve unresolved status when identity, provenance, citation, scope, or subject-linkage signals are missing or ambiguous.
+
+An assistant advisory draft attached to one record must not be generalized to a neighboring recommendation, case, action, lineage-relative surface, or same-parent record unless an explicit authoritative link says it applies there.
+
+## 8. Maintainability Hotspot Verifier
+
+The maintainability hotspot verifier is `scripts/verify-maintainability-hotspots.sh`.
+
+The verifier reads `docs/maintainability-decomposition-thresholds.md` and `docs/maintainability-hotspot-baseline.txt` to distinguish known reviewed hotspots from new responsibility growth.
+
+The current reviewed baseline intentionally includes:
+
+- `control-plane/aegisops_control_plane/service.py`
+
+This baseline entry is not an exemption for additional responsibility growth. It is an explicit reminder that `AegisOpsControlPlaneService` still concentrates multiple reviewed concerns even after Phase 47 reduced selected routing and coordination responsibilities.
+
+If the verifier reports a new hotspot, maintainers should apply the threshold guidance and open a focused decomposition backlog rather than extend the file by default. If the verifier reports that the baseline entry is stale, maintainers should update the baseline only after confirming the hotspot no longer crosses the responsibility-growth threshold.
+
+## 9. Remaining Service Decomposition Debt
+
+Phase 47 reduced concentration but did not complete third-stage service decomposition.
+
+`control-plane/aegisops_control_plane/service.py` and `AegisOpsControlPlaneService` still remain a known responsibility concentration point for runtime and auth boundaries, detection intake, analyst workflow facade routing, assistant and advisory facade routing, action governance facade routing, readiness and restore facade routing, and Phase 19 slice policy boundaries.
+
+The correct handoff is Phase 49.0:
+
+- continue decomposing the remaining `service.py` responsibility clusters under the existing `docs/control-plane-service-internal-boundaries.md` target shape;
+- preserve public facade entrypoints unless an explicit follow-up changes the reviewed API;
+- keep authority-bearing validation and transaction boundaries anchored to the real enforcement point;
+- add focused regression coverage for each extracted cluster; and
+- avoid combining service decomposition with new feature scope or commercial readiness claims.
+
+Phase 47 must not be cited as proof that AegisOps is commercially ready or that `AegisOpsControlPlaneService` is no longer a maintainability concern.
+
+## 10. Fail-Closed Conditions
+
+Phase 47 must fail closed when any prerequisite provenance, scope, auth context, subject linkage, transaction boundary, snapshot, readiness, evidence, assistant, approval, execution, or reconciliation signal is missing, malformed, stale, mixed, placeholder-like, or only partially trusted.
+
+Blocking conditions include:
+
+- action lifecycle writes lack explicit AegisOps request, approval, payload, scope, expiry, execution, or reconciliation binding;
+- assistant output, optional evidence, downstream receipts, external tickets, browser state, source-substrate status, operator-facing summaries, or convenience projections are treated as authority;
+- external evidence lacks reviewed provenance, source identity, subject linkage, credential custody, or direct AegisOps record binding;
+- readiness status is inferred from summary text, HTTP rendering, optional substrate health, or mixed-snapshot reads instead of authoritative readiness facts;
+- raw forwarded headers, host, proto, tenant, user identity hints, or client-supplied scope fields are trusted without a reviewed authenticated boundary;
+- placeholder, sample, fake, TODO, unsigned, empty, stale, or unreviewed credentials are accepted as live custody;
+- a coordinator extraction changes public behavior, widens authority, collapses approval, execution, and reconciliation, or hides an unresolved state;
+- one logical write persists partial durable state after a rejected, forbidden, failed, or restore-failure path; or
+- documentation, validation commands, fixtures, prompts, or operator notes introduce workstation-local absolute paths, hidden manual steps, live secrets, or production write behavior.
+
+When one of these conditions appears, the correct result is rejection, blocked execution, explicit unresolved or degraded status, unavailable posture, rollback, or a documented follow-up. The system must not infer success from names, path shape, nearby metadata, ticket state, assistant text, receipt wording, or display order.
+
+## 11. Authority Boundary Notes
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, approval, action intent, execution receipt, reconciliation, lifecycle, readiness, release, pilot entry, and audit truth.
+
+The public `AegisOpsControlPlaneService` facade remains the reviewed entrypoint surface for existing callers. Phase 47 coordinator modules are internal decomposition boundaries, not new authority-bearing product surfaces.
+
+Action lifecycle, readiness, evidence, and assistant surfaces remain subordinate to the authoritative AegisOps record chain unless the backend record explicitly binds the context.
+
+Assistant output, optional evidence, downstream receipts, external tickets, browser state, forwarded headers, source substrates, operator-facing summaries, badges, counters, and projections remain subordinate context only.
+
+## 12. Validation Expectations
+
+Validation must remain documentation and boundary focused.
+
+At minimum, validation should prove:
+
+- the Phase 47 boundary and validation docs exist;
+- the docs name in-scope, out-of-scope, fail-closed conditions, verifier references, and authority boundary notes;
+- action lifecycle write routing stays delegated through the coordinator without changing action lifecycle authority;
+- readiness runtime status coordination stays anchored to shared readiness contracts and authoritative readiness facts;
+- external evidence coordination stays subordinate to explicit AegisOps evidence linkage;
+- assistant advisory coordination remains advisory-only and does not gain authority-bearing methods;
+- the maintainability hotspot verifier still records `service.py` as a known reviewed hotspot;
+- Phase 49.0 owns the remaining `service.py` and `AegisOpsControlPlaneService` responsibility concentration follow-up; and
+- no runtime behavior, authority posture, commercial readiness claim, or completed service decomposition claim is introduced.

--- a/docs/phase-47-control-plane-responsibility-decomposition-validation.md
+++ b/docs/phase-47-control-plane-responsibility-decomposition-validation.md
@@ -1,0 +1,94 @@
+# Phase 47 Control-Plane Responsibility Decomposition Validation
+
+- Validation status: PASS
+- Reviewed on: 2026-04-28
+- Scope: confirm that Phase 47 control-plane responsibility decomposition is documented as a behavior-preserving repo-owned contract without changing runtime behavior, action lifecycle authority, evidence authority, assistant authority, readiness behavior, or commercial readiness posture.
+- Reviewed sources: `docs/phase-47-control-plane-responsibility-decomposition-boundary.md`, `docs/control-plane-service-internal-boundaries.md`, `docs/maintainability-decomposition-thresholds.md`, `docs/maintainability-hotspot-baseline.txt`, `docs/control-plane-state-model.md`, `docs/response-action-safety-model.md`, `docs/architecture.md`, `control-plane/aegisops_control_plane/service.py`, `control-plane/aegisops_control_plane/action_lifecycle_write_coordinator.py`, `control-plane/aegisops_control_plane/readiness_contracts.py`, `control-plane/aegisops_control_plane/external_evidence_boundary.py`, `control-plane/aegisops_control_plane/assistant_advisory.py`, `control-plane/tests/test_execution_coordinator_boundary.py`, `control-plane/tests/test_service_boundary_refactor_regression_validation.py`, `control-plane/tests/test_phase28_external_evidence_boundary_refactor.py`, `control-plane/tests/test_service_persistence_assistant_advisory.py`, `control-plane/tests/test_service_internal_boundaries_docs.py`, `scripts/verify-maintainability-hotspots.sh`, `scripts/test-verify-maintainability-hotspots.sh`, `control-plane/tests/test_phase47_responsibility_decomposition_docs.py`
+
+## Verdict
+
+Phase 47 is closed as a documentation-only control-plane responsibility decomposition contract.
+
+The reviewed coordinator extractions reduce selected responsibility concentration behind `AegisOpsControlPlaneService` while preserving the existing public facade and authority posture.
+
+Action lifecycle write routing remains delegated through `ActionLifecycleWriteCoordinator` without making approval, execution, reconciliation, external tickets, assistant output, or downstream receipts interchangeable.
+
+Readiness runtime status coordination remains anchored to shared readiness contracts and authoritative readiness facts rather than projection text or optional substrate status.
+
+External evidence coordination remains subordinate to explicit AegisOps record linkage and reviewed provenance.
+
+Assistant advisory coordination remains advisory-only and does not gain approval, execution, reconciliation, readiness, credential, case closure, or production write authority.
+
+The maintainability hotspot verifier still records `control-plane/aegisops_control_plane/service.py` as a known reviewed hotspot. Phase 49.0 owns the remaining service.py responsibility concentration follow-up.
+
+No runtime behavior, authority posture, or commercial readiness claim is introduced by this validation document.
+
+## Locked Behaviors
+
+- `AegisOpsControlPlaneService` remains the public facade for existing reviewed callers.
+- action lifecycle write routing stays delegated through `control-plane/aegisops_control_plane/action_lifecycle_write_coordinator.py`.
+- approval, execution, and reconciliation remain separate first-class AegisOps records.
+- readiness runtime status coordination stays anchored to `control-plane/aegisops_control_plane/readiness_contracts.py`.
+- external evidence coordination stays delegated through `control-plane/aegisops_control_plane/external_evidence_boundary.py`.
+- assistant advisory coordination stays delegated through `control-plane/aegisops_control_plane/assistant_advisory.py` and remains advisory-only.
+- `scripts/verify-maintainability-hotspots.sh` continues to treat `service.py` as a reviewed baseline hotspot, not as solved debt.
+- AegisOps control-plane records remain authoritative over assistants, optional evidence, downstream receipts, external tickets, browser state, source substrates, summaries, and projections.
+- Phase 49.0 owns the remaining service.py responsibility concentration follow-up.
+
+## Evidence
+
+`docs/phase-47-control-plane-responsibility-decomposition-boundary.md` defines the in-scope and out-of-scope boundary, fail-closed conditions, verifier references, authority notes, and Phase 49.0 handoff for the closed Phase 47 decomposition contract.
+
+`docs/control-plane-service-internal-boundaries.md` defines the target internal collaborator shape for `AegisOpsControlPlaneService`, including facade responsibilities, dependency direction, action governance, assistant advisory assembly, and runtime readiness clusters.
+
+`docs/maintainability-decomposition-thresholds.md` defines the repo-owned threshold rule for opening another decomposition backlog instead of extending a responsibility hotspot.
+
+`docs/maintainability-hotspot-baseline.txt` records `control-plane/aegisops_control_plane/service.py` as the reviewed maintainability hotspot baseline for the verifier.
+
+`control-plane/aegisops_control_plane/action_lifecycle_write_coordinator.py` owns action lifecycle write routing behind the facade while preserving reviewed action, approval, delegation, and reconciliation boundaries.
+
+`control-plane/aegisops_control_plane/readiness_contracts.py` owns readiness aggregate DTOs and runtime status resolution shared by readiness and runtime surfaces.
+
+`control-plane/aegisops_control_plane/external_evidence_boundary.py` owns external evidence coordination while preserving explicit AegisOps record linkage and subordinate evidence posture.
+
+`control-plane/aegisops_control_plane/assistant_advisory.py` owns the assistant advisory coordination wrapper and exposes no authority-bearing methods.
+
+`control-plane/tests/test_execution_coordinator_boundary.py` includes focused regression coverage for the action lifecycle write coordinator and service facade delegation.
+
+`control-plane/tests/test_service_boundary_refactor_regression_validation.py` keeps the boundary refactor regression evidence discoverable for service initialization and coordinator preservation.
+
+`control-plane/tests/test_phase28_external_evidence_boundary_refactor.py` proves MISP, osquery, and endpoint evidence operations delegate to the external evidence boundary.
+
+`control-plane/tests/test_service_persistence_assistant_advisory.py` proves assistant advisory coordination stays advisory-only and preserves fail-closed behavior for authority overreach and ambiguous identity or grounding.
+
+`control-plane/tests/test_service_internal_boundaries_docs.py` keeps the service internal boundary documentation aligned with the extracted collaborators and remaining facade responsibilities.
+
+`scripts/verify-maintainability-hotspots.sh` verifies that any new maintainability hotspot exceeds the reviewed baseline and that stale baseline entries are cleaned up only after decomposition is confirmed.
+
+`scripts/test-verify-maintainability-hotspots.sh` is the focused negative validation for the hotspot verifier.
+
+`control-plane/tests/test_phase47_responsibility_decomposition_docs.py` locks the Phase 47 boundary and validation doc pair so the decomposition contract remains discoverable as a repo-owned artifact.
+
+## Validation Commands
+
+- `python3 -m unittest control-plane/tests/test_phase47_responsibility_decomposition_docs.py`
+- `python3 -m unittest control-plane/tests/test_execution_coordinator_boundary.py`
+- `python3 -m unittest control-plane/tests/test_phase28_external_evidence_boundary_refactor.py`
+- `python3 -m unittest control-plane/tests/test_service_persistence_assistant_advisory.py`
+- `python3 -m unittest control-plane/tests/test_service_internal_boundaries_docs.py`
+- `bash scripts/verify-maintainability-hotspots.sh`
+- `bash scripts/test-verify-maintainability-hotspots.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 888 --config <supervisor-config-path>`
+
+## Non-Expansion Notes
+
+Phase 47 validation is intentionally retroactive and documentation-only.
+
+It does not add runtime behavior, coordinator behavior, public facade methods, action types, evidence sources, assistant capabilities, approval behavior, execution behavior, reconciliation behavior, readiness states, deployment paths, production RBAC behavior, live credential handling, production write behavior, or commercial readiness posture.
+
+The reviewed command references use repo-relative paths and explicit `<codex-supervisor-root>` and `<supervisor-config-path>` placeholders instead of workstation-local absolute paths.
+
+Assistant output, optional evidence, downstream receipts, external tickets, browser state, forwarded headers, source substrates, operator-facing summaries, badges, counters, and projections remain subordinate context unless a reviewed AegisOps backend record explicitly binds them into the authoritative record chain.
+
+Phase 49.0 owns the remaining service.py responsibility concentration follow-up.


### PR DESCRIPTION
## Summary
- Adds the Phase 47 control-plane responsibility decomposition boundary doc.
- Adds the matching Phase 47 validation doc.
- Adds a focused docs regression test for the Phase 47 doc pair.

## Verification
- python3 -m unittest control-plane/tests/test_phase47_responsibility_decomposition_docs.py
- python3 -m unittest control-plane/tests/test_execution_coordinator_boundary.py
- python3 -m unittest control-plane/tests/test_phase28_external_evidence_boundary_refactor.py
- python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py
- python3 -m unittest control-plane/tests/test_service_persistence_assistant_advisory.py
- python3 -m unittest control-plane/tests/test_service_internal_boundaries_docs.py
- bash scripts/verify-maintainability-hotspots.sh
- bash scripts/test-verify-maintainability-hotspots.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node dist/index.js issue-lint 888 --config supervisor.config.aegisops.json

Closes #888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Phase 47 control-plane responsibility decomposition documentation specifying service boundaries, fail-closed conditions, and architectural stability commitments.

* **Tests**
  * Added automated validation tests to verify decomposition documentation contains required terms and maintains proper references and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->