### PR TITLE
Phase 48.5.5: Wire Phase 44-47 docs into guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           bash scripts/verify-parameter-catalog-structure-doc.sh
           bash scripts/verify-parameter-category-docs.sh
           bash scripts/verify-parameter-config-files.sh
+          bash scripts/verify-phase-44-47-boundary-docs.sh
           bash scripts/run-ci-phase-contract.sh all-verifiers
           bash scripts/verify-pilot-pause-rollback-exit-criteria.sh
           bash scripts/verify-positive-smb-value-proposition.sh
@@ -321,6 +322,7 @@ jobs:
           bash scripts/test-verify-detection-lifecycle-and-rule-qa-framework.sh
           bash scripts/test-verify-maintainability-hotspots.sh
           bash scripts/test-verify-positive-smb-value-proposition.sh
+          bash scripts/test-verify-phase-44-47-boundary-docs.sh
           bash scripts/run-ci-phase-contract.sh all-shell-tests
           bash scripts/test-verify-ci-phase-contract-runner.sh
           bash scripts/test-verify-requirements-baseline-control-plane-thesis.sh

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ Canonical cross-phase boundary reference:
 
 - `docs/non-goals-and-expansion-guardrails.md`
 
+Phase 44-47 closure contracts:
+
+- Phase 44-47 boundary docs:
+  - `docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md`
+  - `docs/phase-45-daily-soc-queue-and-operator-ux-hardening-boundary.md`
+  - `docs/phase-46-approval-execution-reconciliation-operations-pack-boundary.md`
+  - `docs/phase-47-control-plane-responsibility-decomposition-boundary.md`
+- Phase 44-47 validation docs:
+  - `docs/phase-44-pilot-ingress-and-operator-surface-closure-validation.md`
+  - `docs/phase-45-daily-soc-queue-and-operator-ux-hardening-validation.md`
+  - `docs/phase-46-approval-execution-reconciliation-operations-pack-validation.md`
+  - `docs/phase-47-control-plane-responsibility-decomposition-validation.md`
+
+AegisOps control-plane records remain authoritative. The operator UI, proxy, Zammad, assistant, optional evidence, downstream receipts, and maintainability projections remain subordinate context.
+
 The repository is no longer design-only: Phase 16 defines the approved first-boot runtime target for Phase 17 bring-up.
 That first-boot target is limited to the AegisOps control-plane service, PostgreSQL for control-plane state, the approved reverse proxy boundary, and reviewed Wazuh-facing analytic-signal intake expectations.
 OpenSearch, n8n, the full analyst-assistant surface, and the high-risk executor path remain optional, deferred, or non-blocking for first boot.

--- a/docs/non-goals-and-expansion-guardrails.md
+++ b/docs/non-goals-and-expansion-guardrails.md
@@ -72,7 +72,22 @@ Missing or obviously fake secrets, placeholder credentials, unsigned tokens, inf
 
 When expansion depends on a later authorization, provenance, or scope-validation step, the reviewed proof must anchor at that real enforcement boundary instead of treating an earlier setup step as sufficient evidence.
 
-## 9. Review Use
+## 9. Phase 44-47 Closed Pilot-Readiness Guardrails
+
+The closed Phase 44-47 contracts cover pilot ingress, daily SOC queue, approval/execution/reconciliation operations, and control-plane responsibility decomposition.
+
+AegisOps control-plane records remain authoritative.
+
+No later roadmap item may use these closed phases to infer new runtime behavior, browser authority, ticket authority, assistant authority, optional-evidence authority, or commercial-readiness claims.
+
+Phase 44-47 boundary docs:
+
+- `docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md`
+- `docs/phase-45-daily-soc-queue-and-operator-ux-hardening-boundary.md`
+- `docs/phase-46-approval-execution-reconciliation-operations-pack-boundary.md`
+- `docs/phase-47-control-plane-responsibility-decomposition-boundary.md`
+
+## 10. Review Use
 
 Use this registry as the default anti-expansion citation target when a proposal touches:
 

--- a/scripts/test-verify-phase-44-47-boundary-docs.sh
+++ b/scripts/test-verify-phase-44-47-boundary-docs.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-44-47-boundary-docs.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+required_docs=(
+  "docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md"
+  "docs/phase-44-pilot-ingress-and-operator-surface-closure-validation.md"
+  "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-boundary.md"
+  "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-validation.md"
+  "docs/phase-46-approval-execution-reconciliation-operations-pack-boundary.md"
+  "docs/phase-46-approval-execution-reconciliation-operations-pack-validation.md"
+  "docs/phase-47-control-plane-responsibility-decomposition-boundary.md"
+  "docs/phase-47-control-plane-responsibility-decomposition-validation.md"
+)
+
+boundary_docs=(
+  "docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md"
+  "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-boundary.md"
+  "docs/phase-46-approval-execution-reconciliation-operations-pack-boundary.md"
+  "docs/phase-47-control-plane-responsibility-decomposition-boundary.md"
+)
+
+validation_docs=(
+  "docs/phase-44-pilot-ingress-and-operator-surface-closure-validation.md"
+  "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-validation.md"
+  "docs/phase-46-approval-execution-reconciliation-operations-pack-validation.md"
+  "docs/phase-47-control-plane-responsibility-decomposition-validation.md"
+)
+
+write_file() {
+  local target="$1"
+  local path="$2"
+  local content="$3"
+
+  mkdir -p "$(dirname "${target}/${path}")"
+  printf '%s\n' "${content}" >"${target}/${path}"
+}
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+
+  for doc in "${required_docs[@]}"; do
+    write_file "${target}" "${doc}" "# ${doc}
+
+Required Phase 44-47 fixture content."
+  done
+
+  {
+    echo "# AegisOps"
+    echo
+    echo "## Phase 44-47 closure contracts"
+    echo
+    echo "Phase 44-47 boundary docs:"
+    for doc in "${boundary_docs[@]}"; do
+      echo "- \`${doc}\`"
+    done
+    echo
+    echo "Phase 44-47 validation docs:"
+    for doc in "${validation_docs[@]}"; do
+      echo "- \`${doc}\`"
+    done
+    echo
+    echo "AegisOps control-plane records remain authoritative."
+    echo "The operator UI, proxy, Zammad, assistant, optional evidence, downstream receipts, and maintainability projections remain subordinate context."
+  } >"${target}/README.md"
+
+  {
+    echo "# AegisOps Non-Goals and Expansion Guardrails"
+    echo
+    echo "## Phase 44-47 Closed Pilot-Readiness Guardrails"
+    echo
+    echo "The closed Phase 44-47 contracts cover pilot ingress, daily SOC queue, approval/execution/reconciliation operations, and control-plane responsibility decomposition."
+    echo
+    echo "AegisOps control-plane records remain authoritative."
+    echo "No later roadmap item may use these closed phases to infer new runtime behavior, browser authority, ticket authority, assistant authority, optional-evidence authority, or commercial-readiness claims."
+    echo
+    echo "Phase 44-47 boundary docs:"
+    for doc in "${boundary_docs[@]}"; do
+      echo "- \`${doc}\`"
+    done
+  } >"${target}/docs/non-goals-and-expansion-guardrails.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-46-approval-execution-reconciliation-operations-pack-validation.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing required Phase 44-47 boundary or validation doc: docs/phase-46-approval-execution-reconciliation-operations-pack-validation.md"
+
+missing_non_goals_link_repo="${workdir}/missing-non-goals-link"
+create_valid_repo "${missing_non_goals_link_repo}"
+perl -0pi -e 's/- `docs\/phase-47-control-plane-responsibility-decomposition-boundary\.md`\n//' \
+  "${missing_non_goals_link_repo}/docs/non-goals-and-expansion-guardrails.md"
+assert_fails_with \
+  "${missing_non_goals_link_repo}" \
+  "Missing Phase 44-47 boundary cross-link in docs/non-goals-and-expansion-guardrails.md: docs/phase-47-control-plane-responsibility-decomposition-boundary.md"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+perl -0pi -e 's/- `docs\/phase-45-daily-soc-queue-and-operator-ux-hardening-validation\.md`\n//' \
+  "${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "Missing Phase 44-47 validation handoff cross-link in README.md: docs/phase-45-daily-soc-queue-and-operator-ux-hardening-validation.md"
+
+echo "verify-phase-44-47-boundary-docs tests passed"

--- a/scripts/verify-phase-44-47-boundary-docs.sh
+++ b/scripts/verify-phase-44-47-boundary-docs.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+required_docs=(
+  "docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md"
+  "docs/phase-44-pilot-ingress-and-operator-surface-closure-validation.md"
+  "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-boundary.md"
+  "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-validation.md"
+  "docs/phase-46-approval-execution-reconciliation-operations-pack-boundary.md"
+  "docs/phase-46-approval-execution-reconciliation-operations-pack-validation.md"
+  "docs/phase-47-control-plane-responsibility-decomposition-boundary.md"
+  "docs/phase-47-control-plane-responsibility-decomposition-validation.md"
+)
+
+boundary_docs=(
+  "docs/phase-44-pilot-ingress-and-operator-surface-closure-boundary.md"
+  "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-boundary.md"
+  "docs/phase-46-approval-execution-reconciliation-operations-pack-boundary.md"
+  "docs/phase-47-control-plane-responsibility-decomposition-boundary.md"
+)
+
+validation_docs=(
+  "docs/phase-44-pilot-ingress-and-operator-surface-closure-validation.md"
+  "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-validation.md"
+  "docs/phase-46-approval-execution-reconciliation-operations-pack-validation.md"
+  "docs/phase-47-control-plane-responsibility-decomposition-validation.md"
+)
+
+non_goals_doc="docs/non-goals-and-expansion-guardrails.md"
+readme_doc="README.md"
+
+require_file() {
+  local relative_path="$1"
+
+  if [[ ! -s "${repo_root}/${relative_path}" ]]; then
+    echo "Missing required Phase 44-47 boundary or validation doc: ${relative_path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local relative_path="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if [[ ! -f "${repo_root}/${relative_path}" ]]; then
+    echo "Missing required navigation document for Phase 44-47 docs: ${relative_path}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${phrase}" "${repo_root}/${relative_path}"; then
+    echo "Missing ${description} in ${relative_path}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+for doc in "${required_docs[@]}"; do
+  require_file "${doc}"
+done
+
+for doc in "${boundary_docs[@]}"; do
+  require_phrase "${non_goals_doc}" "${doc}" "Phase 44-47 boundary cross-link"
+  require_phrase "${readme_doc}" "${doc}" "Phase 44-47 handoff cross-link"
+done
+
+for doc in "${validation_docs[@]}"; do
+  require_phrase "${readme_doc}" "${doc}" "Phase 44-47 validation handoff cross-link"
+done
+
+required_navigation_phrases=(
+  "Phase 44-47 closure contracts"
+  "Phase 44-47 boundary docs"
+  "Phase 44-47 validation docs"
+  "AegisOps control-plane records remain authoritative"
+  "operator UI, proxy, Zammad, assistant, optional evidence, downstream receipts, and maintainability projections remain subordinate context"
+)
+
+for phrase in "${required_navigation_phrases[@]}"; do
+  require_phrase "${readme_doc}" "${phrase}" "Phase 44-47 handoff summary"
+done
+
+required_guardrail_phrases=(
+  "Phase 44-47 Closed Pilot-Readiness Guardrails"
+  "pilot ingress, daily SOC queue, approval/execution/reconciliation operations, and control-plane responsibility decomposition"
+  "AegisOps control-plane records remain authoritative"
+  "No later roadmap item may use these closed phases to infer new runtime behavior, browser authority, ticket authority, assistant authority, optional-evidence authority, or commercial-readiness claims."
+)
+
+for phrase in "${required_guardrail_phrases[@]}"; do
+  require_phrase "${non_goals_doc}" "${phrase}" "Phase 44-47 guardrail summary"
+done
+
+echo "Phase 44-47 boundary and validation docs are present and discoverable."


### PR DESCRIPTION
## Summary
- add a Phase 44-47 boundary/validation docs verifier with positive and negative self-test coverage
- link Phase 44-47 boundary and validation docs from README handoff/navigation
- link Phase 44-47 boundary docs from non-goals guardrails and wire verifier/self-test into CI

## Verification
- bash scripts/verify-phase-44-47-boundary-docs.sh
- bash scripts/test-verify-phase-44-47-boundary-docs.sh
- python3 -m unittest control-plane.tests.test_phase44_pilot_ingress_operator_surface_docs control-plane.tests.test_phase45_daily_soc_queue_docs control-plane.tests.test_phase46_operations_pack_docs control-plane.tests.test_phase47_responsibility_decomposition_docs
- bash scripts/verify-architecture-runbook-validation.sh
- bash scripts/verify-maintainability-hotspots.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 892 --config <supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Phase 44-47 closure contracts section with navigation links to boundary and validation documentation.
  * Introduced pilot-readiness guardrails clarifying that control-plane records remain authoritative while other components (UI, proxy, assistant, evidence) are subordinate context.

* **Chores**
  * Enhanced CI pipeline with automated verification steps for Phase 44-47 boundary documentation consistency across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->