### PR TITLE
Add roadmap materialization preflight contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
           bash scripts/verify-postgres-compose-skeleton.sh
           bash scripts/verify-publishable-path-hygiene.sh
           bash scripts/verify-proxy-compose-skeleton.sh
+          bash scripts/verify-roadmap-materialization-preflight-contract.sh
+          bash scripts/test-verify-roadmap-materialization-preflight-contract.sh
           bash scripts/verify-support-playbook-break-glass-rehearsal.sh
           bash scripts/verify-response-action-safety-model-doc.sh
           bash scripts/verify-requirements-baseline-control-plane-thesis.sh

--- a/docs/roadmap-materialization-preflight-contract.md
+++ b/docs/roadmap-materialization-preflight-contract.md
@@ -1,0 +1,110 @@
+# Roadmap Materialization Preflight Contract
+
+## 1. Purpose and Scope
+
+This contract defines the repo-owned design and data contract for the Phase 48.7 roadmap materialization preflight. The preflight decides whether a later AegisOps phase may be created, scheduled, or executed from the GitHub issue graph and repo-local validation facts without rereading large Obsidian roadmap notes at runtime.
+
+The contract is automation validation only. It does not implement the full GitHub issue graph preflight, create Phase 49.0 or Phase 49 issues, change AegisOps runtime behavior, or change approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, or optional-evidence authority.
+
+AegisOps control-plane records remain authoritative workflow truth. GitHub issues and codex-supervisor issue bodies are execution input and safety-boundary material for automation scheduling only. tickets, assistant output, ML output, endpoint evidence, network evidence, browser state, receipts, and optional extension status remain subordinate context.
+
+## 2. Required Inputs
+
+The preflight input set is a phase graph snapshot. It must be assembled from repo-local roadmap configuration, GitHub issue graph facts, and codex-supervisor lint output. A mixed snapshot must be rejected instead of stitched together from partially refreshed records.
+
+| Field | Required for | Contract |
+| --- | --- | --- |
+| `phase_id` | Every phase record | Stable phase identifier, for example `48.7`, `49.0`, or `49`. |
+| `phase_title` | Every phase record | Human-readable phase name for diagnostics only. |
+| `phase_status` | Every phase record | One of `planned`, `materialized`, `in_progress`, `merged`, `evaluated`, `explicitly_deferred`, or `done`. |
+| `phase_completion_state` | Every phase record | Authoritative lifecycle state for whether implementation work is complete. |
+| `phase_evaluation_state` | Every phase record | Authoritative lifecycle state for review or evaluation closure. |
+| `predecessor_phase_ids` | Every phase with prerequisites | Explicit predecessor list. Do not infer predecessors from numbering, issue titles, labels, or comments. |
+| `epic_issue_number` | Each materialized phase | GitHub Epic issue number. Missing or malformed values classify the phase as `missing`. |
+| `child_issue_numbers` | Each materialized phase | Complete child issue list expected for the phase. Empty or incomplete lists classify the phase as `missing` unless the phase is explicitly deferred. |
+| `issue_number` | Epic and child issue records | GitHub issue number used for lint and dependency checks. |
+| `issue_state` | Epic and child issue records | GitHub lifecycle state, for example open, closed, merged-by-linked-PR, or unknown. Unknown state fails closed. |
+| `Part of:` | Child issue metadata | Required codex-supervisor parent binding. It must explicitly point to the authoritative Epic issue. |
+| `Depends on:` | Epic and child issue metadata | Required dependency field. Placeholder values, TODO text, sample issue numbers, and ambiguous prose are invalid. |
+| `Parallelizable:` | Epic and child issue metadata | Required scheduling field. Missing or malformed values are invalid. |
+| `Execution order` | Epic and child issue metadata | Required scheduling field. Missing, duplicate, or non-monotonic ordering within the same phase is invalid unless explicitly documented by the phase contract. |
+| `issue-lint` | Epic and child issue records | codex-supervisor lint result for the exact issue body being scheduled. |
+| `execution_ready` | `issue-lint` output | Must be `yes` before an issue can be considered execution-ready. |
+| `missing_required` | `issue-lint` output | Must be `none`. |
+| `metadata_errors` | `issue-lint` output | Must be `none`. |
+| `missing_recommended` | `issue-lint` output | Must be `none` for normal scheduling. Any non-`none` value requires explicit operator deferral or issue-body repair before later phases start. |
+| `high_risk_blocking_ambiguity` | `issue-lint` output | Must be `none`. |
+
+## 3. Phase-State Classifications
+
+The preflight must classify each phase from authoritative lifecycle fields, issue graph facts, and lint output. Later phases cannot redefine predecessor truth from summary text, labels, display ordering, badges, or convenience booleans.
+
+| Classification | Meaning | Safe action |
+| --- | --- | --- |
+| `missing` | The phase lacks an Epic issue, lacks required child issues, or has no authoritative phase graph binding. | Create or repair the missing Epic or child issue records before scheduling dependent phases. |
+| `materialized_open` | Epic and child issues exist, but at least one required issue remains open or not yet execution-ready. | Continue the materialized phase; do not start dependent Phase 49.0/49 work. |
+| `blocked` | Required metadata is missing, malformed, placeholder-like, non-lint-clean, or points outside the authoritative phase graph. | Repair the issue body or graph binding and rerun lint. |
+| `execution_ready` | Epic and child issues are lint-clean and schedulable, but the phase is not complete or evaluated. | Allow work on that phase only; dependent phases remain blocked. |
+| `merge_or_evaluation_needed` | Implementation appears merged or complete, but required evaluation, closure, or explicit deferral is absent. | Run or record the evaluation gate before scheduling dependent phases. |
+| `done` | Required issues are materialized, lint-clean, complete, and evaluated, or the phase is explicitly deferred by an authoritative phase record. | Allow the next phase gate to evaluate. |
+
+Unknown, partially trusted, or conflicting input must classify as `blocked` with a concrete `invalid_field`. The preflight must fail closed instead of inferring success from naming conventions, issue labels, nearby comments, or operator-facing summaries.
+
+## 4. Required Outputs
+
+The preflight output must be deterministic and machine-readable.
+
+| Field | Values | Contract |
+| --- | --- | --- |
+| `pass` | boolean | `true` only when every predecessor gate required by the requested phase is `done` or explicitly deferred. |
+| `fail` | boolean | `true` when the requested phase cannot safely start. `pass` and `fail` must not both be true. |
+| `phase_classification` | classification map | Map from `phase_id` to one of the phase-state classifications. |
+| `invalid_field` | string or null | Exact missing or invalid field, for example `child_issue_numbers`, `Depends on:`, `metadata_errors`, or `phase_evaluation_state`. |
+| `invalid_issue_number` | number or null | Exact issue number when the failure belongs to one issue. |
+| `suggested_next_safe_action` | string | Specific next action, for example create a child issue, replace a placeholder dependency, rerun issue-lint, or record evaluation closure. |
+| `evidence` | object | Snapshot identifier, lint command references, issue numbers read, and phase graph source. |
+
+The canonical lint command form for diagnostics is:
+
+```sh
+node <codex-supervisor-root>/dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+```
+
+Do not publish workstation-local absolute paths in validation plans or durable docs. Use `<codex-supervisor-root>`, `<supervisor-config-path>`, `CODEX_SUPERVISOR_CONFIG`, or repo-relative command forms.
+
+## 5. Phase 48.7 Gate for Phase 49.0/49
+
+Phase 48.7 protects Phase 49.0 and Phase 49 from starting before earlier roadmap gates are materialized and reviewed. Phase 49.0 is the behavior-preserving `AegisOpsControlPlaneService` decomposition phase. Phase 49 commercial-readiness work remains downstream of the earlier automation, evidence, and evaluation gates.
+
+Phase 49.0/49 must not start before Phase 48, Phase 48.5, Phase 48.6, and Phase 48.7 gates are materialized, lint-clean, and evaluated or explicitly deferred.
+
+For Phase 49.0 or Phase 49 scheduling, the preflight must:
+
+1. Resolve predecessor phases from explicit phase graph records.
+2. Confirm every predecessor Epic and child issue is materialized.
+3. Confirm every predecessor issue has valid `Part of:`, `Depends on:`, `Parallelizable:`, and `Execution order` metadata.
+4. Confirm codex-supervisor `issue-lint` reports `execution_ready=yes`, `missing_required=none`, `metadata_errors=none`, `missing_recommended=none`, and `high_risk_blocking_ambiguity=none`.
+5. Confirm predecessor phase completion and evaluation state are authoritative, closed, and not derived from summary text.
+6. Reject placeholder dependencies, missing child issue lists, non-lint-clean issue bodies, and missing evaluation closure.
+
+## 6. Example Outcomes
+
+| Example | Input facts | Classification | Output |
+| --- | --- | --- | --- |
+| Complete phase | Phase 48 has an Epic, all child issues are listed, metadata is valid, `issue-lint` reports `execution_ready=yes`, `missing_required=none`, `metadata_errors=none`, and evaluation is closed. | `done` | `pass=true`, `invalid_field=null`, `suggested_next_safe_action="evaluate next phase gate"` |
+| Missing child issue | Phase 48.7 has an Epic, but `child_issue_numbers` omits a required child from the phase graph. | `missing` | `fail=true`, `invalid_field="child_issue_numbers"`, `suggested_next_safe_action="create or bind the missing child issue before scheduling dependent phases"` |
+| Placeholder dependency | A child issue has `Depends on: TBD` or a sample issue number instead of an explicit authoritative dependency or `none`. | `blocked` | `fail=true`, `invalid_field="Depends on:"`, `suggested_next_safe_action="replace the placeholder dependency and rerun issue-lint"` |
+| Non-lint-clean issue | `issue-lint` reports `execution_ready=no` or `metadata_errors` is not `none` for a required Epic or child issue. | `blocked` | `fail=true`, `invalid_field="metadata_errors"`, `invalid_issue_number=<issue-number>`, `suggested_next_safe_action="repair the issue body and rerun issue-lint"` |
+| Evaluation still needed | Required issues are closed or merged, but `phase_evaluation_state` is missing or still open. | `merge_or_evaluation_needed` | `fail=true`, `invalid_field="phase_evaluation_state"`, `suggested_next_safe_action="record evaluation closure or explicit deferral before dependent scheduling"` |
+
+## 7. Validation
+
+Focused validation for this contract:
+
+```sh
+bash scripts/verify-roadmap-materialization-preflight-contract.sh
+bash scripts/test-verify-roadmap-materialization-preflight-contract.sh
+node <codex-supervisor-root>/dist/index.js issue-lint 912 --config <supervisor-config-path>
+```
+
+This validation is documentation and automation-contract focused. It does not authorize production writes, runtime behavior changes, issue creation for Phase 49.0/49, or any authority shift away from AegisOps control-plane records.

--- a/scripts/test-verify-roadmap-materialization-preflight-contract.sh
+++ b/scripts/test-verify-roadmap-materialization-preflight-contract.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-roadmap-materialization-preflight-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+write_valid_contract() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cat >"${target}/docs/roadmap-materialization-preflight-contract.md" <<'EOF'
+# Roadmap Materialization Preflight Contract
+
+Required inputs: phase_id, epic_issue_number, child_issue_numbers, Part of:, Depends on:, Parallelizable:, Execution order, issue-lint, execution_ready, missing_required, metadata_errors, phase_completion_state, phase_evaluation_state.
+
+Required classifications: missing, materialized_open, blocked, execution_ready, merge_or_evaluation_needed, done.
+
+Required outputs: pass, fail, phase_classification, invalid_field, suggested_next_safe_action.
+
+Phase 49.0/49 must not start before Phase 48, Phase 48.5, Phase 48.6, and Phase 48.7 gates are materialized, lint-clean, and evaluated or explicitly deferred.
+
+AegisOps control-plane records remain authoritative workflow truth.
+tickets, assistant output, ML output, endpoint evidence, network evidence, browser state, receipts, and optional extension status remain subordinate context.
+
+Examples: Complete phase, Missing child issue, Placeholder dependency, Non-lint-clean issue.
+
+Validation command: node <codex-supervisor-root>/dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+EOF
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+write_valid_contract "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing roadmap materialization preflight contract: docs/roadmap-materialization-preflight-contract.md"
+
+missing_field_repo="${workdir}/missing-field"
+write_valid_contract "${missing_field_repo}"
+perl -0pi -e 's/, metadata_errors//' \
+  "${missing_field_repo}/docs/roadmap-materialization-preflight-contract.md"
+assert_fails_with \
+  "${missing_field_repo}" \
+  "Missing required contract term in docs/roadmap-materialization-preflight-contract.md: metadata_errors"
+
+missing_gate_repo="${workdir}/missing-gate"
+write_valid_contract "${missing_gate_repo}"
+perl -0pi -e 's/Phase 49\.0\/49 must not start before Phase 48, Phase 48\.5, Phase 48\.6, and Phase 48\.7 gates are materialized, lint-clean, and evaluated or explicitly deferred\.//' \
+  "${missing_gate_repo}/docs/roadmap-materialization-preflight-contract.md"
+assert_fails_with \
+  "${missing_gate_repo}" \
+  "Missing required contract term in docs/roadmap-materialization-preflight-contract.md: Phase 49.0/49 must not start before Phase 48, Phase 48.5, Phase 48.6, and Phase 48.7 gates are materialized, lint-clean, and evaluated or explicitly deferred."
+
+echo "verify-roadmap-materialization-preflight-contract tests passed"

--- a/scripts/verify-roadmap-materialization-preflight-contract.sh
+++ b/scripts/verify-roadmap-materialization-preflight-contract.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/roadmap-materialization-preflight-contract.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+
+require_file() {
+  if [[ ! -s "${absolute_doc_path}" ]]; then
+    echo "Missing roadmap materialization preflight contract: ${doc_path}" >&2
+    exit 1
+  fi
+}
+
+require_phrase() {
+  local phrase="$1"
+  local description="$2"
+
+  if ! grep -Fq -- "${phrase}" "${absolute_doc_path}"; then
+    echo "Missing ${description} in ${doc_path}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+require_file
+
+required_phrases=(
+  "Roadmap Materialization Preflight Contract"
+  "phase_id"
+  "epic_issue_number"
+  "child_issue_numbers"
+  "Part of:"
+  "Depends on:"
+  "Parallelizable:"
+  "Execution order"
+  "issue-lint"
+  "execution_ready"
+  "missing_required"
+  "metadata_errors"
+  "phase_completion_state"
+  "phase_evaluation_state"
+  "missing"
+  "materialized_open"
+  "blocked"
+  "execution_ready"
+  "merge_or_evaluation_needed"
+  "done"
+  "pass"
+  "fail"
+  "phase_classification"
+  "invalid_field"
+  "suggested_next_safe_action"
+  "Phase 49.0/49 must not start before Phase 48, Phase 48.5, Phase 48.6, and Phase 48.7 gates are materialized, lint-clean, and evaluated or explicitly deferred."
+  "AegisOps control-plane records remain authoritative workflow truth."
+  "tickets, assistant output, ML output, endpoint evidence, network evidence, browser state, receipts, and optional extension status remain subordinate context."
+  "Complete phase"
+  "Missing child issue"
+  "Placeholder dependency"
+  "Non-lint-clean issue"
+  "node <codex-supervisor-root>/dist/index.js issue-lint <issue-number> --config <supervisor-config-path>"
+)
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${phrase}" "required contract term"
+done
+
+echo "Roadmap materialization preflight contract is present and defines required inputs, outputs, classifications, examples, and validation commands."


### PR DESCRIPTION
## Summary
- Add a repo-local roadmap materialization preflight design/data contract for Phase 48.7.1.
- Define required inputs, outputs, phase classifications, fail-closed handling, Phase 49.0/49 gate behavior, and concrete examples.
- Add focused verifier coverage and wire it into CI.

## Verification
- bash scripts/verify-roadmap-materialization-preflight-contract.sh
- bash scripts/test-verify-roadmap-materialization-preflight-contract.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 912 --config <supervisor-config-path>

## Notes
- Documentation and automation-contract only; no runtime behavior, authority posture, production write, or Phase 49.0/49 implementation changes.

Closes #912
