### PR TITLE
Phase 49.0.2: Extract intake and triage boundary

### DIFF
--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from .service import AegisOpsControlPlaneService, NativeDetectionRecordAdapter
 
 
-class DetectionLifecycleService:
+class DetectionIntakeService:
     def __init__(
         self,
         service: AegisOpsControlPlaneService,
@@ -33,10 +33,14 @@ class DetectionLifecycleService:
             [object],
             dict[str, str] | None,
         ],
+        case_lifecycle_state_by_triage_disposition: Mapping[str, str],
     ) -> None:
         self._service = service
         self._merge_reviewed_context = merge_reviewed_context
         self._normalize_admission_provenance = normalize_admission_provenance
+        self._case_lifecycle_state_by_triage_disposition = dict(
+            case_lifecycle_state_by_triage_disposition
+        )
 
     def ingest_finding_alert(
         self,
@@ -706,3 +710,60 @@ class DetectionLifecycleService:
                 reconciliation=reconciliation,
                 disposition=ingest_result.disposition,
             )
+
+    def reviewed_context_transitioned_at(
+        self,
+        record: AlertRecord | CaseRecord,
+    ) -> datetime | None:
+        reviewed_context = getattr(record, "reviewed_context", None)
+        if not isinstance(reviewed_context, Mapping):
+            return None
+        triage = reviewed_context.get("triage")
+        if not isinstance(triage, Mapping):
+            return None
+        if not self.triage_disposition_matches_current_state(
+            record,
+            triage.get("disposition"),
+        ):
+            return None
+        raw_recorded_at = triage.get("recorded_at")
+        if not isinstance(raw_recorded_at, str) or not raw_recorded_at.strip():
+            return None
+        try:
+            parsed = datetime.fromisoformat(raw_recorded_at)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            return None
+        return parsed
+
+    def triage_disposition_matches_current_state(
+        self,
+        record: AlertRecord | CaseRecord,
+        disposition: object,
+    ) -> bool:
+        triage_lifecycle_state = self.case_lifecycle_state_for_triage_disposition(
+            disposition
+        )
+        if triage_lifecycle_state is None:
+            return False
+        if isinstance(record, AlertRecord):
+            return record.lifecycle_state == "closed" and triage_lifecycle_state == "closed"
+        return record.lifecycle_state == triage_lifecycle_state
+
+    def case_lifecycle_state_for_triage_disposition(
+        self,
+        disposition: object,
+    ) -> str | None:
+        if not isinstance(disposition, str) or not disposition.strip():
+            return None
+        return self._case_lifecycle_state_by_triage_disposition.get(disposition)
+
+    def case_lifecycle_for_disposition(self, disposition: str) -> str:
+        lifecycle_state = self.case_lifecycle_state_for_triage_disposition(disposition)
+        if lifecycle_state is not None:
+            return lifecycle_state
+        raise ValueError(f"Unsupported case disposition {disposition!r}")
+
+
+DetectionLifecycleService = DetectionIntakeService

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -74,7 +74,7 @@ from .assistant_context import (
     AssistantContextAssembler,
     _advisory_text_claims_authority_or_scope_expansion,
 )
-from .detection_lifecycle import DetectionLifecycleService
+from .detection_lifecycle import DetectionIntakeService
 from .reviewed_slice_policy import (
     REVIEWED_LIVE_SLICE_LABEL,
     REVIEWED_LIVE_SOURCE_FAMILIES,
@@ -1384,10 +1384,13 @@ class AegisOpsControlPlaneService:
             self,
             merge_reviewed_context=_merge_reviewed_context,
         )
-        self._detection_lifecycle_service = DetectionLifecycleService(
+        self._detection_intake_service = DetectionIntakeService(
             self,
             merge_reviewed_context=_merge_reviewed_context,
             normalize_admission_provenance=_normalize_admission_provenance,
+            case_lifecycle_state_by_triage_disposition=(
+                _CASE_LIFECYCLE_STATE_BY_TRIAGE_DISPOSITION
+            ),
         )
         self._execution_coordinator = ExecutionCoordinator(self)
         self._action_lifecycle_write_coordinator = ActionLifecycleWriteCoordinator(self)
@@ -1741,55 +1744,29 @@ class AegisOpsControlPlaneService:
                     return candidate
         return fallback if fallback is not None else datetime.now(timezone.utc)
 
-    @staticmethod
     def _reviewed_context_transitioned_at(
+        self,
         record: AlertRecord | CaseRecord,
     ) -> datetime | None:
-        reviewed_context = getattr(record, "reviewed_context", None)
-        if not isinstance(reviewed_context, Mapping):
-            return None
-        triage = reviewed_context.get("triage")
-        if not isinstance(triage, Mapping):
-            return None
-        if not AegisOpsControlPlaneService._triage_disposition_matches_current_state(
-            record,
-            triage.get("disposition"),
-        ):
-            return None
-        raw_recorded_at = triage.get("recorded_at")
-        if not isinstance(raw_recorded_at, str) or not raw_recorded_at.strip():
-            return None
-        try:
-            parsed = datetime.fromisoformat(raw_recorded_at)
-        except ValueError:
-            return None
-        if parsed.tzinfo is None or parsed.utcoffset() is None:
-            return None
-        return parsed
+        return self._detection_intake_service.reviewed_context_transitioned_at(record)
 
-    @staticmethod
     def _triage_disposition_matches_current_state(
+        self,
         record: AlertRecord | CaseRecord,
         disposition: object,
     ) -> bool:
-        triage_lifecycle_state = (
-            AegisOpsControlPlaneService._case_lifecycle_state_for_triage_disposition(
-                disposition
-            )
+        return self._detection_intake_service.triage_disposition_matches_current_state(
+            record,
+            disposition,
         )
-        if triage_lifecycle_state is None:
-            return False
-        if isinstance(record, AlertRecord):
-            return record.lifecycle_state == "closed" and triage_lifecycle_state == "closed"
-        return record.lifecycle_state == triage_lifecycle_state
 
-    @staticmethod
     def _case_lifecycle_state_for_triage_disposition(
+        self,
         disposition: object,
     ) -> str | None:
-        if not isinstance(disposition, str) or not disposition.strip():
-            return None
-        return _CASE_LIFECYCLE_STATE_BY_TRIAGE_DISPOSITION.get(disposition)
+        return self._detection_intake_service.case_lifecycle_state_for_triage_disposition(
+            disposition
+        )
 
     def _latest_lifecycle_transition(
         self,
@@ -5381,7 +5358,7 @@ class AegisOpsControlPlaneService:
         materially_new_work: bool = False,
         reviewed_context: Mapping[str, object] | None = None,
     ) -> FindingAlertIngestResult:
-        return self._detection_lifecycle_service.ingest_finding_alert(
+        return self._detection_intake_service.ingest_finding_alert(
             finding_id=finding_id,
             analytic_signal_id=analytic_signal_id,
             substrate_detection_record_id=substrate_detection_record_id,
@@ -5399,7 +5376,7 @@ class AegisOpsControlPlaneService:
         case_id: str | None = None,
         case_lifecycle_state: str = "open",
     ) -> CaseRecord:
-        return self._detection_lifecycle_service.promote_alert_to_case(
+        return self._detection_intake_service.promote_alert_to_case(
             alert_id,
             case_id=case_id,
             case_lifecycle_state=case_lifecycle_state,
@@ -5410,7 +5387,7 @@ class AegisOpsControlPlaneService:
         adapter: NativeDetectionRecordAdapter,
         record: NativeDetectionRecord,
     ) -> FindingAlertIngestResult:
-        return self._detection_lifecycle_service.ingest_native_detection_record(
+        return self._detection_intake_service.ingest_native_detection_record(
             adapter,
             record,
         )
@@ -5419,7 +5396,7 @@ class AegisOpsControlPlaneService:
         self,
         admission: AnalyticSignalAdmission,
     ) -> FindingAlertIngestResult:
-        return self._detection_lifecycle_service.ingest_analytic_signal_admission(
+        return self._detection_intake_service.ingest_analytic_signal_admission(
             admission
         )
 
@@ -5430,7 +5407,7 @@ class AegisOpsControlPlaneService:
         ingest_result: FindingAlertIngestResult,
         substrate_detection_record_id: str,
     ) -> FindingAlertIngestResult:
-        return self._detection_lifecycle_service.attach_native_detection_context(
+        return self._detection_intake_service.attach_native_detection_context(
             record=record,
             ingest_result=ingest_result,
             substrate_detection_record_id=substrate_detection_record_id,
@@ -5997,16 +5974,10 @@ class AegisOpsControlPlaneService:
             )
         )
 
-    @staticmethod
-    def _case_lifecycle_for_disposition(disposition: str) -> str:
-        lifecycle_state = (
-            AegisOpsControlPlaneService._case_lifecycle_state_for_triage_disposition(
-                disposition
-            )
+    def _case_lifecycle_for_disposition(self, disposition: str) -> str:
+        return self._detection_intake_service.case_lifecycle_for_disposition(
+            disposition
         )
-        if lifecycle_state is not None:
-            return lifecycle_state
-        raise ValueError(f"Unsupported case disposition {disposition!r}")
 
     @staticmethod
     def _normalize_substrate_detection_record_id(

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -189,9 +189,11 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         )
         intake_delegate.triage_disposition_matches_current_state.return_value = True
         intake_delegate.case_lifecycle_state_for_triage_disposition.return_value = (
-            "pending_action"
+            "triage_pending_action"
         )
-        intake_delegate.case_lifecycle_for_disposition.return_value = "pending_action"
+        intake_delegate.case_lifecycle_for_disposition.return_value = (
+            "disposition_pending_action"
+        )
         service._detection_intake_service = intake_delegate
 
         self.assertIs(
@@ -245,11 +247,11 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             service._case_lifecycle_state_for_triage_disposition(
                 "business_hours_handoff"
             ),
-            "pending_action",
+            "triage_pending_action",
         )
         self.assertEqual(
             service._case_lifecycle_for_disposition("business_hours_handoff"),
-            "pending_action",
+            "disposition_pending_action",
         )
 
         intake_delegate.ingest_finding_alert.assert_called_once_with(

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -11,6 +11,7 @@ if str(TESTS_ROOT) not in sys.path:
 
 import _service_persistence_support as support
 from _service_persistence_support import ServicePersistenceTestBase
+from aegisops_control_plane.detection_lifecycle import DetectionIntakeService
 from aegisops_control_plane.models import AlertRecord, AnalyticSignalRecord, CaseRecord
 
 for name, value in vars(support).items():
@@ -19,6 +20,18 @@ for name, value in vars(support).items():
 
 
 class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
+    def test_service_initializes_dedicated_detection_intake_boundary(self) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        self.assertIsInstance(
+            service._detection_intake_service,
+            DetectionIntakeService,
+        )
+
     def test_service_delegates_case_workflow_mutations(self) -> None:
         store, _ = support.make_store()
         service = support.AegisOpsControlPlaneService(
@@ -134,7 +147,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             recorded_at=observed_at,
         )
 
-    def test_service_delegates_detection_lifecycle_operations(self) -> None:
+    def test_service_delegates_detection_intake_and_triage_operations(self) -> None:
         store, _ = support.make_store()
         service = support.AegisOpsControlPlaneService(
             support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
@@ -164,13 +177,22 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             last_seen_at=first_seen_at,
             reviewed_context={"source": {"source_family": "delegated"}},
         )
-        lifecycle_delegate = support.mock.Mock()
-        lifecycle_delegate.ingest_finding_alert.return_value = ingest_result
-        lifecycle_delegate.promote_alert_to_case.return_value = promoted_case
-        lifecycle_delegate.ingest_native_detection_record.return_value = native_result
-        lifecycle_delegate.ingest_analytic_signal_admission.return_value = ingest_result
-        lifecycle_delegate.attach_native_detection_context.return_value = attach_result
-        service._detection_lifecycle_service = lifecycle_delegate
+        reviewed_transitioned_at = first_seen_at
+        intake_delegate = support.mock.Mock()
+        intake_delegate.ingest_finding_alert.return_value = ingest_result
+        intake_delegate.promote_alert_to_case.return_value = promoted_case
+        intake_delegate.ingest_native_detection_record.return_value = native_result
+        intake_delegate.ingest_analytic_signal_admission.return_value = ingest_result
+        intake_delegate.attach_native_detection_context.return_value = attach_result
+        intake_delegate.reviewed_context_transitioned_at.return_value = (
+            reviewed_transitioned_at
+        )
+        intake_delegate.triage_disposition_matches_current_state.return_value = True
+        intake_delegate.case_lifecycle_state_for_triage_disposition.return_value = (
+            "pending_action"
+        )
+        intake_delegate.case_lifecycle_for_disposition.return_value = "pending_action"
+        service._detection_intake_service = intake_delegate
 
         self.assertIs(
             service.ingest_finding_alert(
@@ -209,8 +231,28 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             ),
             attach_result,
         )
+        self.assertIs(
+            service._reviewed_context_transitioned_at(support.mock.sentinel.record),
+            reviewed_transitioned_at,
+        )
+        self.assertTrue(
+            service._triage_disposition_matches_current_state(
+                support.mock.sentinel.record,
+                "business_hours_handoff",
+            )
+        )
+        self.assertEqual(
+            service._case_lifecycle_state_for_triage_disposition(
+                "business_hours_handoff"
+            ),
+            "pending_action",
+        )
+        self.assertEqual(
+            service._case_lifecycle_for_disposition("business_hours_handoff"),
+            "pending_action",
+        )
 
-        lifecycle_delegate.ingest_finding_alert.assert_called_once_with(
+        intake_delegate.ingest_finding_alert.assert_called_once_with(
             finding_id="finding-delegated-001",
             analytic_signal_id="signal-delegated-001",
             substrate_detection_record_id="substrate-delegated-001",
@@ -220,22 +262,35 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             materially_new_work=True,
             reviewed_context={"source": {"source_family": "delegated"}},
         )
-        lifecycle_delegate.promote_alert_to_case.assert_called_once_with(
+        intake_delegate.promote_alert_to_case.assert_called_once_with(
             "alert-delegated-001",
             case_id="case-delegated-001",
             case_lifecycle_state="investigating",
         )
-        lifecycle_delegate.ingest_native_detection_record.assert_called_once_with(
+        intake_delegate.ingest_native_detection_record.assert_called_once_with(
             adapter,
             native_record,
         )
-        lifecycle_delegate.ingest_analytic_signal_admission.assert_called_once_with(
+        intake_delegate.ingest_analytic_signal_admission.assert_called_once_with(
             admission
         )
-        lifecycle_delegate.attach_native_detection_context.assert_called_once_with(
+        intake_delegate.attach_native_detection_context.assert_called_once_with(
             record=native_record,
             ingest_result=ingest_result,
             substrate_detection_record_id="substrate-delegated-001",
+        )
+        intake_delegate.reviewed_context_transitioned_at.assert_called_once_with(
+            support.mock.sentinel.record
+        )
+        intake_delegate.triage_disposition_matches_current_state.assert_called_once_with(
+            support.mock.sentinel.record,
+            "business_hours_handoff",
+        )
+        intake_delegate.case_lifecycle_state_for_triage_disposition.assert_called_once_with(
+            "business_hours_handoff"
+        )
+        intake_delegate.case_lifecycle_for_disposition.assert_called_once_with(
+            "business_hours_handoff"
         )
 
     def test_service_rejects_promoting_alert_with_missing_linked_case(self) -> None:


### PR DESCRIPTION
## Summary
- Make the intake collaborator explicit as DetectionIntakeService while preserving the AegisOpsControlPlaneService facade.
- Delegate reviewed triage timestamp and disposition lifecycle helpers through the intake boundary.
- Tighten focused intake/triage delegation coverage for the extracted boundary.

## Verification
- python3 -m unittest control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
- python3 -m unittest control-plane/tests/test_phase23_transition_logging_validation.py -k test_transition_logging_only_uses_triage_timestamps_for_current_state
- python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_service_internal_boundaries_docs.py
- python3 -m py_compile control-plane/aegisops_control_plane/service.py control-plane/aegisops_control_plane/detection_lifecycle.py control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
- git diff --check
- bash scripts/verify-phase-49-service-decomposition-adr.sh
- bash scripts/test-verify-phase-49-service-decomposition-adr.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 920 --config <supervisor-config-path>

Closes #920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized detection intake processing to centralize triage-to-case lifecycle mapping and state-derivation logic.
  * Improved reviewed/triage timestamp validation and recording to ensure accurate ISO-8601/timezone-aware timestamps.
  * Streamlined state transition checks and routing in ingestion/promotion flows.

* **Tests**
  * Expanded coverage to validate intake/triage behavior, disposition-to-state mapping, timestamp handling, and ingestion/promotion call paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->