### PR TITLE
Phase 49.0.3: Extract case mutation and evidence linkage boundaries

### DIFF
--- a/control-plane/aegisops_control_plane/case_workflow.py
+++ b/control-plane/aegisops_control_plane/case_workflow.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 from datetime import datetime
 from typing import TYPE_CHECKING, Callable, Mapping
 
+from .evidence_linkage import EvidenceLinkageService
 from .models import (
     AlertRecord,
     CaseRecord,
@@ -21,12 +22,14 @@ class CaseWorkflowService:
         self,
         service: AegisOpsControlPlaneService,
         *,
+        evidence_linkage_service: EvidenceLinkageService,
         merge_reviewed_context: Callable[
             [Mapping[str, object], Mapping[str, object]],
             dict[str, object],
         ],
     ) -> None:
         self._service = service
+        self._evidence_linkage_service = evidence_linkage_service
         self._merge_reviewed_context = merge_reviewed_context
 
     def record_case_observation(
@@ -55,13 +58,13 @@ class CaseWorkflowService:
             lifecycle_state,
             "lifecycle_state",
         )
-        normalized_evidence_ids = service._normalize_linked_record_ids(
+        normalized_evidence_ids = self._evidence_linkage_service.normalize_linked_record_ids(
             supporting_evidence_ids,
             "supporting_evidence_ids",
         )
         with service._store.transaction():
             case = service._require_reviewed_operator_case(case_id)
-            service._validate_case_evidence_linkage(
+            self._evidence_linkage_service.validate_case_evidence_linkage(
                 case=case,
                 evidence_ids=normalized_evidence_ids,
                 field_name="supporting_evidence_ids",
@@ -216,13 +219,13 @@ class CaseWorkflowService:
             "handoff_owner",
         )
         handoff_note = service._require_non_empty_string(handoff_note, "handoff_note")
-        normalized_evidence_ids = service._normalize_linked_record_ids(
+        normalized_evidence_ids = self._evidence_linkage_service.normalize_linked_record_ids(
             follow_up_evidence_ids,
             "follow_up_evidence_ids",
         )
         with service._store.transaction():
             case = service._require_reviewed_operator_case(case_id)
-            service._validate_case_evidence_linkage(
+            self._evidence_linkage_service.validate_case_evidence_linkage(
                 case=case,
                 evidence_ids=normalized_evidence_ids,
                 field_name="follow_up_evidence_ids",

--- a/control-plane/aegisops_control_plane/evidence_linkage.py
+++ b/control-plane/aegisops_control_plane/evidence_linkage.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Callable, Protocol
+
+from .models import AlertRecord, CaseRecord, EvidenceRecord
+
+
+class EvidenceLinkageStore(Protocol):
+    def get(
+        self,
+        record_type: type[EvidenceRecord],
+        record_id: str,
+    ) -> EvidenceRecord | None:
+        ...
+
+
+class EvidenceLinkageService:
+    def __init__(
+        self,
+        *,
+        store: EvidenceLinkageStore,
+        require_non_empty_string: Callable[[object, str], str],
+        merge_linked_ids: Callable[[object, str | None], tuple[str, ...]],
+    ) -> None:
+        self._store = store
+        self._require_non_empty_string = require_non_empty_string
+        self._merge_linked_ids = merge_linked_ids
+
+    def normalize_linked_record_ids(
+        self,
+        record_ids: tuple[str, ...],
+        field_name: str,
+    ) -> tuple[str, ...]:
+        normalized_ids: tuple[str, ...] = ()
+        for record_id in record_ids:
+            normalized_id = self._require_non_empty_string(record_id, field_name)
+            normalized_ids = self._merge_linked_ids(normalized_ids, normalized_id)
+        return normalized_ids
+
+    def validate_case_evidence_linkage(
+        self,
+        *,
+        case: CaseRecord,
+        evidence_ids: tuple[str, ...],
+        field_name: str,
+    ) -> None:
+        for evidence_id in evidence_ids:
+            evidence = self._require_evidence(evidence_id)
+            if evidence.case_id not in {None, case.case_id}:
+                raise ValueError(
+                    f"{field_name} contains evidence {evidence_id!r} linked to "
+                    f"different case {evidence.case_id!r}"
+                )
+            if evidence.case_id is None and evidence.alert_id != case.alert_id:
+                raise ValueError(
+                    f"{field_name} contains evidence {evidence_id!r} that is not "
+                    f"linked to case {case.case_id!r} or its source alert"
+                )
+
+    def validate_alert_evidence_linkage(
+        self,
+        *,
+        alert: AlertRecord,
+        evidence_ids: tuple[str, ...],
+        field_name: str,
+    ) -> None:
+        for evidence_id in evidence_ids:
+            evidence = self._require_evidence(evidence_id)
+            shares_alert = evidence.alert_id == alert.alert_id
+            shares_case = alert.case_id is not None and evidence.case_id == alert.case_id
+            if not shares_alert and not shares_case:
+                raise ValueError(
+                    f"{field_name} contains evidence {evidence_id!r} that is not "
+                    f"linked to alert {alert.alert_id!r}"
+                )
+
+    def _require_evidence(self, evidence_id: str) -> EvidenceRecord:
+        evidence = self._store.get(EvidenceRecord, evidence_id)
+        if evidence is None:
+            raise LookupError(f"Missing evidence {evidence_id!r}")
+        return evidence

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -39,6 +39,7 @@ from .execution_coordinator import (
     ExecutionCoordinator,
     _approved_payload_binding_hash,
 )
+from .evidence_linkage import EvidenceLinkageService
 from .external_evidence_boundary import ExternalEvidenceBoundary
 from .live_assistant_workflow import LiveAssistantWorkflowCoordinator
 from .models import (
@@ -1380,8 +1381,14 @@ class AegisOpsControlPlaneService:
             dedupe_strings=_dedupe_strings,
         )
         self._action_review_write_surface = ActionReviewWriteSurface(self)
+        self._evidence_linkage_service = EvidenceLinkageService(
+            store=self._store,
+            require_non_empty_string=self._require_non_empty_string,
+            merge_linked_ids=self._merge_linked_ids,
+        )
         self._case_workflow_service = CaseWorkflowService(
             self,
+            evidence_linkage_service=self._evidence_linkage_service,
             merge_reviewed_context=_merge_reviewed_context,
         )
         self._detection_intake_service = DetectionIntakeService(
@@ -5903,11 +5910,10 @@ class AegisOpsControlPlaneService:
         record_ids: tuple[str, ...],
         field_name: str,
     ) -> tuple[str, ...]:
-        normalized_ids: tuple[str, ...] = ()
-        for record_id in record_ids:
-            normalized_id = self._require_non_empty_string(record_id, field_name)
-            normalized_ids = self._merge_linked_ids(normalized_ids, normalized_id)
-        return normalized_ids
+        return self._evidence_linkage_service.normalize_linked_record_ids(
+            record_ids,
+            field_name,
+        )
 
     def _validate_case_evidence_linkage(
         self,
@@ -5916,20 +5922,11 @@ class AegisOpsControlPlaneService:
         evidence_ids: tuple[str, ...],
         field_name: str,
     ) -> None:
-        for evidence_id in evidence_ids:
-            evidence = self._store.get(EvidenceRecord, evidence_id)
-            if evidence is None:
-                raise LookupError(f"Missing evidence {evidence_id!r}")
-            if evidence.case_id not in {None, case.case_id}:
-                raise ValueError(
-                    f"{field_name} contains evidence {evidence_id!r} linked to "
-                    f"different case {evidence.case_id!r}"
-                )
-            if evidence.case_id is None and evidence.alert_id != case.alert_id:
-                raise ValueError(
-                    f"{field_name} contains evidence {evidence_id!r} that is not "
-                    f"linked to case {case.case_id!r} or its source alert"
-                )
+        self._evidence_linkage_service.validate_case_evidence_linkage(
+            case=case,
+            evidence_ids=evidence_ids,
+            field_name=field_name,
+        )
 
     def _validate_alert_evidence_linkage(
         self,
@@ -5938,17 +5935,11 @@ class AegisOpsControlPlaneService:
         evidence_ids: tuple[str, ...],
         field_name: str,
     ) -> None:
-        for evidence_id in evidence_ids:
-            evidence = self._store.get(EvidenceRecord, evidence_id)
-            if evidence is None:
-                raise LookupError(f"Missing evidence {evidence_id!r}")
-            shares_alert = evidence.alert_id == alert.alert_id
-            shares_case = alert.case_id is not None and evidence.case_id == alert.case_id
-            if not shares_alert and not shares_case:
-                raise ValueError(
-                    f"{field_name} contains evidence {evidence_id!r} that is not "
-                    f"linked to alert {alert.alert_id!r}"
-                )
+        self._evidence_linkage_service.validate_alert_evidence_linkage(
+            alert=alert,
+            evidence_ids=evidence_ids,
+            field_name=field_name,
+        )
 
     def _observations_for_case(self, case_id: str) -> tuple[ObservationRecord, ...]:
         return tuple(

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -11,7 +11,9 @@ if str(TESTS_ROOT) not in sys.path:
 
 import _service_persistence_support as support
 from _service_persistence_support import ServicePersistenceTestBase
+from aegisops_control_plane.case_workflow import CaseWorkflowService
 from aegisops_control_plane.detection_lifecycle import DetectionIntakeService
+from aegisops_control_plane.evidence_linkage import EvidenceLinkageService
 from aegisops_control_plane.models import AlertRecord, AnalyticSignalRecord, CaseRecord
 
 for name, value in vars(support).items():
@@ -30,6 +32,97 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         self.assertIsInstance(
             service._detection_intake_service,
             DetectionIntakeService,
+        )
+
+    def test_service_initializes_dedicated_case_workflow_and_evidence_linkage_boundaries(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        self.assertIsInstance(
+            service._case_workflow_service,
+            CaseWorkflowService,
+        )
+        self.assertIsInstance(
+            service._evidence_linkage_service,
+            EvidenceLinkageService,
+        )
+        self.assertIs(
+            service._case_workflow_service._evidence_linkage_service,
+            service._evidence_linkage_service,
+        )
+
+    def test_case_workflow_delegates_evidence_linkage_validation(self) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        case = support.CaseRecord(
+            case_id="case-linkage-delegated-001",
+            finding_id="finding-linkage-delegated-001",
+            alert_id="alert-linkage-delegated-001",
+            evidence_ids=("evidence-linkage-delegated-001",),
+            lifecycle_state="investigating",
+            reviewed_context={"source": {"source_family": "github_audit"}},
+        )
+        service._require_case_record = support.mock.Mock(return_value=case)
+        service._require_reviewed_operator_case = support.mock.Mock(return_value=case)
+        linkage_delegate = support.mock.Mock()
+        linkage_delegate.normalize_linked_record_ids.side_effect = (
+            service._evidence_linkage_service.normalize_linked_record_ids
+        )
+        service._evidence_linkage_service = linkage_delegate
+        service._case_workflow_service._evidence_linkage_service = (
+            service._evidence_linkage_service
+        )
+        observed_at = support.datetime(2026, 4, 5, 12, 0, tzinfo=support.timezone.utc)
+
+        service.record_case_observation(
+            case_id=case.case_id,
+            author_identity="analyst-001",
+            observed_at=observed_at,
+            scope_statement="Delegated evidence linkage.",
+            supporting_evidence_ids=("evidence-linkage-delegated-001",),
+            observation_id="observation-linkage-delegated-001",
+        )
+        service.record_case_handoff(
+            case_id=case.case_id,
+            handoff_at=observed_at,
+            handoff_owner="analyst-001",
+            handoff_note="Delegated evidence linkage handoff.",
+            follow_up_evidence_ids=("evidence-linkage-delegated-002",),
+        )
+
+        service._evidence_linkage_service.normalize_linked_record_ids.assert_has_calls(
+            (
+                support.mock.call(
+                    ("evidence-linkage-delegated-001",),
+                    "supporting_evidence_ids",
+                ),
+                support.mock.call(
+                    ("evidence-linkage-delegated-002",),
+                    "follow_up_evidence_ids",
+                ),
+            )
+        )
+        service._evidence_linkage_service.validate_case_evidence_linkage.assert_has_calls(
+            (
+                support.mock.call(
+                    case=case,
+                    evidence_ids=("evidence-linkage-delegated-001",),
+                    field_name="supporting_evidence_ids",
+                ),
+                support.mock.call(
+                    case=case,
+                    evidence_ids=("evidence-linkage-delegated-002",),
+                    field_name="follow_up_evidence_ids",
+                ),
+            )
         )
 
     def test_service_delegates_case_workflow_mutations(self) -> None:


### PR DESCRIPTION
## Summary
- Add a focused `EvidenceLinkageService` for linked-id normalization and case/alert evidence linkage validation.
- Wire `AegisOpsControlPlaneService` to keep the public facade stable while delegating evidence linkage compatibility helpers to the new boundary.
- Route case observation and handoff evidence checks through the extracted linkage boundary and add focused regression coverage.

## Behavior Preservation Notes
- Public case workflow methods remain on `AegisOpsControlPlaneService`.
- Case mutation still requires reviewed operator case records before writes.
- Evidence remains subordinate context: linkage validation still requires explicit case, alert, or source-alert binding and does not infer authority from names or neighboring metadata.

## Verification
- `python3 -m unittest control-plane/tests/test_service_persistence_ingest_case_lifecycle.py`
- `python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py`
- `python3 -m compileall -q control-plane/aegisops_control_plane`
- `bash scripts/verify-phase-49-service-decomposition-adr.sh`
- `bash scripts/test-verify-phase-49-service-decomposition-adr.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 921 --config <supervisor-config-path>`

Closes #921


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored evidence linkage validation and normalization logic into a centralized service component, enabling consistent handling and enforcement of relationships between cases, alerts, and evidence records throughout the system.

* **Tests**
  * Added tests validating proper integration and delegation of evidence linkage operations within case workflow operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->