### PR TITLE
Phase 49.0.4: Extract advisory AI trace lifecycle boundary

### DIFF
--- a/control-plane/aegisops_control_plane/ai_trace_lifecycle.py
+++ b/control-plane/aegisops_control_plane/ai_trace_lifecycle.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .models import (
+    AITraceRecord,
+    ActionExecutionRecord,
+    ActionRequestRecord,
+    ApprovalDecisionRecord,
+    ControlPlaneRecord,
+    EvidenceRecord,
+    ReconciliationRecord,
+    RecommendationRecord,
+)
+
+
+class AITraceLifecycleService:
+    """Owns AI trace linkage helpers used by advisory assembly."""
+
+    def __init__(self, store: Any) -> None:
+        self._store = store
+
+    @staticmethod
+    def ids_from_value(value: object) -> tuple[str, ...]:
+        if isinstance(value, str):
+            return (value,)
+        if isinstance(value, (list, tuple)):
+            return tuple(item for item in value if isinstance(item, str))
+        return ()
+
+    def ids_from_mapping(
+        self,
+        mapping: Mapping[str, object],
+        key: str,
+    ) -> tuple[str, ...]:
+        return self.ids_from_value(mapping.get(key))
+
+    @staticmethod
+    def merge_ids(
+        existing_values: object,
+        incoming_values: object,
+    ) -> tuple[str, ...]:
+        merged: list[str] = []
+        if isinstance(existing_values, (list, tuple)):
+            for value in existing_values:
+                if isinstance(value, str) and value not in merged:
+                    merged.append(value)
+        if isinstance(incoming_values, (list, tuple)):
+            for value in incoming_values:
+                if isinstance(value, str) and value not in merged:
+                    merged.append(value)
+        elif isinstance(incoming_values, str) and incoming_values not in merged:
+            merged.append(incoming_values)
+        return tuple(merged)
+
+    @staticmethod
+    def primary_linked_id(linked_ids: tuple[str, ...]) -> str | None:
+        return linked_ids[0] if linked_ids else None
+
+    def action_lineage_ids(
+        self,
+        record: ControlPlaneRecord,
+    ) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+        action_request_ids = self.ids_from_value(getattr(record, "action_request_id", None))
+        approval_decision_ids = self.ids_from_value(
+            getattr(record, "approval_decision_id", None)
+        )
+        action_execution_ids = self.ids_from_value(
+            getattr(record, "action_execution_id", None)
+        )
+        delegation_ids = self.ids_from_value(getattr(record, "delegation_id", None))
+        if isinstance(record, ReconciliationRecord):
+            action_request_ids = self.merge_ids(
+                action_request_ids,
+                self.ids_from_mapping(record.subject_linkage, "action_request_ids"),
+            )
+            approval_decision_ids = self.merge_ids(
+                approval_decision_ids,
+                self.ids_from_mapping(record.subject_linkage, "approval_decision_ids"),
+            )
+            action_execution_ids = self.merge_ids(
+                action_execution_ids,
+                self.ids_from_mapping(record.subject_linkage, "action_execution_ids"),
+            )
+            delegation_ids = self.merge_ids(
+                delegation_ids,
+                self.ids_from_mapping(record.subject_linkage, "delegation_ids"),
+            )
+        return (
+            action_request_ids,
+            approval_decision_ids,
+            action_execution_ids,
+            delegation_ids,
+        )
+
+    def merge_action_request_linkage(
+        self,
+        *,
+        linked_alert_ids: tuple[str, ...],
+        linked_case_ids: tuple[str, ...],
+        linked_finding_ids: tuple[str, ...],
+        action_request: ActionRequestRecord,
+    ) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+        return (
+            self.merge_ids(linked_alert_ids, action_request.alert_id),
+            self.merge_ids(linked_case_ids, action_request.case_id),
+            self.merge_ids(linked_finding_ids, action_request.finding_id),
+        )
+
+    def action_execution_for_delegation_id(
+        self,
+        delegation_id: str,
+    ) -> ActionExecutionRecord | None:
+        for execution in self._store.list(ActionExecutionRecord):
+            if execution.delegation_id == delegation_id:
+                return execution
+        return None
+
+    def ai_trace_records_for_context(
+        self,
+        record: ControlPlaneRecord,
+    ) -> tuple[AITraceRecord, ...]:
+        records: list[AITraceRecord] = []
+        seen_trace_ids: set[str] = set()
+
+        def add_trace(trace: AITraceRecord | None) -> None:
+            if trace is None or trace.ai_trace_id in seen_trace_ids:
+                return
+            seen_trace_ids.add(trace.ai_trace_id)
+            records.append(trace)
+
+        ai_trace_id = getattr(record, "ai_trace_id", None)
+        if ai_trace_id is not None:
+            add_trace(self._store.get(AITraceRecord, ai_trace_id))
+        if isinstance(record, AITraceRecord):
+            add_trace(record)
+
+        record_recommendation_id = getattr(record, "recommendation_id", None)
+        if record_recommendation_id is not None:
+            for trace in self._store.list(AITraceRecord):
+                if trace.ai_trace_id in seen_trace_ids:
+                    continue
+                if record_recommendation_id in self.ids_from_mapping(
+                    trace.subject_linkage,
+                    "recommendation_ids",
+                ):
+                    add_trace(trace)
+
+        return tuple(records)
+
+    def ai_trace_evidence_ids(
+        self,
+        ai_trace_record: AITraceRecord,
+    ) -> tuple[str, ...]:
+        linked_evidence_ids = self.ids_from_mapping(
+            ai_trace_record.subject_linkage,
+            "evidence_ids",
+        )
+        linked_evidence_ids = self.merge_ids(
+            linked_evidence_ids,
+            ai_trace_record.material_input_refs,
+        )
+        return tuple(
+            evidence_id
+            for evidence_id in linked_evidence_ids
+            if self._store.get(EvidenceRecord, evidence_id) is not None
+        )
+
+    def linked_evidence_ids(self, record: ControlPlaneRecord) -> tuple[str, ...]:
+        linked_evidence_ids = self.ids_from_value(getattr(record, "evidence_ids", ()))
+        linked_evidence_ids = self.merge_ids(
+            linked_evidence_ids,
+            getattr(record, "supporting_evidence_ids", ()),
+        )
+        if isinstance(record, ActionExecutionRecord):
+            linked_evidence_ids = self.merge_ids(
+                linked_evidence_ids,
+                self.ids_from_mapping(record.provenance, "evidence_ids"),
+            )
+        if isinstance(record, ReconciliationRecord):
+            linked_evidence_ids = self.merge_ids(
+                linked_evidence_ids,
+                self.ids_from_mapping(record.subject_linkage, "evidence_ids"),
+            )
+        for ai_trace_record in self.ai_trace_records_for_context(record):
+            linked_evidence_ids = self.merge_ids(
+                linked_evidence_ids,
+                self.ai_trace_evidence_ids(ai_trace_record),
+            )
+        return linked_evidence_ids
+
+    def evidence_siblings(self, record: EvidenceRecord) -> tuple[str, ...]:
+        evidence_records = self.evidence_records_for_context(
+            alert_ids=self.ids_from_value(record.alert_id),
+            case_ids=self.ids_from_value(record.case_id),
+            evidence_ids=(),
+            exclude_evidence_id=record.evidence_id,
+        )
+        return tuple(evidence.evidence_id for evidence in evidence_records)
+
+    def evidence_records_for_context(
+        self,
+        *,
+        alert_ids: tuple[str, ...],
+        case_ids: tuple[str, ...],
+        evidence_ids: tuple[str, ...],
+        exclude_evidence_id: str | None,
+    ) -> tuple[EvidenceRecord, ...]:
+        records: list[EvidenceRecord] = []
+        seen_ids: set[str] = set()
+        for evidence_id in evidence_ids:
+            evidence = self._store.get(EvidenceRecord, evidence_id)
+            if evidence is None:
+                continue
+            if exclude_evidence_id is not None and evidence.evidence_id == exclude_evidence_id:
+                continue
+            if evidence.evidence_id in seen_ids:
+                continue
+            seen_ids.add(evidence.evidence_id)
+            records.append(evidence)
+        for evidence in self._store.list(EvidenceRecord):
+            if exclude_evidence_id is not None and evidence.evidence_id == exclude_evidence_id:
+                continue
+            if evidence.evidence_id in seen_ids:
+                continue
+            if evidence.alert_id in alert_ids or (
+                evidence.case_id is not None and evidence.case_id in case_ids
+            ):
+                seen_ids.add(evidence.evidence_id)
+                records.append(evidence)
+        records.sort(key=lambda evidence: evidence.evidence_id)
+        return tuple(records)
+
+    def recommendation_records_for_context(
+        self,
+        *,
+        record: ControlPlaneRecord,
+        alert_ids: tuple[str, ...],
+        case_ids: tuple[str, ...],
+        ai_trace_records: tuple[AITraceRecord, ...],
+        exclude_recommendation_id: str | None,
+    ) -> tuple[RecommendationRecord, ...]:
+        records: list[RecommendationRecord] = []
+        lead_id = getattr(record, "lead_id", None)
+        hunt_run_id = getattr(record, "hunt_run_id", None)
+        ai_trace_id = getattr(record, "ai_trace_id", None)
+        ai_trace_recommendation_ids: set[str] = set()
+        for ai_trace_record in ai_trace_records:
+            ai_trace_recommendation_ids.update(
+                self.ids_from_mapping(
+                    ai_trace_record.subject_linkage,
+                    "recommendation_ids",
+                )
+            )
+        for recommendation in self._store.list(RecommendationRecord):
+            if (
+                exclude_recommendation_id is not None
+                and recommendation.recommendation_id == exclude_recommendation_id
+            ):
+                continue
+            if recommendation.alert_id in alert_ids:
+                records.append(recommendation)
+                continue
+            if recommendation.case_id is not None and recommendation.case_id in case_ids:
+                records.append(recommendation)
+                continue
+            if lead_id is not None and recommendation.lead_id == lead_id:
+                records.append(recommendation)
+                continue
+            if hunt_run_id is not None and recommendation.hunt_run_id == hunt_run_id:
+                records.append(recommendation)
+                continue
+            if ai_trace_id is not None and recommendation.ai_trace_id == ai_trace_id:
+                records.append(recommendation)
+                continue
+            if recommendation.recommendation_id in ai_trace_recommendation_ids:
+                records.append(recommendation)
+        records.sort(key=lambda recommendation: recommendation.recommendation_id)
+        return tuple(records)
+
+    def reconciliation_records_for_context(
+        self,
+        *,
+        record: ControlPlaneRecord,
+        alert_ids: tuple[str, ...],
+        case_ids: tuple[str, ...],
+        finding_ids: tuple[str, ...],
+        evidence_ids: tuple[str, ...],
+        exclude_reconciliation_id: str | None,
+    ) -> tuple[ReconciliationRecord, ...]:
+        records: list[ReconciliationRecord] = []
+        analytic_signal_id = getattr(record, "analytic_signal_id", None)
+        finding_id = getattr(record, "finding_id", None)
+        (
+            action_request_ids,
+            approval_decision_ids,
+            action_execution_ids,
+            delegation_ids,
+        ) = self.action_lineage_ids(record)
+        linked_finding_ids = set(finding_ids)
+        for reconciliation in self._store.list(ReconciliationRecord):
+            if (
+                exclude_reconciliation_id is not None
+                and reconciliation.reconciliation_id == exclude_reconciliation_id
+            ):
+                continue
+            subject_action_request_ids = self.ids_from_mapping(
+                reconciliation.subject_linkage,
+                "action_request_ids",
+            )
+            if any(
+                action_request_id in subject_action_request_ids
+                for action_request_id in action_request_ids
+            ):
+                records.append(reconciliation)
+                continue
+            subject_approval_decision_ids = self.ids_from_mapping(
+                reconciliation.subject_linkage,
+                "approval_decision_ids",
+            )
+            if any(
+                approval_decision_id in subject_approval_decision_ids
+                for approval_decision_id in approval_decision_ids
+            ):
+                records.append(reconciliation)
+                continue
+            subject_action_execution_ids = self.ids_from_mapping(
+                reconciliation.subject_linkage,
+                "action_execution_ids",
+            )
+            if any(
+                action_execution_id in subject_action_execution_ids
+                for action_execution_id in action_execution_ids
+            ):
+                records.append(reconciliation)
+                continue
+            subject_delegation_ids = self.ids_from_mapping(
+                reconciliation.subject_linkage,
+                "delegation_ids",
+            )
+            if any(delegation_id in subject_delegation_ids for delegation_id in delegation_ids):
+                records.append(reconciliation)
+                continue
+            if reconciliation.alert_id is not None and reconciliation.alert_id in alert_ids:
+                records.append(reconciliation)
+                continue
+            if (
+                analytic_signal_id is not None
+                and reconciliation.analytic_signal_id == analytic_signal_id
+            ):
+                records.append(reconciliation)
+                continue
+            subject_alert_ids = self.ids_from_mapping(
+                reconciliation.subject_linkage,
+                "alert_ids",
+            )
+            if any(alert_id in subject_alert_ids for alert_id in alert_ids):
+                records.append(reconciliation)
+                continue
+            subject_analytic_signal_ids = self.ids_from_mapping(
+                reconciliation.subject_linkage,
+                "analytic_signal_ids",
+            )
+            if (
+                analytic_signal_id is not None
+                and analytic_signal_id in subject_analytic_signal_ids
+            ):
+                records.append(reconciliation)
+                continue
+            if finding_id is not None and reconciliation.finding_id == finding_id:
+                records.append(reconciliation)
+                continue
+            if (
+                reconciliation.finding_id is not None
+                and reconciliation.finding_id in linked_finding_ids
+            ):
+                records.append(reconciliation)
+                continue
+            subject_finding_ids = self.ids_from_mapping(
+                reconciliation.subject_linkage,
+                "finding_ids",
+            )
+            if any(finding_id in subject_finding_ids for finding_id in linked_finding_ids):
+                records.append(reconciliation)
+                continue
+            subject_case_ids = self.ids_from_mapping(
+                reconciliation.subject_linkage,
+                "case_ids",
+            )
+            if any(case_id in subject_case_ids for case_id in case_ids):
+                records.append(reconciliation)
+                continue
+            subject_evidence_ids = self.ids_from_mapping(
+                reconciliation.subject_linkage,
+                "evidence_ids",
+            )
+            if any(evidence_id in subject_evidence_ids for evidence_id in evidence_ids):
+                records.append(reconciliation)
+        records.sort(key=lambda reconciliation: reconciliation.reconciliation_id)
+        return tuple(records)

--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 import re
 from typing import Any, Callable, Mapping
 
+from .ai_trace_lifecycle import AITraceLifecycleService
 from .models import (
     AITraceRecord,
     ActionExecutionRecord,
@@ -565,6 +566,7 @@ class AssistantContextAssembler:
         assistant_context_snapshot_factory: Callable[..., Any],
         advisory_snapshot_from_context: Callable[[Any], Any],
         recommendation_draft_snapshot_from_context: Callable[[Any], Any],
+        ai_trace_lifecycle: AITraceLifecycleService,
     ) -> None:
         self._service = service
         self._record_types_by_family = record_types_by_family
@@ -575,6 +577,7 @@ class AssistantContextAssembler:
         self._recommendation_draft_snapshot_from_context = (
             recommendation_draft_snapshot_from_context
         )
+        self._ai_trace_lifecycle = ai_trace_lifecycle
 
     def inspect_assistant_context(self, record_family: str, record_id: str) -> Any:
         record_family = self._service._require_non_empty_string(record_family, "record_family")
@@ -594,16 +597,16 @@ class AssistantContextAssembler:
         if record_family == "case":
             self._service._require_reviewed_operator_case_record(record)
 
-        linked_alert_ids = self._service._assistant_ids_from_value(
+        linked_alert_ids = self._ai_trace_lifecycle.ids_from_value(
             getattr(record, "alert_id", None)
         )
-        linked_case_ids = self._service._assistant_ids_from_value(
+        linked_case_ids = self._ai_trace_lifecycle.ids_from_value(
             getattr(record, "case_id", None)
         )
-        linked_finding_ids = self._service._assistant_ids_from_value(
+        linked_finding_ids = self._ai_trace_lifecycle.ids_from_value(
             getattr(record, "finding_id", None)
         )
-        linked_evidence_ids = self._service._assistant_linked_evidence_ids(record)
+        linked_evidence_ids = self._ai_trace_lifecycle.linked_evidence_ids(record)
 
         if isinstance(record, (ApprovalDecisionRecord, ActionExecutionRecord)):
             action_request_id = self._service._require_non_empty_string(
@@ -615,40 +618,40 @@ class AssistantContextAssembler:
                 raise LookupError(
                     f"Missing action request {action_request_id!r} for assistant context"
                 )
-            linked_alert_ids = self._service._assistant_merge_ids(
+            linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_alert_ids,
                 action_request.alert_id,
             )
-            linked_case_ids = self._service._assistant_merge_ids(
+            linked_case_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_case_ids,
                 action_request.case_id,
             )
-            linked_finding_ids = self._service._assistant_merge_ids(
+            linked_finding_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_finding_ids,
                 action_request.finding_id,
             )
 
         if isinstance(record, AnalyticSignalRecord):
-            linked_alert_ids = self._service._assistant_merge_ids(
+            linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_alert_ids,
                 record.alert_ids,
             )
-            linked_case_ids = self._service._assistant_merge_ids(
+            linked_case_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_case_ids,
                 record.case_ids,
             )
         elif isinstance(record, CaseRecord):
-            linked_evidence_ids = self._service._assistant_merge_ids(
+            linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_evidence_ids,
                 record.evidence_ids,
             )
         elif isinstance(record, EvidenceRecord):
-            linked_evidence_ids = self._service._assistant_merge_ids(
+            linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_evidence_ids,
-                self._service._assistant_evidence_siblings(record),
+                self._ai_trace_lifecycle.evidence_siblings(record),
             )
         elif isinstance(record, ObservationRecord):
-            linked_evidence_ids = self._service._assistant_merge_ids(
+            linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_evidence_ids,
                 record.supporting_evidence_ids,
             )
@@ -657,16 +660,16 @@ class AssistantContextAssembler:
                 linked_alert_ids,
                 record.alert_id,
             )
-            linked_alert_ids = self._service._assistant_merge_ids(
+            linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_alert_ids,
-                self._service._assistant_ids_from_mapping(record.subject_linkage, "alert_ids"),
+                self._ai_trace_lifecycle.ids_from_mapping(record.subject_linkage, "alert_ids"),
             )
             (
                 action_request_ids,
                 approval_decision_ids,
                 action_execution_ids,
                 delegation_ids,
-            ) = self._service._assistant_action_lineage_ids(record)
+            ) = self._ai_trace_lifecycle.action_lineage_ids(record)
             for action_request_id in action_request_ids:
                 action_request = self._service._store.get(ActionRequestRecord, action_request_id)
                 if action_request is None:
@@ -675,7 +678,7 @@ class AssistantContextAssembler:
                     linked_alert_ids,
                     linked_case_ids,
                     linked_finding_ids,
-                ) = self._service._assistant_merge_action_request_linkage(
+                ) = self._ai_trace_lifecycle.merge_action_request_linkage(
                     linked_alert_ids=linked_alert_ids,
                     linked_case_ids=linked_case_ids,
                     linked_finding_ids=linked_finding_ids,
@@ -698,7 +701,7 @@ class AssistantContextAssembler:
                     linked_alert_ids,
                     linked_case_ids,
                     linked_finding_ids,
-                ) = self._service._assistant_merge_action_request_linkage(
+                ) = self._ai_trace_lifecycle.merge_action_request_linkage(
                     linked_alert_ids=linked_alert_ids,
                     linked_case_ids=linked_case_ids,
                     linked_finding_ids=linked_finding_ids,
@@ -720,18 +723,18 @@ class AssistantContextAssembler:
                         linked_alert_ids,
                         linked_case_ids,
                         linked_finding_ids,
-                    ) = self._service._assistant_merge_action_request_linkage(
+                    ) = self._ai_trace_lifecycle.merge_action_request_linkage(
                         linked_alert_ids=linked_alert_ids,
                         linked_case_ids=linked_case_ids,
                         linked_finding_ids=linked_finding_ids,
                         action_request=action_request,
                     )
-                linked_evidence_ids = self._service._assistant_merge_ids(
+                linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
                     linked_evidence_ids,
-                    self._service._assistant_linked_evidence_ids(action_execution),
+                    self._ai_trace_lifecycle.linked_evidence_ids(action_execution),
                 )
             for delegation_id in delegation_ids:
-                action_execution = self._service._assistant_action_execution_for_delegation_id(
+                action_execution = self._ai_trace_lifecycle.action_execution_for_delegation_id(
                     delegation_id
                 )
                 if action_execution is None:
@@ -745,17 +748,17 @@ class AssistantContextAssembler:
                         linked_alert_ids,
                         linked_case_ids,
                         linked_finding_ids,
-                    ) = self._service._assistant_merge_action_request_linkage(
+                    ) = self._ai_trace_lifecycle.merge_action_request_linkage(
                         linked_alert_ids=linked_alert_ids,
                         linked_case_ids=linked_case_ids,
                         linked_finding_ids=linked_finding_ids,
                         action_request=action_request,
                     )
-                linked_evidence_ids = self._service._assistant_merge_ids(
+                linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
                     linked_evidence_ids,
-                    self._service._assistant_linked_evidence_ids(action_execution),
+                    self._ai_trace_lifecycle.linked_evidence_ids(action_execution),
                 )
-            subject_analytic_signal_ids = self._service._assistant_ids_from_mapping(
+            subject_analytic_signal_ids = self._ai_trace_lifecycle.ids_from_mapping(
                 record.subject_linkage,
                 "analytic_signal_ids",
             )
@@ -763,15 +766,15 @@ class AssistantContextAssembler:
                 signal = self._service._store.get(AnalyticSignalRecord, analytic_signal_id)
                 if signal is None:
                     continue
-                linked_alert_ids = self._service._assistant_merge_ids(
+                linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
                     linked_alert_ids,
                     signal.alert_ids,
                 )
-                linked_case_ids = self._service._assistant_merge_ids(
+                linked_case_ids = self._ai_trace_lifecycle.merge_ids(
                     linked_case_ids,
                     signal.case_ids,
                 )
-                linked_finding_ids = self._service._assistant_merge_ids(
+                linked_finding_ids = self._ai_trace_lifecycle.merge_ids(
                     linked_finding_ids,
                     signal.finding_id,
                 )
@@ -779,54 +782,54 @@ class AssistantContextAssembler:
                 alert = self._service._store.get(AlertRecord, alert_id)
                 if alert is None:
                     continue
-                linked_case_ids = self._service._assistant_merge_ids(
+                linked_case_ids = self._ai_trace_lifecycle.merge_ids(
                     linked_case_ids,
                     alert.case_id,
                 )
-                linked_finding_ids = self._service._assistant_merge_ids(
+                linked_finding_ids = self._ai_trace_lifecycle.merge_ids(
                     linked_finding_ids,
                     alert.finding_id,
                 )
-            linked_case_ids = self._service._assistant_merge_ids(
+            linked_case_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_case_ids,
-                self._service._assistant_ids_from_mapping(record.subject_linkage, "case_ids"),
+                self._ai_trace_lifecycle.ids_from_mapping(record.subject_linkage, "case_ids"),
             )
-            linked_finding_ids = self._service._assistant_merge_ids(
+            linked_finding_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_finding_ids,
-                self._service._assistant_ids_from_mapping(record.subject_linkage, "finding_ids"),
+                self._ai_trace_lifecycle.ids_from_mapping(record.subject_linkage, "finding_ids"),
             )
-            linked_evidence_ids = self._service._assistant_merge_ids(
+            linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_evidence_ids,
-                self._service._assistant_ids_from_mapping(record.subject_linkage, "evidence_ids"),
+                self._ai_trace_lifecycle.ids_from_mapping(record.subject_linkage, "evidence_ids"),
             )
         elif isinstance(record, HuntRunRecord):
-            linked_evidence_ids = self._service._assistant_merge_ids(
+            linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_evidence_ids,
-                self._service._assistant_ids_from_mapping(record.output_linkage, "evidence_ids"),
+                self._ai_trace_lifecycle.ids_from_mapping(record.output_linkage, "evidence_ids"),
             )
 
-        linked_ai_trace_records = self._service._assistant_ai_trace_records_for_context(record)
+        linked_ai_trace_records = self._ai_trace_lifecycle.ai_trace_records_for_context(record)
         for ai_trace_record in linked_ai_trace_records:
-            linked_alert_ids = self._service._assistant_merge_ids(
+            linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_alert_ids,
-                self._service._assistant_ids_from_mapping(
+                self._ai_trace_lifecycle.ids_from_mapping(
                     ai_trace_record.subject_linkage,
                     "alert_ids",
                 ),
             )
-            linked_case_ids = self._service._assistant_merge_ids(
+            linked_case_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_case_ids,
-                self._service._assistant_ids_from_mapping(
+                self._ai_trace_lifecycle.ids_from_mapping(
                     ai_trace_record.subject_linkage,
                     "case_ids",
                 ),
             )
-            linked_evidence_ids = self._service._assistant_merge_ids(
+            linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_evidence_ids,
-                self._service._assistant_ai_trace_evidence_ids(ai_trace_record),
+                self._ai_trace_lifecycle.ai_trace_evidence_ids(ai_trace_record),
             )
 
-        linked_evidence_records = self._service._assistant_evidence_records_for_context(
+        linked_evidence_records = self._ai_trace_lifecycle.evidence_records_for_context(
             alert_ids=linked_alert_ids,
             case_ids=linked_case_ids,
             evidence_ids=linked_evidence_ids,
@@ -834,21 +837,21 @@ class AssistantContextAssembler:
                 record.evidence_id if isinstance(record, EvidenceRecord) else None
             ),
         )
-        linked_evidence_ids = self._service._assistant_merge_ids(
+        linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
             linked_evidence_ids,
             tuple(evidence.evidence_id for evidence in linked_evidence_records),
         )
         for evidence in linked_evidence_records:
-            linked_alert_ids = self._service._assistant_merge_ids(
+            linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_alert_ids,
                 evidence.alert_id,
             )
-            linked_case_ids = self._service._assistant_merge_ids(
+            linked_case_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_case_ids,
                 evidence.case_id,
             )
 
-        linked_recommendation_records = self._service._assistant_recommendation_records_for_context(
+        linked_recommendation_records = self._ai_trace_lifecycle.recommendation_records_for_context(
             record=record,
             alert_ids=linked_alert_ids,
             case_ids=linked_case_ids,
@@ -866,11 +869,11 @@ class AssistantContextAssembler:
         )
         if not has_direct_recommendation_lineage:
             for recommendation in linked_recommendation_records:
-                linked_alert_ids = self._service._assistant_merge_ids(
+                linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
                     linked_alert_ids,
                     recommendation.alert_id,
                 )
-                linked_case_ids = self._service._assistant_merge_ids(
+                linked_case_ids = self._ai_trace_lifecycle.merge_ids(
                     linked_case_ids,
                     recommendation.case_id,
                 )
@@ -889,7 +892,7 @@ class AssistantContextAssembler:
                 linked_case_records_list.append(self._record_to_dict(case))
         linked_case_records = tuple(linked_case_records_list)
 
-        linked_reconciliation_records = self._service._assistant_reconciliation_records_for_context(
+        linked_reconciliation_records = self._ai_trace_lifecycle.reconciliation_records_for_context(
             record=record,
             alert_ids=linked_alert_ids,
             case_ids=linked_case_ids,

--- a/control-plane/aegisops_control_plane/live_assistant_workflow.py
+++ b/control-plane/aegisops_control_plane/live_assistant_workflow.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import json
 from typing import Any, Callable, Protocol
 
+from .ai_trace_lifecycle import AITraceLifecycleService
 from .assistant_provider import (
     AssistantProviderAdapter,
     AssistantProviderAttemptFailure,
@@ -55,27 +56,6 @@ class LiveAssistantWorkflowServiceDependencies(Protocol):
     ) -> str:
         ...
 
-    def _assistant_merge_ids(
-        self,
-        existing_values: tuple[str, ...],
-        *incoming_values: str | None,
-    ) -> tuple[str, ...]:
-        ...
-
-    def _assistant_ids_from_mapping(
-        self,
-        mapping: object,
-        key: str,
-    ) -> tuple[str, ...]:
-        ...
-
-    def _assistant_primary_linked_id(
-        self,
-        linked_ids: tuple[str, ...],
-    ) -> str | None:
-        ...
-
-
 class LiveAssistantWorkflowCoordinator:
     """Owns live assistant workflow orchestration behind the service API."""
 
@@ -92,6 +72,7 @@ class LiveAssistantWorkflowCoordinator:
         citations_from_context: Callable[[object], tuple[dict[str, object], ...]],
         unresolved_reasons_from_flags: Callable[[tuple[str, ...]], tuple[str, ...]],
         prompt_injection_flags: Callable[[object], tuple[str, ...]],
+        ai_trace_lifecycle: AITraceLifecycleService,
     ) -> None:
         self._service = service
         self._workflow_family = workflow_family
@@ -103,6 +84,7 @@ class LiveAssistantWorkflowCoordinator:
         self._citations_from_context = citations_from_context
         self._unresolved_reasons_from_flags = unresolved_reasons_from_flags
         self._prompt_injection_flags = prompt_injection_flags
+        self._ai_trace_lifecycle = ai_trace_lifecycle
 
     def run_live_assistant_workflow(
         self,
@@ -333,8 +315,8 @@ class LiveAssistantWorkflowCoordinator:
 
             updated_subject_linkage = dict(persisted_ai_trace.subject_linkage)
             updated_subject_linkage["recommendation_ids"] = (
-                self._service._assistant_merge_ids(
-                    self._service._assistant_ids_from_mapping(
+                self._ai_trace_lifecycle.merge_ids(
+                    self._ai_trace_lifecycle.ids_from_mapping(
                         persisted_ai_trace.subject_linkage,
                         "recommendation_ids",
                     ),
@@ -749,14 +731,14 @@ class LiveAssistantWorkflowCoordinator:
         source_alert_id = (
             getattr(context_snapshot, "record_id")
             if getattr(context_snapshot, "record_family") == "alert"
-            else self._service._assistant_primary_linked_id(
+            else self._ai_trace_lifecycle.primary_linked_id(
                 getattr(context_snapshot, "linked_alert_ids")
             )
         )
         source_case_id = (
             getattr(context_snapshot, "record_id")
             if getattr(context_snapshot, "record_family") == "case"
-            else self._service._assistant_primary_linked_id(
+            else self._ai_trace_lifecycle.primary_linked_id(
                 getattr(context_snapshot, "linked_case_ids")
             )
         )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -24,6 +24,7 @@ from .adapters.osquery import OsqueryHostContextAdapter
 from .adapters.postgres import PostgresControlPlaneStore
 from .adapters.shuffle import ShuffleActionAdapter
 from .adapters.wazuh import WazuhAlertAdapter
+from .ai_trace_lifecycle import AITraceLifecycleService
 from .assistant_provider import (
     AssistantProviderAdapter,
     AssistantProviderFailure,
@@ -1333,6 +1334,7 @@ class AegisOpsControlPlaneService:
             self,
             normalize_admission_provenance=_normalize_admission_provenance,
         )
+        self._ai_trace_lifecycle_service = AITraceLifecycleService(self._store)
         self._assistant_context_assembler = AssistantContextAssembler(
             self,
             record_types_by_family=RECORD_TYPES_BY_FAMILY,
@@ -1343,6 +1345,7 @@ class AegisOpsControlPlaneService:
             recommendation_draft_snapshot_from_context=(
                 _recommendation_draft_snapshot_from_context
             ),
+            ai_trace_lifecycle=self._ai_trace_lifecycle_service,
         )
         self._assistant_advisory_coordinator = AssistantAdvisoryCoordinator(
             self._assistant_context_assembler
@@ -1366,6 +1369,7 @@ class AegisOpsControlPlaneService:
             prompt_injection_flags=(
                 lambda text: _phase24_live_assistant_prompt_injection_flags(text)
             ),
+            ai_trace_lifecycle=self._ai_trace_lifecycle_service,
         )
         self._operator_inspection_read_surface = OperatorInspectionReadSurface(
             self,
@@ -4509,9 +4513,8 @@ class AegisOpsControlPlaneService:
             record_id=record_id,
         )
 
-    @staticmethod
-    def _assistant_primary_linked_id(linked_ids: tuple[str, ...]) -> str | None:
-        return linked_ids[0] if linked_ids else None
+    def _assistant_primary_linked_id(self, linked_ids: tuple[str, ...]) -> str | None:
+        return self._ai_trace_lifecycle_service.primary_linked_id(linked_ids)
 
     def create_reviewed_action_request_from_advisory(
         self,
@@ -4790,86 +4793,31 @@ class AegisOpsControlPlaneService:
             for detection_id in normalized_substrate_detection_record_ids
         )
 
-    @staticmethod
-    def _assistant_ids_from_value(value: object) -> tuple[str, ...]:
-        if isinstance(value, str):
-            return (value,)
-        if isinstance(value, (list, tuple)):
-            return tuple(item for item in value if isinstance(item, str))
-        return ()
+    def _assistant_ids_from_value(self, value: object) -> tuple[str, ...]:
+        return self._ai_trace_lifecycle_service.ids_from_value(value)
 
-    @staticmethod
     def _assistant_ids_from_mapping(
+        self,
         mapping: Mapping[str, object],
         key: str,
     ) -> tuple[str, ...]:
-        return AegisOpsControlPlaneService._assistant_ids_from_value(mapping.get(key))
+        return self._ai_trace_lifecycle_service.ids_from_mapping(mapping, key)
 
-    @staticmethod
     def _assistant_merge_ids(
+        self,
         existing_values: object,
         incoming_values: object,
     ) -> tuple[str, ...]:
-        merged = AegisOpsControlPlaneService._merge_linked_ids(existing_values, None)
-        if isinstance(incoming_values, (list, tuple)):
-            for value in incoming_values:
-                merged = AegisOpsControlPlaneService._merge_linked_ids(merged, value)
-        else:
-            merged = AegisOpsControlPlaneService._merge_linked_ids(
-                merged,
-                incoming_values if isinstance(incoming_values, str) else None,
-            )
-        return merged
+        return self._ai_trace_lifecycle_service.merge_ids(
+            existing_values,
+            incoming_values,
+        )
 
     def _assistant_action_lineage_ids(
         self,
         record: ControlPlaneRecord,
     ) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
-        action_request_ids = self._assistant_ids_from_value(
-            getattr(record, "action_request_id", None)
-        )
-        approval_decision_ids = self._assistant_ids_from_value(
-            getattr(record, "approval_decision_id", None)
-        )
-        action_execution_ids = self._assistant_ids_from_value(
-            getattr(record, "action_execution_id", None)
-        )
-        delegation_ids = self._assistant_ids_from_value(getattr(record, "delegation_id", None))
-        if isinstance(record, ReconciliationRecord):
-            action_request_ids = self._assistant_merge_ids(
-                action_request_ids,
-                self._assistant_ids_from_mapping(
-                    record.subject_linkage,
-                    "action_request_ids",
-                ),
-            )
-            approval_decision_ids = self._assistant_merge_ids(
-                approval_decision_ids,
-                self._assistant_ids_from_mapping(
-                    record.subject_linkage,
-                    "approval_decision_ids",
-                ),
-            )
-            action_execution_ids = self._assistant_merge_ids(
-                action_execution_ids,
-                self._assistant_ids_from_mapping(
-                    record.subject_linkage,
-                    "action_execution_ids",
-                ),
-            )
-            delegation_ids = self._assistant_merge_ids(
-                delegation_ids,
-                self._assistant_ids_from_mapping(
-                    record.subject_linkage,
-                    "delegation_ids",
-                ),
-            )
-        return (
-            action_request_ids,
-            approval_decision_ids,
-            action_execution_ids,
-            delegation_ids,
-        )
+        return self._ai_trace_lifecycle_service.action_lineage_ids(record)
 
     def _assistant_merge_action_request_linkage(
         self,
@@ -4879,102 +4827,38 @@ class AegisOpsControlPlaneService:
         linked_finding_ids: tuple[str, ...],
         action_request: ActionRequestRecord,
     ) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
-        return (
-            self._assistant_merge_ids(linked_alert_ids, action_request.alert_id),
-            self._assistant_merge_ids(linked_case_ids, action_request.case_id),
-            self._assistant_merge_ids(linked_finding_ids, action_request.finding_id),
+        return self._ai_trace_lifecycle_service.merge_action_request_linkage(
+            linked_alert_ids=linked_alert_ids,
+            linked_case_ids=linked_case_ids,
+            linked_finding_ids=linked_finding_ids,
+            action_request=action_request,
         )
 
     def _assistant_action_execution_for_delegation_id(
         self,
         delegation_id: str,
     ) -> ActionExecutionRecord | None:
-        for execution in self._store.list(ActionExecutionRecord):
-            if execution.delegation_id == delegation_id:
-                return execution
-        return None
+        return self._ai_trace_lifecycle_service.action_execution_for_delegation_id(
+            delegation_id
+        )
 
     def _assistant_ai_trace_records_for_context(
         self,
         record: ControlPlaneRecord,
     ) -> tuple[AITraceRecord, ...]:
-        records: list[AITraceRecord] = []
-        seen_trace_ids: set[str] = set()
-
-        def add_trace(trace: AITraceRecord | None) -> None:
-            if trace is None or trace.ai_trace_id in seen_trace_ids:
-                return
-            seen_trace_ids.add(trace.ai_trace_id)
-            records.append(trace)
-
-        ai_trace_id = getattr(record, "ai_trace_id", None)
-        if ai_trace_id is not None:
-            add_trace(self._store.get(AITraceRecord, ai_trace_id))
-        if isinstance(record, AITraceRecord):
-            add_trace(record)
-
-        record_recommendation_id = getattr(record, "recommendation_id", None)
-        if record_recommendation_id is not None:
-            for trace in self._store.list(AITraceRecord):
-                if trace.ai_trace_id in seen_trace_ids:
-                    continue
-                if record_recommendation_id in self._assistant_ids_from_mapping(
-                    trace.subject_linkage,
-                    "recommendation_ids",
-                ):
-                    add_trace(trace)
-
-        return tuple(records)
+        return self._ai_trace_lifecycle_service.ai_trace_records_for_context(record)
 
     def _assistant_ai_trace_evidence_ids(
         self,
         ai_trace_record: AITraceRecord,
     ) -> tuple[str, ...]:
-        linked_evidence_ids = self._assistant_ids_from_mapping(
-            ai_trace_record.subject_linkage,
-            "evidence_ids",
-        )
-        linked_evidence_ids = self._assistant_merge_ids(
-            linked_evidence_ids,
-            ai_trace_record.material_input_refs,
-        )
-        return tuple(
-            evidence_id
-            for evidence_id in linked_evidence_ids
-            if self._store.get(EvidenceRecord, evidence_id) is not None
-        )
+        return self._ai_trace_lifecycle_service.ai_trace_evidence_ids(ai_trace_record)
 
     def _assistant_linked_evidence_ids(self, record: ControlPlaneRecord) -> tuple[str, ...]:
-        linked_evidence_ids = self._assistant_ids_from_value(getattr(record, "evidence_ids", ()))
-        linked_evidence_ids = self._assistant_merge_ids(
-            linked_evidence_ids,
-            getattr(record, "supporting_evidence_ids", ()),
-        )
-        if isinstance(record, ActionExecutionRecord):
-            linked_evidence_ids = self._assistant_merge_ids(
-                linked_evidence_ids,
-                self._assistant_ids_from_mapping(record.provenance, "evidence_ids"),
-            )
-        if isinstance(record, ReconciliationRecord):
-            linked_evidence_ids = self._assistant_merge_ids(
-                linked_evidence_ids,
-                self._assistant_ids_from_mapping(record.subject_linkage, "evidence_ids"),
-            )
-        for ai_trace_record in self._assistant_ai_trace_records_for_context(record):
-            linked_evidence_ids = self._assistant_merge_ids(
-                linked_evidence_ids,
-                self._assistant_ai_trace_evidence_ids(ai_trace_record),
-            )
-        return linked_evidence_ids
+        return self._ai_trace_lifecycle_service.linked_evidence_ids(record)
 
     def _assistant_evidence_siblings(self, record: EvidenceRecord) -> tuple[str, ...]:
-        evidence_records = self._assistant_evidence_records_for_context(
-            alert_ids=self._assistant_ids_from_value(record.alert_id),
-            case_ids=self._assistant_ids_from_value(record.case_id),
-            evidence_ids=(),
-            exclude_evidence_id=record.evidence_id,
-        )
-        return tuple(evidence.evidence_id for evidence in evidence_records)
+        return self._ai_trace_lifecycle_service.evidence_siblings(record)
 
     def _assistant_evidence_records_for_context(
         self,
@@ -4984,30 +4868,12 @@ class AegisOpsControlPlaneService:
         evidence_ids: tuple[str, ...],
         exclude_evidence_id: str | None,
     ) -> tuple[EvidenceRecord, ...]:
-        records: list[EvidenceRecord] = []
-        seen_ids: set[str] = set()
-        for evidence_id in evidence_ids:
-            evidence = self._store.get(EvidenceRecord, evidence_id)
-            if evidence is None:
-                continue
-            if exclude_evidence_id is not None and evidence.evidence_id == exclude_evidence_id:
-                continue
-            if evidence.evidence_id in seen_ids:
-                continue
-            seen_ids.add(evidence.evidence_id)
-            records.append(evidence)
-        for evidence in self._store.list(EvidenceRecord):
-            if exclude_evidence_id is not None and evidence.evidence_id == exclude_evidence_id:
-                continue
-            if evidence.evidence_id in seen_ids:
-                continue
-            if evidence.alert_id in alert_ids or (
-                evidence.case_id is not None and evidence.case_id in case_ids
-            ):
-                seen_ids.add(evidence.evidence_id)
-                records.append(evidence)
-        records.sort(key=lambda evidence: evidence.evidence_id)
-        return tuple(records)
+        return self._ai_trace_lifecycle_service.evidence_records_for_context(
+            alert_ids=alert_ids,
+            case_ids=case_ids,
+            evidence_ids=evidence_ids,
+            exclude_evidence_id=exclude_evidence_id,
+        )
 
     def _assistant_recommendation_records_for_context(
         self,
@@ -5018,43 +4884,13 @@ class AegisOpsControlPlaneService:
         ai_trace_records: tuple[AITraceRecord, ...],
         exclude_recommendation_id: str | None,
     ) -> tuple[RecommendationRecord, ...]:
-        records: list[RecommendationRecord] = []
-        lead_id = getattr(record, "lead_id", None)
-        hunt_run_id = getattr(record, "hunt_run_id", None)
-        ai_trace_id = getattr(record, "ai_trace_id", None)
-        ai_trace_recommendation_ids: set[str] = set()
-        for ai_trace_record in ai_trace_records:
-            ai_trace_recommendation_ids.update(
-                self._assistant_ids_from_mapping(
-                    ai_trace_record.subject_linkage,
-                    "recommendation_ids",
-                )
-            )
-        for recommendation in self._store.list(RecommendationRecord):
-            if (
-                exclude_recommendation_id is not None
-                and recommendation.recommendation_id == exclude_recommendation_id
-            ):
-                continue
-            if recommendation.alert_id in alert_ids:
-                records.append(recommendation)
-                continue
-            if recommendation.case_id is not None and recommendation.case_id in case_ids:
-                records.append(recommendation)
-                continue
-            if lead_id is not None and recommendation.lead_id == lead_id:
-                records.append(recommendation)
-                continue
-            if hunt_run_id is not None and recommendation.hunt_run_id == hunt_run_id:
-                records.append(recommendation)
-                continue
-            if ai_trace_id is not None and recommendation.ai_trace_id == ai_trace_id:
-                records.append(recommendation)
-                continue
-            if recommendation.recommendation_id in ai_trace_recommendation_ids:
-                records.append(recommendation)
-        records.sort(key=lambda recommendation: recommendation.recommendation_id)
-        return tuple(records)
+        return self._ai_trace_lifecycle_service.recommendation_records_for_context(
+            record=record,
+            alert_ids=alert_ids,
+            case_ids=case_ids,
+            ai_trace_records=ai_trace_records,
+            exclude_recommendation_id=exclude_recommendation_id,
+        )
 
     def _assistant_reconciliation_records_for_context(
         self,
@@ -5066,119 +4902,14 @@ class AegisOpsControlPlaneService:
         evidence_ids: tuple[str, ...],
         exclude_reconciliation_id: str | None,
     ) -> tuple[ReconciliationRecord, ...]:
-        records: list[ReconciliationRecord] = []
-        analytic_signal_id = getattr(record, "analytic_signal_id", None)
-        finding_id = getattr(record, "finding_id", None)
-        (
-            action_request_ids,
-            approval_decision_ids,
-            action_execution_ids,
-            delegation_ids,
-        ) = self._assistant_action_lineage_ids(record)
-        linked_finding_ids = set(finding_ids)
-        for reconciliation in self._store.list(ReconciliationRecord):
-            if (
-                exclude_reconciliation_id is not None
-                and reconciliation.reconciliation_id == exclude_reconciliation_id
-            ):
-                continue
-            subject_action_request_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "action_request_ids",
-            )
-            if any(
-                action_request_id in subject_action_request_ids
-                for action_request_id in action_request_ids
-            ):
-                records.append(reconciliation)
-                continue
-            subject_approval_decision_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "approval_decision_ids",
-            )
-            if any(
-                approval_decision_id in subject_approval_decision_ids
-                for approval_decision_id in approval_decision_ids
-            ):
-                records.append(reconciliation)
-                continue
-            subject_action_execution_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "action_execution_ids",
-            )
-            if any(
-                action_execution_id in subject_action_execution_ids
-                for action_execution_id in action_execution_ids
-            ):
-                records.append(reconciliation)
-                continue
-            subject_delegation_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "delegation_ids",
-            )
-            if any(
-                delegation_id in subject_delegation_ids
-                for delegation_id in delegation_ids
-            ):
-                records.append(reconciliation)
-                continue
-            if reconciliation.alert_id is not None and reconciliation.alert_id in alert_ids:
-                records.append(reconciliation)
-                continue
-            if (
-                analytic_signal_id is not None
-                and reconciliation.analytic_signal_id == analytic_signal_id
-            ):
-                records.append(reconciliation)
-                continue
-            subject_alert_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "alert_ids",
-            )
-            if any(alert_id in subject_alert_ids for alert_id in alert_ids):
-                records.append(reconciliation)
-                continue
-            subject_analytic_signal_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "analytic_signal_ids",
-            )
-            if (
-                analytic_signal_id is not None
-                and analytic_signal_id in subject_analytic_signal_ids
-            ):
-                records.append(reconciliation)
-                continue
-            if finding_id is not None and reconciliation.finding_id == finding_id:
-                records.append(reconciliation)
-                continue
-            if (
-                reconciliation.finding_id is not None
-                and reconciliation.finding_id in linked_finding_ids
-            ):
-                records.append(reconciliation)
-                continue
-            subject_finding_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "finding_ids",
-            )
-            if any(finding_id in subject_finding_ids for finding_id in linked_finding_ids):
-                records.append(reconciliation)
-                continue
-            subject_case_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "case_ids",
-            )
-            if any(case_id in subject_case_ids for case_id in case_ids):
-                records.append(reconciliation)
-                continue
-            subject_evidence_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "evidence_ids",
-            )
-            if any(evidence_id in subject_evidence_ids for evidence_id in evidence_ids):
-                records.append(reconciliation)
-        records.sort(key=lambda reconciliation: reconciliation.reconciliation_id)
-        return tuple(records)
+        return self._ai_trace_lifecycle_service.reconciliation_records_for_context(
+            record=record,
+            alert_ids=alert_ids,
+            case_ids=case_ids,
+            finding_ids=finding_ids,
+            evidence_ids=evidence_ids,
+            exclude_reconciliation_id=exclude_reconciliation_id,
+        )
 
     @staticmethod
     def _require_aware_datetime(value: object, field_name: str) -> datetime:

--- a/control-plane/tests/test_service_persistence_assistant_advisory.py
+++ b/control-plane/tests/test_service_persistence_assistant_advisory.py
@@ -128,6 +128,22 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
             )
         )
 
+    def test_service_initializes_dedicated_ai_trace_lifecycle_boundary(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        self.assertIs(
+            service._assistant_context_assembler._ai_trace_lifecycle,
+            service._ai_trace_lifecycle_service,
+        )
+        self.assertIs(
+            service._live_assistant_workflow_coordinator._ai_trace_lifecycle,
+            service._ai_trace_lifecycle_service,
+        )
+
     def test_service_routes_reviewed_slice_checks_through_policy_module(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/docs/control-plane-service-internal-boundaries.md
+++ b/docs/control-plane-service-internal-boundaries.md
@@ -93,6 +93,12 @@ Current extraction status as of issue `#760`:
 
 - assistant context, advisory output, recommendation draft rendering, and advisory draft attachment now delegate from `AegisOpsControlPlaneService` into `AssistantContextAssembler`.
 
+Current extraction status as of issue `#922`:
+
+- AI trace linkage, material-input evidence selection, advisory citation read sets, and trace-adjacent recommendation/reconciliation discovery now live behind `AITraceLifecycleService`;
+- `AssistantContextAssembler` and the live assistant workflow receive that focused lifecycle boundary instead of owning trace linkage through facade helper callbacks; and
+- compatibility delegates remain on `AegisOpsControlPlaneService` for existing internal collaborators until later Phase 49 slices remove those call sites.
+
 Representative methods include:
 
 - `inspect_assistant_context`
@@ -179,6 +185,8 @@ The target collaborators are:
   Owns the bounded case mutation write path now extracted from `service.py`: observations, leads, recommendations, handoff, and disposition. This is the first extracted write-path slice inside the broader analyst workflow cluster and preserves the stable facade entrypoints on `AegisOpsControlPlaneService`.
 - `AssistantAdvisoryService`
   Owns assistant-context assembly, citation-grounded lineage gathering, advisory output shaping, recommendation draft rendering, and advisory draft attachment.
+- `AITraceLifecycleService`
+  Owns AI trace linkage, material input evidence selection, cited advisory read-set expansion, and trace-adjacent recommendation/reconciliation discovery used by advisory assembly and the live assistant workflow.
 - `ActionGovernanceService`
   Owns action-policy evaluation, action request creation, approval-bound delegation, observed-execution normalization, and action/delegation/reconciliation binding checks.
 - `RestoreReadinessService`


### PR DESCRIPTION
## Summary
- Extract AI trace linkage, material-input evidence selection, and trace-adjacent recommendation/reconciliation discovery into `AITraceLifecycleService`.
- Wire advisory context assembly and live assistant workflow through the new lifecycle boundary while keeping the public facade stable.
- Add focused boundary wiring coverage and update the internal service-boundaries note.

## Behavior preservation
- Assistant output remains advisory-only.
- Public `AegisOpsControlPlaneService` methods remain stable.
- Compatibility delegates remain for existing internal callers; trace read-set ownership is now behind the focused lifecycle service.

## Verification
- `python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory`
- `python3 -m unittest control-plane.tests.test_phase24_live_assistant_feedback_loop_validation`
- `python3 -m unittest control-plane.tests.test_phase24_live_assistant_provider_validation control-plane.tests.test_phase24_live_assistant_validation`
- `python3 -m unittest control-plane.tests.test_operator_inspection_boundary`
- `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_review_surfaces`
- `python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation`
- `python3 -m unittest control-plane.tests.test_service_internal_boundaries_docs control-plane.tests.test_phase47_responsibility_decomposition_docs control-plane.tests.test_maintainability_decomposition_thresholds_docs`
- `python3 -m compileall -q control-plane/aegisops_control_plane`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 922 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.json`

Closes #922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated AI trace lifecycle management into a dedicated internal service, centralizing linkage ID resolution and related record discovery across the control-plane architecture.
  
* **Documentation**
  * Updated internal service boundary documentation to reflect the new lifecycle service ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->