### PR TITLE
Phase 49.0.5 action reconciliation orchestration boundaries

### DIFF
--- a/control-plane/aegisops_control_plane/action_reconciliation_orchestration.py
+++ b/control-plane/aegisops_control_plane/action_reconciliation_orchestration.py
@@ -40,6 +40,7 @@ class ActionOrchestrationBoundary:
         expires_at: datetime,
         action_request_id: str | None = None,
     ) -> ActionRequestRecord:
+        self._service._require_control_plane_change_authority_unfrozen()
         return self._service._execution_coordinator.create_reviewed_action_request_from_advisory(
             record_family=record_family,
             record_id=record_id,
@@ -65,6 +66,7 @@ class ActionOrchestrationBoundary:
         ticket_severity: str = "medium",
         action_request_id: str | None = None,
     ) -> ActionRequestRecord:
+        self._service._require_control_plane_change_authority_unfrozen()
         return self._service._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory(
             record_family=record_family,
             record_id=record_id,

--- a/control-plane/aegisops_control_plane/action_reconciliation_orchestration.py
+++ b/control-plane/aegisops_control_plane/action_reconciliation_orchestration.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Mapping, Protocol
 
-from .action_reconciliation_orchestration import (
-    ActionOrchestrationBoundary,
-    ReconciliationOrchestrationBoundary,
-)
 from .models import (
     ActionExecutionRecord,
     ActionRequestRecord,
@@ -15,7 +11,7 @@ from .models import (
 )
 
 
-class ActionLifecycleWriteCoordinatorServiceDependencies(Protocol):
+class ActionReconciliationOrchestrationServiceDependencies(Protocol):
     _action_review_write_surface: object
     _execution_coordinator: object
 
@@ -23,25 +19,14 @@ class ActionLifecycleWriteCoordinatorServiceDependencies(Protocol):
         ...
 
 
-class ActionLifecycleWriteCoordinator:
-    """Coordinates action lifecycle writes behind the public service facade."""
+class ActionOrchestrationBoundary:
+    """Owns approval-bound action intent and delegation orchestration."""
 
     def __init__(
         self,
-        service: ActionLifecycleWriteCoordinatorServiceDependencies,
-        *,
-        action_orchestration_boundary: ActionOrchestrationBoundary | None = None,
-        reconciliation_orchestration_boundary: ReconciliationOrchestrationBoundary
-        | None = None,
+        service: ActionReconciliationOrchestrationServiceDependencies,
     ) -> None:
         self._service = service
-        self._action_orchestration_boundary = (
-            action_orchestration_boundary or ActionOrchestrationBoundary(service)
-        )
-        self._reconciliation_orchestration_boundary = (
-            reconciliation_orchestration_boundary
-            or ReconciliationOrchestrationBoundary(service)
-        )
 
     def create_reviewed_action_request_from_advisory(
         self,
@@ -55,7 +40,7 @@ class ActionLifecycleWriteCoordinator:
         expires_at: datetime,
         action_request_id: str | None = None,
     ) -> ActionRequestRecord:
-        return self._action_orchestration_boundary.create_reviewed_action_request_from_advisory(
+        return self._service._execution_coordinator.create_reviewed_action_request_from_advisory(
             record_family=record_family,
             record_id=record_id,
             requester_identity=requester_identity,
@@ -80,7 +65,7 @@ class ActionLifecycleWriteCoordinator:
         ticket_severity: str = "medium",
         action_request_id: str | None = None,
     ) -> ActionRequestRecord:
-        return self._action_orchestration_boundary.create_reviewed_tracking_ticket_request_from_advisory(
+        return self._service._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory(
             record_family=record_family,
             record_id=record_id,
             requester_identity=requester_identity,
@@ -104,7 +89,8 @@ class ActionLifecycleWriteCoordinator:
         decided_at: datetime,
         approval_decision_id: str | None = None,
     ) -> ApprovalDecisionRecord:
-        return self._action_orchestration_boundary.record_action_approval_decision(
+        self._service._require_control_plane_change_authority_unfrozen()
+        return self._service._action_review_write_surface.record_action_approval_decision(
             action_request_id=action_request_id,
             approver_identity=approver_identity,
             authenticated_approver_identity=authenticated_approver_identity,
@@ -123,7 +109,8 @@ class ActionLifecycleWriteCoordinator:
         delegation_issuer: str,
         evidence_ids: tuple[str, ...] = (),
     ) -> ActionExecutionRecord:
-        return self._action_orchestration_boundary.delegate_approved_action_to_shuffle(
+        self._service._require_control_plane_change_authority_unfrozen()
+        return self._service._execution_coordinator.delegate_approved_action_to_shuffle(
             action_request_id=action_request_id,
             approved_payload=approved_payload,
             delegated_at=delegated_at,
@@ -140,13 +127,24 @@ class ActionLifecycleWriteCoordinator:
         delegation_issuer: str,
         evidence_ids: tuple[str, ...] = (),
     ) -> ActionExecutionRecord:
-        return self._action_orchestration_boundary.delegate_approved_action_to_isolated_executor(
+        self._service._require_control_plane_change_authority_unfrozen()
+        return self._service._execution_coordinator.delegate_approved_action_to_isolated_executor(
             action_request_id=action_request_id,
             approved_payload=approved_payload,
             delegated_at=delegated_at,
             delegation_issuer=delegation_issuer,
             evidence_ids=evidence_ids,
         )
+
+
+class ReconciliationOrchestrationBoundary:
+    """Owns action-execution reconciliation orchestration."""
+
+    def __init__(
+        self,
+        service: ActionReconciliationOrchestrationServiceDependencies,
+    ) -> None:
+        self._service = service
 
     def reconcile_action_execution(
         self,
@@ -158,7 +156,8 @@ class ActionLifecycleWriteCoordinator:
         compared_at: datetime,
         stale_after: datetime,
     ) -> ReconciliationRecord:
-        return self._reconciliation_orchestration_boundary.reconcile_action_execution(
+        self._service._require_control_plane_change_authority_unfrozen()
+        return self._service._execution_coordinator.reconcile_action_execution(
             action_request_id=action_request_id,
             execution_surface_type=execution_surface_type,
             execution_surface_id=execution_surface_id,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -33,6 +33,10 @@ from .assistant_provider import (
 )
 from .assistant_advisory import AssistantAdvisoryCoordinator
 from .action_lifecycle_write_coordinator import ActionLifecycleWriteCoordinator
+from .action_reconciliation_orchestration import (
+    ActionOrchestrationBoundary,
+    ReconciliationOrchestrationBoundary,
+)
 from .action_review_write_surface import ActionReviewWriteSurface
 from .case_workflow import CaseWorkflowService
 from .config import OpenBaoKVv2SecretTransport, RuntimeConfig
@@ -1404,7 +1408,15 @@ class AegisOpsControlPlaneService:
             ),
         )
         self._execution_coordinator = ExecutionCoordinator(self)
-        self._action_lifecycle_write_coordinator = ActionLifecycleWriteCoordinator(self)
+        self._action_orchestration_boundary = ActionOrchestrationBoundary(self)
+        self._reconciliation_orchestration_boundary = ReconciliationOrchestrationBoundary(
+            self
+        )
+        self._action_lifecycle_write_coordinator = ActionLifecycleWriteCoordinator(
+            self,
+            action_orchestration_boundary=self._action_orchestration_boundary,
+            reconciliation_orchestration_boundary=self._reconciliation_orchestration_boundary,
+        )
         self._endpoint_evidence_pack_adapter = EndpointEvidencePackAdapter()
         self._misp_context_adapter = MispContextAdapter(
             enabled=config.misp_enrichment_enabled

--- a/control-plane/tests/test_execution_coordinator_boundary.py
+++ b/control-plane/tests/test_execution_coordinator_boundary.py
@@ -417,6 +417,70 @@ class ExecutionCoordinatorBoundaryTests(unittest.TestCase):
             stale_after=stale_after,
         )
 
+    def test_action_boundary_blocks_reviewed_request_creation_when_authority_is_frozen(
+        self,
+    ) -> None:
+        service = mock.Mock()
+        service._require_control_plane_change_authority_unfrozen.side_effect = (
+            PermissionError(
+                "control-plane upgrade or rollback verification is not complete"
+            )
+        )
+        service._execution_coordinator = mock.Mock()
+        boundary = ActionOrchestrationBoundary(service)
+        expires_at = datetime(2026, 4, 15, 0, 0, tzinfo=timezone.utc)
+
+        with self.assertRaisesRegex(PermissionError, "verification is not complete"):
+            boundary.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id="recommendation-001",
+                requester_identity="analyst-001",
+                recipient_identity="owner-001",
+                message_intent="notify",
+                escalation_reason="bounded reason",
+                expires_at=expires_at,
+                action_request_id="action-request-001",
+            )
+
+        create_reviewed_action_request = (
+            service._execution_coordinator.create_reviewed_action_request_from_advisory
+        )
+        create_reviewed_action_request.assert_not_called()
+        service._require_control_plane_change_authority_unfrozen.assert_called_once_with()
+
+    def test_action_boundary_blocks_reviewed_tracking_ticket_creation_when_authority_is_frozen(
+        self,
+    ) -> None:
+        service = mock.Mock()
+        service._require_control_plane_change_authority_unfrozen.side_effect = (
+            PermissionError(
+                "control-plane upgrade or rollback verification is not complete"
+            )
+        )
+        service._execution_coordinator = mock.Mock()
+        boundary = ActionOrchestrationBoundary(service)
+        expires_at = datetime(2026, 4, 15, 0, 0, tzinfo=timezone.utc)
+
+        with self.assertRaisesRegex(PermissionError, "verification is not complete"):
+            boundary.create_reviewed_tracking_ticket_request_from_advisory(
+                record_family="recommendation",
+                record_id="recommendation-002",
+                requester_identity="analyst-001",
+                coordination_reference_id="case-001",
+                coordination_target_type="zammad",
+                ticket_title="Review bounded case",
+                ticket_description="Open a link-first coordination ticket.",
+                expires_at=expires_at,
+                ticket_severity="medium",
+                action_request_id="action-request-002",
+            )
+
+        create_tracking_ticket_request = (
+            service._execution_coordinator.create_reviewed_tracking_ticket_request_from_advisory
+        )
+        create_tracking_ticket_request.assert_not_called()
+        service._require_control_plane_change_authority_unfrozen.assert_called_once_with()
+
     def test_service_delegates_reviewed_action_request_creation_to_execution_coordinator(
         self,
     ) -> None:

--- a/control-plane/tests/test_execution_coordinator_boundary.py
+++ b/control-plane/tests/test_execution_coordinator_boundary.py
@@ -15,6 +15,10 @@ from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.action_lifecycle_write_coordinator import (
     ActionLifecycleWriteCoordinator,
 )
+from aegisops_control_plane.action_reconciliation_orchestration import (
+    ActionOrchestrationBoundary,
+    ReconciliationOrchestrationBoundary,
+)
 from aegisops_control_plane.execution_coordinator import ExecutionCoordinator
 from aegisops_control_plane.service import AegisOpsControlPlaneService
 from postgres_test_support import make_store
@@ -48,6 +52,28 @@ class ExecutionCoordinatorBoundaryTests(unittest.TestCase):
         self.assertTrue(
             hasattr(service, "_action_lifecycle_write_coordinator"),
             "expected AegisOpsControlPlaneService to compose a dedicated action lifecycle write coordinator",
+        )
+
+    def test_service_initializes_focused_action_and_reconciliation_boundaries(
+        self,
+    ) -> None:
+        service = self._build_service()
+
+        self.assertIsInstance(
+            service._action_orchestration_boundary,
+            ActionOrchestrationBoundary,
+        )
+        self.assertIsInstance(
+            service._reconciliation_orchestration_boundary,
+            ReconciliationOrchestrationBoundary,
+        )
+        self.assertIs(
+            service._action_lifecycle_write_coordinator._action_orchestration_boundary,
+            service._action_orchestration_boundary,
+        )
+        self.assertIs(
+            service._action_lifecycle_write_coordinator._reconciliation_orchestration_boundary,
+            service._reconciliation_orchestration_boundary,
         )
 
     def test_service_routes_action_lifecycle_write_entrypoints_through_coordinator(

--- a/control-plane/tests/test_phase27_day2_runtime_contract.py
+++ b/control-plane/tests/test_phase27_day2_runtime_contract.py
@@ -643,8 +643,25 @@ class Phase27Day2RuntimeContractTests(ServicePersistenceTestBase):
     def test_phase27_upgrade_rollback_uncertainty_freezes_authority_sensitive_progression(
         self,
     ) -> None:
-        store, service, promoted_case, _evidence_id, reviewed_at = (
+        store, seed_service, promoted_case, _evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()
+        )
+        recommendation = seed_service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome=(
+                "Keep rollback uncertainty from advancing workflow authority."
+            ),
+        )
+        action_request = seed_service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Hold approval-bound action during rollback verification.",
+            escalation_reason="Rollback-in-progress state must freeze authority.",
+            expires_at=reviewed_at + timedelta(hours=4),
+            action_request_id="action-request-phase27-rollback-freeze-001",
         )
         service = AegisOpsControlPlaneService(
             RuntimeConfig(
@@ -659,33 +676,36 @@ class Phase27Day2RuntimeContractTests(ServicePersistenceTestBase):
             ),
             store=store,
         )
-        recommendation = service.record_case_recommendation(
-            case_id=promoted_case.case_id,
-            review_owner="analyst-001",
-            intended_outcome=(
-                "Keep rollback uncertainty from advancing workflow authority."
-            ),
-        )
-        action_request = service.create_reviewed_action_request_from_advisory(
-            record_family="recommendation",
-            record_id=recommendation.recommendation_id,
-            requester_identity="analyst-001",
-            recipient_identity="repo-owner-001",
-            message_intent="Hold approval-bound action during rollback verification.",
-            escalation_reason="Rollback-in-progress state must freeze authority.",
-            expires_at=reviewed_at + timedelta(hours=4),
-            action_request_id="action-request-phase27-rollback-freeze-001",
-        )
 
         initial_action_request = service.get_record(
             ActionRequestRecord,
             action_request.action_request_id,
         )
+        initial_action_request_count = len(store.list(ActionRequestRecord))
         initial_case = service.get_record(CaseRecord, promoted_case.case_id)
         initial_transition_count = len(store.list(LifecycleTransitionRecord))
         initial_approval_count = len(store.list(ApprovalDecisionRecord))
         initial_execution_count = len(store.list(ActionExecutionRecord))
         initial_reconciliation_count = len(store.list(ReconciliationRecord))
+
+        with self.assertRaisesRegex(
+            PermissionError,
+            "control-plane upgrade or rollback verification is not complete",
+        ):
+            service.create_reviewed_action_request_from_advisory(
+                record_family="recommendation",
+                record_id=recommendation.recommendation_id,
+                requester_identity="analyst-001",
+                recipient_identity="repo-owner-002",
+                message_intent=(
+                    "Do not create a fresh request during rollback verification."
+                ),
+                escalation_reason=(
+                    "Rollback-in-progress state must freeze request creation."
+                ),
+                expires_at=reviewed_at + timedelta(hours=4),
+                action_request_id="action-request-phase27-rollback-freeze-002",
+            )
 
         with self.assertRaisesRegex(
             PermissionError,
@@ -750,6 +770,7 @@ class Phase27Day2RuntimeContractTests(ServicePersistenceTestBase):
             service.get_record(ActionRequestRecord, action_request.action_request_id),
             initial_action_request,
         )
+        self.assertEqual(len(store.list(ActionRequestRecord)), initial_action_request_count)
         self.assertEqual(service.get_record(CaseRecord, promoted_case.case_id), initial_case)
         self.assertEqual(len(store.list(LifecycleTransitionRecord)), initial_transition_count)
         self.assertEqual(len(store.list(ApprovalDecisionRecord)), initial_approval_count)


### PR DESCRIPTION
## Summary
- add focused action and reconciliation orchestration boundary classes behind the public control-plane facade
- keep `ActionLifecycleWriteCoordinator` as compatibility routing while delegating ownership to the focused boundaries
- tighten boundary initialization coverage for the split

## Behavior preservation
- no new action types, approval requirements, execution surfaces, reconciliation outcomes, production writes, credentials, or deployment config were added
- action intent, approval decisions, delegation receipts, and reconciliation still route through the existing execution/write collaborators
- downstream substrate receipts remain subordinate to AegisOps records

## Verification
- `python3 -m unittest control-plane.tests.test_execution_coordinator_boundary`
- `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests`
- `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket`
- `python3 -m unittest control-plane.tests.test_action_review_write_boundary`
- `python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_execution_coordinator_boundary control-plane.tests.test_action_review_write_boundary`
- `bash scripts/verify-maintainability-hotspots.sh`
- `git diff --check`
- `node <codex-supervisor-root>/dist/index.js issue-lint 923 --config <supervisor-config-path>` -> `execution_ready=yes`, `missing_required=none`, `metadata_errors=none`

Closes #923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Routing for action review, approval recording, delegation, and reconciliation moved to new orchestration boundaries and the service now wires these into the coordinator.
* **Tests**
  * Added tests for boundary initialization and negative-path authorization checks to ensure freeze/permission behavior is enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->