### PR TITLE
Phase 49.0.6 runtime restore readiness diagnostics boundary

### DIFF
--- a/control-plane/aegisops_control_plane/__init__.py
+++ b/control-plane/aegisops_control_plane/__init__.py
@@ -22,6 +22,9 @@ from .models import (
 )
 from .restore_readiness import RestoreReadinessService
 from .runtime_boundary import RuntimeBoundaryService
+from .runtime_restore_readiness_diagnostics import (
+    RuntimeRestoreReadinessDiagnosticsService,
+)
 from .service import (
     AegisOpsControlPlaneService,
     AnalystAssistantContextSnapshot,
@@ -61,6 +64,7 @@ __all__ = [
     "RuntimeConfig",
     "RuntimeSnapshot",
     "RuntimeBoundaryService",
+    "RuntimeRestoreReadinessDiagnosticsService",
     "WazuhAlertAdapter",
     "build_runtime_service",
     "build_runtime_snapshot",

--- a/control-plane/aegisops_control_plane/operations.py
+++ b/control-plane/aegisops_control_plane/operations.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from .restore_readiness import RestoreReadinessService
 from .runtime_boundary import RuntimeBoundaryService
+from .runtime_restore_readiness_diagnostics import (
+    RuntimeRestoreReadinessDiagnosticsService,
+)
 
 __all__ = [
     "RestoreReadinessService",
     "RuntimeBoundaryService",
+    "RuntimeRestoreReadinessDiagnosticsService",
 ]

--- a/control-plane/aegisops_control_plane/runtime_restore_readiness_diagnostics.py
+++ b/control-plane/aegisops_control_plane/runtime_restore_readiness_diagnostics.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping
+
+from .models import ControlPlaneRecord
+from .readiness_contracts import ReadinessDiagnosticsAggregates
+from .restore_readiness import RestoreReadinessService
+from .runtime_boundary import RuntimeBoundaryService
+
+
+class RuntimeRestoreReadinessDiagnosticsService:
+    """Internal boundary for runtime, restore, and readiness diagnostics surfaces."""
+
+    def __init__(
+        self,
+        *,
+        runtime_boundary_service: RuntimeBoundaryService,
+        restore_readiness_service: RestoreReadinessService,
+    ) -> None:
+        self._runtime_boundary_service = runtime_boundary_service
+        self._restore_readiness_service = restore_readiness_service
+
+    def describe_runtime(self) -> Any:
+        return self._runtime_boundary_service.describe_runtime()
+
+    def validate_wazuh_ingest_runtime(self) -> None:
+        self._runtime_boundary_service.validate_wazuh_ingest_runtime()
+
+    def validate_protected_surface_runtime(self) -> None:
+        self._runtime_boundary_service.validate_protected_surface_runtime()
+
+    def authenticate_protected_surface_request(self, **kwargs: object) -> Any:
+        return self._runtime_boundary_service.authenticate_protected_surface_request(
+            **kwargs
+        )
+
+    def require_admin_bootstrap_token(self, supplied_token: str | None) -> None:
+        self._runtime_boundary_service.require_admin_bootstrap_token(supplied_token)
+
+    def require_break_glass_token(self, supplied_token: str | None) -> None:
+        self._runtime_boundary_service.require_break_glass_token(supplied_token)
+
+    def describe_startup_status(self) -> Any:
+        return self._restore_readiness_service.describe_startup_status()
+
+    def describe_shutdown_status(self) -> Any:
+        return self._restore_readiness_service.describe_shutdown_status()
+
+    def inspect_readiness_diagnostics(self) -> Any:
+        return self._restore_readiness_service.inspect_readiness_diagnostics()
+
+    def inspect_readiness_aggregates(self) -> ReadinessDiagnosticsAggregates:
+        return self._restore_readiness_service.inspect_readiness_aggregates()
+
+    def export_authoritative_record_chain_backup(self) -> dict[str, object]:
+        return self._restore_readiness_service.export_authoritative_record_chain_backup()
+
+    def restore_authoritative_record_chain_backup(
+        self,
+        backup_payload: Mapping[str, object],
+    ) -> Any:
+        return self._restore_readiness_service.restore_authoritative_record_chain_backup(
+            backup_payload
+        )
+
+    @contextmanager
+    def restore_drill_snapshot_transaction(self) -> Iterator[None]:
+        with self._restore_readiness_service.restore_drill_snapshot_transaction():
+            yield
+
+    def run_authoritative_restore_drill(self) -> Any:
+        return self._restore_readiness_service.run_authoritative_restore_drill()
+
+    def run_authoritative_restore_drill_snapshot(self) -> Any:
+        return self._restore_readiness_service.run_authoritative_restore_drill_snapshot()
+
+    def require_empty_authoritative_restore_target(self) -> None:
+        self._restore_readiness_service.require_empty_authoritative_restore_target()
+
+    def validate_authoritative_record_chain_restore(
+        self,
+        records_by_family: Mapping[str, tuple[ControlPlaneRecord, ...]],
+        *,
+        restored_record_counts: Mapping[str, int] | None = None,
+    ) -> None:
+        self._restore_readiness_service.validate_authoritative_record_chain_restore(
+            records_by_family,
+            restored_record_counts=restored_record_counts,
+        )
+
+
+__all__ = [
+    "RuntimeRestoreReadinessDiagnosticsService",
+]

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -76,6 +76,9 @@ from .readiness_contracts import (
 )
 from .restore_readiness import RestoreReadinessService
 from .runtime_boundary import RuntimeBoundaryService, _is_missing_runtime_binding
+from .runtime_restore_readiness_diagnostics import (
+    RuntimeRestoreReadinessDiagnosticsService,
+)
 from .assistant_context import (
     AssistantContextAssembler,
     _advisory_text_claims_authority_or_scope_expansion,
@@ -1483,9 +1486,15 @@ class AegisOpsControlPlaneService:
             ),
             inspect_reconciliation_status=lambda: self.inspect_reconciliation_status(),
         )
+        self._runtime_restore_readiness_diagnostics_service = (
+            RuntimeRestoreReadinessDiagnosticsService(
+                runtime_boundary_service=self._runtime_boundary_service,
+                restore_readiness_service=self._restore_readiness_service,
+            )
+        )
 
     def describe_runtime(self) -> RuntimeSnapshot:
-        return self._runtime_boundary_service.describe_runtime()
+        return self._runtime_restore_readiness_diagnostics_service.describe_runtime()
 
     def persist_record(
         self,
@@ -1884,10 +1893,10 @@ class AegisOpsControlPlaneService:
         return self._store.get(record_type, record_id)
 
     def validate_wazuh_ingest_runtime(self) -> None:
-        self._runtime_boundary_service.validate_wazuh_ingest_runtime()
+        self._runtime_restore_readiness_diagnostics_service.validate_wazuh_ingest_runtime()
 
     def validate_protected_surface_runtime(self) -> None:
-        self._runtime_boundary_service.validate_protected_surface_runtime()
+        self._runtime_restore_readiness_diagnostics_service.validate_protected_surface_runtime()
 
     def authenticate_protected_surface_request(
         self,
@@ -1902,7 +1911,8 @@ class AegisOpsControlPlaneService:
         authenticated_role_header: str | None,
         allowed_roles: tuple[str, ...],
     ) -> AuthenticatedRuntimePrincipal:
-        return self._runtime_boundary_service.authenticate_protected_surface_request(
+        diagnostics_service = self._runtime_restore_readiness_diagnostics_service
+        return diagnostics_service.authenticate_protected_surface_request(
             peer_addr=peer_addr,
             forwarded_proto=forwarded_proto,
             reverse_proxy_secret_header=reverse_proxy_secret_header,
@@ -1915,10 +1925,14 @@ class AegisOpsControlPlaneService:
         )
 
     def require_admin_bootstrap_token(self, supplied_token: str | None) -> None:
-        self._runtime_boundary_service.require_admin_bootstrap_token(supplied_token)
+        self._runtime_restore_readiness_diagnostics_service.require_admin_bootstrap_token(
+            supplied_token
+        )
 
     def require_break_glass_token(self, supplied_token: str | None) -> None:
-        self._runtime_boundary_service.require_break_glass_token(supplied_token)
+        self._runtime_restore_readiness_diagnostics_service.require_break_glass_token(
+            supplied_token
+        )
 
     def ingest_wazuh_alert(
         self,
@@ -2169,13 +2183,19 @@ class AegisOpsControlPlaneService:
         )
 
     def describe_startup_status(self) -> StartupStatusSnapshot:
-        return self._restore_readiness_service.describe_startup_status()
+        return (
+            self._runtime_restore_readiness_diagnostics_service.describe_startup_status()
+        )
 
     def describe_shutdown_status(self) -> ShutdownStatusSnapshot:
-        return self._restore_readiness_service.describe_shutdown_status()
+        return (
+            self._runtime_restore_readiness_diagnostics_service.describe_shutdown_status()
+        )
 
     def inspect_readiness_diagnostics(self) -> ReadinessDiagnosticsSnapshot:
-        return self._restore_readiness_service.inspect_readiness_diagnostics()
+        return (
+            self._runtime_restore_readiness_diagnostics_service.inspect_readiness_diagnostics()
+        )
 
     def control_plane_change_authority_freeze_status(self) -> dict[str, object]:
         change_state = self._config.control_plane_change_state.strip()
@@ -2203,29 +2223,37 @@ class AegisOpsControlPlaneService:
         )
 
     def _inspect_readiness_aggregates(self) -> ReadinessDiagnosticsAggregates:
-        return self._restore_readiness_service.inspect_readiness_aggregates()
+        return (
+            self._runtime_restore_readiness_diagnostics_service.inspect_readiness_aggregates()
+        )
 
     def export_authoritative_record_chain_backup(self) -> dict[str, object]:
-        return self._restore_readiness_service.export_authoritative_record_chain_backup()
+        diagnostics_service = self._runtime_restore_readiness_diagnostics_service
+        return diagnostics_service.export_authoritative_record_chain_backup()
 
     def restore_authoritative_record_chain_backup(
         self,
         backup_payload: Mapping[str, object],
     ) -> RestoreSummarySnapshot:
-        return self._restore_readiness_service.restore_authoritative_record_chain_backup(
+        diagnostics_service = self._runtime_restore_readiness_diagnostics_service
+        return diagnostics_service.restore_authoritative_record_chain_backup(
             backup_payload
         )
 
     @contextmanager
     def _restore_drill_snapshot_transaction(self) -> Iterator[None]:
-        with self._restore_readiness_service.restore_drill_snapshot_transaction():
+        diagnostics_service = self._runtime_restore_readiness_diagnostics_service
+        with diagnostics_service.restore_drill_snapshot_transaction():
             yield
 
     def run_authoritative_restore_drill(self) -> RestoreDrillSnapshot:
-        return self._restore_readiness_service.run_authoritative_restore_drill()
+        return (
+            self._runtime_restore_readiness_diagnostics_service.run_authoritative_restore_drill()
+        )
 
     def _run_authoritative_restore_drill_snapshot(self) -> RestoreDrillSnapshot:
-        return self._restore_readiness_service.run_authoritative_restore_drill_snapshot()
+        diagnostics_service = self._runtime_restore_readiness_diagnostics_service
+        return diagnostics_service.run_authoritative_restore_drill_snapshot()
 
     def _build_action_review_record_index(self) -> _ActionReviewRecordIndex:
         return _action_review_projection.build_action_review_record_index(self)
@@ -5491,7 +5519,8 @@ class AegisOpsControlPlaneService:
         return f"analytic-signal-{uuid.uuid5(uuid.NAMESPACE_URL, mint_material)}"
 
     def _require_empty_authoritative_restore_target(self) -> None:
-        self._restore_readiness_service.require_empty_authoritative_restore_target()
+        diagnostics_service = self._runtime_restore_readiness_diagnostics_service
+        diagnostics_service.require_empty_authoritative_restore_target()
 
     def _validate_authoritative_record_chain_restore(
         self,
@@ -5499,7 +5528,8 @@ class AegisOpsControlPlaneService:
         *,
         restored_record_counts: Mapping[str, int] | None = None,
     ) -> None:
-        self._restore_readiness_service.validate_authoritative_record_chain_restore(
+        diagnostics_service = self._runtime_restore_readiness_diagnostics_service
+        diagnostics_service.validate_authoritative_record_chain_restore(
             records_by_family,
             restored_record_counts=restored_record_counts,
         )

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -117,10 +117,31 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             wraps=diagnostics_service.export_authoritative_record_chain_backup,
         ) as export_backup:
             service.export_authoritative_record_chain_backup()
+        with mock.patch.object(
+            diagnostics_service,
+            "describe_shutdown_status",
+            wraps=diagnostics_service.describe_shutdown_status,
+        ) as describe_shutdown_status:
+            service.describe_shutdown_status()
+        with mock.patch.object(
+            diagnostics_service,
+            "inspect_readiness_diagnostics",
+            wraps=diagnostics_service.inspect_readiness_diagnostics,
+        ) as inspect_readiness_diagnostics:
+            service.inspect_readiness_diagnostics()
+        with mock.patch.object(
+            diagnostics_service,
+            "run_authoritative_restore_drill",
+            wraps=diagnostics_service.run_authoritative_restore_drill,
+        ) as run_authoritative_restore_drill:
+            service.run_authoritative_restore_drill()
 
         describe_runtime.assert_called_once_with()
         describe_startup_status.assert_called_once_with()
         export_backup.assert_called_once_with()
+        describe_shutdown_status.assert_called_once_with()
+        inspect_readiness_diagnostics.assert_called_once_with()
+        run_authoritative_restore_drill.assert_called_once_with()
 
     def test_backup_restore_validation_does_not_import_postgres_adapter(self) -> None:
         module_path = (

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -60,8 +60,10 @@ class IsolationLevelFallbackProbeStore:
 
 class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
     def test_service_wires_restore_readiness_internal_collaborators(self) -> None:
+        store, _ = make_store()
         service = AegisOpsControlPlaneService(
-            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops")
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
         )
 
         restore_readiness_service = service._restore_readiness_service
@@ -74,6 +76,51 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             hasattr(restore_readiness_service, "_readiness_health_projection"),
             "RestoreReadinessService should delegate readiness projection to a dedicated collaborator",
         )
+
+    def test_service_routes_runtime_restore_and_readiness_through_diagnostics_boundary(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+
+        diagnostics_service = (
+            service._runtime_restore_readiness_diagnostics_service
+        )
+
+        self.assertIs(
+            service._runtime_boundary_service,
+            diagnostics_service._runtime_boundary_service,
+        )
+        self.assertIs(
+            service._restore_readiness_service,
+            diagnostics_service._restore_readiness_service,
+        )
+
+        with mock.patch.object(
+            diagnostics_service,
+            "describe_runtime",
+            wraps=diagnostics_service.describe_runtime,
+        ) as describe_runtime:
+            service.describe_runtime()
+        with mock.patch.object(
+            diagnostics_service,
+            "describe_startup_status",
+            wraps=diagnostics_service.describe_startup_status,
+        ) as describe_startup_status:
+            service.describe_startup_status()
+        with mock.patch.object(
+            diagnostics_service,
+            "export_authoritative_record_chain_backup",
+            wraps=diagnostics_service.export_authoritative_record_chain_backup,
+        ) as export_backup:
+            service.export_authoritative_record_chain_backup()
+
+        describe_runtime.assert_called_once_with()
+        describe_startup_status.assert_called_once_with()
+        export_backup.assert_called_once_with()
 
     def test_backup_restore_validation_does_not_import_postgres_adapter(self) -> None:
         module_path = (


### PR DESCRIPTION
## Summary
- add RuntimeRestoreReadinessDiagnosticsService as the facade-preserving boundary for runtime, restore, and readiness diagnostics surfaces
- route runtime/auth/readiness/restore public facade entrypoints through the diagnostics boundary
- add focused regression coverage proving the service facade uses the boundary

## Verification
- python3 -m unittest control-plane.tests.test_service_persistence_restore_readiness
- python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation control-plane.tests.test_cli_inspection_runtime_surface
- python3 -m unittest control-plane.tests.test_service_persistence_restore_readiness control-plane.tests.test_service_boundary_refactor_regression_validation
- python3 -m py_compile control-plane/aegisops_control_plane/runtime_restore_readiness_diagnostics.py control-plane/aegisops_control_plane/service.py
- bash scripts/verify-maintainability-hotspots.sh
- bash scripts/test-verify-maintainability-hotspots.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 924 --config <supervisor-config-path>

Closes #924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added a diagnostics service that consolidates runtime, restore, and readiness operations.
  * Multiple runtime/restore/readiness APIs now delegate through the new diagnostics layer.

* **Tests**
  * Added tests confirming runtime and restore readiness APIs are routed through the diagnostics boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->