### PR TITLE
Phase 49.0.7 maintainability hotspot baseline

### DIFF
--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import ast
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
+    def _read(self, relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected Phase 49.0 closeout artifact at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def _defined_test_names(self, *relative_paths: str) -> set[str]:
+        defined_names: set[str] = set()
+        for relative_path in relative_paths:
+            source = self._read(relative_path)
+            tree = ast.parse(source, filename=relative_path)
+            defined_names.update(
+                node.name
+                for node in ast.walk(tree)
+                if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
+            )
+        return defined_names
+
+    def _facade_method_count(self) -> int:
+        tree = ast.parse(
+            self._read("control-plane/aegisops_control_plane/service.py"),
+            filename="control-plane/aegisops_control_plane/service.py",
+        )
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and node.name == "AegisOpsControlPlaneService":
+                return sum(
+                    1
+                    for child in node.body
+                    if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                )
+        raise AssertionError("AegisOpsControlPlaneService class not found")
+
+    def _baseline_metadata(self) -> dict[str, str]:
+        for line in self._read("docs/maintainability-hotspot-baseline.txt").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("control-plane/aegisops_control_plane/service.py"):
+                metadata: dict[str, str] = {}
+                for part in stripped.split()[1:]:
+                    key, value = part.split("=", 1)
+                    metadata[key] = value
+                return metadata
+        raise AssertionError("service.py hotspot baseline entry not found")
+
+    def test_closeout_baseline_records_adr_exception_and_current_facade_limits(
+        self,
+    ) -> None:
+        service_text = self._read("control-plane/aegisops_control_plane/service.py")
+        metadata = self._baseline_metadata()
+
+        self.assertEqual(metadata["adr_exception"], "ADR-0003")
+        self.assertEqual(metadata["phase"], "49.0.7")
+        self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
+        self.assertEqual(
+            int(metadata["max_facade_methods"]),
+            self._facade_method_count(),
+        )
+        self.assertGreater(int(metadata["max_lines"]), 1500)
+        self.assertGreater(int(metadata["max_facade_methods"]), 50)
+
+        adr = self._read("docs/adr/0003-phase-49-service-decomposition-boundaries.md")
+        self.assertIn("ADR-approved exception", adr)
+        self.assertIn("1,500-line target", adr)
+        self.assertIn("50-method target", adr)
+
+    def test_phase49_extracted_boundary_modules_remain_present(self) -> None:
+        expected_modules = (
+            "control-plane/aegisops_control_plane/detection_lifecycle.py",
+            "control-plane/aegisops_control_plane/case_workflow.py",
+            "control-plane/aegisops_control_plane/evidence_linkage.py",
+            "control-plane/aegisops_control_plane/ai_trace_lifecycle.py",
+            "control-plane/aegisops_control_plane/action_reconciliation_orchestration.py",
+            "control-plane/aegisops_control_plane/runtime_boundary.py",
+            "control-plane/aegisops_control_plane/restore_readiness.py",
+            "control-plane/aegisops_control_plane/runtime_restore_readiness_diagnostics.py",
+        )
+
+        for relative_path in expected_modules:
+            self.assertTrue((REPO_ROOT / relative_path).is_file(), relative_path)
+
+    def test_phase49_focused_regression_suites_cover_extracted_boundaries(self) -> None:
+        defined_tests = self._defined_test_names(
+            "control-plane/tests/test_service_persistence_ingest_case_lifecycle.py",
+            "control-plane/tests/test_service_persistence_assistant_advisory.py",
+            "control-plane/tests/test_execution_coordinator_boundary.py",
+            "control-plane/tests/test_phase21_runtime_auth_validation.py",
+            "control-plane/tests/test_service_persistence_restore_readiness.py",
+        )
+
+        for test_name in (
+            "test_service_initializes_dedicated_detection_intake_boundary",
+            "test_service_delegates_detection_intake_and_triage_operations",
+            "test_service_initializes_dedicated_case_workflow_and_evidence_linkage_boundaries",
+            "test_service_delegates_assistant_context_to_assembler_and_advisory_to_coordinator",
+            "test_service_initializes_focused_action_and_reconciliation_boundaries",
+            "test_operational_runtime_surfaces_are_extracted_into_dedicated_collaborators",
+            "test_service_routes_runtime_restore_and_readiness_through_diagnostics_boundary",
+            "test_service_wires_restore_readiness_internal_collaborators",
+        ):
+            self.assertIn(test_name, defined_tests)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -27,19 +27,26 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
             )
         return defined_names
 
-    def _facade_method_count(self) -> int:
+    def _facade_method_count(self, class_name: str) -> int:
         tree = ast.parse(
             self._read("control-plane/aegisops_control_plane/service.py"),
             filename="control-plane/aegisops_control_plane/service.py",
         )
         for node in tree.body:
-            if isinstance(node, ast.ClassDef) and node.name == "AegisOpsControlPlaneService":
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
                 return sum(
                     1
                     for child in node.body
                     if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
                 )
-        raise AssertionError("AegisOpsControlPlaneService class not found")
+        raise AssertionError(f"{class_name} class not found")
+
+    def _effective_line_count(self, text: str) -> int:
+        return sum(
+            1
+            for line in text.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        )
 
     def _baseline_metadata(self) -> dict[str, str]:
         for line in self._read("docs/maintainability-hotspot-baseline.txt").splitlines():
@@ -60,10 +67,15 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
         self.assertEqual(metadata["phase"], "49.0.7")
+        self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
         self.assertEqual(
+            int(metadata["max_effective_lines"]),
+            self._effective_line_count(service_text),
+        )
+        self.assertEqual(
             int(metadata["max_facade_methods"]),
-            self._facade_method_count(),
+            self._facade_method_count(metadata["facade_class"]),
         )
         self.assertGreater(int(metadata["max_lines"]), 1500)
         self.assertGreater(int(metadata["max_facade_methods"]), 50)

--- a/docs/adr/0003-phase-49-service-decomposition-boundaries.md
+++ b/docs/adr/0003-phase-49-service-decomposition-boundaries.md
@@ -155,6 +155,8 @@ Every extraction slice must keep the facade behavior-preserving and add focused 
 
 \#925 owns hotspot baseline refresh and validation closeout. It must run the maintainability hotspot verifier, refresh the baseline only after extraction is real, and preserve the public facade contract unless a later accepted decision changes it.
 
+The #925 closeout keeps one ADR-approved exception because the accepted child issues decomposed internal ownership while preserving the public facade. At closeout, `control-plane/aegisops_control_plane/service.py` remains above the long-term 1,500-line target and `AegisOpsControlPlaneService` remains above the long-term 50-method target. The refreshed baseline must therefore record the current closeout ceilings and fail on any silent facade re-growth rather than claiming the hotspot has been eliminated.
+
 No deployment manifest, runtime configuration, database migration, credential source, endpoint exposure, browser behavior, operator UI capability, or commercial readiness workflow changes through this ADR.
 
 ## 8. Security Impact

--- a/docs/maintainability-decomposition-thresholds.md
+++ b/docs/maintainability-decomposition-thresholds.md
@@ -204,6 +204,11 @@ It reports a candidate only when a tracked control-plane Python module is both l
 Known current candidates are recorded in `docs/maintainability-hotspot-baseline.txt`.
 If the verifier reports only known baseline entries, maintainers should treat the output as a reminder that those files remain reviewed hotspots and should not absorb unrelated responsibility growth without a decomposition decision.
 
+Baseline entries may also record Phase closeout ceilings such as `max_lines`, `max_effective_lines`, and `max_facade_methods`.
+Those ceilings are not success targets; they are ADR-documented exception limits for known hotspots that remain above the long-term threshold after an accepted extraction sequence.
+If a known hotspot exceeds a recorded ceiling, the verifier fails because the facade or successor hotspot has grown beyond the reviewed closeout state.
+The expected response is to lower the hotspot through another decomposition issue or update the governing ADR before accepting the growth.
+
 If the verifier fails with a new candidate, reviewers should use the threshold rule above before extending the file further.
 The expected response is either a narrow justification that the current change stays inside one cohesive responsibility or a follow-up maintainability backlog that preserves public behavior while extracting the next coherent cluster.
 

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -8,4 +8,4 @@
 # ceiling and fails on silent re-growth. A future ADR or maintainability backlog
 # must lower or replace these limits before unrelated Phase 49 feature expansion
 # lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=5799 max_effective_lines=5389 max_facade_methods=202 adr_exception=ADR-0003 phase=49.0.7
+control-plane/aegisops_control_plane/service.py max_lines=5799 max_effective_lines=5389 max_facade_methods=202 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=49.0.7

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,3 +1,11 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
-control-plane/aegisops_control_plane/service.py
+#
+# Phase 49.0 closeout exception:
+# ADR-0003 accepted facade-preserving extraction behind AegisOpsControlPlaneService.
+# The facade remains above the long-term 1,500-line and 50-method targets after
+# the Phase 49.0 child issues, so this baseline records the current closeout
+# ceiling and fails on silent re-growth. A future ADR or maintainability backlog
+# must lower or replace these limits before unrelated Phase 49 feature expansion
+# lands in the facade.
+control-plane/aegisops_control_plane/service.py max_lines=5799 max_effective_lines=5389 max_facade_methods=202 adr_exception=ADR-0003 phase=49.0.7

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -51,7 +51,7 @@ append_repeated_lines() {
   local count="$4"
 
   for ((index = 1; index <= count; index++)); do
-    printf '    %s_%03d = %03d\n' "${prefix}" "${index}" "${index}" >>"${target}/${path}"
+    printf '    %s_%03d = %d\n' "${prefix}" "${index}" "${index}" >>"${target}/${path}"
   done
 }
 
@@ -97,7 +97,7 @@ assert_passes "${single_responsibility_repo}"
 baseline_repo="${workdir}/baseline"
 create_repo \
   "${baseline_repo}" \
-  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py" \
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=960 max_effective_lines=960 max_facade_methods=1 adr_exception=ADR-0003" \
   "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
     def describe_runtime(self):
         auth_principal = 'trusted-runtime-boundary'
@@ -115,6 +115,35 @@ assert_passes "${baseline_repo}"
 if ! grep -F "Known maintainability hotspot baseline remains present" "${pass_stdout}" >/dev/null; then
   echo "Expected pass output to report the known baseline hotspot." >&2
   cat "${pass_stdout}" >&2
+  exit 1
+fi
+if ! grep -F "AegisOpsControlPlaneService methods=1" "${pass_stdout}" >/dev/null; then
+  echo "Expected pass output to report the facade method count." >&2
+  cat "${pass_stdout}" >&2
+  exit 1
+fi
+
+regrowth_repo="${workdir}/regrowth"
+create_repo \
+  "${regrowth_repo}" \
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=959 max_effective_lines=959 max_facade_methods=0 adr_exception=ADR-0003" \
+  "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
+    def describe_runtime(self):
+        auth_principal = 'trusted-runtime-boundary'
+        queue_status = {'operator': auth_principal}
+        case_transition = queue_status
+        assistant_recommendation = case_transition
+        action_reconciliation = assistant_recommendation
+        restore_backup_export = action_reconciliation
+        evidence_admission = restore_backup_export
+        return evidence_admission"
+append_repeated_lines "${regrowth_repo}" "control-plane/aegisops_control_plane/service.py" "mixed_line" 950
+git -C "${regrowth_repo}" add .
+git -C "${regrowth_repo}" commit -q -m "hotspot growth past baseline"
+assert_fails_with "${regrowth_repo}" "Maintainability hotspot baseline limits were exceeded"
+if ! grep -F "max_facade_methods=0" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the facade method limit." >&2
+  cat "${fail_stderr}" >&2
   exit 1
 fi
 

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -97,7 +97,7 @@ assert_passes "${single_responsibility_repo}"
 baseline_repo="${workdir}/baseline"
 create_repo \
   "${baseline_repo}" \
-  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=960 max_effective_lines=960 max_facade_methods=1 adr_exception=ADR-0003" \
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=960 max_effective_lines=960 max_facade_methods=1 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003" \
   "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
     def describe_runtime(self):
         auth_principal = 'trusted-runtime-boundary'
@@ -126,8 +126,8 @@ fi
 regrowth_repo="${workdir}/regrowth"
 create_repo \
   "${regrowth_repo}" \
-  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=959 max_effective_lines=959 max_facade_methods=0 adr_exception=ADR-0003" \
-  "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=959 max_effective_lines=959 max_facade_methods=0 facade_class=RenamedControlPlaneService adr_exception=ADR-0003" \
+  "control-plane/aegisops_control_plane/service.py" "class RenamedControlPlaneService:
     def describe_runtime(self):
         auth_principal = 'trusted-runtime-boundary'
         queue_status = {'operator': auth_principal}
@@ -141,8 +141,23 @@ append_repeated_lines "${regrowth_repo}" "control-plane/aegisops_control_plane/s
 git -C "${regrowth_repo}" add .
 git -C "${regrowth_repo}" commit -q -m "hotspot growth past baseline"
 assert_fails_with "${regrowth_repo}" "Maintainability hotspot baseline limits were exceeded"
+if ! grep -F "lines=960 exceeds max_lines=959" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the line-count limit." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
+if ! grep -F "effective_lines=960 exceeds max_effective_lines=959" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the effective-line limit." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
 if ! grep -F "max_facade_methods=0" "${fail_stderr}" >/dev/null; then
   echo "Expected failure output to report the facade method limit." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
+if ! grep -F "RenamedControlPlaneService methods=1" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the configured successor facade class." >&2
   cat "${fail_stderr}" >&2
   exit 1
 fi

--- a/scripts/verify-maintainability-hotspots.sh
+++ b/scripts/verify-maintainability-hotspots.sh
@@ -34,6 +34,8 @@ import pathlib
 import re
 import subprocess
 import sys
+import ast
+from typing import Mapping
 
 repo_root = pathlib.Path(os.environ["AEGISOPS_REPO_ROOT"])
 baseline_path = repo_root / os.environ["AEGISOPS_MAINTAINABILITY_BASELINE"]
@@ -76,17 +78,29 @@ def tracked_python_files() -> list[str]:
     return [line for line in result.stdout.splitlines() if line.endswith(".py")]
 
 
-def read_baseline() -> set[str]:
+def read_baseline() -> dict[str, dict[str, str]]:
     if not baseline_path.exists():
-        return set()
+        return {}
 
-    entries: set[str] = set()
+    entries: dict[str, dict[str, str]] = {}
     for line in baseline_path.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
-        entries.add(stripped.split()[0])
+        parts = stripped.split()
+        metadata: dict[str, str] = {}
+        for part in parts[1:]:
+            if "=" not in part:
+                continue
+            key, value = part.split("=", 1)
+            if key:
+                metadata[key] = value
+        entries[parts[0]] = metadata
     return entries
+
+
+def physical_line_count(text: str) -> int:
+    return len(text.splitlines())
 
 
 def effective_line_count(text: str) -> int:
@@ -99,7 +113,21 @@ def effective_line_count(text: str) -> int:
     return count
 
 
-def candidate_for(relative_path: str) -> tuple[str, int, tuple[str, ...]] | None:
+def class_method_count(text: str, class_name: str) -> int | None:
+    tree = ast.parse(text)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return sum(
+                1
+                for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
+    return None
+
+
+def candidate_for(
+    relative_path: str,
+) -> tuple[str, int, int, int | None, tuple[str, ...]] | None:
     path = repo_root / relative_path
     text = path.read_text(encoding="utf-8", errors="replace")
     facade_like = (
@@ -110,7 +138,9 @@ def candidate_for(relative_path: str) -> tuple[str, int, tuple[str, ...]] | None
     if not facade_like:
         return None
 
+    physical_lines = physical_line_count(text)
     effective_lines = effective_line_count(text)
+    facade_method_count = class_method_count(text, "AegisOpsControlPlaneService")
     present_signals = tuple(
         signal_name
         for signal_name, pattern in signal_patterns.items()
@@ -124,15 +154,65 @@ def candidate_for(relative_path: str) -> tuple[str, int, tuple[str, ...]] | None
     if not required_boundary_signals.intersection(present_signals):
         return None
 
-    return (relative_path, effective_lines, present_signals)
+    return (relative_path, physical_lines, effective_lines, facade_method_count, present_signals)
+
+
+def integer_metadata(
+    metadata: Mapping[str, str],
+    key: str,
+    relative_path: str,
+) -> int | None:
+    value = metadata.get(key)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        print(
+            f"Maintainability baseline entry for {relative_path} has invalid {key}={value!r}.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 baseline_entries = read_baseline()
 candidates = [candidate for relative_path in tracked_python_files() if (candidate := candidate_for(relative_path))]
-candidate_paths = {relative_path for relative_path, _, _ in candidates}
+candidate_paths = {relative_path for relative_path, _, _, _, _ in candidates}
 
 unknown_candidates = [candidate for candidate in candidates if candidate[0] not in baseline_entries]
-stale_baseline_entries = sorted(baseline_entries - candidate_paths)
+stale_baseline_entries = sorted(set(baseline_entries) - candidate_paths)
+baseline_regressions: list[str] = []
+
+for relative_path, physical_lines, effective_lines, facade_method_count, _signals in candidates:
+    metadata = baseline_entries.get(relative_path, {})
+    max_lines = integer_metadata(metadata, "max_lines", relative_path)
+    max_effective_lines = integer_metadata(
+        metadata,
+        "max_effective_lines",
+        relative_path,
+    )
+    max_facade_methods = integer_metadata(
+        metadata,
+        "max_facade_methods",
+        relative_path,
+    )
+
+    if max_lines is not None and physical_lines > max_lines:
+        baseline_regressions.append(
+            f"{relative_path}: lines={physical_lines} exceeds max_lines={max_lines}"
+        )
+    if max_effective_lines is not None and effective_lines > max_effective_lines:
+        baseline_regressions.append(
+            f"{relative_path}: effective_lines={effective_lines} exceeds max_effective_lines={max_effective_lines}"
+        )
+    if (
+        max_facade_methods is not None
+        and facade_method_count is not None
+        and facade_method_count > max_facade_methods
+    ):
+        baseline_regressions.append(
+            f"{relative_path}: AegisOpsControlPlaneService methods={facade_method_count} exceeds max_facade_methods={max_facade_methods}"
+        )
 
 if unknown_candidates:
     print(
@@ -143,9 +223,14 @@ if unknown_candidates:
         f"Review {threshold_doc} before extending these files or open a decomposition backlog.",
         file=sys.stderr,
     )
-    for relative_path, effective_lines, signals in unknown_candidates:
+    for relative_path, physical_lines, effective_lines, facade_method_count, signals in unknown_candidates:
+        method_summary = (
+            f", AegisOpsControlPlaneService methods={facade_method_count}"
+            if facade_method_count is not None
+            else ""
+        )
         print(
-            f"- {relative_path}: effective_lines={effective_lines}, signals={', '.join(signals)}",
+            f"- {relative_path}: lines={physical_lines}, effective_lines={effective_lines}{method_summary}, signals={', '.join(signals)}",
             file=sys.stderr,
         )
     sys.exit(1)
@@ -160,11 +245,29 @@ if stale_baseline_entries:
     print(f"Update {baseline_path.relative_to(repo_root)} after confirming the hotspot was decomposed.", file=sys.stderr)
     sys.exit(1)
 
+if baseline_regressions:
+    print(
+        "Maintainability hotspot baseline limits were exceeded.",
+        file=sys.stderr,
+    )
+    print(
+        "Open or update a decomposition decision before allowing facade hotspot growth.",
+        file=sys.stderr,
+    )
+    for regression in baseline_regressions:
+        print(f"- {regression}", file=sys.stderr)
+    sys.exit(1)
+
 if candidates:
     print("Known maintainability hotspot baseline remains present:")
-    for relative_path, effective_lines, signals in candidates:
+    for relative_path, physical_lines, effective_lines, facade_method_count, signals in candidates:
+        method_summary = (
+            f", AegisOpsControlPlaneService methods={facade_method_count}"
+            if facade_method_count is not None
+            else ""
+        )
         print(
-            f"- {relative_path}: effective_lines={effective_lines}, signals={len(signals)}; see {threshold_doc}"
+            f"- {relative_path}: lines={physical_lines}, effective_lines={effective_lines}{method_summary}, signals={len(signals)}; see {threshold_doc}"
         )
 else:
     print(f"No maintainability hotspot candidates found. See {threshold_doc}.")

--- a/scripts/verify-maintainability-hotspots.sh
+++ b/scripts/verify-maintainability-hotspots.sh
@@ -113,6 +113,10 @@ def effective_line_count(text: str) -> int:
     return count
 
 
+def read_python_file(relative_path: str) -> str:
+    return (repo_root / relative_path).read_text(encoding="utf-8", errors="replace")
+
+
 def class_method_count(text: str, class_name: str) -> int | None:
     tree = ast.parse(text)
     for node in tree.body:
@@ -125,22 +129,32 @@ def class_method_count(text: str, class_name: str) -> int | None:
     return None
 
 
+def detected_facade_class(text: str) -> str | None:
+    tree = ast.parse(text)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and re.search(r"(Service|Facade)$", node.name):
+            return node.name
+    return None
+
+
 def candidate_for(
     relative_path: str,
-) -> tuple[str, int, int, int | None, tuple[str, ...]] | None:
-    path = repo_root / relative_path
-    text = path.read_text(encoding="utf-8", errors="replace")
+) -> tuple[str, int, int, str | None, int | None, tuple[str, ...]] | None:
+    text = read_python_file(relative_path)
+    facade_class = detected_facade_class(text)
     facade_like = (
         pathlib.Path(relative_path).name == "service.py"
         or "facade" in relative_path.lower()
-        or re.search(r"^class\s+\w*(Service|Facade)\b", text, re.M) is not None
+        or facade_class is not None
     )
     if not facade_like:
         return None
 
     physical_lines = physical_line_count(text)
     effective_lines = effective_line_count(text)
-    facade_method_count = class_method_count(text, "AegisOpsControlPlaneService")
+    facade_method_count = (
+        class_method_count(text, facade_class) if facade_class is not None else None
+    )
     present_signals = tuple(
         signal_name
         for signal_name, pattern in signal_patterns.items()
@@ -154,7 +168,14 @@ def candidate_for(
     if not required_boundary_signals.intersection(present_signals):
         return None
 
-    return (relative_path, physical_lines, effective_lines, facade_method_count, present_signals)
+    return (
+        relative_path,
+        physical_lines,
+        effective_lines,
+        facade_class,
+        facade_method_count,
+        present_signals,
+    )
 
 
 def integer_metadata(
@@ -177,13 +198,13 @@ def integer_metadata(
 
 baseline_entries = read_baseline()
 candidates = [candidate for relative_path in tracked_python_files() if (candidate := candidate_for(relative_path))]
-candidate_paths = {relative_path for relative_path, _, _, _, _ in candidates}
+candidate_paths = {relative_path for relative_path, _, _, _, _, _ in candidates}
 
 unknown_candidates = [candidate for candidate in candidates if candidate[0] not in baseline_entries]
 stale_baseline_entries = sorted(set(baseline_entries) - candidate_paths)
 baseline_regressions: list[str] = []
 
-for relative_path, physical_lines, effective_lines, facade_method_count, _signals in candidates:
+for relative_path, physical_lines, effective_lines, facade_class, facade_method_count, _signals in candidates:
     metadata = baseline_entries.get(relative_path, {})
     max_lines = integer_metadata(metadata, "max_lines", relative_path)
     max_effective_lines = integer_metadata(
@@ -196,6 +217,12 @@ for relative_path, physical_lines, effective_lines, facade_method_count, _signal
         "max_facade_methods",
         relative_path,
     )
+    configured_facade_class = metadata.get("facade_class") or facade_class
+    configured_facade_method_count = (
+        class_method_count(read_python_file(relative_path), configured_facade_class)
+        if configured_facade_class is not None
+        else None
+    )
 
     if max_lines is not None and physical_lines > max_lines:
         baseline_regressions.append(
@@ -207,11 +234,26 @@ for relative_path, physical_lines, effective_lines, facade_method_count, _signal
         )
     if (
         max_facade_methods is not None
-        and facade_method_count is not None
-        and facade_method_count > max_facade_methods
+        and configured_facade_class is None
     ):
         baseline_regressions.append(
-            f"{relative_path}: AegisOpsControlPlaneService methods={facade_method_count} exceeds max_facade_methods={max_facade_methods}"
+            f"{relative_path}: facade_class is required for max_facade_methods={max_facade_methods}"
+        )
+    if (
+        max_facade_methods is not None
+        and configured_facade_class is not None
+        and configured_facade_method_count is None
+    ):
+        baseline_regressions.append(
+            f"{relative_path}: facade_class={configured_facade_class} not found for max_facade_methods={max_facade_methods}"
+        )
+    if (
+        max_facade_methods is not None
+        and configured_facade_method_count is not None
+        and configured_facade_method_count > max_facade_methods
+    ):
+        baseline_regressions.append(
+            f"{relative_path}: {configured_facade_class} methods={configured_facade_method_count} exceeds max_facade_methods={max_facade_methods}"
         )
 
 if unknown_candidates:
@@ -223,10 +265,10 @@ if unknown_candidates:
         f"Review {threshold_doc} before extending these files or open a decomposition backlog.",
         file=sys.stderr,
     )
-    for relative_path, physical_lines, effective_lines, facade_method_count, signals in unknown_candidates:
+    for relative_path, physical_lines, effective_lines, facade_class, facade_method_count, signals in unknown_candidates:
         method_summary = (
-            f", AegisOpsControlPlaneService methods={facade_method_count}"
-            if facade_method_count is not None
+            f", {facade_class} methods={facade_method_count}"
+            if facade_class is not None and facade_method_count is not None
             else ""
         )
         print(
@@ -260,10 +302,10 @@ if baseline_regressions:
 
 if candidates:
     print("Known maintainability hotspot baseline remains present:")
-    for relative_path, physical_lines, effective_lines, facade_method_count, signals in candidates:
+    for relative_path, physical_lines, effective_lines, facade_class, facade_method_count, signals in candidates:
         method_summary = (
-            f", AegisOpsControlPlaneService methods={facade_method_count}"
-            if facade_method_count is not None
+            f", {facade_class} methods={facade_method_count}"
+            if facade_class is not None and facade_method_count is not None
             else ""
         )
         print(


### PR DESCRIPTION
## Summary
- refresh the maintainability hotspot baseline for Phase 49.0.7 with ADR-0003 exception limits for `service.py`
- make the hotspot verifier fail on line/effective-line/facade-method growth beyond the recorded closeout baseline
- add a focused Phase 49 closeout regression test for extracted boundary modules, coverage anchors, and baseline metadata

## Verification
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-phase-49-service-decomposition-adr.sh`
- `bash scripts/test-verify-phase-49-service-decomposition-adr.sh`
- `python3 -m unittest control-plane.tests.test_phase49_service_decomposition_closeout`
- `python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation control-plane.tests.test_execution_coordinator_boundary control-plane.tests.test_phase21_runtime_auth_validation`
- `bash scripts/verify-phase-44-47-boundary-docs.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash scripts/verify-documentation-ownership-map.sh`
- `python3 -m unittest control-plane.tests.test_maintainability_decomposition_thresholds_docs control-plane.tests.test_phase49_service_decomposition_closeout`
- `git diff --check`
- `node dist/index.js issue-lint 925 --config supervisor.config.aegisops.json` from `<codex-supervisor-root>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive Phase 49 closeout validation suite covering baseline records, boundary modules, and regression coverage.

* **Documentation**
  * Recorded Phase 49 closeout ceilings and ADR exception in the ADR and baseline docs.
  * Clarified maintainability threshold guidance to treat recorded ceilings as enforceable closeout limits.

* **Chores**
  * Strengthened verification tooling to enforce numeric line/method ceilings and fail on regrowth beyond configured limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->