### PR TITLE
Phase 49.1 RBAC auth hardening contract

### DIFF
--- a/docs/documentation-ownership-map.md
+++ b/docs/documentation-ownership-map.md
@@ -33,6 +33,7 @@ If a document inside one of these areas has its own `Owner` or `Owners` field, t
 | `docs/secops-domain-model.md` | SecOps domain model baseline | IT Operations, Information Systems Department |
 | `docs/secops-business-hours-operating-model.md` | Business-hours SecOps daily operating model baseline | IT Operations, Information Systems Department |
 | `docs/auth-baseline.md` | Authentication, authorization, and service account ownership baseline | IT Operations, Information Systems Department |
+| `docs/phase-49-production-rbac-auth-hardening-contract.md` | Production RBAC and auth hardening contract | IT Operations, Information Systems Department |
 | `docs/asset-identity-privilege-context-baseline.md` | Asset, identity, and privilege context baseline | IT Operations, Information Systems Department |
 | `docs/response-action-safety-model.md` | Response action safety and approval binding baseline | IT Operations, Information Systems Department |
 | `docs/automation-substrate-contract.md` | Approved automation delegation contract baseline | IT Operations, Information Systems Department |
@@ -63,6 +64,8 @@ The SecOps domain model document remains the shared semantic reference for basel
 The business-hours SecOps operating model remains the analyst-workflow reference for triage, case creation, approval timeout handling, after-hours escalation, and handoff expectations under the non-24x7 baseline.
 
 The auth baseline remains the policy reference for operator personas, least-privilege authorization boundaries, machine identity ownership, and secret lifecycle expectations across future monitors, workflows, approvals, and integrations.
+
+The Phase 49.1 production RBAC and auth hardening contract remains the commercial-readiness reference for backend-authoritative protected-surface authorization, fail-closed identity handling, and forbidden subordinate trust paths.
 
 The asset, identity, and privilege context baseline remains the Phase 7 design reference for reviewed alias handling, ownership expectations, criticality context, and privilege-relevant entity reasoning without implying live CMDB or IdP authority.
 

--- a/docs/phase-49-production-rbac-auth-hardening-contract.md
+++ b/docs/phase-49-production-rbac-auth-hardening-contract.md
@@ -1,0 +1,135 @@
+# Phase 49.1 Production RBAC and Auth Hardening Contract
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/auth-baseline.md`, `docs/architecture.md`, `docs/response-action-safety-model.md`, `docs/control-plane-state-model.md`, `docs/adr/0003-phase-49-service-decomposition-boundaries.md`
+- **Related Issue**: #934
+
+## 1. Purpose
+
+This contract fixes the production RBAC and authentication hardening posture for later Phase 49 implementation work without changing runtime behavior in this issue.
+
+It turns the existing auth baseline into a commercial-readiness contract for protected operator and backend surfaces while preserving the AegisOps authority model.
+
+AegisOps control-plane records remain authoritative for approval decisions, action requests, action executions, evidence linkage, lifecycle state, and reconciliation truth.
+
+This contract is design and validation only. It does not create live users, integrate an IdP, mint secrets, change approval behavior, or introduce production writes.
+
+## 2. Production Role Contract
+
+Production implementation must start from these least-privilege roles. A later issue may split a role into narrower implementation claims, but it must not weaken the forbidden shortcuts or make subordinate context authoritative.
+
+| Role | Allowed authority | Forbidden shortcut |
+| ---- | ---- | ---- |
+| `analyst` | Review assigned alerts, cases, evidence, observations, leads, recommendations, advisory context, and reconciliation status; create or update investigation notes and submit approval-bound action requests inside assigned scope. | Approve approval-sensitive actions, execute actions directly, administer platform identity, or override reconciliation truth. |
+| `approver` | Review approval-bound action requests, inspect the authoritative evidence and scope bindings, approve or reject delegated actions within the assigned action class, and record the approval decision. | Approve requests without an attributable requester, approve their own approval-sensitive request, execute actions as the approving human, or use assistant/ticket/browser context as approval authority. |
+| `platform_admin` | Operate platform configuration, secret delivery paths, identity-provider wiring, service accounts, readiness checks, and recovery procedures. | Use administrative access as a response-action approval path, mutate workflow truth without the control-plane record chain, or grant broad role overlap without a reviewed exception. |
+
+Role assignment must be attributable to one reviewed human or machine identity record. Shared interactive administrator accounts, anonymous operator identities, mailbox-backed users, and human-owned automation tokens remain forbidden shortcuts.
+
+## 3. Permission Contract
+
+Authorization must be evaluated by the backend control-plane boundary for every protected read, every write-capable operator action, every approval decision, every action execution delegation, and every reconciliation closeout.
+
+The backend authorization decision must bind at least:
+
+- reviewed identity-provider boundary;
+- authenticated provider subject;
+- reviewed AegisOps identity;
+- reviewed role claim;
+- action class or protected surface;
+- authoritative record identifier;
+- tenant or environment scope when that scope exists; and
+- requester, approver, and executor separation when the operation touches approval or execution.
+
+Browser route gating, UI menu visibility, reverse-proxy access control, external-ticket assignment, assistant output, endpoint evidence, network evidence, downstream receipts, and optional extension state are subordinate controls or context only.
+
+If browser and backend authorization disagree, the backend denial wins and the browser must preserve the denial explicitly instead of rendering guessed or cached protected content.
+
+## 4. Trusted Identity Boundary
+
+The trusted identity boundary is a reviewed IdP session normalized by the approved reverse-proxy path and bound to backend-reviewed claims before the control plane admits protected access.
+
+The approved boundary must make these signals available to backend authorization:
+
+- reviewed identity-provider identifier;
+- authenticated provider subject;
+- reviewed AegisOps identity string;
+- reviewed role or role set;
+- session freshness or expiry status;
+- scope binding for the protected record or environment; and
+- provenance that the signal crossed the approved proxy boundary.
+
+Raw `X-Forwarded-*`, `Forwarded`, `Host`, `X-User`, `X-Email`, tenant, proto, role, or scope headers must not be trusted unless the approved proxy has authenticated, normalized, and sealed the boundary before backend evaluation.
+
+Placeholder credentials, sample tokens, unsigned tokens, TODO values, empty secrets, stale secret reads, and locally guessed identity values must be rejected.
+
+Machine identity for automation must remain separate from human operator identity. A human approval record may authorize a bounded action, but execution must still occur under a reviewed machine or executor identity that can be reconciled back to the approved action scope.
+
+## 5. Fail-Closed Conditions
+
+If the authenticated subject, reviewed provider, role assignment, action scope, tenant or environment scope, approval binding, requester identity, or executor identity is missing, stale, ambiguous, malformed, or contradictory, the protected path must fail closed.
+
+Fail-closed means the backend rejects the protected operation, leaves authoritative workflow records unchanged, records or surfaces the reason for operator follow-up, and does not substitute guessed context.
+
+Specific fail-closed examples:
+
+- missing reviewed IdP binding rejects protected operator access as unauthorized;
+- authenticated session without a reviewed role claim rejects protected access as forbidden or invalid-session;
+- conflicting `analyst` and `approver` claims on an approval-sensitive self-approval path rejects the approval;
+- raw forwarded identity headers without a sealed proxy boundary reject the request;
+- external ticket assignee or browser route state cannot authorize a protected backend read;
+- assistant recommendation, endpoint evidence, network evidence, or downstream receipt cannot approve, execute, or close a workflow record;
+- stale or unreadable secret-backed identity context blocks the protected operation instead of falling back to plaintext or a cached sample value; and
+- restore, export, backup, or readiness paths that cannot prove a snapshot-consistent identity and record chain must reject or escalate instead of presenting a mixed-state success.
+
+Rejected, forbidden, failed, or restore-failure paths must not leave orphan records, partial durable writes, half-restored state, or authority-shaped derived summaries behind.
+
+## 6. Subordinate Context and Forbidden Trust Paths
+
+Subordinate sources must never become authority for identity, role, approval, execution, reconciliation, case lifecycle, evidence custody, or commercial-readiness state.
+
+The forbidden authority sources are:
+
+- raw browser headers or client-supplied identity fields;
+- browser route state, menu visibility, cached shell state, local storage, or optional extension state;
+- external tickets, ticket assignees, ticket comments, ticket closure, or support workflow state;
+- assistant output, model output, recommendations, summaries, or advisory lineage;
+- ML, endpoint evidence, network evidence, OpenSearch documents, Wazuh local state, Shuffle state, n8n state, receipts, or downstream run metadata;
+- naming conventions, path shape, nearby metadata, comments, labels, badges, counters, or operator-facing projection text; and
+- placeholder credentials, sample tokens, unsigned tokens, TODO values, empty secrets, or stale secret reads.
+
+Those sources may support explanation, triage, or reconciliation only after they are explicitly bound to the authoritative AegisOps control-plane record chain.
+
+## 7. Validation Expectations
+
+Protected-surface validation must include negative cases for missing identity-provider binding, unreviewed provider boundary, missing reviewed role claim, ambiguous role overlap, raw forwarded-header identity, placeholder credentials, and stale or unreadable secret-backed identity context.
+
+Implementation issues must anchor tests at the enforcement boundary that actually authorizes or rejects the protected operation. Setup-only tests are not sufficient when later authorization, provenance, scope, or durable-state checks decide the outcome.
+
+Failure-path validation must prove durable state remains clean after rejected, forbidden, failed, or restore-failure paths, not only that an exception or error was returned.
+
+Validation for backup, restore, export, readiness, and detail aggregation must prove snapshot-consistent reads or explicit rejection of mixed-snapshot results.
+
+Validation for one logical change that writes multiple records must prove all-or-nothing persistence and must not hold database transactions open across network hops, queued jobs, adapter dispatch, or remote waits.
+
+## 8. Scope Boundaries
+
+This contract does not implement runtime RBAC, change approval or action execution policy, add audit export, retention, observability, reporting, multi-tenant, MSSP, HA, or production write behavior, or expand `service.py` responsibilities beyond the ADR-0003 closeout ceiling.
+
+Later Phase 49 implementation may add code and tests for this posture, but it must preserve:
+
+- backend-authoritative approval and action governance;
+- the existing public control-plane authority boundary;
+- separation between requester, approver, and executor identity;
+- the subordinate posture of tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, and optional extension state; and
+- fail-closed behavior when prerequisite identity, scope, provenance, or durable-state signals are not trustworthy.
+
+## 9. Verification Commands
+
+Run `bash scripts/verify-phase-49-production-rbac-auth-contract.sh`.
+
+Run `bash scripts/test-verify-phase-49-production-rbac-auth-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 934 --config <supervisor-config-path>`.

--- a/scripts/ci-phase-contract-commands.sh
+++ b/scripts/ci-phase-contract-commands.sh
@@ -11,6 +11,7 @@ bash scripts/verify-phase-6-initial-telemetry-slice-doc.sh
 bash scripts/verify-phase-6-opensearch-detector-artifacts.sh
 bash scripts/verify-phase-6-replay-to-notify-validation.sh
 bash scripts/verify-phase-25-multi-source-case-review-runbook.sh
+bash scripts/verify-phase-49-production-rbac-auth-contract.sh
 EOF
 }
 
@@ -61,5 +62,6 @@ bash scripts/test-verify-ci-phase-27-workflow-coverage.sh
 bash scripts/test-verify-phase-6-initial-telemetry-slice-doc.sh
 bash scripts/test-verify-phase-6-opensearch-detector-artifacts.sh
 bash scripts/test-verify-phase-6-replay-to-notify-validation.sh
+bash scripts/test-verify-phase-49-production-rbac-auth-contract.sh
 EOF
 }

--- a/scripts/test-verify-phase-49-production-rbac-auth-contract.sh
+++ b/scripts/test-verify-phase-49-production-rbac-auth-contract.sh
@@ -111,6 +111,22 @@ valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
 
+partial_heading_repo="${workdir}/partial-heading"
+create_valid_repo "${partial_heading_repo}"
+perl -0pi -e 's/## 1\. Purpose/## 1. Purpose \(draft\)/g' \
+  "${partial_heading_repo}/docs/phase-49-production-rbac-auth-hardening-contract.md"
+assert_fails_with \
+  "${partial_heading_repo}" \
+  "Missing Phase 49.1 production RBAC/auth contract heading: ## 1. Purpose"
+
+partial_statement_repo="${workdir}/partial-statement"
+create_valid_repo "${partial_statement_repo}"
+perl -0pi -e 's/This contract fixes the production RBAC and authentication hardening posture for later Phase 49 implementation work without changing runtime behavior in this issue\./This contract fixes the production RBAC and authentication hardening posture for later Phase 49 implementation work without changing runtime behavior in this issue. Draft./g' \
+  "${partial_statement_repo}/docs/phase-49-production-rbac-auth-hardening-contract.md"
+assert_fails_with \
+  "${partial_statement_repo}" \
+  "Missing Phase 49.1 production RBAC/auth contract statement: This contract fixes the production RBAC and authentication hardening posture for later Phase 49 implementation work without changing runtime behavior in this issue."
+
 missing_doc_repo="${workdir}/missing-doc"
 mkdir -p "${missing_doc_repo}/docs"
 assert_fails_with \

--- a/scripts/test-verify-phase-49-production-rbac-auth-contract.sh
+++ b/scripts/test-verify-phase-49-production-rbac-auth-contract.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-49-production-rbac-auth-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+write_contract_doc() {
+  local target="$1"
+  local content="$2"
+
+  mkdir -p "${target}/docs"
+  printf '%s\n' "${content}" >"${target}/docs/phase-49-production-rbac-auth-hardening-contract.md"
+}
+
+create_valid_repo() {
+  local target="$1"
+
+  write_contract_doc "${target}" '# Phase 49.1 Production RBAC and Auth Hardening Contract
+
+## 1. Purpose
+
+This contract fixes the production RBAC and authentication hardening posture for later Phase 49 implementation work without changing runtime behavior in this issue.
+
+AegisOps control-plane records remain authoritative for approval decisions, action requests, action executions, evidence linkage, lifecycle state, and reconciliation truth.
+
+## 2. Production Role Contract
+
+| Role | Allowed authority | Forbidden shortcut |
+| ---- | ---- | ---- |
+| `analyst` | Review assigned alerts, cases, evidence, observations, leads, recommendations, advisory context, and reconciliation status; create or update investigation notes and submit approval-bound action requests inside assigned scope. | Approve approval-sensitive actions, execute actions directly, administer platform identity, or override reconciliation truth. |
+| `approver` | Review approval-bound action requests, inspect the authoritative evidence and scope bindings, approve or reject delegated actions within the assigned action class, and record the approval decision. | Approve requests without an attributable requester, approve their own approval-sensitive request, execute actions as the approving human, or use assistant/ticket/browser context as approval authority. |
+| `platform_admin` | Operate platform configuration, secret delivery paths, identity-provider wiring, service accounts, readiness checks, and recovery procedures. | Use administrative access as a response-action approval path, mutate workflow truth without the control-plane record chain, or grant broad role overlap without a reviewed exception. |
+
+## 3. Permission Contract
+
+Authorization must be evaluated by the backend control-plane boundary for every protected read, every write-capable operator action, every approval decision, every action execution delegation, and every reconciliation closeout.
+
+Browser route gating, UI menu visibility, reverse-proxy access control, external-ticket assignment, assistant output, endpoint evidence, network evidence, downstream receipts, and optional extension state are subordinate controls or context only.
+
+## 4. Trusted Identity Boundary
+
+The trusted identity boundary is a reviewed IdP session normalized by the approved reverse-proxy path and bound to backend-reviewed claims before the control plane admits protected access.
+
+Raw `X-Forwarded-*`, `Forwarded`, `Host`, `X-User`, `X-Email`, tenant, proto, role, or scope headers must not be trusted unless the approved proxy has authenticated, normalized, and sealed the boundary before backend evaluation.
+
+Placeholder credentials, sample tokens, unsigned tokens, TODO values, empty secrets, stale secret reads, and locally guessed identity values must be rejected.
+
+## 5. Fail-Closed Conditions
+
+If the authenticated subject, reviewed provider, role assignment, action scope, tenant or environment scope, approval binding, requester identity, or executor identity is missing, stale, ambiguous, malformed, or contradictory, the protected path must fail closed.
+
+Fail-closed means the backend rejects the protected operation, leaves authoritative workflow records unchanged, records or surfaces the reason for operator follow-up, and does not substitute guessed context.
+
+## 6. Subordinate Context and Forbidden Trust Paths
+
+Subordinate sources must never become authority for identity, role, approval, execution, reconciliation, case lifecycle, evidence custody, or commercial-readiness state.
+
+## 7. Validation Expectations
+
+Protected-surface validation must include negative cases for missing identity-provider binding, unreviewed provider boundary, missing reviewed role claim, ambiguous role overlap, raw forwarded-header identity, placeholder credentials, and stale or unreadable secret-backed identity context.
+
+Failure-path validation must prove durable state remains clean after rejected, forbidden, failed, or restore-failure paths, not only that an exception or error was returned.
+
+## 8. Scope Boundaries
+
+This contract does not implement runtime RBAC, change approval or action execution policy, add audit export, retention, observability, reporting, multi-tenant, MSSP, HA, or production write behavior, or expand `service.py` responsibilities beyond the ADR-0003 closeout ceiling.
+
+## 9. Verification Commands
+
+Run `bash scripts/verify-phase-49-production-rbac-auth-contract.sh`.
+Run `bash scripts/test-verify-phase-49-production-rbac-auth-contract.sh`.
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 934 --config <supervisor-config-path>`.'
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 49.1 production RBAC/auth contract"
+
+missing_forwarded_header_repo="${workdir}/missing-forwarded-header"
+create_valid_repo "${missing_forwarded_header_repo}"
+perl -0pi -e 's/Raw `X-Forwarded-\*`, `Forwarded`, `Host`, `X-User`, `X-Email`, tenant, proto, role, or scope headers must not be trusted unless the approved proxy has authenticated, normalized, and sealed the boundary before backend evaluation\.//g' \
+  "${missing_forwarded_header_repo}/docs/phase-49-production-rbac-auth-hardening-contract.md"
+assert_fails_with \
+  "${missing_forwarded_header_repo}" \
+  'Missing Phase 49.1 production RBAC/auth contract statement: Raw `X-Forwarded-*`, `Forwarded`, `Host`, `X-User`, `X-Email`, tenant, proto, role, or scope headers must not be trusted unless the approved proxy has authenticated, normalized, and sealed the boundary before backend evaluation.'
+
+missing_fail_closed_repo="${workdir}/missing-fail-closed"
+create_valid_repo "${missing_fail_closed_repo}"
+perl -0pi -e 's/If the authenticated subject, reviewed provider, role assignment, action scope, tenant or environment scope, approval binding, requester identity, or executor identity is missing, stale, ambiguous, malformed, or contradictory, the protected path must fail closed\.//g' \
+  "${missing_fail_closed_repo}/docs/phase-49-production-rbac-auth-hardening-contract.md"
+assert_fails_with \
+  "${missing_fail_closed_repo}" \
+  "Missing Phase 49.1 production RBAC/auth contract statement: If the authenticated subject, reviewed provider, role assignment, action scope, tenant or environment scope, approval binding, requester identity, or executor identity is missing, stale, ambiguous, malformed, or contradictory, the protected path must fail closed."
+
+missing_state_clean_repo="${workdir}/missing-state-clean"
+create_valid_repo "${missing_state_clean_repo}"
+perl -0pi -e 's/Failure-path validation must prove durable state remains clean after rejected, forbidden, failed, or restore-failure paths, not only that an exception or error was returned\.//g' \
+  "${missing_state_clean_repo}/docs/phase-49-production-rbac-auth-hardening-contract.md"
+assert_fails_with \
+  "${missing_state_clean_repo}" \
+  "Missing Phase 49.1 production RBAC/auth contract statement: Failure-path validation must prove durable state remains clean after rejected, forbidden, failed, or restore-failure paths, not only that an exception or error was returned."
+
+echo "verify-phase-49-production-rbac-auth-contract tests passed"

--- a/scripts/verify-phase-49-production-rbac-auth-contract.sh
+++ b/scripts/verify-phase-49-production-rbac-auth-contract.sh
@@ -46,14 +46,14 @@ if [[ ! -f "${doc_path}" ]]; then
 fi
 
 for heading in "${required_headings[@]}"; do
-  if ! grep -Fq -- "${heading}" "${doc_path}"; then
+  if ! grep -Fxq -- "${heading}" "${doc_path}"; then
     echo "Missing Phase 49.1 production RBAC/auth contract heading: ${heading}" >&2
     exit 1
   fi
 done
 
 for phrase in "${required_phrases[@]}"; do
-  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+  if ! grep -Fxq -- "${phrase}" "${doc_path}"; then
     echo "Missing Phase 49.1 production RBAC/auth contract statement: ${phrase}" >&2
     exit 1
   fi

--- a/scripts/verify-phase-49-production-rbac-auth-contract.sh
+++ b/scripts/verify-phase-49-production-rbac-auth-contract.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-49-production-rbac-auth-hardening-contract.md"
+
+required_headings=(
+  "# Phase 49.1 Production RBAC and Auth Hardening Contract"
+  "## 1. Purpose"
+  "## 2. Production Role Contract"
+  "## 3. Permission Contract"
+  "## 4. Trusted Identity Boundary"
+  "## 5. Fail-Closed Conditions"
+  "## 6. Subordinate Context and Forbidden Trust Paths"
+  "## 7. Validation Expectations"
+  "## 8. Scope Boundaries"
+  "## 9. Verification Commands"
+)
+
+required_phrases=(
+  "This contract fixes the production RBAC and authentication hardening posture for later Phase 49 implementation work without changing runtime behavior in this issue."
+  "AegisOps control-plane records remain authoritative for approval decisions, action requests, action executions, evidence linkage, lifecycle state, and reconciliation truth."
+  '| `analyst` | Review assigned alerts, cases, evidence, observations, leads, recommendations, advisory context, and reconciliation status; create or update investigation notes and submit approval-bound action requests inside assigned scope. | Approve approval-sensitive actions, execute actions directly, administer platform identity, or override reconciliation truth. |'
+  '| `approver` | Review approval-bound action requests, inspect the authoritative evidence and scope bindings, approve or reject delegated actions within the assigned action class, and record the approval decision. | Approve requests without an attributable requester, approve their own approval-sensitive request, execute actions as the approving human, or use assistant/ticket/browser context as approval authority. |'
+  '| `platform_admin` | Operate platform configuration, secret delivery paths, identity-provider wiring, service accounts, readiness checks, and recovery procedures. | Use administrative access as a response-action approval path, mutate workflow truth without the control-plane record chain, or grant broad role overlap without a reviewed exception. |'
+  "Authorization must be evaluated by the backend control-plane boundary for every protected read, every write-capable operator action, every approval decision, every action execution delegation, and every reconciliation closeout."
+  "Browser route gating, UI menu visibility, reverse-proxy access control, external-ticket assignment, assistant output, endpoint evidence, network evidence, downstream receipts, and optional extension state are subordinate controls or context only."
+  "The trusted identity boundary is a reviewed IdP session normalized by the approved reverse-proxy path and bound to backend-reviewed claims before the control plane admits protected access."
+  'Raw `X-Forwarded-*`, `Forwarded`, `Host`, `X-User`, `X-Email`, tenant, proto, role, or scope headers must not be trusted unless the approved proxy has authenticated, normalized, and sealed the boundary before backend evaluation.'
+  "Placeholder credentials, sample tokens, unsigned tokens, TODO values, empty secrets, stale secret reads, and locally guessed identity values must be rejected."
+  "If the authenticated subject, reviewed provider, role assignment, action scope, tenant or environment scope, approval binding, requester identity, or executor identity is missing, stale, ambiguous, malformed, or contradictory, the protected path must fail closed."
+  "Fail-closed means the backend rejects the protected operation, leaves authoritative workflow records unchanged, records or surfaces the reason for operator follow-up, and does not substitute guessed context."
+  "Subordinate sources must never become authority for identity, role, approval, execution, reconciliation, case lifecycle, evidence custody, or commercial-readiness state."
+  "Protected-surface validation must include negative cases for missing identity-provider binding, unreviewed provider boundary, missing reviewed role claim, ambiguous role overlap, raw forwarded-header identity, placeholder credentials, and stale or unreadable secret-backed identity context."
+  "Failure-path validation must prove durable state remains clean after rejected, forbidden, failed, or restore-failure paths, not only that an exception or error was returned."
+  'This contract does not implement runtime RBAC, change approval or action execution policy, add audit export, retention, observability, reporting, multi-tenant, MSSP, HA, or production write behavior, or expand `service.py` responsibilities beyond the ADR-0003 closeout ceiling.'
+  'Run `bash scripts/verify-phase-49-production-rbac-auth-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-49-production-rbac-auth-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 934 --config <supervisor-config-path>`.'
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 49.1 production RBAC/auth contract: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq -- "${heading}" "${doc_path}"; then
+    echo "Missing Phase 49.1 production RBAC/auth contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 49.1 production RBAC/auth contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 49.1 production RBAC/auth contract is present and preserves backend authority, fail-closed identity handling, and forbidden trust paths."


### PR DESCRIPTION
## Summary
- Adds the Phase 49.1 production RBAC/auth hardening contract.
- Adds a focused verifier and verifier self-test for backend authority, fail-closed identity handling, forbidden trust paths, and validation expectations.
- Wires the verifier into the shared phase-contract command list and records document ownership.

## Verification
- `bash scripts/verify-phase-49-production-rbac-auth-contract.sh`
- `bash scripts/test-verify-phase-49-production-rbac-auth-contract.sh`
- `bash scripts/verify-documentation-ownership-map.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash scripts/test-verify-ci-phase-contract-runner.sh`
- `python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation`
- `python3 -m unittest control-plane.tests.test_runtime_secret_boundary`
- `node <codex-supervisor-root>/dist/index.js issue-lint 934 --config <supervisor-config-path>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 49.1 Production RBAC and Authentication Hardening Contract specifying least-privilege role requirements, forbidden shortcuts, control-plane boundary validation, trusted-identity expectations, and fail-closed behaviors.
  * Updated documentation ownership map to include the new contract.

* **Tests**
  * Added verification tests covering valid and multiple malformed contract scenarios.

* **Chores**
  * Integrated contract verification into CI/test command sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->