### PR TITLE
Phase 49.3 operator health readiness signals

### DIFF
--- a/control-plane/aegisops_control_plane/restore_readiness_projection.py
+++ b/control-plane/aegisops_control_plane/restore_readiness_projection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 
 from .config import RuntimeConfig
 from .models import (
@@ -190,6 +190,17 @@ class _ReadinessHealthProjection:
                 control_plane_change_authority_freeze["state"] == "frozen"
             ),
         )
+        operator_health = self._build_operator_health_signal(
+            readiness_status=status,
+            startup_ready=startup.startup_ready,
+            shutdown_ready=shutdown.shutdown_ready,
+            readiness_aggregates=readiness_aggregates,
+            review_path_health=review_path_health,
+            source_health=source_health,
+            automation_substrate_health=automation_substrate_health,
+            optional_extensions=optional_extensions,
+            control_plane_change_authority_freeze=control_plane_change_authority_freeze,
+        )
 
         metrics = {
             "alerts": {
@@ -266,6 +277,7 @@ class _ReadinessHealthProjection:
             "control_plane_change_authority_freeze": (
                 control_plane_change_authority_freeze
             ),
+            "operator_health": operator_health,
         }
 
         return self._readiness_diagnostics_snapshot_factory(
@@ -282,6 +294,131 @@ class _ReadinessHealthProjection:
                 if readiness_aggregates.latest_reconciliation is not None
                 else None
             ),
+        )
+
+    def _build_operator_health_signal(
+        self,
+        *,
+        readiness_status: str,
+        startup_ready: bool,
+        shutdown_ready: bool,
+        readiness_aggregates: ReadinessDiagnosticsAggregates,
+        review_path_health: dict[str, object],
+        source_health: dict[str, object],
+        automation_substrate_health: dict[str, object],
+        optional_extensions: dict[str, object],
+        control_plane_change_authority_freeze: dict[str, object],
+    ) -> dict[str, object]:
+        subordinate_context = {
+            "source_health": self._operator_subordinate_context_entry(
+                state=str(source_health.get("overall_state", "unknown")),
+                tracked_count=int(source_health.get("tracked_sources", 0)),
+            ),
+            "automation_substrate_health": self._operator_subordinate_context_entry(
+                state=str(automation_substrate_health.get("overall_state", "unknown")),
+                tracked_count=int(
+                    automation_substrate_health.get("tracked_surfaces", 0)
+                ),
+            ),
+            "optional_extensions": {
+                **self._operator_subordinate_context_entry(
+                    state=str(optional_extensions.get("overall_state", "unknown")),
+                    tracked_count=int(optional_extensions.get("tracked_extensions", 0)),
+                ),
+                "degraded_extensions": tuple(
+                    extension_name
+                    for extension_name, extension in sorted(
+                        self._operator_extension_entries(optional_extensions).items()
+                    )
+                    if extension.get("readiness") == "degraded"
+                ),
+            },
+        }
+        subordinate_state = self._operator_worst_state(
+            entry["state"] for entry in subordinate_context.values()
+        )
+        mainline_state = readiness_status
+        overall_state = self._operator_worst_state((mainline_state, subordinate_state))
+
+        return {
+            "contract": "phase49_commercial_operator_health",
+            "overall_state": overall_state,
+            "authority_source": "aegisops_control_plane_records",
+            "subordinate_signal_policy": "visibility_only",
+            "subordinate_signals_authoritative": False,
+            "mainline": {
+                "readiness_status": readiness_status,
+                "startup_ready": startup_ready,
+                "shutdown_ready": shutdown_ready,
+                "review_path_state": review_path_health.get("overall_state"),
+                "authority_freeze_state": control_plane_change_authority_freeze.get(
+                    "state"
+                ),
+                "open_case_count": len(readiness_aggregates.open_case_ids),
+                "active_action_request_count": len(
+                    readiness_aggregates.active_action_request_ids
+                ),
+                "active_action_execution_count": len(
+                    readiness_aggregates.active_action_execution_ids
+                ),
+                "unresolved_reconciliation_count": len(
+                    readiness_aggregates.unresolved_reconciliation_ids
+                ),
+            },
+            "subordinate_context": subordinate_context,
+            "commercial_claims": (),
+        }
+
+    @staticmethod
+    def _operator_subordinate_context_entry(
+        *,
+        state: str,
+        tracked_count: int,
+    ) -> dict[str, object]:
+        return {
+            "state": state,
+            "tracked_count": tracked_count,
+            "authority_mode": "non_authoritative",
+            "mainline_dependency": "non_blocking",
+        }
+
+    @staticmethod
+    def _operator_extension_entries(
+        optional_extensions: dict[str, object],
+    ) -> dict[str, dict[str, object]]:
+        extensions = optional_extensions.get("extensions")
+        if not isinstance(extensions, dict):
+            return {}
+        return {
+            str(extension_name): dict(extension)
+            for extension_name, extension in extensions.items()
+            if isinstance(extension, dict)
+        }
+
+    @staticmethod
+    def _operator_worst_state(states: Iterable[object]) -> str:
+        severity = {
+            "ready": 0,
+            "healthy": 0,
+            "not_applicable": 0,
+            "delayed": 1,
+            "degraded": 2,
+            "stale": 2,
+            "failed": 3,
+            "failing_closed": 3,
+            "frozen": 3,
+            "unknown": 3,
+        }
+        normalized_states = [
+            str(state)
+            for state in states
+            if isinstance(state, str) and state.strip()
+        ]
+        if not normalized_states:
+            return "unknown"
+        return max(
+            normalized_states,
+            key=lambda state: severity.get(state, severity["unknown"]),
         )
 
     def _control_plane_change_authority_freeze_status(self) -> dict[str, object]:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import copy
+from datetime import datetime, timedelta, timezone
 import pathlib
 import sys
 
@@ -12,6 +13,7 @@ if str(TESTS_ROOT) not in sys.path:
 import _service_persistence_support as support
 from _service_persistence_support import (
     AegisOpsControlPlaneService,
+    AITraceRecord,
     RuntimeConfig,
     ServicePersistenceTestBase,
 )

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -3861,6 +3861,90 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             },
         )
 
+    def test_service_phase493_operator_health_labels_optional_degradation_subordinate(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+            ),
+            store=store,
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-phase493-timeout-001",
+                subject_linkage={
+                    "provider_identity": "openai",
+                    "provider_status": "timeout",
+                    "provider_failure_summary": "attempt 1: timeout: provider timed out",
+                    "provider_operational_quality": {
+                        "availability": "unavailable",
+                        "posture": "timeout",
+                        "retry_policy": "retry_exhausted",
+                    },
+                },
+                model_identity="openai/gpt-5.4",
+                prompt_version="phase24-case-summary-v1",
+                generated_at=datetime(2026, 4, 29, 9, 0, tzinfo=timezone.utc),
+                material_input_refs=("case-001",),
+                reviewer_identity="system://bounded-live-assistant",
+                lifecycle_state="under_review",
+            )
+        )
+
+        readiness = service.inspect_readiness_diagnostics()
+        operator_health = readiness.metrics["operator_health"]
+
+        self.assertEqual(readiness.status, "ready")
+        self.assertEqual(operator_health["overall_state"], "degraded")
+        self.assertEqual(
+            operator_health["authority_source"],
+            "aegisops_control_plane_records",
+        )
+        self.assertEqual(
+            operator_health["subordinate_signal_policy"],
+            "visibility_only",
+        )
+        self.assertFalse(operator_health["subordinate_signals_authoritative"])
+        self.assertEqual(
+            operator_health["mainline"]["readiness_status"],
+            "ready",
+        )
+        self.assertEqual(operator_health["mainline"]["open_case_count"], 0)
+        self.assertEqual(
+            operator_health["mainline"]["active_action_request_count"],
+            0,
+        )
+        self.assertEqual(
+            operator_health["mainline"]["active_action_execution_count"],
+            0,
+        )
+        self.assertEqual(
+            operator_health["mainline"]["unresolved_reconciliation_count"],
+            0,
+        )
+        self.assertEqual(
+            operator_health["subordinate_context"]["optional_extensions"]["state"],
+            "degraded",
+        )
+        self.assertEqual(
+            operator_health["subordinate_context"]["optional_extensions"][
+                "authority_mode"
+            ],
+            "non_authoritative",
+        )
+        self.assertEqual(
+            operator_health["subordinate_context"]["optional_extensions"][
+                "degraded_extensions"
+            ],
+            ("assistant",),
+        )
+        self.assertEqual(operator_health["commercial_claims"], ())
+
     def test_service_phase21_readiness_source_health_ignores_predelegation_backlog(
         self,
     ) -> None:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -410,6 +410,8 @@ The operator health review contract is the reviewed business-hours cadence for d
 
 Each business day, operators must review `curl -fsS http://127.0.0.1:<proxy-port>/readyz`, `curl -fsS http://127.0.0.1:<proxy-port>/runtime`, the reviewed queue and alert surfaces, and any explicit degraded-state markers before treating the platform as ready for normal work.
 
+The readiness diagnostics `metrics.operator_health` block is the bounded commercial operator-health rollup for this review. It is derived from AegisOps control-plane records and labels source, automation substrate, and optional-extension signals as visibility-only subordinate context; it does not create an SLA claim or make subordinate health authoritative for case, action, approval, execution, or reconciliation lifecycle state.
+
 The reviewed queue lanes for action-required, reconciliation mismatch, stale receipt, optional-extension degraded, and clean states are visibility aids for this review. They do not make optional extension health, downstream receipts, or browser-rendered state authoritative for workflow closure.
 
 The daily review must classify each degraded condition as safe for continued business-hours inspection, requiring same-day follow-up, or requiring escalation before normal operation continues.


### PR DESCRIPTION
## Summary
- add a Phase 49 commercial operator-health rollup to readiness diagnostics
- label source, automation substrate, and optional-extension signals as visibility-only subordinate context
- document the new metrics.operator_health block in the runbook

Closes #936

## Verification
- python3 -m unittest control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_surfaces_source_and_automation_health control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase21_readiness_surfaces_optional_extension_operability_defaults control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_phase493_operator_health_labels_optional_degradation_subordinate control-plane.tests.test_phase30f_operator_ui_validation.Phase30FOperatorUiValidationTests.test_phase30f_readiness_exposes_assistant_provider_timeout_posture
- bash scripts/verify-runbook-doc.sh
- bash scripts/verify-publishable-path-hygiene.sh
- python3 -m compileall -q control-plane/aegisops_control_plane/restore_readiness_projection.py
- git diff --check
- node dist/index.js issue-lint 936 --config supervisor.config.aegisops.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced operator health metric to readiness diagnostics, providing visibility into overall system health status alongside existing readiness assessments.

* **Tests**
  * Added test coverage validating operator health metric behavior under various operational conditions.

* **Documentation**
  * Clarified that operator health metrics are for visibility purposes only and do not constitute SLA commitments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->