### PR TITLE
Phase 49.5: Add pilot executive summary export

### DIFF
--- a/control-plane/aegisops_control_plane/pilot_reporting_export.py
+++ b/control-plane/aegisops_control_plane/pilot_reporting_export.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections import Counter
+from contextlib import AbstractContextManager
+from dataclasses import fields
+from datetime import datetime
+from typing import Mapping, Protocol, Type, TypeVar
+
+from .audit_export import _redact_audit_export_value
+from .models import CaseRecord, ControlPlaneRecord, EvidenceRecord
+from .publishable_paths import is_workstation_local_path
+
+
+RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
+
+
+class PilotReportingExportStore(Protocol):
+    def list(self, record_type: Type[RecordT]) -> tuple[RecordT, ...]:
+        ...
+
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> AbstractContextManager[None]:
+        ...
+
+
+_UNSUPPORTED_PILOT_CLAIM_FRAGMENTS = (
+    "compliance certification is complete",
+    "compliance certified",
+    "sla is promised",
+    "sla guarantee",
+    "24x7 support is promised",
+    "autonomous response is approved",
+    "autonomous-response marketing",
+    "multi-customer rollout is approved",
+)
+_SECRET_LOOKING_KEY_FRAGMENTS = (
+    "api_key",
+    "authorization",
+    "credential",
+    "password",
+    "private_key",
+    "secret",
+    "token",
+)
+
+
+def _json_ready(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    return value
+
+
+def _record_to_dict(record: ControlPlaneRecord) -> dict[str, object]:
+    return {field.name: getattr(record, field.name) for field in fields(record)}
+
+
+def _validate_no_unsupported_pilot_claims(value: object) -> None:
+    if isinstance(value, str):
+        normalized = " ".join(value.lower().split())
+        if any(
+            fragment in normalized
+            for fragment in _UNSUPPORTED_PILOT_CLAIM_FRAGMENTS
+        ):
+            raise ValueError("unsupported pilot executive summary claim")
+        if is_workstation_local_path(value):
+            raise ValueError("workstation-local pilot executive summary path")
+        if any(
+            f"{fragment}:" in normalized or f"{fragment}=" in normalized
+            for fragment in _SECRET_LOOKING_KEY_FRAGMENTS
+        ):
+            raise ValueError("secret-looking pilot executive summary value")
+        return
+    if isinstance(value, Mapping):
+        for item in value.values():
+            _validate_no_unsupported_pilot_claims(item)
+        return
+    if isinstance(value, (tuple, list)):
+        for item in value:
+            _validate_no_unsupported_pilot_claims(item)
+
+
+def _case_matches_release(case: CaseRecord, release_identifier: str) -> bool:
+    return case.reviewed_context.get("pilot_release_identifier") == release_identifier
+
+
+def _subordinate_evidence_payload(evidence: EvidenceRecord) -> dict[str, object]:
+    return {
+        "authority_role": "subordinate_evidence",
+        "promotion_allowed": False,
+        "source_system": evidence.source_system,
+        "source_record_id": evidence.source_record_id,
+        "derivation_relationship": evidence.derivation_relationship,
+        "lifecycle_state": evidence.lifecycle_state,
+        "acquired_at": evidence.acquired_at.isoformat(),
+        "provenance": _redact_audit_export_value(evidence.provenance),
+        "content": _redact_audit_export_value(evidence.content),
+    }
+
+
+def _authoritative_case_payload(
+    case: CaseRecord,
+    *,
+    evidence_by_id: Mapping[str, EvidenceRecord],
+) -> dict[str, object]:
+    payload = {
+        key: _redact_audit_export_value(_json_ready(value), key=key)
+        for key, value in _record_to_dict(case).items()
+    }
+    payload["authority_role"] = "authoritative_control_plane_record"
+    payload["subordinate_evidence"] = [
+        _subordinate_evidence_payload(evidence_by_id[evidence_id])
+        for evidence_id in case.evidence_ids
+        if evidence_id in evidence_by_id
+    ]
+    return payload
+
+
+def export_pilot_executive_summary(
+    *,
+    store: PilotReportingExportStore,
+    export_id: str,
+    release_identifier: str,
+    exported_at: datetime,
+    executive_note: str | None = None,
+) -> dict[str, object]:
+    _validate_no_unsupported_pilot_claims(executive_note)
+
+    with store.transaction(isolation_level="REPEATABLE READ"):
+        evidence_by_id = {
+            evidence.evidence_id: evidence
+            for evidence in store.list(EvidenceRecord)
+        }
+        cases = tuple(
+            case
+            for case in store.list(CaseRecord)
+            if _case_matches_release(case, release_identifier)
+        )
+        case_payloads = [
+            _authoritative_case_payload(case, evidence_by_id=evidence_by_id)
+            for case in cases
+        ]
+
+    _validate_no_unsupported_pilot_claims(case_payloads)
+
+    return {
+        "schema_version": "phase49.5.pilot-summary.v1",
+        "export_id": export_id,
+        "release_identifier": release_identifier,
+        "exported_at": exported_at.isoformat(),
+        "source_of_truth": "aegisops_authoritative_records",
+        "executive_note": executive_note,
+        "claim_boundaries": {
+            "compliance_certification_claim": False,
+            "sla_guarantee_claim": False,
+            "autonomous_response_claim": False,
+            "customer_portal_claim": False,
+            "multi_tenant_reporting_claim": False,
+        },
+        "case_summary": {
+            "total_cases": len(cases),
+            "by_lifecycle_state": dict(
+                sorted(Counter(case.lifecycle_state for case in cases).items())
+            ),
+        },
+        "authoritative_records": {
+            "cases": case_payloads,
+        },
+        "subordinate_evidence_policy": {
+            "authority_role": "subordinate_evidence",
+            "promotion_allowed": False,
+            "label_required": True,
+        },
+    }

--- a/control-plane/aegisops_control_plane/pilot_reporting_export.py
+++ b/control-plane/aegisops_control_plane/pilot_reporting_export.py
@@ -132,6 +132,14 @@ def export_pilot_executive_summary(
     exported_at: datetime,
     executive_note: str | None = None,
 ) -> dict[str, object]:
+    if not isinstance(export_id, str) or export_id.strip() == "":
+        raise ValueError("export_id must be a non-empty string")
+    if not isinstance(release_identifier, str) or release_identifier.strip() == "":
+        raise ValueError("release_identifier must be a non-empty string")
+    if not isinstance(exported_at, datetime) or exported_at.tzinfo is None:
+        raise ValueError("exported_at must be a timezone-aware datetime")
+    export_id = export_id.strip()
+    release_identifier = release_identifier.strip()
     _validate_no_unsupported_pilot_claims(executive_note)
 
     with store.transaction(isolation_level="REPEATABLE READ"):

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -32,6 +32,7 @@ from .assistant_provider import (
     AssistantProviderTransport,
 )
 from .audit_export import export_audit_retention_baseline
+from .pilot_reporting_export import export_pilot_executive_summary
 from .assistant_advisory import AssistantAdvisoryCoordinator
 from .action_lifecycle_write_coordinator import ActionLifecycleWriteCoordinator
 from .action_reconciliation_orchestration import (
@@ -2199,6 +2200,31 @@ class AegisOpsControlPlaneService:
             record_types=AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES,
             export_id=export_id,
             exported_at=exported_at,
+        )
+
+    def export_pilot_executive_summary(
+        self,
+        *,
+        export_id: str,
+        release_identifier: str,
+        exported_at: datetime,
+        executive_note: str | None = None,
+    ) -> dict[str, object]:
+        export_id = self._require_non_empty_string(export_id, "export_id")
+        release_identifier = self._require_non_empty_string(
+            release_identifier,
+            "release_identifier",
+        )
+        exported_at = self._require_aware_datetime(
+            exported_at,
+            "exported_at",
+        )
+        return export_pilot_executive_summary(
+            store=self._store,
+            export_id=export_id,
+            release_identifier=release_identifier,
+            exported_at=exported_at,
+            executive_note=executive_note,
         )
 
     def describe_startup_status(self) -> StartupStatusSnapshot:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -32,7 +32,6 @@ from .assistant_provider import (
     AssistantProviderTransport,
 )
 from .audit_export import export_audit_retention_baseline
-from .pilot_reporting_export import export_pilot_executive_summary
 from .assistant_advisory import AssistantAdvisoryCoordinator
 from .action_lifecycle_write_coordinator import ActionLifecycleWriteCoordinator
 from .action_reconciliation_orchestration import (
@@ -2200,31 +2199,6 @@ class AegisOpsControlPlaneService:
             record_types=AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES,
             export_id=export_id,
             exported_at=exported_at,
-        )
-
-    def export_pilot_executive_summary(
-        self,
-        *,
-        export_id: str,
-        release_identifier: str,
-        exported_at: datetime,
-        executive_note: str | None = None,
-    ) -> dict[str, object]:
-        export_id = self._require_non_empty_string(export_id, "export_id")
-        release_identifier = self._require_non_empty_string(
-            release_identifier,
-            "release_identifier",
-        )
-        exported_at = self._require_aware_datetime(
-            exported_at,
-            "exported_at",
-        )
-        return export_pilot_executive_summary(
-            store=self._store,
-            export_id=export_id,
-            release_identifier=release_identifier,
-            exported_at=exported_at,
-            executive_note=executive_note,
         )
 
     def describe_startup_status(self) -> StartupStatusSnapshot:

--- a/control-plane/tests/test_phase49_5_pilot_reporting_export.py
+++ b/control-plane/tests/test_phase49_5_pilot_reporting_export.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import pathlib
+import sys
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+
+from aegisops_control_plane.config import RuntimeConfig
+from aegisops_control_plane.models import CaseRecord, EvidenceRecord
+from aegisops_control_plane.service import AegisOpsControlPlaneService
+from postgres_test_support import make_store
+
+
+LOCAL_EXPORT_PATH = (
+    "/Users/alice/aegisops/pilot-summary.json"  # publishable-path-hygiene: allowlist
+)
+
+
+class Phase495PilotReportingExportTests(unittest.TestCase):
+    def test_executive_summary_derives_authoritative_records_and_labels_subordinate_evidence(
+        self,
+    ) -> None:
+        store, backend = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        exported_at = datetime(2026, 4, 29, 3, 20, tzinfo=timezone.utc)
+        evidence_acquired_at = datetime(2026, 4, 29, 3, 10, tzinfo=timezone.utc)
+
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-pilot-summary-1",
+                source_record_id="native-pilot-summary-1",
+                alert_id="alert-pilot-summary-1",
+                case_id="case-pilot-summary-1",
+                source_system="zammad",
+                collector_identity="collector://zammad/reviewed-export",
+                acquired_at=evidence_acquired_at,
+                derivation_relationship="coordination_context",
+                lifecycle_state="collected",
+                provenance={
+                    "ticket_url": "https://tickets.example.invalid/123",
+                    "workspace_path": LOCAL_EXPORT_PATH,
+                },
+                content={
+                    "coordination_summary": "customer ticket confirms contact",
+                    "api_token": "live-token-must-not-export",
+                },
+            ),
+            transitioned_at=evidence_acquired_at,
+        )
+        service.persist_record(
+            CaseRecord(
+                case_id="case-pilot-summary-1",
+                alert_id="alert-pilot-summary-1",
+                finding_id="finding-pilot-summary-1",
+                evidence_ids=("evidence-pilot-summary-1",),
+                lifecycle_state="pending_action",
+                reviewed_context={
+                    "pilot_release_identifier": (
+                        "aegisops-single-customer-pilot-2026-04-27-c4527e5"
+                    ),
+                    "operator_summary": "Reviewed case remains bounded.",
+                },
+            ),
+            transitioned_at=exported_at,
+        )
+
+        export = service.export_pilot_executive_summary(
+            export_id="pilot-exec-summary-phase49-5",
+            release_identifier="aegisops-single-customer-pilot-2026-04-27-c4527e5",
+            exported_at=exported_at,
+        )
+
+        self.assertEqual(export["schema_version"], "phase49.5.pilot-summary.v1")
+        self.assertEqual(export["source_of_truth"], "aegisops_authoritative_records")
+        self.assertEqual(
+            export["claim_boundaries"],
+            {
+                "compliance_certification_claim": False,
+                "sla_guarantee_claim": False,
+                "autonomous_response_claim": False,
+                "customer_portal_claim": False,
+                "multi_tenant_reporting_claim": False,
+            },
+        )
+        self.assertEqual(export["case_summary"]["total_cases"], 1)
+        self.assertEqual(export["case_summary"]["by_lifecycle_state"], {"pending_action": 1})
+        self.assertEqual(
+            export["subordinate_evidence_policy"],
+            {
+                "authority_role": "subordinate_evidence",
+                "promotion_allowed": False,
+                "label_required": True,
+            },
+        )
+
+        case = export["authoritative_records"]["cases"][0]
+        self.assertEqual(case["case_id"], "case-pilot-summary-1")
+        self.assertEqual(case["authority_role"], "authoritative_control_plane_record")
+        subordinate = case["subordinate_evidence"][0]
+        self.assertEqual(subordinate["authority_role"], "subordinate_evidence")
+        self.assertFalse(subordinate["promotion_allowed"])
+        self.assertEqual(subordinate["source_system"], "zammad")
+        self.assertEqual(subordinate["content"]["api_token"], "<redacted-secret>")
+        self.assertEqual(
+            subordinate["provenance"]["workspace_path"],
+            "<redacted-local-path>",
+        )
+
+        serialized = json.dumps(export, sort_keys=True)
+        self.assertNotIn("live-token-must-not-export", serialized)
+        self.assertNotIn(LOCAL_EXPORT_PATH, serialized)
+        self.assertNotIn("SLA is promised", serialized)
+
+        self.assertTrue(
+            any(
+                statement.startswith("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+                for statement, _params in backend.statements
+            ),
+            "pilot executive summary export must read one authoritative snapshot",
+        )
+
+    def test_executive_summary_rejects_unsupported_customer_facing_claims(self) -> None:
+        store, backend = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        exported_at = datetime(2026, 4, 29, 3, 45, tzinfo=timezone.utc)
+
+        for claim, expected in (
+            (
+                "Compliance certification is complete.",
+                "unsupported pilot executive summary claim",
+            ),
+            (
+                "SLA is promised for 24x7 response.",
+                "unsupported pilot executive summary claim",
+            ),
+            (
+                "Autonomous response is approved for production.",
+                "unsupported pilot executive summary claim",
+            ),
+            (
+                "Token: abc123 must not appear in the executive export.",
+                "secret-looking pilot executive summary value",
+            ),
+            (
+                f"Review the local export at {LOCAL_EXPORT_PATH}.",
+                "workstation-local pilot executive summary path",
+            ),
+        ):
+            with self.subTest(claim=claim):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    expected,
+                ):
+                    service.export_pilot_executive_summary(
+                        export_id="pilot-exec-summary-phase49-5",
+                        release_identifier=(
+                            "aegisops-single-customer-pilot-2026-04-27-c4527e5"
+                        ),
+                        exported_at=exported_at,
+                        executive_note=claim,
+                    )
+
+        self.assertFalse(
+            any(
+                statement.startswith("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+                for statement, _params in backend.statements
+            ),
+            "invalid executive notes must be rejected before the export snapshot opens",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase49_5_pilot_reporting_export.py
+++ b/control-plane/tests/test_phase49_5_pilot_reporting_export.py
@@ -14,6 +14,9 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 
 from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.models import CaseRecord, EvidenceRecord
+from aegisops_control_plane.pilot_reporting_export import (
+    export_pilot_executive_summary,
+)
 from aegisops_control_plane.service import AegisOpsControlPlaneService
 from postgres_test_support import make_store
 
@@ -74,7 +77,8 @@ class Phase495PilotReportingExportTests(unittest.TestCase):
             transitioned_at=exported_at,
         )
 
-        export = service.export_pilot_executive_summary(
+        export = export_pilot_executive_summary(
+            store=store,
             export_id="pilot-exec-summary-phase49-5",
             release_identifier="aegisops-single-customer-pilot-2026-04-27-c4527e5",
             exported_at=exported_at,
@@ -164,7 +168,8 @@ class Phase495PilotReportingExportTests(unittest.TestCase):
                     ValueError,
                     expected,
                 ):
-                    service.export_pilot_executive_summary(
+                    export_pilot_executive_summary(
+                        store=store,
                         export_id="pilot-exec-summary-phase49-5",
                         release_identifier=(
                             "aegisops-single-customer-pilot-2026-04-27-c4527e5"

--- a/control-plane/tests/test_phase49_5_pilot_reporting_export_docs.py
+++ b/control-plane/tests/test_phase49_5_pilot_reporting_export_docs.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase495PilotReportingExportDocsTests(unittest.TestCase):
+    def test_phase49_5_validation_doc_records_bounded_export_contract(self) -> None:
+        path = (
+            REPO_ROOT
+            / "docs/phase-49-5-pilot-reporting-executive-summary-export-validation.md"
+        )
+        text = path.read_text(encoding="utf-8")
+
+        for term in (
+            "Phase 49.5 Pilot Reporting and Executive Summary Export Validation",
+            "Validation status: PASS",
+            "export_pilot_executive_summary",
+            "control-plane/aegisops_control_plane/pilot_reporting_export.py",
+            "AegisOps authoritative case records",
+            "explicit reviewed pilot release identifier",
+            "one repeatable-read snapshot",
+            "subordinate_evidence",
+            "promotion_allowed: false",
+            "do not become workflow truth",
+            "compliance certification",
+            "SLA guarantees",
+            "autonomous response",
+            "customer portal availability",
+            "multi-tenant reporting",
+            "fail closed",
+            "secret-looking",
+            "workstation-local path",
+            "python3 -m unittest control-plane/tests/test_phase49_5_pilot_reporting_export.py",
+            "bash scripts/verify-publishable-path-hygiene.sh",
+            "No runtime authority, approval, execution, reconciliation, ticket, assistant, optional-extension, or production write behavior changes are introduced by this export.",
+        ):
+            self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-49-5-pilot-reporting-executive-summary-export-validation.md
+++ b/docs/phase-49-5-pilot-reporting-executive-summary-export-validation.md
@@ -2,7 +2,7 @@
 
 Validation status: PASS
 
-This document records the bounded Phase 49.5 pilot reporting export baseline. The implemented artifact is the `export_pilot_executive_summary` service boundary in `control-plane/aegisops_control_plane/pilot_reporting_export.py`.
+This document records the bounded Phase 49.5 pilot reporting export baseline. The implemented artifact is the `export_pilot_executive_summary` report/export boundary in `control-plane/aegisops_control_plane/pilot_reporting_export.py`.
 
 The export derives its customer-facing summary from AegisOps authoritative case records selected by an explicit reviewed pilot release identifier. It reads the selected case records and linked evidence in one repeatable-read snapshot, so the summary does not stitch together mixed lifecycle views from different points in time.
 

--- a/docs/phase-49-5-pilot-reporting-executive-summary-export-validation.md
+++ b/docs/phase-49-5-pilot-reporting-executive-summary-export-validation.md
@@ -1,0 +1,15 @@
+# Phase 49.5 Pilot Reporting and Executive Summary Export Validation
+
+Validation status: PASS
+
+This document records the bounded Phase 49.5 pilot reporting export baseline. The implemented artifact is the `export_pilot_executive_summary` service boundary in `control-plane/aegisops_control_plane/pilot_reporting_export.py`.
+
+The export derives its customer-facing summary from AegisOps authoritative case records selected by an explicit reviewed pilot release identifier. It reads the selected case records and linked evidence in one repeatable-read snapshot, so the summary does not stitch together mixed lifecycle views from different points in time.
+
+Subordinate evidence remains labeled as `subordinate_evidence`, is marked `promotion_allowed: false`, and is attached only to the directly linked authoritative case record. Zammad, assistant output, downstream receipts, ML shadow observations, optional endpoint evidence, optional network evidence, browser state, and optional extension health do not become workflow truth through this export.
+
+The export intentionally sets bounded claim flags for compliance certification, SLA guarantees, autonomous response, customer portal availability, and multi-tenant reporting to false. Executive notes fail closed when they contain unsupported compliance, SLA, autonomous-response, secret-looking, or workstation-local path wording.
+
+Secrets and workstation-local paths from subordinate evidence are redacted before export. The focused regression coverage is `python3 -m unittest control-plane/tests/test_phase49_5_pilot_reporting_export.py`, and publishable path hygiene remains covered by `bash scripts/verify-publishable-path-hygiene.sh`.
+
+No runtime authority, approval, execution, reconciliation, ticket, assistant, optional-extension, or production write behavior changes are introduced by this export.


### PR DESCRIPTION
## Summary
- add a bounded pilot executive summary export derived from authoritative case records
- label directly linked evidence as subordinate and redact secret/path leakage
- document the Phase 49.5 export contract and focused validation

## Verification
- python3 -m unittest control-plane/tests/test_phase49_5_pilot_reporting_export.py control-plane/tests/test_phase49_5_pilot_reporting_export_docs.py
- python3 -m unittest control-plane/tests/test_phase49_audit_export_retention_baseline.py control-plane/tests/test_phase49_5_pilot_reporting_export.py control-plane/tests/test_phase49_5_pilot_reporting_export_docs.py
- bash scripts/verify-publishable-path-hygiene.sh
- git diff --check
- node <codex-supervisor-root>/dist/index.js issue-lint 938 --config <supervisor-config-path>

Closes #938

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pilot reporting executive summary export capability with comprehensive input validation, automatic redaction of sensitive information, and structured output containing export metadata and case lifecycle summaries.

* **Tests**
  * Added comprehensive validation tests for export functionality, sensitivity redaction behavior, and documentation compliance verification.

* **Documentation**
  * Added Phase 49.5 pilot reporting export validation guide documenting export contract, compliance requirements, and supported behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->