### PR TITLE
Phase 50.2 slim control-plane service composition

### DIFF
--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -104,7 +104,7 @@ class DetectionIntakeService:
                     f"Alert {alert_id!r} references missing case {resolved_case_id!r}"
                 )
 
-            evidence_records = service._list_alert_evidence_records(
+            evidence_records = self._list_alert_evidence_records(
                 alert_id=alert.alert_id,
                 case_id=resolved_case_id,
             )
@@ -199,11 +199,11 @@ class DetectionIntakeService:
                 )
             )
             if promoted_alert.analytic_signal_id is not None:
-                service._link_case_to_analytic_signals(
+                self._link_case_to_analytic_signals(
                     (promoted_alert.analytic_signal_id,),
                     promoted_case.case_id,
                 )
-            service._link_case_to_alert_reconciliations(
+            self._link_case_to_alert_reconciliations(
                 alert_id=promoted_alert.alert_id,
                 case_id=promoted_case.case_id,
                 evidence_ids=merged_evidence_ids,
@@ -513,7 +513,7 @@ class DetectionIntakeService:
                     )
                 )
 
-            service._link_case_to_analytic_signals(linked_signal_ids, alert.case_id)
+            self._link_case_to_analytic_signals(linked_signal_ids, alert.case_id)
 
             subject_linkage = (
                 dict(latest_reconciliation.subject_linkage)
@@ -736,6 +736,113 @@ class DetectionIntakeService:
         if parsed.tzinfo is None or parsed.utcoffset() is None:
             return None
         return parsed
+
+    def _link_case_to_analytic_signals(
+        self,
+        analytic_signal_ids: tuple[str, ...],
+        case_id: str | None,
+    ) -> None:
+        if case_id is None:
+            return
+
+        service = self._service
+        for analytic_signal_id in analytic_signal_ids:
+            existing_signal = service._store.get(
+                AnalyticSignalRecord,
+                analytic_signal_id,
+            )
+            if existing_signal is None:
+                continue
+            linked_case_ids = service._merge_linked_ids(
+                existing_signal.case_ids,
+                case_id,
+            )
+            if linked_case_ids == existing_signal.case_ids:
+                continue
+            service.persist_record(
+                AnalyticSignalRecord(
+                    analytic_signal_id=existing_signal.analytic_signal_id,
+                    substrate_detection_record_id=(
+                        existing_signal.substrate_detection_record_id
+                    ),
+                    finding_id=existing_signal.finding_id,
+                    alert_ids=existing_signal.alert_ids,
+                    case_ids=linked_case_ids,
+                    correlation_key=existing_signal.correlation_key,
+                    first_seen_at=existing_signal.first_seen_at,
+                    last_seen_at=existing_signal.last_seen_at,
+                    lifecycle_state=existing_signal.lifecycle_state,
+                    reviewed_context=existing_signal.reviewed_context,
+                )
+            )
+
+    def _list_alert_evidence_records(
+        self,
+        *,
+        alert_id: str,
+        case_id: str | None,
+    ) -> tuple[EvidenceRecord, ...]:
+        evidence_records: list[EvidenceRecord] = []
+        for evidence in self._service._store.list(EvidenceRecord):
+            if evidence.alert_id == alert_id or (
+                case_id is not None and evidence.case_id == case_id
+            ):
+                evidence_records.append(evidence)
+        return tuple(evidence_records)
+
+    def _link_case_to_alert_reconciliations(
+        self,
+        *,
+        alert_id: str,
+        case_id: str,
+        evidence_ids: tuple[str, ...],
+    ) -> None:
+        service = self._service
+        for reconciliation in service._store.list(ReconciliationRecord):
+            if reconciliation.alert_id != alert_id:
+                continue
+            subject_linkage = dict(reconciliation.subject_linkage)
+            updated_case_ids = service._merge_linked_ids(
+                subject_linkage.get("case_ids"),
+                case_id,
+            )
+            updated_evidence_ids = service._merge_linked_ids(
+                subject_linkage.get("evidence_ids"),
+                None,
+            )
+            for evidence_id in evidence_ids:
+                updated_evidence_ids = service._merge_linked_ids(
+                    updated_evidence_ids,
+                    evidence_id,
+                )
+            if (
+                tuple(subject_linkage.get("case_ids", ())) == updated_case_ids
+                and tuple(subject_linkage.get("evidence_ids", ()))
+                == updated_evidence_ids
+            ):
+                continue
+            subject_linkage["case_ids"] = updated_case_ids
+            subject_linkage["evidence_ids"] = updated_evidence_ids
+            service.persist_record(
+                ReconciliationRecord(
+                    reconciliation_id=reconciliation.reconciliation_id,
+                    subject_linkage=subject_linkage,
+                    alert_id=reconciliation.alert_id,
+                    finding_id=reconciliation.finding_id,
+                    analytic_signal_id=reconciliation.analytic_signal_id,
+                    execution_run_id=reconciliation.execution_run_id,
+                    linked_execution_run_ids=(
+                        reconciliation.linked_execution_run_ids
+                    ),
+                    correlation_key=reconciliation.correlation_key,
+                    first_seen_at=reconciliation.first_seen_at,
+                    last_seen_at=reconciliation.last_seen_at,
+                    ingest_disposition=reconciliation.ingest_disposition,
+                    mismatch_summary=reconciliation.mismatch_summary,
+                    compared_at=reconciliation.compared_at,
+                    lifecycle_state=reconciliation.lifecycle_state,
+                )
+            )
 
     def triage_disposition_matches_current_state(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1338,7 +1338,9 @@ class AegisOpsControlPlaneService:
                 ),
                 live_assistant_snapshot_factory=_phase24_live_assistant_snapshot,
                 live_assistant_citations_from_context=(
-                    _phase24_live_assistant_citations_from_context
+                    lambda snapshot: _phase24_live_assistant_citations_from_context(
+                        snapshot
+                    )
                 ),
                 live_assistant_unresolved_reasons=(
                     _phase24_live_assistant_unresolved_reasons

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -16,38 +16,14 @@ from typing import Iterable, Iterator, Mapping, Protocol, Type, TypeVar
 _DATETIME_TYPE = datetime
 
 from . import action_review_projection as _action_review_projection
-from .adapters.executor import IsolatedExecutorAdapter
-from .adapters.endpoint_evidence import EndpointEvidencePackAdapter
-from .adapters.misp import MispContextAdapter
-from .adapters.n8n import N8NReconciliationAdapter
-from .adapters.osquery import OsqueryHostContextAdapter
-from .adapters.postgres import PostgresControlPlaneStore
-from .adapters.shuffle import ShuffleActionAdapter
 from .adapters.wazuh import WazuhAlertAdapter
-from .ai_trace_lifecycle import AITraceLifecycleService
 from .assistant_provider import (
-    AssistantProviderAdapter,
     AssistantProviderFailure,
     AssistantProviderResult,
     AssistantProviderTransport,
 )
 from .audit_export import export_audit_retention_baseline
-from .assistant_advisory import AssistantAdvisoryCoordinator
-from .action_lifecycle_write_coordinator import ActionLifecycleWriteCoordinator
-from .action_reconciliation_orchestration import (
-    ActionOrchestrationBoundary,
-    ReconciliationOrchestrationBoundary,
-)
-from .action_review_write_surface import ActionReviewWriteSurface
-from .case_workflow import CaseWorkflowService
 from .config import OpenBaoKVv2SecretTransport, RuntimeConfig
-from .execution_coordinator import (
-    ExecutionCoordinator,
-    _approved_payload_binding_hash,
-)
-from .evidence_linkage import EvidenceLinkageService
-from .external_evidence_boundary import ExternalEvidenceBoundary
-from .live_assistant_workflow import LiveAssistantWorkflowCoordinator
 from .models import (
     AITraceRecord,
     ActionExecutionRecord,
@@ -69,28 +45,22 @@ from .models import (
     ReconciliationRecord,
     RecommendationRecord,
 )
-from .operator_inspection import OperatorInspectionReadSurface
 from .readiness_contracts import (
     ReadinessDiagnosticsAggregates,
     ReadinessReviewPathRecords,
     resolve_current_readiness_runtime_status,
 )
-from .restore_readiness import RestoreReadinessService
 from .runtime_boundary import RuntimeBoundaryService, _is_missing_runtime_binding
-from .runtime_restore_readiness_diagnostics import (
-    RuntimeRestoreReadinessDiagnosticsService,
-)
-from .assistant_context import (
-    AssistantContextAssembler,
-    _advisory_text_claims_authority_or_scope_expansion,
-)
-from .detection_lifecycle import DetectionIntakeService
 from .reviewed_slice_policy import (
     REVIEWED_LIVE_SLICE_LABEL,
     REVIEWED_LIVE_SOURCE_FAMILIES,
     ReviewedSlicePolicy,
 )
 from .action_review_projection import _ActionReviewRecordIndex
+from .service_composition import (
+    ControlPlaneServiceCompositionDependencies,
+    build_control_plane_service_composition,
+)
 
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
@@ -1323,175 +1293,110 @@ class AegisOpsControlPlaneService:
         store: ControlPlaneStore | None = None,
     ) -> None:
         self._config = config
-        self._store = store or PostgresControlPlaneStore(config.postgres_dsn)
-        self._reconciliation = N8NReconciliationAdapter(config.n8n_base_url)
-        self._shuffle = ShuffleActionAdapter(config.shuffle_base_url)
-        self._isolated_executor = IsolatedExecutorAdapter(
-            config.isolated_executor_base_url
-        )
         self._logger = logging.getLogger("aegisops.control_plane")
-        self._assistant_provider_adapter = AssistantProviderAdapter(
-            provider_identity="reviewed_local",
-            model_identity="bounded_reviewed_summary",
-            prompt_version=_PHASE24_WORKFLOW_PROMPT_VERSIONS["case_summary"],
-            request_timeout_seconds=5.0,
-            max_attempts=1,
-            transport=_ReviewedSummaryTransport(),
-        )
-        self._reviewed_slice_policy = ReviewedSlicePolicy(
-            self,
-            normalize_admission_provenance=_normalize_admission_provenance,
-        )
-        self._ai_trace_lifecycle_service = AITraceLifecycleService(self._store)
-        self._assistant_context_assembler = AssistantContextAssembler(
-            self,
-            record_types_by_family=RECORD_TYPES_BY_FAMILY,
-            record_to_dict=_record_to_dict,
-            merge_reviewed_context=_merge_reviewed_context,
-            assistant_context_snapshot_factory=AnalystAssistantContextSnapshot,
-            advisory_snapshot_from_context=_advisory_inspection_snapshot_from_context,
-            recommendation_draft_snapshot_from_context=(
-                _recommendation_draft_snapshot_from_context
-            ),
-            ai_trace_lifecycle=self._ai_trace_lifecycle_service,
-        )
-        self._assistant_advisory_coordinator = AssistantAdvisoryCoordinator(
-            self._assistant_context_assembler
-        )
-        self._live_assistant_workflow_coordinator = LiveAssistantWorkflowCoordinator(
-            self,
-            workflow_family=_PHASE24_WORKFLOW_FAMILY,
-            workflow_prompt_versions=_PHASE24_WORKFLOW_PROMPT_VERSIONS,
-            json_ready=lambda value: _json_ready(value),
-            dedupe_strings=lambda values: _dedupe_strings(values),
-            advisory_scope_expansion_flags=(
-                lambda text: _advisory_text_claims_authority_or_scope_expansion(text)
-            ),
-            snapshot_factory=lambda **kwargs: _phase24_live_assistant_snapshot(**kwargs),
-            citations_from_context=(
-                lambda snapshot: _phase24_live_assistant_citations_from_context(snapshot)
-            ),
-            unresolved_reasons_from_flags=(
-                lambda flags: _phase24_live_assistant_unresolved_reasons(flags)
-            ),
-            prompt_injection_flags=(
-                lambda text: _phase24_live_assistant_prompt_injection_flags(text)
-            ),
-            ai_trace_lifecycle=self._ai_trace_lifecycle_service,
-        )
-        self._operator_inspection_read_surface = OperatorInspectionReadSurface(
-            self,
-            analyst_queue_snapshot_factory=AnalystQueueSnapshot,
-            alert_detail_snapshot_factory=AlertDetailSnapshot,
-            case_detail_snapshot_factory=CaseDetailSnapshot,
-            action_review_detail_snapshot_factory=ActionReviewDetailSnapshot,
-            record_to_dict=_record_to_dict,
-            redacted_reconciliation_payload=_redacted_reconciliation_payload,
-            normalize_admission_provenance=_normalize_admission_provenance,
-            coordination_reference_payload=_coordination_reference_payload,
-            coordination_reference_signature=_coordination_reference_signature,
-            dedupe_strings=_dedupe_strings,
-        )
-        self._action_review_write_surface = ActionReviewWriteSurface(self)
-        self._evidence_linkage_service = EvidenceLinkageService(
-            store=self._store,
-            require_non_empty_string=self._require_non_empty_string,
-            merge_linked_ids=self._merge_linked_ids,
-        )
-        self._case_workflow_service = CaseWorkflowService(
-            self,
-            evidence_linkage_service=self._evidence_linkage_service,
-            merge_reviewed_context=_merge_reviewed_context,
-        )
-        self._detection_intake_service = DetectionIntakeService(
-            self,
-            merge_reviewed_context=_merge_reviewed_context,
-            normalize_admission_provenance=_normalize_admission_provenance,
-            case_lifecycle_state_by_triage_disposition=(
-                _CASE_LIFECYCLE_STATE_BY_TRIAGE_DISPOSITION
+        composition = build_control_plane_service_composition(
+            service=self,
+            config=config,
+            store=store,
+            dependencies=ControlPlaneServiceCompositionDependencies(
+                runtime_snapshot_factory=RuntimeSnapshot,
+                authenticated_principal_factory=AuthenticatedRuntimePrincipal,
+                reviewed_summary_transport_factory=_ReviewedSummaryTransport,
+                workflow_family=_PHASE24_WORKFLOW_FAMILY,
+                workflow_prompt_versions=_PHASE24_WORKFLOW_PROMPT_VERSIONS,
+                record_types_by_family=RECORD_TYPES_BY_FAMILY,
+                authoritative_record_chain_record_types=(
+                    AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES
+                ),
+                authoritative_record_chain_backup_schema_version=(
+                    AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION
+                ),
+                authoritative_primary_id_field_by_family=(
+                    _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY
+                ),
+                normalize_admission_provenance=_normalize_admission_provenance,
+                merge_reviewed_context=_merge_reviewed_context,
+                case_lifecycle_state_by_triage_disposition=(
+                    _CASE_LIFECYCLE_STATE_BY_TRIAGE_DISPOSITION
+                ),
+                record_to_dict=_record_to_dict,
+                json_ready=_json_ready,
+                redacted_reconciliation_payload=_redacted_reconciliation_payload,
+                coordination_reference_payload=_coordination_reference_payload,
+                coordination_reference_signature=_coordination_reference_signature,
+                dedupe_strings=_dedupe_strings,
+                analyst_queue_snapshot_factory=AnalystQueueSnapshot,
+                alert_detail_snapshot_factory=AlertDetailSnapshot,
+                case_detail_snapshot_factory=CaseDetailSnapshot,
+                action_review_detail_snapshot_factory=ActionReviewDetailSnapshot,
+                assistant_context_snapshot_factory=AnalystAssistantContextSnapshot,
+                advisory_snapshot_from_context=(
+                    _advisory_inspection_snapshot_from_context
+                ),
+                recommendation_draft_snapshot_from_context=(
+                    _recommendation_draft_snapshot_from_context
+                ),
+                live_assistant_snapshot_factory=_phase24_live_assistant_snapshot,
+                live_assistant_citations_from_context=(
+                    _phase24_live_assistant_citations_from_context
+                ),
+                live_assistant_unresolved_reasons=(
+                    _phase24_live_assistant_unresolved_reasons
+                ),
+                live_assistant_prompt_injection_flags=(
+                    _phase24_live_assistant_prompt_injection_flags
+                ),
+                startup_status_snapshot_factory=StartupStatusSnapshot,
+                readiness_diagnostics_snapshot_factory=ReadinessDiagnosticsSnapshot,
+                restore_drill_snapshot_factory=RestoreDrillSnapshot,
+                restore_summary_snapshot_factory=RestoreSummarySnapshot,
+                build_shutdown_status_snapshot=_build_shutdown_status_snapshot,
+                derive_readiness_status=_derive_readiness_status,
+                record_from_backup_payload=_record_from_backup_payload,
+                find_duplicate_strings=_find_duplicate_strings,
             ),
         )
-        self._execution_coordinator = ExecutionCoordinator(self)
-        self._action_orchestration_boundary = ActionOrchestrationBoundary(self)
-        self._reconciliation_orchestration_boundary = ReconciliationOrchestrationBoundary(
-            self
+        self._store = composition.store
+        self._reconciliation = composition.reconciliation
+        self._shuffle = composition.shuffle
+        self._isolated_executor = composition.isolated_executor
+        self._assistant_provider_adapter = composition.assistant_provider_adapter
+        self._reviewed_slice_policy = composition.reviewed_slice_policy
+        self._ai_trace_lifecycle_service = composition.ai_trace_lifecycle_service
+        self._assistant_context_assembler = composition.assistant_context_assembler
+        self._assistant_advisory_coordinator = (
+            composition.assistant_advisory_coordinator
         )
-        self._action_lifecycle_write_coordinator = ActionLifecycleWriteCoordinator(
-            self,
-            action_orchestration_boundary=self._action_orchestration_boundary,
-            reconciliation_orchestration_boundary=self._reconciliation_orchestration_boundary,
+        self._live_assistant_workflow_coordinator = (
+            composition.live_assistant_workflow_coordinator
         )
-        self._endpoint_evidence_pack_adapter = EndpointEvidencePackAdapter()
-        self._misp_context_adapter = MispContextAdapter(
-            enabled=config.misp_enrichment_enabled
+        self._operator_inspection_read_surface = (
+            composition.operator_inspection_read_surface
         )
-        self._external_evidence_boundary = ExternalEvidenceBoundary(self)
-        self._osquery_host_context_adapter = OsqueryHostContextAdapter()
-        self._runtime_boundary_service = RuntimeBoundaryService(
-            config=self._config,
-            store=self._store,
-            reconciliation_adapter=self._reconciliation,
-            shuffle_adapter=self._shuffle,
-            isolated_executor_adapter=self._isolated_executor,
-            runtime_snapshot_factory=RuntimeSnapshot,
-            authenticated_principal_factory=AuthenticatedRuntimePrincipal,
+        self._action_review_write_surface = composition.action_review_write_surface
+        self._evidence_linkage_service = composition.evidence_linkage_service
+        self._case_workflow_service = composition.case_workflow_service
+        self._detection_intake_service = composition.detection_intake_service
+        self._execution_coordinator = composition.execution_coordinator
+        self._action_orchestration_boundary = (
+            composition.action_orchestration_boundary
         )
-        self._restore_readiness_service = RestoreReadinessService(
-            config=self._config,
-            store=self._store,
-            runtime_boundary_service=self._runtime_boundary_service,
-            startup_status_snapshot_factory=StartupStatusSnapshot,
-            readiness_diagnostics_snapshot_factory=ReadinessDiagnosticsSnapshot,
-            restore_drill_snapshot_factory=RestoreDrillSnapshot,
-            restore_summary_snapshot_factory=RestoreSummarySnapshot,
-            record_to_dict=_record_to_dict,
-            json_ready=_json_ready,
-            redacted_reconciliation_payload=_redacted_reconciliation_payload,
-            collect_readiness_review_snapshots=self._collect_readiness_review_snapshots,
-            build_readiness_review_path_health=self._build_readiness_review_path_health,
-            build_readiness_source_health=self._build_readiness_source_health,
-            build_readiness_automation_substrate_health=(
-                self._build_readiness_automation_substrate_health
-            ),
-            build_optional_extension_operability=(
-                self._build_optional_extension_operability
-            ),
-            build_shutdown_status_snapshot=_build_shutdown_status_snapshot,
-            derive_readiness_status=_derive_readiness_status,
-            record_from_backup_payload=_record_from_backup_payload,
-            authoritative_record_chain_record_types=(
-                AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES
-            ),
-            authoritative_record_chain_backup_schema_version=(
-                AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION
-            ),
-            authoritative_primary_id_field_by_family=(
-                _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY
-            ),
-            record_types_by_family=RECORD_TYPES_BY_FAMILY,
-            find_duplicate_strings=_find_duplicate_strings,
-            synthesize_lifecycle_transition_record=(
-                lambda record, initial_transitioned_at_fallback=None: self._build_lifecycle_transition_record(
-                    record,
-                    existing_record=None,
-                    initial_transitioned_at_fallback=initial_transitioned_at_fallback,
-                )
-            ),
-            assistant_ids_from_mapping=self._assistant_ids_from_mapping,
-            inspect_case_detail=lambda case_id: self.inspect_case_detail(case_id),
-            inspect_assistant_context=(
-                lambda record_family, record_id: self.inspect_assistant_context(
-                    record_family,
-                    record_id,
-                )
-            ),
-            inspect_reconciliation_status=lambda: self.inspect_reconciliation_status(),
+        self._reconciliation_orchestration_boundary = (
+            composition.reconciliation_orchestration_boundary
         )
+        self._action_lifecycle_write_coordinator = (
+            composition.action_lifecycle_write_coordinator
+        )
+        self._endpoint_evidence_pack_adapter = (
+            composition.endpoint_evidence_pack_adapter
+        )
+        self._misp_context_adapter = composition.misp_context_adapter
+        self._external_evidence_boundary = composition.external_evidence_boundary
+        self._osquery_host_context_adapter = composition.osquery_host_context_adapter
+        self._runtime_boundary_service = composition.runtime_boundary_service
+        self._restore_readiness_service = composition.restore_readiness_service
         self._runtime_restore_readiness_diagnostics_service = (
-            RuntimeRestoreReadinessDiagnosticsService(
-                runtime_boundary_service=self._runtime_boundary_service,
-                restore_readiness_service=self._restore_readiness_service,
-            )
+            composition.runtime_restore_readiness_diagnostics_service
         )
 
     def describe_runtime(self) -> RuntimeSnapshot:
@@ -5398,32 +5303,10 @@ class AegisOpsControlPlaneService:
         analytic_signal_ids: tuple[str, ...],
         case_id: str | None,
     ) -> None:
-        if case_id is None:
-            return
-
-        for analytic_signal_id in analytic_signal_ids:
-            existing_signal = self._store.get(AnalyticSignalRecord, analytic_signal_id)
-            if existing_signal is None:
-                continue
-            linked_case_ids = self._merge_linked_ids(existing_signal.case_ids, case_id)
-            if linked_case_ids == existing_signal.case_ids:
-                continue
-            self.persist_record(
-                AnalyticSignalRecord(
-                    analytic_signal_id=existing_signal.analytic_signal_id,
-                    substrate_detection_record_id=(
-                        existing_signal.substrate_detection_record_id
-                    ),
-                    finding_id=existing_signal.finding_id,
-                    alert_ids=existing_signal.alert_ids,
-                    case_ids=linked_case_ids,
-                    correlation_key=existing_signal.correlation_key,
-                    first_seen_at=existing_signal.first_seen_at,
-                    last_seen_at=existing_signal.last_seen_at,
-                    lifecycle_state=existing_signal.lifecycle_state,
-                    reviewed_context=existing_signal.reviewed_context,
-                )
-            )
+        self._detection_intake_service._link_case_to_analytic_signals(
+            analytic_signal_ids,
+            case_id,
+        )
 
     def _list_alert_evidence_records(
         self,
@@ -5431,13 +5314,10 @@ class AegisOpsControlPlaneService:
         alert_id: str,
         case_id: str | None,
     ) -> tuple[EvidenceRecord, ...]:
-        evidence_records: list[EvidenceRecord] = []
-        for evidence in self._store.list(EvidenceRecord):
-            if evidence.alert_id == alert_id or (
-                case_id is not None and evidence.case_id == case_id
-            ):
-                evidence_records.append(evidence)
-        return tuple(evidence_records)
+        return self._detection_intake_service._list_alert_evidence_records(
+            alert_id=alert_id,
+            case_id=case_id,
+        )
 
     def _link_case_to_alert_reconciliations(
         self,
@@ -5446,51 +5326,11 @@ class AegisOpsControlPlaneService:
         case_id: str,
         evidence_ids: tuple[str, ...],
     ) -> None:
-        for reconciliation in self._store.list(ReconciliationRecord):
-            if reconciliation.alert_id != alert_id:
-                continue
-            subject_linkage = dict(reconciliation.subject_linkage)
-            updated_case_ids = self._merge_linked_ids(
-                subject_linkage.get("case_ids"),
-                case_id,
-            )
-            updated_evidence_ids = self._merge_linked_ids(
-                subject_linkage.get("evidence_ids"),
-                None,
-            )
-            for evidence_id in evidence_ids:
-                updated_evidence_ids = self._merge_linked_ids(
-                    updated_evidence_ids,
-                    evidence_id,
-                )
-            if (
-                tuple(subject_linkage.get("case_ids", ())) == updated_case_ids
-                and tuple(subject_linkage.get("evidence_ids", ()))
-                == updated_evidence_ids
-            ):
-                continue
-            subject_linkage["case_ids"] = updated_case_ids
-            subject_linkage["evidence_ids"] = updated_evidence_ids
-            self.persist_record(
-                ReconciliationRecord(
-                    reconciliation_id=reconciliation.reconciliation_id,
-                    subject_linkage=subject_linkage,
-                    alert_id=reconciliation.alert_id,
-                    finding_id=reconciliation.finding_id,
-                    analytic_signal_id=reconciliation.analytic_signal_id,
-                    execution_run_id=reconciliation.execution_run_id,
-                    linked_execution_run_ids=(
-                        reconciliation.linked_execution_run_ids
-                    ),
-                    correlation_key=reconciliation.correlation_key,
-                    first_seen_at=reconciliation.first_seen_at,
-                    last_seen_at=reconciliation.last_seen_at,
-                    ingest_disposition=reconciliation.ingest_disposition,
-                    mismatch_summary=reconciliation.mismatch_summary,
-                    compared_at=reconciliation.compared_at,
-                    lifecycle_state=reconciliation.lifecycle_state,
-                )
-            )
+        self._detection_intake_service._link_case_to_alert_reconciliations(
+            alert_id=alert_id,
+            case_id=case_id,
+            evidence_ids=evidence_ids,
+        )
 
     def _resolve_analytic_signal_id(
         self,

--- a/control-plane/aegisops_control_plane/service_composition.py
+++ b/control-plane/aegisops_control_plane/service_composition.py
@@ -132,7 +132,9 @@ def build_control_plane_service_composition(
     store: Any | None,
     dependencies: ControlPlaneServiceCompositionDependencies,
 ) -> ControlPlaneServiceComposition:
-    resolved_store = store or PostgresControlPlaneStore(config.postgres_dsn)
+    resolved_store = (
+        store if store is not None else PostgresControlPlaneStore(config.postgres_dsn)
+    )
     reconciliation = N8NReconciliationAdapter(config.n8n_base_url)
     shuffle = ShuffleActionAdapter(config.shuffle_base_url)
     isolated_executor = IsolatedExecutorAdapter(config.isolated_executor_base_url)

--- a/control-plane/aegisops_control_plane/service_composition.py
+++ b/control-plane/aegisops_control_plane/service_composition.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Mapping, Type
+
+from .adapters.endpoint_evidence import EndpointEvidencePackAdapter
+from .adapters.executor import IsolatedExecutorAdapter
+from .adapters.misp import MispContextAdapter
+from .adapters.n8n import N8NReconciliationAdapter
+from .adapters.osquery import OsqueryHostContextAdapter
+from .adapters.postgres import PostgresControlPlaneStore
+from .adapters.shuffle import ShuffleActionAdapter
+from .ai_trace_lifecycle import AITraceLifecycleService
+from .assistant_advisory import AssistantAdvisoryCoordinator
+from .assistant_context import (
+    AssistantContextAssembler,
+    _advisory_text_claims_authority_or_scope_expansion,
+)
+from .assistant_provider import AssistantProviderAdapter
+from .action_lifecycle_write_coordinator import ActionLifecycleWriteCoordinator
+from .action_reconciliation_orchestration import (
+    ActionOrchestrationBoundary,
+    ReconciliationOrchestrationBoundary,
+)
+from .action_review_write_surface import ActionReviewWriteSurface
+from .case_workflow import CaseWorkflowService
+from .config import RuntimeConfig
+from .detection_lifecycle import DetectionIntakeService
+from .evidence_linkage import EvidenceLinkageService
+from .execution_coordinator import ExecutionCoordinator
+from .external_evidence_boundary import ExternalEvidenceBoundary
+from .live_assistant_workflow import LiveAssistantWorkflowCoordinator
+from .models import ControlPlaneRecord, ReconciliationRecord
+from .operator_inspection import OperatorInspectionReadSurface
+from .restore_readiness import RestoreReadinessService
+from .reviewed_slice_policy import ReviewedSlicePolicy
+from .runtime_boundary import RuntimeBoundaryService
+from .runtime_restore_readiness_diagnostics import (
+    RuntimeRestoreReadinessDiagnosticsService,
+)
+
+
+@dataclass(frozen=True)
+class ControlPlaneServiceCompositionDependencies:
+    runtime_snapshot_factory: Callable[..., Any]
+    authenticated_principal_factory: Callable[..., Any]
+    reviewed_summary_transport_factory: Callable[[], Any]
+    workflow_family: str
+    workflow_prompt_versions: Mapping[str, str]
+    record_types_by_family: Mapping[str, Type[ControlPlaneRecord]]
+    authoritative_record_chain_record_types: tuple[Type[ControlPlaneRecord], ...]
+    authoritative_record_chain_backup_schema_version: str
+    authoritative_primary_id_field_by_family: Mapping[str, str]
+    normalize_admission_provenance: Callable[[object], dict[str, str] | None]
+    merge_reviewed_context: Callable[
+        [Mapping[str, object], Mapping[str, object]],
+        dict[str, object],
+    ]
+    case_lifecycle_state_by_triage_disposition: Mapping[str, str]
+    record_to_dict: Callable[[ControlPlaneRecord], dict[str, object]]
+    json_ready: Callable[[object], object]
+    redacted_reconciliation_payload: Callable[
+        [ReconciliationRecord],
+        dict[str, object],
+    ]
+    coordination_reference_payload: Callable[
+        [Mapping[str, object]],
+        dict[str, object] | None,
+    ]
+    coordination_reference_signature: Callable[[Mapping[str, object]], str | None]
+    dedupe_strings: Callable[[Iterable[str]], tuple[str, ...]]
+    analyst_queue_snapshot_factory: Callable[..., Any]
+    alert_detail_snapshot_factory: Callable[..., Any]
+    case_detail_snapshot_factory: Callable[..., Any]
+    action_review_detail_snapshot_factory: Callable[..., Any]
+    assistant_context_snapshot_factory: Callable[..., Any]
+    advisory_snapshot_from_context: Callable[[Any], Any]
+    recommendation_draft_snapshot_from_context: Callable[[Any], Any]
+    live_assistant_snapshot_factory: Callable[..., Any]
+    live_assistant_citations_from_context: Callable[[Any], Any]
+    live_assistant_unresolved_reasons: Callable[[Any], Any]
+    live_assistant_prompt_injection_flags: Callable[[object], tuple[str, ...]]
+    startup_status_snapshot_factory: Callable[..., Any]
+    readiness_diagnostics_snapshot_factory: Callable[..., Any]
+    restore_drill_snapshot_factory: Callable[..., Any]
+    restore_summary_snapshot_factory: Callable[..., Any]
+    build_shutdown_status_snapshot: Callable[..., Any]
+    derive_readiness_status: Callable[..., str]
+    record_from_backup_payload: Callable[
+        [Type[ControlPlaneRecord], Mapping[str, object]],
+        ControlPlaneRecord,
+    ]
+    find_duplicate_strings: Callable[[tuple[str, ...]], tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class ControlPlaneServiceComposition:
+    store: Any
+    reconciliation: N8NReconciliationAdapter
+    shuffle: ShuffleActionAdapter
+    isolated_executor: IsolatedExecutorAdapter
+    assistant_provider_adapter: AssistantProviderAdapter
+    reviewed_slice_policy: ReviewedSlicePolicy
+    ai_trace_lifecycle_service: AITraceLifecycleService
+    assistant_context_assembler: AssistantContextAssembler
+    assistant_advisory_coordinator: AssistantAdvisoryCoordinator
+    live_assistant_workflow_coordinator: LiveAssistantWorkflowCoordinator
+    operator_inspection_read_surface: OperatorInspectionReadSurface
+    action_review_write_surface: ActionReviewWriteSurface
+    evidence_linkage_service: EvidenceLinkageService
+    case_workflow_service: CaseWorkflowService
+    detection_intake_service: DetectionIntakeService
+    execution_coordinator: ExecutionCoordinator
+    action_orchestration_boundary: ActionOrchestrationBoundary
+    reconciliation_orchestration_boundary: ReconciliationOrchestrationBoundary
+    action_lifecycle_write_coordinator: ActionLifecycleWriteCoordinator
+    endpoint_evidence_pack_adapter: EndpointEvidencePackAdapter
+    misp_context_adapter: MispContextAdapter
+    external_evidence_boundary: ExternalEvidenceBoundary
+    osquery_host_context_adapter: OsqueryHostContextAdapter
+    runtime_boundary_service: RuntimeBoundaryService
+    restore_readiness_service: RestoreReadinessService
+    runtime_restore_readiness_diagnostics_service: (
+        RuntimeRestoreReadinessDiagnosticsService
+    )
+
+
+def build_control_plane_service_composition(
+    *,
+    service: Any,
+    config: RuntimeConfig,
+    store: Any | None,
+    dependencies: ControlPlaneServiceCompositionDependencies,
+) -> ControlPlaneServiceComposition:
+    resolved_store = store or PostgresControlPlaneStore(config.postgres_dsn)
+    reconciliation = N8NReconciliationAdapter(config.n8n_base_url)
+    shuffle = ShuffleActionAdapter(config.shuffle_base_url)
+    isolated_executor = IsolatedExecutorAdapter(config.isolated_executor_base_url)
+    assistant_provider_adapter = AssistantProviderAdapter(
+        provider_identity="reviewed_local",
+        model_identity="bounded_reviewed_summary",
+        prompt_version=dependencies.workflow_prompt_versions["case_summary"],
+        request_timeout_seconds=5.0,
+        max_attempts=1,
+        transport=dependencies.reviewed_summary_transport_factory(),
+    )
+    reviewed_slice_policy = ReviewedSlicePolicy(
+        service,
+        normalize_admission_provenance=dependencies.normalize_admission_provenance,
+    )
+    ai_trace_lifecycle_service = AITraceLifecycleService(resolved_store)
+    assistant_context_assembler = AssistantContextAssembler(
+        service,
+        record_types_by_family=dependencies.record_types_by_family,
+        record_to_dict=dependencies.record_to_dict,
+        merge_reviewed_context=dependencies.merge_reviewed_context,
+        assistant_context_snapshot_factory=(
+            dependencies.assistant_context_snapshot_factory
+        ),
+        advisory_snapshot_from_context=dependencies.advisory_snapshot_from_context,
+        recommendation_draft_snapshot_from_context=(
+            dependencies.recommendation_draft_snapshot_from_context
+        ),
+        ai_trace_lifecycle=ai_trace_lifecycle_service,
+    )
+    assistant_advisory_coordinator = AssistantAdvisoryCoordinator(
+        assistant_context_assembler
+    )
+    live_assistant_workflow_coordinator = LiveAssistantWorkflowCoordinator(
+        service,
+        workflow_family=dependencies.workflow_family,
+        workflow_prompt_versions=dependencies.workflow_prompt_versions,
+        json_ready=lambda value: dependencies.json_ready(value),
+        dedupe_strings=lambda values: dependencies.dedupe_strings(values),
+        advisory_scope_expansion_flags=(
+            lambda text: _advisory_text_claims_authority_or_scope_expansion(text)
+        ),
+        snapshot_factory=(
+            lambda **kwargs: dependencies.live_assistant_snapshot_factory(**kwargs)
+        ),
+        citations_from_context=(
+            lambda snapshot: dependencies.live_assistant_citations_from_context(
+                snapshot
+            )
+        ),
+        unresolved_reasons_from_flags=(
+            lambda flags: dependencies.live_assistant_unresolved_reasons(flags)
+        ),
+        prompt_injection_flags=(
+            lambda text: dependencies.live_assistant_prompt_injection_flags(text)
+        ),
+        ai_trace_lifecycle=ai_trace_lifecycle_service,
+    )
+    operator_inspection_read_surface = OperatorInspectionReadSurface(
+        service,
+        analyst_queue_snapshot_factory=dependencies.analyst_queue_snapshot_factory,
+        alert_detail_snapshot_factory=dependencies.alert_detail_snapshot_factory,
+        case_detail_snapshot_factory=dependencies.case_detail_snapshot_factory,
+        action_review_detail_snapshot_factory=(
+            dependencies.action_review_detail_snapshot_factory
+        ),
+        record_to_dict=dependencies.record_to_dict,
+        redacted_reconciliation_payload=(
+            dependencies.redacted_reconciliation_payload
+        ),
+        normalize_admission_provenance=dependencies.normalize_admission_provenance,
+        coordination_reference_payload=dependencies.coordination_reference_payload,
+        coordination_reference_signature=dependencies.coordination_reference_signature,
+        dedupe_strings=dependencies.dedupe_strings,
+    )
+    action_review_write_surface = ActionReviewWriteSurface(service)
+    evidence_linkage_service = EvidenceLinkageService(
+        store=resolved_store,
+        require_non_empty_string=service._require_non_empty_string,
+        merge_linked_ids=service._merge_linked_ids,
+    )
+    case_workflow_service = CaseWorkflowService(
+        service,
+        evidence_linkage_service=evidence_linkage_service,
+        merge_reviewed_context=dependencies.merge_reviewed_context,
+    )
+    detection_intake_service = DetectionIntakeService(
+        service,
+        merge_reviewed_context=dependencies.merge_reviewed_context,
+        normalize_admission_provenance=dependencies.normalize_admission_provenance,
+        case_lifecycle_state_by_triage_disposition=(
+            dependencies.case_lifecycle_state_by_triage_disposition
+        ),
+    )
+    execution_coordinator = ExecutionCoordinator(service)
+    action_orchestration_boundary = ActionOrchestrationBoundary(service)
+    reconciliation_orchestration_boundary = ReconciliationOrchestrationBoundary(
+        service
+    )
+    action_lifecycle_write_coordinator = ActionLifecycleWriteCoordinator(
+        service,
+        action_orchestration_boundary=action_orchestration_boundary,
+        reconciliation_orchestration_boundary=reconciliation_orchestration_boundary,
+    )
+    endpoint_evidence_pack_adapter = EndpointEvidencePackAdapter()
+    misp_context_adapter = MispContextAdapter(
+        enabled=config.misp_enrichment_enabled
+    )
+    external_evidence_boundary = ExternalEvidenceBoundary(service)
+    osquery_host_context_adapter = OsqueryHostContextAdapter()
+    runtime_boundary_service = RuntimeBoundaryService(
+        config=config,
+        store=resolved_store,
+        reconciliation_adapter=reconciliation,
+        shuffle_adapter=shuffle,
+        isolated_executor_adapter=isolated_executor,
+        runtime_snapshot_factory=dependencies.runtime_snapshot_factory,
+        authenticated_principal_factory=(
+            dependencies.authenticated_principal_factory
+        ),
+    )
+    restore_readiness_service = RestoreReadinessService(
+        config=config,
+        store=resolved_store,
+        runtime_boundary_service=runtime_boundary_service,
+        startup_status_snapshot_factory=dependencies.startup_status_snapshot_factory,
+        readiness_diagnostics_snapshot_factory=(
+            dependencies.readiness_diagnostics_snapshot_factory
+        ),
+        restore_drill_snapshot_factory=dependencies.restore_drill_snapshot_factory,
+        restore_summary_snapshot_factory=dependencies.restore_summary_snapshot_factory,
+        record_to_dict=dependencies.record_to_dict,
+        json_ready=dependencies.json_ready,
+        redacted_reconciliation_payload=(
+            dependencies.redacted_reconciliation_payload
+        ),
+        collect_readiness_review_snapshots=(
+            service._collect_readiness_review_snapshots
+        ),
+        build_readiness_review_path_health=(
+            service._build_readiness_review_path_health
+        ),
+        build_readiness_source_health=service._build_readiness_source_health,
+        build_readiness_automation_substrate_health=(
+            service._build_readiness_automation_substrate_health
+        ),
+        build_optional_extension_operability=(
+            service._build_optional_extension_operability
+        ),
+        build_shutdown_status_snapshot=(
+            dependencies.build_shutdown_status_snapshot
+        ),
+        derive_readiness_status=dependencies.derive_readiness_status,
+        record_from_backup_payload=dependencies.record_from_backup_payload,
+        authoritative_record_chain_record_types=(
+            dependencies.authoritative_record_chain_record_types
+        ),
+        authoritative_record_chain_backup_schema_version=(
+            dependencies.authoritative_record_chain_backup_schema_version
+        ),
+        authoritative_primary_id_field_by_family=(
+            dependencies.authoritative_primary_id_field_by_family
+        ),
+        record_types_by_family=dependencies.record_types_by_family,
+        find_duplicate_strings=dependencies.find_duplicate_strings,
+        synthesize_lifecycle_transition_record=(
+            lambda record, initial_transitioned_at_fallback=None: service._build_lifecycle_transition_record(
+                record,
+                existing_record=None,
+                initial_transitioned_at_fallback=initial_transitioned_at_fallback,
+            )
+        ),
+        assistant_ids_from_mapping=service._assistant_ids_from_mapping,
+        inspect_case_detail=lambda case_id: service.inspect_case_detail(case_id),
+        inspect_assistant_context=(
+            lambda record_family, record_id: service.inspect_assistant_context(
+                record_family,
+                record_id,
+            )
+        ),
+        inspect_reconciliation_status=lambda: service.inspect_reconciliation_status(),
+    )
+    runtime_restore_readiness_diagnostics_service = (
+        RuntimeRestoreReadinessDiagnosticsService(
+            runtime_boundary_service=runtime_boundary_service,
+            restore_readiness_service=restore_readiness_service,
+        )
+    )
+
+    return ControlPlaneServiceComposition(
+        store=resolved_store,
+        reconciliation=reconciliation,
+        shuffle=shuffle,
+        isolated_executor=isolated_executor,
+        assistant_provider_adapter=assistant_provider_adapter,
+        reviewed_slice_policy=reviewed_slice_policy,
+        ai_trace_lifecycle_service=ai_trace_lifecycle_service,
+        assistant_context_assembler=assistant_context_assembler,
+        assistant_advisory_coordinator=assistant_advisory_coordinator,
+        live_assistant_workflow_coordinator=live_assistant_workflow_coordinator,
+        operator_inspection_read_surface=operator_inspection_read_surface,
+        action_review_write_surface=action_review_write_surface,
+        evidence_linkage_service=evidence_linkage_service,
+        case_workflow_service=case_workflow_service,
+        detection_intake_service=detection_intake_service,
+        execution_coordinator=execution_coordinator,
+        action_orchestration_boundary=action_orchestration_boundary,
+        reconciliation_orchestration_boundary=reconciliation_orchestration_boundary,
+        action_lifecycle_write_coordinator=action_lifecycle_write_coordinator,
+        endpoint_evidence_pack_adapter=endpoint_evidence_pack_adapter,
+        misp_context_adapter=misp_context_adapter,
+        external_evidence_boundary=external_evidence_boundary,
+        osquery_host_context_adapter=osquery_host_context_adapter,
+        runtime_boundary_service=runtime_boundary_service,
+        restore_readiness_service=restore_readiness_service,
+        runtime_restore_readiness_diagnostics_service=(
+            runtime_restore_readiness_diagnostics_service
+        ),
+    )
+
+
+__all__ = [
+    "ControlPlaneServiceComposition",
+    "ControlPlaneServiceCompositionDependencies",
+    "build_control_plane_service_composition",
+]

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -237,6 +237,126 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         ):
             self.assertIn(term, boundary_tests)
 
+    def test_phase50_constructor_delegates_collaborator_composition(self) -> None:
+        service_source = self._read("control-plane/aegisops_control_plane/service.py")
+        tree = ast.parse(service_source)
+        service_class = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        constructor = next(
+            node
+            for node in service_class.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "__init__"
+        )
+
+        direct_constructor_calls = {
+            node.func.id
+            for node in ast.walk(constructor)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id
+            in {
+                "ActionLifecycleWriteCoordinator",
+                "ActionOrchestrationBoundary",
+                "ActionReviewWriteSurface",
+                "AssistantAdvisoryCoordinator",
+                "AssistantContextAssembler",
+                "AssistantProviderAdapter",
+                "CaseWorkflowService",
+                "DetectionIntakeService",
+                "EndpointEvidencePackAdapter",
+                "EvidenceLinkageService",
+                "ExecutionCoordinator",
+                "ExternalEvidenceBoundary",
+                "IsolatedExecutorAdapter",
+                "LiveAssistantWorkflowCoordinator",
+                "MispContextAdapter",
+                "N8NReconciliationAdapter",
+                "OperatorInspectionReadSurface",
+                "OsqueryHostContextAdapter",
+                "PostgresControlPlaneStore",
+                "ReconciliationOrchestrationBoundary",
+                "RestoreReadinessService",
+                "ReviewedSlicePolicy",
+                "RuntimeBoundaryService",
+                "RuntimeRestoreReadinessDiagnosticsService",
+                "ShuffleActionAdapter",
+            }
+        }
+        composition_call_names = {
+            node.func.id
+            for node in ast.walk(constructor)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+        }
+
+        self.assertFalse(
+            direct_constructor_calls,
+            "facade constructor should delegate collaborator wiring, found "
+            f"{sorted(direct_constructor_calls)}",
+        )
+        self.assertIn(
+            "build_control_plane_service_composition",
+            composition_call_names,
+        )
+
+    def test_phase50_detection_linkage_helpers_live_with_detection_intake(
+        self,
+    ) -> None:
+        service_source = self._read("control-plane/aegisops_control_plane/service.py")
+        detection_source = self._read(
+            "control-plane/aegisops_control_plane/detection_lifecycle.py"
+        )
+        service_tree = ast.parse(service_source)
+        detection_tree = ast.parse(detection_source)
+        service_class = next(
+            node
+            for node in service_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        detection_class = next(
+            node
+            for node in detection_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "DetectionIntakeService"
+        )
+
+        moved_helper_names = {
+            "_link_case_to_analytic_signals",
+            "_list_alert_evidence_records",
+            "_link_case_to_alert_reconciliations",
+        }
+        detection_method_names = {
+            node.name
+            for node in detection_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+        self.assertTrue(moved_helper_names.issubset(detection_method_names))
+
+        service_methods = {
+            node.name: node
+            for node in service_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+        for helper_name in moved_helper_names:
+            service_method = service_methods[helper_name]
+            calls = [
+                node
+                for node in ast.walk(service_method)
+                if isinstance(node, ast.Attribute)
+                and node.attr == helper_name
+            ]
+            self.assertEqual(
+                len(calls),
+                1,
+                f"{helper_name} should remain only as a facade compatibility delegate",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -260,6 +260,7 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             and isinstance(node.func, ast.Name)
             and node.func.id
             in {
+                "AITraceLifecycleService",
                 "ActionLifecycleWriteCoordinator",
                 "ActionOrchestrationBoundary",
                 "ActionReviewWriteSurface",
@@ -348,8 +349,13 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             calls = [
                 node
                 for node in ast.walk(service_method)
-                if isinstance(node, ast.Attribute)
-                and node.attr == helper_name
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == helper_name
+                and isinstance(node.func.value, ast.Attribute)
+                and node.func.value.attr == "_detection_intake_service"
+                and isinstance(node.func.value.value, ast.Name)
+                and node.func.value.value.id == "self"
             ]
             self.assertEqual(
                 len(calls),

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -21,7 +21,30 @@ for name, value in vars(support).items():
         globals()[name] = value
 
 
+class _FalseyStoreAdapter:
+    def __init__(self, inner: object) -> None:
+        self._inner = inner
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._inner, name)
+
+
 class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
+    def test_service_preserves_explicit_falsey_store_adapter(self) -> None:
+        store, _ = support.make_store()
+        falsey_store = _FalseyStoreAdapter(store)
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=falsey_store,
+        )
+
+        self.assertIs(service._store, falsey_store)
+        self.assertIs(service._ai_trace_lifecycle_service._store, falsey_store)
+        self.assertIs(service._evidence_linkage_service._store, falsey_store)
+
     def test_service_initializes_dedicated_detection_intake_boundary(self) -> None:
         store, _ = support.make_store()
         service = support.AegisOpsControlPlaneService(

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -8,4 +8,4 @@
 # ceiling and fails on silent re-growth. A future ADR or maintainability backlog
 # must lower or replace these limits before unrelated Phase 49 feature expansion
 # lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=5818 max_effective_lines=5407 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=49.0.7
+control-plane/aegisops_control_plane/service.py max_lines=5658 max_effective_lines=5248 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.2

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -8,4 +8,4 @@
 # ceiling and fails on silent re-growth. A future ADR or maintainability backlog
 # must lower or replace these limits before unrelated Phase 49 feature expansion
 # lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=5658 max_effective_lines=5248 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.2
+control-plane/aegisops_control_plane/service.py max_lines=5660 max_effective_lines=5250 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=49.0.7


### PR DESCRIPTION
## Summary
- Extracted AegisOpsControlPlaneService collaborator construction into `service_composition.py`.
- Moved detection intake case-linkage helper ownership into `DetectionIntakeService` while keeping facade compatibility delegates.
- Added focused Phase 50.2 structural regression coverage and lowered the maintainability hotspot ceiling for `service.py`.

## Verification
- `python3 -m py_compile control-plane/aegisops_control_plane/service.py control-plane/aegisops_control_plane/service_composition.py control-plane/aegisops_control_plane/detection_lifecycle.py`
- `python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation`
- `python3 -m unittest control-plane.tests.test_service_persistence_ingest_case_lifecycle control-plane.tests.test_operator_inspection_boundary control-plane.tests.test_action_review_write_boundary`
- `python3 -m unittest discover -s control-plane/tests -p 'test_service*.py'`
- `bash scripts/verify-maintainability-hotspots.sh`
- `git diff --check`
- `node dist/index.js issue-lint 948 --config supervisor.config.aegisops.coderabbit.json`

Closes #948


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized control-plane service construction to a composition pattern and moved evidence/alert linkage responsibilities into the detection intake component.
  * Ensured provided store instances are preserved unchanged when supplied.

* **Tests**
  * Added regression tests validating constructor composition, detection-linkage helper placement, and preservation of supplied store behavior.

* **Documentation**
  * Tightened a maintainability baseline threshold for the control-plane service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->