### PR TITLE
Phase 50.3 restore validation decomposition

### DIFF
--- a/control-plane/aegisops_control_plane/restore_readiness_backup_restore.py
+++ b/control-plane/aegisops_control_plane/restore_readiness_backup_restore.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Iterator, Mapping, Type
 
@@ -87,6 +88,113 @@ def _unexpected_restore_record_family_keys(
 
 def _is_valid_restore_record_count(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
+
+
+@dataclass(frozen=True)
+class _RestoreRecordFamilies:
+    analytic_signals: tuple[AnalyticSignalRecord, ...]
+    alerts: tuple[AlertRecord, ...]
+    evidence: tuple[EvidenceRecord, ...]
+    observations: tuple[ObservationRecord, ...]
+    leads: tuple[LeadRecord, ...]
+    cases: tuple[CaseRecord, ...]
+    recommendations: tuple[RecommendationRecord, ...]
+    lifecycle_transitions: tuple[LifecycleTransitionRecord, ...]
+    approval_decisions: tuple[ApprovalDecisionRecord, ...]
+    action_requests: tuple[ActionRequestRecord, ...]
+    action_executions: tuple[ActionExecutionRecord, ...]
+    hunts: tuple[HuntRecord, ...]
+    hunt_runs: tuple[HuntRunRecord, ...]
+    ai_traces: tuple[AITraceRecord, ...]
+    reconciliations: tuple[ReconciliationRecord, ...]
+
+    @property
+    def by_family(self) -> tuple[tuple[str, tuple[ControlPlaneRecord, ...]], ...]:
+        return (
+            ("analytic_signal", self.analytic_signals),
+            ("alert", self.alerts),
+            ("evidence", self.evidence),
+            ("observation", self.observations),
+            ("lead", self.leads),
+            ("case", self.cases),
+            ("recommendation", self.recommendations),
+            ("lifecycle_transition", self.lifecycle_transitions),
+            ("approval_decision", self.approval_decisions),
+            ("action_request", self.action_requests),
+            ("action_execution", self.action_executions),
+            ("hunt", self.hunts),
+            ("hunt_run", self.hunt_runs),
+            ("ai_trace", self.ai_traces),
+            ("reconciliation", self.reconciliations),
+        )
+
+
+@dataclass(frozen=True)
+class _RestoreRecordIndexes:
+    analytic_signals: Mapping[str, AnalyticSignalRecord]
+    alerts: Mapping[str, AlertRecord]
+    evidence: Mapping[str, EvidenceRecord]
+    observations: Mapping[str, ObservationRecord]
+    leads: Mapping[str, LeadRecord]
+    cases: Mapping[str, CaseRecord]
+    recommendations: Mapping[str, RecommendationRecord]
+    approval_decisions: Mapping[str, ApprovalDecisionRecord]
+    action_requests: Mapping[str, ActionRequestRecord]
+    action_executions: Mapping[str, ActionExecutionRecord]
+    hunts: Mapping[str, HuntRecord]
+    hunt_runs: Mapping[str, HuntRunRecord]
+    ai_traces: Mapping[str, AITraceRecord]
+    action_executions_by_run_id: Mapping[str, ActionExecutionRecord]
+    reconciliations: Mapping[str, ReconciliationRecord]
+
+    @property
+    def authoritative_subject_ids_by_family(self) -> dict[str, set[str]]:
+        return {
+            "analytic_signal": set(self.analytic_signals),
+            "alert": set(self.alerts),
+            "evidence": set(self.evidence),
+            "observation": set(self.observations),
+            "lead": set(self.leads),
+            "case": set(self.cases),
+            "recommendation": set(self.recommendations),
+            "approval_decision": set(self.approval_decisions),
+            "action_request": set(self.action_requests),
+            "action_execution": set(self.action_executions),
+            "hunt": set(self.hunts),
+            "hunt_run": set(self.hunt_runs),
+            "ai_trace": set(self.ai_traces),
+            "reconciliation": set(self.reconciliations),
+        }
+
+    @property
+    def authoritative_subject_records_by_family(
+        self,
+    ) -> dict[str, Mapping[str, ControlPlaneRecord]]:
+        return {
+            "analytic_signal": self.analytic_signals,
+            "alert": self.alerts,
+            "evidence": self.evidence,
+            "observation": self.observations,
+            "lead": self.leads,
+            "case": self.cases,
+            "recommendation": self.recommendations,
+            "approval_decision": self.approval_decisions,
+            "action_request": self.action_requests,
+            "action_execution": self.action_executions,
+            "hunt": self.hunts,
+            "hunt_run": self.hunt_runs,
+            "ai_trace": self.ai_traces,
+            "reconciliation": self.reconciliations,
+        }
+
+
+@dataclass(frozen=True)
+class _RestoreDrillVerifiedIds:
+    case_ids: tuple[str, ...]
+    recommendation_ids: tuple[str, ...]
+    approval_decision_ids: tuple[str, ...]
+    action_execution_ids: tuple[str, ...]
+    reconciliation_ids: tuple[str, ...]
 
 
 class _BackupRestoreFlow:
@@ -318,59 +426,70 @@ class _BackupRestoreFlow:
             self._list_authoritative_record_chain_records(),
             require_lifecycle_transition_history=require_lifecycle_transition_history,
         )
-        verified_case_ids = tuple(
-            record.case_id for record in self._store.list(CaseRecord)
-        )
-        verified_recommendation_ids = tuple(
-            record.recommendation_id
-            for record in self._store.list(RecommendationRecord)
-        )
-        verified_approval_decision_ids = tuple(
-            record.approval_decision_id
-            for record in self._store.list(ApprovalDecisionRecord)
-        )
-        verified_action_execution_ids = tuple(
-            record.action_execution_id
-            for record in self._store.list(ActionExecutionRecord)
-        )
-        verified_reconciliation_ids = tuple(
-            record.reconciliation_id
-            for record in self._store.list(ReconciliationRecord)
+        verified_ids = self._collect_restore_drill_verified_ids()
+        self._probe_restore_drill_verified_surfaces(verified_ids)
+        readiness_status = self._derive_restore_drill_readiness_status()
+
+        return self._restore_drill_snapshot_factory(
+            read_only=True,
+            drill_passed=readiness_status == "ready",
+            verified_case_ids=verified_ids.case_ids,
+            verified_recommendation_ids=verified_ids.recommendation_ids,
+            verified_approval_decision_ids=verified_ids.approval_decision_ids,
+            verified_action_execution_ids=verified_ids.action_execution_ids,
+            verified_reconciliation_ids=verified_ids.reconciliation_ids,
         )
 
-        for case_id in verified_case_ids:
+    def _collect_restore_drill_verified_ids(self) -> _RestoreDrillVerifiedIds:
+        return _RestoreDrillVerifiedIds(
+            case_ids=tuple(record.case_id for record in self._store.list(CaseRecord)),
+            recommendation_ids=tuple(
+                record.recommendation_id
+                for record in self._store.list(RecommendationRecord)
+            ),
+            approval_decision_ids=tuple(
+                record.approval_decision_id
+                for record in self._store.list(ApprovalDecisionRecord)
+            ),
+            action_execution_ids=tuple(
+                record.action_execution_id
+                for record in self._store.list(ActionExecutionRecord)
+            ),
+            reconciliation_ids=tuple(
+                record.reconciliation_id
+                for record in self._store.list(ReconciliationRecord)
+            ),
+        )
+
+    def _probe_restore_drill_verified_surfaces(
+        self,
+        verified_ids: _RestoreDrillVerifiedIds,
+    ) -> None:
+        for case_id in verified_ids.case_ids:
             self._inspect_case_detail(case_id)
-        for recommendation_id in verified_recommendation_ids:
+        for recommendation_id in verified_ids.recommendation_ids:
             self._inspect_assistant_context("recommendation", recommendation_id)
-        for approval_decision_id in verified_approval_decision_ids:
+        for approval_decision_id in verified_ids.approval_decision_ids:
             self._inspect_assistant_context("approval_decision", approval_decision_id)
-        for action_execution_id in verified_action_execution_ids:
+        for action_execution_id in verified_ids.action_execution_ids:
             self._inspect_assistant_context("action_execution", action_execution_id)
-        for reconciliation_id in verified_reconciliation_ids:
+        for reconciliation_id in verified_ids.reconciliation_ids:
             self._inspect_assistant_context("reconciliation", reconciliation_id)
         self._inspect_reconciliation_status()
+
+    def _derive_restore_drill_readiness_status(self) -> str:
         startup = self._describe_startup_status()
         readiness_aggregates = self._inspect_readiness_aggregates()
         readiness_review_snapshots = self._collect_readiness_review_snapshots(
             readiness_aggregates
         )
-        readiness_status = self._derive_readiness_status(
+        return self._derive_readiness_status(
             startup_ready=startup.startup_ready,
             reconciliation_lifecycle_counts=readiness_aggregates.reconciliation_lifecycle_counts,
             review_path_health_overall_state=self._build_readiness_review_path_health(
                 readiness_aggregates,
                 readiness_review_snapshots,
             )["overall_state"],
-        )
-
-        return self._restore_drill_snapshot_factory(
-            read_only=True,
-            drill_passed=readiness_status == "ready",
-            verified_case_ids=verified_case_ids,
-            verified_recommendation_ids=verified_recommendation_ids,
-            verified_approval_decision_ids=verified_approval_decision_ids,
-            verified_action_execution_ids=verified_action_execution_ids,
-            verified_reconciliation_ids=verified_reconciliation_ids,
         )
 
     def _list_authoritative_record_chain_records(
@@ -491,103 +610,156 @@ class _BackupRestoreFlow:
                 f"records for {', '.join(populated_families)}"
             )
 
-    def validate_authoritative_record_chain_restore(
+    def _duplicate_restore_count_suffix(
+        self,
+        family: str,
+        restored_record_counts: Mapping[str, int] | None,
+    ) -> str:
+        if restored_record_counts is None:
+            return ""
+        return (
+            "; restored_record_counts"
+            f"[{family!r}]={restored_record_counts.get(family)!r}"
+        )
+
+    def _require_restore_family_records(
         self,
         records_by_family: Mapping[str, tuple[ControlPlaneRecord, ...]],
-        *,
-        require_lifecycle_transition_history: bool = True,
-        restored_record_counts: Mapping[str, int] | None = None,
-    ) -> None:
-        def duplicate_restore_count_suffix(family: str) -> str:
-            if restored_record_counts is None:
-                return ""
-            return (
-                "; restored_record_counts"
-                f"[{family!r}]={restored_record_counts.get(family)!r}"
+        family: str,
+        expected_type: Type[ControlPlaneRecord],
+    ) -> tuple[ControlPlaneRecord, ...]:
+        family_records = tuple(records_by_family.get(family, ()))
+        unexpected_types = tuple(
+            type(record).__name__
+            for record in family_records
+            if not isinstance(record, expected_type)
+        )
+        if unexpected_types:
+            raise ValueError(
+                "restore payload contains unexpected record types for "
+                f"{family!r}: {unexpected_types!r}"
             )
+        return family_records
 
-        def require_family_records(
-            family: str,
-            expected_type: Type[ControlPlaneRecord],
-        ) -> tuple[ControlPlaneRecord, ...]:
-            family_records = tuple(records_by_family.get(family, ()))
-            unexpected_types = tuple(
-                type(record).__name__
-                for record in family_records
-                if not isinstance(record, expected_type)
-            )
-            if unexpected_types:
-                raise ValueError(
-                    "restore payload contains unexpected record types for "
-                    f"{family!r}: {unexpected_types!r}"
+    def _collect_restore_record_families(
+        self,
+        records_by_family: Mapping[str, tuple[ControlPlaneRecord, ...]],
+    ) -> _RestoreRecordFamilies:
+        return _RestoreRecordFamilies(
+            analytic_signals=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "analytic_signal",
+                    AnalyticSignalRecord,
                 )
-            return family_records
+            ),
+            alerts=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "alert",
+                    AlertRecord,
+                )
+            ),
+            evidence=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "evidence",
+                    EvidenceRecord,
+                )
+            ),
+            observations=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "observation",
+                    ObservationRecord,
+                )
+            ),
+            leads=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "lead",
+                    LeadRecord,
+                )
+            ),
+            cases=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "case",
+                    CaseRecord,
+                )
+            ),
+            recommendations=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "recommendation",
+                    RecommendationRecord,
+                )
+            ),
+            lifecycle_transitions=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "lifecycle_transition",
+                    LifecycleTransitionRecord,
+                )
+            ),
+            approval_decisions=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "approval_decision",
+                    ApprovalDecisionRecord,
+                )
+            ),
+            action_requests=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "action_request",
+                    ActionRequestRecord,
+                )
+            ),
+            action_executions=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "action_execution",
+                    ActionExecutionRecord,
+                )
+            ),
+            hunts=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "hunt",
+                    HuntRecord,
+                )
+            ),
+            hunt_runs=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "hunt_run",
+                    HuntRunRecord,
+                )
+            ),
+            ai_traces=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "ai_trace",
+                    AITraceRecord,
+                )
+            ),
+            reconciliations=tuple(
+                self._require_restore_family_records(
+                    records_by_family,
+                    "reconciliation",
+                    ReconciliationRecord,
+                )
+            ),
+        )
 
-        analytic_signal_records = tuple(
-            require_family_records("analytic_signal", AnalyticSignalRecord)
-        )
-        alert_records = tuple(
-            require_family_records("alert", AlertRecord)
-        )
-        evidence_record_family = tuple(
-            require_family_records("evidence", EvidenceRecord)
-        )
-        observation_records = tuple(
-            require_family_records("observation", ObservationRecord)
-        )
-        lead_records = tuple(
-            require_family_records("lead", LeadRecord)
-        )
-        case_records = tuple(
-            require_family_records("case", CaseRecord)
-        )
-        recommendation_records = tuple(
-            require_family_records("recommendation", RecommendationRecord)
-        )
-        lifecycle_transition_records = tuple(
-            require_family_records(
-                "lifecycle_transition",
-                LifecycleTransitionRecord,
-            )
-        )
-        approval_decision_records = tuple(
-            require_family_records("approval_decision", ApprovalDecisionRecord)
-        )
-        action_request_records = tuple(
-            require_family_records("action_request", ActionRequestRecord)
-        )
-        action_execution_records = tuple(
-            require_family_records("action_execution", ActionExecutionRecord)
-        )
-        hunt_records = tuple(
-            require_family_records("hunt", HuntRecord)
-        )
-        hunt_run_records = tuple(
-            require_family_records("hunt_run", HuntRunRecord)
-        )
-        ai_trace_records = tuple(
-            require_family_records("ai_trace", AITraceRecord)
-        )
-        reconciliations = tuple(
-            require_family_records("reconciliation", ReconciliationRecord)
-        )
-        for family, records in (
-            ("analytic_signal", analytic_signal_records),
-            ("alert", alert_records),
-            ("evidence", evidence_record_family),
-            ("observation", observation_records),
-            ("lead", lead_records),
-            ("case", case_records),
-            ("recommendation", recommendation_records),
-            ("lifecycle_transition", lifecycle_transition_records),
-            ("approval_decision", approval_decision_records),
-            ("action_request", action_request_records),
-            ("action_execution", action_execution_records),
-            ("hunt", hunt_records),
-            ("hunt_run", hunt_run_records),
-            ("ai_trace", ai_trace_records),
-            ("reconciliation", reconciliations),
-        ):
+    def _reject_duplicate_restore_identifiers(
+        self,
+        families: _RestoreRecordFamilies,
+        *,
+        restored_record_counts: Mapping[str, int] | None,
+    ) -> None:
+        for family, records in families.by_family:
             duplicates = self._find_duplicate_strings(
                 tuple(
                     getattr(record, self._authoritative_primary_id_field_by_family[family])
@@ -598,19 +770,13 @@ class _BackupRestoreFlow:
                 raise ValueError(
                     "restore payload contains duplicate "
                     f"{family} identifiers {duplicates!r}"
-                    f"{duplicate_restore_count_suffix(family)}"
+                    f"{self._duplicate_restore_count_suffix(family, restored_record_counts)}"
                 )
 
-        for record in (
-            *observation_records,
-            *lead_records,
-            *recommendation_records,
-        ):
-            _validate_record(record)
         duplicate_execution_run_ids = self._find_duplicate_strings(
             tuple(
                 record.execution_run_id
-                for record in action_execution_records
+                for record in families.action_executions
                 if record.execution_run_id is not None
             )
         )
@@ -618,82 +784,75 @@ class _BackupRestoreFlow:
             raise ValueError(
                 "restore payload contains duplicate action_execution "
                 f"execution_run_id values {duplicate_execution_run_ids!r}"
-                f"{duplicate_restore_count_suffix('action_execution')}"
+                f"{self._duplicate_restore_count_suffix('action_execution', restored_record_counts)}"
             )
 
-        analytic_signals = {
-            record.analytic_signal_id: record for record in analytic_signal_records
-        }
-        alerts = {record.alert_id: record for record in alert_records}
-        evidence_records = {
-            record.evidence_id: record for record in evidence_record_family
-        }
-        observations = {
-            record.observation_id: record for record in observation_records
-        }
-        leads = {record.lead_id: record for record in lead_records}
-        cases = {record.case_id: record for record in case_records}
-        recommendations = {
-            record.recommendation_id: record for record in recommendation_records
-        }
-        approval_decisions = {
-            record.approval_decision_id: record
-            for record in approval_decision_records
-        }
-        action_requests = {
-            record.action_request_id: record for record in action_request_records
-        }
-        action_executions = {
-            record.action_execution_id: record for record in action_execution_records
-        }
-        hunts = {record.hunt_id: record for record in hunt_records}
-        hunt_runs = {record.hunt_run_id: record for record in hunt_run_records}
-        ai_traces = {record.ai_trace_id: record for record in ai_trace_records}
-        action_executions_by_run_id = {
-            record.execution_run_id: record
-            for record in action_execution_records
-            if record.execution_run_id is not None
-        }
-        reconciliations_by_id = {
-            record.reconciliation_id: record for record in reconciliations
-        }
-        authoritative_subject_ids_by_family: dict[str, set[str]] = {
-            "analytic_signal": set(analytic_signals),
-            "alert": set(alerts),
-            "evidence": set(evidence_records),
-            "observation": set(observations),
-            "lead": set(leads),
-            "case": set(cases),
-            "recommendation": set(recommendations),
-            "approval_decision": set(approval_decisions),
-            "action_request": set(action_requests),
-            "action_execution": set(action_executions),
-            "hunt": set(hunts),
-            "hunt_run": set(hunt_runs),
-            "ai_trace": set(ai_traces),
-            "reconciliation": set(reconciliations_by_id),
-        }
-        authoritative_subject_records_by_family: dict[
-            str, Mapping[str, ControlPlaneRecord]
-        ] = {
-            "analytic_signal": analytic_signals,
-            "alert": alerts,
-            "evidence": evidence_records,
-            "observation": observations,
-            "lead": leads,
-            "case": cases,
-            "recommendation": recommendations,
-            "approval_decision": approval_decisions,
-            "action_request": action_requests,
-            "action_execution": action_executions,
-            "hunt": hunts,
-            "hunt_run": hunt_runs,
-            "ai_trace": ai_traces,
-            "reconciliation": reconciliations_by_id,
-        }
+    def _validate_restore_record_shapes(
+        self,
+        families: _RestoreRecordFamilies,
+    ) -> None:
+        for record in (
+            *families.observations,
+            *families.leads,
+            *families.recommendations,
+        ):
+            _validate_record(record)
 
-        for alert in alerts.values():
-            if alert.analytic_signal_id and alert.analytic_signal_id not in analytic_signals:
+    def _build_restore_record_indexes(
+        self,
+        families: _RestoreRecordFamilies,
+    ) -> _RestoreRecordIndexes:
+        return _RestoreRecordIndexes(
+            analytic_signals={
+                record.analytic_signal_id: record
+                for record in families.analytic_signals
+            },
+            alerts={record.alert_id: record for record in families.alerts},
+            evidence={record.evidence_id: record for record in families.evidence},
+            observations={
+                record.observation_id: record for record in families.observations
+            },
+            leads={record.lead_id: record for record in families.leads},
+            cases={record.case_id: record for record in families.cases},
+            recommendations={
+                record.recommendation_id: record
+                for record in families.recommendations
+            },
+            approval_decisions={
+                record.approval_decision_id: record
+                for record in families.approval_decisions
+            },
+            action_requests={
+                record.action_request_id: record
+                for record in families.action_requests
+            },
+            action_executions={
+                record.action_execution_id: record
+                for record in families.action_executions
+            },
+            hunts={record.hunt_id: record for record in families.hunts},
+            hunt_runs={
+                record.hunt_run_id: record for record in families.hunt_runs
+            },
+            ai_traces={record.ai_trace_id: record for record in families.ai_traces},
+            action_executions_by_run_id={
+                record.execution_run_id: record
+                for record in families.action_executions
+                if record.execution_run_id is not None
+            },
+            reconciliations={
+                record.reconciliation_id: record
+                for record in families.reconciliations
+            },
+        )
+
+    def _validate_restore_record_links(
+        self,
+        families: _RestoreRecordFamilies,
+        indexes: _RestoreRecordIndexes,
+    ) -> None:
+        for alert in indexes.alerts.values():
+            if alert.analytic_signal_id and alert.analytic_signal_id not in indexes.analytic_signals:
                 raise ValueError(
                     f"missing analytic_signal record {alert.analytic_signal_id!r} required by alert "
                     f"{alert.alert_id!r}"
@@ -701,166 +860,173 @@ class _BackupRestoreFlow:
             if (
                 alert.analytic_signal_id
                 and alert.alert_id
-                not in analytic_signals[alert.analytic_signal_id].alert_ids
+                not in indexes.analytic_signals[alert.analytic_signal_id].alert_ids
             ):
                 raise ValueError(
                     f"alert {alert.alert_id!r} does not match analytic signal binding "
                     f"{alert.analytic_signal_id!r}"
                 )
-            if alert.case_id and alert.case_id not in cases:
+            if alert.case_id and alert.case_id not in indexes.cases:
                 raise ValueError(
                     f"missing case record {alert.case_id!r} required by alert {alert.alert_id!r}"
                 )
-            if alert.case_id and cases[alert.case_id].alert_id != alert.alert_id:
+            if alert.case_id and indexes.cases[alert.case_id].alert_id != alert.alert_id:
                 raise ValueError(
                     f"alert {alert.alert_id!r} does not match case binding {alert.case_id!r}"
                 )
 
-        for analytic_signal in analytic_signals.values():
+        for analytic_signal in indexes.analytic_signals.values():
             for alert_id in analytic_signal.alert_ids:
-                if alert_id not in alerts:
+                if alert_id not in indexes.alerts:
                     raise ValueError(
                         f"missing alert record {alert_id!r} required by analytic signal "
                         f"{analytic_signal.analytic_signal_id!r}"
                     )
-                if alerts[alert_id].analytic_signal_id != analytic_signal.analytic_signal_id:
+                if indexes.alerts[alert_id].analytic_signal_id != analytic_signal.analytic_signal_id:
                     raise ValueError(
                         f"analytic signal {analytic_signal.analytic_signal_id!r} does not match "
                         f"alert binding {alert_id!r}"
                     )
             for case_id in analytic_signal.case_ids:
-                if case_id not in cases:
+                if case_id not in indexes.cases:
                     raise ValueError(
                         f"missing case record {case_id!r} required by analytic signal "
                         f"{analytic_signal.analytic_signal_id!r}"
                     )
 
-        for evidence in evidence_records.values():
-            if evidence.alert_id and evidence.alert_id not in alerts:
+        for evidence in indexes.evidence.values():
+            if evidence.alert_id and evidence.alert_id not in indexes.alerts:
                 raise ValueError(
                     f"missing alert record {evidence.alert_id!r} required by evidence "
                     f"{evidence.evidence_id!r}"
                 )
-            if evidence.case_id and evidence.case_id not in cases:
+            if evidence.case_id and evidence.case_id not in indexes.cases:
                 raise ValueError(
                     f"missing case record {evidence.case_id!r} required by evidence "
                     f"{evidence.evidence_id!r}"
                 )
 
-        for observation in observations.values():
-            if observation.hunt_id and observation.hunt_id not in hunts:
+        for observation in indexes.observations.values():
+            if observation.hunt_id and observation.hunt_id not in indexes.hunts:
                 raise ValueError(
                     f"missing hunt record {observation.hunt_id!r} required by observation "
                     f"{observation.observation_id!r}"
                 )
-            if observation.hunt_run_id and observation.hunt_run_id not in hunt_runs:
+            if observation.hunt_run_id and observation.hunt_run_id not in indexes.hunt_runs:
                 raise ValueError(
                     f"missing hunt_run record {observation.hunt_run_id!r} required by observation "
                     f"{observation.observation_id!r}"
                 )
-            if observation.alert_id and observation.alert_id not in alerts:
+            if observation.alert_id and observation.alert_id not in indexes.alerts:
                 raise ValueError(
                     f"missing alert record {observation.alert_id!r} required by observation "
                     f"{observation.observation_id!r}"
                 )
-            if observation.case_id and observation.case_id not in cases:
+            if observation.case_id and observation.case_id not in indexes.cases:
                 raise ValueError(
                     f"missing case record {observation.case_id!r} required by observation "
                     f"{observation.observation_id!r}"
                 )
             for evidence_id in observation.supporting_evidence_ids:
-                if evidence_id not in evidence_records:
+                if evidence_id not in indexes.evidence:
                     raise ValueError(
                         f"missing evidence record {evidence_id!r} required by observation "
                         f"{observation.observation_id!r}"
                     )
 
-        for lead in leads.values():
-            if lead.observation_id and lead.observation_id not in observations:
+        for lead in indexes.leads.values():
+            if lead.observation_id and lead.observation_id not in indexes.observations:
                 raise ValueError(
                     f"missing observation record {lead.observation_id!r} required by lead "
                     f"{lead.lead_id!r}"
                 )
-            if lead.hunt_run_id and lead.hunt_run_id not in hunt_runs:
+            if lead.hunt_run_id and lead.hunt_run_id not in indexes.hunt_runs:
                 raise ValueError(
                     f"missing hunt_run record {lead.hunt_run_id!r} required by lead "
                     f"{lead.lead_id!r}"
                 )
-            if lead.alert_id and lead.alert_id not in alerts:
+            if lead.alert_id and lead.alert_id not in indexes.alerts:
                 raise ValueError(
                     f"missing alert record {lead.alert_id!r} required by lead {lead.lead_id!r}"
                 )
-            if lead.case_id and lead.case_id not in cases:
+            if lead.case_id and lead.case_id not in indexes.cases:
                 raise ValueError(
                     f"missing case record {lead.case_id!r} required by lead {lead.lead_id!r}"
                 )
 
-        for case in cases.values():
-            if case.alert_id and case.alert_id not in alerts:
+        for case in indexes.cases.values():
+            if case.alert_id and case.alert_id not in indexes.alerts:
                 raise ValueError(
                     f"missing alert record {case.alert_id!r} required by case {case.case_id!r}"
                 )
-            if case.alert_id and alerts[case.alert_id].case_id != case.case_id:
+            if case.alert_id and indexes.alerts[case.alert_id].case_id != case.case_id:
                 raise ValueError(
                     f"case {case.case_id!r} does not match alert binding {case.alert_id!r}"
                 )
             for evidence_id in case.evidence_ids:
-                if evidence_id not in evidence_records:
+                if evidence_id not in indexes.evidence:
                     raise ValueError(
                         f"missing evidence record {evidence_id!r} required by case {case.case_id!r}"
                     )
 
-        for recommendation in recommendations.values():
-            if recommendation.lead_id and recommendation.lead_id not in leads:
+        for recommendation in indexes.recommendations.values():
+            if recommendation.lead_id and recommendation.lead_id not in indexes.leads:
                 raise ValueError(
                     "missing lead record "
                     f"{recommendation.lead_id!r} required by recommendation "
                     f"{recommendation.recommendation_id!r}"
                 )
-            if recommendation.hunt_run_id and recommendation.hunt_run_id not in hunt_runs:
+            if recommendation.hunt_run_id and recommendation.hunt_run_id not in indexes.hunt_runs:
                 raise ValueError(
                     "missing hunt_run record "
                     f"{recommendation.hunt_run_id!r} required by recommendation "
                     f"{recommendation.recommendation_id!r}"
                 )
-            if recommendation.alert_id and recommendation.alert_id not in alerts:
+            if recommendation.alert_id and recommendation.alert_id not in indexes.alerts:
                 raise ValueError(
                     "missing alert record "
                     f"{recommendation.alert_id!r} required by recommendation "
                     f"{recommendation.recommendation_id!r}"
                 )
-            if recommendation.case_id and recommendation.case_id not in cases:
+            if recommendation.case_id and recommendation.case_id not in indexes.cases:
                 raise ValueError(
                     "missing case record "
                     f"{recommendation.case_id!r} required by recommendation "
                     f"{recommendation.recommendation_id!r}"
                 )
-            if recommendation.ai_trace_id and recommendation.ai_trace_id not in ai_traces:
+            if recommendation.ai_trace_id and recommendation.ai_trace_id not in indexes.ai_traces:
                 raise ValueError(
                     "missing ai_trace record "
                     f"{recommendation.ai_trace_id!r} required by recommendation "
                     f"{recommendation.recommendation_id!r}"
                 )
 
-        for hunt in hunts.values():
-            if hunt.alert_id and hunt.alert_id not in alerts:
+        for hunt in indexes.hunts.values():
+            if hunt.alert_id and hunt.alert_id not in indexes.alerts:
                 raise ValueError(
                     f"missing alert record {hunt.alert_id!r} required by hunt {hunt.hunt_id!r}"
                 )
-            if hunt.case_id and hunt.case_id not in cases:
+            if hunt.case_id and hunt.case_id not in indexes.cases:
                 raise ValueError(
                     f"missing case record {hunt.case_id!r} required by hunt {hunt.hunt_id!r}"
                 )
 
-        for hunt_run in hunt_runs.values():
-            if hunt_run.hunt_id not in hunts:
+        for hunt_run in indexes.hunt_runs.values():
+            if hunt_run.hunt_id not in indexes.hunts:
                 raise ValueError(
                     f"missing hunt record {hunt_run.hunt_id!r} required by hunt_run "
                     f"{hunt_run.hunt_run_id!r}"
                 )
 
-        for approval_decision in approval_decisions.values():
-            action_request = action_requests.get(approval_decision.action_request_id)
+        self._validate_restore_approval_and_execution_links(indexes)
+        self._validate_restore_reconciliation_links(families, indexes)
+
+    def _validate_restore_approval_and_execution_links(
+        self,
+        indexes: _RestoreRecordIndexes,
+    ) -> None:
+        for approval_decision in indexes.approval_decisions.values():
+            action_request = indexes.action_requests.get(approval_decision.action_request_id)
             if action_request is None:
                 raise ValueError(
                     f"missing action_request record {approval_decision.action_request_id!r} required by "
@@ -877,26 +1043,26 @@ class _BackupRestoreFlow:
                     "action request payload binding"
                 )
 
-        for action_request in action_requests.values():
-            if action_request.case_id and action_request.case_id not in cases:
+        for action_request in indexes.action_requests.values():
+            if action_request.case_id and action_request.case_id not in indexes.cases:
                 raise ValueError(
                     f"missing case record {action_request.case_id!r} required by action request "
                     f"{action_request.action_request_id!r}"
                 )
-            if action_request.alert_id and action_request.alert_id not in alerts:
+            if action_request.alert_id and action_request.alert_id not in indexes.alerts:
                 raise ValueError(
                     f"missing alert record {action_request.alert_id!r} required by action request "
                     f"{action_request.action_request_id!r}"
                 )
             if (
                 action_request.approval_decision_id
-                and action_request.approval_decision_id not in approval_decisions
+                and action_request.approval_decision_id not in indexes.approval_decisions
             ):
                 raise ValueError(
                     f"missing approval_decision record {action_request.approval_decision_id!r} "
                     f"required by action request {action_request.action_request_id!r}"
                 )
-            approval_decision = approval_decisions.get(action_request.approval_decision_id)
+            approval_decision = indexes.approval_decisions.get(action_request.approval_decision_id)
             if approval_decision is None:
                 continue
             if approval_decision.action_request_id != action_request.action_request_id:
@@ -915,19 +1081,19 @@ class _BackupRestoreFlow:
                     "decision payload binding"
                 )
 
-        for action_execution in action_executions.values():
-            action_request = action_requests.get(action_execution.action_request_id)
+        for action_execution in indexes.action_executions.values():
+            action_request = indexes.action_requests.get(action_execution.action_request_id)
             if action_request is None:
                 raise ValueError(
                     f"missing action_request record {action_execution.action_request_id!r} required by "
                     f"action execution {action_execution.action_execution_id!r}"
                 )
-            if action_execution.approval_decision_id not in approval_decisions:
+            if action_execution.approval_decision_id not in indexes.approval_decisions:
                 raise ValueError(
                     f"missing approval_decision record {action_execution.approval_decision_id!r} "
                     f"required by action execution {action_execution.action_execution_id!r}"
                 )
-            approval_decision = approval_decisions[action_execution.approval_decision_id]
+            approval_decision = indexes.approval_decisions[action_execution.approval_decision_id]
             if action_request.approval_decision_id != action_execution.approval_decision_id:
                 raise ValueError(
                     f"action execution {action_execution.action_execution_id!r} does not match action "
@@ -1004,25 +1170,30 @@ class _BackupRestoreFlow:
                     "expiry binding"
                 )
 
-        for reconciliation in reconciliations:
+    def _validate_restore_reconciliation_links(
+        self,
+        families: _RestoreRecordFamilies,
+        indexes: _RestoreRecordIndexes,
+    ) -> None:
+        for reconciliation in families.reconciliations:
             subject_action_execution_ids = self._assistant_ids_from_mapping(
                 reconciliation.subject_linkage,
                 "action_execution_ids",
             )
             subject_execution_run_ids = {
-                action_executions[action_execution_id].execution_run_id
+                indexes.action_executions[action_execution_id].execution_run_id
                 for action_execution_id in subject_action_execution_ids
-                if action_execution_id in action_executions
-                and action_executions[action_execution_id].execution_run_id is not None
+                if action_execution_id in indexes.action_executions
+                and indexes.action_executions[action_execution_id].execution_run_id is not None
             }
-            if reconciliation.alert_id and reconciliation.alert_id not in alerts:
+            if reconciliation.alert_id and reconciliation.alert_id not in indexes.alerts:
                 raise ValueError(
                     f"missing alert record {reconciliation.alert_id!r} required by reconciliation "
                     f"{reconciliation.reconciliation_id!r}"
                 )
             if (
                 reconciliation.analytic_signal_id
-                and reconciliation.analytic_signal_id not in analytic_signals
+                and reconciliation.analytic_signal_id not in indexes.analytic_signals
             ):
                 raise ValueError(
                     f"missing analytic_signal record {reconciliation.analytic_signal_id!r} required by "
@@ -1030,7 +1201,7 @@ class _BackupRestoreFlow:
                 )
             if (
                 reconciliation.execution_run_id
-                and reconciliation.execution_run_id not in action_executions_by_run_id
+                and reconciliation.execution_run_id not in indexes.action_executions_by_run_id
             ):
                 raise ValueError(
                     f"missing action execution run {reconciliation.execution_run_id!r} required by "
@@ -1046,7 +1217,7 @@ class _BackupRestoreFlow:
                     "execution run binding"
                 )
             for linked_execution_run_id in reconciliation.linked_execution_run_ids:
-                if linked_execution_run_id not in action_executions_by_run_id:
+                if linked_execution_run_id not in indexes.action_executions_by_run_id:
                     raise ValueError(
                         f"missing action execution run {linked_execution_run_id!r} required by "
                         f"reconciliation {reconciliation.reconciliation_id!r}"
@@ -1060,13 +1231,13 @@ class _BackupRestoreFlow:
                         "action execution runs"
                     )
             for field_name, known_ids in (
-                ("analytic_signal_ids", analytic_signals),
-                ("alert_ids", alerts),
-                ("case_ids", cases),
-                ("evidence_ids", evidence_records),
-                ("approval_decision_ids", approval_decisions),
-                ("action_request_ids", action_requests),
-                ("action_execution_ids", action_executions),
+                ("analytic_signal_ids", indexes.analytic_signals),
+                ("alert_ids", indexes.alerts),
+                ("case_ids", indexes.cases),
+                ("evidence_ids", indexes.evidence),
+                ("approval_decision_ids", indexes.approval_decisions),
+                ("action_request_ids", indexes.action_requests),
+                ("action_execution_ids", indexes.action_executions),
             ):
                 for linked_id in self._assistant_ids_from_mapping(
                     reconciliation.subject_linkage,
@@ -1083,10 +1254,18 @@ class _BackupRestoreFlow:
                             f"{reconciliation.reconciliation_id!r}"
                         )
 
+    def _validate_restore_lifecycle_transitions(
+        self,
+        families: _RestoreRecordFamilies,
+        indexes: _RestoreRecordIndexes,
+        *,
+        require_lifecycle_transition_history: bool,
+    ) -> None:
         lifecycle_transitions_by_subject: dict[
             tuple[str, str], list[LifecycleTransitionRecord]
         ] = {}
-        for transition in lifecycle_transition_records:
+        authoritative_subject_ids_by_family = indexes.authoritative_subject_ids_by_family
+        for transition in families.lifecycle_transitions:
             subject_ids = authoritative_subject_ids_by_family.get(
                 transition.subject_record_family
             )
@@ -1111,6 +1290,9 @@ class _BackupRestoreFlow:
                 [],
             ).append(transition)
 
+        authoritative_subject_records_by_family = (
+            indexes.authoritative_subject_records_by_family
+        )
         if require_lifecycle_transition_history:
             for subject_family, subject_records in authoritative_subject_records_by_family.items():
                 for subject_id, subject_record in subject_records.items():
@@ -1185,3 +1367,24 @@ class _BackupRestoreFlow:
                     f"{latest_transition.transition_id!r} state "
                     f"{latest_transition.lifecycle_state!r}"
                 )
+
+    def validate_authoritative_record_chain_restore(
+        self,
+        records_by_family: Mapping[str, tuple[ControlPlaneRecord, ...]],
+        *,
+        require_lifecycle_transition_history: bool = True,
+        restored_record_counts: Mapping[str, int] | None = None,
+    ) -> None:
+        families = self._collect_restore_record_families(records_by_family)
+        self._reject_duplicate_restore_identifiers(
+            families,
+            restored_record_counts=restored_record_counts,
+        )
+        self._validate_restore_record_shapes(families)
+        indexes = self._build_restore_record_indexes(families)
+        self._validate_restore_record_links(families, indexes)
+        self._validate_restore_lifecycle_transitions(
+            families,
+            indexes,
+            require_lifecycle_transition_history=require_lifecycle_transition_history,
+        )

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -82,7 +82,7 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
     def test_service_decomposes_restore_validation_into_internal_helpers(
         self,
     ) -> None:
-        store, _ = make_store()
+        store, _ = support.make_store()
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=store,

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -79,6 +79,29 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             "RestoreReadinessService should delegate readiness projection to a dedicated collaborator",
         )
 
+    def test_service_decomposes_restore_validation_into_internal_helpers(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        backup_restore_flow = (
+            service._restore_readiness_service._backup_restore_flow
+        )
+
+        for helper_name in (
+            "_collect_restore_record_families",
+            "_reject_duplicate_restore_identifiers",
+            "_validate_restore_record_links",
+            "_validate_restore_lifecycle_transitions",
+            "_collect_restore_drill_verified_ids",
+            "_derive_restore_drill_readiness_status",
+        ):
+            with self.subTest(helper_name=helper_name):
+                self.assertTrue(hasattr(backup_restore_flow, helper_name))
+
     def test_service_routes_runtime_restore_and_readiness_through_diagnostics_boundary(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- Split the restore validator into focused helpers for family collection, duplicate checks, record-shape checks, cross-record link validation, and lifecycle-chain validation.
- Split restore-drill proof assembly into verified-id collection, surface probing, and readiness-status derivation helpers.
- Added a focused regression test that keeps the internal restore validation/drill helper boundaries present.

## Verification
- `python3 -m unittest control-plane.tests.test_service_persistence_restore_readiness`
- `python3 -m unittest control-plane.tests.test_phase27_day2_runtime_contract`
- `bash scripts/verify-maintainability-hotspots.sh`
- `git diff --check`
- `node <codex-supervisor-root>/dist/index.js issue-lint 949 --config <supervisor-config-path>` -> `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`

Closes #949


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized the restore-readiness backup/restore validation flow for clearer, more maintainable verification steps while preserving duplicate identifier detection and error formatting.

* **Tests**
  * Added unit test coverage to ensure the restore validation flow is decomposed into the expected verification components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->