### PR TITLE
Phase 50.5: reduce boundary second-hotspot growth

### DIFF
--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from dataclasses import replace
 import re
 from typing import Any, Callable, Mapping
@@ -555,6 +556,34 @@ def _build_assistant_advisory_output(
     }
 
 
+@dataclass(frozen=True)
+class _AssistantContextLineage:
+    alert_ids: tuple[str, ...]
+    case_ids: tuple[str, ...]
+    finding_ids: tuple[str, ...]
+    evidence_ids: tuple[str, ...]
+    ai_trace_records: tuple[AITraceRecord, ...]
+    recommendation_records: tuple[RecommendationRecord, ...]
+    reconciliation_records: tuple[ReconciliationRecord, ...]
+
+
+@dataclass(frozen=True)
+class _AssistantContextLinkedRecords:
+    alert_records: tuple[dict[str, object], ...]
+    case_records: tuple[dict[str, object], ...]
+    evidence_records: tuple[EvidenceRecord, ...]
+    recommendation_payloads: tuple[dict[str, object], ...]
+    reconciliation_records: tuple[ReconciliationRecord, ...]
+
+
+@dataclass(frozen=True)
+class _AssistantContextIds:
+    alert_ids: tuple[str, ...]
+    case_ids: tuple[str, ...]
+    finding_ids: tuple[str, ...]
+    evidence_ids: tuple[str, ...]
+
+
 class AssistantContextAssembler:
     def __init__(
         self,
@@ -582,6 +611,24 @@ class AssistantContextAssembler:
     def inspect_assistant_context(self, record_family: str, record_id: str) -> Any:
         record_family = self._service._require_non_empty_string(record_family, "record_family")
         record_id = self._service._require_non_empty_string(record_id, "record_id")
+        record = self._require_context_record(record_family, record_id)
+        lineage = self._context_lineage(record)
+        linked_records = self._linked_records_for_context(record, lineage)
+        reviewed_context = self._context_reviewed_context(
+            record=record,
+            linked_alert_records=linked_records.alert_records,
+            linked_case_records=linked_records.case_records,
+        )
+        return self._build_context_snapshot(
+            record_family=record_family,
+            record_id=record_id,
+            record=record,
+            lineage=lineage,
+            linked_records=linked_records,
+            reviewed_context=reviewed_context,
+        )
+
+    def _require_context_record(self, record_family: str, record_id: str) -> object:
         record_type = self._record_types_by_family.get(record_family)
         if record_type is None:
             known_families = ", ".join(sorted(self._record_types_by_family))
@@ -596,7 +643,41 @@ class AssistantContextAssembler:
             )
         if record_family == "case":
             self._service._require_reviewed_operator_case_record(record)
+        return record
 
+    def _context_lineage(self, record: object) -> _AssistantContextLineage:
+        ids = self._anchor_record_lineage(record)
+        linked_ai_trace_records = self._ai_trace_lifecycle.ai_trace_records_for_context(record)
+        ids = self._merge_ai_trace_lineage(ids, linked_ai_trace_records)
+        linked_evidence_records, ids = self._merge_evidence_lineage(record, ids)
+        linked_recommendation_records, ids = self._merge_recommendation_lineage(
+            record=record,
+            ids=ids,
+            linked_ai_trace_records=linked_ai_trace_records,
+        )
+        linked_reconciliation_records = (
+            self._ai_trace_lifecycle.reconciliation_records_for_context(
+                record=record,
+                alert_ids=ids.alert_ids,
+                case_ids=ids.case_ids,
+                finding_ids=ids.finding_ids,
+                evidence_ids=ids.evidence_ids,
+                exclude_reconciliation_id=(
+                    record.record_id if isinstance(record, ReconciliationRecord) else None
+                ),
+            )
+        )
+        return _AssistantContextLineage(
+            alert_ids=ids.alert_ids,
+            case_ids=ids.case_ids,
+            finding_ids=ids.finding_ids,
+            evidence_ids=ids.evidence_ids,
+            ai_trace_records=linked_ai_trace_records,
+            recommendation_records=linked_recommendation_records,
+            reconciliation_records=linked_reconciliation_records,
+        )
+
+    def _anchor_record_lineage(self, record: object) -> _AssistantContextIds:
         linked_alert_ids = self._ai_trace_lifecycle.ids_from_value(
             getattr(record, "alert_id", None)
         )
@@ -656,151 +737,14 @@ class AssistantContextAssembler:
                 record.supporting_evidence_ids,
             )
         elif isinstance(record, ReconciliationRecord):
-            linked_alert_ids = self._service._merge_linked_ids(
-                linked_alert_ids,
-                record.alert_id,
-            )
-            linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
-                linked_alert_ids,
-                self._ai_trace_lifecycle.ids_from_mapping(record.subject_linkage, "alert_ids"),
-            )
-            (
-                action_request_ids,
-                approval_decision_ids,
-                action_execution_ids,
-                delegation_ids,
-            ) = self._ai_trace_lifecycle.action_lineage_ids(record)
-            for action_request_id in action_request_ids:
-                action_request = self._service._store.get(ActionRequestRecord, action_request_id)
-                if action_request is None:
-                    continue
-                (
-                    linked_alert_ids,
-                    linked_case_ids,
-                    linked_finding_ids,
-                ) = self._ai_trace_lifecycle.merge_action_request_linkage(
-                    linked_alert_ids=linked_alert_ids,
-                    linked_case_ids=linked_case_ids,
-                    linked_finding_ids=linked_finding_ids,
-                    action_request=action_request,
-                )
-            for approval_decision_id in approval_decision_ids:
-                approval_decision = self._service._store.get(
-                    ApprovalDecisionRecord,
-                    approval_decision_id,
-                )
-                if approval_decision is None:
-                    continue
-                action_request = self._service._store.get(
-                    ActionRequestRecord,
-                    approval_decision.action_request_id,
-                )
-                if action_request is None:
-                    continue
-                (
-                    linked_alert_ids,
-                    linked_case_ids,
-                    linked_finding_ids,
-                ) = self._ai_trace_lifecycle.merge_action_request_linkage(
-                    linked_alert_ids=linked_alert_ids,
-                    linked_case_ids=linked_case_ids,
-                    linked_finding_ids=linked_finding_ids,
-                    action_request=action_request,
-                )
-            for action_execution_id in action_execution_ids:
-                action_execution = self._service._store.get(
-                    ActionExecutionRecord,
-                    action_execution_id,
-                )
-                if action_execution is None:
-                    continue
-                action_request = self._service._store.get(
-                    ActionRequestRecord,
-                    action_execution.action_request_id,
-                )
-                if action_request is not None:
-                    (
-                        linked_alert_ids,
-                        linked_case_ids,
-                        linked_finding_ids,
-                    ) = self._ai_trace_lifecycle.merge_action_request_linkage(
-                        linked_alert_ids=linked_alert_ids,
-                        linked_case_ids=linked_case_ids,
-                        linked_finding_ids=linked_finding_ids,
-                        action_request=action_request,
-                    )
-                linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
-                    linked_evidence_ids,
-                    self._ai_trace_lifecycle.linked_evidence_ids(action_execution),
-                )
-            for delegation_id in delegation_ids:
-                action_execution = self._ai_trace_lifecycle.action_execution_for_delegation_id(
-                    delegation_id
-                )
-                if action_execution is None:
-                    continue
-                action_request = self._service._store.get(
-                    ActionRequestRecord,
-                    action_execution.action_request_id,
-                )
-                if action_request is not None:
-                    (
-                        linked_alert_ids,
-                        linked_case_ids,
-                        linked_finding_ids,
-                    ) = self._ai_trace_lifecycle.merge_action_request_linkage(
-                        linked_alert_ids=linked_alert_ids,
-                        linked_case_ids=linked_case_ids,
-                        linked_finding_ids=linked_finding_ids,
-                        action_request=action_request,
-                    )
-                linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
-                    linked_evidence_ids,
-                    self._ai_trace_lifecycle.linked_evidence_ids(action_execution),
-                )
-            subject_analytic_signal_ids = self._ai_trace_lifecycle.ids_from_mapping(
-                record.subject_linkage,
-                "analytic_signal_ids",
-            )
-            for analytic_signal_id in subject_analytic_signal_ids:
-                signal = self._service._store.get(AnalyticSignalRecord, analytic_signal_id)
-                if signal is None:
-                    continue
-                linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
-                    linked_alert_ids,
-                    signal.alert_ids,
-                )
-                linked_case_ids = self._ai_trace_lifecycle.merge_ids(
-                    linked_case_ids,
-                    signal.case_ids,
-                )
-                linked_finding_ids = self._ai_trace_lifecycle.merge_ids(
-                    linked_finding_ids,
-                    signal.finding_id,
-                )
-            for alert_id in linked_alert_ids:
-                alert = self._service._store.get(AlertRecord, alert_id)
-                if alert is None:
-                    continue
-                linked_case_ids = self._ai_trace_lifecycle.merge_ids(
-                    linked_case_ids,
-                    alert.case_id,
-                )
-                linked_finding_ids = self._ai_trace_lifecycle.merge_ids(
-                    linked_finding_ids,
-                    alert.finding_id,
-                )
-            linked_case_ids = self._ai_trace_lifecycle.merge_ids(
-                linked_case_ids,
-                self._ai_trace_lifecycle.ids_from_mapping(record.subject_linkage, "case_ids"),
-            )
-            linked_finding_ids = self._ai_trace_lifecycle.merge_ids(
-                linked_finding_ids,
-                self._ai_trace_lifecycle.ids_from_mapping(record.subject_linkage, "finding_ids"),
-            )
-            linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
-                linked_evidence_ids,
-                self._ai_trace_lifecycle.ids_from_mapping(record.subject_linkage, "evidence_ids"),
+            return self._reconciliation_anchor_lineage(
+                record,
+                _AssistantContextIds(
+                    alert_ids=linked_alert_ids,
+                    case_ids=linked_case_ids,
+                    finding_ids=linked_finding_ids,
+                    evidence_ids=linked_evidence_ids,
+                ),
             )
         elif isinstance(record, HuntRunRecord):
             linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
@@ -808,7 +752,216 @@ class AssistantContextAssembler:
                 self._ai_trace_lifecycle.ids_from_mapping(record.output_linkage, "evidence_ids"),
             )
 
-        linked_ai_trace_records = self._ai_trace_lifecycle.ai_trace_records_for_context(record)
+        return _AssistantContextIds(
+            alert_ids=linked_alert_ids,
+            case_ids=linked_case_ids,
+            finding_ids=linked_finding_ids,
+            evidence_ids=linked_evidence_ids,
+        )
+
+    def _reconciliation_anchor_lineage(
+        self,
+        record: ReconciliationRecord,
+        ids: _AssistantContextIds,
+    ) -> _AssistantContextIds:
+        linked_alert_ids = self._service._merge_linked_ids(ids.alert_ids, record.alert_id)
+        linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
+            linked_alert_ids,
+            self._ai_trace_lifecycle.ids_from_mapping(record.subject_linkage, "alert_ids"),
+        )
+        linked_case_ids = ids.case_ids
+        linked_finding_ids = ids.finding_ids
+        linked_evidence_ids = ids.evidence_ids
+        (
+            action_request_ids,
+            approval_decision_ids,
+            action_execution_ids,
+            delegation_ids,
+        ) = self._ai_trace_lifecycle.action_lineage_ids(record)
+        for action_request_id in action_request_ids:
+            action_request = self._service._store.get(ActionRequestRecord, action_request_id)
+            if action_request is not None:
+                (
+                    linked_alert_ids,
+                    linked_case_ids,
+                    linked_finding_ids,
+                ) = self._ai_trace_lifecycle.merge_action_request_linkage(
+                    linked_alert_ids=linked_alert_ids,
+                    linked_case_ids=linked_case_ids,
+                    linked_finding_ids=linked_finding_ids,
+                    action_request=action_request,
+                )
+        for approval_decision_id in approval_decision_ids:
+            approval_decision = self._service._store.get(
+                ApprovalDecisionRecord,
+                approval_decision_id,
+            )
+            if approval_decision is None:
+                continue
+            action_request = self._service._store.get(
+                ActionRequestRecord,
+                approval_decision.action_request_id,
+            )
+            if action_request is not None:
+                (
+                    linked_alert_ids,
+                    linked_case_ids,
+                    linked_finding_ids,
+                ) = self._ai_trace_lifecycle.merge_action_request_linkage(
+                    linked_alert_ids=linked_alert_ids,
+                    linked_case_ids=linked_case_ids,
+                    linked_finding_ids=linked_finding_ids,
+                    action_request=action_request,
+                )
+        linked_alert_ids, linked_case_ids, linked_finding_ids, linked_evidence_ids = (
+            self._merge_reconciliation_execution_lineage(
+                action_execution_ids=action_execution_ids,
+                delegation_ids=delegation_ids,
+                linked_alert_ids=linked_alert_ids,
+                linked_case_ids=linked_case_ids,
+                linked_finding_ids=linked_finding_ids,
+                linked_evidence_ids=linked_evidence_ids,
+            )
+        )
+        for analytic_signal_id in self._ai_trace_lifecycle.ids_from_mapping(
+            record.subject_linkage,
+            "analytic_signal_ids",
+        ):
+            signal = self._service._store.get(AnalyticSignalRecord, analytic_signal_id)
+            if signal is None:
+                continue
+            linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
+                linked_alert_ids,
+                signal.alert_ids,
+            )
+            linked_case_ids = self._ai_trace_lifecycle.merge_ids(
+                linked_case_ids,
+                signal.case_ids,
+            )
+            linked_finding_ids = self._ai_trace_lifecycle.merge_ids(
+                linked_finding_ids,
+                signal.finding_id,
+            )
+        for alert_id in linked_alert_ids:
+            alert = self._service._store.get(AlertRecord, alert_id)
+            if alert is None:
+                continue
+            linked_case_ids = self._ai_trace_lifecycle.merge_ids(
+                linked_case_ids,
+                alert.case_id,
+            )
+            linked_finding_ids = self._ai_trace_lifecycle.merge_ids(
+                linked_finding_ids,
+                alert.finding_id,
+            )
+        return _AssistantContextIds(
+            alert_ids=linked_alert_ids,
+            case_ids=self._ai_trace_lifecycle.merge_ids(
+                linked_case_ids,
+                self._ai_trace_lifecycle.ids_from_mapping(
+                    record.subject_linkage,
+                    "case_ids",
+                ),
+            ),
+            finding_ids=self._ai_trace_lifecycle.merge_ids(
+                linked_finding_ids,
+                self._ai_trace_lifecycle.ids_from_mapping(
+                    record.subject_linkage,
+                    "finding_ids",
+                ),
+            ),
+            evidence_ids=self._ai_trace_lifecycle.merge_ids(
+                linked_evidence_ids,
+                self._ai_trace_lifecycle.ids_from_mapping(
+                    record.subject_linkage,
+                    "evidence_ids",
+                ),
+            ),
+        )
+
+    def _merge_reconciliation_execution_lineage(
+        self,
+        *,
+        action_execution_ids: tuple[str, ...],
+        delegation_ids: tuple[str, ...],
+        linked_alert_ids: tuple[str, ...],
+        linked_case_ids: tuple[str, ...],
+        linked_finding_ids: tuple[str, ...],
+        linked_evidence_ids: tuple[str, ...],
+    ) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+        for action_execution_id in action_execution_ids:
+            action_execution = self._service._store.get(
+                ActionExecutionRecord,
+                action_execution_id,
+            )
+            if action_execution is None:
+                continue
+            linked_alert_ids, linked_case_ids, linked_finding_ids = (
+                self._merge_action_execution_request_lineage(
+                    action_execution=action_execution,
+                    linked_alert_ids=linked_alert_ids,
+                    linked_case_ids=linked_case_ids,
+                    linked_finding_ids=linked_finding_ids,
+                )
+            )
+            linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
+                linked_evidence_ids,
+                self._ai_trace_lifecycle.linked_evidence_ids(action_execution),
+            )
+        for delegation_id in delegation_ids:
+            action_execution = self._ai_trace_lifecycle.action_execution_for_delegation_id(
+                delegation_id
+            )
+            if action_execution is None:
+                continue
+            linked_alert_ids, linked_case_ids, linked_finding_ids = (
+                self._merge_action_execution_request_lineage(
+                    action_execution=action_execution,
+                    linked_alert_ids=linked_alert_ids,
+                    linked_case_ids=linked_case_ids,
+                    linked_finding_ids=linked_finding_ids,
+                )
+            )
+            linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
+                linked_evidence_ids,
+                self._ai_trace_lifecycle.linked_evidence_ids(action_execution),
+            )
+        return (
+            linked_alert_ids,
+            linked_case_ids,
+            linked_finding_ids,
+            linked_evidence_ids,
+        )
+
+    def _merge_action_execution_request_lineage(
+        self,
+        *,
+        action_execution: ActionExecutionRecord,
+        linked_alert_ids: tuple[str, ...],
+        linked_case_ids: tuple[str, ...],
+        linked_finding_ids: tuple[str, ...],
+    ) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+        action_request = self._service._store.get(
+            ActionRequestRecord,
+            action_execution.action_request_id,
+        )
+        if action_request is None:
+            return linked_alert_ids, linked_case_ids, linked_finding_ids
+        return self._ai_trace_lifecycle.merge_action_request_linkage(
+            linked_alert_ids=linked_alert_ids,
+            linked_case_ids=linked_case_ids,
+            linked_finding_ids=linked_finding_ids,
+            action_request=action_request,
+        )
+
+    def _merge_ai_trace_lineage(
+        self,
+        ids: _AssistantContextIds,
+        linked_ai_trace_records: tuple[AITraceRecord, ...],
+    ) -> _AssistantContextIds:
+        linked_alert_ids = ids.alert_ids
+        linked_case_ids = ids.case_ids
+        linked_evidence_ids = ids.evidence_ids
         for ai_trace_record in linked_ai_trace_records:
             linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_alert_ids,
@@ -828,19 +981,32 @@ class AssistantContextAssembler:
                 linked_evidence_ids,
                 self._ai_trace_lifecycle.ai_trace_evidence_ids(ai_trace_record),
             )
-
-        linked_evidence_records = self._ai_trace_lifecycle.evidence_records_for_context(
+        return _AssistantContextIds(
             alert_ids=linked_alert_ids,
             case_ids=linked_case_ids,
+            finding_ids=ids.finding_ids,
             evidence_ids=linked_evidence_ids,
+        )
+
+    def _merge_evidence_lineage(
+        self,
+        record: object,
+        ids: _AssistantContextIds,
+    ) -> tuple[tuple[EvidenceRecord, ...], _AssistantContextIds]:
+        linked_evidence_records = self._ai_trace_lifecycle.evidence_records_for_context(
+            alert_ids=ids.alert_ids,
+            case_ids=ids.case_ids,
+            evidence_ids=ids.evidence_ids,
             exclude_evidence_id=(
                 record.evidence_id if isinstance(record, EvidenceRecord) else None
             ),
         )
         linked_evidence_ids = self._ai_trace_lifecycle.merge_ids(
-            linked_evidence_ids,
+            ids.evidence_ids,
             tuple(evidence.evidence_id for evidence in linked_evidence_records),
         )
+        linked_alert_ids = ids.alert_ids
+        linked_case_ids = ids.case_ids
         for evidence in linked_evidence_records:
             linked_alert_ids = self._ai_trace_lifecycle.merge_ids(
                 linked_alert_ids,
@@ -850,20 +1016,34 @@ class AssistantContextAssembler:
                 linked_case_ids,
                 evidence.case_id,
             )
+        return (
+            linked_evidence_records,
+            _AssistantContextIds(
+                alert_ids=linked_alert_ids,
+                case_ids=linked_case_ids,
+                finding_ids=ids.finding_ids,
+                evidence_ids=linked_evidence_ids,
+            ),
+        )
 
+    def _merge_recommendation_lineage(
+        self,
+        *,
+        record: object,
+        ids: _AssistantContextIds,
+        linked_ai_trace_records: tuple[AITraceRecord, ...],
+    ) -> tuple[tuple[RecommendationRecord, ...], _AssistantContextIds]:
         linked_recommendation_records = self._ai_trace_lifecycle.recommendation_records_for_context(
             record=record,
-            alert_ids=linked_alert_ids,
-            case_ids=linked_case_ids,
+            alert_ids=ids.alert_ids,
+            case_ids=ids.case_ids,
             ai_trace_records=linked_ai_trace_records,
             exclude_recommendation_id=(
                 record.record_id if isinstance(record, RecommendationRecord) else None
             ),
         )
-        linked_recommendation_ids = tuple(
-            recommendation.recommendation_id
-            for recommendation in linked_recommendation_records
-        )
+        linked_alert_ids = ids.alert_ids
+        linked_case_ids = ids.case_ids
         has_direct_recommendation_lineage = isinstance(record, RecommendationRecord) and (
             record.alert_id is not None or record.case_id is not None
         )
@@ -877,36 +1057,60 @@ class AssistantContextAssembler:
                     linked_case_ids,
                     recommendation.case_id,
                 )
+        return (
+            linked_recommendation_records,
+            _AssistantContextIds(
+                alert_ids=linked_alert_ids,
+                case_ids=linked_case_ids,
+                finding_ids=ids.finding_ids,
+                evidence_ids=ids.evidence_ids,
+            ),
+        )
 
+    def _linked_records_for_context(
+        self,
+        record: object,
+        lineage: _AssistantContextLineage,
+    ) -> _AssistantContextLinkedRecords:
         linked_alert_records_list: list[dict[str, object]] = []
-        for alert_id in linked_alert_ids:
+        for alert_id in lineage.alert_ids:
             alert = self._service._store.get(AlertRecord, alert_id)
             if alert is not None:
                 linked_alert_records_list.append(self._record_to_dict(alert))
         linked_alert_records = tuple(linked_alert_records_list)
 
         linked_case_records_list: list[dict[str, object]] = []
-        for case_id in linked_case_ids:
+        for case_id in lineage.case_ids:
             case = self._service._store.get(CaseRecord, case_id)
             if case is not None:
                 linked_case_records_list.append(self._record_to_dict(case))
         linked_case_records = tuple(linked_case_records_list)
 
-        linked_reconciliation_records = self._ai_trace_lifecycle.reconciliation_records_for_context(
-            record=record,
-            alert_ids=linked_alert_ids,
-            case_ids=linked_case_ids,
-            finding_ids=linked_finding_ids,
-            evidence_ids=linked_evidence_ids,
-            exclude_reconciliation_id=(
-                record.record_id if isinstance(record, ReconciliationRecord) else None
+        return _AssistantContextLinkedRecords(
+            alert_records=linked_alert_records,
+            case_records=linked_case_records,
+            evidence_records=self._ai_trace_lifecycle.evidence_records_for_context(
+                alert_ids=lineage.alert_ids,
+                case_ids=lineage.case_ids,
+                evidence_ids=lineage.evidence_ids,
+                exclude_evidence_id=(
+                    record.evidence_id if isinstance(record, EvidenceRecord) else None
+                ),
             ),
-        )
-        linked_reconciliation_ids = tuple(
-            reconciliation.reconciliation_id
-            for reconciliation in linked_reconciliation_records
+            recommendation_payloads=tuple(
+                self._record_to_dict(recommendation)
+                for recommendation in lineage.recommendation_records
+            ),
+            reconciliation_records=lineage.reconciliation_records,
         )
 
+    def _context_reviewed_context(
+        self,
+        *,
+        record: object,
+        linked_alert_records: tuple[dict[str, object], ...],
+        linked_case_records: tuple[dict[str, object], ...],
+    ) -> dict[str, object]:
         reviewed_context: dict[str, object] = {}
         raw_reviewed_context = getattr(record, "reviewed_context", None)
         if isinstance(raw_reviewed_context, Mapping):
@@ -932,11 +1136,25 @@ class AssistantContextAssembler:
                     reviewed_context,
                     case.get("reviewed_context"),
                 )
+        return reviewed_context
 
+    def _build_context_snapshot(
+        self,
+        *,
+        record_family: str,
+        record_id: str,
+        record: object,
+        lineage: _AssistantContextLineage,
+        linked_records: _AssistantContextLinkedRecords,
+        reviewed_context: dict[str, object],
+    ) -> Any:
         record_payload = self._record_to_dict(record)
-        linked_recommendation_payloads = tuple(
-            self._record_to_dict(recommendation)
-            for recommendation in linked_recommendation_records
+        linked_evidence_payloads = tuple(
+            self._record_to_dict(evidence) for evidence in linked_records.evidence_records
+        )
+        linked_reconciliation_ids = tuple(
+            reconciliation.reconciliation_id
+            for reconciliation in linked_records.reconciliation_records
         )
 
         return self._assistant_context_snapshot_factory(
@@ -949,32 +1167,34 @@ class AssistantContextAssembler:
                 record_id=record_id,
                 record=record_payload,
                 reviewed_context=reviewed_context,
-                linked_alert_ids=linked_alert_ids,
-                linked_case_ids=linked_case_ids,
-                linked_evidence_ids=linked_evidence_ids,
-                linked_recommendation_ids=linked_recommendation_ids,
-                linked_alert_records=linked_alert_records,
-                linked_case_records=linked_case_records,
-                linked_evidence_records=tuple(
-                    self._record_to_dict(evidence) for evidence in linked_evidence_records
+                linked_alert_ids=lineage.alert_ids,
+                linked_case_ids=lineage.case_ids,
+                linked_evidence_ids=lineage.evidence_ids,
+                linked_recommendation_ids=tuple(
+                    recommendation.recommendation_id
+                    for recommendation in lineage.recommendation_records
                 ),
-                linked_recommendation_records=linked_recommendation_payloads,
+                linked_alert_records=linked_records.alert_records,
+                linked_case_records=linked_records.case_records,
+                linked_evidence_records=linked_evidence_payloads,
+                linked_recommendation_records=linked_records.recommendation_payloads,
             ),
             reviewed_context=reviewed_context,
-            linked_alert_ids=linked_alert_ids,
-            linked_case_ids=linked_case_ids,
-            linked_evidence_ids=linked_evidence_ids,
-            linked_recommendation_ids=linked_recommendation_ids,
-            linked_reconciliation_ids=linked_reconciliation_ids,
-            linked_alert_records=linked_alert_records,
-            linked_case_records=linked_case_records,
-            linked_evidence_records=tuple(
-                self._record_to_dict(evidence) for evidence in linked_evidence_records
+            linked_alert_ids=lineage.alert_ids,
+            linked_case_ids=lineage.case_ids,
+            linked_evidence_ids=lineage.evidence_ids,
+            linked_recommendation_ids=tuple(
+                recommendation.recommendation_id
+                for recommendation in lineage.recommendation_records
             ),
-            linked_recommendation_records=linked_recommendation_payloads,
+            linked_reconciliation_ids=linked_reconciliation_ids,
+            linked_alert_records=linked_records.alert_records,
+            linked_case_records=linked_records.case_records,
+            linked_evidence_records=linked_evidence_payloads,
+            linked_recommendation_records=linked_records.recommendation_payloads,
             linked_reconciliation_records=tuple(
                 self._record_to_dict(reconciliation)
-                for reconciliation in linked_reconciliation_records
+                for reconciliation in linked_records.reconciliation_records
             ),
             lifecycle_transitions=tuple(
                 self._record_to_dict(transition)

--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Callable, Mapping
-import uuid
 
+from .detection_native_context import NativeDetectionContextAttacher
 from .models import (
     AnalyticSignalAdmission,
     AnalyticSignalRecord,
@@ -18,6 +18,31 @@ from .models import (
 
 if TYPE_CHECKING:
     from .service import AegisOpsControlPlaneService, NativeDetectionRecordAdapter
+
+
+@dataclass(frozen=True)
+class _AnalyticSignalAdmissionInputs:
+    finding_id: str
+    analytic_signal_id: str | None
+    substrate_detection_record_id: str | None
+    correlation_key: str
+    first_seen_at: datetime
+    last_seen_at: datetime
+    materially_new_work: bool
+    reviewed_context: dict[str, object]
+
+
+@dataclass(frozen=True)
+class _AnalyticSignalAdmissionState:
+    alert: AlertRecord
+    disposition: str
+    linked_finding_ids: tuple[str, ...]
+    linked_signal_ids: tuple[str, ...]
+    linked_substrate_detection_ids: tuple[str, ...]
+    linked_case_ids: tuple[str, ...]
+    persisted_first_seen: datetime
+    persisted_last_seen: datetime
+    subject_linkage: dict[str, object]
 
 
 class DetectionIntakeService:
@@ -40,6 +65,11 @@ class DetectionIntakeService:
         self._normalize_admission_provenance = normalize_admission_provenance
         self._case_lifecycle_state_by_triage_disposition = dict(
             case_lifecycle_state_by_triage_disposition
+        )
+        self._native_context_attacher = NativeDetectionContextAttacher(
+            service,
+            merge_reviewed_context=merge_reviewed_context,
+            normalize_admission_provenance=normalize_admission_provenance,
         )
 
     def ingest_finding_alert(
@@ -283,22 +313,63 @@ class DetectionIntakeService:
         admission: AnalyticSignalAdmission,
     ) -> FindingAlertIngestResult:
         service = self._service
-        finding_id = service._require_non_empty_string(
-            admission.finding_id,
-            "finding_id",
-        )
-        analytic_signal_id = service._normalize_optional_string(
-            admission.analytic_signal_id,
-            "analytic_signal_id",
-        )
-        substrate_detection_record_id = service._normalize_optional_string(
-            admission.substrate_detection_record_id,
-            "substrate_detection_record_id",
-        )
-        correlation_key = service._require_non_empty_string(
-            admission.correlation_key,
-            "correlation_key",
-        )
+        inputs = self._resolve_admission_inputs(admission)
+        with service._store.transaction():
+            latest_reconciliation = service._store.latest_reconciliation_for_correlation_key(
+                inputs.correlation_key,
+                require_alert_id=True,
+            )
+            inputs = _AnalyticSignalAdmissionInputs(
+                finding_id=inputs.finding_id,
+                analytic_signal_id=service._resolve_analytic_signal_id(
+                    analytic_signal_id=inputs.analytic_signal_id,
+                    finding_id=inputs.finding_id,
+                    correlation_key=inputs.correlation_key,
+                    substrate_detection_record_id=inputs.substrate_detection_record_id,
+                    latest_reconciliation=latest_reconciliation,
+                ),
+                substrate_detection_record_id=inputs.substrate_detection_record_id,
+                correlation_key=inputs.correlation_key,
+                first_seen_at=inputs.first_seen_at,
+                last_seen_at=inputs.last_seen_at,
+                materially_new_work=inputs.materially_new_work,
+                reviewed_context=inputs.reviewed_context,
+            )
+
+            state = (
+                self._admit_new_alert(inputs)
+                if latest_reconciliation is None
+                else self._merge_existing_alert_admission(
+                    inputs,
+                    latest_reconciliation=latest_reconciliation,
+                    admission_reviewed_context=admission.reviewed_context,
+                )
+            )
+            self._persist_analytic_signal_admission(
+                inputs,
+                alert=state.alert,
+                admission_reviewed_context=admission.reviewed_context,
+            )
+            self._link_case_to_analytic_signals(
+                state.linked_signal_ids,
+                state.alert.case_id,
+            )
+            reconciliation = self._persist_admission_reconciliation(
+                inputs,
+                latest_reconciliation=latest_reconciliation,
+                state=state,
+            )
+            return FindingAlertIngestResult(
+                alert=state.alert,
+                reconciliation=reconciliation,
+                disposition=state.disposition,
+            )
+
+    def _resolve_admission_inputs(
+        self,
+        admission: AnalyticSignalAdmission,
+    ) -> _AnalyticSignalAdmissionInputs:
+        service = self._service
         first_seen_at = service._require_aware_datetime(
             admission.first_seen_at,
             "first_seen_at",
@@ -311,248 +382,302 @@ class DetectionIntakeService:
             raise ValueError(
                 "last_seen_at must be greater than or equal to first_seen_at"
             )
-        materially_new_work = admission.materially_new_work
-        reviewed_context = self._merge_reviewed_context({}, admission.reviewed_context)
-        with service._store.transaction():
-            latest_reconciliation = service._store.latest_reconciliation_for_correlation_key(
-                correlation_key,
-                require_alert_id=True,
-            )
-            analytic_signal_id = service._resolve_analytic_signal_id(
-                analytic_signal_id=analytic_signal_id,
-                finding_id=finding_id,
-                correlation_key=correlation_key,
-                substrate_detection_record_id=substrate_detection_record_id,
-                latest_reconciliation=latest_reconciliation,
-            )
+        return _AnalyticSignalAdmissionInputs(
+            finding_id=service._require_non_empty_string(
+                admission.finding_id,
+                "finding_id",
+            ),
+            analytic_signal_id=service._normalize_optional_string(
+                admission.analytic_signal_id,
+                "analytic_signal_id",
+            ),
+            substrate_detection_record_id=service._normalize_optional_string(
+                admission.substrate_detection_record_id,
+                "substrate_detection_record_id",
+            ),
+            correlation_key=service._require_non_empty_string(
+                admission.correlation_key,
+                "correlation_key",
+            ),
+            first_seen_at=first_seen_at,
+            last_seen_at=last_seen_at,
+            materially_new_work=admission.materially_new_work,
+            reviewed_context=self._merge_reviewed_context(
+                {},
+                admission.reviewed_context,
+            ),
+        )
 
-            if latest_reconciliation is None:
-                alert = service.persist_record(
-                    AlertRecord(
-                        alert_id=service._next_identifier("alert"),
-                        finding_id=finding_id,
-                        analytic_signal_id=analytic_signal_id,
-                        case_id=None,
-                        lifecycle_state="new",
-                        reviewed_context=reviewed_context,
-                    )
-                )
-                disposition = "created"
-                linked_finding_ids = (finding_id,)
-                linked_signal_ids = (
-                    (analytic_signal_id,) if analytic_signal_id is not None else tuple()
-                )
-                linked_substrate_detection_ids = service._merge_linked_ids(
-                    (),
-                    substrate_detection_record_id,
-                )
-                linked_case_ids = service._merge_linked_ids((), alert.case_id)
-                persisted_first_seen = first_seen_at
-                persisted_last_seen = last_seen_at
-            else:
-                alert = service._store.get(AlertRecord, latest_reconciliation.alert_id)
-                if alert is None:
-                    raise LookupError(
-                        f"Missing alert {latest_reconciliation.alert_id!r} for correlation key {correlation_key!r}"
-                    )
-                merged_reviewed_context = self._merge_reviewed_context(
-                    alert.reviewed_context,
-                    admission.reviewed_context,
-                )
-                existing_finding_ids = latest_reconciliation.subject_linkage.get("finding_ids")
-                existing_signal_ids = latest_reconciliation.subject_linkage.get(
-                    "analytic_signal_ids"
-                )
-                existing_substrate_detection_ids = latest_reconciliation.subject_linkage.get(
-                    "substrate_detection_record_ids"
-                )
-                existing_case_ids = latest_reconciliation.subject_linkage.get("case_ids")
-                linked_finding_ids = service._merge_linked_ids(
-                    existing_finding_ids,
-                    finding_id,
-                )
-                linked_signal_ids = service._merge_linked_ids(
+    def _admit_new_alert(
+        self,
+        inputs: _AnalyticSignalAdmissionInputs,
+    ) -> _AnalyticSignalAdmissionState:
+        service = self._service
+        alert = service.persist_record(
+            AlertRecord(
+                alert_id=service._next_identifier("alert"),
+                finding_id=inputs.finding_id,
+                analytic_signal_id=inputs.analytic_signal_id,
+                case_id=None,
+                lifecycle_state="new",
+                reviewed_context=inputs.reviewed_context,
+            )
+        )
+        return _AnalyticSignalAdmissionState(
+            alert=alert,
+            disposition="created",
+            linked_finding_ids=(inputs.finding_id,),
+            linked_signal_ids=(
+                (inputs.analytic_signal_id,)
+                if inputs.analytic_signal_id is not None
+                else tuple()
+            ),
+            linked_substrate_detection_ids=service._merge_linked_ids(
+                (),
+                inputs.substrate_detection_record_id,
+            ),
+            linked_case_ids=service._merge_linked_ids((), alert.case_id),
+            persisted_first_seen=inputs.first_seen_at,
+            persisted_last_seen=inputs.last_seen_at,
+            subject_linkage={},
+        )
+
+    def _merge_existing_alert_admission(
+        self,
+        inputs: _AnalyticSignalAdmissionInputs,
+        *,
+        latest_reconciliation: ReconciliationRecord,
+        admission_reviewed_context: Mapping[str, object],
+    ) -> _AnalyticSignalAdmissionState:
+        service = self._service
+        alert = service._store.get(AlertRecord, latest_reconciliation.alert_id)
+        if alert is None:
+            raise LookupError(
+                f"Missing alert {latest_reconciliation.alert_id!r} "
+                f"for correlation key {inputs.correlation_key!r}"
+            )
+        merged_reviewed_context = self._merge_reviewed_context(
+            alert.reviewed_context,
+            admission_reviewed_context,
+        )
+        existing_finding_ids = latest_reconciliation.subject_linkage.get("finding_ids")
+        existing_signal_ids = latest_reconciliation.subject_linkage.get(
+            "analytic_signal_ids"
+        )
+        existing_substrate_detection_ids = latest_reconciliation.subject_linkage.get(
+            "substrate_detection_record_ids"
+        )
+        existing_case_ids = latest_reconciliation.subject_linkage.get("case_ids")
+        already_linked = (
+            service._linked_id_exists(existing_finding_ids, inputs.finding_id)
+            and (
+                inputs.analytic_signal_id is None
+                or service._linked_id_exists(
                     existing_signal_ids,
-                    analytic_signal_id,
+                    inputs.analytic_signal_id,
                 )
-                linked_substrate_detection_ids = service._merge_linked_ids(
+            )
+            and (
+                inputs.substrate_detection_record_id is None
+                or service._linked_id_exists(
                     existing_substrate_detection_ids,
-                    substrate_detection_record_id,
+                    inputs.substrate_detection_record_id,
                 )
-                linked_case_ids = service._merge_linked_ids(
-                    existing_case_ids,
-                    alert.case_id,
-                )
-                persisted_first_seen = min(
-                    latest_reconciliation.first_seen_at or first_seen_at,
-                    first_seen_at,
-                )
-                persisted_last_seen = max(
-                    latest_reconciliation.last_seen_at or last_seen_at,
-                    last_seen_at,
-                )
-                already_linked = (
-                    service._linked_id_exists(existing_finding_ids, finding_id)
-                    and (
-                        analytic_signal_id is None
-                        or service._linked_id_exists(
-                            existing_signal_ids,
-                            analytic_signal_id,
-                        )
-                    )
-                    and (
-                        substrate_detection_record_id is None
-                        or service._linked_id_exists(
-                            existing_substrate_detection_ids,
-                            substrate_detection_record_id,
-                        )
-                    )
-                )
-                if materially_new_work:
-                    alert = service.persist_record(
-                        replace(
-                            alert,
-                            finding_id=finding_id,
-                            analytic_signal_id=analytic_signal_id,
-                            reviewed_context=merged_reviewed_context,
-                        )
-                    )
-                    disposition = "updated"
-                elif merged_reviewed_context != alert.reviewed_context:
-                    alert = service.persist_record(
-                        replace(
-                            alert,
-                            reviewed_context=merged_reviewed_context,
-                        )
-                    )
-                    disposition = "updated"
-                elif analytic_signal_id != alert.analytic_signal_id:
-                    alert = service.persist_record(
-                        replace(
-                            alert,
-                            analytic_signal_id=analytic_signal_id,
-                        )
-                    )
-                    disposition = "restated"
-                elif already_linked:
-                    disposition = "deduplicated"
-                else:
-                    disposition = "restated"
+            )
+        )
+        alert, disposition = self._persist_existing_admission_alert(
+            alert=alert,
+            inputs=inputs,
+            merged_reviewed_context=merged_reviewed_context,
+            already_linked=already_linked,
+        )
+        self._merge_existing_alert_case_context(alert)
+        return _AnalyticSignalAdmissionState(
+            alert=alert,
+            disposition=disposition,
+            linked_finding_ids=service._merge_linked_ids(
+                existing_finding_ids,
+                inputs.finding_id,
+            ),
+            linked_signal_ids=service._merge_linked_ids(
+                existing_signal_ids,
+                inputs.analytic_signal_id,
+            ),
+            linked_substrate_detection_ids=service._merge_linked_ids(
+                existing_substrate_detection_ids,
+                inputs.substrate_detection_record_id,
+            ),
+            linked_case_ids=service._merge_linked_ids(existing_case_ids, alert.case_id),
+            persisted_first_seen=min(
+                latest_reconciliation.first_seen_at or inputs.first_seen_at,
+                inputs.first_seen_at,
+            ),
+            persisted_last_seen=max(
+                latest_reconciliation.last_seen_at or inputs.last_seen_at,
+                inputs.last_seen_at,
+            ),
+            subject_linkage=dict(latest_reconciliation.subject_linkage),
+        )
 
-                if alert.case_id is not None:
-                    existing_case = service._store.get(CaseRecord, alert.case_id)
-                    if existing_case is None:
-                        raise LookupError(
-                            f"Alert {alert.alert_id!r} references missing case {alert.case_id!r}"
-                        )
-                    merged_case_reviewed_context = self._merge_reviewed_context(
-                        existing_case.reviewed_context,
-                        alert.reviewed_context,
+    def _persist_existing_admission_alert(
+        self,
+        *,
+        alert: AlertRecord,
+        inputs: _AnalyticSignalAdmissionInputs,
+        merged_reviewed_context: dict[str, object],
+        already_linked: bool,
+    ) -> tuple[AlertRecord, str]:
+        service = self._service
+        if inputs.materially_new_work:
+            return (
+                service.persist_record(
+                    replace(
+                        alert,
+                        finding_id=inputs.finding_id,
+                        analytic_signal_id=inputs.analytic_signal_id,
+                        reviewed_context=merged_reviewed_context,
                     )
-                    if (
-                        existing_case.finding_id != alert.finding_id
-                        or merged_case_reviewed_context != existing_case.reviewed_context
-                    ):
-                        service.persist_record(
-                            replace(
-                                existing_case,
-                                finding_id=alert.finding_id,
-                                reviewed_context=merged_case_reviewed_context,
-                            )
-                        )
+                ),
+                "updated",
+            )
+        if merged_reviewed_context != alert.reviewed_context:
+            return (
+                service.persist_record(
+                    replace(alert, reviewed_context=merged_reviewed_context)
+                ),
+                "updated",
+            )
+        if inputs.analytic_signal_id != alert.analytic_signal_id:
+            return (
+                service.persist_record(
+                    replace(alert, analytic_signal_id=inputs.analytic_signal_id)
+                ),
+                "restated",
+            )
+        return alert, "deduplicated" if already_linked else "restated"
 
-            if analytic_signal_id is not None:
-                existing_signal = service._store.get(
-                    AnalyticSignalRecord,
-                    analytic_signal_id,
+    def _merge_existing_alert_case_context(self, alert: AlertRecord) -> None:
+        if alert.case_id is None:
+            return
+        service = self._service
+        existing_case = service._store.get(CaseRecord, alert.case_id)
+        if existing_case is None:
+            raise LookupError(
+                f"Alert {alert.alert_id!r} references missing case {alert.case_id!r}"
+            )
+        merged_case_reviewed_context = self._merge_reviewed_context(
+            existing_case.reviewed_context,
+            alert.reviewed_context,
+        )
+        if (
+            existing_case.finding_id != alert.finding_id
+            or merged_case_reviewed_context != existing_case.reviewed_context
+        ):
+            service.persist_record(
+                replace(
+                    existing_case,
+                    finding_id=alert.finding_id,
+                    reviewed_context=merged_case_reviewed_context,
                 )
-                if existing_signal is not None:
-                    if existing_signal.correlation_key != correlation_key:
-                        raise ValueError(
-                            f"Analytic signal {analytic_signal_id!r} already belongs to "
-                            f"correlation key {existing_signal.correlation_key!r}"
-                        )
-                signal_reviewed_context = self._merge_reviewed_context(
-                    alert.reviewed_context,
-                    admission.reviewed_context,
-                )
-                signal_alert_ids = service._merge_linked_ids(
+            )
+
+    def _persist_analytic_signal_admission(
+        self,
+        inputs: _AnalyticSignalAdmissionInputs,
+        *,
+        alert: AlertRecord,
+        admission_reviewed_context: Mapping[str, object],
+    ) -> None:
+        if inputs.analytic_signal_id is None:
+            return
+        service = self._service
+        existing_signal = service._store.get(
+            AnalyticSignalRecord,
+            inputs.analytic_signal_id,
+        )
+        if (
+            existing_signal is not None
+            and existing_signal.correlation_key != inputs.correlation_key
+        ):
+            raise ValueError(
+                f"Analytic signal {inputs.analytic_signal_id!r} already belongs to "
+                f"correlation key {existing_signal.correlation_key!r}"
+            )
+        signal_first_seen = inputs.first_seen_at
+        if existing_signal is not None and existing_signal.first_seen_at is not None:
+            signal_first_seen = min(existing_signal.first_seen_at, inputs.first_seen_at)
+        signal_last_seen = inputs.last_seen_at
+        if existing_signal is not None and existing_signal.last_seen_at is not None:
+            signal_last_seen = max(existing_signal.last_seen_at, inputs.last_seen_at)
+        service.persist_record(
+            AnalyticSignalRecord(
+                analytic_signal_id=inputs.analytic_signal_id,
+                substrate_detection_record_id=(
+                    inputs.substrate_detection_record_id
+                    if inputs.substrate_detection_record_id is not None
+                    else (
+                        existing_signal.substrate_detection_record_id
+                        if existing_signal is not None
+                        else None
+                    )
+                ),
+                finding_id=inputs.finding_id,
+                alert_ids=service._merge_linked_ids(
                     existing_signal.alert_ids if existing_signal is not None else (),
                     alert.alert_id,
-                )
-                signal_case_ids = service._merge_linked_ids(
+                ),
+                case_ids=service._merge_linked_ids(
                     existing_signal.case_ids if existing_signal is not None else (),
                     alert.case_id,
-                )
-                signal_first_seen = first_seen_at
-                if existing_signal is not None and existing_signal.first_seen_at is not None:
-                    signal_first_seen = min(existing_signal.first_seen_at, first_seen_at)
-                signal_last_seen = last_seen_at
-                if existing_signal is not None and existing_signal.last_seen_at is not None:
-                    signal_last_seen = max(existing_signal.last_seen_at, last_seen_at)
-                service.persist_record(
-                    AnalyticSignalRecord(
-                        analytic_signal_id=analytic_signal_id,
-                        substrate_detection_record_id=(
-                            substrate_detection_record_id
-                            if substrate_detection_record_id is not None
-                            else (
-                                existing_signal.substrate_detection_record_id
-                                if existing_signal is not None
-                                else None
-                            )
-                        ),
-                        finding_id=finding_id,
-                        alert_ids=signal_alert_ids,
-                        case_ids=signal_case_ids,
-                        correlation_key=correlation_key,
-                        first_seen_at=signal_first_seen,
-                        last_seen_at=signal_last_seen,
-                        lifecycle_state="active",
-                        reviewed_context=signal_reviewed_context,
-                    )
-                )
+                ),
+                correlation_key=inputs.correlation_key,
+                first_seen_at=signal_first_seen,
+                last_seen_at=signal_last_seen,
+                lifecycle_state="active",
+                reviewed_context=self._merge_reviewed_context(
+                    alert.reviewed_context,
+                    admission_reviewed_context,
+                ),
+            )
+        )
 
-            self._link_case_to_analytic_signals(linked_signal_ids, alert.case_id)
-
-            subject_linkage = (
-                dict(latest_reconciliation.subject_linkage)
-                if latest_reconciliation is not None
-                else {}
+    def _persist_admission_reconciliation(
+        self,
+        inputs: _AnalyticSignalAdmissionInputs,
+        *,
+        latest_reconciliation: ReconciliationRecord | None,
+        state: _AnalyticSignalAdmissionState,
+    ) -> ReconciliationRecord:
+        subject_linkage = dict(state.subject_linkage)
+        subject_linkage.update(
+            {
+                "alert_ids": (state.alert.alert_id,),
+                "case_ids": state.linked_case_ids,
+                "substrate_detection_record_ids": state.linked_substrate_detection_ids,
+                "finding_ids": state.linked_finding_ids,
+                "analytic_signal_ids": state.linked_signal_ids,
+            }
+        )
+        return self._service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id=self._service._next_identifier("reconciliation"),
+                subject_linkage=subject_linkage,
+                alert_id=state.alert.alert_id,
+                finding_id=inputs.finding_id,
+                analytic_signal_id=inputs.analytic_signal_id,
+                execution_run_id=None,
+                linked_execution_run_ids=(),
+                correlation_key=inputs.correlation_key,
+                first_seen_at=state.persisted_first_seen,
+                last_seen_at=state.persisted_last_seen,
+                ingest_disposition=state.disposition,
+                mismatch_summary=(
+                    f"{state.disposition} upstream analytic signal into alert lifecycle"
+                ),
+                compared_at=datetime.now(timezone.utc),
+                lifecycle_state="matched",
             )
-            subject_linkage.update(
-                {
-                    "alert_ids": (alert.alert_id,),
-                    "case_ids": linked_case_ids,
-                    "substrate_detection_record_ids": linked_substrate_detection_ids,
-                    "finding_ids": linked_finding_ids,
-                    "analytic_signal_ids": linked_signal_ids,
-                }
-            )
-            reconciliation = service.persist_record(
-                ReconciliationRecord(
-                    reconciliation_id=service._next_identifier("reconciliation"),
-                    subject_linkage=subject_linkage,
-                    alert_id=alert.alert_id,
-                    finding_id=finding_id,
-                    analytic_signal_id=analytic_signal_id,
-                    execution_run_id=None,
-                    linked_execution_run_ids=(),
-                    correlation_key=correlation_key,
-                    first_seen_at=persisted_first_seen,
-                    last_seen_at=persisted_last_seen,
-                    ingest_disposition=disposition,
-                    mismatch_summary=f"{disposition} upstream analytic signal into alert lifecycle",
-                    compared_at=datetime.now(timezone.utc),
-                    lifecycle_state="matched",
-                )
-            )
-
-            return FindingAlertIngestResult(
-                alert=alert,
-                reconciliation=reconciliation,
-                disposition=disposition,
-            )
+        )
 
     def attach_native_detection_context(
         self,
@@ -561,155 +686,11 @@ class DetectionIntakeService:
         ingest_result: FindingAlertIngestResult,
         substrate_detection_record_id: str,
     ) -> FindingAlertIngestResult:
-        service = self._service
-        with service._store.transaction():
-            source_system = service._normalize_optional_string(
-                record.metadata.get("source_system"),
-                "metadata.source_system",
-            ) or record.substrate_key
-            evidence_id = (
-                f"evidence-{uuid.uuid5(uuid.NAMESPACE_URL, substrate_detection_record_id)}"
-            )
-            case_id = ingest_result.alert.case_id
-            existing_case = None
-            if case_id is not None:
-                existing_case = service._store.get(CaseRecord, case_id)
-                if existing_case is None:
-                    raise LookupError(
-                        f"Alert {ingest_result.alert.alert_id!r} references missing case {case_id!r}"
-                    )
-            evidence = service.persist_record(
-                EvidenceRecord(
-                    evidence_id=evidence_id,
-                    source_record_id=substrate_detection_record_id,
-                    alert_id=ingest_result.alert.alert_id,
-                    case_id=case_id,
-                    source_system=source_system,
-                    collector_identity=f"{record.substrate_key}-native-detection-adapter",
-                    acquired_at=service._require_aware_datetime(
-                        record.first_seen_at,
-                        "record.first_seen_at",
-                    ),
-                    derivation_relationship="native_detection_record",
-                    lifecycle_state="linked" if case_id is not None else "collected",
-                    provenance={},
-                    content={},
-                )
-            )
-
-            if existing_case is not None:
-                merged_case_evidence_ids = service._merge_linked_ids(
-                    existing_case.evidence_ids,
-                    evidence.evidence_id,
-                )
-                merged_case_reviewed_context = self._merge_reviewed_context(
-                    existing_case.reviewed_context,
-                    ingest_result.alert.reviewed_context,
-                )
-                if (
-                    merged_case_evidence_ids != existing_case.evidence_ids
-                    or merged_case_reviewed_context != existing_case.reviewed_context
-                ):
-                    service.persist_record(
-                        replace(
-                            existing_case,
-                            evidence_ids=merged_case_evidence_ids,
-                            reviewed_context=merged_case_reviewed_context,
-                        )
-                    )
-
-            subject_linkage = dict(ingest_result.reconciliation.subject_linkage)
-            subject_linkage["evidence_ids"] = service._merge_linked_ids(
-                subject_linkage.get("evidence_ids"),
-                evidence.evidence_id,
-            )
-            subject_linkage["source_systems"] = service._merge_linked_ids(
-                subject_linkage.get("source_systems"),
-                source_system,
-            )
-
-            source_provenance = record.metadata.get("source_provenance")
-            if isinstance(source_provenance, Mapping):
-                accountable_source_identity = service._normalize_optional_string(
-                    source_provenance.get("accountable_source_identity"),
-                    "metadata.source_provenance.accountable_source_identity",
-                )
-                if accountable_source_identity is not None:
-                    subject_linkage["accountable_source_identities"] = (
-                        service._merge_linked_ids(
-                            subject_linkage.get("accountable_source_identities"),
-                            accountable_source_identity,
-                        )
-                    )
-
-            native_rule = record.metadata.get("native_rule")
-            if isinstance(native_rule, Mapping):
-                native_rule_id = service._normalize_optional_string(
-                    native_rule.get("id"),
-                    "metadata.native_rule.id",
-                )
-                native_rule_description = service._normalize_optional_string(
-                    native_rule.get("description"),
-                    "metadata.native_rule.description",
-                )
-                rule_level = native_rule.get("level")
-                subject_linkage["latest_native_rule"] = {
-                    "id": native_rule_id,
-                    "level": rule_level if isinstance(rule_level, int) else None,
-                    "description": native_rule_description,
-                }
-
-            reviewed_correlation_context = record.metadata.get(
-                "reviewed_correlation_context"
-            )
-            if isinstance(reviewed_correlation_context, Mapping):
-                subject_linkage["reviewed_correlation_context"] = {
-                    str(field_name): field_value
-                    for field_name, field_value in reviewed_correlation_context.items()
-                    if isinstance(field_value, str) and field_value.strip()
-                }
-
-            reviewed_source_profile = record.metadata.get("reviewed_source_profile")
-            if isinstance(reviewed_source_profile, Mapping):
-                subject_linkage["reviewed_source_profile"] = dict(
-                    reviewed_source_profile
-                )
-
-            raw_alert = record.metadata.get("raw_alert")
-            if isinstance(raw_alert, Mapping):
-                subject_linkage["latest_native_payload"] = dict(raw_alert)
-
-            admission_provenance = self._normalize_admission_provenance(
-                record.metadata.get("admission_provenance")
-            )
-            if admission_provenance is not None:
-                subject_linkage["admission_provenance"] = admission_provenance
-
-            reconciliation = service.persist_record(
-                ReconciliationRecord(
-                    reconciliation_id=ingest_result.reconciliation.reconciliation_id,
-                    subject_linkage=subject_linkage,
-                    alert_id=ingest_result.reconciliation.alert_id,
-                    finding_id=ingest_result.reconciliation.finding_id,
-                    analytic_signal_id=ingest_result.reconciliation.analytic_signal_id,
-                    execution_run_id=ingest_result.reconciliation.execution_run_id,
-                    linked_execution_run_ids=(
-                        ingest_result.reconciliation.linked_execution_run_ids
-                    ),
-                    correlation_key=ingest_result.reconciliation.correlation_key,
-                    first_seen_at=ingest_result.reconciliation.first_seen_at,
-                    last_seen_at=ingest_result.reconciliation.last_seen_at,
-                    ingest_disposition=ingest_result.reconciliation.ingest_disposition,
-                    mismatch_summary=ingest_result.reconciliation.mismatch_summary,
-                    compared_at=ingest_result.reconciliation.compared_at,
-                    lifecycle_state=ingest_result.reconciliation.lifecycle_state,
-                )
-            )
-            return FindingAlertIngestResult(
-                alert=ingest_result.alert,
-                reconciliation=reconciliation,
-                disposition=ingest_result.disposition,
-            )
+        return self._native_context_attacher.attach_native_detection_context(
+            record=record,
+            ingest_result=ingest_result,
+            substrate_detection_record_id=substrate_detection_record_id,
+        )
 
     def reviewed_context_transitioned_at(
         self,

--- a/control-plane/aegisops_control_plane/detection_native_context.py
+++ b/control-plane/aegisops_control_plane/detection_native_context.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Callable, Mapping
+import uuid
+
+from .models import (
+    CaseRecord,
+    EvidenceRecord,
+    FindingAlertIngestResult,
+    NativeDetectionRecord,
+    ReconciliationRecord,
+)
+
+if TYPE_CHECKING:
+    from .service import AegisOpsControlPlaneService
+
+
+class NativeDetectionContextAttacher:
+    def __init__(
+        self,
+        service: AegisOpsControlPlaneService,
+        *,
+        merge_reviewed_context: Callable[
+            [Mapping[str, object], Mapping[str, object]],
+            dict[str, object],
+        ],
+        normalize_admission_provenance: Callable[
+            [object],
+            dict[str, str] | None,
+        ],
+    ) -> None:
+        self._service = service
+        self._merge_reviewed_context = merge_reviewed_context
+        self._normalize_admission_provenance = normalize_admission_provenance
+
+    def attach_native_detection_context(
+        self,
+        *,
+        record: NativeDetectionRecord,
+        ingest_result: FindingAlertIngestResult,
+        substrate_detection_record_id: str,
+    ) -> FindingAlertIngestResult:
+        service = self._service
+        with service._store.transaction():
+            source_system = service._normalize_optional_string(
+                record.metadata.get("source_system"),
+                "metadata.source_system",
+            ) or record.substrate_key
+            evidence_id = (
+                f"evidence-{uuid.uuid5(uuid.NAMESPACE_URL, substrate_detection_record_id)}"
+            )
+            case_id = ingest_result.alert.case_id
+            existing_case = None
+            if case_id is not None:
+                existing_case = service._store.get(CaseRecord, case_id)
+                if existing_case is None:
+                    raise LookupError(
+                        f"Alert {ingest_result.alert.alert_id!r} "
+                        f"references missing case {case_id!r}"
+                    )
+            evidence = service.persist_record(
+                EvidenceRecord(
+                    evidence_id=evidence_id,
+                    source_record_id=substrate_detection_record_id,
+                    alert_id=ingest_result.alert.alert_id,
+                    case_id=case_id,
+                    source_system=source_system,
+                    collector_identity=f"{record.substrate_key}-native-detection-adapter",
+                    acquired_at=service._require_aware_datetime(
+                        record.first_seen_at,
+                        "record.first_seen_at",
+                    ),
+                    derivation_relationship="native_detection_record",
+                    lifecycle_state="linked" if case_id is not None else "collected",
+                    provenance={},
+                    content={},
+                )
+            )
+            if existing_case is not None:
+                self._merge_case_context(
+                    existing_case=existing_case,
+                    evidence_id=evidence.evidence_id,
+                    ingest_result=ingest_result,
+                )
+
+            subject_linkage = dict(ingest_result.reconciliation.subject_linkage)
+            subject_linkage["evidence_ids"] = service._merge_linked_ids(
+                subject_linkage.get("evidence_ids"),
+                evidence.evidence_id,
+            )
+            subject_linkage["source_systems"] = service._merge_linked_ids(
+                subject_linkage.get("source_systems"),
+                source_system,
+            )
+            self._attach_native_source_metadata(
+                subject_linkage=subject_linkage,
+                record=record,
+            )
+            reconciliation = service.persist_record(
+                ReconciliationRecord(
+                    reconciliation_id=ingest_result.reconciliation.reconciliation_id,
+                    subject_linkage=subject_linkage,
+                    alert_id=ingest_result.reconciliation.alert_id,
+                    finding_id=ingest_result.reconciliation.finding_id,
+                    analytic_signal_id=ingest_result.reconciliation.analytic_signal_id,
+                    execution_run_id=ingest_result.reconciliation.execution_run_id,
+                    linked_execution_run_ids=(
+                        ingest_result.reconciliation.linked_execution_run_ids
+                    ),
+                    correlation_key=ingest_result.reconciliation.correlation_key,
+                    first_seen_at=ingest_result.reconciliation.first_seen_at,
+                    last_seen_at=ingest_result.reconciliation.last_seen_at,
+                    ingest_disposition=ingest_result.reconciliation.ingest_disposition,
+                    mismatch_summary=ingest_result.reconciliation.mismatch_summary,
+                    compared_at=ingest_result.reconciliation.compared_at,
+                    lifecycle_state=ingest_result.reconciliation.lifecycle_state,
+                )
+            )
+            return FindingAlertIngestResult(
+                alert=ingest_result.alert,
+                reconciliation=reconciliation,
+                disposition=ingest_result.disposition,
+            )
+
+    def _merge_case_context(
+        self,
+        *,
+        existing_case: CaseRecord,
+        evidence_id: str,
+        ingest_result: FindingAlertIngestResult,
+    ) -> None:
+        service = self._service
+        merged_case_evidence_ids = service._merge_linked_ids(
+            existing_case.evidence_ids,
+            evidence_id,
+        )
+        merged_case_reviewed_context = self._merge_reviewed_context(
+            existing_case.reviewed_context,
+            ingest_result.alert.reviewed_context,
+        )
+        if (
+            merged_case_evidence_ids != existing_case.evidence_ids
+            or merged_case_reviewed_context != existing_case.reviewed_context
+        ):
+            service.persist_record(
+                replace(
+                    existing_case,
+                    evidence_ids=merged_case_evidence_ids,
+                    reviewed_context=merged_case_reviewed_context,
+                )
+            )
+
+    def _attach_native_source_metadata(
+        self,
+        *,
+        subject_linkage: dict[str, object],
+        record: NativeDetectionRecord,
+    ) -> None:
+        service = self._service
+        source_provenance = record.metadata.get("source_provenance")
+        if isinstance(source_provenance, Mapping):
+            accountable_source_identity = service._normalize_optional_string(
+                source_provenance.get("accountable_source_identity"),
+                "metadata.source_provenance.accountable_source_identity",
+            )
+            if accountable_source_identity is not None:
+                subject_linkage["accountable_source_identities"] = (
+                    service._merge_linked_ids(
+                        subject_linkage.get("accountable_source_identities"),
+                        accountable_source_identity,
+                    )
+                )
+
+        native_rule = record.metadata.get("native_rule")
+        if isinstance(native_rule, Mapping):
+            native_rule_id = service._normalize_optional_string(
+                native_rule.get("id"),
+                "metadata.native_rule.id",
+            )
+            native_rule_description = service._normalize_optional_string(
+                native_rule.get("description"),
+                "metadata.native_rule.description",
+            )
+            rule_level = native_rule.get("level")
+            subject_linkage["latest_native_rule"] = {
+                "id": native_rule_id,
+                "level": rule_level if isinstance(rule_level, int) else None,
+                "description": native_rule_description,
+            }
+
+        reviewed_correlation_context = record.metadata.get(
+            "reviewed_correlation_context"
+        )
+        if isinstance(reviewed_correlation_context, Mapping):
+            subject_linkage["reviewed_correlation_context"] = {
+                str(field_name): field_value
+                for field_name, field_value in reviewed_correlation_context.items()
+                if isinstance(field_value, str) and field_value.strip()
+            }
+
+        reviewed_source_profile = record.metadata.get("reviewed_source_profile")
+        if isinstance(reviewed_source_profile, Mapping):
+            subject_linkage["reviewed_source_profile"] = dict(reviewed_source_profile)
+
+        raw_alert = record.metadata.get("raw_alert")
+        if isinstance(raw_alert, Mapping):
+            subject_linkage["latest_native_payload"] = dict(raw_alert)
+
+        admission_provenance = self._normalize_admission_provenance(
+            record.metadata.get("admission_provenance")
+        )
+        if admission_provenance is not None:
+            subject_linkage["admission_provenance"] = admission_provenance

--- a/control-plane/aegisops_control_plane/detection_native_context.py
+++ b/control-plane/aegisops_control_plane/detection_native_context.py
@@ -59,23 +59,13 @@ class NativeDetectionContextAttacher:
                         f"Alert {ingest_result.alert.alert_id!r} "
                         f"references missing case {case_id!r}"
                     )
-            evidence = service.persist_record(
-                EvidenceRecord(
-                    evidence_id=evidence_id,
-                    source_record_id=substrate_detection_record_id,
-                    alert_id=ingest_result.alert.alert_id,
-                    case_id=case_id,
-                    source_system=source_system,
-                    collector_identity=f"{record.substrate_key}-native-detection-adapter",
-                    acquired_at=service._require_aware_datetime(
-                        record.first_seen_at,
-                        "record.first_seen_at",
-                    ),
-                    derivation_relationship="native_detection_record",
-                    lifecycle_state="linked" if case_id is not None else "collected",
-                    provenance={},
-                    content={},
-                )
+            evidence = self._persist_native_context_evidence(
+                evidence_id=evidence_id,
+                substrate_detection_record_id=substrate_detection_record_id,
+                record=record,
+                ingest_result=ingest_result,
+                case_id=case_id,
+                source_system=source_system,
             )
             if existing_case is not None:
                 self._merge_case_context(
@@ -122,6 +112,47 @@ class NativeDetectionContextAttacher:
                 reconciliation=reconciliation,
                 disposition=ingest_result.disposition,
             )
+
+    def _persist_native_context_evidence(
+        self,
+        *,
+        evidence_id: str,
+        substrate_detection_record_id: str,
+        record: NativeDetectionRecord,
+        ingest_result: FindingAlertIngestResult,
+        case_id: str | None,
+        source_system: str,
+    ) -> EvidenceRecord:
+        service = self._service
+        existing_evidence = service._store.get(EvidenceRecord, evidence_id)
+        evidence_fields = {
+            "source_record_id": substrate_detection_record_id,
+            "alert_id": ingest_result.alert.alert_id,
+            "case_id": case_id,
+            "source_system": source_system,
+            "collector_identity": f"{record.substrate_key}-native-detection-adapter",
+            "acquired_at": service._require_aware_datetime(
+                record.first_seen_at,
+                "record.first_seen_at",
+            ),
+            "derivation_relationship": "native_detection_record",
+            "lifecycle_state": "linked" if case_id is not None else "collected",
+        }
+        if existing_evidence is not None:
+            return service.persist_record(
+                replace(
+                    existing_evidence,
+                    **evidence_fields,
+                )
+            )
+        return service.persist_record(
+            EvidenceRecord(
+                evidence_id=evidence_id,
+                provenance={},
+                content={},
+                **evidence_fields,
+            )
+        )
 
     def _merge_case_context(
         self,

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -461,123 +461,137 @@ class OperatorInspectionReadSurface:
 
             if not self._service._reconciliation_is_wazuh_origin(reconciliation):
                 continue
-            source_systems = self._service._merge_linked_ids(
-                reconciliation.subject_linkage.get("source_systems"),
-                None,
-            )
-            substrate_detection_record_ids = self._service._merge_linked_ids(
-                reconciliation.subject_linkage.get("substrate_detection_record_ids"),
-                None,
-            )
-            case_record = (
-                self._service._store.get(CaseRecord, alert.case_id)
-                if alert.case_id is not None
-                else None
-            )
-            action_reviews = self._service._action_review_chains_for_scope(
-                case_id=alert.case_id,
-                alert_id=alert.alert_id,
-                record_index=action_review_index,
-            )
-            review_state = self._service._alert_review_state(alert)
-            ai_trace_review_groups = self._ai_trace_review_groups_for_queue_record(
-                alert_id=alert.alert_id,
-                case_id=alert.case_id,
-                ai_trace_records=ai_trace_records,
-            )
-            queue_lanes, queue_lane_details = self._queue_lanes_for_record(
-                alert=alert,
-                reconciliation=reconciliation,
-                review_state=review_state,
-                action_reviews=action_reviews,
-            )
-            now = datetime.now(timezone.utc)
-            first_seen_at = reconciliation.first_seen_at
-            age_seconds = (
-                max(0, int((now - first_seen_at).total_seconds()))
-                if first_seen_at is not None
-                else 0
-            )
-            last_activity_at = reconciliation.last_seen_at or first_seen_at
-            owner_reviewed_context = (
-                case_record.reviewed_context if case_record is not None else alert.reviewed_context
-            )
             queue_records.append(
-                {
-                    "alert_id": alert.alert_id,
-                    "finding_id": alert.finding_id,
-                    "analytic_signal_id": alert.analytic_signal_id,
-                    "case_id": alert.case_id,
-                    "case_lifecycle_state": (
-                        case_record.lifecycle_state if case_record is not None else None
-                    ),
-                    "queue_selection": "business_hours_triage",
-                    "review_state": review_state,
-                    "escalation_boundary": self._service._alert_escalation_boundary(alert),
-                    "source_system": (
-                        "wazuh"
-                        if self._service._reconciliation_is_wazuh_origin(reconciliation)
-                        else (source_systems[0] if source_systems else "wazuh")
-                    ),
-                    "substrate_detection_record_ids": substrate_detection_record_ids,
-                    "accountable_source_identities": self._service._merge_linked_ids(
-                        reconciliation.subject_linkage.get(
-                            "accountable_source_identities"
-                        ),
-                        None,
-                    ),
-                    "reviewed_context": dict(alert.reviewed_context),
-                    "native_rule": reconciliation.subject_linkage.get(
-                        "latest_native_rule"
-                    ),
-                    "evidence_ids": self._service._merge_linked_ids(
-                        reconciliation.subject_linkage.get("evidence_ids"),
-                        None,
-                    ),
-                    "correlation_key": reconciliation.correlation_key,
-                    "first_seen_at": reconciliation.first_seen_at,
-                    "last_seen_at": reconciliation.last_seen_at,
-                    "owner": self._queue_owner(
-                        alert_id=alert.alert_id,
-                        case_id=alert.case_id,
-                        reviewed_context=owner_reviewed_context,
-                        action_reviews=action_reviews,
-                    ),
-                    "age_seconds": age_seconds,
-                    "age_bucket": self._queue_age_bucket(age_seconds),
-                    "severity": self._queue_severity_from_reviewed_context(
-                        alert.reviewed_context,
-                    ),
-                    "last_activity_at": last_activity_at,
-                    "next_action": self._queue_next_action(
-                        alert_id=alert.alert_id,
-                        case_id=alert.case_id,
-                        review_state=review_state,
-                        action_reviews=action_reviews,
-                    ),
-                    "queue_lanes": queue_lanes,
-                    "queue_lane_details": queue_lane_details,
-                    "current_action_review": (
-                        dict(action_reviews[0]) if action_reviews else None
-                    ),
-                    "ai_trace_review_groups": ai_trace_review_groups,
-                }
+                self._queue_record_for_alert(
+                    alert=alert,
+                    reconciliation=reconciliation,
+                    action_review_index=action_review_index,
+                    ai_trace_records=ai_trace_records,
+                )
             )
 
-        queue_records.sort(
-            key=lambda record: (
-                record["last_seen_at"]
-                or datetime.min.replace(tzinfo=timezone.utc),
-                record["alert_id"],
-            ),
-            reverse=True,
-        )
+        queue_records = self._sorted_queue_records(queue_records)
         return self._analyst_queue_snapshot_factory(
             read_only=True,
             queue_name="analyst_review",
             total_records=len(queue_records),
             lane_counts=self._queue_lane_counts(queue_records),
             records=tuple(queue_records),
+        )
+
+    def _queue_record_for_alert(
+        self,
+        *,
+        alert: AlertRecord,
+        reconciliation: ReconciliationRecord,
+        action_review_index: object,
+        ai_trace_records: tuple[AITraceRecord, ...],
+    ) -> dict[str, object]:
+        source_systems = self._service._merge_linked_ids(
+            reconciliation.subject_linkage.get("source_systems"),
+            None,
+        )
+        substrate_detection_record_ids = self._service._merge_linked_ids(
+            reconciliation.subject_linkage.get("substrate_detection_record_ids"),
+            None,
+        )
+        case_record = (
+            self._service._store.get(CaseRecord, alert.case_id)
+            if alert.case_id is not None
+            else None
+        )
+        action_reviews = self._service._action_review_chains_for_scope(
+            case_id=alert.case_id,
+            alert_id=alert.alert_id,
+            record_index=action_review_index,
+        )
+        review_state = self._service._alert_review_state(alert)
+        ai_trace_review_groups = self._ai_trace_review_groups_for_queue_record(
+            alert_id=alert.alert_id,
+            case_id=alert.case_id,
+            ai_trace_records=ai_trace_records,
+        )
+        queue_lanes, queue_lane_details = self._queue_lanes_for_record(
+            alert=alert,
+            reconciliation=reconciliation,
+            review_state=review_state,
+            action_reviews=action_reviews,
+        )
+        now = datetime.now(timezone.utc)
+        first_seen_at = reconciliation.first_seen_at
+        age_seconds = (
+            max(0, int((now - first_seen_at).total_seconds()))
+            if first_seen_at is not None
+            else 0
+        )
+        last_activity_at = reconciliation.last_seen_at or first_seen_at
+        owner_reviewed_context = (
+            case_record.reviewed_context if case_record is not None else alert.reviewed_context
+        )
+        return {
+            "alert_id": alert.alert_id,
+            "finding_id": alert.finding_id,
+            "analytic_signal_id": alert.analytic_signal_id,
+            "case_id": alert.case_id,
+            "case_lifecycle_state": (
+                case_record.lifecycle_state if case_record is not None else None
+            ),
+            "queue_selection": "business_hours_triage",
+            "review_state": review_state,
+            "escalation_boundary": self._service._alert_escalation_boundary(alert),
+            "source_system": (
+                "wazuh"
+                if self._service._reconciliation_is_wazuh_origin(reconciliation)
+                else (source_systems[0] if source_systems else "wazuh")
+            ),
+            "substrate_detection_record_ids": substrate_detection_record_ids,
+            "accountable_source_identities": self._service._merge_linked_ids(
+                reconciliation.subject_linkage.get("accountable_source_identities"),
+                None,
+            ),
+            "reviewed_context": dict(alert.reviewed_context),
+            "native_rule": reconciliation.subject_linkage.get("latest_native_rule"),
+            "evidence_ids": self._service._merge_linked_ids(
+                reconciliation.subject_linkage.get("evidence_ids"),
+                None,
+            ),
+            "correlation_key": reconciliation.correlation_key,
+            "first_seen_at": reconciliation.first_seen_at,
+            "last_seen_at": reconciliation.last_seen_at,
+            "owner": self._queue_owner(
+                alert_id=alert.alert_id,
+                case_id=alert.case_id,
+                reviewed_context=owner_reviewed_context,
+                action_reviews=action_reviews,
+            ),
+            "age_seconds": age_seconds,
+            "age_bucket": self._queue_age_bucket(age_seconds),
+            "severity": self._queue_severity_from_reviewed_context(alert.reviewed_context),
+            "last_activity_at": last_activity_at,
+            "next_action": self._queue_next_action(
+                alert_id=alert.alert_id,
+                case_id=alert.case_id,
+                review_state=review_state,
+                action_reviews=action_reviews,
+            ),
+            "queue_lanes": queue_lanes,
+            "queue_lane_details": queue_lane_details,
+            "current_action_review": dict(action_reviews[0]) if action_reviews else None,
+            "ai_trace_review_groups": ai_trace_review_groups,
+        }
+
+    @staticmethod
+    def _sorted_queue_records(
+        queue_records: list[dict[str, object]],
+    ) -> list[dict[str, object]]:
+        return sorted(
+            queue_records,
+            key=lambda record: (
+                record["last_seen_at"]
+                or datetime.min.replace(tzinfo=timezone.utc),
+                record["alert_id"],
+            ),
+            reverse=True,
         )
 
     def _queue_lanes_for_record(

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -363,6 +363,83 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
                 f"{helper_name} should remain only as a facade compatibility delegate",
             )
 
+    def test_phase50_5_second_hotspot_boundary_methods_are_split(self) -> None:
+        targets = {
+            (
+                "control-plane/aegisops_control_plane/assistant_context.py",
+                "AssistantContextAssembler",
+                "inspect_assistant_context",
+            ): {
+                "max_lines": 180,
+                "required_helpers": {
+                    "_require_context_record",
+                    "_context_lineage",
+                    "_linked_records_for_context",
+                    "_context_reviewed_context",
+                    "_build_context_snapshot",
+                },
+            },
+            (
+                "control-plane/aegisops_control_plane/detection_lifecycle.py",
+                "DetectionIntakeService",
+                "ingest_analytic_signal_admission",
+            ): {
+                "max_lines": 170,
+                "required_helpers": {
+                    "_resolve_admission_inputs",
+                    "_admit_new_alert",
+                    "_merge_existing_alert_admission",
+                    "_persist_analytic_signal_admission",
+                    "_persist_admission_reconciliation",
+                },
+            },
+            (
+                "control-plane/aegisops_control_plane/operator_inspection.py",
+                "OperatorInspectionReadSurface",
+                "inspect_analyst_queue",
+            ): {
+                "max_lines": 90,
+                "required_helpers": {
+                    "_queue_record_for_alert",
+                    "_sorted_queue_records",
+                },
+            },
+        }
+
+        for (relative_path, class_name, method_name), expectation in targets.items():
+            source = self._read(relative_path)
+            tree = ast.parse(source, filename=relative_path)
+            target_class = next(
+                node
+                for node in tree.body
+                if isinstance(node, ast.ClassDef) and node.name == class_name
+            )
+            methods = {
+                node.name: node
+                for node in target_class.body
+                if isinstance(node, ast.FunctionDef)
+            }
+            self.assertTrue(
+                expectation["required_helpers"].issubset(methods),
+                f"{class_name} should split {method_name} through focused helpers",
+            )
+            target_method = methods[method_name]
+            self.assertLessEqual(
+                target_method.end_lineno - target_method.lineno + 1,
+                expectation["max_lines"],
+                f"{class_name}.{method_name} remains a second-hotspot candidate",
+            )
+            oversized_helpers = {
+                helper_name: helper.end_lineno - helper.lineno + 1
+                for helper_name, helper in methods.items()
+                if helper.end_lineno - helper.lineno + 1 > 180
+            }
+            self.assertEqual(
+                oversized_helpers,
+                {},
+                f"{class_name} should not replace one hotspot with a broad helper",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -771,6 +771,58 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             (promoted_case.case_id, promoted_case.case_id),
         )
 
+    def test_service_preserves_native_detection_evidence_metadata_on_idempotent_reingest(
+        self,
+    ) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        adapter = WazuhAlertAdapter()
+        payload = _load_wazuh_fixture("agent-origin-alert.json")
+        created = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(payload),
+        )
+        native_evidence = next(
+            evidence
+            for evidence in store.list(EvidenceRecord)
+            if evidence.alert_id == created.alert.alert_id
+            and evidence.derivation_relationship == "native_detection_record"
+        )
+        enriched_evidence = service.persist_record(
+            replace(
+                native_evidence,
+                provenance={
+                    "classification": "reviewed-native-context",
+                    "reviewed_by": "analyst-001",
+                },
+                content={
+                    "triage_note": "Retained enrichment on replay.",
+                    "reviewed_fields": ("agent.id", "rule.id"),
+                },
+            )
+        )
+
+        replayed = service.ingest_native_detection_record(
+            adapter,
+            adapter.build_native_detection_record(
+                _load_wazuh_fixture("agent-origin-alert.json")
+            ),
+        )
+
+        persisted_evidence = service.get_record(
+            EvidenceRecord,
+            enriched_evidence.evidence_id,
+        )
+        self.assertEqual(replayed.disposition, "deduplicated")
+        self.assertIsNotNone(persisted_evidence)
+        self.assertEqual(persisted_evidence.provenance, enriched_evidence.provenance)
+        self.assertEqual(persisted_evidence.content, enriched_evidence.content)
+        self.assertEqual(persisted_evidence.alert_id, created.alert.alert_id)
+        self.assertEqual(persisted_evidence.lifecycle_state, "collected")
+
     def test_service_keeps_distinct_wazuh_incidents_separate_when_native_context_differs(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -812,11 +812,22 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             ),
         )
 
+        native_evidence_records = tuple(
+            evidence
+            for evidence in store.list(EvidenceRecord)
+            if evidence.alert_id == created.alert.alert_id
+            and evidence.derivation_relationship == "native_detection_record"
+        )
         persisted_evidence = service.get_record(
             EvidenceRecord,
             enriched_evidence.evidence_id,
         )
         self.assertEqual(replayed.disposition, "deduplicated")
+        self.assertEqual(len(native_evidence_records), 1)
+        self.assertEqual(
+            native_evidence_records[0].evidence_id,
+            enriched_evidence.evidence_id,
+        )
         self.assertIsNotNone(persisted_evidence)
         self.assertEqual(persisted_evidence.provenance, enriched_evidence.provenance)
         self.assertEqual(persisted_evidence.content, enriched_evidence.content)


### PR DESCRIPTION
## Summary
- split assistant context inspection into explicit record, lineage, linked-record, reviewed-context, and snapshot helpers
- split analytic signal admission and move native detection context attachment behind a dedicated collaborator
- split operator analyst queue inspection into record assembly and sorting helpers
- add Phase 50.5 AST regression coverage to prevent replacement helper hotspots

## Verification
- `python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation.ServiceBoundaryRefactorRegressionValidationTests.test_phase50_5_second_hotspot_boundary_methods_are_split`
- `python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation`
- `python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory control-plane.tests.test_service_persistence_ingest_case_lifecycle control-plane.tests.test_operator_inspection_boundary`
- `bash scripts/verify-maintainability-hotspots.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 951 --config <supervisor-config-path>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized control-plane workflows for clearer, stepwise assembly of assistant context, ingestion flow, and operator queue snapshot generation.

* **Bug Fixes**
  * Improved native detection reconciliation to reliably preserve/merge evidence and case data.
  * Stabilized analyst queue record construction and sorting.

* **Tests**
  * Added regression and persistence tests protecting refactor boundaries and idempotent ingest behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->