### PR TITLE
Phase 50.7 maintainability closeout

### DIFF
--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,7 +66,7 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "49.0.7")
+        self.assertIn(metadata["phase"], {"49.0.7", "50.7"})
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
         self.assertEqual(

--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,7 +66,7 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertIn(metadata["phase"], {"49.0.7", "50.7"})
+        self.assertEqual(metadata["phase"], "50.7")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
         self.assertEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import pathlib
+import shutil
 import subprocess
 import unittest
 
@@ -89,12 +90,17 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             self.assertIn(required, closeout)
 
     def test_verifier_reports_only_phase50_accepted_hotspot(self) -> None:
+        bash_executable = shutil.which("bash")
+        if bash_executable is None:
+            self.fail("bash executable not found")
+
         result = subprocess.run(
-            ["bash", "scripts/verify-maintainability-hotspots.sh"],
+            [bash_executable, "scripts/verify-maintainability-hotspots.sh"],
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,
             check=True,
+            timeout=30,
         )
 
         self.assertIn("Known maintainability hotspot baseline remains present", result.stdout)

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import ast
+import pathlib
+import subprocess
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
+    def _read(self, relative_path: str) -> str:
+        path = REPO_ROOT / relative_path
+        if not path.exists():
+            raise AssertionError(f"expected Phase 50 closeout artifact at {path}")
+        return path.read_text(encoding="utf-8")
+
+    def _effective_line_count(self, text: str) -> int:
+        return sum(
+            1
+            for line in text.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        )
+
+    def _facade_method_count(self, class_name: str) -> int:
+        service_text = self._read("control-plane/aegisops_control_plane/service.py")
+        tree = ast.parse(
+            service_text,
+            filename="control-plane/aegisops_control_plane/service.py",
+        )
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                return sum(
+                    1
+                    for child in node.body
+                    if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                )
+        raise AssertionError(f"{class_name} class not found")
+
+    def _baseline_metadata(self) -> dict[str, str]:
+        for line in self._read("docs/maintainability-hotspot-baseline.txt").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("control-plane/aegisops_control_plane/service.py"):
+                metadata: dict[str, str] = {}
+                for part in stripped.split()[1:]:
+                    key, value = part.split("=", 1)
+                    metadata[key] = value
+                return metadata
+        raise AssertionError("service.py hotspot baseline entry not found")
+
+    def test_baseline_records_phase50_closeout_ceiling(self) -> None:
+        service_text = self._read("control-plane/aegisops_control_plane/service.py")
+        metadata = self._baseline_metadata()
+
+        self.assertEqual(metadata["adr_exception"], "ADR-0003")
+        self.assertEqual(metadata["phase"], "50.7")
+        self.assertEqual(metadata["issue"], "#953")
+        self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
+        self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
+        self.assertEqual(
+            int(metadata["max_effective_lines"]),
+            self._effective_line_count(service_text),
+        )
+        self.assertEqual(
+            int(metadata["max_facade_methods"]),
+            self._facade_method_count(metadata["facade_class"]),
+        )
+
+    def test_closeout_notes_preserve_remaining_hotspot_and_trigger(self) -> None:
+        closeout = self._read("docs/phase-50-maintainability-closeout.md")
+
+        for required in (
+            "Phase 50.7",
+            "control-plane/aegisops_control_plane/service.py",
+            "AegisOpsControlPlaneService",
+            "max_lines=5660",
+            "max_effective_lines=5250",
+            "max_facade_methods=203",
+            "ADR-0004",
+            "ADR-0003",
+            "#953",
+            "remaining accepted hotspot",
+            "silent re-growth",
+            "another decomposition decision",
+            "bash scripts/verify-maintainability-hotspots.sh",
+            "bash scripts/test-verify-maintainability-hotspots.sh",
+        ):
+            self.assertIn(required, closeout)
+
+    def test_verifier_reports_only_phase50_accepted_hotspot(self) -> None:
+        result = subprocess.run(
+            ["bash", "scripts/verify-maintainability-hotspots.sh"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        self.assertIn("Known maintainability hotspot baseline remains present", result.stdout)
+        self.assertIn("control-plane/aegisops_control_plane/service.py", result.stdout)
+        self.assertNotIn("baseline limits were exceeded", result.stderr)
+
+    def test_negative_verifier_coverage_keeps_regrowth_path(self) -> None:
+        verifier_test = self._read("scripts/test-verify-maintainability-hotspots.sh")
+
+        for required in (
+            "regrowth_repo",
+            "Maintainability hotspot baseline limits were exceeded",
+            "lines=960 exceeds max_lines=959",
+            "effective_lines=960 exceeds max_effective_lines=959",
+            "max_facade_methods=0",
+        ):
+            self.assertIn(required, verifier_test)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,11 +1,12 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 49.0 closeout exception:
-# ADR-0003 accepted facade-preserving extraction behind AegisOpsControlPlaneService.
+# Phase 50.7 closeout exception:
+# ADR-0004 accepted ordered hotspot reduction after the ADR-0003
+# facade-preservation exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 49.0 child issues, so this baseline records the current closeout
-# ceiling and fails on silent re-growth. A future ADR or maintainability backlog
-# must lower or replace these limits before unrelated Phase 49 feature expansion
-# lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=5660 max_effective_lines=5250 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=49.0.7
+# the Phase 50 child issues, so this baseline records the accepted Phase 50.7
+# closeout ceiling and fails on silent re-growth. A future ADR or
+# maintainability backlog must lower or replace these limits before unrelated
+# feature expansion lands in the facade.
+control-plane/aegisops_control_plane/service.py max_lines=5660 max_effective_lines=5250 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.7 issue=#953

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,0 +1,42 @@
+# Phase 50 Maintainability Closeout
+
+Phase 50.7 closes the ordered maintainability hotspot reduction sequence governed by ADR-0004.
+
+This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
+
+ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
+
+## Accepted Verifier State
+
+The maintainability verifier still reports one remaining accepted hotspot:
+
+- `control-plane/aegisops_control_plane/service.py`
+
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50 extraction and fencing work. The accepted closeout ceiling for #953 is:
+
+- `max_lines=5660`
+- `max_effective_lines=5250`
+- `max_facade_methods=203`
+- `facade_class=AegisOpsControlPlaneService`
+- `adr_exception=ADR-0003`
+- `phase=50.7`
+
+No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, or operator UI route tests because the verifier does not report those areas as current responsibility-growth candidates.
+
+## Follow-Up Trigger
+
+The service facade remains above the long-term 1,500-line and 50-method targets. It is therefore an accepted exception, not a success target.
+
+Any silent re-growth beyond the recorded ceiling must fail the verifier. The expected response is another decomposition decision or maintainability backlog before unrelated feature expansion lands in the facade.
+
+If a later extraction lowers the facade below the verifier threshold, maintainers should remove or lower the baseline only after confirming that the file no longer crosses the responsibility-growth threshold.
+
+## Verification Evidence
+
+Run:
+
+- `bash scripts/verify-maintainability-hotspots.sh`
+- `bash scripts/test-verify-maintainability-hotspots.sh`
+- `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py`
+
+The focused negative verifier coverage remains in `scripts/test-verify-maintainability-hotspots.sh` through the `regrowth_repo` fixture, which verifies that line-count, effective-line, and facade-method growth beyond the recorded ceiling still fails closed.


### PR DESCRIPTION
## Summary
- refresh the maintainability hotspot baseline to record the Phase 50.7 closeout ceiling for #953
- add Phase 50 closeout evidence documenting the remaining accepted service facade hotspot and follow-up trigger
- add focused closeout regression coverage while preserving the Phase 49 ADR-0003 facade exception check

## Verification
- bash scripts/verify-maintainability-hotspots.sh
- bash scripts/test-verify-maintainability-hotspots.sh
- bash scripts/verify-phase-50-maintainability-adr.sh
- bash scripts/test-verify-phase-50-maintainability-adr.sh
- python3 -m unittest control-plane/tests/test_phase49_service_decomposition_closeout.py control-plane/tests/test_phase50_maintainability_closeout.py control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_publishable_path_hygiene.py
- node dist/index.js issue-lint 953 --config supervisor.config.aegisops.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Phase 50 maintainability closeout tests validating ceiling limits, verifier behavior, and regrowth detection.
  * Updated Phase 49 closeout test to reflect the Phase 50.7 baseline change.

* **Documentation**
  * Added Phase 50.7 maintainability closeout page and updated the hotspot baseline to record Phase 50.7 acceptance, issue reference, and ADR linkage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->