### PR TITLE
Phase 50.8 residual service hotspot contract

### DIFF
--- a/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md
+++ b/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md
@@ -1,0 +1,120 @@
+# ADR-0005: Phase 50.8 Residual Service Hotspot Migration Contract
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/requirements-baseline.md`
+- **Product**: AegisOps
+- **Related Issues**: #961, #962
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+---
+
+## 1. Context
+
+Phase 50.7 closed the first Phase 50 maintainability sequence, but it intentionally left `control-plane/aegisops_control_plane/service.py` as the one accepted residual hotspot.
+
+ADR-0004 remains authoritative for the Phase 50 hotspot ordering decision.
+
+ADR-0003 remains authoritative for the public facade-preservation exception.
+
+Phase 50.7 recorded the current residual service ceiling in `docs/maintainability-hotspot-baseline.txt`.
+
+This ADR does not refresh the baseline because implementation evidence does not exist yet.
+
+The next Phase 50.8 implementation slices need a repo-owned residual map before production code extraction starts. Without this contract, later child issues could choose local helper order, refresh the baseline from a desired projection, or treat the Phase 50.7 ceiling as approval for further growth.
+
+## 2. Decision
+
+Phase 50.8 will migrate the remaining `service.py` helper pressure in a fixed, behavior-preserving order.
+
+The residual Phase 50.8 `service.py` helper clusters are:
+
+- readiness helper cluster
+- action-review helper cluster
+- intake/lifecycle helper cluster
+- action-policy helper cluster
+
+Public service entrypoints, runtime behavior, configuration shape, authority semantics, and durable-state side effects remain unchanged.
+
+AegisOps control-plane records remain authoritative workflow truth.
+
+Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, and Zammad remain subordinate context.
+
+## 3. Residual Hotspot Map
+
+The residual hotspot map is limited to helper migration inside `AegisOpsControlPlaneService`.
+
+The readiness helper cluster covers readiness review health, readiness source health, automation-substrate health, optional extension operability, assistant provider operability, endpoint evidence operability, dominant-reason selection, affected-review counts, and readiness aggregate shaping.
+
+The action-review helper cluster covers action-review record indexing, review-chain snapshots, path health, runtime visibility, after-hours handoff visibility, manual fallback visibility, escalation visibility, timeline shaping, mismatch inspection, coordination-ticket outcomes, downstream binding, and terminal issue detection.
+
+The intake/lifecycle helper cluster covers lifecycle transition creation, lifecycle transition identifiers, latest lifecycle selection, transition attribution, alert/case lifecycle linkage, analytic-signal linkage, alert evidence listing, detection reconciliation linkage, and reviewed intake admission helpers that bind alerts, cases, evidence, and lifecycle records.
+
+The action-policy helper cluster covers action-policy basis normalization, policy determination, policy evaluation overrides, review-bound action-request checks, approved payload binding, approver policy checks, and action request state decisions.
+
+These clusters describe extraction ownership only. They do not create a new runtime service, new endpoint, new approval path, new action catalog, new evidence source, new ticket authority, or new operator workflow.
+
+## 4. Migration Order
+
+The Phase 50.8 migration order is:
+
+1. readiness helper cluster
+2. action-review helper cluster
+3. intake/lifecycle helper cluster
+4. action-policy helper cluster
+
+Readiness helpers must move before action-review helpers that consume readiness projections.
+
+Action-review helpers must move before action-policy helpers so review-state projections stay anchored to authoritative action records.
+
+Intake/lifecycle helpers must move before action-policy helpers so action policy does not infer case, alert, lifecycle, or evidence linkage from names, paths, comments, or neighboring records.
+
+The child issues are not parallelizable by default. A later issue may change the order only through another repo-owned decision that explicitly preserves the authority-boundary and measurement rules in this ADR.
+
+## 5. Measurement Guard
+
+The current Phase 50.7 ceiling remains:
+
+- `max_lines=5660`
+- `max_effective_lines=5250`
+- `max_facade_methods=203`
+
+The Phase 50.8 implementation target is:
+
+- `max_lines <= 5200`
+- `max_effective_lines <= 4850`
+- `max_facade_methods <= 175`
+
+A Phase 50.8 closeout may record an exception only if it names the unresolved cluster, records the measured line, effective-line, and facade-method counts, and keeps the exception lower than the Phase 50.7 ceiling.
+
+Any baseline refresh before implementation evidence exists is forbidden.
+
+If a child issue cannot meet the target, the correct closeout is a documented lower exception plus a follow-up backlog, not a silent threshold redefinition. The exception must still prove that the facade did not grow beyond the accepted Phase 50.7 ceiling.
+
+## 6. Validation
+
+Run `bash scripts/verify-phase-50-8-residual-service-hotspot-contract.sh`.
+
+Run `bash scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh`.
+
+Run `bash scripts/verify-maintainability-hotspots.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 962 --config <supervisor-config-path>`.
+
+## 7. Non-Goals
+
+- No production code extraction is approved by this ADR.
+- No approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority behavior is changed.
+- No deployment, database, migration, credential source, external substrate, HTTP surface, CLI surface, or operator UI behavior is changed.
+- No baseline refresh is approved before Phase 50.8 implementation evidence exists.
+- No subordinate source becomes authoritative workflow truth.
+- No exception may raise the Phase 50.7 ceiling.
+
+## 8. Approval
+
+- **Proposed By**: Codex for Issue #962
+- **Reviewed By**: AegisOps maintainers
+- **Approved By**: AegisOps maintainers
+- **Approval Date**: 2026-04-29

--- a/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+write_contract() {
+  local target="$1"
+  local content="$2"
+
+  mkdir -p "${target}/docs/adr"
+  printf '%s\n' "${content}" >"${target}/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md"
+}
+
+write_baseline() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  printf '%s\n' \
+    "control-plane/aegisops_control_plane/service.py max_lines=5660 max_effective_lines=5250 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.7 issue=#953" \
+    >"${target}/docs/maintainability-hotspot-baseline.txt"
+}
+
+create_valid_repo() {
+  local target="$1"
+
+  write_baseline "${target}"
+  write_contract "${target}" '# ADR-0005: Phase 50.8 Residual Service Hotspot Migration Contract
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/requirements-baseline.md`
+- **Product**: AegisOps
+- **Related Issues**: #961, #962
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+## 1. Context
+
+ADR-0004 remains authoritative for the Phase 50 hotspot ordering decision.
+
+ADR-0003 remains authoritative for the public facade-preservation exception.
+
+Phase 50.7 recorded the current residual service ceiling in `docs/maintainability-hotspot-baseline.txt`.
+
+This ADR does not refresh the baseline because implementation evidence does not exist yet.
+
+## 2. Decision
+
+The residual Phase 50.8 `service.py` helper clusters are:
+
+- readiness helper cluster
+- action-review helper cluster
+- intake/lifecycle helper cluster
+- action-policy helper cluster
+
+Public service entrypoints, runtime behavior, configuration shape, authority semantics, and durable-state side effects remain unchanged.
+
+AegisOps control-plane records remain authoritative workflow truth.
+
+Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, and Zammad remain subordinate context.
+
+## 3. Residual Hotspot Map
+
+Residual helper migration only.
+
+## 4. Migration Order
+
+The Phase 50.8 migration order is:
+
+1. readiness helper cluster
+2. action-review helper cluster
+3. intake/lifecycle helper cluster
+4. action-policy helper cluster
+
+Readiness helpers must move before action-review helpers that consume readiness projections.
+
+Action-review helpers must move before action-policy helpers so review-state projections stay anchored to authoritative action records.
+
+Intake/lifecycle helpers must move before action-policy helpers so action policy does not infer case, alert, lifecycle, or evidence linkage from names, paths, comments, or neighboring records.
+
+## 5. Measurement Guard
+
+The current Phase 50.7 ceiling remains:
+
+- `max_lines=5660`
+- `max_effective_lines=5250`
+- `max_facade_methods=203`
+
+The Phase 50.8 implementation target is:
+
+- `max_lines <= 5200`
+- `max_effective_lines <= 4850`
+- `max_facade_methods <= 175`
+
+A Phase 50.8 closeout may record an exception only if it names the unresolved cluster, records the measured line, effective-line, and facade-method counts, and keeps the exception lower than the Phase 50.7 ceiling.
+
+Any baseline refresh before implementation evidence exists is forbidden.
+
+## 6. Validation
+
+Run `bash scripts/verify-phase-50-8-residual-service-hotspot-contract.sh`.
+
+Run `bash scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh`.
+
+Run `bash scripts/verify-maintainability-hotspots.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 962 --config <supervisor-config-path>`.
+
+## 7. Non-Goals
+
+- No production code extraction is approved by this ADR.
+- No approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority behavior is changed.
+
+## 8. Approval
+
+- **Proposed By**: Codex for Issue #962
+- **Reviewed By**: AegisOps maintainers
+- **Approved By**: AegisOps maintainers
+- **Approval Date**: 2026-04-29'
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 50.8 residual service hotspot contract"
+
+missing_cluster_repo="${workdir}/missing-cluster"
+create_valid_repo "${missing_cluster_repo}"
+perl -0pi -e 's/- intake\/lifecycle helper cluster\n//g' \
+  "${missing_cluster_repo}/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md"
+assert_fails_with \
+  "${missing_cluster_repo}" \
+  "Missing Phase 50.8 residual service hotspot contract statement: - intake/lifecycle helper cluster"
+
+missing_target_repo="${workdir}/missing-target"
+create_valid_repo "${missing_target_repo}"
+perl -0pi -e 's/- `max_effective_lines <= 4850`\n//g' \
+  "${missing_target_repo}/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md"
+assert_fails_with \
+  "${missing_target_repo}" \
+  "Missing Phase 50.8 residual service hotspot contract statement: - \`max_effective_lines <= 4850\`"
+
+premature_baseline_repo="${workdir}/premature-baseline"
+create_valid_repo "${premature_baseline_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=5200 max_effective_lines=4850 max_facade_methods=175 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0005 phase=50.8 issue=#962" \
+  >"${premature_baseline_repo}/docs/maintainability-hotspot-baseline.txt"
+assert_fails_with \
+  "${premature_baseline_repo}" \
+  "Phase 50.8 contract requires the Phase 50.7 service.py ceiling to remain unchanged until implementation evidence exists."
+
+missing_authority_repo="${workdir}/missing-authority"
+create_valid_repo "${missing_authority_repo}"
+perl -0pi -e 's/AegisOps control-plane records remain authoritative workflow truth\.//g' \
+  "${missing_authority_repo}/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md"
+assert_fails_with \
+  "${missing_authority_repo}" \
+  "Missing Phase 50.8 residual service hotspot contract statement: AegisOps control-plane records remain authoritative workflow truth."
+
+echo "verify-phase-50-8-residual-service-hotspot-contract tests passed"

--- a/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md"
+baseline_path="${repo_root}/docs/maintainability-hotspot-baseline.txt"
+
+required_headings=(
+  "# ADR-0005: Phase 50.8 Residual Service Hotspot Migration Contract"
+  "## 1. Context"
+  "## 2. Decision"
+  "## 3. Residual Hotspot Map"
+  "## 4. Migration Order"
+  "## 5. Measurement Guard"
+  "## 6. Validation"
+  "## 7. Non-Goals"
+  "## 8. Approval"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-04-29"
+  "- **Related Issues**: #961, #962"
+  "ADR-0004 remains authoritative for the Phase 50 hotspot ordering decision."
+  "ADR-0003 remains authoritative for the public facade-preservation exception."
+  "Phase 50.7 recorded the current residual service ceiling in \`docs/maintainability-hotspot-baseline.txt\`."
+  "This ADR does not refresh the baseline because implementation evidence does not exist yet."
+  "The residual Phase 50.8 \`service.py\` helper clusters are:"
+  "- readiness helper cluster"
+  "- action-review helper cluster"
+  "- intake/lifecycle helper cluster"
+  "- action-policy helper cluster"
+  "The Phase 50.8 migration order is:"
+  "1. readiness helper cluster"
+  "2. action-review helper cluster"
+  "3. intake/lifecycle helper cluster"
+  "4. action-policy helper cluster"
+  "Readiness helpers must move before action-review helpers that consume readiness projections."
+  "Action-review helpers must move before action-policy helpers so review-state projections stay anchored to authoritative action records."
+  "Intake/lifecycle helpers must move before action-policy helpers so action policy does not infer case, alert, lifecycle, or evidence linkage from names, paths, comments, or neighboring records."
+  "The current Phase 50.7 ceiling remains:"
+  "- \`max_lines=5660\`"
+  "- \`max_effective_lines=5250\`"
+  "- \`max_facade_methods=203\`"
+  "The Phase 50.8 implementation target is:"
+  "- \`max_lines <= 5200\`"
+  "- \`max_effective_lines <= 4850\`"
+  "- \`max_facade_methods <= 175\`"
+  "A Phase 50.8 closeout may record an exception only if it names the unresolved cluster, records the measured line, effective-line, and facade-method counts, and keeps the exception lower than the Phase 50.7 ceiling."
+  "Any baseline refresh before implementation evidence exists is forbidden."
+  "Public service entrypoints, runtime behavior, configuration shape, authority semantics, and durable-state side effects remain unchanged."
+  "AegisOps control-plane records remain authoritative workflow truth."
+  "Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, and Zammad remain subordinate context."
+  "Run \`bash scripts/verify-phase-50-8-residual-service-hotspot-contract.sh\`."
+  "Run \`bash scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh\`."
+  "Run \`bash scripts/verify-maintainability-hotspots.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 962 --config <supervisor-config-path>\`."
+  "No production code extraction is approved by this ADR."
+  "No approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority behavior is changed."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 50.8 residual service hotspot contract: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${baseline_path}" ]]; then
+  echo "Missing maintainability hotspot baseline: ${baseline_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq -- "${heading}" "${doc_path}"; then
+    echo "Missing Phase 50.8 residual service hotspot contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 50.8 residual service hotspot contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+required_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=5660 max_effective_lines=5250 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.7 issue=#953"
+if ! grep -Fq -- "${required_baseline_entry}" "${baseline_path}"; then
+  echo "Phase 50.8 contract requires the Phase 50.7 service.py ceiling to remain unchanged until implementation evidence exists." >&2
+  exit 1
+fi
+
+echo "Phase 50.8 residual service hotspot contract fixes clusters, migration order, measurement guard, non-goals, and validation commands."


### PR DESCRIPTION
## Summary
- Add ADR-0005 for the Phase 50.8 residual `service.py` hotspot contract.
- Fix the residual cluster map, migration order, measurement guard, non-goals, and validation commands.
- Add focused verifier and negative verifier coverage for the contract and premature baseline refresh.

## Verification
- `bash scripts/verify-phase-50-8-residual-service-hotspot-contract.sh`
- `bash scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh`
- `bash scripts/verify-maintainability-hotspots.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 962 --config <supervisor-config-path>`

Closes #962
