### PR TITLE
Phase 50.8.3: Extract action-review projection helpers

### DIFF
--- a/control-plane/aegisops_control_plane/action_review_projection.py
+++ b/control-plane/aegisops_control_plane/action_review_projection.py
@@ -196,48 +196,67 @@ def build_action_review_record_index(
     )
 
 
-def _action_review_terminal_non_delegated_path_health() -> dict[str, dict[str, str]]:
+def _action_review_path_health_entry(path: Mapping[str, str]) -> dict[str, str]:
+    normalized = dict(path)
+    normalized.setdefault("health", normalized.get("state", "degraded"))
+    return normalized
+
+
+def _action_review_path_health_entries(
+    paths: Mapping[str, Mapping[str, str]],
+) -> dict[str, dict[str, str]]:
     return {
-        "ingest": {
-            "state": "healthy",
-            "reason": "review_closed_before_ingest",
-        },
-        "delegation": {
-            "state": "healthy",
-            "reason": "review_closed_without_delegation",
-        },
-        "provider": {
-            "state": "healthy",
-            "reason": "review_closed_before_provider",
-        },
-        "persistence": {
-            "state": "healthy",
-            "reason": "review_closed_before_reconciliation",
-        },
+        path_name: _action_review_path_health_entry(path)
+        for path_name, path in paths.items()
     }
+
+
+def _action_review_terminal_non_delegated_path_health() -> dict[str, dict[str, str]]:
+    return _action_review_path_health_entries(
+        {
+            "ingest": {
+                "state": "healthy",
+                "reason": "review_closed_before_ingest",
+            },
+            "delegation": {
+                "state": "healthy",
+                "reason": "review_closed_without_delegation",
+            },
+            "provider": {
+                "state": "healthy",
+                "reason": "review_closed_before_provider",
+            },
+            "persistence": {
+                "state": "healthy",
+                "reason": "review_closed_before_reconciliation",
+            },
+        }
+    )
 
 
 def _action_review_unresolved_without_execution_path_health() -> (
     dict[str, dict[str, str]]
 ):
-    return {
-        "ingest": {
-            "state": "degraded",
-            "reason": "ingest_signal_missing_after_approval",
-        },
-        "delegation": {
-            "state": "degraded",
-            "reason": "reviewed_delegation_missing_after_approval",
-        },
-        "provider": {
-            "state": "degraded",
-            "reason": "provider_signal_missing_after_approval",
-        },
-        "persistence": {
-            "state": "degraded",
-            "reason": "reconciliation_missing_after_approval",
-        },
-    }
+    return _action_review_path_health_entries(
+        {
+            "ingest": {
+                "state": "degraded",
+                "reason": "ingest_signal_missing_after_approval",
+            },
+            "delegation": {
+                "state": "degraded",
+                "reason": "reviewed_delegation_missing_after_approval",
+            },
+            "provider": {
+                "state": "degraded",
+                "reason": "provider_signal_missing_after_approval",
+            },
+            "persistence": {
+                "state": "degraded",
+                "reason": "reconciliation_missing_after_approval",
+            },
+        }
+    )
 
 
 def _action_review_reconciliation_without_execution_path_health(
@@ -254,22 +273,26 @@ def _action_review_reconciliation_without_execution_path_health(
         review_state=review_state,
     )
     if delegation_path["state"] != "healthy":
-        delegation_path = {
-            "state": "degraded",
-            "reason": "reviewed_delegation_record_missing",
+        delegation_path = _action_review_path_health_entry(
+            {
+                "state": "degraded",
+                "reason": "reviewed_delegation_record_missing",
+            }
+        )
+    return _action_review_path_health_entries(
+        {
+            "ingest": _action_review_ingest_path_health(reconciliation),
+            "delegation": delegation_path,
+            "provider": {
+                "state": "degraded",
+                "reason": "provider_execution_record_missing",
+            },
+            "persistence": {
+                "state": "degraded",
+                "reason": "reconciliation_execution_lineage_missing",
+            },
         }
-    return {
-        "ingest": _action_review_ingest_path_health(reconciliation),
-        "delegation": delegation_path,
-        "provider": {
-            "state": "degraded",
-            "reason": "provider_execution_record_missing",
-        },
-        "persistence": {
-            "state": "degraded",
-            "reason": "reconciliation_execution_lineage_missing",
-        },
-    }
+    )
 
 
 def _action_review_visibility_deadline(
@@ -305,72 +328,86 @@ def _action_review_overdue_path_health(
     if action_execution is None:
         if review_state in {"approved", "executing"}:
             return _action_review_unresolved_without_execution_path_health()
-        return {path_name: dict(path) for path_name, path in paths.items()}
+        return _action_review_path_health_entries(paths)
 
     overdue_paths = {path_name: dict(path) for path_name, path in paths.items()}
     if overdue_paths["ingest"].get("reason") == "awaiting_ingest_signal":
-        overdue_paths["ingest"] = {
-            "state": "degraded",
-            "reason": "ingest_signal_timeout",
-        }
+        overdue_paths["ingest"] = _action_review_path_health_entry(
+            {
+                "state": "degraded",
+                "reason": "ingest_signal_timeout",
+            }
+        )
     if overdue_paths["delegation"].get("reason") == "awaiting_receipt":
-        overdue_paths["delegation"] = {
-            "state": "degraded",
-            "reason": "delegation_receipt_timeout",
-        }
+        overdue_paths["delegation"] = _action_review_path_health_entry(
+            {
+                "state": "degraded",
+                "reason": "delegation_receipt_timeout",
+            }
+        )
     if overdue_paths["provider"].get("reason") == "awaiting_provider_receipt":
-        overdue_paths["provider"] = {
-            "state": "degraded",
-            "reason": "provider_receipt_timeout",
-        }
+        overdue_paths["provider"] = _action_review_path_health_entry(
+            {
+                "state": "degraded",
+                "reason": "provider_receipt_timeout",
+            }
+        )
     elif overdue_paths["provider"].get("reason") == "awaiting_authoritative_outcome":
-        overdue_paths["provider"] = {
-            "state": "degraded",
-            "reason": "authoritative_outcome_timeout",
-        }
+        overdue_paths["provider"] = _action_review_path_health_entry(
+            {
+                "state": "degraded",
+                "reason": "authoritative_outcome_timeout",
+            }
+        )
     if overdue_paths["persistence"].get("reason") == "awaiting_reconciliation":
-        overdue_paths["persistence"] = {
-            "state": "degraded",
-            "reason": "reconciliation_timeout",
-        }
-    return overdue_paths
+        overdue_paths["persistence"] = _action_review_path_health_entry(
+            {
+                "state": "degraded",
+                "reason": "reconciliation_timeout",
+            }
+        )
+    return _action_review_path_health_entries(overdue_paths)
 
 
 def _action_review_ingest_path_health(
     reconciliation: ReconciliationRecord | None,
 ) -> dict[str, str]:
     if reconciliation is None:
-        return {
-            "state": "delayed",
-            "reason": "awaiting_ingest_signal",
-        }
-    return {
-        "matched": {
-            "state": "healthy",
-            "reason": "observations_current",
-        },
-        "missing": {
-            "state": "delayed",
-            "reason": "observation_missing",
-        },
-        "stale": {
-            "state": "degraded",
-            "reason": "stale_observation",
-        },
-        "duplicate": {
-            "state": "degraded",
-            "reason": "duplicate_observations",
-        },
-        "mismatch": {
-            "state": "degraded",
-            "reason": "mismatch_detected",
-        },
-    }.get(
-        reconciliation.ingest_disposition,
+        return _action_review_path_health_entry(
+            {
+                "state": "delayed",
+                "reason": "awaiting_ingest_signal",
+            }
+        )
+    return _action_review_path_health_entry(
         {
-            "state": "degraded",
-            "reason": "ingest_anomaly",
-        },
+            "matched": {
+                "state": "healthy",
+                "reason": "observations_current",
+            },
+            "missing": {
+                "state": "delayed",
+                "reason": "observation_missing",
+            },
+            "stale": {
+                "state": "degraded",
+                "reason": "stale_observation",
+            },
+            "duplicate": {
+                "state": "degraded",
+                "reason": "duplicate_observations",
+            },
+            "mismatch": {
+                "state": "degraded",
+                "reason": "mismatch_detected",
+            },
+        }.get(
+            reconciliation.ingest_disposition,
+            {
+                "state": "degraded",
+                "reason": "ingest_anomaly",
+            },
+        )
     )
 
 
@@ -383,85 +420,99 @@ def _action_review_delegation_path_health(
 ) -> dict[str, str]:
     if action_execution is not None:
         if action_execution.lifecycle_state == "dispatching":
-            return {
-                "state": "delayed",
-                "reason": "awaiting_receipt",
+            return _action_review_path_health_entry(
+                {
+                    "state": "delayed",
+                    "reason": "awaiting_receipt",
+                }
+            )
+        return _action_review_path_health_entry(
+            {
+                "state": "healthy",
+                "reason": "delegated",
             }
-        return {
-            "state": "healthy",
-            "reason": "delegated",
-        }
+        )
     if approval_decision is not None and approval_decision.lifecycle_state == "approved":
-        return {
-            "state": "delayed",
-            "reason": "awaiting_reviewed_delegation",
-        }
+        return _action_review_path_health_entry(
+            {
+                "state": "delayed",
+                "reason": "awaiting_reviewed_delegation",
+            }
+        )
     if review_state == "approved" or action_request.lifecycle_state == "approved":
-        return {
+        return _action_review_path_health_entry(
+            {
+                "state": "delayed",
+                "reason": "awaiting_reviewed_delegation",
+            }
+        )
+    return _action_review_path_health_entry(
+        {
             "state": "delayed",
-            "reason": "awaiting_reviewed_delegation",
+            "reason": "awaiting_approval",
         }
-    return {
-        "state": "delayed",
-        "reason": "awaiting_approval",
-    }
+    )
 
 
 def _action_review_provider_path_health(
     action_execution: ActionExecutionRecord | None,
 ) -> dict[str, str]:
     if action_execution is None:
-        return {
-            "state": "delayed",
-            "reason": "awaiting_delegation",
-        }
-    return {
-        "dispatching": {
-            "state": "delayed",
-            "reason": "awaiting_provider_receipt",
-        },
-        "queued": {
-            "state": "delayed",
-            "reason": "awaiting_authoritative_outcome",
-        },
-        "running": {
-            "state": "delayed",
-            "reason": "awaiting_authoritative_outcome",
-        },
-        "succeeded": {
-            "state": "healthy",
-            "reason": "execution_succeeded",
-        },
-        "failed": {
-            "state": "failed",
-            "reason": "execution_failed",
-        },
-        "canceled": {
-            "state": "failed",
-            "reason": "execution_canceled",
-        },
-        "unresolved": {
-            "state": "degraded",
-            "reason": "execution_unresolved",
-        },
-        "expired": {
-            "state": "failed",
-            "reason": "execution_expired",
-        },
-        "rejected": {
-            "state": "failed",
-            "reason": "execution_rejected",
-        },
-        "superseded": {
-            "state": "degraded",
-            "reason": "execution_superseded",
-        },
-    }.get(
-        action_execution.lifecycle_state,
+        return _action_review_path_health_entry(
+            {
+                "state": "delayed",
+                "reason": "awaiting_delegation",
+            }
+        )
+    return _action_review_path_health_entry(
         {
-            "state": "degraded",
-            "reason": "provider_anomaly",
-        },
+            "dispatching": {
+                "state": "delayed",
+                "reason": "awaiting_provider_receipt",
+            },
+            "queued": {
+                "state": "delayed",
+                "reason": "awaiting_authoritative_outcome",
+            },
+            "running": {
+                "state": "delayed",
+                "reason": "awaiting_authoritative_outcome",
+            },
+            "succeeded": {
+                "state": "healthy",
+                "reason": "execution_succeeded",
+            },
+            "failed": {
+                "state": "failed",
+                "reason": "execution_failed",
+            },
+            "canceled": {
+                "state": "failed",
+                "reason": "execution_canceled",
+            },
+            "unresolved": {
+                "state": "degraded",
+                "reason": "execution_unresolved",
+            },
+            "expired": {
+                "state": "failed",
+                "reason": "execution_expired",
+            },
+            "rejected": {
+                "state": "failed",
+                "reason": "execution_rejected",
+            },
+            "superseded": {
+                "state": "degraded",
+                "reason": "execution_superseded",
+            },
+        }.get(
+            action_execution.lifecycle_state,
+            {
+                "state": "degraded",
+                "reason": "provider_anomaly",
+            },
+        )
     )
 
 
@@ -469,33 +520,37 @@ def _action_review_persistence_path_health(
     reconciliation: ReconciliationRecord | None,
 ) -> dict[str, str]:
     if reconciliation is None:
-        return {
-            "state": "delayed",
-            "reason": "awaiting_reconciliation",
-        }
-    return {
-        "matched": {
-            "state": "healthy",
-            "reason": "reconciliation_matched",
-        },
-        "pending": {
-            "state": "delayed",
-            "reason": "reconciliation_pending",
-        },
-        "mismatched": {
-            "state": "degraded",
-            "reason": "reconciliation_mismatched",
-        },
-        "stale": {
-            "state": "degraded",
-            "reason": "reconciliation_stale",
-        },
-    }.get(
-        reconciliation.lifecycle_state,
+        return _action_review_path_health_entry(
+            {
+                "state": "delayed",
+                "reason": "awaiting_reconciliation",
+            }
+        )
+    return _action_review_path_health_entry(
         {
-            "state": "degraded",
-            "reason": "persistence_anomaly",
-        },
+            "matched": {
+                "state": "healthy",
+                "reason": "reconciliation_matched",
+            },
+            "pending": {
+                "state": "delayed",
+                "reason": "reconciliation_pending",
+            },
+            "mismatched": {
+                "state": "degraded",
+                "reason": "reconciliation_mismatched",
+            },
+            "stale": {
+                "state": "degraded",
+                "reason": "reconciliation_stale",
+            },
+        }.get(
+            reconciliation.lifecycle_state,
+            {
+                "state": "degraded",
+                "reason": "persistence_anomaly",
+            },
+        )
     )
 
 

--- a/control-plane/aegisops_control_plane/action_review_projection.py
+++ b/control-plane/aegisops_control_plane/action_review_projection.py
@@ -321,6 +321,8 @@ def _action_review_visibility_deadline(
 
 def _action_review_overdue_path_health(
     *,
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
     review_state: str,
     action_execution: ActionExecutionRecord | None,
     reconciliation: ReconciliationRecord | None,
@@ -329,7 +331,12 @@ def _action_review_overdue_path_health(
     if action_execution is None:
         if review_state in {"approved", "executing"}:
             if reconciliation is not None:
-                return _action_review_path_health_entries(paths)
+                return _action_review_reconciliation_without_execution_path_health(
+                    action_request=action_request,
+                    approval_decision=approval_decision,
+                    reconciliation=reconciliation,
+                    review_state=review_state,
+                )
             return _action_review_unresolved_without_execution_path_health()
         return _action_review_path_health_entries(paths)
 
@@ -1498,6 +1505,8 @@ def action_review_path_health(
     )
     if deadline is not None and deadline <= as_of:
         paths = _action_review_overdue_path_health(
+            action_request=action_request,
+            approval_decision=approval_decision,
             review_state=review_state,
             action_execution=action_execution,
             reconciliation=reconciliation,

--- a/control-plane/aegisops_control_plane/action_review_projection.py
+++ b/control-plane/aegisops_control_plane/action_review_projection.py
@@ -323,10 +323,13 @@ def _action_review_overdue_path_health(
     *,
     review_state: str,
     action_execution: ActionExecutionRecord | None,
+    reconciliation: ReconciliationRecord | None,
     paths: Mapping[str, Mapping[str, str]],
 ) -> dict[str, dict[str, str]]:
     if action_execution is None:
         if review_state in {"approved", "executing"}:
+            if reconciliation is not None:
+                return _action_review_path_health_entries(paths)
             return _action_review_unresolved_without_execution_path_health()
         return _action_review_path_health_entries(paths)
 
@@ -439,7 +442,10 @@ def _action_review_delegation_path_health(
                 "reason": "awaiting_reviewed_delegation",
             }
         )
-    if review_state == "approved" or action_request.lifecycle_state == "approved":
+    if (
+        review_state in {"approved", "executing"}
+        or action_request.lifecycle_state == "approved"
+    ):
         return _action_review_path_health_entry(
             {
                 "state": "delayed",
@@ -1494,6 +1500,7 @@ def action_review_path_health(
         paths = _action_review_overdue_path_health(
             review_state=review_state,
             action_execution=action_execution,
+            reconciliation=reconciliation,
             paths=paths,
         )
     overall_state = _action_review_overall_path_state(paths.values())

--- a/control-plane/aegisops_control_plane/action_review_projection.py
+++ b/control-plane/aegisops_control_plane/action_review_projection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Iterable, Mapping
 
 from .models import (
     ActionExecutionRecord,
@@ -16,6 +16,14 @@ from .models import (
 
 if TYPE_CHECKING:
     from .service import AegisOpsControlPlaneService
+
+
+_AFTER_HOURS_HANDOFF_TRIAGE_DISPOSITIONS = frozenset(
+    {
+        "business_hours_handoff",
+        "awaiting_business_hours_review",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -188,6 +196,948 @@ def build_action_review_record_index(
     )
 
 
+def _action_review_terminal_non_delegated_path_health() -> dict[str, dict[str, str]]:
+    return {
+        "ingest": {
+            "state": "healthy",
+            "reason": "review_closed_before_ingest",
+        },
+        "delegation": {
+            "state": "healthy",
+            "reason": "review_closed_without_delegation",
+        },
+        "provider": {
+            "state": "healthy",
+            "reason": "review_closed_before_provider",
+        },
+        "persistence": {
+            "state": "healthy",
+            "reason": "review_closed_before_reconciliation",
+        },
+    }
+
+
+def _action_review_unresolved_without_execution_path_health() -> (
+    dict[str, dict[str, str]]
+):
+    return {
+        "ingest": {
+            "state": "degraded",
+            "reason": "ingest_signal_missing_after_approval",
+        },
+        "delegation": {
+            "state": "degraded",
+            "reason": "reviewed_delegation_missing_after_approval",
+        },
+        "provider": {
+            "state": "degraded",
+            "reason": "provider_signal_missing_after_approval",
+        },
+        "persistence": {
+            "state": "degraded",
+            "reason": "reconciliation_missing_after_approval",
+        },
+    }
+
+
+def _action_review_reconciliation_without_execution_path_health(
+    *,
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+    reconciliation: ReconciliationRecord,
+    review_state: str,
+) -> dict[str, dict[str, str]]:
+    delegation_path = _action_review_delegation_path_health(
+        action_request=action_request,
+        approval_decision=approval_decision,
+        action_execution=None,
+        review_state=review_state,
+    )
+    if delegation_path["state"] != "healthy":
+        delegation_path = {
+            "state": "degraded",
+            "reason": "reviewed_delegation_record_missing",
+        }
+    return {
+        "ingest": _action_review_ingest_path_health(reconciliation),
+        "delegation": delegation_path,
+        "provider": {
+            "state": "degraded",
+            "reason": "provider_execution_record_missing",
+        },
+        "persistence": {
+            "state": "degraded",
+            "reason": "reconciliation_execution_lineage_missing",
+        },
+    }
+
+
+def _action_review_visibility_deadline(
+    *,
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+    action_execution: ActionExecutionRecord | None,
+) -> datetime | None:
+    return min(
+        (
+            candidate
+            for candidate in (
+                None if action_execution is None else action_execution.expires_at,
+                (
+                    None
+                    if approval_decision is None
+                    else approval_decision.approved_expires_at
+                ),
+                action_request.expires_at,
+            )
+            if candidate is not None
+        ),
+        default=None,
+    )
+
+
+def _action_review_overdue_path_health(
+    *,
+    review_state: str,
+    action_execution: ActionExecutionRecord | None,
+    paths: Mapping[str, Mapping[str, str]],
+) -> dict[str, dict[str, str]]:
+    if action_execution is None:
+        if review_state in {"approved", "executing"}:
+            return _action_review_unresolved_without_execution_path_health()
+        return {path_name: dict(path) for path_name, path in paths.items()}
+
+    overdue_paths = {path_name: dict(path) for path_name, path in paths.items()}
+    if overdue_paths["ingest"].get("reason") == "awaiting_ingest_signal":
+        overdue_paths["ingest"] = {
+            "state": "degraded",
+            "reason": "ingest_signal_timeout",
+        }
+    if overdue_paths["delegation"].get("reason") == "awaiting_receipt":
+        overdue_paths["delegation"] = {
+            "state": "degraded",
+            "reason": "delegation_receipt_timeout",
+        }
+    if overdue_paths["provider"].get("reason") == "awaiting_provider_receipt":
+        overdue_paths["provider"] = {
+            "state": "degraded",
+            "reason": "provider_receipt_timeout",
+        }
+    elif overdue_paths["provider"].get("reason") == "awaiting_authoritative_outcome":
+        overdue_paths["provider"] = {
+            "state": "degraded",
+            "reason": "authoritative_outcome_timeout",
+        }
+    if overdue_paths["persistence"].get("reason") == "awaiting_reconciliation":
+        overdue_paths["persistence"] = {
+            "state": "degraded",
+            "reason": "reconciliation_timeout",
+        }
+    return overdue_paths
+
+
+def _action_review_ingest_path_health(
+    reconciliation: ReconciliationRecord | None,
+) -> dict[str, str]:
+    if reconciliation is None:
+        return {
+            "state": "delayed",
+            "reason": "awaiting_ingest_signal",
+        }
+    return {
+        "matched": {
+            "state": "healthy",
+            "reason": "observations_current",
+        },
+        "missing": {
+            "state": "delayed",
+            "reason": "observation_missing",
+        },
+        "stale": {
+            "state": "degraded",
+            "reason": "stale_observation",
+        },
+        "duplicate": {
+            "state": "degraded",
+            "reason": "duplicate_observations",
+        },
+        "mismatch": {
+            "state": "degraded",
+            "reason": "mismatch_detected",
+        },
+    }.get(
+        reconciliation.ingest_disposition,
+        {
+            "state": "degraded",
+            "reason": "ingest_anomaly",
+        },
+    )
+
+
+def _action_review_delegation_path_health(
+    *,
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+    action_execution: ActionExecutionRecord | None,
+    review_state: str,
+) -> dict[str, str]:
+    if action_execution is not None:
+        if action_execution.lifecycle_state == "dispatching":
+            return {
+                "state": "delayed",
+                "reason": "awaiting_receipt",
+            }
+        return {
+            "state": "healthy",
+            "reason": "delegated",
+        }
+    if approval_decision is not None and approval_decision.lifecycle_state == "approved":
+        return {
+            "state": "delayed",
+            "reason": "awaiting_reviewed_delegation",
+        }
+    if review_state == "approved" or action_request.lifecycle_state == "approved":
+        return {
+            "state": "delayed",
+            "reason": "awaiting_reviewed_delegation",
+        }
+    return {
+        "state": "delayed",
+        "reason": "awaiting_approval",
+    }
+
+
+def _action_review_provider_path_health(
+    action_execution: ActionExecutionRecord | None,
+) -> dict[str, str]:
+    if action_execution is None:
+        return {
+            "state": "delayed",
+            "reason": "awaiting_delegation",
+        }
+    return {
+        "dispatching": {
+            "state": "delayed",
+            "reason": "awaiting_provider_receipt",
+        },
+        "queued": {
+            "state": "delayed",
+            "reason": "awaiting_authoritative_outcome",
+        },
+        "running": {
+            "state": "delayed",
+            "reason": "awaiting_authoritative_outcome",
+        },
+        "succeeded": {
+            "state": "healthy",
+            "reason": "execution_succeeded",
+        },
+        "failed": {
+            "state": "failed",
+            "reason": "execution_failed",
+        },
+        "canceled": {
+            "state": "failed",
+            "reason": "execution_canceled",
+        },
+        "unresolved": {
+            "state": "degraded",
+            "reason": "execution_unresolved",
+        },
+        "expired": {
+            "state": "failed",
+            "reason": "execution_expired",
+        },
+        "rejected": {
+            "state": "failed",
+            "reason": "execution_rejected",
+        },
+        "superseded": {
+            "state": "degraded",
+            "reason": "execution_superseded",
+        },
+    }.get(
+        action_execution.lifecycle_state,
+        {
+            "state": "degraded",
+            "reason": "provider_anomaly",
+        },
+    )
+
+
+def _action_review_persistence_path_health(
+    reconciliation: ReconciliationRecord | None,
+) -> dict[str, str]:
+    if reconciliation is None:
+        return {
+            "state": "delayed",
+            "reason": "awaiting_reconciliation",
+        }
+    return {
+        "matched": {
+            "state": "healthy",
+            "reason": "reconciliation_matched",
+        },
+        "pending": {
+            "state": "delayed",
+            "reason": "reconciliation_pending",
+        },
+        "mismatched": {
+            "state": "degraded",
+            "reason": "reconciliation_mismatched",
+        },
+        "stale": {
+            "state": "degraded",
+            "reason": "reconciliation_stale",
+        },
+    }.get(
+        reconciliation.lifecycle_state,
+        {
+            "state": "degraded",
+            "reason": "persistence_anomaly",
+        },
+    )
+
+
+def _action_review_overall_path_state(
+    paths: Iterable[Mapping[str, str]],
+) -> str:
+    severity = {
+        "healthy": 0,
+        "delayed": 1,
+        "degraded": 2,
+        "failed": 3,
+    }
+    highest = max(
+        (
+            severity.get(path.get("state", "degraded"), severity["degraded"])
+            for path in paths
+        ),
+        default=severity["healthy"],
+    )
+    for state, rank in severity.items():
+        if rank == highest:
+            return state
+    return "degraded"
+
+
+def _action_review_path_health_summary(
+    *,
+    overall_state: str,
+    paths: Mapping[str, Mapping[str, str]],
+) -> str:
+    active_paths = [
+        f"{path_name} {path['reason'].replace('_', ' ')}"
+        for path_name, path in paths.items()
+        if path.get("state") != "healthy"
+    ]
+    if not active_paths:
+        return "all reviewed execution visibility paths are healthy"
+    primary = active_paths[:2]
+    joined = "; ".join(primary)
+    return f"{overall_state} path visibility: {joined}"
+
+
+def _action_review_after_hours_handoff_visibility(
+    *,
+    reviewed_context: Mapping[str, object],
+    review_state: str,
+) -> dict[str, object] | None:
+    if review_state in {"completed", "failed", "canceled"}:
+        return None
+    handoff = reviewed_context.get("handoff")
+    triage = reviewed_context.get("triage")
+    triage_disposition = triage.get("disposition") if isinstance(triage, Mapping) else None
+    if (
+        not isinstance(handoff, Mapping)
+        and triage_disposition not in _AFTER_HOURS_HANDOFF_TRIAGE_DISPOSITIONS
+    ):
+        return None
+
+    visibility: dict[str, object] = {}
+    if isinstance(handoff, Mapping):
+        for source_key, target_key in (
+            ("handoff_at", "handoff_at"),
+            ("handoff_owner", "handoff_owner"),
+            ("note", "note"),
+            ("follow_up_evidence_ids", "follow_up_evidence_ids"),
+        ):
+            value = handoff.get(source_key)
+            if value is not None:
+                visibility[target_key] = value
+    if (
+        isinstance(triage, Mapping)
+        and triage_disposition in _AFTER_HOURS_HANDOFF_TRIAGE_DISPOSITIONS
+    ):
+        for source_key, target_key in (
+            ("disposition", "disposition"),
+            ("recorded_at", "recorded_at"),
+        ):
+            value = triage.get(source_key)
+            if value is not None:
+                visibility[target_key] = value
+        rationale = triage.get("closure_rationale")
+        if rationale is None:
+            rationale = triage.get("rationale")
+        if rationale is not None:
+            visibility["rationale"] = rationale
+    return visibility or None
+
+
+def _action_review_visibility_context(
+    service: AegisOpsControlPlaneService,
+    action_request: ActionRequestRecord,
+) -> Mapping[str, object] | None:
+    case = (
+        service._store.get(CaseRecord, action_request.case_id)
+        if action_request.case_id is not None
+        else None
+    )
+    alert = (
+        service._store.get(AlertRecord, action_request.alert_id)
+        if action_request.alert_id is not None
+        else None
+    )
+    if case is not None and isinstance(case.reviewed_context, Mapping):
+        return case.reviewed_context
+    if alert is not None and isinstance(alert.reviewed_context, Mapping):
+        return alert.reviewed_context
+    return None
+
+
+def _action_review_manual_fallback_visibility(
+    *,
+    reviewed_context: Mapping[str, object],
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+    review_state: str,
+    allow_unscoped_context: bool,
+) -> dict[str, object] | None:
+    manual_fallback = _action_review_visibility_entry(
+        reviewed_context=reviewed_context,
+        action_request_id=action_request.action_request_id,
+        context_key="manual_fallback",
+    )
+    if not isinstance(manual_fallback, Mapping):
+        return None
+
+    approval_decision_id = (
+        approval_decision.approval_decision_id
+        if approval_decision is not None
+        else action_request.approval_decision_id
+    )
+    if (
+        approval_decision is None
+        or approval_decision.lifecycle_state != "approved"
+        or review_state in {"pending", "rejected", "expired", "superseded"}
+    ):
+        return None
+    if not _action_review_context_matches_lineage(
+        visibility_context=manual_fallback,
+        action_request_id=action_request.action_request_id,
+        approval_decision_id=approval_decision_id,
+        allow_unscoped_context=allow_unscoped_context,
+    ):
+        return None
+
+    visibility: dict[str, object] = {}
+    for source_key in ("action_request_id", "approval_decision_id"):
+        value = manual_fallback.get(source_key)
+        if value is not None:
+            visibility[source_key] = value
+    for source_key, target_key in (
+        ("fallback_at", "fallback_at"),
+        ("performed_at", "fallback_at"),
+        ("fallback_actor_identity", "fallback_actor_identity"),
+        ("authority_boundary", "authority_boundary"),
+        ("reason", "reason"),
+        ("action_taken", "action_taken"),
+        ("verification_evidence_ids", "verification_evidence_ids"),
+        ("residual_uncertainty", "residual_uncertainty"),
+    ):
+        value = manual_fallback.get(source_key)
+        if value is None:
+            continue
+        if source_key == "performed_at" and target_key in visibility:
+            continue
+        visibility[target_key] = value
+    return visibility
+
+
+def _action_review_escalation_visibility(
+    *,
+    reviewed_context: Mapping[str, object],
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+    review_state: str,
+    allow_unscoped_context: bool,
+) -> dict[str, object] | None:
+    requested_payload = action_request.requested_payload
+    escalation_context = _action_review_visibility_entry(
+        reviewed_context=reviewed_context,
+        action_request_id=action_request.action_request_id,
+        context_key="escalation",
+    )
+    if not isinstance(escalation_context, Mapping):
+        return None
+
+    approval_decision_id = (
+        approval_decision.approval_decision_id
+        if approval_decision is not None
+        else action_request.approval_decision_id
+    )
+    if not _action_review_context_matches_lineage(
+        visibility_context=escalation_context,
+        action_request_id=action_request.action_request_id,
+        approval_decision_id=approval_decision_id,
+        allow_unscoped_context=allow_unscoped_context,
+    ):
+        return None
+
+    recorded_review_state = escalation_context.get("review_state")
+    visibility: dict[str, object] = {
+        "action_request_id": action_request.action_request_id,
+        "approval_decision_id": approval_decision_id,
+        "requester_identity": action_request.requester_identity,
+        "review_state": (
+            recorded_review_state
+            if isinstance(recorded_review_state, str) and recorded_review_state.strip()
+            else review_state
+        ),
+    }
+    escalation_reason = requested_payload.get("escalation_reason")
+    if escalation_reason is not None:
+        visibility["escalation_reason"] = escalation_reason
+    for source_key, target_key in (
+        ("escalated_at", "escalated_at"),
+        ("escalated_to", "escalated_to"),
+        ("escalated_by_identity", "escalated_by_identity"),
+        ("note", "note"),
+    ):
+        value = escalation_context.get(source_key)
+        if value is not None:
+            visibility[target_key] = value
+    return visibility
+
+
+def _action_review_context_matches_lineage(
+    *,
+    visibility_context: Mapping[str, object],
+    action_request_id: str,
+    approval_decision_id: str | None,
+    allow_unscoped_context: bool,
+) -> bool:
+    scoped_action_request_id = visibility_context.get("action_request_id")
+    scoped_approval_decision_id = visibility_context.get("approval_decision_id")
+
+    if scoped_action_request_id is None:
+        if scoped_approval_decision_id is not None:
+            return (
+                approval_decision_id is not None
+                and scoped_approval_decision_id == approval_decision_id
+            )
+        return allow_unscoped_context
+
+    if scoped_action_request_id != action_request_id:
+        return False
+    if scoped_approval_decision_id is not None:
+        return (
+            approval_decision_id is not None
+            and scoped_approval_decision_id == approval_decision_id
+        )
+    return True
+
+
+def _action_review_visibility_entry(
+    *,
+    reviewed_context: Mapping[str, object],
+    action_request_id: str,
+    context_key: str,
+) -> Mapping[str, object] | None:
+    action_review_visibility = reviewed_context.get("action_review_visibility")
+    if isinstance(action_review_visibility, Mapping):
+        scoped_visibility = action_review_visibility.get(action_request_id)
+        if isinstance(scoped_visibility, Mapping):
+            scoped_entry = scoped_visibility.get(context_key)
+            if isinstance(scoped_entry, Mapping):
+                return scoped_entry
+    legacy_entry = reviewed_context.get(context_key)
+    if isinstance(legacy_entry, Mapping):
+        return legacy_entry
+    return None
+
+
+def _action_review_visibility_update(
+    *,
+    action_request_id: str,
+    context_key: str,
+    context_value: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        "action_review_visibility": {
+            action_request_id: {
+                context_key: dict(context_value),
+            }
+        }
+    }
+
+
+def _case_has_single_review_bound_action_request(
+    service: AegisOpsControlPlaneService,
+    case_id: str | None,
+    *,
+    record_index: _ActionReviewRecordIndex | None = None,
+) -> bool:
+    if case_id is None:
+        return False
+    if record_index is not None:
+        matching_requests = record_index.requests_by_case_id.get(case_id, ())
+    else:
+        matching_requests = tuple(
+            record
+            for record in service._store.list(ActionRequestRecord)
+            if record.case_id == case_id
+        )
+    review_bound_count = sum(
+        1
+        for record in matching_requests
+        if _action_request_is_review_bound(record)
+    )
+    return review_bound_count == 1
+
+
+def _action_review_approval_decision(
+    service: AegisOpsControlPlaneService,
+    action_request: ActionRequestRecord,
+    *,
+    record_index: _ActionReviewRecordIndex | None = None,
+) -> ApprovalDecisionRecord | None:
+    if record_index is not None and action_request.approval_decision_id:
+        decision = record_index.approvals_by_id.get(action_request.approval_decision_id)
+        if decision is not None:
+            return decision
+    if action_request.approval_decision_id:
+        decision = service._store.get(
+            ApprovalDecisionRecord,
+            action_request.approval_decision_id,
+        )
+        if decision is not None:
+            return decision
+    if record_index is not None:
+        matches = list(
+            record_index.approvals_by_action_request_id.get(
+                action_request.action_request_id,
+                (),
+            )
+        )
+    else:
+        matches = [
+            record
+            for record in service._store.list(ApprovalDecisionRecord)
+            if record.action_request_id == action_request.action_request_id
+        ]
+    if not matches:
+        return None
+    matches.sort(
+        key=lambda record: (
+            record.decided_at or datetime.min.replace(tzinfo=timezone.utc),
+            record.approval_decision_id,
+        ),
+        reverse=True,
+    )
+    return matches[0]
+
+
+def _action_review_execution(
+    service: AegisOpsControlPlaneService,
+    action_request: ActionRequestRecord,
+    *,
+    record_index: _ActionReviewRecordIndex | None = None,
+) -> ActionExecutionRecord | None:
+    if record_index is not None:
+        matches = list(
+            record_index.executions_by_action_request_id.get(
+                action_request.action_request_id,
+                (),
+            )
+        )
+    else:
+        matches = [
+            record
+            for record in service._store.list(ActionExecutionRecord)
+            if record.action_request_id == action_request.action_request_id
+        ]
+    if not matches:
+        return None
+    matches.sort(
+        key=lambda record: (
+            record.delegated_at,
+            record.action_execution_id,
+        ),
+        reverse=True,
+    )
+    return matches[0]
+
+
+def _latest_action_review_reconciliation(
+    service: AegisOpsControlPlaneService,
+    *,
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+    action_execution: ActionExecutionRecord | None,
+    record_index: _ActionReviewRecordIndex | None = None,
+) -> ReconciliationRecord | None:
+    def _dedupe(
+        reconciliations: tuple[ReconciliationRecord, ...] | list[ReconciliationRecord],
+    ) -> list[ReconciliationRecord]:
+        by_id: dict[str, ReconciliationRecord] = {}
+        for reconciliation in reconciliations:
+            by_id[reconciliation.reconciliation_id] = reconciliation
+        return list(by_id.values())
+
+    def _matches_current_execution_lineage(
+        reconciliation: ReconciliationRecord,
+    ) -> bool:
+        if action_execution is None:
+            return False
+        subject_action_execution_ids = service._assistant_ids_from_mapping(
+            reconciliation.subject_linkage,
+            "action_execution_ids",
+        )
+        if action_execution.action_execution_id in subject_action_execution_ids:
+            return True
+        subject_delegation_ids = service._assistant_ids_from_mapping(
+            reconciliation.subject_linkage,
+            "delegation_ids",
+        )
+        return action_execution.delegation_id in subject_delegation_ids
+
+    def _matches_review_lineage(reconciliation: ReconciliationRecord) -> bool:
+        if _matches_current_execution_lineage(reconciliation):
+            return True
+        if approval_decision is not None:
+            subject_approval_decision_ids = service._assistant_ids_from_mapping(
+                reconciliation.subject_linkage,
+                "approval_decision_ids",
+            )
+            if approval_decision.approval_decision_id in subject_approval_decision_ids:
+                return True
+        subject_action_request_ids = service._assistant_ids_from_mapping(
+            reconciliation.subject_linkage,
+            "action_request_ids",
+        )
+        return action_request.action_request_id in subject_action_request_ids
+
+    matches: list[ReconciliationRecord] = []
+    if record_index is not None:
+        indexed_matches: list[ReconciliationRecord] = list(
+            record_index.reconciliations_by_action_request_id.get(
+                action_request.action_request_id,
+                (),
+            )
+        )
+        if approval_decision is not None:
+            indexed_matches += list(
+                record_index.reconciliations_by_approval_decision_id.get(
+                    approval_decision.approval_decision_id,
+                    (),
+                )
+            )
+        if action_execution is not None:
+            indexed_matches += list(
+                record_index.reconciliations_by_action_execution_id.get(
+                    action_execution.action_execution_id,
+                    (),
+                )
+            )
+            indexed_matches += list(
+                record_index.reconciliations_by_delegation_id.get(
+                    action_execution.delegation_id,
+                    (),
+                )
+            )
+        matches = _dedupe(indexed_matches)
+    else:
+        for reconciliation in service._store.list(ReconciliationRecord):
+            if _matches_review_lineage(reconciliation):
+                matches.append(reconciliation)
+    if not matches:
+        return None
+    matches.sort(
+        key=lambda record: (
+            1 if _matches_current_execution_lineage(record) else 0,
+            record.compared_at or record.last_seen_at or record.first_seen_at,
+            record.reconciliation_id,
+        ),
+        reverse=True,
+    )
+    return matches[0]
+
+
+def _action_review_approval_state(
+    *,
+    action_request: ActionRequestRecord,
+    approval_decision: ApprovalDecisionRecord | None,
+) -> str | None:
+    if approval_decision is not None:
+        return approval_decision.lifecycle_state
+    if action_request.lifecycle_state == "pending_approval":
+        return "pending"
+    if action_request.lifecycle_state in {"rejected", "expired", "superseded", "canceled"}:
+        return action_request.lifecycle_state
+    return None
+
+
+def _action_review_state(
+    *,
+    action_request: ActionRequestRecord,
+    approval_state: str | None,
+    action_execution: ActionExecutionRecord | None,
+) -> str:
+    lifecycle_state = action_request.lifecycle_state
+    execution_state = (
+        action_execution.lifecycle_state if action_execution is not None else None
+    )
+    terminal_execution_review_states = {
+        "succeeded": "completed",
+        "failed": "failed",
+        "canceled": "canceled",
+        "superseded": "superseded",
+        "unresolved": "unresolved",
+        "expired": "expired",
+        "rejected": "rejected",
+    }
+    if lifecycle_state in {"expired", "rejected", "superseded", "canceled"}:
+        return lifecycle_state
+    if lifecycle_state in {"completed", "failed", "unresolved"}:
+        return lifecycle_state
+    if execution_state in terminal_execution_review_states:
+        return terminal_execution_review_states[execution_state]
+    if execution_state is not None:
+        return "executing"
+    if lifecycle_state == "executing":
+        return "executing"
+    if approval_state in {"expired", "rejected", "superseded", "canceled"}:
+        return approval_state
+    if approval_state == "approved":
+        return "approved"
+    if lifecycle_state == "approved":
+        return "approved"
+    if lifecycle_state == "pending_approval" or approval_state == "pending":
+        return "pending"
+    return lifecycle_state
+
+
+def _replacement_action_request(
+    service: AegisOpsControlPlaneService,
+    action_request: ActionRequestRecord,
+    *,
+    record_index: _ActionReviewRecordIndex | None = None,
+) -> ActionRequestRecord | None:
+    if action_request.lifecycle_state != "superseded":
+        return None
+    requested_payload = dict(action_request.requested_payload)
+    recommendation_id = requested_payload.get("recommendation_id")
+    action_type = requested_payload.get("action_type")
+    if record_index is not None:
+        candidate_requests = record_index.matching_requests(
+            case_id=action_request.case_id,
+            alert_id=action_request.alert_id,
+        )
+        matches = [
+            record
+            for record in candidate_requests
+            if record.action_request_id != action_request.action_request_id
+            and _action_request_is_review_bound(record)
+            and record.requested_at >= action_request.requested_at
+            and record.lifecycle_state != "superseded"
+            and dict(record.requested_payload).get("action_type") == action_type
+            and (
+                recommendation_id is None
+                or dict(record.requested_payload).get("recommendation_id")
+                == recommendation_id
+            )
+        ]
+    else:
+        matches = [
+            record
+            for record in service._store.list(ActionRequestRecord)
+            if record.action_request_id != action_request.action_request_id
+            and _action_request_is_review_bound(record)
+            and (
+                (
+                    action_request.case_id is not None
+                    and record.case_id == action_request.case_id
+                )
+                or (
+                    action_request.alert_id is not None
+                    and record.alert_id == action_request.alert_id
+                )
+            )
+            and record.requested_at >= action_request.requested_at
+            and record.lifecycle_state != "superseded"
+            and dict(record.requested_payload).get("action_type") == action_type
+            and (
+                recommendation_id is None
+                or dict(record.requested_payload).get("recommendation_id")
+                == recommendation_id
+            )
+        ]
+    if not matches:
+        return None
+    matches.sort(
+        key=lambda record: (record.requested_at, record.action_request_id),
+        reverse=True,
+    )
+    return matches[0]
+
+
+def _action_request_is_review_bound(action_request: ActionRequestRecord) -> bool:
+    return not (
+        action_request.policy_evaluation.get("approval_requirement")
+        == "policy_authorized"
+        and action_request.approval_decision_id is None
+    )
+
+
+def _next_expected_action_for_review_state(review_state: str) -> str | None:
+    return {
+        "pending": "await_approver_decision",
+        "approved": "await_reviewed_delegation",
+        "executing": "await_execution_reconciliation",
+        "expired": "create_replacement_or_close_case",
+        "rejected": "review_rejection_and_record_follow_up",
+        "canceled": "investigate_execution_cancellation",
+        "superseded": "inspect_replacing_review_record",
+        "completed": "review_execution_outcome",
+        "failed": "investigate_execution_failure",
+        "unresolved": "investigate_reconciliation_gap",
+    }.get(review_state)
+
+
+def _action_review_stage_snapshot(
+    *,
+    stage: str,
+    record_family: str,
+    record_id: str | None,
+    state: str,
+    occurred_at: datetime | None,
+    actor_identities: tuple[str, ...] = (),
+    details: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    snapshot = {
+        "stage": stage,
+        "record_family": record_family,
+        "record_id": record_id,
+        "state": state,
+        "occurred_at": occurred_at,
+        "actor_identities": actor_identities,
+    }
+    if details:
+        snapshot["details"] = dict(details)
+    return snapshot
+
+
 def action_review_chains_for_scope(
     service: AegisOpsControlPlaneService,
     *,
@@ -247,7 +1197,7 @@ def action_review_chains_for_scope(
     matching_requests = [
         record
         for record in matching_requests
-        if service._action_request_is_review_bound(record)
+        if _action_request_is_review_bound(record)
     ]
     chains = [
         build_action_review_chain_snapshot(
@@ -287,25 +1237,28 @@ def build_action_review_chain_snapshot(
     *,
     record_index: _ActionReviewRecordIndex | None = None,
 ) -> dict[str, object]:
-    approval_decision = service._action_review_approval_decision(
+    approval_decision = _action_review_approval_decision(
+        service,
         action_request,
         record_index=record_index,
     )
-    action_execution = service._action_review_execution(
+    action_execution = _action_review_execution(
+        service,
         action_request,
         record_index=record_index,
     )
-    reconciliation = service._latest_action_review_reconciliation(
+    reconciliation = _latest_action_review_reconciliation(
+        service,
         action_request=action_request,
         approval_decision=approval_decision,
         action_execution=action_execution,
         record_index=record_index,
     )
-    approval_state = service._action_review_approval_state(
+    approval_state = _action_review_approval_state(
         action_request=action_request,
         approval_decision=approval_decision,
     )
-    review_state = service._action_review_state(
+    review_state = _action_review_state(
         action_request=action_request,
         approval_state=approval_state,
         action_execution=action_execution,
@@ -320,7 +1273,8 @@ def build_action_review_chain_snapshot(
     )
     mismatch_inspection = action_review_mismatch_inspection(reconciliation)
     reconciliation_detail = action_review_reconciliation_detail(reconciliation)
-    replacement_action_request = service._replacement_action_request(
+    replacement_action_request = _replacement_action_request(
+        service,
         action_request,
         record_index=record_index,
     )
@@ -355,9 +1309,7 @@ def build_action_review_chain_snapshot(
 
     return {
         "review_state": review_state,
-        "next_expected_action": service._next_expected_action_for_review_state(
-            review_state
-        ),
+        "next_expected_action": _next_expected_action_for_review_state(review_state),
         "action_request_id": action_request.action_request_id,
         "action_request_state": action_request.lifecycle_state,
         "approval_decision_id": (
@@ -440,29 +1392,27 @@ def action_review_path_health(
 ) -> dict[str, object]:
     if action_execution is None and reconciliation is None:
         if review_state in {"rejected", "expired", "superseded", "canceled"}:
-            paths = service._action_review_terminal_non_delegated_path_health()
+            paths = _action_review_terminal_non_delegated_path_health()
         elif (
             review_state == "unresolved"
             and approval_decision is not None
             and approval_decision.lifecycle_state == "approved"
         ):
-            paths = service._action_review_unresolved_without_execution_path_health()
+            paths = _action_review_unresolved_without_execution_path_health()
         else:
             paths = {
-                "ingest": service._action_review_ingest_path_health(reconciliation),
-                "delegation": service._action_review_delegation_path_health(
+                "ingest": _action_review_ingest_path_health(reconciliation),
+                "delegation": _action_review_delegation_path_health(
                     action_request=action_request,
                     approval_decision=approval_decision,
                     action_execution=action_execution,
                     review_state=review_state,
                 ),
-                "provider": service._action_review_provider_path_health(action_execution),
-                "persistence": service._action_review_persistence_path_health(
-                    reconciliation
-                ),
+                "provider": _action_review_provider_path_health(action_execution),
+                "persistence": _action_review_persistence_path_health(reconciliation),
             }
     elif action_execution is None:
-        paths = service._action_review_reconciliation_without_execution_path_health(
+        paths = _action_review_reconciliation_without_execution_path_health(
             action_request=action_request,
             approval_decision=approval_decision,
             reconciliation=reconciliation,
@@ -470,31 +1420,31 @@ def action_review_path_health(
         )
     else:
         paths = {
-            "ingest": service._action_review_ingest_path_health(reconciliation),
-            "delegation": service._action_review_delegation_path_health(
+            "ingest": _action_review_ingest_path_health(reconciliation),
+            "delegation": _action_review_delegation_path_health(
                 action_request=action_request,
                 approval_decision=approval_decision,
                 action_execution=action_execution,
                 review_state=review_state,
             ),
-            "provider": service._action_review_provider_path_health(action_execution),
-            "persistence": service._action_review_persistence_path_health(reconciliation),
+            "provider": _action_review_provider_path_health(action_execution),
+            "persistence": _action_review_persistence_path_health(reconciliation),
         }
-    deadline = service._action_review_visibility_deadline(
+    deadline = _action_review_visibility_deadline(
         action_request=action_request,
         approval_decision=approval_decision,
         action_execution=action_execution,
     )
     if deadline is not None and deadline <= as_of:
-        paths = service._action_review_overdue_path_health(
+        paths = _action_review_overdue_path_health(
             review_state=review_state,
             action_execution=action_execution,
             paths=paths,
         )
-    overall_state = service._action_review_overall_path_state(paths.values())
+    overall_state = _action_review_overall_path_state(paths.values())
     return {
         "overall_state": overall_state,
-        "summary": service._action_review_path_health_summary(
+        "summary": _action_review_path_health_summary(
             overall_state=overall_state,
             paths=paths,
         ),
@@ -510,23 +1460,24 @@ def action_review_runtime_visibility(
     review_state: str,
     record_index: _ActionReviewRecordIndex | None = None,
 ) -> dict[str, object] | None:
-    reviewed_context = service._action_review_visibility_context(action_request)
+    reviewed_context = _action_review_visibility_context(service, action_request)
     if reviewed_context is None:
         return None
 
-    allow_unscoped_action_visibility = service._case_has_single_review_bound_action_request(
+    allow_unscoped_action_visibility = _case_has_single_review_bound_action_request(
+        service,
         action_request.case_id,
         record_index=record_index,
     )
     visibility: dict[str, object] = {}
-    after_hours_handoff = service._action_review_after_hours_handoff_visibility(
+    after_hours_handoff = _action_review_after_hours_handoff_visibility(
         reviewed_context=reviewed_context,
         review_state=review_state,
     )
     if after_hours_handoff is not None:
         visibility["after_hours_handoff"] = after_hours_handoff
 
-    manual_fallback = service._action_review_manual_fallback_visibility(
+    manual_fallback = _action_review_manual_fallback_visibility(
         reviewed_context=reviewed_context,
         action_request=action_request,
         approval_decision=approval_decision,
@@ -536,7 +1487,7 @@ def action_review_runtime_visibility(
     if manual_fallback is not None:
         visibility["manual_fallback"] = manual_fallback
 
-    escalation_notes = service._action_review_escalation_visibility(
+    escalation_notes = _action_review_escalation_visibility(
         reviewed_context=reviewed_context,
         action_request=action_request,
         approval_decision=approval_decision,
@@ -577,7 +1528,7 @@ def action_review_timeline(
         if isinstance(adapter_base_url, str) and adapter_base_url.strip():
             action_execution_details["adapter_base_url"] = adapter_base_url
     timeline = (
-        service._action_review_stage_snapshot(
+        _action_review_stage_snapshot(
             stage="action_request",
             record_family="action_request",
             record_id=action_request.action_request_id,
@@ -600,7 +1551,7 @@ def action_review_timeline(
                 ),
             },
         ),
-        service._action_review_stage_snapshot(
+        _action_review_stage_snapshot(
             stage="approval_decision",
             record_family="approval_decision",
             record_id=(
@@ -630,7 +1581,7 @@ def action_review_timeline(
                 }
             ),
         ),
-        service._action_review_stage_snapshot(
+        _action_review_stage_snapshot(
             stage="delegation",
             record_family="action_execution",
             record_id=(
@@ -656,7 +1607,7 @@ def action_review_timeline(
             ),
             details=delegation_details,
         ),
-        service._action_review_stage_snapshot(
+        _action_review_stage_snapshot(
             stage="action_execution",
             record_family="action_execution",
             record_id=(
@@ -682,7 +1633,7 @@ def action_review_timeline(
                 }
             ),
         ),
-        service._action_review_stage_snapshot(
+        _action_review_stage_snapshot(
             stage="reconciliation",
             record_family="reconciliation",
             record_id=(

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -64,12 +64,6 @@ from .service_composition import (
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
 
-_AFTER_HOURS_HANDOFF_TRIAGE_DISPOSITIONS = frozenset(
-    {
-        "business_hours_handoff",
-        "awaiting_business_hours_review",
-    }
-)
 _CASE_CLOSED_TRIAGE_DISPOSITIONS = frozenset(
     {
         "closed_benign",
@@ -2228,47 +2222,13 @@ class AegisOpsControlPlaneService:
 
     @staticmethod
     def _action_review_terminal_non_delegated_path_health() -> dict[str, dict[str, str]]:
-        return {
-            "ingest": {
-                "state": "healthy",
-                "reason": "review_closed_before_ingest",
-            },
-            "delegation": {
-                "state": "healthy",
-                "reason": "review_closed_without_delegation",
-            },
-            "provider": {
-                "state": "healthy",
-                "reason": "review_closed_before_provider",
-            },
-            "persistence": {
-                "state": "healthy",
-                "reason": "review_closed_before_reconciliation",
-            },
-        }
+        return _action_review_projection._action_review_terminal_non_delegated_path_health()
 
     @staticmethod
     def _action_review_unresolved_without_execution_path_health() -> (
         dict[str, dict[str, str]]
     ):
-        return {
-            "ingest": {
-                "state": "degraded",
-                "reason": "ingest_signal_missing_after_approval",
-            },
-            "delegation": {
-                "state": "degraded",
-                "reason": "reviewed_delegation_missing_after_approval",
-            },
-            "provider": {
-                "state": "degraded",
-                "reason": "provider_signal_missing_after_approval",
-            },
-            "persistence": {
-                "state": "degraded",
-                "reason": "reconciliation_missing_after_approval",
-            },
-        }
+        return _action_review_projection._action_review_unresolved_without_execution_path_health()
 
     def _action_review_reconciliation_without_execution_path_health(
         self,
@@ -2278,29 +2238,12 @@ class AegisOpsControlPlaneService:
         reconciliation: ReconciliationRecord,
         review_state: str,
     ) -> dict[str, dict[str, str]]:
-        delegation_path = self._action_review_delegation_path_health(
+        return _action_review_projection._action_review_reconciliation_without_execution_path_health(
             action_request=action_request,
             approval_decision=approval_decision,
-            action_execution=None,
+            reconciliation=reconciliation,
             review_state=review_state,
         )
-        if delegation_path["state"] != "healthy":
-            delegation_path = {
-                "state": "degraded",
-                "reason": "reviewed_delegation_record_missing",
-            }
-        return {
-            "ingest": self._action_review_ingest_path_health(reconciliation),
-            "delegation": delegation_path,
-            "provider": {
-                "state": "degraded",
-                "reason": "provider_execution_record_missing",
-            },
-            "persistence": {
-                "state": "degraded",
-                "reason": "reconciliation_execution_lineage_missing",
-            },
-        }
 
     @staticmethod
     def _action_review_visibility_deadline(
@@ -2309,21 +2252,10 @@ class AegisOpsControlPlaneService:
         approval_decision: ApprovalDecisionRecord | None,
         action_execution: ActionExecutionRecord | None,
     ) -> datetime | None:
-        return min(
-            (
-                candidate
-                for candidate in (
-                    None if action_execution is None else action_execution.expires_at,
-                    (
-                        None
-                        if approval_decision is None
-                        else approval_decision.approved_expires_at
-                    ),
-                    action_request.expires_at,
-                )
-                if candidate is not None
-            ),
-            default=None,
+        return _action_review_projection._action_review_visibility_deadline(
+            action_request=action_request,
+            approval_decision=approval_decision,
+            action_execution=action_execution,
         )
 
     @classmethod
@@ -2334,75 +2266,18 @@ class AegisOpsControlPlaneService:
         action_execution: ActionExecutionRecord | None,
         paths: Mapping[str, Mapping[str, str]],
     ) -> dict[str, dict[str, str]]:
-        if action_execution is None:
-            if review_state in {"approved", "executing"}:
-                return cls._action_review_unresolved_without_execution_path_health()
-            return {path_name: dict(path) for path_name, path in paths.items()}
-
-        overdue_paths = {path_name: dict(path) for path_name, path in paths.items()}
-        if overdue_paths["ingest"].get("reason") == "awaiting_ingest_signal":
-            overdue_paths["ingest"] = {
-                "state": "degraded",
-                "reason": "ingest_signal_timeout",
-            }
-        if overdue_paths["delegation"].get("reason") == "awaiting_receipt":
-            overdue_paths["delegation"] = {
-                "state": "degraded",
-                "reason": "delegation_receipt_timeout",
-            }
-        if overdue_paths["provider"].get("reason") == "awaiting_provider_receipt":
-            overdue_paths["provider"] = {
-                "state": "degraded",
-                "reason": "provider_receipt_timeout",
-            }
-        elif overdue_paths["provider"].get("reason") == "awaiting_authoritative_outcome":
-            overdue_paths["provider"] = {
-                "state": "degraded",
-                "reason": "authoritative_outcome_timeout",
-            }
-        if overdue_paths["persistence"].get("reason") == "awaiting_reconciliation":
-            overdue_paths["persistence"] = {
-                "state": "degraded",
-                "reason": "reconciliation_timeout",
-            }
-        return overdue_paths
+        return _action_review_projection._action_review_overdue_path_health(
+            review_state=review_state,
+            action_execution=action_execution,
+            paths=paths,
+        )
 
     @staticmethod
     def _action_review_ingest_path_health(
         reconciliation: ReconciliationRecord | None,
     ) -> dict[str, str]:
-        if reconciliation is None:
-            return {
-                "state": "delayed",
-                "reason": "awaiting_ingest_signal",
-            }
-        return {
-            "matched": {
-                "state": "healthy",
-                "reason": "observations_current",
-            },
-            "missing": {
-                "state": "delayed",
-                "reason": "observation_missing",
-            },
-            "stale": {
-                "state": "degraded",
-                "reason": "stale_observation",
-            },
-            "duplicate": {
-                "state": "degraded",
-                "reason": "duplicate_observations",
-            },
-            "mismatch": {
-                "state": "degraded",
-                "reason": "mismatch_detected",
-            },
-        }.get(
-            reconciliation.ingest_disposition,
-            {
-                "state": "degraded",
-                "reason": "ingest_anomaly",
-            },
+        return _action_review_projection._action_review_ingest_path_health(
+            reconciliation
         )
 
     @staticmethod
@@ -2413,144 +2288,34 @@ class AegisOpsControlPlaneService:
         action_execution: ActionExecutionRecord | None,
         review_state: str,
     ) -> dict[str, str]:
-        if action_execution is not None:
-            if action_execution.lifecycle_state == "dispatching":
-                return {
-                    "state": "delayed",
-                    "reason": "awaiting_receipt",
-                }
-            return {
-                "state": "healthy",
-                "reason": "delegated",
-            }
-        if approval_decision is not None and approval_decision.lifecycle_state == "approved":
-            return {
-                "state": "delayed",
-                "reason": "awaiting_reviewed_delegation",
-            }
-        if review_state == "approved" or action_request.lifecycle_state == "approved":
-            return {
-                "state": "delayed",
-                "reason": "awaiting_reviewed_delegation",
-            }
-        return {
-            "state": "delayed",
-            "reason": "awaiting_approval",
-        }
+        return _action_review_projection._action_review_delegation_path_health(
+            action_request=action_request,
+            approval_decision=approval_decision,
+            action_execution=action_execution,
+            review_state=review_state,
+        )
 
     @staticmethod
     def _action_review_provider_path_health(
         action_execution: ActionExecutionRecord | None,
     ) -> dict[str, str]:
-        if action_execution is None:
-            return {
-                "state": "delayed",
-                "reason": "awaiting_delegation",
-            }
-        return {
-            "dispatching": {
-                "state": "delayed",
-                "reason": "awaiting_provider_receipt",
-            },
-            "queued": {
-                "state": "delayed",
-                "reason": "awaiting_authoritative_outcome",
-            },
-            "running": {
-                "state": "delayed",
-                "reason": "awaiting_authoritative_outcome",
-            },
-            "succeeded": {
-                "state": "healthy",
-                "reason": "execution_succeeded",
-            },
-            "failed": {
-                "state": "failed",
-                "reason": "execution_failed",
-            },
-            "canceled": {
-                "state": "failed",
-                "reason": "execution_canceled",
-            },
-            "unresolved": {
-                "state": "degraded",
-                "reason": "execution_unresolved",
-            },
-            "expired": {
-                "state": "failed",
-                "reason": "execution_expired",
-            },
-            "rejected": {
-                "state": "failed",
-                "reason": "execution_rejected",
-            },
-            "superseded": {
-                "state": "degraded",
-                "reason": "execution_superseded",
-            },
-        }.get(
-            action_execution.lifecycle_state,
-            {
-                "state": "degraded",
-                "reason": "provider_anomaly",
-            },
+        return _action_review_projection._action_review_provider_path_health(
+            action_execution
         )
 
     @staticmethod
     def _action_review_persistence_path_health(
         reconciliation: ReconciliationRecord | None,
     ) -> dict[str, str]:
-        if reconciliation is None:
-            return {
-                "state": "delayed",
-                "reason": "awaiting_reconciliation",
-            }
-        return {
-            "matched": {
-                "state": "healthy",
-                "reason": "reconciliation_matched",
-            },
-            "pending": {
-                "state": "delayed",
-                "reason": "reconciliation_pending",
-            },
-            "mismatched": {
-                "state": "degraded",
-                "reason": "reconciliation_mismatched",
-            },
-            "stale": {
-                "state": "degraded",
-                "reason": "reconciliation_stale",
-            },
-        }.get(
-            reconciliation.lifecycle_state,
-            {
-                "state": "degraded",
-                "reason": "persistence_anomaly",
-            },
+        return _action_review_projection._action_review_persistence_path_health(
+            reconciliation
         )
 
     @staticmethod
     def _action_review_overall_path_state(
         paths: Iterable[Mapping[str, str]],
     ) -> str:
-        severity = {
-            "healthy": 0,
-            "delayed": 1,
-            "degraded": 2,
-            "failed": 3,
-        }
-        highest = max(
-            (
-                severity.get(path.get("state", "degraded"), severity["degraded"])
-                for path in paths
-            ),
-            default=severity["healthy"],
-        )
-        for state, rank in severity.items():
-            if rank == highest:
-                return state
-        return "degraded"
+        return _action_review_projection._action_review_overall_path_state(paths)
 
     @staticmethod
     def _action_review_path_health_summary(
@@ -2558,16 +2323,10 @@ class AegisOpsControlPlaneService:
         overall_state: str,
         paths: Mapping[str, Mapping[str, str]],
     ) -> str:
-        active_paths = [
-            f"{path_name} {path['reason'].replace('_', ' ')}"
-            for path_name, path in paths.items()
-            if path.get("state") != "healthy"
-        ]
-        if not active_paths:
-            return "all reviewed execution visibility paths are healthy"
-        primary = active_paths[:2]
-        joined = "; ".join(primary)
-        return f"{overall_state} path visibility: {joined}"
+        return _action_review_projection._action_review_path_health_summary(
+            overall_state=overall_state,
+            paths=paths,
+        )
 
     def _action_review_runtime_visibility(
         self,
@@ -2591,65 +2350,19 @@ class AegisOpsControlPlaneService:
         reviewed_context: Mapping[str, object],
         review_state: str,
     ) -> dict[str, object] | None:
-        if review_state in {"completed", "failed", "canceled"}:
-            return None
-        handoff = reviewed_context.get("handoff")
-        triage = reviewed_context.get("triage")
-        triage_disposition = triage.get("disposition") if isinstance(triage, Mapping) else None
-        if (
-            not isinstance(handoff, Mapping)
-            and triage_disposition not in _AFTER_HOURS_HANDOFF_TRIAGE_DISPOSITIONS
-        ):
-            return None
-
-        visibility: dict[str, object] = {}
-        if isinstance(handoff, Mapping):
-            for source_key, target_key in (
-                ("handoff_at", "handoff_at"),
-                ("handoff_owner", "handoff_owner"),
-                ("note", "note"),
-                ("follow_up_evidence_ids", "follow_up_evidence_ids"),
-            ):
-                value = handoff.get(source_key)
-                if value is not None:
-                    visibility[target_key] = value
-        if (
-            isinstance(triage, Mapping)
-            and triage_disposition in _AFTER_HOURS_HANDOFF_TRIAGE_DISPOSITIONS
-        ):
-            for source_key, target_key in (
-                ("disposition", "disposition"),
-                ("recorded_at", "recorded_at"),
-            ):
-                value = triage.get(source_key)
-                if value is not None:
-                    visibility[target_key] = value
-            rationale = triage.get("closure_rationale")
-            if rationale is None:
-                rationale = triage.get("rationale")
-            if rationale is not None:
-                visibility["rationale"] = rationale
-        return visibility or None
+        return _action_review_projection._action_review_after_hours_handoff_visibility(
+            reviewed_context=reviewed_context,
+            review_state=review_state,
+        )
 
     def _action_review_visibility_context(
         self,
         action_request: ActionRequestRecord,
     ) -> Mapping[str, object] | None:
-        case = (
-            self._store.get(CaseRecord, action_request.case_id)
-            if action_request.case_id is not None
-            else None
+        return _action_review_projection._action_review_visibility_context(
+            self,
+            action_request,
         )
-        alert = (
-            self._store.get(AlertRecord, action_request.alert_id)
-            if action_request.alert_id is not None
-            else None
-        )
-        if case is not None and isinstance(case.reviewed_context, Mapping):
-            return case.reviewed_context
-        if alert is not None and isinstance(alert.reviewed_context, Mapping):
-            return alert.reviewed_context
-        return None
 
     @staticmethod
     def _action_review_manual_fallback_visibility(
@@ -2660,55 +2373,13 @@ class AegisOpsControlPlaneService:
         review_state: str,
         allow_unscoped_context: bool,
     ) -> dict[str, object] | None:
-        manual_fallback = AegisOpsControlPlaneService._action_review_visibility_entry(
+        return _action_review_projection._action_review_manual_fallback_visibility(
             reviewed_context=reviewed_context,
-            action_request_id=action_request.action_request_id,
-            context_key="manual_fallback",
-        )
-        if not isinstance(manual_fallback, Mapping):
-            return None
-
-        approval_decision_id = (
-            approval_decision.approval_decision_id
-            if approval_decision is not None
-            else action_request.approval_decision_id
-        )
-        if (
-            approval_decision is None
-            or approval_decision.lifecycle_state != "approved"
-            or review_state in {"pending", "rejected", "expired", "superseded"}
-        ):
-            return None
-        if not AegisOpsControlPlaneService._action_review_context_matches_lineage(
-            visibility_context=manual_fallback,
-            action_request_id=action_request.action_request_id,
-            approval_decision_id=approval_decision_id,
+            action_request=action_request,
+            approval_decision=approval_decision,
+            review_state=review_state,
             allow_unscoped_context=allow_unscoped_context,
-        ):
-            return None
-
-        visibility: dict[str, object] = {}
-        for source_key in ("action_request_id", "approval_decision_id"):
-            value = manual_fallback.get(source_key)
-            if value is not None:
-                visibility[source_key] = value
-        for source_key, target_key in (
-            ("fallback_at", "fallback_at"),
-            ("performed_at", "fallback_at"),
-            ("fallback_actor_identity", "fallback_actor_identity"),
-            ("authority_boundary", "authority_boundary"),
-            ("reason", "reason"),
-            ("action_taken", "action_taken"),
-            ("verification_evidence_ids", "verification_evidence_ids"),
-            ("residual_uncertainty", "residual_uncertainty"),
-        ):
-            value = manual_fallback.get(source_key)
-            if value is None:
-                continue
-            if source_key == "performed_at" and target_key in visibility:
-                continue
-            visibility[target_key] = value
-        return visibility
+        )
 
     @staticmethod
     def _action_review_escalation_visibility(
@@ -2719,52 +2390,13 @@ class AegisOpsControlPlaneService:
         review_state: str,
         allow_unscoped_context: bool,
     ) -> dict[str, object] | None:
-        requested_payload = action_request.requested_payload
-        escalation_context = AegisOpsControlPlaneService._action_review_visibility_entry(
+        return _action_review_projection._action_review_escalation_visibility(
             reviewed_context=reviewed_context,
-            action_request_id=action_request.action_request_id,
-            context_key="escalation",
-        )
-        if not isinstance(escalation_context, Mapping):
-            return None
-
-        approval_decision_id = (
-            approval_decision.approval_decision_id
-            if approval_decision is not None
-            else action_request.approval_decision_id
-        )
-        if not AegisOpsControlPlaneService._action_review_context_matches_lineage(
-            visibility_context=escalation_context,
-            action_request_id=action_request.action_request_id,
-            approval_decision_id=approval_decision_id,
+            action_request=action_request,
+            approval_decision=approval_decision,
+            review_state=review_state,
             allow_unscoped_context=allow_unscoped_context,
-        ):
-            return None
-
-        recorded_review_state = escalation_context.get("review_state")
-        visibility: dict[str, object] = {
-            "action_request_id": action_request.action_request_id,
-            "approval_decision_id": approval_decision_id,
-            "requester_identity": action_request.requester_identity,
-            "review_state": (
-                recorded_review_state
-                if isinstance(recorded_review_state, str) and recorded_review_state.strip()
-                else review_state
-            ),
-        }
-        escalation_reason = requested_payload.get("escalation_reason")
-        if escalation_reason is not None:
-            visibility["escalation_reason"] = escalation_reason
-        for source_key, target_key in (
-            ("escalated_at", "escalated_at"),
-            ("escalated_to", "escalated_to"),
-            ("escalated_by_identity", "escalated_by_identity"),
-            ("note", "note"),
-        ):
-            value = escalation_context.get(source_key)
-            if value is not None:
-                visibility[target_key] = value
-        return visibility
+        )
 
     @staticmethod
     def _action_review_context_matches_lineage(
@@ -2774,25 +2406,12 @@ class AegisOpsControlPlaneService:
         approval_decision_id: str | None,
         allow_unscoped_context: bool,
     ) -> bool:
-        scoped_action_request_id = visibility_context.get("action_request_id")
-        scoped_approval_decision_id = visibility_context.get("approval_decision_id")
-
-        if scoped_action_request_id is None:
-            if scoped_approval_decision_id is not None:
-                return (
-                    approval_decision_id is not None
-                    and scoped_approval_decision_id == approval_decision_id
-                )
-            return allow_unscoped_context
-
-        if scoped_action_request_id != action_request_id:
-            return False
-        if scoped_approval_decision_id is not None:
-            return (
-                approval_decision_id is not None
-                and scoped_approval_decision_id == approval_decision_id
-            )
-        return True
+        return _action_review_projection._action_review_context_matches_lineage(
+            visibility_context=visibility_context,
+            action_request_id=action_request_id,
+            approval_decision_id=approval_decision_id,
+            allow_unscoped_context=allow_unscoped_context,
+        )
 
     @staticmethod
     def _action_review_visibility_entry(
@@ -2801,17 +2420,11 @@ class AegisOpsControlPlaneService:
         action_request_id: str,
         context_key: str,
     ) -> Mapping[str, object] | None:
-        action_review_visibility = reviewed_context.get("action_review_visibility")
-        if isinstance(action_review_visibility, Mapping):
-            scoped_visibility = action_review_visibility.get(action_request_id)
-            if isinstance(scoped_visibility, Mapping):
-                scoped_entry = scoped_visibility.get(context_key)
-                if isinstance(scoped_entry, Mapping):
-                    return scoped_entry
-        legacy_entry = reviewed_context.get(context_key)
-        if isinstance(legacy_entry, Mapping):
-            return legacy_entry
-        return None
+        return _action_review_projection._action_review_visibility_entry(
+            reviewed_context=reviewed_context,
+            action_request_id=action_request_id,
+            context_key=context_key,
+        )
 
     @staticmethod
     def _action_review_visibility_update(
@@ -2820,13 +2433,11 @@ class AegisOpsControlPlaneService:
         context_key: str,
         context_value: Mapping[str, object],
     ) -> dict[str, object]:
-        return {
-            "action_review_visibility": {
-                action_request_id: {
-                    context_key: dict(context_value),
-                }
-            }
-        }
+        return _action_review_projection._action_review_visibility_update(
+            action_request_id=action_request_id,
+            context_key=context_key,
+            context_value=context_value,
+        )
 
     def _case_has_single_review_bound_action_request(
         self,
@@ -2834,22 +2445,11 @@ class AegisOpsControlPlaneService:
         *,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> bool:
-        if case_id is None:
-            return False
-        if record_index is not None:
-            matching_requests = record_index.requests_by_case_id.get(case_id, ())
-        else:
-            matching_requests = tuple(
-                record
-                for record in self._store.list(ActionRequestRecord)
-                if record.case_id == case_id
-            )
-        review_bound_count = sum(
-            1
-            for record in matching_requests
-            if self._action_request_is_review_bound(record)
+        return _action_review_projection._case_has_single_review_bound_action_request(
+            self,
+            case_id,
+            record_index=record_index,
         )
-        return review_bound_count == 1
 
     def _action_review_approval_decision(
         self,
@@ -2857,40 +2457,11 @@ class AegisOpsControlPlaneService:
         *,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> ApprovalDecisionRecord | None:
-        if record_index is not None and action_request.approval_decision_id:
-            decision = record_index.approvals_by_id.get(action_request.approval_decision_id)
-            if decision is not None:
-                return decision
-        if action_request.approval_decision_id:
-            decision = self._store.get(
-                ApprovalDecisionRecord,
-                action_request.approval_decision_id,
-            )
-            if decision is not None:
-                return decision
-        if record_index is not None:
-            matches = list(
-                record_index.approvals_by_action_request_id.get(
-                    action_request.action_request_id,
-                    (),
-                )
-            )
-        else:
-            matches = [
-                record
-                for record in self._store.list(ApprovalDecisionRecord)
-                if record.action_request_id == action_request.action_request_id
-            ]
-        if not matches:
-            return None
-        matches.sort(
-            key=lambda record: (
-                record.decided_at or datetime.min.replace(tzinfo=timezone.utc),
-                record.approval_decision_id,
-            ),
-            reverse=True,
+        return _action_review_projection._action_review_approval_decision(
+            self,
+            action_request,
+            record_index=record_index,
         )
-        return matches[0]
 
     def _action_review_execution(
         self,
@@ -2898,29 +2469,11 @@ class AegisOpsControlPlaneService:
         *,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> ActionExecutionRecord | None:
-        if record_index is not None:
-            matches = list(
-                record_index.executions_by_action_request_id.get(
-                    action_request.action_request_id,
-                    (),
-                )
-            )
-        else:
-            matches = [
-                record
-                for record in self._store.list(ActionExecutionRecord)
-                if record.action_request_id == action_request.action_request_id
-            ]
-        if not matches:
-            return None
-        matches.sort(
-            key=lambda record: (
-                record.delegated_at,
-                record.action_execution_id,
-            ),
-            reverse=True,
+        return _action_review_projection._action_review_execution(
+            self,
+            action_request,
+            record_index=record_index,
         )
-        return matches[0]
 
     def _latest_action_review_reconciliation(
         self,
@@ -2930,91 +2483,13 @@ class AegisOpsControlPlaneService:
         action_execution: ActionExecutionRecord | None,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> ReconciliationRecord | None:
-        def _dedupe(
-            reconciliations: tuple[ReconciliationRecord, ...] | list[ReconciliationRecord],
-        ) -> list[ReconciliationRecord]:
-            by_id: dict[str, ReconciliationRecord] = {}
-            for reconciliation in reconciliations:
-                by_id[reconciliation.reconciliation_id] = reconciliation
-            return list(by_id.values())
-
-        def _matches_current_execution_lineage(
-            reconciliation: ReconciliationRecord,
-        ) -> bool:
-            if action_execution is None:
-                return False
-            subject_action_execution_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "action_execution_ids",
-            )
-            if action_execution.action_execution_id in subject_action_execution_ids:
-                return True
-            subject_delegation_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "delegation_ids",
-            )
-            return action_execution.delegation_id in subject_delegation_ids
-
-        def _matches_review_lineage(reconciliation: ReconciliationRecord) -> bool:
-            if _matches_current_execution_lineage(reconciliation):
-                return True
-            if approval_decision is not None:
-                subject_approval_decision_ids = self._assistant_ids_from_mapping(
-                    reconciliation.subject_linkage,
-                    "approval_decision_ids",
-                )
-                if approval_decision.approval_decision_id in subject_approval_decision_ids:
-                    return True
-            subject_action_request_ids = self._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "action_request_ids",
-            )
-            return action_request.action_request_id in subject_action_request_ids
-
-        matches: list[ReconciliationRecord] = []
-        if record_index is not None:
-            indexed_matches: list[ReconciliationRecord] = list(
-                record_index.reconciliations_by_action_request_id.get(
-                    action_request.action_request_id,
-                    (),
-                )
-            )
-            if approval_decision is not None:
-                indexed_matches += list(
-                    record_index.reconciliations_by_approval_decision_id.get(
-                        approval_decision.approval_decision_id,
-                        (),
-                    )
-                )
-            if action_execution is not None:
-                indexed_matches += list(
-                    record_index.reconciliations_by_action_execution_id.get(
-                        action_execution.action_execution_id,
-                        (),
-                    )
-                )
-                indexed_matches += list(
-                    record_index.reconciliations_by_delegation_id.get(
-                        action_execution.delegation_id,
-                        (),
-                    )
-                )
-            matches = _dedupe(indexed_matches)
-        else:
-            for reconciliation in self._store.list(ReconciliationRecord):
-                if _matches_review_lineage(reconciliation):
-                    matches.append(reconciliation)
-        if not matches:
-            return None
-        matches.sort(
-            key=lambda record: (
-                1 if _matches_current_execution_lineage(record) else 0,
-                record.compared_at or record.last_seen_at or record.first_seen_at,
-                record.reconciliation_id,
-            ),
-            reverse=True,
+        return _action_review_projection._latest_action_review_reconciliation(
+            self,
+            action_request=action_request,
+            approval_decision=approval_decision,
+            action_execution=action_execution,
+            record_index=record_index,
         )
-        return matches[0]
 
     @staticmethod
     def _action_review_approval_state(
@@ -3022,13 +2497,10 @@ class AegisOpsControlPlaneService:
         action_request: ActionRequestRecord,
         approval_decision: ApprovalDecisionRecord | None,
     ) -> str | None:
-        if approval_decision is not None:
-            return approval_decision.lifecycle_state
-        if action_request.lifecycle_state == "pending_approval":
-            return "pending"
-        if action_request.lifecycle_state in {"rejected", "expired", "superseded", "canceled"}:
-            return action_request.lifecycle_state
-        return None
+        return _action_review_projection._action_review_approval_state(
+            action_request=action_request,
+            approval_decision=approval_decision,
+        )
 
     @staticmethod
     def _action_review_state(
@@ -3037,38 +2509,11 @@ class AegisOpsControlPlaneService:
         approval_state: str | None,
         action_execution: ActionExecutionRecord | None,
     ) -> str:
-        lifecycle_state = action_request.lifecycle_state
-        execution_state = (
-            action_execution.lifecycle_state if action_execution is not None else None
+        return _action_review_projection._action_review_state(
+            action_request=action_request,
+            approval_state=approval_state,
+            action_execution=action_execution,
         )
-        terminal_execution_review_states = {
-            "succeeded": "completed",
-            "failed": "failed",
-            "canceled": "canceled",
-            "superseded": "superseded",
-            "unresolved": "unresolved",
-            "expired": "expired",
-            "rejected": "rejected",
-        }
-        if lifecycle_state in {"expired", "rejected", "superseded", "canceled"}:
-            return lifecycle_state
-        if lifecycle_state in {"completed", "failed", "unresolved"}:
-            return lifecycle_state
-        if execution_state in terminal_execution_review_states:
-            return terminal_execution_review_states[execution_state]
-        if execution_state is not None:
-            return "executing"
-        if lifecycle_state == "executing":
-            return "executing"
-        if approval_state in {"expired", "rejected", "superseded", "canceled"}:
-            return approval_state
-        if approval_state == "approved":
-            return "approved"
-        if lifecycle_state == "approved":
-            return "approved"
-        if lifecycle_state == "pending_approval" or approval_state == "pending":
-            return "pending"
-        return lifecycle_state
 
     def _replacement_action_request(
         self,
@@ -3076,85 +2521,21 @@ class AegisOpsControlPlaneService:
         *,
         record_index: _ActionReviewRecordIndex | None = None,
     ) -> ActionRequestRecord | None:
-        if action_request.lifecycle_state != "superseded":
-            return None
-        requested_payload = dict(action_request.requested_payload)
-        recommendation_id = requested_payload.get("recommendation_id")
-        action_type = requested_payload.get("action_type")
-        if record_index is not None:
-            candidate_requests = record_index.matching_requests(
-                case_id=action_request.case_id,
-                alert_id=action_request.alert_id,
-            )
-            matches = [
-                record
-                for record in candidate_requests
-                if record.action_request_id != action_request.action_request_id
-                and self._action_request_is_review_bound(record)
-                and record.requested_at >= action_request.requested_at
-                and record.lifecycle_state != "superseded"
-                and dict(record.requested_payload).get("action_type") == action_type
-                and (
-                    recommendation_id is None
-                    or dict(record.requested_payload).get("recommendation_id")
-                    == recommendation_id
-                )
-            ]
-        else:
-            matches = [
-                record
-                for record in self._store.list(ActionRequestRecord)
-                if record.action_request_id != action_request.action_request_id
-                and self._action_request_is_review_bound(record)
-                and (
-                    (
-                        action_request.case_id is not None
-                        and record.case_id == action_request.case_id
-                    )
-                    or (
-                        action_request.alert_id is not None
-                        and record.alert_id == action_request.alert_id
-                    )
-                )
-                and record.requested_at >= action_request.requested_at
-                and record.lifecycle_state != "superseded"
-                and dict(record.requested_payload).get("action_type") == action_type
-                and (
-                    recommendation_id is None
-                    or dict(record.requested_payload).get("recommendation_id")
-                    == recommendation_id
-                )
-            ]
-        if not matches:
-            return None
-        matches.sort(
-            key=lambda record: (record.requested_at, record.action_request_id),
-            reverse=True,
+        return _action_review_projection._replacement_action_request(
+            self,
+            action_request,
+            record_index=record_index,
         )
-        return matches[0]
 
     @staticmethod
     def _action_request_is_review_bound(action_request: ActionRequestRecord) -> bool:
-        return not (
-            action_request.policy_evaluation.get("approval_requirement")
-            == "policy_authorized"
-            and action_request.approval_decision_id is None
-        )
+        return _action_review_projection._action_request_is_review_bound(action_request)
 
     @staticmethod
     def _next_expected_action_for_review_state(review_state: str) -> str | None:
-        return {
-            "pending": "await_approver_decision",
-            "approved": "await_reviewed_delegation",
-            "executing": "await_execution_reconciliation",
-            "expired": "create_replacement_or_close_case",
-            "rejected": "review_rejection_and_record_follow_up",
-            "canceled": "investigate_execution_cancellation",
-            "superseded": "inspect_replacing_review_record",
-            "completed": "review_execution_outcome",
-            "failed": "investigate_execution_failure",
-            "unresolved": "investigate_reconciliation_gap",
-        }.get(review_state)
+        return _action_review_projection._next_expected_action_for_review_state(
+            review_state
+        )
 
     @staticmethod
     def _action_review_stage_snapshot(
@@ -3167,17 +2548,15 @@ class AegisOpsControlPlaneService:
         actor_identities: tuple[str, ...] = (),
         details: Mapping[str, object] | None = None,
     ) -> dict[str, object]:
-        snapshot = {
-            "stage": stage,
-            "record_family": record_family,
-            "record_id": record_id,
-            "state": state,
-            "occurred_at": occurred_at,
-            "actor_identities": actor_identities,
-        }
-        if details:
-            snapshot["details"] = dict(details)
-        return snapshot
+        return _action_review_projection._action_review_stage_snapshot(
+            stage=stage,
+            record_family=record_family,
+            record_id=record_id,
+            state=state,
+            occurred_at=occurred_at,
+            actor_identities=actor_identities,
+            details=details,
+        )
 
     def _action_review_timeline(
         self,

--- a/control-plane/tests/test_cli_inspection_action_reviews.py
+++ b/control-plane/tests/test_cli_inspection_action_reviews.py
@@ -12,6 +12,15 @@ from _cli_inspection_support import *  # noqa: F403
 from _cli_inspection_support import _approved_payload_binding_hash, _load_wazuh_fixture
 
 
+def _expected_action_review_path_health_paths(
+    paths: dict[str, dict[str, str]],
+) -> dict[str, dict[str, str]]:
+    return {
+        path_name: {**path, "health": path["state"]}
+        for path_name, path in paths.items()
+    }
+
+
 class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
     def test_cli_renders_recommendation_draft_view_for_a_case(self) -> None:
         _, service, promoted_case, evidence_id, _ = self._build_phase19_in_scope_case()
@@ -214,24 +223,26 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
         action_reviews_by_id = {
             record["action_request_id"]: record for record in payload["action_reviews"]
         }
-        expected_paths = {
-            "ingest": {
-                "state": "healthy",
-                "reason": "review_closed_before_ingest",
-            },
-            "delegation": {
-                "state": "healthy",
-                "reason": "review_closed_without_delegation",
-            },
-            "provider": {
-                "state": "healthy",
-                "reason": "review_closed_before_provider",
-            },
-            "persistence": {
-                "state": "healthy",
-                "reason": "review_closed_before_reconciliation",
-            },
-        }
+        expected_paths = _expected_action_review_path_health_paths(
+            {
+                "ingest": {
+                    "state": "healthy",
+                    "reason": "review_closed_before_ingest",
+                },
+                "delegation": {
+                    "state": "healthy",
+                    "reason": "review_closed_without_delegation",
+                },
+                "provider": {
+                    "state": "healthy",
+                    "reason": "review_closed_before_provider",
+                },
+                "persistence": {
+                    "state": "healthy",
+                    "reason": "review_closed_before_reconciliation",
+                },
+            }
+        )
 
         for action_request in (
             seeded["rejected_request"],
@@ -782,24 +793,26 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
         self.assertEqual(review["path_health"]["overall_state"], "delayed")
         self.assertEqual(
             review["path_health"]["paths"],
-            {
-                "ingest": {
-                    "state": "delayed",
-                    "reason": "awaiting_ingest_signal",
-                },
-                "delegation": {
-                    "state": "delayed",
-                    "reason": "awaiting_approval",
-                },
-                "provider": {
-                    "state": "delayed",
-                    "reason": "awaiting_delegation",
-                },
-                "persistence": {
-                    "state": "delayed",
-                    "reason": "awaiting_reconciliation",
-                },
-            },
+            _expected_action_review_path_health_paths(
+                {
+                    "ingest": {
+                        "state": "delayed",
+                        "reason": "awaiting_ingest_signal",
+                    },
+                    "delegation": {
+                        "state": "delayed",
+                        "reason": "awaiting_approval",
+                    },
+                    "provider": {
+                        "state": "delayed",
+                        "reason": "awaiting_delegation",
+                    },
+                    "persistence": {
+                        "state": "delayed",
+                        "reason": "awaiting_reconciliation",
+                    },
+                }
+            ),
         )
 
     def test_cli_inspect_case_detail_classifies_stale_delegation_receipt_timeout(
@@ -884,24 +897,26 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
         self.assertEqual(review["path_health"]["overall_state"], "degraded")
         self.assertEqual(
             review["path_health"]["paths"],
-            {
-                "ingest": {
-                    "state": "degraded",
-                    "reason": "ingest_signal_timeout",
-                },
-                "delegation": {
-                    "state": "degraded",
-                    "reason": "delegation_receipt_timeout",
-                },
-                "provider": {
-                    "state": "degraded",
-                    "reason": "provider_receipt_timeout",
-                },
-                "persistence": {
-                    "state": "degraded",
-                    "reason": "reconciliation_timeout",
-                },
-            },
+            _expected_action_review_path_health_paths(
+                {
+                    "ingest": {
+                        "state": "degraded",
+                        "reason": "ingest_signal_timeout",
+                    },
+                    "delegation": {
+                        "state": "degraded",
+                        "reason": "delegation_receipt_timeout",
+                    },
+                    "provider": {
+                        "state": "degraded",
+                        "reason": "provider_receipt_timeout",
+                    },
+                    "persistence": {
+                        "state": "degraded",
+                        "reason": "reconciliation_timeout",
+                    },
+                }
+            ),
         )
 
     def test_cli_inspect_case_detail_surfaces_create_tracking_ticket_outcome(
@@ -1737,24 +1752,26 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
         self.assertEqual(review["path_health"]["overall_state"], "degraded")
         self.assertEqual(
             review["path_health"]["paths"],
-            {
-                "ingest": {
-                    "state": "degraded",
-                    "reason": "ingest_signal_missing_after_approval",
-                },
-                "delegation": {
-                    "state": "degraded",
-                    "reason": "reviewed_delegation_missing_after_approval",
-                },
-                "provider": {
-                    "state": "degraded",
-                    "reason": "provider_signal_missing_after_approval",
-                },
-                "persistence": {
-                    "state": "degraded",
-                    "reason": "reconciliation_missing_after_approval",
-                },
-            },
+            _expected_action_review_path_health_paths(
+                {
+                    "ingest": {
+                        "state": "degraded",
+                        "reason": "ingest_signal_missing_after_approval",
+                    },
+                    "delegation": {
+                        "state": "degraded",
+                        "reason": "reviewed_delegation_missing_after_approval",
+                    },
+                    "provider": {
+                        "state": "degraded",
+                        "reason": "provider_signal_missing_after_approval",
+                    },
+                    "persistence": {
+                        "state": "degraded",
+                        "reason": "reconciliation_missing_after_approval",
+                    },
+                }
+            ),
         )
 
     def test_cli_inspect_case_detail_keeps_reconciliation_bound_to_selected_execution(
@@ -1896,24 +1913,26 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
         self.assertTrue(review["path_health"]["summary"])
         self.assertEqual(
             review["path_health"]["paths"],
-            {
-                "ingest": {
-                    "state": "degraded",
-                    "reason": "mismatch_detected",
-                },
-                "delegation": {
-                    "state": "healthy",
-                    "reason": "delegated",
-                },
-                "provider": {
-                    "state": "delayed",
-                    "reason": "awaiting_authoritative_outcome",
-                },
-                "persistence": {
-                    "state": "degraded",
-                    "reason": "reconciliation_mismatched",
-                },
-            },
+            _expected_action_review_path_health_paths(
+                {
+                    "ingest": {
+                        "state": "degraded",
+                        "reason": "mismatch_detected",
+                    },
+                    "delegation": {
+                        "state": "healthy",
+                        "reason": "delegated",
+                    },
+                    "provider": {
+                        "state": "delayed",
+                        "reason": "awaiting_authoritative_outcome",
+                    },
+                    "persistence": {
+                        "state": "degraded",
+                        "reason": "reconciliation_mismatched",
+                    },
+                }
+            ),
         )
 
     def test_cli_inspect_analyst_queue_renders_review_timeline_and_mismatch_details(

--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,7 +66,7 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.8.2")
+        self.assertEqual(metadata["phase"], "50.8.3")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
         self.assertEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -55,8 +55,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.8.2")
-        self.assertEqual(metadata["issue"], "#963")
+        self.assertEqual(metadata["phase"], "50.8.3")
+        self.assertEqual(metadata["issue"], "#964")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
         self.assertEqual(
@@ -72,15 +72,15 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         closeout = self._read("docs/phase-50-maintainability-closeout.md")
 
         for required in (
-            "Phase 50.8.2",
+            "Phase 50.8.3",
             "control-plane/aegisops_control_plane/service.py",
             "AegisOpsControlPlaneService",
-            "max_lines=4708",
-            "max_effective_lines=4343",
+            "max_lines=4087",
+            "max_effective_lines=3733",
             "max_facade_methods=188",
             "ADR-0004",
             "ADR-0003",
-            "#963",
+            "#964",
             "remaining accepted hotspot",
             "silent re-growth",
             "another decomposition decision",

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -237,6 +237,66 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         ):
             self.assertIn(term, boundary_tests)
 
+    def test_phase50_8_action_review_helpers_live_with_projection_boundary(
+        self,
+    ) -> None:
+        service_source = self._read("control-plane/aegisops_control_plane/service.py")
+        projection_source = self._read(
+            "control-plane/aegisops_control_plane/action_review_projection.py"
+        )
+        service_tree = ast.parse(service_source)
+        projection_tree = ast.parse(projection_source)
+        service_class = next(
+            node
+            for node in service_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        service_methods = {
+            node.name: node
+            for node in service_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+        projection_functions = {
+            node.name for node in projection_tree.body if isinstance(node, ast.FunctionDef)
+        }
+        moved_helper_names = {
+            "_action_review_after_hours_handoff_visibility",
+            "_action_review_approval_decision",
+            "_action_review_approval_state",
+            "_action_review_context_matches_lineage",
+            "_action_review_execution",
+            "_action_review_escalation_visibility",
+            "_action_review_ingest_path_health",
+            "_action_review_manual_fallback_visibility",
+            "_action_review_overall_path_state",
+            "_action_review_path_health_summary",
+            "_action_review_persistence_path_health",
+            "_action_review_provider_path_health",
+            "_action_review_state",
+            "_action_review_visibility_context",
+            "_latest_action_review_reconciliation",
+            "_replacement_action_request",
+        }
+        self.assertTrue(moved_helper_names.issubset(projection_functions))
+
+        for helper_name in moved_helper_names:
+            service_method = service_methods[helper_name]
+            calls = [
+                node
+                for node in ast.walk(service_method)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == helper_name
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "_action_review_projection"
+            ]
+            self.assertEqual(
+                len(calls),
+                1,
+                f"{helper_name} should remain only as a facade compatibility delegate",
+            )
+
     def test_phase50_constructor_delegates_collaborator_composition(self) -> None:
         service_source = self._read("control-plane/aegisops_control_plane/service.py")
         tree = ast.parse(service_source)

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -261,6 +261,7 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             node.name for node in projection_tree.body if isinstance(node, ast.FunctionDef)
         }
         moved_helper_names = {
+            "_action_request_is_review_bound",
             "_action_review_after_hours_handoff_visibility",
             "_action_review_approval_decision",
             "_action_review_approval_state",
@@ -274,8 +275,12 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             "_action_review_persistence_path_health",
             "_action_review_provider_path_health",
             "_action_review_state",
+            "_action_review_stage_snapshot",
+            "_action_review_visibility_entry",
             "_action_review_visibility_context",
+            "_action_review_visibility_update",
             "_latest_action_review_reconciliation",
+            "_next_expected_action_for_review_state",
             "_replacement_action_request",
         }
         self.assertTrue(moved_helper_names.issubset(projection_functions))

--- a/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py
@@ -30,6 +30,140 @@ from _service_persistence_support import (
 )
 
 class ActionReviewSurfacePersistenceTests(ServicePersistenceTestBase):
+    def test_action_review_path_health_preserves_overdue_reconciliation_without_execution(
+        self,
+    ) -> None:
+        requested_at = datetime(2026, 4, 27, 9, 0, tzinfo=timezone.utc)
+        expires_at = requested_at + timedelta(minutes=30)
+        action_request = ActionRequestRecord(
+            action_request_id="action-request-path-health-reconciliation-no-execution-001",
+            approval_decision_id="approval-path-health-reconciliation-no-execution-001",
+            case_id="case-path-health-reconciliation-no-execution-001",
+            alert_id="alert-path-health-reconciliation-no-execution-001",
+            finding_id="finding-path-health-reconciliation-no-execution-001",
+            idempotency_key="idempotency-path-health-reconciliation-no-execution-001",
+            target_scope={
+                "record_family": "recommendation",
+                "record_id": "recommendation-path-health-reconciliation-no-execution-001",
+                "case_id": "case-path-health-reconciliation-no-execution-001",
+                "alert_id": "alert-path-health-reconciliation-no-execution-001",
+                "finding_id": "finding-path-health-reconciliation-no-execution-001",
+                "recipient_identity": "repo-owner-001",
+            },
+            payload_hash="payload-hash-path-health-reconciliation-no-execution-001",
+            requested_at=requested_at,
+            expires_at=expires_at,
+            lifecycle_state="approved",
+            requester_identity="analyst-001",
+            requested_payload={
+                "action_type": "notify_identity_owner",
+                "recipient_identity": "repo-owner-001",
+            },
+        )
+        approval = ApprovalDecisionRecord(
+            approval_decision_id="approval-path-health-reconciliation-no-execution-001",
+            action_request_id=action_request.action_request_id,
+            approver_identities=("approver-001",),
+            target_snapshot=dict(action_request.target_scope),
+            payload_hash=action_request.payload_hash,
+            decided_at=requested_at + timedelta(minutes=5),
+            lifecycle_state="approved",
+            approved_expires_at=expires_at,
+        )
+        reconciliation = support.ReconciliationRecord(
+            reconciliation_id="reconciliation-path-health-no-execution-001",
+            subject_linkage={
+                "action_request_ids": (action_request.action_request_id,),
+                "approval_decision_ids": (approval.approval_decision_id,),
+            },
+            alert_id=action_request.alert_id,
+            finding_id=action_request.finding_id,
+            analytic_signal_id=None,
+            execution_run_id=None,
+            linked_execution_run_ids=(),
+            correlation_key=f"reconciliation-no-execution:{action_request.action_request_id}",
+            first_seen_at=requested_at + timedelta(minutes=10),
+            last_seen_at=requested_at + timedelta(minutes=10),
+            ingest_disposition="matched",
+            mismatch_summary="reconciliation observed without persisted execution",
+            compared_at=requested_at + timedelta(minutes=11),
+            lifecycle_state="matched",
+        )
+
+        path_health = action_review_projection.action_review_path_health(
+            service=None,
+            action_request=action_request,
+            approval_decision=approval,
+            action_execution=None,
+            reconciliation=reconciliation,
+            review_state="approved",
+            as_of=expires_at + timedelta(minutes=5),
+        )
+
+        self.assertEqual(path_health["overall_state"], "degraded")
+        self.assertEqual(
+            path_health["paths"]["ingest"]["reason"],
+            "observations_current",
+        )
+        self.assertEqual(
+            path_health["paths"]["delegation"]["reason"],
+            "reviewed_delegation_record_missing",
+        )
+        self.assertEqual(
+            path_health["paths"]["provider"]["reason"],
+            "provider_execution_record_missing",
+        )
+        self.assertEqual(
+            path_health["paths"]["persistence"]["reason"],
+            "reconciliation_execution_lineage_missing",
+        )
+
+    def test_action_review_path_health_treats_executing_without_execution_as_reviewed(
+        self,
+    ) -> None:
+        requested_at = datetime(2026, 4, 27, 9, 0, tzinfo=timezone.utc)
+        action_request = ActionRequestRecord(
+            action_request_id="action-request-path-health-executing-no-execution-001",
+            approval_decision_id=None,
+            case_id="case-path-health-executing-no-execution-001",
+            alert_id="alert-path-health-executing-no-execution-001",
+            finding_id="finding-path-health-executing-no-execution-001",
+            idempotency_key="idempotency-path-health-executing-no-execution-001",
+            target_scope={
+                "record_family": "recommendation",
+                "record_id": "recommendation-path-health-executing-no-execution-001",
+                "case_id": "case-path-health-executing-no-execution-001",
+                "alert_id": "alert-path-health-executing-no-execution-001",
+                "finding_id": "finding-path-health-executing-no-execution-001",
+                "recipient_identity": "repo-owner-001",
+            },
+            payload_hash="payload-hash-path-health-executing-no-execution-001",
+            requested_at=requested_at,
+            expires_at=requested_at + timedelta(hours=1),
+            lifecycle_state="executing",
+            requester_identity="analyst-001",
+            requested_payload={
+                "action_type": "notify_identity_owner",
+                "recipient_identity": "repo-owner-001",
+            },
+        )
+
+        path_health = action_review_projection.action_review_path_health(
+            service=None,
+            action_request=action_request,
+            approval_decision=None,
+            action_execution=None,
+            reconciliation=None,
+            review_state="executing",
+            as_of=requested_at + timedelta(minutes=10),
+        )
+
+        self.assertEqual(path_health["overall_state"], "delayed")
+        self.assertEqual(
+            path_health["paths"]["delegation"]["reason"],
+            "awaiting_reviewed_delegation",
+        )
+
     def test_action_review_reconciliation_detail_names_expected_received_and_closeout_guidance(
         self,
     ) -> None:

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,12 +1,12 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.8.2 lowered residual exception:
+# Phase 50.8.3 lowered residual exception:
 # ADR-0004 accepted ordered hotspot reduction after the ADR-0003
 # facade-preservation exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the readiness operability extraction, so this baseline records the lowered
-# Phase 50.8.2 ceiling and fails on silent re-growth. A future ADR or
+# the action-review helper extraction, so this baseline records the lowered
+# Phase 50.8.3 ceiling and fails on silent re-growth. A future ADR or
 # maintainability backlog must lower or replace these limits before unrelated
 # feature expansion lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=4708 max_effective_lines=4343 max_facade_methods=188 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.2 issue=#963
+control-plane/aegisops_control_plane/service.py max_lines=4087 max_effective_lines=3733 max_facade_methods=188 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.3 issue=#964

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,6 +1,6 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.8.2 closes the ordered maintainability hotspot reduction sequence governed by ADR-0004.
+Phase 50.8.3 continues the ordered maintainability hotspot reduction sequence governed by ADR-0004.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
@@ -12,14 +12,14 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50 extraction and fencing work. Phase 50.8.2 lowered the accepted residual ceiling for #963 to:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50 extraction and fencing work. Phase 50.8.3 lowered the accepted residual ceiling for #964 to:
 
-- `max_lines=4708`
-- `max_effective_lines=4343`
+- `max_lines=4087`
+- `max_effective_lines=3733`
 - `max_facade_methods=188`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.8.2`
+- `phase=50.8.3`
 
 No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, or operator UI route tests because the verifier does not report those areas as current responsibility-growth candidates.
 


### PR DESCRIPTION
## Summary
- move action-review visibility, state, latest reconciliation, replacement, and path-health helper ownership into `action_review_projection.py`
- keep `AegisOpsControlPlaneService` helper methods as compatibility delegates for existing collaborators
- add an AST regression proving the extracted helper set lives behind the projection boundary

## Verification
- `PYTHONPATH=control-plane python3 control-plane/tests/test_service_boundary_refactor_regression_validation.py -k phase50_8`
- `PYTHONPATH=control-plane:control-plane/tests python3 -m unittest control-plane.tests.test_action_review_write_boundary`
- `PYTHONPATH=control-plane:control-plane/tests python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_review_surfaces`
- `PYTHONPATH=control-plane:control-plane/tests python3 -m unittest control-plane.tests.test_cli_inspection_action_reviews`
- `PYTHONPATH=control-plane python3 control-plane/tests/test_service_boundary_refactor_regression_validation.py`
- `PYTHONPATH=control-plane:control-plane/tests python3 -m unittest control-plane.tests.test_service_persistence_restore_readiness`
- `PYTHONPATH=control-plane python3 -m py_compile control-plane/aegisops_control_plane/service.py control-plane/aegisops_control_plane/action_review_projection.py control-plane/tests/test_service_boundary_refactor_regression_validation.py`
- `git diff --check`
- `bash scripts/verify-maintainability-hotspots.sh`
- `node dist/index.js issue-lint 964 --config supervisor.config.aegisops.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved action-review computation into a dedicated projection to simplify service logic, centralize stage/timeline snapshotting, and standardize per-path health, severity, and overdue handling.
  * Advanced maintainability closeout baselines to the next phase with tighter thresholds.

* **Tests**
  * Added regression and unit tests enforcing the new helper boundary and validating updated path-health, visibility, and reconciliation behaviors.
  * Updated existing tests/helpers to match the new health-structure outputs.

* **Documentation**
  * Updated maintainability hotspot docs and baseline metadata to reflect the refactor and new phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->