### PR TITLE
Phase 50.8.4 detection lifecycle helper extraction

### DIFF
--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -4,6 +4,11 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Callable, Mapping
 
+from .detection_lifecycle_helpers import (
+    DetectionLifecycleTransitionHelper,
+    DetectionReconciliationResolver,
+    LiveWazuhIntakeHandler,
+)
 from .detection_native_context import NativeDetectionContextAttacher
 from .models import (
     AnalyticSignalAdmission,
@@ -70,6 +75,26 @@ class DetectionIntakeService:
             service,
             merge_reviewed_context=merge_reviewed_context,
             normalize_admission_provenance=normalize_admission_provenance,
+        )
+        self.lifecycle_transition_helper = DetectionLifecycleTransitionHelper(service)
+        self.reconciliation_resolver = DetectionReconciliationResolver(service)
+        self.wazuh_intake_handler = LiveWazuhIntakeHandler(service, self)
+
+    def ingest_wazuh_alert(
+        self,
+        *,
+        raw_alert: Mapping[str, object],
+        authorization_header: str | None,
+        forwarded_proto: str | None,
+        reverse_proxy_secret_header: str | None,
+        peer_addr: str | None,
+    ) -> FindingAlertIngestResult:
+        return self.wazuh_intake_handler.ingest_wazuh_alert(
+            raw_alert=raw_alert,
+            authorization_header=authorization_header,
+            forwarded_proto=forwarded_proto,
+            reverse_proxy_secret_header=reverse_proxy_secret_header,
+            peer_addr=peer_addr,
         )
 
     def ingest_finding_alert(
@@ -321,7 +346,7 @@ class DetectionIntakeService:
             )
             inputs = _AnalyticSignalAdmissionInputs(
                 finding_id=inputs.finding_id,
-                analytic_signal_id=service._resolve_analytic_signal_id(
+                analytic_signal_id=self.resolve_analytic_signal_id(
                     analytic_signal_id=inputs.analytic_signal_id,
                     finding_id=inputs.finding_id,
                     correlation_key=inputs.correlation_key,
@@ -690,6 +715,23 @@ class DetectionIntakeService:
             record=record,
             ingest_result=ingest_result,
             substrate_detection_record_id=substrate_detection_record_id,
+        )
+
+    def resolve_analytic_signal_id(
+        self,
+        *,
+        analytic_signal_id: str | None,
+        finding_id: str,
+        correlation_key: str,
+        substrate_detection_record_id: str | None,
+        latest_reconciliation: ReconciliationRecord | None,
+    ) -> str:
+        return self.reconciliation_resolver.resolve_analytic_signal_id(
+            analytic_signal_id=analytic_signal_id,
+            finding_id=finding_id,
+            correlation_key=correlation_key,
+            substrate_detection_record_id=substrate_detection_record_id,
+            latest_reconciliation=latest_reconciliation,
         )
 
     def reviewed_context_transitioned_at(

--- a/control-plane/aegisops_control_plane/detection_lifecycle_helpers.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle_helpers.py
@@ -115,10 +115,7 @@ class DetectionLifecycleTransitionHelper:
                     f"{record.record_family} record {record.record_id!r} has orphaned "
                     "lifecycle transition history without a current-state record"
                 )
-            if (
-                existing_record is not None
-                and existing_lifecycle_state != latest_transition.lifecycle_state
-            ):
+            if existing_lifecycle_state != latest_transition.lifecycle_state:
                 raise ValueError(
                     f"{record.record_family} record {record.record_id!r} lifecycle_state "
                     f"{existing_lifecycle_state!r} does not match latest lifecycle "

--- a/control-plane/aegisops_control_plane/detection_lifecycle_helpers.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle_helpers.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import hmac
+import logging
+from typing import TYPE_CHECKING, Mapping
+import uuid
+
+from .adapters.wazuh import WazuhAlertAdapter
+from .models import (
+    AITraceRecord,
+    ActionExecutionRecord,
+    ActionRequestRecord,
+    AnalyticSignalRecord,
+    AlertRecord,
+    ApprovalDecisionRecord,
+    CaseRecord,
+    ControlPlaneRecord,
+    EvidenceRecord,
+    FindingAlertIngestResult,
+    HuntRecord,
+    HuntRunRecord,
+    LeadRecord,
+    LifecycleTransitionRecord,
+    ObservationRecord,
+    ReconciliationRecord,
+    RecommendationRecord,
+)
+from .reviewed_slice_policy import REVIEWED_LIVE_SOURCE_FAMILIES
+
+if TYPE_CHECKING:
+    from .detection_lifecycle import DetectionIntakeService
+    from .service import AegisOpsControlPlaneService
+
+
+LATEST_LIFECYCLE_TRANSITION_UNSET = object()
+_LINKED_ALERT_CASE_LIFECYCLE_LOCK_FAMILY = "linked_alert_case_lifecycle"
+_SAME_TIMESTAMP_LIFECYCLE_TRANSITION_ID_PREFIX = "~"
+
+
+class DetectionLifecycleTransitionHelper:
+    def __init__(self, service: AegisOpsControlPlaneService) -> None:
+        self._service = service
+
+    def lock_lifecycle_transition_subject(
+        self,
+        record_family: str,
+        record_id: str,
+    ) -> None:
+        lock_subject = getattr(
+            self._service._store,
+            "lock_lifecycle_transition_subject",
+            None,
+        )
+        if callable(lock_subject):
+            lock_subject(record_family, record_id)
+
+    @staticmethod
+    def linked_alert_case_lifecycle_lock_subject(
+        record: ControlPlaneRecord,
+    ) -> tuple[str, str] | None:
+        if isinstance(record, AlertRecord):
+            alert_id = record.alert_id
+            case_id = record.case_id
+        elif isinstance(record, CaseRecord):
+            alert_id = record.alert_id
+            case_id = record.case_id
+        else:
+            return None
+
+        if not isinstance(alert_id, str) or not alert_id.strip():
+            return None
+        if not isinstance(case_id, str) or not case_id.strip():
+            return None
+
+        return (
+            _LINKED_ALERT_CASE_LIFECYCLE_LOCK_FAMILY,
+            f"alert:{alert_id}|case:{case_id}",
+        )
+
+    def build_lifecycle_transition_record(
+        self,
+        record: ControlPlaneRecord,
+        *,
+        existing_record: ControlPlaneRecord | None,
+        transitioned_at: datetime | None = None,
+        initial_transitioned_at_fallback: datetime | None = None,
+        must_precede_transitioned_at: datetime | None = None,
+        latest_transition: LifecycleTransitionRecord | None | object = (
+            LATEST_LIFECYCLE_TRANSITION_UNSET
+        ),
+    ) -> LifecycleTransitionRecord | None:
+        if isinstance(record, LifecycleTransitionRecord):
+            return None
+        if not hasattr(record, "lifecycle_state"):
+            return None
+
+        existing_lifecycle_state = (
+            getattr(existing_record, "lifecycle_state", None)
+            if existing_record is not None
+            else None
+        )
+        next_lifecycle_state = getattr(record, "lifecycle_state", None)
+        if not isinstance(next_lifecycle_state, str) or not next_lifecycle_state.strip():
+            return None
+        if latest_transition is LATEST_LIFECYCLE_TRANSITION_UNSET:
+            latest_transition = self.latest_lifecycle_transition(
+                record.record_family,
+                record.record_id,
+            )
+        previous_lifecycle_state = existing_lifecycle_state
+        if latest_transition is not None:
+            if existing_record is None:
+                raise ValueError(
+                    f"{record.record_family} record {record.record_id!r} has orphaned "
+                    "lifecycle transition history without a current-state record"
+                )
+            if (
+                existing_record is not None
+                and existing_lifecycle_state != latest_transition.lifecycle_state
+            ):
+                raise ValueError(
+                    f"{record.record_family} record {record.record_id!r} lifecycle_state "
+                    f"{existing_lifecycle_state!r} does not match latest lifecycle "
+                    f"transition {latest_transition.transition_id!r} state "
+                    f"{latest_transition.lifecycle_state!r}"
+                )
+            previous_lifecycle_state = latest_transition.lifecycle_state
+        if previous_lifecycle_state == next_lifecycle_state:
+            return None
+
+        explicit_transitioned_at = transitioned_at is not None
+        resolved_transitioned_at = (
+            transitioned_at
+            if transitioned_at is not None
+            else (
+                self.initial_lifecycle_transitioned_at(
+                    record,
+                    fallback=initial_transitioned_at_fallback,
+                )
+                if existing_record is None
+                else datetime.now(timezone.utc)
+            )
+        )
+        if (
+            must_precede_transitioned_at is not None
+            and resolved_transitioned_at >= must_precede_transitioned_at
+        ):
+            resolved_transitioned_at = must_precede_transitioned_at - timedelta(
+                microseconds=1
+            )
+        if (
+            latest_transition is not None
+            and resolved_transitioned_at < latest_transition.transitioned_at
+        ):
+            if explicit_transitioned_at:
+                raise ValueError(
+                    "transitioned_at must not precede the latest lifecycle transition "
+                    f"for {record.record_family} record {record.record_id!r}"
+                )
+            resolved_transitioned_at = latest_transition.transitioned_at + timedelta(
+                microseconds=1
+            )
+        transition_timestamp = resolved_transitioned_at.astimezone(
+            timezone.utc
+        ).strftime("%Y%m%dT%H%M%S.%fZ")
+        return LifecycleTransitionRecord(
+            transition_id=self.lifecycle_transition_id(
+                transition_timestamp=transition_timestamp,
+                transitioned_at=resolved_transitioned_at,
+                latest_transition=latest_transition,
+            ),
+            subject_record_family=record.record_family,
+            subject_record_id=record.record_id,
+            previous_lifecycle_state=(
+                previous_lifecycle_state
+                if isinstance(previous_lifecycle_state, str)
+                and previous_lifecycle_state.strip()
+                else None
+            ),
+            lifecycle_state=next_lifecycle_state,
+            transitioned_at=resolved_transitioned_at,
+            attribution=self.lifecycle_transition_attribution(record),
+        )
+
+    def lifecycle_transition_id(
+        self,
+        *,
+        transition_timestamp: str,
+        transitioned_at: datetime,
+        latest_transition: LifecycleTransitionRecord | None,
+    ) -> str:
+        if (
+            latest_transition is None
+            or transitioned_at != latest_transition.transitioned_at
+        ):
+            return f"{transition_timestamp}:{uuid.uuid4()}"
+
+        sequence = 1
+        prefix = (
+            f"{_SAME_TIMESTAMP_LIFECYCLE_TRANSITION_ID_PREFIX}{transition_timestamp}:"
+        )
+        if latest_transition.transition_id.startswith(prefix):
+            sequence_text = latest_transition.transition_id[len(prefix) :].split(":", 1)[
+                0
+            ]
+            if sequence_text.isdigit():
+                sequence = int(sequence_text) + 1
+        return f"{prefix}{sequence:06d}:{uuid.uuid4()}"
+
+    def build_lifecycle_transition_records(
+        self,
+        record: ControlPlaneRecord,
+        *,
+        existing_record: ControlPlaneRecord | None,
+        transitioned_at: datetime | None = None,
+    ) -> tuple[LifecycleTransitionRecord, ...]:
+        if isinstance(record, LifecycleTransitionRecord):
+            return ()
+        if not hasattr(record, "lifecycle_state"):
+            return ()
+
+        latest_transition = self.latest_lifecycle_transition(
+            record.record_family,
+            record.record_id,
+        )
+        transition_records: list[LifecycleTransitionRecord] = []
+        if latest_transition is None and existing_record is not None:
+            anchor_transition = self.build_lifecycle_transition_record(
+                existing_record,
+                existing_record=None,
+                must_precede_transitioned_at=transitioned_at,
+                latest_transition=None,
+            )
+            if anchor_transition is not None:
+                transition_records.append(anchor_transition)
+                latest_transition = anchor_transition
+
+        transition_record = self.build_lifecycle_transition_record(
+            record,
+            existing_record=existing_record,
+            transitioned_at=transitioned_at,
+            latest_transition=latest_transition,
+        )
+        if transition_record is not None:
+            transition_records.append(transition_record)
+        return tuple(transition_records)
+
+    def initial_lifecycle_transitioned_at(
+        self,
+        record: ControlPlaneRecord,
+        *,
+        fallback: datetime | None = None,
+    ) -> datetime:
+        service = self._service
+        if isinstance(record, AnalyticSignalRecord):
+            if record.first_seen_at is not None:
+                return record.first_seen_at
+            if record.last_seen_at is not None:
+                return record.last_seen_at
+        elif isinstance(record, EvidenceRecord):
+            return record.acquired_at
+        elif isinstance(record, ObservationRecord):
+            return record.observed_at
+        elif isinstance(record, HuntRecord):
+            return record.opened_at
+        elif isinstance(record, HuntRunRecord):
+            for candidate in (record.started_at, record.completed_at):
+                if candidate is not None:
+                    return candidate
+        elif isinstance(record, (AlertRecord, CaseRecord)):
+            reviewed_transitioned_at = service._reviewed_context_transitioned_at(record)
+            if reviewed_transitioned_at is not None:
+                return reviewed_transitioned_at
+        elif isinstance(record, ApprovalDecisionRecord):
+            if record.decided_at is not None:
+                return record.decided_at
+        elif isinstance(record, ActionRequestRecord):
+            return record.requested_at
+        elif isinstance(record, ActionExecutionRecord):
+            return record.delegated_at
+        elif isinstance(record, AITraceRecord):
+            return record.generated_at
+        elif isinstance(record, ReconciliationRecord):
+            for candidate in (
+                record.first_seen_at,
+                record.last_seen_at,
+                record.compared_at,
+            ):
+                if candidate is not None:
+                    return candidate
+        return fallback if fallback is not None else datetime.now(timezone.utc)
+
+    def latest_lifecycle_transition(
+        self,
+        record_family: str,
+        record_id: str,
+    ) -> LifecycleTransitionRecord | None:
+        return self._service._store.latest_lifecycle_transition(record_family, record_id)
+
+    def lifecycle_transition_attribution(
+        self,
+        record: ControlPlaneRecord,
+    ) -> dict[str, object]:
+        service = self._service
+        actor_identities: tuple[str, ...] = ()
+        source = "aegisops-control-plane"
+
+        if isinstance(record, ObservationRecord):
+            actor_identities = service._merge_linked_ids((), record.author_identity)
+            source = "observation-author"
+        elif isinstance(record, LeadRecord):
+            actor_identities = service._merge_linked_ids((), record.triage_owner)
+            source = "lead-triage-owner"
+        elif isinstance(record, RecommendationRecord):
+            actor_identities = service._merge_linked_ids((), record.review_owner)
+            source = "recommendation-review-owner"
+        elif isinstance(record, ActionRequestRecord):
+            actor_identities = service._merge_linked_ids((), record.requester_identity)
+            source = "action-request"
+        elif isinstance(record, ApprovalDecisionRecord):
+            actor_identities = service._merge_linked_ids(
+                record.approver_identities,
+                None,
+            )
+            source = "approval-decision"
+        elif isinstance(record, HuntRecord):
+            actor_identities = service._merge_linked_ids((), record.owner_identity)
+            source = "hunt-owner"
+        elif isinstance(record, AITraceRecord):
+            actor_identities = service._merge_linked_ids((), record.reviewer_identity)
+            source = "ai-trace-reviewer"
+
+        return {
+            "source": source,
+            "actor_identities": actor_identities,
+        }
+
+
+class DetectionReconciliationResolver:
+    def __init__(self, service: AegisOpsControlPlaneService) -> None:
+        self._service = service
+
+    def resolve_analytic_signal_id(
+        self,
+        *,
+        analytic_signal_id: str | None,
+        finding_id: str,
+        correlation_key: str,
+        substrate_detection_record_id: str | None,
+        latest_reconciliation: ReconciliationRecord | None,
+    ) -> str:
+        service = self._service
+        if analytic_signal_id is not None:
+            return analytic_signal_id
+
+        existing_signal_ids = service._merge_linked_ids(
+            (
+                latest_reconciliation.subject_linkage.get("analytic_signal_ids")
+                if latest_reconciliation is not None
+                else ()
+            ),
+            None,
+        )
+        if substrate_detection_record_id is not None:
+            for existing_signal_id in existing_signal_ids:
+                existing_signal = service._store.get(
+                    AnalyticSignalRecord,
+                    existing_signal_id,
+                )
+                if (
+                    existing_signal is not None
+                    and existing_signal.substrate_detection_record_id
+                    == substrate_detection_record_id
+                ):
+                    return existing_signal_id
+
+        if substrate_detection_record_id is None and len(existing_signal_ids) == 1:
+            return existing_signal_ids[0]
+
+        mint_material = "|".join(
+            (
+                finding_id,
+                correlation_key,
+                substrate_detection_record_id or "",
+            )
+        )
+        return f"analytic-signal-{uuid.uuid5(uuid.NAMESPACE_URL, mint_material)}"
+
+    def reconciliation_has_detection_lineage(self, record: ReconciliationRecord) -> bool:
+        service = self._service
+        return any(
+            (
+                record.analytic_signal_id is not None,
+                bool(
+                    service._merge_linked_ids(
+                        record.subject_linkage.get("analytic_signal_ids"),
+                        None,
+                    )
+                ),
+                bool(
+                    service._merge_linked_ids(
+                        record.subject_linkage.get("substrate_detection_record_ids"),
+                        None,
+                    )
+                ),
+                bool(
+                    service._merge_linked_ids(
+                        record.subject_linkage.get("source_systems"),
+                        None,
+                    )
+                ),
+            )
+        )
+
+    def latest_detection_reconciliation_for_alert(
+        self,
+        alert_id: str,
+    ) -> ReconciliationRecord | None:
+        latest: ReconciliationRecord | None = None
+        for record in self._service._store.list(ReconciliationRecord):
+            if (
+                record.alert_id != alert_id
+                or not self.reconciliation_has_detection_lineage(record)
+                or not self.reconciliation_is_wazuh_origin(record)
+            ):
+                continue
+            if latest is None or (
+                record.compared_at,
+                record.reconciliation_id,
+            ) > (
+                latest.compared_at,
+                latest.reconciliation_id,
+            ):
+                latest = record
+        return latest
+
+    def latest_detection_reconciliations_by_alert_id(
+        self,
+    ) -> dict[str, ReconciliationRecord]:
+        latest_by_alert_id: dict[str, ReconciliationRecord] = {}
+        for record in self._service._store.list(ReconciliationRecord):
+            if (
+                record.alert_id is None
+                or not self.reconciliation_has_detection_lineage(record)
+                or not self.reconciliation_is_wazuh_origin(record)
+            ):
+                continue
+            current = latest_by_alert_id.get(record.alert_id)
+            if current is None or (
+                record.compared_at,
+                record.reconciliation_id,
+            ) > (
+                current.compared_at,
+                current.reconciliation_id,
+            ):
+                latest_by_alert_id[record.alert_id] = record
+        return latest_by_alert_id
+
+    def reconciliation_is_wazuh_origin(self, record: ReconciliationRecord) -> bool:
+        service = self._service
+        source_systems = service._merge_linked_ids(
+            record.subject_linkage.get("source_systems"),
+            None,
+        )
+        substrate_detection_record_ids = service._merge_linked_ids(
+            record.subject_linkage.get("substrate_detection_record_ids"),
+            None,
+        )
+        normalized_source_systems = tuple(
+            source_system.strip().lower() for source_system in source_systems
+        )
+        normalized_substrate_detection_record_ids = tuple(
+            detection_id.strip().lower()
+            for detection_id in substrate_detection_record_ids
+        )
+        return "wazuh" in normalized_source_systems or any(
+            detection_id.startswith("wazuh:")
+            for detection_id in normalized_substrate_detection_record_ids
+        )
+
+
+class LiveWazuhIntakeHandler:
+    def __init__(
+        self,
+        service: AegisOpsControlPlaneService,
+        intake: DetectionIntakeService,
+    ) -> None:
+        self._service = service
+        self._intake = intake
+
+    def ingest_wazuh_alert(
+        self,
+        *,
+        raw_alert: Mapping[str, object],
+        authorization_header: str | None,
+        forwarded_proto: str | None,
+        reverse_proxy_secret_header: str | None,
+        peer_addr: str | None,
+    ) -> FindingAlertIngestResult:
+        service = self._service
+        service._runtime_boundary_service.validate_wazuh_ingest_runtime()
+
+        if not service._runtime_boundary_service.is_trusted_wazuh_ingest_peer(peer_addr):
+            service._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="untrusted_peer",
+                peer_addr=peer_addr,
+            )
+            raise PermissionError(
+                "live Wazuh ingest rejects requests that bypass the reviewed reverse proxy peer boundary"
+            )
+
+        if (forwarded_proto or "").strip().lower() != "https":
+            service._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="forwarded_proto_not_https",
+                peer_addr=peer_addr,
+            )
+            raise PermissionError(
+                "live Wazuh ingest requires the reviewed reverse proxy HTTPS boundary"
+            )
+        if not hmac.compare_digest(
+            (reverse_proxy_secret_header or "").strip(),
+            service._config.wazuh_ingest_reverse_proxy_secret,
+        ):
+            service._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="reverse_proxy_secret_mismatch",
+                peer_addr=peer_addr,
+            )
+            raise PermissionError(
+                "live Wazuh ingest requires the reviewed reverse proxy boundary credential"
+            )
+
+        scheme, separator, supplied_secret = (authorization_header or "").partition(" ")
+        if separator == "" or scheme != "Bearer" or supplied_secret.strip() == "":
+            service._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="missing_bearer_secret",
+                peer_addr=peer_addr,
+            )
+            raise PermissionError(
+                "live Wazuh ingest requires Authorization: Bearer <shared secret>"
+            )
+        if not hmac.compare_digest(
+            supplied_secret.strip(),
+            service._config.wazuh_ingest_shared_secret,
+        ):
+            service._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="bearer_secret_mismatch",
+                peer_addr=peer_addr,
+            )
+            raise PermissionError(
+                "live Wazuh ingest bearer credential did not match the reviewed shared secret"
+            )
+
+        native_alert = service._require_mapping(raw_alert, "alert")
+        source_family = service._normalize_optional_string(
+            (
+                service._require_mapping(
+                    native_alert.get("data"),
+                    "data",
+                )
+            ).get("source_family"),
+            "data.source_family",
+        )
+        if source_family not in REVIEWED_LIVE_SOURCE_FAMILIES:
+            service._emit_structured_event(
+                logging.WARNING,
+                "wazuh_ingest_rejected",
+                reason="unsupported_source_family",
+                peer_addr=peer_addr,
+                source_family=source_family,
+            )
+            raise ValueError(
+                "live Wazuh ingest only admits the reviewed github_audit and entra_id live source families"
+            )
+
+        adapter = WazuhAlertAdapter()
+        native_record = service._with_native_detection_admission_provenance(
+            adapter.build_native_detection_record(native_alert),
+            admission_kind="live",
+            admission_channel="live_wazuh_webhook",
+        )
+        ingest_result = self._intake.ingest_native_detection_record(
+            adapter,
+            native_record,
+        )
+        service._emit_structured_event(
+            logging.INFO,
+            "wazuh_ingest_admitted",
+            peer_addr=peer_addr,
+            source_family=source_family,
+            disposition=ingest_result.disposition,
+            alert_id=ingest_result.alert.alert_id,
+            finding_id=ingest_result.alert.finding_id,
+            reconciliation_id=ingest_result.reconciliation.reconciliation_id,
+        )
+        return ingest_result

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from contextlib import AbstractContextManager, contextmanager
 from collections import Counter
 from dataclasses import asdict, dataclass, fields, replace
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import hashlib
-import hmac
 import ipaddress
 import json
 import logging
@@ -16,7 +15,6 @@ from typing import Iterable, Iterator, Mapping, Protocol, Type, TypeVar
 _DATETIME_TYPE = datetime
 
 from . import action_review_projection as _action_review_projection
-from .adapters.wazuh import WazuhAlertAdapter
 from .assistant_provider import (
     AssistantProviderFailure,
     AssistantProviderResult,
@@ -52,10 +50,10 @@ from .readiness_contracts import (
 from .runtime_boundary import RuntimeBoundaryService
 from .reviewed_slice_policy import (
     REVIEWED_LIVE_SLICE_LABEL,
-    REVIEWED_LIVE_SOURCE_FAMILIES,
     ReviewedSlicePolicy,
 )
 from .action_review_projection import _ActionReviewRecordIndex
+from .detection_lifecycle_helpers import LATEST_LIFECYCLE_TRANSITION_UNSET
 from .service_composition import (
     ControlPlaneServiceCompositionDependencies,
     build_control_plane_service_composition,
@@ -92,9 +90,7 @@ _CASE_LIFECYCLE_STATE_BY_TRIAGE_DISPOSITION = {
     "investigating": "investigating",
 }
 
-_LATEST_LIFECYCLE_TRANSITION_UNSET = object()
-_LINKED_ALERT_CASE_LIFECYCLE_LOCK_FAMILY = "linked_alert_case_lifecycle"
-_SAME_TIMESTAMP_LIFECYCLE_TRANSITION_ID_PREFIX = "~"
+_LATEST_LIFECYCLE_TRANSITION_UNSET = LATEST_LIFECYCLE_TRANSITION_UNSET
 _PHASE24_WORKFLOW_FAMILY = "first_live_assistant_summary_family"
 _PHASE24_WORKFLOW_PROMPT_VERSIONS = {
     "case_summary": "phase24-case-summary-v1",
@@ -1429,33 +1425,17 @@ class AegisOpsControlPlaneService:
         record_family: str,
         record_id: str,
     ) -> None:
-        lock_subject = getattr(self._store, "lock_lifecycle_transition_subject", None)
-        if callable(lock_subject):
-            lock_subject(record_family, record_id)
+        self._detection_intake_service.lifecycle_transition_helper.lock_lifecycle_transition_subject(
+            record_family,
+            record_id,
+        )
 
-    @staticmethod
     def _linked_alert_case_lifecycle_lock_subject(
+        self,
         record: ControlPlaneRecord,
     ) -> tuple[str, str] | None:
-        if isinstance(record, AlertRecord):
-            alert_id = record.alert_id
-            case_id = record.case_id
-        elif isinstance(record, CaseRecord):
-            alert_id = record.alert_id
-            case_id = record.case_id
-        else:
-            return None
-
-        if not isinstance(alert_id, str) or not alert_id.strip():
-            return None
-        if not isinstance(case_id, str) or not case_id.strip():
-            return None
-
-        # Serialize linked alert/case lifecycle mutations on one shared key so
-        # opposite record-specific update orders cannot deadlock.
-        return (
-            _LINKED_ALERT_CASE_LIFECYCLE_LOCK_FAMILY,
-            f"alert:{alert_id}|case:{case_id}",
+        return self._detection_intake_service.lifecycle_transition_helper.linked_alert_case_lifecycle_lock_subject(
+            record
         )
 
     def _build_lifecycle_transition_record(
@@ -1470,97 +1450,13 @@ class AegisOpsControlPlaneService:
             _LATEST_LIFECYCLE_TRANSITION_UNSET
         ),
     ) -> LifecycleTransitionRecord | None:
-        if isinstance(record, LifecycleTransitionRecord):
-            return None
-        if not hasattr(record, "lifecycle_state"):
-            return None
-
-        existing_lifecycle_state = (
-            getattr(existing_record, "lifecycle_state", None)
-            if existing_record is not None
-            else None
-        )
-        next_lifecycle_state = getattr(record, "lifecycle_state", None)
-        if not isinstance(next_lifecycle_state, str) or not next_lifecycle_state.strip():
-            return None
-        if latest_transition is _LATEST_LIFECYCLE_TRANSITION_UNSET:
-            latest_transition = self._latest_lifecycle_transition(
-                record.record_family,
-                record.record_id,
-            )
-        previous_lifecycle_state = existing_lifecycle_state
-        if latest_transition is not None:
-            if existing_record is None:
-                raise ValueError(
-                    f"{record.record_family} record {record.record_id!r} has orphaned "
-                    "lifecycle transition history without a current-state record"
-                )
-            if (
-                existing_record is not None
-                and existing_lifecycle_state != latest_transition.lifecycle_state
-            ):
-                raise ValueError(
-                    f"{record.record_family} record {record.record_id!r} lifecycle_state "
-                    f"{existing_lifecycle_state!r} does not match latest lifecycle "
-                    f"transition {latest_transition.transition_id!r} state "
-                    f"{latest_transition.lifecycle_state!r}"
-                )
-            previous_lifecycle_state = latest_transition.lifecycle_state
-        if previous_lifecycle_state == next_lifecycle_state:
-            return None
-
-        explicit_transitioned_at = transitioned_at is not None
-        resolved_transitioned_at = (
-            transitioned_at
-            if transitioned_at is not None
-            else (
-                self._initial_lifecycle_transitioned_at(
-                    record,
-                    fallback=initial_transitioned_at_fallback,
-                )
-                if existing_record is None
-                else datetime.now(timezone.utc)
-            )
-        )
-        if (
-            must_precede_transitioned_at is not None
-            and resolved_transitioned_at >= must_precede_transitioned_at
-        ):
-            resolved_transitioned_at = must_precede_transitioned_at - timedelta(
-                microseconds=1
-            )
-        if (
-            latest_transition is not None
-            and resolved_transitioned_at < latest_transition.transitioned_at
-        ):
-            if explicit_transitioned_at:
-                raise ValueError(
-                    "transitioned_at must not precede the latest lifecycle transition "
-                    f"for {record.record_family} record {record.record_id!r}"
-                )
-            resolved_transitioned_at = latest_transition.transitioned_at + timedelta(
-                microseconds=1
-            )
-        transition_timestamp = resolved_transitioned_at.astimezone(
-            timezone.utc
-        ).strftime("%Y%m%dT%H%M%S.%fZ")
-        return LifecycleTransitionRecord(
-            transition_id=self._lifecycle_transition_id(
-                transition_timestamp=transition_timestamp,
-                transitioned_at=resolved_transitioned_at,
-                latest_transition=latest_transition,
-            ),
-            subject_record_family=record.record_family,
-            subject_record_id=record.record_id,
-            previous_lifecycle_state=(
-                previous_lifecycle_state
-                if isinstance(previous_lifecycle_state, str)
-                and previous_lifecycle_state.strip()
-                else None
-            ),
-            lifecycle_state=next_lifecycle_state,
-            transitioned_at=resolved_transitioned_at,
-            attribution=self._lifecycle_transition_attribution(record),
+        return self._detection_intake_service.lifecycle_transition_helper.build_lifecycle_transition_record(
+            record,
+            existing_record=existing_record,
+            transitioned_at=transitioned_at,
+            initial_transitioned_at_fallback=initial_transitioned_at_fallback,
+            must_precede_transitioned_at=must_precede_transitioned_at,
+            latest_transition=latest_transition,
         )
 
     def _lifecycle_transition_id(
@@ -1570,23 +1466,11 @@ class AegisOpsControlPlaneService:
         transitioned_at: datetime,
         latest_transition: LifecycleTransitionRecord | None,
     ) -> str:
-        if (
-            latest_transition is None
-            or transitioned_at != latest_transition.transitioned_at
-        ):
-            return f"{transition_timestamp}:{uuid.uuid4()}"
-
-        sequence = 1
-        prefix = (
-            f"{_SAME_TIMESTAMP_LIFECYCLE_TRANSITION_ID_PREFIX}{transition_timestamp}:"
+        return self._detection_intake_service.lifecycle_transition_helper.lifecycle_transition_id(
+            transition_timestamp=transition_timestamp,
+            transitioned_at=transitioned_at,
+            latest_transition=latest_transition,
         )
-        if latest_transition.transition_id.startswith(prefix):
-            sequence_text = latest_transition.transition_id[len(prefix) :].split(":", 1)[
-                0
-            ]
-            if sequence_text.isdigit():
-                sequence = int(sequence_text) + 1
-        return f"{prefix}{sequence:06d}:{uuid.uuid4()}"
 
     def _build_lifecycle_transition_records(
         self,
@@ -1595,36 +1479,11 @@ class AegisOpsControlPlaneService:
         existing_record: ControlPlaneRecord | None,
         transitioned_at: datetime | None = None,
     ) -> tuple[LifecycleTransitionRecord, ...]:
-        if isinstance(record, LifecycleTransitionRecord):
-            return ()
-        if not hasattr(record, "lifecycle_state"):
-            return ()
-
-        latest_transition = self._latest_lifecycle_transition(
-            record.record_family,
-            record.record_id,
-        )
-        transition_records: list[LifecycleTransitionRecord] = []
-        if latest_transition is None and existing_record is not None:
-            anchor_transition = self._build_lifecycle_transition_record(
-                existing_record,
-                existing_record=None,
-                must_precede_transitioned_at=transitioned_at,
-                latest_transition=None,
-            )
-            if anchor_transition is not None:
-                transition_records.append(anchor_transition)
-                latest_transition = anchor_transition
-
-        transition_record = self._build_lifecycle_transition_record(
+        return self._detection_intake_service.lifecycle_transition_helper.build_lifecycle_transition_records(
             record,
             existing_record=existing_record,
             transitioned_at=transitioned_at,
-            latest_transition=latest_transition,
         )
-        if transition_record is not None:
-            transition_records.append(transition_record)
-        return tuple(transition_records)
 
     def _initial_lifecycle_transitioned_at(
         self,
@@ -1632,43 +1491,10 @@ class AegisOpsControlPlaneService:
         *,
         fallback: datetime | None = None,
     ) -> datetime:
-        if isinstance(record, AnalyticSignalRecord):
-            if record.first_seen_at is not None:
-                return record.first_seen_at
-            if record.last_seen_at is not None:
-                return record.last_seen_at
-        elif isinstance(record, EvidenceRecord):
-            return record.acquired_at
-        elif isinstance(record, ObservationRecord):
-            return record.observed_at
-        elif isinstance(record, HuntRecord):
-            return record.opened_at
-        elif isinstance(record, HuntRunRecord):
-            for candidate in (record.started_at, record.completed_at):
-                if candidate is not None:
-                    return candidate
-        elif isinstance(record, (AlertRecord, CaseRecord)):
-            reviewed_transitioned_at = self._reviewed_context_transitioned_at(record)
-            if reviewed_transitioned_at is not None:
-                return reviewed_transitioned_at
-        elif isinstance(record, ApprovalDecisionRecord):
-            if record.decided_at is not None:
-                return record.decided_at
-        elif isinstance(record, ActionRequestRecord):
-            return record.requested_at
-        elif isinstance(record, ActionExecutionRecord):
-            return record.delegated_at
-        elif isinstance(record, AITraceRecord):
-            return record.generated_at
-        elif isinstance(record, ReconciliationRecord):
-            for candidate in (
-                record.first_seen_at,
-                record.last_seen_at,
-                record.compared_at,
-            ):
-                if candidate is not None:
-                    return candidate
-        return fallback if fallback is not None else datetime.now(timezone.utc)
+        return self._detection_intake_service.lifecycle_transition_helper.initial_lifecycle_transitioned_at(
+            record,
+            fallback=fallback,
+        )
 
     def _reviewed_context_transitioned_at(
         self,
@@ -1699,44 +1525,18 @@ class AegisOpsControlPlaneService:
         record_family: str,
         record_id: str,
     ) -> LifecycleTransitionRecord | None:
-        return self._store.latest_lifecycle_transition(record_family, record_id)
+        return self._detection_intake_service.lifecycle_transition_helper.latest_lifecycle_transition(
+            record_family,
+            record_id,
+        )
 
     def _lifecycle_transition_attribution(
         self,
         record: ControlPlaneRecord,
     ) -> dict[str, object]:
-        actor_identities: tuple[str, ...] = ()
-        source = "aegisops-control-plane"
-
-        if isinstance(record, ObservationRecord):
-            actor_identities = self._merge_linked_ids((), record.author_identity)
-            source = "observation-author"
-        elif isinstance(record, LeadRecord):
-            actor_identities = self._merge_linked_ids((), record.triage_owner)
-            source = "lead-triage-owner"
-        elif isinstance(record, RecommendationRecord):
-            actor_identities = self._merge_linked_ids((), record.review_owner)
-            source = "recommendation-review-owner"
-        elif isinstance(record, ActionRequestRecord):
-            actor_identities = self._merge_linked_ids((), record.requester_identity)
-            source = "action-request"
-        elif isinstance(record, ApprovalDecisionRecord):
-            actor_identities = self._merge_linked_ids(
-                record.approver_identities,
-                None,
-            )
-            source = "approval-decision"
-        elif isinstance(record, HuntRecord):
-            actor_identities = self._merge_linked_ids((), record.owner_identity)
-            source = "hunt-owner"
-        elif isinstance(record, AITraceRecord):
-            actor_identities = self._merge_linked_ids((), record.reviewer_identity)
-            source = "ai-trace-reviewer"
-
-        return {
-            "source": source,
-            "actor_identities": actor_identities,
-        }
+        return self._detection_intake_service.lifecycle_transition_helper.lifecycle_transition_attribution(
+            record
+        )
 
     def list_lifecycle_transitions(
         self,
@@ -1837,108 +1637,13 @@ class AegisOpsControlPlaneService:
         reverse_proxy_secret_header: str | None,
         peer_addr: str | None,
     ) -> FindingAlertIngestResult:
-        self._runtime_boundary_service.validate_wazuh_ingest_runtime()
-
-        if not self._runtime_boundary_service.is_trusted_wazuh_ingest_peer(peer_addr):
-            self._emit_structured_event(
-                logging.WARNING,
-                "wazuh_ingest_rejected",
-                reason="untrusted_peer",
-                peer_addr=peer_addr,
-            )
-            raise PermissionError(
-                "live Wazuh ingest rejects requests that bypass the reviewed reverse proxy peer boundary"
-            )
-
-        if (forwarded_proto or "").strip().lower() != "https":
-            self._emit_structured_event(
-                logging.WARNING,
-                "wazuh_ingest_rejected",
-                reason="forwarded_proto_not_https",
-                peer_addr=peer_addr,
-            )
-            raise PermissionError(
-                "live Wazuh ingest requires the reviewed reverse proxy HTTPS boundary"
-            )
-        if not hmac.compare_digest(
-            (reverse_proxy_secret_header or "").strip(),
-            self._config.wazuh_ingest_reverse_proxy_secret,
-        ):
-            self._emit_structured_event(
-                logging.WARNING,
-                "wazuh_ingest_rejected",
-                reason="reverse_proxy_secret_mismatch",
-                peer_addr=peer_addr,
-            )
-            raise PermissionError(
-                "live Wazuh ingest requires the reviewed reverse proxy boundary credential"
-            )
-
-        scheme, separator, supplied_secret = (authorization_header or "").partition(" ")
-        if separator == "" or scheme != "Bearer" or supplied_secret.strip() == "":
-            self._emit_structured_event(
-                logging.WARNING,
-                "wazuh_ingest_rejected",
-                reason="missing_bearer_secret",
-                peer_addr=peer_addr,
-            )
-            raise PermissionError(
-                "live Wazuh ingest requires Authorization: Bearer <shared secret>"
-            )
-        if not hmac.compare_digest(
-            supplied_secret.strip(),
-            self._config.wazuh_ingest_shared_secret,
-        ):
-            self._emit_structured_event(
-                logging.WARNING,
-                "wazuh_ingest_rejected",
-                reason="bearer_secret_mismatch",
-                peer_addr=peer_addr,
-            )
-            raise PermissionError(
-                "live Wazuh ingest bearer credential did not match the reviewed shared secret"
-            )
-
-        native_alert = self._require_mapping(raw_alert, "alert")
-        source_family = self._normalize_optional_string(
-            (
-                self._require_mapping(
-                    native_alert.get("data"),
-                    "data",
-                )
-            ).get("source_family"),
-            "data.source_family",
-        )
-        if source_family not in REVIEWED_LIVE_SOURCE_FAMILIES:
-            self._emit_structured_event(
-                logging.WARNING,
-                "wazuh_ingest_rejected",
-                reason="unsupported_source_family",
-                peer_addr=peer_addr,
-                source_family=source_family,
-            )
-            raise ValueError(
-                "live Wazuh ingest only admits the reviewed github_audit and entra_id live source families"
-            )
-
-        adapter = WazuhAlertAdapter()
-        native_record = self._with_native_detection_admission_provenance(
-            adapter.build_native_detection_record(native_alert),
-            admission_kind="live",
-            admission_channel="live_wazuh_webhook",
-        )
-        ingest_result = self.ingest_native_detection_record(adapter, native_record)
-        self._emit_structured_event(
-            logging.INFO,
-            "wazuh_ingest_admitted",
+        return self._detection_intake_service.ingest_wazuh_alert(
+            raw_alert=raw_alert,
+            authorization_header=authorization_header,
+            forwarded_proto=forwarded_proto,
+            reverse_proxy_secret_header=reverse_proxy_secret_header,
             peer_addr=peer_addr,
-            source_family=source_family,
-            disposition=ingest_result.disposition,
-            alert_id=ingest_result.alert.alert_id,
-            finding_id=ingest_result.alert.finding_id,
-            reconciliation_id=ingest_result.reconciliation.reconciliation_id,
         )
-        return ingest_result
 
     def _listener_is_loopback(self) -> bool:
         return self._runtime_boundary_service.listener_is_loopback()
@@ -3097,93 +2802,26 @@ class AegisOpsControlPlaneService:
     def _reconciliation_has_detection_lineage(
         self, record: ReconciliationRecord
     ) -> bool:
-        return any(
-            (
-                record.analytic_signal_id is not None,
-                bool(
-                    self._merge_linked_ids(
-                        record.subject_linkage.get("analytic_signal_ids"),
-                        None,
-                    )
-                ),
-                bool(
-                    self._merge_linked_ids(
-                        record.subject_linkage.get("substrate_detection_record_ids"),
-                        None,
-                    )
-                ),
-                bool(
-                    self._merge_linked_ids(
-                        record.subject_linkage.get("source_systems"),
-                        None,
-                    )
-                ),
-            )
+        return self._detection_intake_service.reconciliation_resolver.reconciliation_has_detection_lineage(
+            record
         )
 
     def _latest_detection_reconciliation_for_alert(
         self,
         alert_id: str,
     ) -> ReconciliationRecord | None:
-        latest: ReconciliationRecord | None = None
-        for record in self._store.list(ReconciliationRecord):
-            if (
-                record.alert_id != alert_id
-                or not self._reconciliation_has_detection_lineage(record)
-                or not self._reconciliation_is_wazuh_origin(record)
-            ):
-                continue
-            if latest is None or (
-                record.compared_at,
-                record.reconciliation_id,
-            ) > (
-                latest.compared_at,
-                latest.reconciliation_id,
-            ):
-                latest = record
-        return latest
+        return self._detection_intake_service.reconciliation_resolver.latest_detection_reconciliation_for_alert(
+            alert_id
+        )
 
     def _latest_detection_reconciliations_by_alert_id(
         self,
     ) -> dict[str, ReconciliationRecord]:
-        latest_by_alert_id: dict[str, ReconciliationRecord] = {}
-        for record in self._store.list(ReconciliationRecord):
-            if (
-                record.alert_id is None
-                or not self._reconciliation_has_detection_lineage(record)
-                or not self._reconciliation_is_wazuh_origin(record)
-            ):
-                continue
-            current = latest_by_alert_id.get(record.alert_id)
-            if current is None or (
-                record.compared_at,
-                record.reconciliation_id,
-            ) > (
-                current.compared_at,
-                current.reconciliation_id,
-            ):
-                latest_by_alert_id[record.alert_id] = record
-        return latest_by_alert_id
+        return self._detection_intake_service.reconciliation_resolver.latest_detection_reconciliations_by_alert_id()
 
     def _reconciliation_is_wazuh_origin(self, record: ReconciliationRecord) -> bool:
-        source_systems = self._merge_linked_ids(
-            record.subject_linkage.get("source_systems"),
-            None,
-        )
-        substrate_detection_record_ids = self._merge_linked_ids(
-            record.subject_linkage.get("substrate_detection_record_ids"),
-            None,
-        )
-        normalized_source_systems = tuple(
-            source_system.strip().lower() for source_system in source_systems
-        )
-        normalized_substrate_detection_record_ids = tuple(
-            detection_id.strip().lower()
-            for detection_id in substrate_detection_record_ids
-        )
-        return "wazuh" in normalized_source_systems or any(
-            detection_id.startswith("wazuh:")
-            for detection_id in normalized_substrate_detection_record_ids
+        return self._detection_intake_service.reconciliation_resolver.reconciliation_is_wazuh_origin(
+            record
         )
 
     def _assistant_ids_from_value(self, value: object) -> tuple[str, ...]:
@@ -3770,41 +3408,13 @@ class AegisOpsControlPlaneService:
         substrate_detection_record_id: str | None,
         latest_reconciliation: ReconciliationRecord | None,
     ) -> str:
-        if analytic_signal_id is not None:
-            return analytic_signal_id
-
-        existing_signal_ids = self._merge_linked_ids(
-            (
-                latest_reconciliation.subject_linkage.get("analytic_signal_ids")
-                if latest_reconciliation is not None
-                else ()
-            ),
-            None,
+        return self._detection_intake_service.resolve_analytic_signal_id(
+            analytic_signal_id=analytic_signal_id,
+            finding_id=finding_id,
+            correlation_key=correlation_key,
+            substrate_detection_record_id=substrate_detection_record_id,
+            latest_reconciliation=latest_reconciliation,
         )
-        if substrate_detection_record_id is not None:
-            for existing_signal_id in existing_signal_ids:
-                existing_signal = self._store.get(
-                    AnalyticSignalRecord,
-                    existing_signal_id,
-                )
-                if (
-                    existing_signal is not None
-                    and existing_signal.substrate_detection_record_id
-                    == substrate_detection_record_id
-                ):
-                    return existing_signal_id
-
-        if substrate_detection_record_id is None and len(existing_signal_ids) == 1:
-            return existing_signal_ids[0]
-
-        mint_material = "|".join(
-            (
-                finding_id,
-                correlation_key,
-                substrate_detection_record_id or "",
-            )
-        )
-        return f"analytic-signal-{uuid.uuid5(uuid.NAMESPACE_URL, mint_material)}"
 
     def _require_empty_authoritative_restore_target(self) -> None:
         diagnostics_service = self._runtime_restore_readiness_diagnostics_service

--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,7 +66,7 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.8.3")
+        self.assertEqual(metadata["phase"], "50.8.4")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
         self.assertEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -55,8 +55,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.8.3")
-        self.assertEqual(metadata["issue"], "#964")
+        self.assertEqual(metadata["phase"], "50.8.4")
+        self.assertEqual(metadata["issue"], "#965")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
         self.assertEqual(
@@ -72,15 +72,15 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         closeout = self._read("docs/phase-50-maintainability-closeout.md")
 
         for required in (
-            "Phase 50.8.3",
+            "Phase 50.8.4",
             "control-plane/aegisops_control_plane/service.py",
             "AegisOpsControlPlaneService",
-            "max_lines=4087",
-            "max_effective_lines=3733",
+            "max_lines=3697",
+            "max_effective_lines=3362",
             "max_facade_methods=188",
             "ADR-0004",
             "ADR-0003",
-            "#964",
+            "#965",
             "remaining accepted hotspot",
             "silent re-growth",
             "another decomposition decision",

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -16,6 +16,8 @@ from aegisops_control_plane.detection_lifecycle import DetectionIntakeService
 from aegisops_control_plane.evidence_linkage import EvidenceLinkageService
 from aegisops_control_plane.models import AlertRecord, AnalyticSignalRecord, CaseRecord
 
+REVIEWED_PROXY_SECRET = "reviewed-proxy-secret"  # noqa: S105 - test fixture secret
+
 for name, value in vars(support).items():
     if not (name.startswith("__") and name.endswith("__")):
         globals()[name] = value
@@ -395,7 +397,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
                 raw_alert={"alert": {"data": {"source_family": "github_audit"}}},
                 authorization_header="Bearer reviewed-shared-secret",
                 forwarded_proto="https",
-                reverse_proxy_secret_header="reviewed-proxy-secret",
+                reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
                 peer_addr="10.10.0.5",
             ),
             wazuh_result,
@@ -530,7 +532,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             raw_alert={"alert": {"data": {"source_family": "github_audit"}}},
             authorization_header="Bearer reviewed-shared-secret",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",
+            reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
             peer_addr="10.10.0.5",
         )
         lifecycle_delegate.build_lifecycle_transition_record.assert_called_once_with(

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -274,6 +274,13 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         native_result = support.SimpleNamespace(name="native-result")
         attach_result = support.SimpleNamespace(name="attach-result")
         promoted_case = support.SimpleNamespace(case_id="case-delegated-001")
+        wazuh_result = support.SimpleNamespace(name="wazuh-result")
+        transition_record = support.SimpleNamespace(name="transition-record")
+        transition_records = (transition_record,)
+        latest_transition = support.SimpleNamespace(name="latest-transition")
+        attribution = {"source": "delegated-lifecycle", "actor_identities": ()}
+        reconciliation = support.SimpleNamespace(name="reconciliation")
+        reconciliation_map = {"alert-delegated-001": reconciliation}
         adapter = support.SimpleNamespace(substrate_key="wazuh")
         native_record = support.NativeDetectionRecord(
             substrate_key="wazuh",
@@ -300,6 +307,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         intake_delegate.ingest_native_detection_record.return_value = native_result
         intake_delegate.ingest_analytic_signal_admission.return_value = ingest_result
         intake_delegate.attach_native_detection_context.return_value = attach_result
+        intake_delegate.ingest_wazuh_alert.return_value = wazuh_result
         intake_delegate.reviewed_context_transitioned_at.return_value = (
             reviewed_transitioned_at
         )
@@ -310,6 +318,39 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         intake_delegate.case_lifecycle_for_disposition.return_value = (
             "disposition_pending_action"
         )
+        intake_delegate.resolve_analytic_signal_id.return_value = (
+            "signal-delegated-001"
+        )
+        lifecycle_delegate = support.mock.Mock()
+        lifecycle_delegate.build_lifecycle_transition_record.return_value = (
+            transition_record
+        )
+        lifecycle_delegate.build_lifecycle_transition_records.return_value = (
+            transition_records
+        )
+        lifecycle_delegate.initial_lifecycle_transitioned_at.return_value = (
+            reviewed_transitioned_at
+        )
+        lifecycle_delegate.latest_lifecycle_transition.return_value = latest_transition
+        lifecycle_delegate.lifecycle_transition_attribution.return_value = attribution
+        lifecycle_delegate.lifecycle_transition_id.return_value = (
+            "delegated-transition-id"
+        )
+        lifecycle_delegate.linked_alert_case_lifecycle_lock_subject.return_value = (
+            "linked_alert_case_lifecycle",
+            "alert:alert-delegated-001|case:case-delegated-001",
+        )
+        intake_delegate.lifecycle_transition_helper = lifecycle_delegate
+        reconciliation_delegate = support.mock.Mock()
+        reconciliation_delegate.reconciliation_has_detection_lineage.return_value = True
+        reconciliation_delegate.latest_detection_reconciliation_for_alert.return_value = (
+            reconciliation
+        )
+        reconciliation_delegate.latest_detection_reconciliations_by_alert_id.return_value = (
+            reconciliation_map
+        )
+        reconciliation_delegate.reconciliation_is_wazuh_origin.return_value = True
+        intake_delegate.reconciliation_resolver = reconciliation_delegate
         service._detection_intake_service = intake_delegate
 
         self.assertIs(
@@ -348,6 +389,94 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
                 substrate_detection_record_id="substrate-delegated-001",
             ),
             attach_result,
+        )
+        self.assertIs(
+            service.ingest_wazuh_alert(
+                raw_alert={"alert": {"data": {"source_family": "github_audit"}}},
+                authorization_header="Bearer reviewed-shared-secret",
+                forwarded_proto="https",
+                reverse_proxy_secret_header="reviewed-proxy-secret",
+                peer_addr="10.10.0.5",
+            ),
+            wazuh_result,
+        )
+        self.assertIs(
+            service._build_lifecycle_transition_record(
+                support.mock.sentinel.record,
+                existing_record=support.mock.sentinel.existing_record,
+                transitioned_at=first_seen_at,
+                latest_transition=support.mock.sentinel.latest_transition,
+            ),
+            transition_record,
+        )
+        self.assertIs(
+            service._build_lifecycle_transition_records(
+                support.mock.sentinel.record,
+                existing_record=support.mock.sentinel.existing_record,
+                transitioned_at=first_seen_at,
+            ),
+            transition_records,
+        )
+        self.assertEqual(
+            service._lifecycle_transition_id(
+                transition_timestamp="20260405T120000.000000Z",
+                transitioned_at=first_seen_at,
+                latest_transition=support.mock.sentinel.latest_transition,
+            ),
+            "delegated-transition-id",
+        )
+        self.assertEqual(
+            service._linked_alert_case_lifecycle_lock_subject(
+                support.mock.sentinel.record
+            ),
+            (
+                "linked_alert_case_lifecycle",
+                "alert:alert-delegated-001|case:case-delegated-001",
+            ),
+        )
+        service._lock_lifecycle_transition_subject("alert", "alert-delegated-001")
+        self.assertIs(
+            service._initial_lifecycle_transitioned_at(
+                support.mock.sentinel.record,
+                fallback=first_seen_at,
+            ),
+            reviewed_transitioned_at,
+        )
+        self.assertIs(
+            service._latest_lifecycle_transition("alert", "alert-delegated-001"),
+            latest_transition,
+        )
+        self.assertEqual(
+            service._lifecycle_transition_attribution(support.mock.sentinel.record),
+            attribution,
+        )
+        self.assertEqual(
+            service._resolve_analytic_signal_id(
+                analytic_signal_id=None,
+                finding_id="finding-delegated-001",
+                correlation_key="claim:delegated",
+                substrate_detection_record_id="substrate-delegated-001",
+                latest_reconciliation=None,
+            ),
+            "signal-delegated-001",
+        )
+        self.assertTrue(
+            service._reconciliation_has_detection_lineage(
+                support.mock.sentinel.reconciliation
+            )
+        )
+        self.assertIs(
+            service._latest_detection_reconciliation_for_alert("alert-delegated-001"),
+            reconciliation,
+        )
+        self.assertIs(
+            service._latest_detection_reconciliations_by_alert_id(),
+            reconciliation_map,
+        )
+        self.assertTrue(
+            service._reconciliation_is_wazuh_origin(
+                support.mock.sentinel.reconciliation
+            )
         )
         self.assertIs(
             service._reviewed_context_transitioned_at(support.mock.sentinel.record),
@@ -396,6 +525,66 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             record=native_record,
             ingest_result=ingest_result,
             substrate_detection_record_id="substrate-delegated-001",
+        )
+        intake_delegate.ingest_wazuh_alert.assert_called_once_with(
+            raw_alert={"alert": {"data": {"source_family": "github_audit"}}},
+            authorization_header="Bearer reviewed-shared-secret",
+            forwarded_proto="https",
+            reverse_proxy_secret_header="reviewed-proxy-secret",
+            peer_addr="10.10.0.5",
+        )
+        lifecycle_delegate.build_lifecycle_transition_record.assert_called_once_with(
+            support.mock.sentinel.record,
+            existing_record=support.mock.sentinel.existing_record,
+            transitioned_at=first_seen_at,
+            initial_transitioned_at_fallback=None,
+            must_precede_transitioned_at=None,
+            latest_transition=support.mock.sentinel.latest_transition,
+        )
+        lifecycle_delegate.build_lifecycle_transition_records.assert_called_once_with(
+            support.mock.sentinel.record,
+            existing_record=support.mock.sentinel.existing_record,
+            transitioned_at=first_seen_at,
+        )
+        lifecycle_delegate.lifecycle_transition_id.assert_called_once_with(
+            transition_timestamp="20260405T120000.000000Z",
+            transitioned_at=first_seen_at,
+            latest_transition=support.mock.sentinel.latest_transition,
+        )
+        lifecycle_delegate.linked_alert_case_lifecycle_lock_subject.assert_called_once_with(
+            support.mock.sentinel.record
+        )
+        lifecycle_delegate.lock_lifecycle_transition_subject.assert_called_once_with(
+            "alert",
+            "alert-delegated-001",
+        )
+        lifecycle_delegate.initial_lifecycle_transitioned_at.assert_called_once_with(
+            support.mock.sentinel.record,
+            fallback=first_seen_at,
+        )
+        lifecycle_delegate.latest_lifecycle_transition.assert_called_once_with(
+            "alert",
+            "alert-delegated-001",
+        )
+        lifecycle_delegate.lifecycle_transition_attribution.assert_called_once_with(
+            support.mock.sentinel.record
+        )
+        intake_delegate.resolve_analytic_signal_id.assert_called_once_with(
+            analytic_signal_id=None,
+            finding_id="finding-delegated-001",
+            correlation_key="claim:delegated",
+            substrate_detection_record_id="substrate-delegated-001",
+            latest_reconciliation=None,
+        )
+        reconciliation_delegate.reconciliation_has_detection_lineage.assert_called_once_with(
+            support.mock.sentinel.reconciliation
+        )
+        reconciliation_delegate.latest_detection_reconciliation_for_alert.assert_called_once_with(
+            "alert-delegated-001"
+        )
+        reconciliation_delegate.latest_detection_reconciliations_by_alert_id.assert_called_once_with()
+        reconciliation_delegate.reconciliation_is_wazuh_origin.assert_called_once_with(
+            support.mock.sentinel.reconciliation
         )
         intake_delegate.reviewed_context_transitioned_at.assert_called_once_with(
             support.mock.sentinel.record

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,12 +1,12 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.8.3 lowered residual exception:
+# Phase 50.8.4 lowered residual exception:
 # ADR-0004 accepted ordered hotspot reduction after the ADR-0003
 # facade-preservation exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the action-review helper extraction, so this baseline records the lowered
-# Phase 50.8.3 ceiling and fails on silent re-growth. A future ADR or
+# the lifecycle/intake helper extraction, so this baseline records the lowered
+# Phase 50.8.4 ceiling and fails on silent re-growth. A future ADR or
 # maintainability backlog must lower or replace these limits before unrelated
 # feature expansion lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=4087 max_effective_lines=3733 max_facade_methods=188 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.3 issue=#964
+control-plane/aegisops_control_plane/service.py max_lines=3697 max_effective_lines=3362 max_facade_methods=188 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.4 issue=#965

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,6 +1,6 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.8.3 continues the ordered maintainability hotspot reduction sequence governed by ADR-0004.
+Phase 50.8.4 continues the ordered maintainability hotspot reduction sequence governed by ADR-0004.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
@@ -12,14 +12,14 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50 extraction and fencing work. Phase 50.8.3 lowered the accepted residual ceiling for #964 to:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50 extraction and fencing work. Phase 50.8.4 lowered the accepted residual ceiling for #965 to:
 
-- `max_lines=4087`
-- `max_effective_lines=3733`
+- `max_lines=3697`
+- `max_effective_lines=3362`
 - `max_facade_methods=188`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.8.3`
+- `phase=50.8.4`
 
 No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, or operator UI route tests because the verifier does not report those areas as current responsibility-growth candidates.
 


### PR DESCRIPTION
## Summary
- Extract lifecycle transition construction, live Wazuh intake, analytic-signal resolution, and Wazuh reconciliation lineage helpers out of service.py into detection lifecycle helper ownership.
- Keep service.py public/compatibility methods as thin delegates so runtime behavior and authority semantics remain unchanged.
- Lower Phase 50 maintainability hotspot closeout ceilings to the new service.py size.

## Verification
- python3 -m unittest control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
- python3 -m unittest control-plane/tests/test_phase21_end_to_end_validation.py control-plane/tests/test_service_persistence_assistant_advisory.py
- python3 -m unittest discover -s control-plane/tests -p 'test_*ingest*.py'
- bash scripts/verify-maintainability-hotspots.sh
- python3 -m unittest control-plane/tests/test_phase49_service_decomposition_closeout.py control-plane/tests/test_phase50_maintainability_closeout.py
- python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
- git diff --check
- node dist/index.js issue-lint 965 --config supervisor.config.aegisops.json

Closes #965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live Wazuh alert webhook ingestion with strict security boundary enforcement, including peer validation, secret verification, and source family gating.

* **Refactor**
  * Improved code organization by delegating lifecycle transition, reconciliation, and detection intake logic to specialized helper classes, reducing monolithic service complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->