### PR TITLE
Phase 50.8.6 closeout baseline refresh

### DIFF
--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,7 +66,7 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.8.5")
+        self.assertEqual(metadata["phase"], "50.8.6")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
         self.assertEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -55,8 +55,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.8.5")
-        self.assertEqual(metadata["issue"], "#966")
+        self.assertEqual(metadata["phase"], "50.8.6")
+        self.assertEqual(metadata["issue"], "#967")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), len(service_text.splitlines()))
         self.assertEqual(
@@ -72,7 +72,7 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         closeout = self._read("docs/phase-50-maintainability-closeout.md")
 
         for required in (
-            "Phase 50.8.5",
+            "Phase 50.8.6",
             "control-plane/aegisops_control_plane/service.py",
             "AegisOpsControlPlaneService",
             "max_lines=3505",
@@ -80,8 +80,10 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "max_facade_methods=185",
             "ADR-0004",
             "ADR-0003",
-            "#966",
+            "#967",
             "remaining accepted hotspot",
+            "action review projection and visibility helper cluster",
+            "intake and authoritative-state guard helpers",
             "silent re-growth",
             "another decomposition decision",
             "bash scripts/verify-maintainability-hotspots.sh",

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,12 +1,12 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.8.5 lowered residual exception:
+# Phase 50.8.6 final residual exception:
 # ADR-0004 accepted ordered hotspot reduction after the ADR-0003
 # facade-preservation exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the action-policy helper extraction, so this baseline records the lowered
-# Phase 50.8.5 ceiling and fails on silent re-growth. A future ADR or
+# the Phase 50.8 extraction sequence, so this baseline records the final
+# Phase 50.8.6 ceiling and fails on silent re-growth. A future ADR or
 # maintainability backlog must lower or replace these limits before unrelated
 # feature expansion lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=3505 max_effective_lines=3182 max_facade_methods=185 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.5 issue=#966
+control-plane/aegisops_control_plane/service.py max_lines=3505 max_effective_lines=3182 max_facade_methods=185 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.6 issue=#967

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,10 +1,10 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.8.5 continues the ordered maintainability hotspot reduction sequence governed by ADR-0004.
+Phase 50.8.6 closes the ordered maintainability hotspot reduction sequence governed by ADR-0004 and ADR-0005.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
-ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
+ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0005 governs the Phase 50.8 residual service migration contract. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
 
 ## Accepted Verifier State
 
@@ -12,16 +12,18 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50 extraction and fencing work. Phase 50.8.5 lowered the accepted residual ceiling for #966 to:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.8 extraction and fencing work. The final Phase 50.8.6 closeout for #967 records the accepted residual ceiling as:
 
 - `max_lines=3505`
 - `max_effective_lines=3182`
 - `max_facade_methods=185`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.8.5`
+- `phase=50.8.6`
 
 No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, or operator UI route tests because the verifier does not report those areas as current responsibility-growth candidates.
+
+The remaining accepted hotspot is not a general extension target. The residual helper pressure is concentrated in the action review projection and visibility helper cluster plus intake and authoritative-state guard helpers that still sit behind the public facade. Those helpers remain review-visible because they protect action review state, detection intake linkage, and fail-closed authoritative-state reads at the service boundary.
 
 ## Follow-Up Trigger
 
@@ -30,6 +32,8 @@ The service facade remains above the long-term 1,500-line and 50-method targets.
 Any silent re-growth beyond the recorded ceiling must fail the verifier. The expected response is another decomposition decision or maintainability backlog before unrelated feature expansion lands in the facade.
 
 If a later extraction lowers the facade below the verifier threshold, maintainers should remove or lower the baseline only after confirming that the file no longer crosses the responsibility-growth threshold.
+
+If future work needs to add another action-review surface, intake pathway, authoritative restore/read guard, or cross-record projection helper to `service.py`, that is the follow-up trigger for another maintainability issue. The follow-up should extract or fence the directly linked helper cluster instead of using this exception as approval for new facade responsibility.
 
 ## Verification Evidence
 

--- a/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -160,6 +160,15 @@ valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
 
+duplicate_baseline_repo="${workdir}/duplicate-baseline"
+create_valid_repo "${duplicate_baseline_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=3505 max_effective_lines=3182 max_facade_methods=185 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.6 issue=#967" \
+  >>"${duplicate_baseline_repo}/docs/maintainability-hotspot-baseline.txt"
+assert_fails_with \
+  "${duplicate_baseline_repo}" \
+  "Phase 50.8 contract requires exactly one service.py hotspot baseline entry."
+
 final_closeout_repo="${workdir}/final-closeout"
 create_valid_repo "${final_closeout_repo}"
 printf '%s\n' \

--- a/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -160,6 +160,26 @@ valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
 
+final_closeout_repo="${workdir}/final-closeout"
+create_valid_repo "${final_closeout_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=3505 max_effective_lines=3182 max_facade_methods=185 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.6 issue=#967" \
+  >"${final_closeout_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${final_closeout_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.8.6 records the final #967 closeout baseline.
+
+- `max_lines=3505`
+- `max_effective_lines=3182`
+- `max_facade_methods=185`
+
+The remaining accepted hotspot is the action review projection and visibility helper cluster plus intake and authoritative-state guard helpers.
+
+Any silent re-growth requires another decomposition decision.
+EOF
+assert_passes "${final_closeout_repo}"
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md"

--- a/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -86,15 +86,20 @@ for phrase in "${required_phrases[@]}"; do
 done
 
 phase50_7_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=5660 max_effective_lines=5250 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.7 issue=#953"
-if grep -Fq -- "${phase50_7_baseline_entry}" "${baseline_path}"; then
-  echo "Phase 50.8 residual service hotspot contract fixes clusters, migration order, measurement guard, non-goals, and validation commands."
-  exit 0
-fi
-
 baseline_entry="$(grep -E '^control-plane/aegisops_control_plane/service.py[[:space:]]' "${baseline_path}" || true)"
-if [[ -z "${baseline_entry}" ]]; then
+baseline_entry_count="$(printf '%s\n' "${baseline_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [[ "${baseline_entry_count}" -eq 0 ]]; then
   echo "Phase 50.8 contract requires a service.py hotspot baseline entry." >&2
   exit 1
+fi
+if [[ "${baseline_entry_count}" -ne 1 ]]; then
+  echo "Phase 50.8 contract requires exactly one service.py hotspot baseline entry." >&2
+  exit 1
+fi
+
+if [[ "${baseline_entry}" == "${phase50_7_baseline_entry}" ]]; then
+  echo "Phase 50.8 residual service hotspot contract fixes clusters, migration order, measurement guard, non-goals, and validation commands."
+  exit 0
 fi
 
 metadata_value() {

--- a/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 doc_path="${repo_root}/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md"
 baseline_path="${repo_root}/docs/maintainability-hotspot-baseline.txt"
+closeout_path="${repo_root}/docs/phase-50-maintainability-closeout.md"
 
 required_headings=(
   "# ADR-0005: Phase 50.8 Residual Service Hotspot Migration Contract"
@@ -84,10 +85,85 @@ for phrase in "${required_phrases[@]}"; do
   fi
 done
 
-required_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=5660 max_effective_lines=5250 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.7 issue=#953"
-if ! grep -Fq -- "${required_baseline_entry}" "${baseline_path}"; then
-  echo "Phase 50.8 contract requires the Phase 50.7 service.py ceiling to remain unchanged until implementation evidence exists." >&2
+phase50_7_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=5660 max_effective_lines=5250 max_facade_methods=203 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.7 issue=#953"
+if grep -Fq -- "${phase50_7_baseline_entry}" "${baseline_path}"; then
+  echo "Phase 50.8 residual service hotspot contract fixes clusters, migration order, measurement guard, non-goals, and validation commands."
+  exit 0
+fi
+
+baseline_entry="$(grep -E '^control-plane/aegisops_control_plane/service.py[[:space:]]' "${baseline_path}" || true)"
+if [[ -z "${baseline_entry}" ]]; then
+  echo "Phase 50.8 contract requires a service.py hotspot baseline entry." >&2
   exit 1
 fi
+
+metadata_value() {
+  local key="$1"
+  awk -v key="${key}" '
+    {
+      for (field_index = 2; field_index <= NF; field_index++) {
+        split($field_index, item, "=")
+        if (item[1] == key) {
+          print item[2]
+          exit
+        }
+      }
+    }
+  ' <<<"${baseline_entry}"
+}
+
+max_lines="$(metadata_value max_lines)"
+max_effective_lines="$(metadata_value max_effective_lines)"
+max_facade_methods="$(metadata_value max_facade_methods)"
+facade_class="$(metadata_value facade_class)"
+adr_exception="$(metadata_value adr_exception)"
+phase="$(metadata_value phase)"
+issue="$(metadata_value issue)"
+
+if [[
+  "${facade_class}" != "AegisOpsControlPlaneService" ||
+  "${adr_exception}" != "ADR-0003" ||
+  "${phase}" != "50.8.6" ||
+  "${issue}" != "#967"
+]]; then
+  echo "Phase 50.8 contract requires the Phase 50.7 service.py ceiling to remain unchanged until implementation evidence exists. After implementation evidence exists, it requires a final Phase 50.8.6 closeout baseline for #967." >&2
+  exit 1
+fi
+
+if [[
+  -z "${max_lines}" ||
+  -z "${max_effective_lines}" ||
+  -z "${max_facade_methods}" ||
+  "${max_lines}" -ge 5660 ||
+  "${max_effective_lines}" -ge 5250 ||
+  "${max_facade_methods}" -ge 203
+]]; then
+  echo "Phase 50.8 final closeout baseline must remain lower than the Phase 50.7 ceiling." >&2
+  exit 1
+fi
+
+if [[ ! -f "${closeout_path}" ]]; then
+  echo "Phase 50.8 final baseline refresh requires closeout evidence: ${closeout_path}" >&2
+  exit 1
+fi
+
+closeout_required_phrases=(
+  "Phase 50.8.6"
+  "#967"
+  "\`max_lines=${max_lines}\`"
+  "\`max_effective_lines=${max_effective_lines}\`"
+  "\`max_facade_methods=${max_facade_methods}\`"
+  "action review projection and visibility helper cluster"
+  "intake and authoritative-state guard helpers"
+  "silent re-growth"
+  "another decomposition decision"
+)
+
+for phrase in "${closeout_required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
+    echo "Phase 50.8 final closeout evidence is missing: ${phrase}" >&2
+    exit 1
+  fi
+done
 
 echo "Phase 50.8 residual service hotspot contract fixes clusters, migration order, measurement guard, non-goals, and validation commands."


### PR DESCRIPTION
## Summary
- Refresh the residual `service.py` maintainability hotspot baseline to the final Phase 50.8.6/#967 closeout evidence.
- Document the remaining action-review projection/visibility and intake/authoritative-state guard helper clusters plus follow-up triggers.
- Tighten closeout and ADR-0005 verifier coverage so final baseline refresh requires lower ceilings and closeout evidence.

## Verification
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-phase-50-8-residual-service-hotspot-contract.sh`
- `bash scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh`
- `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py`
- `python3 -m unittest control-plane/tests/test_phase49_service_decomposition_closeout.py control-plane/tests/test_service_persistence_restore_readiness.py control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py control-plane/tests/test_cli_inspection_action_reviews.py control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_service_persistence_ingest_case_lifecycle.py control-plane/tests/test_action_review_write_boundary.py`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
- `node <codex-supervisor-root>/dist/index.js issue-lint 967 --config <supervisor-config-path>`

Part of #961.
Closes #967.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated maintainability hotspot baseline and Phase 50 closeout from 50.8.5 to 50.8.6, clarified governance and narrowed allowed responsibility areas.

* **Tests**
  * Updated validations to reference Phase 50.8.6 and issue #967 and require additional hotspot closeout notes.
  * Strengthened verification scripts/tests to enforce a single baseline entry and added duplicate-baseline and final-closeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->