### PR TITLE
Phase 50.9.3 residual helper extraction

### DIFF
--- a/control-plane/aegisops_control_plane/persistence_lifecycle.py
+++ b/control-plane/aegisops_control_plane/persistence_lifecycle.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from datetime import datetime
+from typing import Callable, Protocol, Type, TypeVar
+
+from .models import (
+    ControlPlaneRecord,
+    LifecycleTransitionRecord,
+)
+
+
+RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
+
+
+class _PersistenceStore(Protocol):
+    def get(self, record_type: Type[RecordT], record_id: str) -> RecordT | None:
+        ...
+
+    def save(self, record: RecordT) -> RecordT:
+        ...
+
+    def transaction(
+        self,
+        *,
+        isolation_level: str | None = None,
+    ) -> AbstractContextManager[None]:
+        ...
+
+
+class _LifecycleTransitionHelper(Protocol):
+    def linked_alert_case_lifecycle_lock_subject(
+        self,
+        record: ControlPlaneRecord,
+    ) -> tuple[str, str] | None:
+        ...
+
+    def lock_lifecycle_transition_subject(
+        self,
+        record_family: str,
+        record_id: str,
+    ) -> None:
+        ...
+
+    def build_lifecycle_transition_records(
+        self,
+        record: ControlPlaneRecord,
+        *,
+        existing_record: ControlPlaneRecord | None,
+        transitioned_at: datetime | None = None,
+    ) -> tuple[LifecycleTransitionRecord, ...]:
+        ...
+
+
+class PersistenceLifecycleService:
+    def __init__(
+        self,
+        *,
+        store: _PersistenceStore,
+        lifecycle_transition_helper: _LifecycleTransitionHelper,
+        require_aware_datetime: Callable[[datetime, str], datetime],
+    ) -> None:
+        self._store = store
+        self._lifecycle_transition_helper = lifecycle_transition_helper
+        self._require_aware_datetime = require_aware_datetime
+
+    def persist_record(
+        self,
+        record: RecordT,
+        *,
+        transitioned_at: datetime | None = None,
+    ) -> RecordT:
+        if isinstance(record, LifecycleTransitionRecord):
+            raise ValueError(
+                "persist_record does not accept direct lifecycle transition records"
+            )
+        if transitioned_at is not None:
+            transitioned_at = self._require_aware_datetime(
+                transitioned_at,
+                "transitioned_at",
+            )
+        with self._store.transaction():
+            lineage_lock_subject = (
+                self._lifecycle_transition_helper.linked_alert_case_lifecycle_lock_subject(
+                    record
+                )
+            )
+            if lineage_lock_subject is not None:
+                self._lifecycle_transition_helper.lock_lifecycle_transition_subject(
+                    *lineage_lock_subject
+                )
+            self._lifecycle_transition_helper.lock_lifecycle_transition_subject(
+                record.record_family,
+                record.record_id,
+            )
+            existing_record = self._store.get(type(record), record.record_id)
+            persisted_record = self._store.save(record)
+            transition_records = (
+                self._lifecycle_transition_helper.build_lifecycle_transition_records(
+                    persisted_record,
+                    existing_record=existing_record,
+                    transitioned_at=transitioned_at,
+                )
+            )
+            for transition_record in transition_records:
+                self._store.save(transition_record)
+            return persisted_record
+
+
+__all__ = [
+    "PersistenceLifecycleService",
+]

--- a/control-plane/aegisops_control_plane/restore_readiness.py
+++ b/control-plane/aegisops_control_plane/restore_readiness.py
@@ -30,12 +30,8 @@ class RestoreReadinessService:
         json_ready: Callable[[object], object],
         redacted_reconciliation_payload: Callable[[ReconciliationRecord], dict[str, object]],
         readiness_operability_helper: Any,
-        build_shutdown_status_snapshot: Callable[..., Any],
+        shutdown_status_snapshot_factory: Callable[..., Any],
         derive_readiness_status: Callable[..., str],
-        record_from_backup_payload: Callable[
-            [Type[ControlPlaneRecord], Mapping[str, object]],
-            ControlPlaneRecord,
-        ],
         authoritative_record_chain_record_types: tuple[Type[ControlPlaneRecord], ...],
         authoritative_record_chain_backup_schema_version: str,
         authoritative_primary_id_field_by_family: Mapping[str, str],
@@ -105,7 +101,7 @@ class RestoreReadinessService:
                     snapshots,
                 )
             ),
-            build_shutdown_status_snapshot=build_shutdown_status_snapshot,
+            shutdown_status_snapshot_factory=shutdown_status_snapshot_factory,
             derive_readiness_status=derive_readiness_status,
         )
         self._backup_restore_flow = _BackupRestoreFlow(
@@ -126,7 +122,6 @@ class RestoreReadinessService:
                 )
             ),
             derive_readiness_status=derive_readiness_status,
-            record_from_backup_payload=record_from_backup_payload,
             authoritative_record_chain_record_types=(
                 authoritative_record_chain_record_types
             ),

--- a/control-plane/aegisops_control_plane/restore_readiness.py
+++ b/control-plane/aegisops_control_plane/restore_readiness.py
@@ -41,7 +41,7 @@ class RestoreReadinessService:
             [ControlPlaneRecord, datetime | None],
             LifecycleTransitionRecord | None,
         ],
-        assistant_ids_from_mapping: Callable[[Mapping[str, object] | None, str], tuple[str, ...]],
+        assistant_ids_from_mapping: Callable[[Mapping[str, object], str], tuple[str, ...]],
         inspect_case_detail: Callable[[str], Any],
         inspect_assistant_context: Callable[[str, str], Any],
         inspect_reconciliation_status: Callable[[], Any],

--- a/control-plane/aegisops_control_plane/restore_readiness_backup_restore.py
+++ b/control-plane/aegisops_control_plane/restore_readiness_backup_restore.py
@@ -155,13 +155,21 @@ def _record_from_backup_payload(
                     f"{family}.{field_info.name} must contain only non-empty strings"
                 )
         elif field_info.name in mapping_fields:
-            if not isinstance(value, Mapping):
-                raise ValueError(
-                    f"{family}.{field_info.name} must be a JSON object in restore payload"
-                )
-            value = {str(key): item for key, item in value.items()}
+            value = _parse_backup_mapping(value, family, field_info.name)
         kwargs[field_info.name] = value
     return record_type(**kwargs)
+
+
+def _parse_backup_mapping(
+    value: object,
+    family: str,
+    field_name: str,
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(
+            f"{family}.{field_name} must be a JSON object in restore payload"
+        )
+    return {str(key): item for key, item in value.items()}
 
 
 def _is_nested_transaction_isolation_level_error(exc: ValueError) -> bool:

--- a/control-plane/aegisops_control_plane/restore_readiness_backup_restore.py
+++ b/control-plane/aegisops_control_plane/restore_readiness_backup_restore.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Iterator, Mapping, Type
+from typing import Any, Callable, Iterator, Mapping, Type, TypeVar
 
 from .models import (
     AITraceRecord,
@@ -48,6 +48,48 @@ _NESTED_TRANSACTION_ISOLATION_LEVEL_ERROR_SNIPPETS = (
     "isolation_level",
     "active transaction",
 )
+_BACKUP_DATETIME_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
+    "analytic_signal": ("first_seen_at", "last_seen_at"),
+    "evidence": ("acquired_at",),
+    "observation": ("observed_at",),
+    "lifecycle_transition": ("transitioned_at",),
+    "approval_decision": ("decided_at", "approved_expires_at"),
+    "action_request": ("requested_at", "expires_at"),
+    "action_execution": ("delegated_at", "expires_at"),
+    "hunt": ("opened_at",),
+    "hunt_run": ("started_at", "completed_at"),
+    "ai_trace": ("generated_at",),
+    "reconciliation": ("first_seen_at", "last_seen_at", "compared_at"),
+}
+_BACKUP_TUPLE_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
+    "analytic_signal": ("alert_ids", "case_ids"),
+    "case": ("evidence_ids",),
+    "observation": ("supporting_evidence_ids",),
+    "approval_decision": ("approver_identities",),
+    "ai_trace": ("material_input_refs",),
+    "reconciliation": ("linked_execution_run_ids",),
+}
+_BACKUP_MAPPING_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
+    "analytic_signal": ("reviewed_context",),
+    "alert": ("reviewed_context",),
+    "case": ("reviewed_context",),
+    "recommendation": ("reviewed_context", "assistant_advisory_draft"),
+    "lifecycle_transition": ("attribution",),
+    "approval_decision": ("target_snapshot",),
+    "action_request": (
+        "target_scope",
+        "requested_payload",
+        "policy_basis",
+        "policy_evaluation",
+    ),
+    "action_execution": ("target_scope", "approved_payload", "provenance"),
+    "hunt_run": ("scope_snapshot", "output_linkage"),
+    "ai_trace": ("subject_linkage", "assistant_advisory_draft"),
+    "reconciliation": ("subject_linkage",),
+}
+
+
+RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
 
 
 def _parse_optional_backup_created_at(value: object) -> datetime | None:
@@ -62,6 +104,64 @@ def _parse_optional_backup_created_at(value: object) -> datetime | None:
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         return None
     return parsed
+
+
+def _parse_backup_datetime(value: object, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty ISO 8601 datetime")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be a valid ISO 8601 datetime") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone offset")
+    return parsed
+
+
+def _record_from_backup_payload(
+    record_type: Type[RecordT],
+    payload: Mapping[str, object],
+) -> RecordT:
+    if not isinstance(payload, Mapping):
+        raise ValueError(
+            f"{record_type.record_family} backup entries must be JSON objects"
+        )
+    family = record_type.record_family
+    datetime_fields = set(_BACKUP_DATETIME_FIELDS_BY_FAMILY.get(family, ()))
+    tuple_fields = set(_BACKUP_TUPLE_FIELDS_BY_FAMILY.get(family, ()))
+    mapping_fields = set(_BACKUP_MAPPING_FIELDS_BY_FAMILY.get(family, ()))
+    kwargs: dict[str, object] = {}
+    for field_info in fields(record_type):
+        if field_info.name not in payload:
+            raise ValueError(
+                f"{family} backup entry is missing required field {field_info.name!r}"
+            )
+        value = payload[field_info.name]
+        if field_info.name in datetime_fields:
+            value = _parse_backup_datetime(value, field_info.name)
+        elif field_info.name in tuple_fields:
+            if value is None:
+                value = ()
+            elif isinstance(value, list):
+                value = tuple(value)
+            elif not isinstance(value, tuple):
+                raise ValueError(
+                    f"{family}.{field_info.name} must be a JSON array in restore payload"
+                )
+            if any(not isinstance(item, str) or not item.strip() for item in value):
+                raise ValueError(
+                    f"{family}.{field_info.name} must contain only non-empty strings"
+                )
+        elif field_info.name in mapping_fields:
+            if not isinstance(value, Mapping):
+                raise ValueError(
+                    f"{family}.{field_info.name} must be a JSON object in restore payload"
+                )
+            value = {str(key): item for key, item in value.items()}
+        kwargs[field_info.name] = value
+    return record_type(**kwargs)
 
 
 def _is_nested_transaction_isolation_level_error(exc: ValueError) -> bool:
@@ -211,10 +311,6 @@ class _BackupRestoreFlow:
             [Any, list[dict[str, object]]], dict[str, object]
         ],
         derive_readiness_status: Callable[..., str],
-        record_from_backup_payload: Callable[
-            [Type[ControlPlaneRecord], Mapping[str, object]],
-            ControlPlaneRecord,
-        ],
         authoritative_record_chain_record_types: tuple[Type[ControlPlaneRecord], ...],
         authoritative_record_chain_backup_schema_version: str,
         authoritative_primary_id_field_by_family: Mapping[str, str],
@@ -242,7 +338,7 @@ class _BackupRestoreFlow:
             build_readiness_review_path_health
         )
         self._derive_readiness_status = derive_readiness_status
-        self._record_from_backup_payload = record_from_backup_payload
+        self._record_from_backup_payload = _record_from_backup_payload
         self._authoritative_record_chain_record_types = (
             authoritative_record_chain_record_types
         )

--- a/control-plane/aegisops_control_plane/restore_readiness_backup_restore.py
+++ b/control-plane/aegisops_control_plane/restore_readiness_backup_restore.py
@@ -319,7 +319,7 @@ class _BackupRestoreFlow:
             [ControlPlaneRecord, datetime | None],
             LifecycleTransitionRecord | None,
         ],
-        assistant_ids_from_mapping: Callable[[Mapping[str, object] | None, str], tuple[str, ...]],
+        assistant_ids_from_mapping: Callable[[Mapping[str, object], str], tuple[str, ...]],
         inspect_case_detail: Callable[[str], Any],
         inspect_assistant_context: Callable[[str, str], Any],
         inspect_reconciliation_status: Callable[[], Any],

--- a/control-plane/aegisops_control_plane/restore_readiness_projection.py
+++ b/control-plane/aegisops_control_plane/restore_readiness_projection.py
@@ -40,7 +40,7 @@ class _ReadinessHealthProjection:
         build_optional_extension_operability: Callable[
             [ReadinessDiagnosticsAggregates, list[dict[str, object]]], dict[str, object]
         ],
-        build_shutdown_status_snapshot: Callable[..., Any],
+        shutdown_status_snapshot_factory: Callable[..., Any],
         derive_readiness_status: Callable[..., str],
     ) -> None:
         self._config = config
@@ -64,7 +64,7 @@ class _ReadinessHealthProjection:
         self._build_optional_extension_operability = (
             build_optional_extension_operability
         )
-        self._build_shutdown_status_snapshot = build_shutdown_status_snapshot
+        self._shutdown_status_snapshot_factory = shutdown_status_snapshot_factory
         self._derive_readiness_status = derive_readiness_status
 
     def describe_startup_status(self) -> Any:
@@ -144,6 +144,41 @@ class _ReadinessHealthProjection:
             active_action_request_ids=readiness_aggregates.active_action_request_ids,
             active_action_execution_ids=readiness_aggregates.active_action_execution_ids,
             unresolved_reconciliation_ids=readiness_aggregates.unresolved_reconciliation_ids,
+        )
+
+    def _build_shutdown_status_snapshot(
+        self,
+        *,
+        open_case_ids: tuple[str, ...],
+        active_action_request_ids: tuple[str, ...],
+        active_action_execution_ids: tuple[str, ...],
+        unresolved_reconciliation_ids: tuple[str, ...],
+    ) -> Any:
+        blocking_reasons: list[str] = []
+        if open_case_ids:
+            blocking_reasons.append(
+                "controlled shutdown requires resolving or explicitly handing off open casework"
+            )
+        if active_action_request_ids:
+            blocking_reasons.append(
+                "controlled shutdown requires approval-bound action requests to leave an inactive state"
+            )
+        if active_action_execution_ids:
+            blocking_reasons.append(
+                "controlled shutdown requires dispatching, queued, or running executions to reach a terminal state"
+            )
+        if unresolved_reconciliation_ids:
+            blocking_reasons.append(
+                "controlled shutdown requires pending reconciliation mismatches to be reviewed first"
+            )
+        return self._shutdown_status_snapshot_factory(
+            read_only=True,
+            shutdown_ready=not blocking_reasons,
+            blocking_reasons=tuple(blocking_reasons),
+            open_case_ids=open_case_ids,
+            active_action_request_ids=active_action_request_ids,
+            active_action_execution_ids=active_action_execution_ids,
+            unresolved_reconciliation_ids=unresolved_reconciliation_ids,
         )
 
     def inspect_readiness_diagnostics(self) -> Any:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -44,7 +44,6 @@ from .models import (
     ReconciliationRecord,
     RecommendationRecord,
 )
-from .persistence_lifecycle import PersistenceLifecycleService
 from .readiness_contracts import (
     ReadinessDiagnosticsAggregates,
     resolve_current_readiness_runtime_status,
@@ -1214,12 +1213,8 @@ class AegisOpsControlPlaneService:
         self._runtime_restore_readiness_diagnostics_service = (
             composition.runtime_restore_readiness_diagnostics_service
         )
-        self._persistence_lifecycle_service = PersistenceLifecycleService(
-            store=self._store,
-            lifecycle_transition_helper=(
-                self._detection_intake_service.lifecycle_transition_helper
-            ),
-            require_aware_datetime=self._require_aware_datetime,
+        self._persistence_lifecycle_service = (
+            composition.persistence_lifecycle_service
         )
 
     def describe_runtime(self) -> RuntimeSnapshot:

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -44,6 +44,7 @@ from .models import (
     ReconciliationRecord,
     RecommendationRecord,
 )
+from .persistence_lifecycle import PersistenceLifecycleService
 from .readiness_contracts import (
     ReadinessDiagnosticsAggregates,
     resolve_current_readiness_runtime_status,
@@ -694,45 +695,6 @@ _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY: dict[str, str] = {
     "ai_trace": "ai_trace_id",
     "reconciliation": "reconciliation_id",
 }
-_BACKUP_DATETIME_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
-    "analytic_signal": ("first_seen_at", "last_seen_at"),
-    "evidence": ("acquired_at",),
-    "observation": ("observed_at",),
-    "lifecycle_transition": ("transitioned_at",),
-    "approval_decision": ("decided_at", "approved_expires_at"),
-    "action_request": ("requested_at", "expires_at"),
-    "action_execution": ("delegated_at", "expires_at"),
-    "hunt": ("opened_at",),
-    "hunt_run": ("started_at", "completed_at"),
-    "ai_trace": ("generated_at",),
-    "reconciliation": ("first_seen_at", "last_seen_at", "compared_at"),
-}
-_BACKUP_TUPLE_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
-    "analytic_signal": ("alert_ids", "case_ids"),
-    "case": ("evidence_ids",),
-    "observation": ("supporting_evidence_ids",),
-    "approval_decision": ("approver_identities",),
-    "ai_trace": ("material_input_refs",),
-    "reconciliation": ("linked_execution_run_ids",),
-}
-_BACKUP_MAPPING_FIELDS_BY_FAMILY: dict[str, tuple[str, ...]] = {
-    "analytic_signal": ("reviewed_context",),
-    "alert": ("reviewed_context",),
-    "case": ("reviewed_context",),
-    "recommendation": ("reviewed_context", "assistant_advisory_draft"),
-    "lifecycle_transition": ("attribution",),
-    "approval_decision": ("target_snapshot",),
-    "action_request": (
-        "target_scope",
-        "requested_payload",
-        "policy_basis",
-        "policy_evaluation",
-    ),
-    "action_execution": ("target_scope", "approved_payload", "provenance"),
-    "hunt_run": ("scope_snapshot", "output_linkage"),
-    "ai_trace": ("subject_linkage", "assistant_advisory_draft"),
-    "reconciliation": ("subject_linkage",),
-}
 
 def _json_ready(value: object) -> object:
     if isinstance(value, _DATETIME_TYPE):
@@ -857,98 +819,6 @@ def _redacted_reconciliation_payload(
         payload["subject_linkage"] = redacted_subject_linkage
     return payload
 
-
-def _build_shutdown_status_snapshot(
-    *,
-    open_case_ids: tuple[str, ...],
-    active_action_request_ids: tuple[str, ...],
-    active_action_execution_ids: tuple[str, ...],
-    unresolved_reconciliation_ids: tuple[str, ...],
-) -> ShutdownStatusSnapshot:
-    blocking_reasons: list[str] = []
-    if open_case_ids:
-        blocking_reasons.append(
-            "controlled shutdown requires resolving or explicitly handing off open casework"
-        )
-    if active_action_request_ids:
-        blocking_reasons.append(
-            "controlled shutdown requires approval-bound action requests to leave an inactive state"
-        )
-    if active_action_execution_ids:
-        blocking_reasons.append(
-            "controlled shutdown requires dispatching, queued, or running executions to reach a terminal state"
-        )
-    if unresolved_reconciliation_ids:
-        blocking_reasons.append(
-            "controlled shutdown requires pending reconciliation mismatches to be reviewed first"
-        )
-    return ShutdownStatusSnapshot(
-        read_only=True,
-        shutdown_ready=not blocking_reasons,
-        blocking_reasons=tuple(blocking_reasons),
-        open_case_ids=open_case_ids,
-        active_action_request_ids=active_action_request_ids,
-        active_action_execution_ids=active_action_execution_ids,
-        unresolved_reconciliation_ids=unresolved_reconciliation_ids,
-    )
-
-
-def _parse_backup_datetime(value: object, field_name: str) -> datetime | None:
-    if value is None:
-        return None
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{field_name} must be a non-empty ISO 8601 datetime")
-    try:
-        parsed = datetime.fromisoformat(value)
-    except ValueError as exc:
-        raise ValueError(f"{field_name} must be a valid ISO 8601 datetime") from exc
-    if parsed.tzinfo is None:
-        raise ValueError(f"{field_name} must include a timezone offset")
-    return parsed
-
-
-def _record_from_backup_payload(
-    record_type: Type[RecordT],
-    payload: Mapping[str, object],
-) -> RecordT:
-    if not isinstance(payload, Mapping):
-        raise ValueError(
-            f"{record_type.record_family} backup entries must be JSON objects"
-        )
-    family = record_type.record_family
-    datetime_fields = set(_BACKUP_DATETIME_FIELDS_BY_FAMILY.get(family, ()))
-    tuple_fields = set(_BACKUP_TUPLE_FIELDS_BY_FAMILY.get(family, ()))
-    mapping_fields = set(_BACKUP_MAPPING_FIELDS_BY_FAMILY.get(family, ()))
-    kwargs: dict[str, object] = {}
-    for field_info in fields(record_type):
-        if field_info.name not in payload:
-            raise ValueError(
-                f"{family} backup entry is missing required field {field_info.name!r}"
-            )
-        value = payload[field_info.name]
-        if field_info.name in datetime_fields:
-            value = _parse_backup_datetime(value, field_info.name)
-        elif field_info.name in tuple_fields:
-            if value is None:
-                value = ()
-            elif isinstance(value, list):
-                value = tuple(value)
-            elif not isinstance(value, tuple):
-                raise ValueError(
-                    f"{family}.{field_info.name} must be a JSON array in restore payload"
-                )
-            if any(not isinstance(item, str) or not item.strip() for item in value):
-                raise ValueError(
-                    f"{family}.{field_info.name} must contain only non-empty strings"
-                )
-        elif field_info.name in mapping_fields:
-            if not isinstance(value, Mapping):
-                raise ValueError(
-                    f"{family}.{field_info.name} must be a JSON object in restore payload"
-                )
-            value = {str(key): item for key, item in value.items()}
-        kwargs[field_info.name] = value
-    return record_type(**kwargs)
 
 def _merge_reviewed_context(
     existing_context: Mapping[str, object] | None,
@@ -1294,9 +1164,8 @@ class AegisOpsControlPlaneService:
                 readiness_diagnostics_snapshot_factory=ReadinessDiagnosticsSnapshot,
                 restore_drill_snapshot_factory=RestoreDrillSnapshot,
                 restore_summary_snapshot_factory=RestoreSummarySnapshot,
-                build_shutdown_status_snapshot=_build_shutdown_status_snapshot,
+                shutdown_status_snapshot_factory=ShutdownStatusSnapshot,
                 derive_readiness_status=_derive_readiness_status,
-                record_from_backup_payload=_record_from_backup_payload,
                 find_duplicate_strings=_find_duplicate_strings,
             ),
         )
@@ -1345,6 +1214,13 @@ class AegisOpsControlPlaneService:
         self._runtime_restore_readiness_diagnostics_service = (
             composition.runtime_restore_readiness_diagnostics_service
         )
+        self._persistence_lifecycle_service = PersistenceLifecycleService(
+            store=self._store,
+            lifecycle_transition_helper=(
+                self._detection_intake_service.lifecycle_transition_helper
+            ),
+            require_aware_datetime=self._require_aware_datetime,
+        )
 
     def describe_runtime(self) -> RuntimeSnapshot:
         return self._runtime_restore_readiness_diagnostics_service.describe_runtime()
@@ -1355,33 +1231,10 @@ class AegisOpsControlPlaneService:
         *,
         transitioned_at: datetime | None = None,
     ) -> RecordT:
-        if isinstance(record, LifecycleTransitionRecord):
-            raise ValueError(
-                "persist_record does not accept direct lifecycle transition records"
-            )
-        if transitioned_at is not None:
-            transitioned_at = self._require_aware_datetime(
-                transitioned_at,
-                "transitioned_at",
-            )
-        with self._store.transaction():
-            lineage_lock_subject = self._linked_alert_case_lifecycle_lock_subject(record)
-            if lineage_lock_subject is not None:
-                self._lock_lifecycle_transition_subject(*lineage_lock_subject)
-            self._lock_lifecycle_transition_subject(
-                record.record_family,
-                record.record_id,
-            )
-            existing_record = self._store.get(type(record), record.record_id)
-            persisted_record = self._store.save(record)
-            transition_records = self._build_lifecycle_transition_records(
-                persisted_record,
-                existing_record=existing_record,
-                transitioned_at=transitioned_at,
-            )
-            for transition_record in transition_records:
-                self._store.save(transition_record)
-            return persisted_record
+        return self._persistence_lifecycle_service.persist_record(
+            record,
+            transitioned_at=transitioned_at,
+        )
 
     def _lock_lifecycle_transition_subject(
         self,

--- a/control-plane/aegisops_control_plane/service_composition.py
+++ b/control-plane/aegisops_control_plane/service_composition.py
@@ -85,12 +85,8 @@ class ControlPlaneServiceCompositionDependencies:
     readiness_diagnostics_snapshot_factory: Callable[..., Any]
     restore_drill_snapshot_factory: Callable[..., Any]
     restore_summary_snapshot_factory: Callable[..., Any]
-    build_shutdown_status_snapshot: Callable[..., Any]
+    shutdown_status_snapshot_factory: Callable[..., Any]
     derive_readiness_status: Callable[..., str]
-    record_from_backup_payload: Callable[
-        [Type[ControlPlaneRecord], Mapping[str, object]],
-        ControlPlaneRecord,
-    ]
     find_duplicate_strings: Callable[[tuple[str, ...]], tuple[str, ...]]
 
 
@@ -279,11 +275,10 @@ def build_control_plane_service_composition(
             dependencies.redacted_reconciliation_payload
         ),
         readiness_operability_helper=readiness_operability_helper,
-        build_shutdown_status_snapshot=(
-            dependencies.build_shutdown_status_snapshot
+        shutdown_status_snapshot_factory=(
+            dependencies.shutdown_status_snapshot_factory
         ),
         derive_readiness_status=dependencies.derive_readiness_status,
-        record_from_backup_payload=dependencies.record_from_backup_payload,
         authoritative_record_chain_record_types=(
             dependencies.authoritative_record_chain_record_types
         ),

--- a/control-plane/aegisops_control_plane/service_composition.py
+++ b/control-plane/aegisops_control_plane/service_composition.py
@@ -32,6 +32,7 @@ from .external_evidence_boundary import ExternalEvidenceBoundary
 from .live_assistant_workflow import LiveAssistantWorkflowCoordinator
 from .models import ControlPlaneRecord, ReconciliationRecord
 from .operator_inspection import OperatorInspectionReadSurface
+from .persistence_lifecycle import PersistenceLifecycleService
 from .readiness_operability import ReadinessOperabilityHelper
 from .restore_readiness import RestoreReadinessService
 from .reviewed_slice_policy import ReviewedSlicePolicy
@@ -121,6 +122,7 @@ class ControlPlaneServiceComposition:
     runtime_restore_readiness_diagnostics_service: (
         RuntimeRestoreReadinessDiagnosticsService
     )
+    persistence_lifecycle_service: PersistenceLifecycleService
 
 
 def build_control_plane_service_composition(
@@ -313,6 +315,13 @@ def build_control_plane_service_composition(
             restore_readiness_service=restore_readiness_service,
         )
     )
+    persistence_lifecycle_service = PersistenceLifecycleService(
+        store=resolved_store,
+        lifecycle_transition_helper=(
+            detection_intake_service.lifecycle_transition_helper
+        ),
+        require_aware_datetime=service._require_aware_datetime,
+    )
 
     return ControlPlaneServiceComposition(
         store=resolved_store,
@@ -344,6 +353,7 @@ def build_control_plane_service_composition(
         runtime_restore_readiness_diagnostics_service=(
             runtime_restore_readiness_diagnostics_service
         ),
+        persistence_lifecycle_service=persistence_lifecycle_service,
     )
 
 

--- a/control-plane/tests/test_phase21_end_to_end_validation.py
+++ b/control-plane/tests/test_phase21_end_to_end_validation.py
@@ -417,7 +417,10 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
 
         post_rejection_queue = service.inspect_analyst_queue()
         self.assertEqual(post_rejection_queue.total_records, queue_view.total_records)
-        self.assertEqual(post_rejection_queue.records, queue_view.records)
+        self.assertEqual(
+            self._without_volatile_queue_age(post_rejection_queue.records),
+            self._without_volatile_queue_age(queue_view.records),
+        )
         post_rejection_readiness = service.inspect_readiness_diagnostics()
         self.assertEqual(
             post_rejection_readiness.metrics["alerts"],
@@ -426,6 +429,19 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
         self.assertEqual(
             post_rejection_readiness.metrics["cases"],
             baseline_readiness.metrics["cases"],
+        )
+
+    @staticmethod
+    def _without_volatile_queue_age(
+        records: tuple[dict[str, object], ...],
+    ) -> tuple[dict[str, object], ...]:
+        return tuple(
+            {
+                key: value
+                for key, value in record.items()
+                if key not in {"age_seconds", "age_bucket"}
+            }
+            for record in records
         )
 
 

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -442,20 +442,23 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         self.assertIn("persist_record", persistence_methods)
 
         persist_record = service_methods["persist_record"]
-        persisted_delegate_calls = [
-            node
-            for node in ast.walk(persist_record)
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "persist_record"
-            and isinstance(node.func.value, ast.Attribute)
-            and node.func.value.attr == "_persistence_lifecycle_service"
-        ]
         self.assertEqual(
-            len(persisted_delegate_calls),
+            len(persist_record.body),
             1,
-            "service.persist_record should remain a facade delegate",
+            "service.persist_record should stay as a single return delegate",
         )
+        self.assertIsInstance(persist_record.body[0], ast.Return)
+        delegate_call = persist_record.body[0].value
+        self.assertIsInstance(delegate_call, ast.Call)
+        self.assertIsInstance(delegate_call.func, ast.Attribute)
+        self.assertEqual(delegate_call.func.attr, "persist_record")
+        self.assertIsInstance(delegate_call.func.value, ast.Attribute)
+        self.assertEqual(
+            delegate_call.func.value.attr,
+            "_persistence_lifecycle_service",
+        )
+        self.assertIsInstance(delegate_call.func.value.value, ast.Name)
+        self.assertEqual(delegate_call.func.value.value.id, "self")
 
     def test_phase50_detection_linkage_helpers_live_with_detection_intake(
         self,

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -370,6 +370,93 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             composition_call_names,
         )
 
+    def test_phase50_9_3_persistence_restore_and_status_helpers_leave_service_facade(
+        self,
+    ) -> None:
+        service_source = self._read("control-plane/aegisops_control_plane/service.py")
+        backup_restore_source = self._read(
+            "control-plane/aegisops_control_plane/restore_readiness_backup_restore.py"
+        )
+        projection_source = self._read(
+            "control-plane/aegisops_control_plane/restore_readiness_projection.py"
+        )
+        persistence_source = self._read(
+            "control-plane/aegisops_control_plane/persistence_lifecycle.py"
+        )
+        service_tree = ast.parse(service_source)
+        backup_restore_functions = {
+            node.name
+            for node in ast.parse(backup_restore_source).body
+            if isinstance(node, ast.FunctionDef)
+        }
+        projection_class = next(
+            node
+            for node in ast.parse(projection_source).body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "_ReadinessHealthProjection"
+        )
+        projection_methods = {
+            node.name for node in projection_class.body if isinstance(node, ast.FunctionDef)
+        }
+        persistence_class = next(
+            node
+            for node in ast.parse(persistence_source).body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "PersistenceLifecycleService"
+        )
+        persistence_methods = {
+            node.name
+            for node in persistence_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+        service_class = next(
+            node
+            for node in service_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        service_methods = {
+            node.name: node
+            for node in service_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+        service_module_functions = {
+            node.name for node in service_tree.body if isinstance(node, ast.FunctionDef)
+        }
+
+        self.assertNotIn("_build_shutdown_status_snapshot", service_module_functions)
+        self.assertIn("_build_shutdown_status_snapshot", projection_methods)
+        self.assertFalse(
+            {
+                "_parse_backup_datetime",
+                "_record_from_backup_payload",
+            }
+            & service_module_functions
+        )
+        self.assertTrue(
+            {
+                "_parse_backup_datetime",
+                "_record_from_backup_payload",
+            }.issubset(backup_restore_functions)
+        )
+        self.assertIn("persist_record", persistence_methods)
+
+        persist_record = service_methods["persist_record"]
+        persisted_delegate_calls = [
+            node
+            for node in ast.walk(persist_record)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "persist_record"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "_persistence_lifecycle_service"
+        ]
+        self.assertEqual(
+            len(persisted_delegate_calls),
+            1,
+            "service.persist_record should remain a facade delegate",
+        )
+
     def test_phase50_detection_linkage_helpers_live_with_detection_intake(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -5805,7 +5805,7 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
         backup = service.export_authoritative_record_chain_backup()
         backup["record_families"]["reconciliation"][0]["subject_linkage"] = None
 
-        restored_store, _ = make_store()
+        restored_store, _ = support.make_store()
         restored_service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
             store=restored_store,

--- a/control-plane/tests/test_service_persistence_restore_readiness.py
+++ b/control-plane/tests/test_service_persistence_restore_readiness.py
@@ -5798,6 +5798,26 @@ class RestoreReadinessPersistenceTests(ServicePersistenceTestBase):
             restored_service.restore_authoritative_record_chain_backup(backup)
         self._assert_authoritative_store_empty(restored_store)
 
+    def test_service_phase21_restore_rejects_null_mapping_payload_fields(self) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["reconciliation"][0]["subject_linkage"] = None
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "reconciliation.subject_linkage must be a JSON object in restore payload",
+        ):
+            restored_service.restore_authoritative_record_chain_backup(backup)
+        self._assert_authoritative_store_empty(restored_store)
+
     def test_service_phase21_restore_rejects_approval_target_binding_mismatch(self) -> None:
         _store, service, promoted_case, _evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()


### PR DESCRIPTION
Summary:
- Extracted persistence lifecycle write sequencing into PersistenceLifecycleService.
- Moved backup restore payload parsing into restore_readiness_backup_restore and shutdown status shaping into restore_readiness_projection.
- Added Phase 50.9.3 boundary regression coverage.
- Stabilized the Phase 21 second-source queue assertion so it compares durable queue fields instead of volatile age projections.

Verification:
- PYTHONPATH=control-plane uv run python -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py -k phase50_9_3
- PYTHONPATH=control-plane uv run python -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py
- PYTHONPATH=control-plane uv run python -m unittest control-plane/tests/test_service_persistence_restore_readiness.py
- PYTHONPATH=control-plane uv run python -m unittest control-plane/tests/test_service_persistence.py
- PYTHONPATH=control-plane uv run python -m unittest control-plane/tests/test_phase21_end_to_end_validation.py -k test_phase21_end_to_end_second_source_onboarding_stays_narrow
- PYTHONPATH=control-plane uv run python -m unittest discover -s control-plane/tests -p 'test_*.py'
- PYTHONPATH=control-plane uv run python -m py_compile touched control-plane modules and test
- bash scripts/verify-maintainability-hotspots.sh
- node dist/index.js issue-lint 977 --config supervisor.config.aegisops.json
- GitHub CI on PR #983: all checks passed

Refs #977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Persistence lifecycle handling moved into a dedicated service and service composition simplified.
  * Shutdown-readiness snapshot construction centralized and backup-restore parsing/coercion consolidated.

* **Bug Fixes**
  * Restore flow enforces stricter payload validation (including datetime/tuple/mapping rules) and fails fast on invalid linkage data.

* **Tests**
  * Added end-to-end normalization, AST-based regression, and restore-readiness validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->