### PR TITLE
Phase 50.9.4: reduce internal facade delegates

### DIFF
--- a/control-plane/aegisops_control_plane/action_review_write_surface.py
+++ b/control-plane/aegisops_control_plane/action_review_write_surface.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import logging
 from typing import TYPE_CHECKING, Protocol
 
+from . import action_review_projection as _action_review_projection
 from .action_policy import evaluate_action_policy_record
 from .models import (
     ActionRequestRecord,
@@ -46,32 +47,6 @@ class ActionReviewWriteSurfaceDependencies(Protocol):
     ) -> ActionRequestRecord:
         ...
 
-    def _action_review_approval_decision(
-        self,
-        action_request: ActionRequestRecord,
-    ) -> ApprovalDecisionRecord | None:
-        ...
-
-    def _action_review_approval_state(
-        self,
-        *,
-        action_request: ActionRequestRecord,
-        approval_decision: ApprovalDecisionRecord | None,
-    ) -> str:
-        ...
-
-    def _action_review_execution(self, action_request: ActionRequestRecord) -> object:
-        ...
-
-    def _action_review_state(
-        self,
-        *,
-        action_request: ActionRequestRecord,
-        approval_state: str,
-        action_execution: object,
-    ) -> str:
-        ...
-
     def _require_action_review_visibility_context_record(
         self,
         action_request: ActionRequestRecord,
@@ -102,15 +77,6 @@ class ActionReviewWriteSurfaceDependencies(Protocol):
         context_record: CaseRecord | AlertRecord,
         reviewed_context_update: dict[str, object],
     ) -> CaseRecord | AlertRecord:
-        ...
-
-    def _action_review_visibility_update(
-        self,
-        *,
-        action_request_id: str,
-        context_key: str,
-        context_value: dict[str, object],
-    ) -> dict[str, object]:
         ...
 
     def _require_reviewed_action_approver_policy(
@@ -184,16 +150,29 @@ class ActionReviewWriteSurface:
             "residual_uncertainty",
         )
         with service._store.transaction():
-            action_request = service._require_review_bound_action_request(action_request_id)
-            approval_decision = service._action_review_approval_decision(action_request)
-            approval_state = service._action_review_approval_state(
-                action_request=action_request,
-                approval_decision=approval_decision,
+            action_request = service._require_review_bound_action_request(
+                action_request_id
             )
-            review_state = service._action_review_state(
+            approval_decision = (
+                _action_review_projection._action_review_approval_decision(
+                    service,
+                    action_request,
+                )
+            )
+            approval_state = (
+                _action_review_projection._action_review_approval_state(
+                    action_request=action_request,
+                    approval_decision=approval_decision,
+                )
+            )
+            action_execution = _action_review_projection._action_review_execution(
+                service,
+                action_request,
+            )
+            review_state = _action_review_projection._action_review_state(
                 action_request=action_request,
                 approval_state=approval_state,
-                action_execution=service._action_review_execution(action_request),
+                action_execution=action_execution,
             )
             if (
                 approval_decision is None
@@ -201,7 +180,8 @@ class ActionReviewWriteSurface:
                 or review_state in {"pending", "rejected", "expired", "superseded"}
             ):
                 raise ValueError(
-                    "manual fallback requires an approved action review in a live post-approval state"
+                    "manual fallback requires an approved action review in a live "
+                    "post-approval state"
                 )
             context_record = service._require_action_review_visibility_context_record(
                 action_request
@@ -234,10 +214,12 @@ class ActionReviewWriteSurface:
                 )
             return service._persist_action_review_visibility_context_record(
                 context_record=context_record,
-                reviewed_context_update=service._action_review_visibility_update(
-                    action_request_id=action_request.action_request_id,
-                    context_key="manual_fallback",
-                    context_value=manual_fallback_context,
+                reviewed_context_update=(
+                    _action_review_projection._action_review_visibility_update(
+                        action_request_id=action_request.action_request_id,
+                        context_key="manual_fallback",
+                        context_value=manual_fallback_context,
+                    )
                 ),
             )
 
@@ -262,16 +244,29 @@ class ActionReviewWriteSurface:
         )
         note = service._require_non_empty_string(note, "note")
         with service._store.transaction():
-            action_request = service._require_review_bound_action_request(action_request_id)
-            approval_decision = service._action_review_approval_decision(action_request)
-            approval_state = service._action_review_approval_state(
-                action_request=action_request,
-                approval_decision=approval_decision,
+            action_request = service._require_review_bound_action_request(
+                action_request_id
             )
-            review_state = service._action_review_state(
+            approval_decision = (
+                _action_review_projection._action_review_approval_decision(
+                    service,
+                    action_request,
+                )
+            )
+            approval_state = (
+                _action_review_projection._action_review_approval_state(
+                    action_request=action_request,
+                    approval_decision=approval_decision,
+                )
+            )
+            action_execution = _action_review_projection._action_review_execution(
+                service,
+                action_request,
+            )
+            review_state = _action_review_projection._action_review_state(
                 action_request=action_request,
                 approval_state=approval_state,
-                action_execution=service._action_review_execution(action_request),
+                action_execution=action_execution,
             )
             context_record = service._require_action_review_visibility_context_record(
                 action_request
@@ -290,10 +285,12 @@ class ActionReviewWriteSurface:
                 )
             return service._persist_action_review_visibility_context_record(
                 context_record=context_record,
-                reviewed_context_update=service._action_review_visibility_update(
-                    action_request_id=action_request.action_request_id,
-                    context_key="escalation",
-                    context_value=escalation_context,
+                reviewed_context_update=(
+                    _action_review_projection._action_review_visibility_update(
+                        action_request_id=action_request.action_request_id,
+                        context_key="escalation",
+                        context_value=escalation_context,
+                    )
                 ),
             )
 

--- a/control-plane/aegisops_control_plane/readiness_operability.py
+++ b/control-plane/aegisops_control_plane/readiness_operability.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from typing import Any
 
+from . import action_review_projection as _action_review_projection
 from .action_review_projection import _ActionReviewRecordIndex
 from .models import (
     AITraceRecord,
@@ -339,11 +340,11 @@ class ReadinessOperabilityHelper:
             approval_decision = approval_decisions_by_action_request_id.get(action_request_id)
             action_execution = executions_by_action_request_id.get(action_request_id)
             reconciliation = reconciliations_by_action_request_id.get(action_request_id)
-            approval_state = self._action_review_approval_state(
+            approval_state = _action_review_projection._action_review_approval_state(
                 action_request=action_request,
                 approval_decision=approval_decision,
             )
-            review_state = self._action_review_state(
+            review_state = _action_review_projection._action_review_state(
                 action_request=action_request,
                 approval_state=approval_state,
                 action_execution=action_execution,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1917,19 +1917,6 @@ class AegisOpsControlPlaneService:
             context_key=context_key,
         )
 
-    @staticmethod
-    def _action_review_visibility_update(
-        *,
-        action_request_id: str,
-        context_key: str,
-        context_value: Mapping[str, object],
-    ) -> dict[str, object]:
-        return _action_review_projection._action_review_visibility_update(
-            action_request_id=action_request_id,
-            context_key=context_key,
-            context_value=context_value,
-        )
-
     def _case_has_single_review_bound_action_request(
         self,
         case_id: str | None,
@@ -1939,30 +1926,6 @@ class AegisOpsControlPlaneService:
         return _action_review_projection._case_has_single_review_bound_action_request(
             self,
             case_id,
-            record_index=record_index,
-        )
-
-    def _action_review_approval_decision(
-        self,
-        action_request: ActionRequestRecord,
-        *,
-        record_index: _ActionReviewRecordIndex | None = None,
-    ) -> ApprovalDecisionRecord | None:
-        return _action_review_projection._action_review_approval_decision(
-            self,
-            action_request,
-            record_index=record_index,
-        )
-
-    def _action_review_execution(
-        self,
-        action_request: ActionRequestRecord,
-        *,
-        record_index: _ActionReviewRecordIndex | None = None,
-    ) -> ActionExecutionRecord | None:
-        return _action_review_projection._action_review_execution(
-            self,
-            action_request,
             record_index=record_index,
         )
 
@@ -1982,30 +1945,6 @@ class AegisOpsControlPlaneService:
             record_index=record_index,
         )
 
-    @staticmethod
-    def _action_review_approval_state(
-        *,
-        action_request: ActionRequestRecord,
-        approval_decision: ApprovalDecisionRecord | None,
-    ) -> str | None:
-        return _action_review_projection._action_review_approval_state(
-            action_request=action_request,
-            approval_decision=approval_decision,
-        )
-
-    @staticmethod
-    def _action_review_state(
-        *,
-        action_request: ActionRequestRecord,
-        approval_state: str | None,
-        action_execution: ActionExecutionRecord | None,
-    ) -> str:
-        return _action_review_projection._action_review_state(
-            action_request=action_request,
-            approval_state=approval_state,
-            action_execution=action_execution,
-        )
-
     def _replacement_action_request(
         self,
         action_request: ActionRequestRecord,
@@ -2017,10 +1956,6 @@ class AegisOpsControlPlaneService:
             action_request,
             record_index=record_index,
         )
-
-    @staticmethod
-    def _action_request_is_review_bound(action_request: ActionRequestRecord) -> bool:
-        return _action_review_projection._action_request_is_review_bound(action_request)
 
     @staticmethod
     def _next_expected_action_for_review_state(review_state: str) -> str | None:
@@ -2978,7 +2913,9 @@ class AegisOpsControlPlaneService:
         action_request_id: str,
     ) -> ActionRequestRecord:
         action_request = self._require_action_request_record(action_request_id)
-        if not self._action_request_is_review_bound(action_request):
+        if not _action_review_projection._action_request_is_review_bound(
+            action_request
+        ):
             raise ValueError(
                 "action_request_id must reference a reviewed action request"
             )

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -260,13 +260,9 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         projection_functions = {
             node.name for node in projection_tree.body if isinstance(node, ast.FunctionDef)
         }
-        moved_helper_names = {
-            "_action_request_is_review_bound",
+        retained_delegate_names = {
             "_action_review_after_hours_handoff_visibility",
-            "_action_review_approval_decision",
-            "_action_review_approval_state",
             "_action_review_context_matches_lineage",
-            "_action_review_execution",
             "_action_review_escalation_visibility",
             "_action_review_ingest_path_health",
             "_action_review_manual_fallback_visibility",
@@ -274,18 +270,32 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             "_action_review_path_health_summary",
             "_action_review_persistence_path_health",
             "_action_review_provider_path_health",
-            "_action_review_state",
             "_action_review_stage_snapshot",
             "_action_review_visibility_entry",
             "_action_review_visibility_context",
-            "_action_review_visibility_update",
             "_latest_action_review_reconciliation",
             "_next_expected_action_for_review_state",
             "_replacement_action_request",
         }
+        removed_internal_delegate_names = {
+            "_action_request_is_review_bound",
+            "_action_review_approval_decision",
+            "_action_review_approval_state",
+            "_action_review_execution",
+            "_action_review_state",
+            "_action_review_visibility_update",
+        }
+        moved_helper_names = retained_delegate_names | removed_internal_delegate_names
         self.assertTrue(moved_helper_names.issubset(projection_functions))
 
-        for helper_name in moved_helper_names:
+        for helper_name in removed_internal_delegate_names:
+            self.assertNotIn(
+                helper_name,
+                service_methods,
+                f"{helper_name} should be bypassed by internal collaborators instead of retained on the facade",
+            )
+
+        for helper_name in retained_delegate_names:
             service_method = service_methods[helper_name]
             calls = [
                 node
@@ -301,6 +311,66 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
                 1,
                 f"{helper_name} should remain only as a facade compatibility delegate",
             )
+
+    def test_phase50_9_4_internal_action_review_write_delegates_bypass_service_facade(
+        self,
+    ) -> None:
+        write_surface_source = self._read(
+            "control-plane/aegisops_control_plane/action_review_write_surface.py"
+        )
+        service_source = self._read("control-plane/aegisops_control_plane/service.py")
+        http_sources = "\n".join(
+            self._read(relative_path)
+            for relative_path in (
+                "control-plane/aegisops_control_plane/http_surface.py",
+                "control-plane/aegisops_control_plane/http_runtime_surface.py",
+                "control-plane/aegisops_control_plane/http_protected_surface.py",
+                "control-plane/aegisops_control_plane/cli.py",
+            )
+        )
+        write_surface_tree = ast.parse(write_surface_source)
+        service_tree = ast.parse(service_source)
+        service_class = next(
+            node
+            for node in service_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        service_method_names = {
+            node.name
+            for node in service_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+        removed_internal_delegate_names = {
+            "_action_request_is_review_bound",
+            "_action_review_approval_decision",
+            "_action_review_approval_state",
+            "_action_review_execution",
+            "_action_review_state",
+            "_action_review_visibility_update",
+        }
+
+        self.assertFalse(removed_internal_delegate_names & service_method_names)
+        for helper_name in removed_internal_delegate_names:
+            self.assertNotIn(helper_name, http_sources)
+
+        projection_calls = {
+            node.func.attr
+            for node in ast.walk(write_surface_tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "_action_review_projection"
+        }
+        self.assertTrue(
+            {
+                "_action_review_approval_decision",
+                "_action_review_approval_state",
+                "_action_review_execution",
+                "_action_review_state",
+                "_action_review_visibility_update",
+            }.issubset(projection_calls)
+        )
 
     def test_phase50_constructor_delegates_collaborator_composition(self) -> None:
         service_source = self._read("control-plane/aegisops_control_plane/service.py")

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -318,6 +318,9 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         write_surface_source = self._read(
             "control-plane/aegisops_control_plane/action_review_write_surface.py"
         )
+        readiness_operability_source = self._read(
+            "control-plane/aegisops_control_plane/readiness_operability.py"
+        )
         service_source = self._read("control-plane/aegisops_control_plane/service.py")
         http_sources = "\n".join(
             self._read(relative_path)
@@ -329,6 +332,7 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             )
         )
         write_surface_tree = ast.parse(write_surface_source)
+        readiness_operability_tree = ast.parse(readiness_operability_source)
         service_tree = ast.parse(service_source)
         service_class = next(
             node
@@ -354,9 +358,10 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         for helper_name in removed_internal_delegate_names:
             self.assertNotIn(helper_name, http_sources)
 
-        projection_calls = {
+        direct_projection_call_names = {
             node.func.attr
-            for node in ast.walk(write_surface_tree)
+            for tree in (write_surface_tree, readiness_operability_tree)
+            for node in ast.walk(tree)
             if isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
@@ -369,8 +374,26 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
                 "_action_review_execution",
                 "_action_review_state",
                 "_action_review_visibility_update",
-            }.issubset(projection_calls)
+            }.issubset(direct_projection_call_names)
         )
+        service_facade_delegate_names = removed_internal_delegate_names - {
+            "_action_request_is_review_bound",
+        }
+        for helper_name in service_facade_delegate_names:
+            for tree in (write_surface_tree, readiness_operability_tree):
+                service_facade_calls = [
+                    node
+                    for node in ast.walk(tree)
+                    if isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == helper_name
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id in {"self", "service"}
+                ]
+                self.assertFalse(
+                    service_facade_calls,
+                    f"{helper_name} must not be reached through the service facade",
+                )
 
     def test_phase50_constructor_delegates_collaborator_composition(self) -> None:
         service_source = self._read("control-plane/aegisops_control_plane/service.py")


### PR DESCRIPTION
## Summary
- Bypass six internal-only action-review projection delegates from ActionReviewWriteSurface.
- Remove the corresponding private compatibility delegates from AegisOpsControlPlaneService.
- Tighten the boundary regression test to prove the removed helpers are absent from the facade and HTTP/CLI entrypoint sources while retained delegates stay explicit.

## Verification
- python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation
- python3 -m unittest control-plane.tests.test_action_review_write_boundary control-plane.tests.test_service_persistence_action_reconciliation_review_surfaces
- python3 -m compileall -q control-plane/aegisops_control_plane/service.py control-plane/aegisops_control_plane/action_review_write_surface.py control-plane/tests/test_service_boundary_refactor_regression_validation.py
- bash scripts/verify-maintainability-hotspots.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 978 --config "$CODEX_SUPERVISOR_CONFIG"

Closes #978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal restructuring of action review processing logic to improve code organization and maintainability.

* **Tests**
  * Enhanced test coverage to validate internal component boundaries and integration points.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->