### PR TITLE
Phase 50.9.6 hotspot baseline closeout

### DIFF
--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,7 +66,7 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.8.6")
+        self.assertEqual(metadata["phase"], "50.9.6")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -50,13 +50,13 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
                 return metadata
         raise AssertionError("service.py hotspot baseline entry not found")
 
-    def test_baseline_records_phase50_closeout_ceiling(self) -> None:
+    def test_baseline_records_phase50_9_closeout_ceiling(self) -> None:
         service_text = self._read("control-plane/aegisops_control_plane/service.py")
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.8.6")
-        self.assertEqual(metadata["issue"], "#967")
+        self.assertEqual(metadata["phase"], "50.9.6")
+        self.assertEqual(metadata["issue"], "#980")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(
@@ -67,23 +67,29 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             self._facade_method_count(metadata["facade_class"]),
             int(metadata["max_facade_methods"]),
         )
+        self.assertLess(int(metadata["max_lines"]), 3505)
+        self.assertLess(int(metadata["max_effective_lines"]), 3182)
+        self.assertLess(int(metadata["max_facade_methods"]), 185)
 
-    def test_closeout_notes_preserve_remaining_hotspot_and_trigger(self) -> None:
+    def test_closeout_notes_preserve_phase50_9_hotspot_and_trigger(self) -> None:
         closeout = self._read("docs/phase-50-maintainability-closeout.md")
 
         for required in (
-            "Phase 50.8.6",
+            "Phase 50.9.6",
             "control-plane/aegisops_control_plane/service.py",
+            "control-plane/aegisops_control_plane/action_review_projection.py",
             "AegisOpsControlPlaneService",
-            "max_lines=3505",
-            "max_effective_lines=3182",
-            "max_facade_methods=185",
+            "max_lines=3158",
+            "max_effective_lines=2853",
+            "max_facade_methods=173",
+            "projection lines=105",
+            "projection effective_lines=103",
             "ADR-0004",
             "ADR-0003",
-            "#967",
+            "#980",
             "remaining accepted hotspot",
-            "action review projection and visibility helper cluster",
-            "intake and authoritative-state guard helpers",
+            "facade dispatch and authority-boundary guard helpers",
+            "projection split does not require a baseline entry",
             "silent re-growth",
             "another decomposition decision",
             "bash scripts/verify-maintainability-hotspots.sh",

--- a/docs/adr/0006-phase-50-9-residual-facade-convergence-and-projection-guard.md
+++ b/docs/adr/0006-phase-50-9-residual-facade-convergence-and-projection-guard.md
@@ -5,7 +5,7 @@
 - **Owners**: AegisOps maintainers
 - **Related Baseline**: `docs/requirements-baseline.md`
 - **Product**: AegisOps
-- **Related Issues**: #974, #975
+- **Related Issues**: #974, #975, #980
 - **Depends On**: #967
 - **Supersedes**: N/A
 - **Superseded By**: N/A
@@ -26,7 +26,7 @@ ADR-0005 remains authoritative for the Phase 50.8 residual helper migration cont
 
 Phase 50.9 needs a repo-owned contract before the next implementation sequence starts so later slices do not choose local extraction order, treat the final Phase 50.8 ceiling as permission for facade growth, or move action-review projection pressure into another unchecked hotspot.
 
-This ADR does not refresh the baseline because Phase 50.9 implementation evidence does not exist yet.
+This ADR did not refresh the baseline before implementation evidence existed. Phase 50.9.6 closeout issue #980 later refreshed the baseline after the extraction sequence landed.
 
 ## 2. Decision
 
@@ -48,7 +48,7 @@ Tickets, assistant output, ML, endpoint evidence, network evidence, browser stat
 
 ## 3. Residual Facade Targets
 
-The current Phase 50.8.6 ceiling remains:
+The Phase 50.8.6 starting ceiling was:
 
 - `max_lines=3505`
 - `max_effective_lines=3182`
@@ -63,6 +63,14 @@ The Phase 50.9 implementation target for `control-plane/aegisops_control_plane/s
 A Phase 50.9 closeout may record a lower exception only if it names the unresolved cluster, records the measured line, effective-line, and facade-method counts, and keeps the exception lower than the Phase 50.8.6 ceiling.
 
 Any `service.py` baseline refresh before Phase 50.9 implementation evidence exists is forbidden.
+
+Phase 50.9.6 closeout issue #980 records the accepted residual `service.py` ceiling as:
+
+- `max_lines=3158`
+- `max_effective_lines=2853`
+- `max_facade_methods=173`
+- `phase=50.9.6`
+- `issue=#980`
 
 ## 4. Projection Hotspot Guard
 
@@ -84,6 +92,8 @@ An `action_review_projection.py` baseline may be recorded only at Phase 50.9 clo
 - the closeout explicitly states why another split would be riskier than accepting the temporary projection hotspot.
 
 If those criteria are not all true, the correct result is a follow-up decomposition issue, not a silent projection hotspot exception.
+
+Phase 50.9.6 measured `control-plane/aegisops_control_plane/action_review_projection.py` at `projection lines=105` and `projection effective_lines=103`, which is below the verifier threshold and below the pre-Phase 50.9 projection measurement. No projection baseline entry is recorded.
 
 ## 5. Migration Order
 
@@ -114,6 +124,8 @@ Run `bash scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh
 Run `bash scripts/verify-maintainability-hotspots.sh`.
 
 Run `node <codex-supervisor-root>/dist/index.js issue-lint 975 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 980 --config <supervisor-config-path>`.
 
 ## 7. Non-Goals
 

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,12 +1,12 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.8.6 final residual exception:
+# Phase 50.9.6 final residual exception:
 # ADR-0004 accepted ordered hotspot reduction after the ADR-0003
 # facade-preservation exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 50.8 extraction sequence, so this baseline records the final
-# Phase 50.8.6 ceiling and fails on silent re-growth. A future ADR or
+# the Phase 50.9 extraction sequence, so this baseline records the final
+# Phase 50.9.6 ceiling and fails on silent re-growth. A future ADR or
 # maintainability backlog must lower or replace these limits before unrelated
 # feature expansion lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=3505 max_effective_lines=3182 max_facade_methods=185 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.6 issue=#967
+control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=173 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.9.6 issue=#980

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,10 +1,10 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.8.6 closes the ordered maintainability hotspot reduction sequence governed by ADR-0004 and ADR-0005.
+Phase 50.9.6 closes the ordered maintainability hotspot reduction sequence governed by ADR-0004, ADR-0005, and ADR-0006.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
-ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0005 governs the Phase 50.8 residual service migration contract. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
+ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0005 governs the Phase 50.8 residual service migration contract. ADR-0006 governs the Phase 50.9 residual facade convergence and projection guard. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
 
 ## Accepted Verifier State
 
@@ -12,18 +12,18 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.8 extraction and fencing work. The final Phase 50.8.6 closeout for #967 records the accepted residual ceiling as:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.9 extraction and fencing work. The final Phase 50.9.6 closeout for #980 records the accepted residual ceiling as:
 
-- `max_lines=3505`
-- `max_effective_lines=3182`
-- `max_facade_methods=185`
+- `max_lines=3158`
+- `max_effective_lines=2853`
+- `max_facade_methods=173`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.8.6`
+- `phase=50.9.6`
 
-No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, or operator UI route tests because the verifier does not report those areas as current responsibility-growth candidates.
+No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, operator UI route tests, or `control-plane/aegisops_control_plane/action_review_projection.py` because the verifier does not report those areas as current responsibility-growth candidates. The Phase 50.9.6 projection measurement is `projection lines=105` and `projection effective_lines=103`, so the projection split does not require a baseline entry.
 
-The remaining accepted hotspot is not a general extension target. The residual helper pressure is concentrated in the action review projection and visibility helper cluster plus intake and authoritative-state guard helpers that still sit behind the public facade. Those helpers remain review-visible because they protect action review state, detection intake linkage, and fail-closed authoritative-state reads at the service boundary.
+The remaining accepted hotspot is not a general extension target. The residual helper pressure is concentrated in facade dispatch and authority-boundary guard helpers that still sit behind the public facade. Those helpers remain review-visible because they protect action review state, detection intake linkage, and fail-closed authoritative-state reads at the service boundary.
 
 ## Follow-Up Trigger
 
@@ -33,7 +33,7 @@ Any silent re-growth beyond the recorded ceiling must fail the verifier. The exp
 
 If a later extraction lowers the facade below the verifier threshold, maintainers should remove or lower the baseline only after confirming that the file no longer crosses the responsibility-growth threshold.
 
-If future work needs to add another action-review surface, intake pathway, authoritative restore/read guard, or cross-record projection helper to `service.py`, that is the follow-up trigger for another maintainability issue. The follow-up should extract or fence the directly linked helper cluster instead of using this exception as approval for new facade responsibility.
+If future work needs to add another action-review surface, intake pathway, authoritative restore/read guard, or cross-record projection helper to `service.py`, that is the follow-up trigger for another maintainability issue. The follow-up should extract or fence the directly linked helper cluster instead of using this exception as approval for new facade responsibility. If `action_review_projection.py` grows back toward the Phase 50.9 pre-split measurement of `max_lines=2034` or `max_effective_lines=1911`, the follow-up should split that directly linked projection cluster instead of silently recording a new projection hotspot exception.
 
 ## Verification Evidence
 

--- a/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -219,7 +219,7 @@ printf '%s\n' \
   >"${premature_baseline_repo}/docs/maintainability-hotspot-baseline.txt"
 assert_fails_with \
   "${premature_baseline_repo}" \
-  "Phase 50.8 contract requires the Phase 50.7 service.py ceiling to remain unchanged until implementation evidence exists."
+  "After implementation evidence exists, it requires either the final Phase 50.8.6 closeout baseline for #967 or the lower superseding Phase 50.9.6 closeout baseline for #980."
 
 missing_authority_repo="${workdir}/missing-authority"
 create_valid_repo "${missing_authority_repo}"

--- a/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -189,6 +189,52 @@ Any silent re-growth requires another decomposition decision.
 EOF
 assert_passes "${final_closeout_repo}"
 
+superseding_closeout_repo="${workdir}/superseding-closeout"
+create_valid_repo "${superseding_closeout_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=173 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.9.6 issue=#980" \
+  >"${superseding_closeout_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${superseding_closeout_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.9.6 records the final #980 closeout baseline.
+
+- `max_lines=3158`
+- `max_effective_lines=2853`
+- `max_facade_methods=173`
+
+The remaining accepted hotspot is the facade dispatch and authority-boundary guard helpers.
+
+The projection split does not require a baseline entry.
+
+Any silent re-growth requires another decomposition decision.
+EOF
+assert_passes "${superseding_closeout_repo}"
+
+superseding_regrowth_repo="${workdir}/superseding-regrowth"
+create_valid_repo "${superseding_regrowth_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=3159 max_effective_lines=2854 max_facade_methods=174 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.9.6 issue=#980" \
+  >"${superseding_regrowth_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${superseding_regrowth_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.9.6 records a regrown #980 closeout baseline.
+
+- `max_lines=3159`
+- `max_effective_lines=2854`
+- `max_facade_methods=174`
+
+The remaining accepted hotspot is the facade dispatch and authority-boundary guard helpers.
+
+The projection split does not require a baseline entry.
+
+Any silent re-growth requires another decomposition decision.
+EOF
+assert_fails_with \
+  "${superseding_regrowth_repo}" \
+  "Phase 50.9 superseding closeout baseline must remain at or below the accepted #980 ceiling."
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md"

--- a/scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh
+++ b/scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh
@@ -26,7 +26,7 @@ write_baseline() {
 
   mkdir -p "${target}/docs"
   printf '%s\n' \
-    "control-plane/aegisops_control_plane/service.py max_lines=3505 max_effective_lines=3182 max_facade_methods=185 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.6 issue=#967" \
+    "control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=173 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.9.6 issue=#980" \
     >"${target}/docs/maintainability-hotspot-baseline.txt"
 }
 
@@ -41,7 +41,7 @@ create_valid_repo() {
 - **Owners**: AegisOps maintainers
 - **Related Baseline**: `docs/requirements-baseline.md`
 - **Product**: AegisOps
-- **Related Issues**: #974, #975
+- **Related Issues**: #974, #975, #980
 - **Depends On**: #967
 - **Supersedes**: N/A
 - **Superseded By**: N/A
@@ -58,7 +58,7 @@ ADR-0005 remains authoritative for the Phase 50.8 residual helper migration cont
 
 `docs/maintainability-decomposition-thresholds.md` remains the governing hotspot trigger policy.
 
-This ADR does not refresh the baseline because Phase 50.9 implementation evidence does not exist yet.
+This ADR did not refresh the baseline before implementation evidence existed. Phase 50.9.6 closeout issue #980 later refreshed the baseline after the extraction sequence landed.
 
 ## 2. Decision
 
@@ -78,7 +78,7 @@ Tickets, assistant output, ML, endpoint evidence, network evidence, browser stat
 
 ## 3. Residual Facade Targets
 
-The current Phase 50.8.6 ceiling remains:
+The Phase 50.8.6 starting ceiling was:
 
 - `max_lines=3505`
 - `max_effective_lines=3182`
@@ -93,6 +93,14 @@ The Phase 50.9 implementation target for `control-plane/aegisops_control_plane/s
 A Phase 50.9 closeout may record a lower exception only if it names the unresolved cluster, records the measured line, effective-line, and facade-method counts, and keeps the exception lower than the Phase 50.8.6 ceiling.
 
 Any `service.py` baseline refresh before Phase 50.9 implementation evidence exists is forbidden.
+
+Phase 50.9.6 closeout issue #980 records the accepted residual `service.py` ceiling as:
+
+- `max_lines=3158`
+- `max_effective_lines=2853`
+- `max_facade_methods=173`
+- `phase=50.9.6`
+- `issue=#980`
 
 ## 4. Projection Hotspot Guard
 
@@ -112,6 +120,8 @@ An `action_review_projection.py` baseline may be recorded only at Phase 50.9 clo
 - the recorded projection ceiling is lower than the pre-Phase 50.9 projection measurement of `max_lines=2034` and `max_effective_lines=1911`;
 - the baseline entry names a Phase 50.9 closeout phase and issue;
 - the closeout explicitly states why another split would be riskier than accepting the temporary projection hotspot.
+
+Phase 50.9.6 measured `control-plane/aegisops_control_plane/action_review_projection.py` at `projection lines=105` and `projection effective_lines=103`, which is below the verifier threshold and below the pre-Phase 50.9 projection measurement. No projection baseline entry is recorded.
 
 ## 5. Migration Order
 
@@ -140,6 +150,8 @@ Run `bash scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh
 Run `bash scripts/verify-maintainability-hotspots.sh`.
 
 Run `node <codex-supervisor-root>/dist/index.js issue-lint 975 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 980 --config <supervisor-config-path>`.
 
 ## 7. Non-Goals
 
@@ -218,7 +230,7 @@ printf '%s\n' \
   >"${premature_service_baseline_repo}/docs/maintainability-hotspot-baseline.txt"
 assert_fails_with \
   "${premature_service_baseline_repo}" \
-  "Phase 50.9 contract requires the Phase 50.8.6 service.py ceiling to remain unchanged until implementation evidence exists."
+  "Phase 50.9 closeout requires the accepted Phase 50.9.6 service.py ceiling after implementation evidence exists."
 
 premature_projection_baseline_repo="${workdir}/premature-projection-baseline"
 create_valid_repo "${premature_projection_baseline_repo}"

--- a/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -127,9 +127,7 @@ issue="$(metadata_value issue)"
 
 if [[
   "${facade_class}" != "AegisOpsControlPlaneService" ||
-  "${adr_exception}" != "ADR-0003" ||
-  "${phase}" != "50.8.6" ||
-  "${issue}" != "#967"
+  "${adr_exception}" != "ADR-0003"
 ]]; then
   echo "Phase 50.8 contract requires the Phase 50.7 service.py ceiling to remain unchanged until implementation evidence exists. After implementation evidence exists, it requires a final Phase 50.8.6 closeout baseline for #967." >&2
   exit 1
@@ -152,17 +150,42 @@ if [[ ! -f "${closeout_path}" ]]; then
   exit 1
 fi
 
-closeout_required_phrases=(
-  "Phase 50.8.6"
-  "#967"
-  "\`max_lines=${max_lines}\`"
-  "\`max_effective_lines=${max_effective_lines}\`"
-  "\`max_facade_methods=${max_facade_methods}\`"
-  "action review projection and visibility helper cluster"
-  "intake and authoritative-state guard helpers"
-  "silent re-growth"
-  "another decomposition decision"
-)
+if [[ "${phase}" == "50.8.6" && "${issue}" == "#967" ]]; then
+  closeout_required_phrases=(
+    "Phase 50.8.6"
+    "#967"
+    "\`max_lines=${max_lines}\`"
+    "\`max_effective_lines=${max_effective_lines}\`"
+    "\`max_facade_methods=${max_facade_methods}\`"
+    "action review projection and visibility helper cluster"
+    "intake and authoritative-state guard helpers"
+    "silent re-growth"
+    "another decomposition decision"
+  )
+elif [[ "${phase}" == "50.9.6" && "${issue}" == "#980" ]]; then
+  if [[
+    "${max_lines}" -ge 3505 ||
+    "${max_effective_lines}" -ge 3182 ||
+    "${max_facade_methods}" -ge 185
+  ]]; then
+    echo "Phase 50.9 superseding closeout baseline must remain lower than the Phase 50.8.6 ceiling." >&2
+    exit 1
+  fi
+  closeout_required_phrases=(
+    "Phase 50.9.6"
+    "#980"
+    "\`max_lines=${max_lines}\`"
+    "\`max_effective_lines=${max_effective_lines}\`"
+    "\`max_facade_methods=${max_facade_methods}\`"
+    "facade dispatch and authority-boundary guard helpers"
+    "projection split does not require a baseline entry"
+    "silent re-growth"
+    "another decomposition decision"
+  )
+else
+  echo "Phase 50.8 contract requires a final Phase 50.8.6 closeout baseline for #967 or a lower superseding Phase 50.9.6 closeout baseline for #980." >&2
+  exit 1
+fi
 
 for phrase in "${closeout_required_phrases[@]}"; do
   if ! grep -Fq -- "${phrase}" "${closeout_path}"; then

--- a/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -164,11 +164,11 @@ if [[ "${phase}" == "50.8.6" && "${issue}" == "#967" ]]; then
   )
 elif [[ "${phase}" == "50.9.6" && "${issue}" == "#980" ]]; then
   if [[
-    "${max_lines}" -ge 3505 ||
-    "${max_effective_lines}" -ge 3182 ||
-    "${max_facade_methods}" -ge 185
+    "${max_lines}" -gt 3158 ||
+    "${max_effective_lines}" -gt 2853 ||
+    "${max_facade_methods}" -gt 173
   ]]; then
-    echo "Phase 50.9 superseding closeout baseline must remain lower than the Phase 50.8.6 ceiling." >&2
+    echo "Phase 50.9 superseding closeout baseline must remain at or below the accepted #980 ceiling." >&2
     exit 1
   fi
   closeout_required_phrases=(

--- a/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -129,7 +129,7 @@ if [[
   "${facade_class}" != "AegisOpsControlPlaneService" ||
   "${adr_exception}" != "ADR-0003"
 ]]; then
-  echo "Phase 50.8 contract requires the Phase 50.7 service.py ceiling to remain unchanged until implementation evidence exists. After implementation evidence exists, it requires a final Phase 50.8.6 closeout baseline for #967." >&2
+  echo "Phase 50.8 contract requires the Phase 50.7 service.py ceiling to remain unchanged until implementation evidence exists. After implementation evidence exists, it requires either the final Phase 50.8.6 closeout baseline for #967 or the lower superseding Phase 50.9.6 closeout baseline for #980." >&2
   exit 1
 fi
 

--- a/scripts/verify-phase-50-9-residual-facade-convergence-contract.sh
+++ b/scripts/verify-phase-50-9-residual-facade-convergence-contract.sh
@@ -21,14 +21,14 @@ required_headings=(
 required_phrases=(
   "- **Status**: Accepted"
   "- **Date**: 2026-04-29"
-  "- **Related Issues**: #974, #975"
+  "- **Related Issues**: #974, #975, #980"
   "- **Depends On**: #967"
   "Phase 50.8.6 closed #967 and recorded the current residual \`service.py\` ceiling in \`docs/maintainability-hotspot-baseline.txt\`."
   "ADR-0003 remains authoritative for the public facade-preservation exception."
   "ADR-0004 remains authoritative for the Phase 50 ordered hotspot-reduction rule."
   "ADR-0005 remains authoritative for the Phase 50.8 residual helper migration contract and the rule that baseline refreshes require implementation evidence."
   "\`docs/maintainability-decomposition-thresholds.md\` remains the governing hotspot trigger policy."
-  "This ADR does not refresh the baseline because Phase 50.9 implementation evidence does not exist yet."
+  "This ADR did not refresh the baseline before implementation evidence existed. Phase 50.9.6 closeout issue #980 later refreshed the baseline after the extraction sequence landed."
   "The residual Phase 50.9 target clusters are:"
   "- external evidence helper cluster"
   "- persistence and record-shaping helper cluster"
@@ -38,7 +38,7 @@ required_phrases=(
   "Public service entrypoints, runtime behavior, configuration shape, authority semantics, projection response semantics, and durable-state side effects remain unchanged."
   "AegisOps control-plane records remain authoritative workflow truth."
   "Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, and projections remain subordinate context."
-  "The current Phase 50.8.6 ceiling remains:"
+  "The Phase 50.8.6 starting ceiling was:"
   "- \`max_lines=3505\`"
   "- \`max_effective_lines=3182\`"
   "- \`max_facade_methods=185\`"
@@ -48,6 +48,12 @@ required_phrases=(
   "- \`max_facade_methods <= 160\`"
   "A Phase 50.9 closeout may record a lower exception only if it names the unresolved cluster, records the measured line, effective-line, and facade-method counts, and keeps the exception lower than the Phase 50.8.6 ceiling."
   "Any \`service.py\` baseline refresh before Phase 50.9 implementation evidence exists is forbidden."
+  "Phase 50.9.6 closeout issue #980 records the accepted residual \`service.py\` ceiling as:"
+  "- \`max_lines=3158\`"
+  "- \`max_effective_lines=2853\`"
+  "- \`max_facade_methods=173\`"
+  "- \`phase=50.9.6\`"
+  "- \`issue=#980\`"
   "The action-review projection split target is \`control-plane/aegisops_control_plane/action_review_projection.py\`."
   "The projection split must preserve directly linked authoritative action-review records as the anchor for approval, execution, reconciliation, mismatch inspection, path health, coordination outcome, and runtime visibility surfaces."
   "The projection split must not widen advisory context, recommendation lineage, evidence anchors, reconciliation subject linkage, or operator-facing detail surfaces beyond directly linked authoritative records."
@@ -59,6 +65,7 @@ required_phrases=(
   "- the recorded projection ceiling is lower than the pre-Phase 50.9 projection measurement of \`max_lines=2034\` and \`max_effective_lines=1911\`;"
   "- the baseline entry names a Phase 50.9 closeout phase and issue;"
   "- the closeout explicitly states why another split would be riskier than accepting the temporary projection hotspot."
+  "Phase 50.9.6 measured \`control-plane/aegisops_control_plane/action_review_projection.py\` at \`projection lines=105\` and \`projection effective_lines=103\`, which is below the verifier threshold and below the pre-Phase 50.9 projection measurement. No projection baseline entry is recorded."
   "The Phase 50.9 migration order is:"
   "1. external evidence helper cluster"
   "2. persistence and record-shaping helper cluster"
@@ -73,6 +80,7 @@ required_phrases=(
   "Run \`bash scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh\`."
   "Run \`bash scripts/verify-maintainability-hotspots.sh\`."
   "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 975 --config <supervisor-config-path>\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 980 --config <supervisor-config-path>\`."
   "No production code extraction is approved by this ADR."
   "No projection module split is approved by this ADR."
   "No approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, detection, external-evidence, or operator authority behavior is changed."
@@ -105,19 +113,19 @@ for phrase in "${required_phrases[@]}"; do
   fi
 done
 
-service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=3505 max_effective_lines=3182 max_facade_methods=185 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.8.6 issue=#967"
+service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=173 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.9.6 issue=#980"
 service_entry="$(grep -E '^control-plane/aegisops_control_plane/service.py[[:space:]]' "${baseline_path}" || true)"
 service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 if [[ "${service_entry_count}" -eq 0 ]]; then
-  echo "Phase 50.9 contract requires the Phase 50.8.6 service.py hotspot baseline entry." >&2
+  echo "Phase 50.9 closeout requires the accepted Phase 50.9.6 service.py hotspot baseline entry." >&2
   exit 1
 fi
 if [[ "${service_entry_count}" -ne 1 ]]; then
-  echo "Phase 50.9 contract requires exactly one service.py hotspot baseline entry." >&2
+  echo "Phase 50.9 closeout requires exactly one service.py hotspot baseline entry." >&2
   exit 1
 fi
 if [[ "${service_entry}" != "${service_baseline_entry}" ]]; then
-  echo "Phase 50.9 contract requires the Phase 50.8.6 service.py ceiling to remain unchanged until implementation evidence exists." >&2
+  echo "Phase 50.9 closeout requires the accepted Phase 50.9.6 service.py ceiling after implementation evidence exists." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- refresh the accepted Phase 50.9.6 `service.py` hotspot baseline to 3158 physical lines, 2853 effective lines, and 173 facade methods
- record that `action_review_projection.py` is below verifier threshold and does not need a baseline entry
- tighten closeout and contract verification around the superseding Phase 50.9.6 baseline

## Verification
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-phase-50-8-residual-service-hotspot-contract.sh`
- `bash scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh`
- `bash scripts/verify-phase-50-9-residual-facade-convergence-contract.sh`
- `bash scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh`
- `python3 -m unittest control-plane/tests/test_phase49_service_decomposition_closeout.py control-plane/tests/test_phase50_maintainability_closeout.py`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`\n- `node dist/index.js issue-lint 980 --config supervisor.config.aegisops.json`\n- `node dist/index.js issue-lint 980 --config supervisor.config.aegisops.coderabbit.json`\n\nPart of #974\nCloses #980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated assertions and test names to reference Phase 50.9.6 and issue #980; added stricter numeric ceiling checks and updated closeout-note expectations.

* **Documentation**
  * Revised ADRs and closeout docs to record Phase 50.9.6 acceptance, lowered baseline thresholds, added projection measurements, and updated helper-cluster wording; added guidance including an issue-lint run for #980.

* **Scripts**
  * Updated verification scripts to validate Phase 50.9.6/#980 closeout criteria, handle superseding baselines, and adjust related messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->