### PR TITLE
Phase 50.10.4 external evidence facade extraction

### DIFF
--- a/control-plane/aegisops_control_plane/external_evidence_facade.py
+++ b/control-plane/aegisops_control_plane/external_evidence_facade.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping
+
+from .models import ActionRequestRecord, EvidenceRecord, ObservationRecord
+
+
+class ExternalEvidenceFacade:
+    """Public external-evidence service methods backed by the boundary object."""
+
+    def attach_osquery_host_context(
+        self,
+        *,
+        case_id: str,
+        host_identifier: str,
+        query_name: str,
+        query_sql: str,
+        result_kind: str,
+        rows: tuple[Mapping[str, object], ...],
+        collected_at: datetime,
+        reviewed_by: str,
+        source_id: str,
+        collection_path: str,
+        query_context: Mapping[str, object] | None = None,
+        evidence_id: str | None = None,
+        observation_scope_statement: str | None = None,
+        observation_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ObservationRecord | None]:
+        return self._external_evidence_boundary.attach_osquery_host_context(
+            case_id=case_id,
+            host_identifier=host_identifier,
+            query_name=query_name,
+            query_sql=query_sql,
+            result_kind=result_kind,
+            rows=rows,
+            collected_at=collected_at,
+            reviewed_by=reviewed_by,
+            source_id=source_id,
+            collection_path=collection_path,
+            query_context=query_context,
+            evidence_id=evidence_id,
+            observation_scope_statement=observation_scope_statement,
+            observation_id=observation_id,
+        )
+
+    def attach_misp_context(
+        self,
+        *,
+        case_id: str,
+        admitting_evidence_id: str,
+        queried_object_type: str,
+        queried_object_value: str,
+        looked_up_at: datetime,
+        reviewed_by: str,
+        event_id: str,
+        event_info: str,
+        event_published_at: datetime | None = None,
+        iocs: tuple[Mapping[str, object], ...] = (),
+        taxonomies: tuple[Mapping[str, object], ...] = (),
+        warninglists: tuple[Mapping[str, object], ...] = (),
+        galaxies: tuple[Mapping[str, object], ...] = (),
+        sightings: tuple[Mapping[str, object], ...] = (),
+        citation_url: str = "",
+        staleness_marker: Mapping[str, object] | None = None,
+        conflict_marker: Mapping[str, object] | None = None,
+        evidence_id: str | None = None,
+        observation_scope_statement: str | None = None,
+        observation_id: str | None = None,
+    ) -> tuple[EvidenceRecord, ObservationRecord | None]:
+        return self._external_evidence_boundary.attach_misp_context(
+            case_id=case_id,
+            admitting_evidence_id=admitting_evidence_id,
+            queried_object_type=queried_object_type,
+            queried_object_value=queried_object_value,
+            looked_up_at=looked_up_at,
+            reviewed_by=reviewed_by,
+            event_id=event_id,
+            event_info=event_info,
+            event_published_at=event_published_at,
+            iocs=iocs,
+            taxonomies=taxonomies,
+            warninglists=warninglists,
+            galaxies=galaxies,
+            sightings=sightings,
+            citation_url=citation_url,
+            staleness_marker=staleness_marker,
+            conflict_marker=conflict_marker,
+            evidence_id=evidence_id,
+            observation_scope_statement=observation_scope_statement,
+            observation_id=observation_id,
+        )
+
+    def create_endpoint_evidence_collection_request(
+        self,
+        *,
+        case_id: str,
+        admitting_evidence_id: str,
+        requester_identity: str,
+        host_identifier: str,
+        evidence_gap: str,
+        artifact_classes: tuple[str, ...],
+        expires_at: datetime,
+        reviewed_gap_id: str | None = None,
+        reviewed_follow_up_decision_id: str | None = None,
+        action_request_id: str | None = None,
+    ) -> ActionRequestRecord:
+        return self._external_evidence_boundary.create_endpoint_evidence_collection_request(
+            case_id=case_id,
+            admitting_evidence_id=admitting_evidence_id,
+            requester_identity=requester_identity,
+            host_identifier=host_identifier,
+            evidence_gap=evidence_gap,
+            artifact_classes=artifact_classes,
+            expires_at=expires_at,
+            reviewed_gap_id=reviewed_gap_id,
+            reviewed_follow_up_decision_id=reviewed_follow_up_decision_id,
+            action_request_id=action_request_id,
+        )
+
+    def ingest_endpoint_evidence_artifacts(
+        self,
+        *,
+        action_request_id: str,
+        artifacts: tuple[Mapping[str, object], ...],
+        admitted_by: str,
+    ) -> tuple[EvidenceRecord, ...]:
+        return self._external_evidence_boundary.ingest_endpoint_evidence_artifacts(
+            action_request_id=action_request_id,
+            artifacts=artifacts,
+            admitted_by=admitted_by,
+        )

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -55,6 +55,7 @@ from .reviewed_slice_policy import (
 )
 from .action_review_projection import _ActionReviewRecordIndex
 from .detection_lifecycle_helpers import LATEST_LIFECYCLE_TRANSITION_UNSET
+from .external_evidence_facade import ExternalEvidenceFacade
 from .service_composition import (
     ControlPlaneServiceCompositionDependencies,
     build_control_plane_service_composition,
@@ -1095,7 +1096,7 @@ def _phase24_live_assistant_snapshot(
     )
 
 
-class AegisOpsControlPlaneService:
+class AegisOpsControlPlaneService(ExternalEvidenceFacade):
     """Minimal local runtime skeleton for the first control-plane service."""
 
     def __init__(
@@ -2086,88 +2087,6 @@ class AegisOpsControlPlaneService:
             action_request_id
         )
 
-    def attach_osquery_host_context(
-        self,
-        *,
-        case_id: str,
-        host_identifier: str,
-        query_name: str,
-        query_sql: str,
-        result_kind: str,
-        rows: tuple[Mapping[str, object], ...],
-        collected_at: datetime,
-        reviewed_by: str,
-        source_id: str,
-        collection_path: str,
-        query_context: Mapping[str, object] | None = None,
-        evidence_id: str | None = None,
-        observation_scope_statement: str | None = None,
-        observation_id: str | None = None,
-    ) -> tuple[EvidenceRecord, ObservationRecord | None]:
-        return self._external_evidence_boundary.attach_osquery_host_context(
-            case_id=case_id,
-            host_identifier=host_identifier,
-            query_name=query_name,
-            query_sql=query_sql,
-            result_kind=result_kind,
-            rows=rows,
-            collected_at=collected_at,
-            reviewed_by=reviewed_by,
-            source_id=source_id,
-            collection_path=collection_path,
-            query_context=query_context,
-            evidence_id=evidence_id,
-            observation_scope_statement=observation_scope_statement,
-            observation_id=observation_id,
-        )
-
-    def attach_misp_context(
-        self,
-        *,
-        case_id: str,
-        admitting_evidence_id: str,
-        queried_object_type: str,
-        queried_object_value: str,
-        looked_up_at: datetime,
-        reviewed_by: str,
-        event_id: str,
-        event_info: str,
-        event_published_at: datetime | None = None,
-        iocs: tuple[Mapping[str, object], ...] = (),
-        taxonomies: tuple[Mapping[str, object], ...] = (),
-        warninglists: tuple[Mapping[str, object], ...] = (),
-        galaxies: tuple[Mapping[str, object], ...] = (),
-        sightings: tuple[Mapping[str, object], ...] = (),
-        citation_url: str = "",
-        staleness_marker: Mapping[str, object] | None = None,
-        conflict_marker: Mapping[str, object] | None = None,
-        evidence_id: str | None = None,
-        observation_scope_statement: str | None = None,
-        observation_id: str | None = None,
-    ) -> tuple[EvidenceRecord, ObservationRecord | None]:
-        return self._external_evidence_boundary.attach_misp_context(
-            case_id=case_id,
-            admitting_evidence_id=admitting_evidence_id,
-            queried_object_type=queried_object_type,
-            queried_object_value=queried_object_value,
-            looked_up_at=looked_up_at,
-            reviewed_by=reviewed_by,
-            event_id=event_id,
-            event_info=event_info,
-            event_published_at=event_published_at,
-            iocs=iocs,
-            taxonomies=taxonomies,
-            warninglists=warninglists,
-            galaxies=galaxies,
-            sightings=sightings,
-            citation_url=citation_url,
-            staleness_marker=staleness_marker,
-            conflict_marker=conflict_marker,
-            evidence_id=evidence_id,
-            observation_scope_statement=observation_scope_statement,
-            observation_id=observation_id,
-        )
-
     def record_case_observation(
         self,
         *,
@@ -2383,46 +2302,6 @@ class AegisOpsControlPlaneService:
             expires_at=expires_at,
             ticket_severity=ticket_severity,
             action_request_id=action_request_id,
-        )
-
-    def create_endpoint_evidence_collection_request(
-        self,
-        *,
-        case_id: str,
-        admitting_evidence_id: str,
-        requester_identity: str,
-        host_identifier: str,
-        evidence_gap: str,
-        artifact_classes: tuple[str, ...],
-        expires_at: datetime,
-        reviewed_gap_id: str | None = None,
-        reviewed_follow_up_decision_id: str | None = None,
-        action_request_id: str | None = None,
-    ) -> ActionRequestRecord:
-        return self._external_evidence_boundary.create_endpoint_evidence_collection_request(
-            case_id=case_id,
-            admitting_evidence_id=admitting_evidence_id,
-            requester_identity=requester_identity,
-            host_identifier=host_identifier,
-            evidence_gap=evidence_gap,
-            artifact_classes=artifact_classes,
-            expires_at=expires_at,
-            reviewed_gap_id=reviewed_gap_id,
-            reviewed_follow_up_decision_id=reviewed_follow_up_decision_id,
-            action_request_id=action_request_id,
-        )
-
-    def ingest_endpoint_evidence_artifacts(
-        self,
-        *,
-        action_request_id: str,
-        artifacts: tuple[Mapping[str, object], ...],
-        admitted_by: str,
-    ) -> tuple[EvidenceRecord, ...]:
-        return self._external_evidence_boundary.ingest_endpoint_evidence_artifacts(
-            action_request_id=action_request_id,
-            artifacts=artifacts,
-            admitted_by=admitted_by,
         )
 
     def record_action_approval_decision(

--- a/control-plane/tests/test_phase28_external_evidence_boundary_refactor.py
+++ b/control-plane/tests/test_phase28_external_evidence_boundary_refactor.py
@@ -15,6 +15,7 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane import external_evidence_boundary
 from aegisops_control_plane import external_evidence_endpoint
+from aegisops_control_plane import external_evidence_facade
 from aegisops_control_plane.service import AegisOpsControlPlaneService
 from postgres_test_support import make_store
 
@@ -260,6 +261,33 @@ class Phase28ExternalEvidenceBoundaryRefactorTests(unittest.TestCase):
                     hasattr(AegisOpsControlPlaneService, helper_name),
                     f"{helper_name} should be owned by the external evidence boundary",
                 )
+
+    def test_external_evidence_public_routes_are_not_defined_in_service_module(
+        self,
+    ) -> None:
+        service_source = (
+            CONTROL_PLANE_ROOT / "aegisops_control_plane" / "service.py"
+        ).read_text(encoding="utf-8")
+        facade_source = (
+            CONTROL_PLANE_ROOT / "aegisops_control_plane" / "external_evidence_facade.py"
+        ).read_text(encoding="utf-8")
+        public_route_names = (
+            "attach_misp_context",
+            "attach_osquery_host_context",
+            "create_endpoint_evidence_collection_request",
+            "ingest_endpoint_evidence_artifacts",
+        )
+
+        self.assertTrue(
+            issubclass(
+                AegisOpsControlPlaneService,
+                external_evidence_facade.ExternalEvidenceFacade,
+            )
+        )
+        for route_name in public_route_names:
+            with self.subTest(route_name=route_name):
+                self.assertNotIn(f"    def {route_name}(", service_source)
+                self.assertIn(f"    def {route_name}(", facade_source)
 
     def test_misp_and_osquery_helpers_are_extracted_from_boundary_module(self) -> None:
         extracted_helper_names = (


### PR DESCRIPTION
## Summary
- Move external-evidence public facade route methods from `service.py` into `ExternalEvidenceFacade`.
- Keep `AegisOpsControlPlaneService` public method names/signatures stable via inheritance.
- Add focused regression coverage proving service.py no longer defines those external-evidence routes while the facade owns them.

## Verification
- `python3 -m unittest control-plane.tests.test_phase28_external_evidence_boundary_refactor`
- `python3 -m py_compile control-plane/aegisops_control_plane/service.py control-plane/aegisops_control_plane/external_evidence_facade.py control-plane/aegisops_control_plane/external_evidence_boundary.py`
- `python3 -m unittest control-plane.tests.test_phase25_osquery_host_context_validation control-plane.tests.test_phase28_endpoint_evidence_pack_validation control-plane.tests.test_phase28_external_evidence_boundary_refactor`
- `bash scripts/verify-maintainability-hotspots.sh`
- `node dist/index.js issue-lint 991 --config supervisor.config.aegisops.json` from `<codex-supervisor-root>`

## Maintainability impact
- `service.py`: 3158 lines before, 3037 lines after.
- Hotspot verifier still reports the known service.py baseline fence: 3037 lines, 2736 effective lines, 169 methods.

Closes #991


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal architecture for external evidence operations to improve code maintainability and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->