### PR TITLE
Phase 50.10.5: reduce lifecycle facade delegates

### DIFF
--- a/control-plane/aegisops_control_plane/external_evidence_endpoint.py
+++ b/control-plane/aegisops_control_plane/external_evidence_endpoint.py
@@ -18,11 +18,8 @@ from .models import (
 )
 
 
-class EndpointExternalEvidenceDependencies(Protocol):
-    _store: object
-    _endpoint_evidence_pack_adapter: object
-
-    def _build_lifecycle_transition_records(
+class _LifecycleTransitionHelper(Protocol):
+    def build_lifecycle_transition_records(
         self,
         record: ControlPlaneRecord,
         *,
@@ -30,6 +27,16 @@ class EndpointExternalEvidenceDependencies(Protocol):
         transitioned_at: datetime | None = None,
     ) -> tuple[LifecycleTransitionRecord, ...]:
         ...
+
+
+class _DetectionIntakeBoundary(Protocol):
+    lifecycle_transition_helper: _LifecycleTransitionHelper
+
+
+class EndpointExternalEvidenceDependencies(Protocol):
+    _store: object
+    _endpoint_evidence_pack_adapter: object
+    _detection_intake_service: _DetectionIntakeBoundary
 
     def persist_record(
         self,
@@ -273,7 +280,10 @@ class EndpointExternalEvidenceHelper:
                 )
             )
             if created:
-                for transition_record in self._service._build_lifecycle_transition_records(
+                transition_helper = (
+                    self._service._detection_intake_service.lifecycle_transition_helper
+                )
+                for transition_record in transition_helper.build_lifecycle_transition_records(
                     action_request,
                     existing_record=None,
                     transitioned_at=requested_at,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1250,27 +1250,6 @@ class AegisOpsControlPlaneService(ExternalEvidenceFacade):
             record
         )
 
-    def _build_lifecycle_transition_record(
-        self,
-        record: ControlPlaneRecord,
-        *,
-        existing_record: ControlPlaneRecord | None,
-        transitioned_at: datetime | None = None,
-        initial_transitioned_at_fallback: datetime | None = None,
-        must_precede_transitioned_at: datetime | None = None,
-        latest_transition: LifecycleTransitionRecord | None | object = (
-            _LATEST_LIFECYCLE_TRANSITION_UNSET
-        ),
-    ) -> LifecycleTransitionRecord | None:
-        return self._detection_intake_service.lifecycle_transition_helper.build_lifecycle_transition_record(
-            record,
-            existing_record=existing_record,
-            transitioned_at=transitioned_at,
-            initial_transitioned_at_fallback=initial_transitioned_at_fallback,
-            must_precede_transitioned_at=must_precede_transitioned_at,
-            latest_transition=latest_transition,
-        )
-
     def _lifecycle_transition_id(
         self,
         *,
@@ -1282,19 +1261,6 @@ class AegisOpsControlPlaneService(ExternalEvidenceFacade):
             transition_timestamp=transition_timestamp,
             transitioned_at=transitioned_at,
             latest_transition=latest_transition,
-        )
-
-    def _build_lifecycle_transition_records(
-        self,
-        record: ControlPlaneRecord,
-        *,
-        existing_record: ControlPlaneRecord | None,
-        transitioned_at: datetime | None = None,
-    ) -> tuple[LifecycleTransitionRecord, ...]:
-        return self._detection_intake_service.lifecycle_transition_helper.build_lifecycle_transition_records(
-            record,
-            existing_record=existing_record,
-            transitioned_at=transitioned_at,
         )
 
     def _initial_lifecycle_transitioned_at(

--- a/control-plane/aegisops_control_plane/service_composition.py
+++ b/control-plane/aegisops_control_plane/service_composition.py
@@ -261,6 +261,20 @@ def build_control_plane_service_composition(
         config=config,
         store=resolved_store,
     )
+    lifecycle_transition_helper = (
+        detection_intake_service.lifecycle_transition_helper
+    )
+
+    def synthesize_lifecycle_transition_record(
+        record: ControlPlaneRecord,
+        initial_transitioned_at_fallback: Any | None = None,
+    ) -> Any:
+        return lifecycle_transition_helper.build_lifecycle_transition_record(
+            record,
+            existing_record=None,
+            initial_transitioned_at_fallback=initial_transitioned_at_fallback,
+        )
+
     restore_readiness_service = RestoreReadinessService(
         config=config,
         store=resolved_store,
@@ -292,13 +306,7 @@ def build_control_plane_service_composition(
         ),
         record_types_by_family=dependencies.record_types_by_family,
         find_duplicate_strings=dependencies.find_duplicate_strings,
-        synthesize_lifecycle_transition_record=(
-            lambda record, initial_transitioned_at_fallback=None: service._build_lifecycle_transition_record(
-                record,
-                existing_record=None,
-                initial_transitioned_at_fallback=initial_transitioned_at_fallback,
-            )
-        ),
+        synthesize_lifecycle_transition_record=synthesize_lifecycle_transition_record,
         assistant_ids_from_mapping=service._assistant_ids_from_mapping,
         inspect_case_detail=lambda case_id: service.inspect_case_detail(case_id),
         inspect_assistant_context=(

--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,7 +66,7 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.9.6")
+        self.assertEqual(metadata["phase"], "50.10.5")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -55,8 +55,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.9.6")
-        self.assertEqual(metadata["issue"], "#980")
+        self.assertEqual(metadata["phase"], "50.10.5")
+        self.assertEqual(metadata["issue"], "#992")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -619,6 +619,48 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
                 f"{helper_name} should remain only as a facade compatibility delegate",
             )
 
+    def test_phase50_10_5_lifecycle_transition_callers_bypass_facade_delegates(
+        self,
+    ) -> None:
+        service_source = self._read("control-plane/aegisops_control_plane/service.py")
+        composition_source = self._read(
+            "control-plane/aegisops_control_plane/service_composition.py"
+        )
+        endpoint_source = self._read(
+            "control-plane/aegisops_control_plane/external_evidence_endpoint.py"
+        )
+        service_tree = ast.parse(service_source)
+        service_class = next(
+            node
+            for node in service_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        service_method_names = {
+            node.name
+            for node in service_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+
+        self.assertNotIn("_build_lifecycle_transition_record", service_method_names)
+        self.assertNotIn("_build_lifecycle_transition_records", service_method_names)
+        self.assertIn(
+            "lifecycle_transition_helper.build_lifecycle_transition_record",
+            composition_source,
+        )
+        self.assertIn(
+            "transition_helper.build_lifecycle_transition_records",
+            endpoint_source,
+        )
+        self.assertNotIn(
+            "service._build_lifecycle_transition_record",
+            composition_source,
+        )
+        self.assertNotIn(
+            "self._service._build_lifecycle_transition_records",
+            endpoint_source,
+        )
+
     def test_phase50_5_second_hotspot_boundary_methods_are_split(self) -> None:
         targets = {
             (

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -277,8 +277,6 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
         attach_result = support.SimpleNamespace(name="attach-result")
         promoted_case = support.SimpleNamespace(case_id="case-delegated-001")
         wazuh_result = support.SimpleNamespace(name="wazuh-result")
-        transition_record = support.SimpleNamespace(name="transition-record")
-        transition_records = (transition_record,)
         latest_transition = support.SimpleNamespace(name="latest-transition")
         attribution = {"source": "delegated-lifecycle", "actor_identities": ()}
         reconciliation = support.SimpleNamespace(name="reconciliation")
@@ -324,12 +322,6 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             "signal-delegated-001"
         )
         lifecycle_delegate = support.mock.Mock()
-        lifecycle_delegate.build_lifecycle_transition_record.return_value = (
-            transition_record
-        )
-        lifecycle_delegate.build_lifecycle_transition_records.return_value = (
-            transition_records
-        )
         lifecycle_delegate.initial_lifecycle_transitioned_at.return_value = (
             reviewed_transitioned_at
         )
@@ -401,23 +393,6 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
                 peer_addr="10.10.0.5",
             ),
             wazuh_result,
-        )
-        self.assertIs(
-            service._build_lifecycle_transition_record(
-                support.mock.sentinel.record,
-                existing_record=support.mock.sentinel.existing_record,
-                transitioned_at=first_seen_at,
-                latest_transition=support.mock.sentinel.latest_transition,
-            ),
-            transition_record,
-        )
-        self.assertIs(
-            service._build_lifecycle_transition_records(
-                support.mock.sentinel.record,
-                existing_record=support.mock.sentinel.existing_record,
-                transitioned_at=first_seen_at,
-            ),
-            transition_records,
         )
         self.assertEqual(
             service._lifecycle_transition_id(
@@ -534,19 +509,6 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             forwarded_proto="https",
             reverse_proxy_secret_header=REVIEWED_PROXY_SECRET,
             peer_addr="10.10.0.5",
-        )
-        lifecycle_delegate.build_lifecycle_transition_record.assert_called_once_with(
-            support.mock.sentinel.record,
-            existing_record=support.mock.sentinel.existing_record,
-            transitioned_at=first_seen_at,
-            initial_transitioned_at_fallback=None,
-            must_precede_transitioned_at=None,
-            latest_transition=support.mock.sentinel.latest_transition,
-        )
-        lifecycle_delegate.build_lifecycle_transition_records.assert_called_once_with(
-            support.mock.sentinel.record,
-            existing_record=support.mock.sentinel.existing_record,
-            transitioned_at=first_seen_at,
         )
         lifecycle_delegate.lifecycle_transition_id.assert_called_once_with(
             transition_timestamp="20260405T120000.000000Z",

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,12 +1,12 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.9.6 final residual exception:
+# Phase 50.10.5 residual exception:
 # ADR-0004 accepted ordered hotspot reduction after the ADR-0003
 # facade-preservation exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 50.9 extraction sequence, so this baseline records the final
-# Phase 50.9.6 ceiling and fails on silent re-growth. A future ADR or
+# the Phase 50.10.5 internal caller rewiring, so this baseline records the
+# reduced ceiling and fails on silent re-growth. A future ADR or
 # maintainability backlog must lower or replace these limits before unrelated
 # feature expansion lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=173 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.9.6 issue=#980
+control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.5 issue=#992

--- a/docs/phase-50-10-5-facade-method-rewiring.md
+++ b/docs/phase-50-10-5-facade-method-rewiring.md
@@ -1,0 +1,36 @@
+# Phase 50.10.5 Facade Method Rewiring
+
+Phase 50.10.5 is a behavior-preserving maintainability slice for issue #992. It reduces `AegisOpsControlPlaneService` facade pressure by rewiring internal lifecycle-transition callers to the focused detection lifecycle collaborator.
+
+## Rewired Callers
+
+- `control-plane/aegisops_control_plane/service_composition.py` now passes restore/readiness lifecycle synthesis through `DetectionIntakeService.lifecycle_transition_helper.build_lifecycle_transition_record`.
+- `control-plane/aegisops_control_plane/external_evidence_endpoint.py` now builds endpoint action-request lifecycle transitions through `DetectionIntakeService.lifecycle_transition_helper.build_lifecycle_transition_records`.
+
+The removed facade delegates were private lifecycle-transition compatibility methods:
+
+- `_build_lifecycle_transition_record`
+- `_build_lifecycle_transition_records`
+
+HTTP, CLI, and documented public service entrypoints remain unchanged.
+
+## Accepted Residual Facade Ceiling
+
+After this rewiring, the maintainability verifier reports the remaining accepted service hotspot as:
+
+- `lines=3003`
+- `effective_lines=2704`
+- `max_facade_methods=167`
+- `facade_class=AegisOpsControlPlaneService`
+- `adr_exception=ADR-0003`
+- `phase=50.10.5`
+- `issue=#992`
+
+The facade remains above the long-term 1,500-line and 50-method targets, so the baseline is still an exception and not a general growth allowance.
+
+## Verification
+
+Run:
+
+- `python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_service_persistence_ingest_case_lifecycle.py`
+- `bash scripts/verify-maintainability-hotspots.sh`


### PR DESCRIPTION
## Summary
- Rewire lifecycle-transition internal callers from private `AegisOpsControlPlaneService` delegates to `DetectionIntakeService.lifecycle_transition_helper`.
- Remove `_build_lifecycle_transition_record` and `_build_lifecycle_transition_records` from the service facade.
- Lower the accepted facade-method hotspot ceiling to 167 and document the Phase 50.10.5 evidence.

## Verification
- `python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_service_persistence_ingest_case_lifecycle.py`
- `python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_service_persistence_ingest_case_lifecycle.py control-plane/tests/test_cli_inspection.py control-plane/tests/test_runtime_skeleton.py control-plane/tests/test_phase28_external_evidence_boundary_refactor.py`
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node dist/index.js issue-lint 992 --config "$CODEX_SUPERVISOR_CONFIG"` from `<codex-supervisor-root>`

Closes #992


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganized to improve system maintainability and architectural clarity.

* **Tests**
  * Added new regression validation tests and updated existing test expectations for consistency.

* **Documentation**
  * Maintainability hotspot baseline metrics updated.
  * Phase 50.10.5 documentation added, describing internal architectural improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->