### PR TITLE
Phase 50.10.6 hotspot closeout baseline

### DIFF
--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,7 +66,7 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.10.5")
+        self.assertEqual(metadata["phase"], "50.10.6")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -50,13 +50,13 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
                 return metadata
         raise AssertionError("service.py hotspot baseline entry not found")
 
-    def test_baseline_records_phase50_9_closeout_ceiling(self) -> None:
+    def test_baseline_records_phase50_10_closeout_ceiling(self) -> None:
         service_text = self._read("control-plane/aegisops_control_plane/service.py")
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.10.5")
-        self.assertEqual(metadata["issue"], "#992")
+        self.assertEqual(metadata["phase"], "50.10.6")
+        self.assertEqual(metadata["issue"], "#993")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(
@@ -71,25 +71,30 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         self.assertLess(int(metadata["max_effective_lines"]), 3182)
         self.assertLess(int(metadata["max_facade_methods"]), 185)
 
-    def test_closeout_notes_preserve_phase50_9_hotspot_and_trigger(self) -> None:
+    def test_closeout_notes_preserve_phase50_10_hotspot_and_trigger(self) -> None:
         closeout = self._read("docs/phase-50-maintainability-closeout.md")
 
         for required in (
-            "Phase 50.9.6",
+            "Phase 50.10.6",
             "control-plane/aegisops_control_plane/service.py",
             "control-plane/aegisops_control_plane/action_review_projection.py",
+            "control-plane/aegisops_control_plane/external_evidence_boundary.py",
             "AegisOpsControlPlaneService",
-            "max_lines=3158",
-            "max_effective_lines=2853",
-            "max_facade_methods=173",
+            "max_lines=3003",
+            "max_effective_lines=2704",
+            "max_facade_methods=167",
             "projection lines=105",
             "projection effective_lines=103",
+            "external_evidence_boundary.py lines=216",
+            "external_evidence_boundary.py effective_lines=195",
+            "ADR-0007",
             "ADR-0004",
             "ADR-0003",
-            "#980",
+            "#993",
             "remaining accepted hotspot",
-            "facade dispatch and authority-boundary guard helpers",
+            "facade dispatch, compatibility entrypoints, and authority-boundary guard helpers",
             "projection split does not require a baseline entry",
+            "external-evidence split does not require a baseline entry",
             "silent re-growth",
             "another decomposition decision",
             "bash scripts/verify-maintainability-hotspots.sh",
@@ -120,9 +125,12 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
 
         for required in (
             "regrowth_repo",
+            "phase50_10_regrowth_repo",
             "Maintainability hotspot baseline limits were exceeded",
             "lines=960 exceeds max_lines=959",
             "effective_lines=960 exceeds max_effective_lines=959",
+            "lines=3004 exceeds max_lines=3003",
+            "effective_lines=3004 exceeds max_effective_lines=2704",
             "max_facade_methods=0",
         ):
             self.assertIn(required, verifier_test)

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,12 +1,12 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.10.5 residual exception:
+# Phase 50.10.6 residual exception:
 # ADR-0004 accepted ordered hotspot reduction after the ADR-0003
 # facade-preservation exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 50.10.5 internal caller rewiring, so this baseline records the
+# the Phase 50.10.6 closeout verification, so this baseline records the
 # reduced ceiling and fails on silent re-growth. A future ADR or
 # maintainability backlog must lower or replace these limits before unrelated
 # feature expansion lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.5 issue=#992
+control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,10 +1,10 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.9.6 closes the ordered maintainability hotspot reduction sequence governed by ADR-0004, ADR-0005, and ADR-0006.
+Phase 50.10.6 closes the ordered maintainability hotspot reduction sequence governed by ADR-0004, ADR-0005, ADR-0006, and ADR-0007.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
-ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0005 governs the Phase 50.8 residual service migration contract. ADR-0006 governs the Phase 50.9 residual facade convergence and projection guard. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
+ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0005 governs the Phase 50.8 residual service migration contract. ADR-0006 governs the Phase 50.9 residual facade convergence and projection guard. ADR-0007 governs the Phase 50.10 facade floor and external-evidence guard. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
 
 ## Accepted Verifier State
 
@@ -12,18 +12,18 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.9 extraction and fencing work. The final Phase 50.9.6 closeout for #980 records the accepted residual ceiling as:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.10 extraction, service-facade rewiring, and internal-caller rewiring work. The final Phase 50.10.6 closeout for #993 records the accepted residual ceiling as:
 
-- `max_lines=3158`
-- `max_effective_lines=2853`
-- `max_facade_methods=173`
+- `max_lines=3003`
+- `max_effective_lines=2704`
+- `max_facade_methods=167`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.9.6`
+- `phase=50.10.6`
 
-No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, operator UI route tests, or `control-plane/aegisops_control_plane/action_review_projection.py` because the verifier does not report those areas as current responsibility-growth candidates. The Phase 50.9.6 projection measurement is `projection lines=105` and `projection effective_lines=103`, so the projection split does not require a baseline entry.
+No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, operator UI route tests, `control-plane/aegisops_control_plane/action_review_projection.py`, or `control-plane/aegisops_control_plane/external_evidence_boundary.py` because the verifier does not report those areas as current responsibility-growth candidates. The Phase 50.9.6 projection measurement is `projection lines=105` and `projection effective_lines=103`, so the projection split does not require a baseline entry. The Phase 50.10.6 external-evidence measurement is `external_evidence_boundary.py lines=216` and `external_evidence_boundary.py effective_lines=195`, so the external-evidence split does not require a baseline entry.
 
-The remaining accepted hotspot is not a general extension target. The residual helper pressure is concentrated in facade dispatch and authority-boundary guard helpers that still sit behind the public facade. Those helpers remain review-visible because they protect action review state, detection intake linkage, and fail-closed authoritative-state reads at the service boundary.
+The remaining accepted hotspot is not a general extension target. The residual helper pressure is concentrated in facade dispatch, compatibility entrypoints, and authority-boundary guard helpers that still sit behind the public facade. Those helpers remain review-visible because they protect action review state, detection intake linkage, external-evidence linkage, and fail-closed authoritative-state reads at the service boundary.
 
 ## Follow-Up Trigger
 
@@ -33,7 +33,7 @@ Any silent re-growth beyond the recorded ceiling must fail the verifier. The exp
 
 If a later extraction lowers the facade below the verifier threshold, maintainers should remove or lower the baseline only after confirming that the file no longer crosses the responsibility-growth threshold.
 
-If future work needs to add another action-review surface, intake pathway, authoritative restore/read guard, or cross-record projection helper to `service.py`, that is the follow-up trigger for another maintainability issue. The follow-up should extract or fence the directly linked helper cluster instead of using this exception as approval for new facade responsibility. If `action_review_projection.py` grows back toward the Phase 50.9 pre-split measurement of `max_lines=2034` or `max_effective_lines=1911`, the follow-up should split that directly linked projection cluster instead of silently recording a new projection hotspot exception.
+If future work needs to add another action-review surface, intake pathway, authoritative restore/read guard, external-evidence linkage path, or cross-record projection helper to `service.py`, that is the follow-up trigger for another maintainability issue. The follow-up should extract or fence the directly linked helper cluster instead of using this exception as approval for new facade responsibility. If `action_review_projection.py` grows back toward the Phase 50.9 pre-split measurement of `max_lines=2034` or `max_effective_lines=1911`, the follow-up should split that directly linked projection cluster instead of silently recording a new projection hotspot exception. If `external_evidence_boundary.py` grows back toward the pre-Phase 50.10 measurement of `max_lines=1083` or `max_effective_lines=1033`, the follow-up should split the directly linked MISP, osquery, or endpoint-evidence helper cluster instead of recording a silent external-evidence hotspot exception.
 
 ## Verification Evidence
 

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -162,6 +162,35 @@ if ! grep -F "RenamedControlPlaneService methods=1" "${fail_stderr}" >/dev/null;
   exit 1
 fi
 
+phase50_10_regrowth_repo="${workdir}/phase50-10-regrowth"
+create_repo \
+  "${phase50_10_regrowth_repo}" \
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993" \
+  "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
+    def describe_runtime(self):
+        auth_principal = 'trusted-runtime-boundary'
+        queue_status = {'operator': auth_principal}
+        case_transition = queue_status
+        assistant_recommendation = case_transition
+        action_reconciliation = assistant_recommendation
+        restore_backup_export = action_reconciliation
+        evidence_admission = restore_backup_export
+        return evidence_admission"
+append_repeated_lines "${phase50_10_regrowth_repo}" "control-plane/aegisops_control_plane/service.py" "phase50_10_growth_line" 2994
+git -C "${phase50_10_regrowth_repo}" add .
+git -C "${phase50_10_regrowth_repo}" commit -q -m "phase 50.10 regrowth past accepted closeout"
+assert_fails_with "${phase50_10_regrowth_repo}" "Maintainability hotspot baseline limits were exceeded"
+if ! grep -F "lines=3004 exceeds max_lines=3003" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the Phase 50.10 line-count limit." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
+if ! grep -F "effective_lines=3004 exceeds max_effective_lines=2704" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the Phase 50.10 effective-line limit." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
+
 new_hotspot_repo="${workdir}/new-hotspot"
 create_repo \
   "${new_hotspot_repo}" \

--- a/scripts/test-verify-phase-50-10-facade-floor-external-evidence-contract.sh
+++ b/scripts/test-verify-phase-50-10-facade-floor-external-evidence-contract.sh
@@ -30,6 +30,36 @@ write_baseline() {
     >"${target}/docs/maintainability-hotspot-baseline.txt"
 }
 
+write_closeout_baseline() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  printf '%s\n' \
+    "control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993" \
+    >"${target}/docs/maintainability-hotspot-baseline.txt"
+}
+
+write_closeout_evidence() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cat >"${target}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.10.6 closes the ordered maintainability hotspot reduction sequence.
+
+The final Phase 50.10.6 closeout for #993 records the accepted residual ceiling as:
+
+- `max_lines=3003`
+- `max_effective_lines=2704`
+- `max_facade_methods=167`
+
+The Phase 50.10.6 external-evidence measurement is `external_evidence_boundary.py lines=216` and `external_evidence_boundary.py effective_lines=195`, so the external-evidence split does not require a baseline entry.
+
+Any silent re-growth beyond the recorded ceiling must fail the verifier. The expected response is another decomposition decision or maintainability backlog.
+EOF
+}
+
 create_valid_repo() {
   local target="$1"
 
@@ -193,6 +223,12 @@ valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
 
+final_closeout_repo="${workdir}/final-closeout"
+create_valid_repo "${final_closeout_repo}"
+write_closeout_baseline "${final_closeout_repo}"
+write_closeout_evidence "${final_closeout_repo}"
+assert_passes "${final_closeout_repo}"
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/adr/0007-phase-50-10-facade-floor-and-external-evidence-guard.md"
@@ -224,6 +260,23 @@ printf '%s\n' \
 assert_fails_with \
   "${premature_service_baseline_repo}" \
   "Phase 50.10 contract forbids refreshing the service.py baseline before implementation evidence exists."
+
+missing_closeout_evidence_repo="${workdir}/missing-closeout-evidence"
+create_valid_repo "${missing_closeout_evidence_repo}"
+write_closeout_baseline "${missing_closeout_evidence_repo}"
+assert_fails_with \
+  "${missing_closeout_evidence_repo}" \
+  "Phase 50.10 final baseline refresh requires closeout evidence"
+
+incomplete_closeout_evidence_repo="${workdir}/incomplete-closeout-evidence"
+create_valid_repo "${incomplete_closeout_evidence_repo}"
+write_closeout_baseline "${incomplete_closeout_evidence_repo}"
+write_closeout_evidence "${incomplete_closeout_evidence_repo}"
+perl -0pi -e 's/external-evidence split does not require a baseline entry//g' \
+  "${incomplete_closeout_evidence_repo}/docs/phase-50-maintainability-closeout.md"
+assert_fails_with \
+  "${incomplete_closeout_evidence_repo}" \
+  "Phase 50.10 final closeout evidence is missing: external-evidence split does not require a baseline entry"
 
 premature_external_baseline_repo="${workdir}/premature-external-baseline"
 create_valid_repo "${premature_external_baseline_repo}"

--- a/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -211,6 +211,28 @@ Any silent re-growth requires another decomposition decision.
 EOF
 assert_passes "${superseding_closeout_repo}"
 
+phase50_10_superseding_closeout_repo="${workdir}/phase50-10-superseding-closeout"
+create_valid_repo "${phase50_10_superseding_closeout_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993" \
+  >"${phase50_10_superseding_closeout_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${phase50_10_superseding_closeout_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.10.6 records the final #993 closeout baseline.
+
+- `max_lines=3003`
+- `max_effective_lines=2704`
+- `max_facade_methods=167`
+
+The remaining accepted hotspot is the facade dispatch, compatibility entrypoints, and authority-boundary guard helpers.
+
+The external-evidence split does not require a baseline entry.
+
+Any silent re-growth requires another decomposition decision.
+EOF
+assert_passes "${phase50_10_superseding_closeout_repo}"
+
 superseding_regrowth_repo="${workdir}/superseding-regrowth"
 create_valid_repo "${superseding_regrowth_repo}"
 printf '%s\n' \
@@ -234,6 +256,30 @@ EOF
 assert_fails_with \
   "${superseding_regrowth_repo}" \
   "Phase 50.9 superseding closeout baseline must remain at or below the accepted #980 ceiling."
+
+phase50_10_superseding_regrowth_repo="${workdir}/phase50-10-superseding-regrowth"
+create_valid_repo "${phase50_10_superseding_regrowth_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=3004 max_effective_lines=2705 max_facade_methods=168 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993" \
+  >"${phase50_10_superseding_regrowth_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${phase50_10_superseding_regrowth_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.10.6 records a regrown #993 closeout baseline.
+
+- `max_lines=3004`
+- `max_effective_lines=2705`
+- `max_facade_methods=168`
+
+The remaining accepted hotspot is the facade dispatch, compatibility entrypoints, and authority-boundary guard helpers.
+
+The external-evidence split does not require a baseline entry.
+
+Any silent re-growth requires another decomposition decision.
+EOF
+assert_fails_with \
+  "${phase50_10_superseding_regrowth_repo}" \
+  "Phase 50.10 superseding closeout baseline must remain at or below the accepted #993 ceiling."
 
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"

--- a/scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh
+++ b/scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh
@@ -30,6 +30,34 @@ write_baseline() {
     >"${target}/docs/maintainability-hotspot-baseline.txt"
 }
 
+write_phase50_10_baseline() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  printf '%s\n' \
+    "control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993" \
+    >"${target}/docs/maintainability-hotspot-baseline.txt"
+}
+
+write_phase50_10_closeout() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cat >"${target}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.10.6 records the final #993 closeout baseline.
+
+- `max_lines=3003`
+- `max_effective_lines=2704`
+- `max_facade_methods=167`
+
+The external-evidence split does not require a baseline entry.
+
+Any silent re-growth requires another decomposition decision.
+EOF
+}
+
 create_valid_repo() {
   local target="$1"
 
@@ -199,6 +227,19 @@ assert_fails_with() {
 valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
+
+phase50_10_superseding_repo="${workdir}/phase50-10-superseding"
+create_valid_repo "${phase50_10_superseding_repo}"
+write_phase50_10_baseline "${phase50_10_superseding_repo}"
+write_phase50_10_closeout "${phase50_10_superseding_repo}"
+assert_passes "${phase50_10_superseding_repo}"
+
+missing_phase50_10_closeout_repo="${workdir}/missing-phase50-10-closeout"
+create_valid_repo "${missing_phase50_10_closeout_repo}"
+write_phase50_10_baseline "${missing_phase50_10_closeout_repo}"
+assert_fails_with \
+  "${missing_phase50_10_closeout_repo}" \
+  "Phase 50.9 superseding Phase 50.10 baseline requires closeout evidence"
 
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"

--- a/scripts/verify-phase-50-10-facade-floor-external-evidence-contract.sh
+++ b/scripts/verify-phase-50-10-facade-floor-external-evidence-contract.sh
@@ -109,7 +109,8 @@ for phrase in "${required_phrases[@]}"; do
   fi
 done
 
-service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=173 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.9.6 issue=#980"
+starting_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=173 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.9.6 issue=#980"
+closeout_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993"
 service_entry="$(grep -E '^control-plane/aegisops_control_plane/service.py[[:space:]]' "${baseline_path}" || true)"
 service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 if [[ "${service_entry_count}" -eq 0 ]]; then
@@ -120,7 +121,33 @@ if [[ "${service_entry_count}" -ne 1 ]]; then
   echo "Phase 50.10 contract requires exactly one service.py hotspot baseline entry." >&2
   exit 1
 fi
-if [[ "${service_entry}" != "${service_baseline_entry}" ]]; then
+if [[ "${service_entry}" == "${starting_service_baseline_entry}" ]]; then
+  :
+elif [[ "${service_entry}" == "${closeout_service_baseline_entry}" ]]; then
+  closeout_path="${repo_root}/docs/phase-50-maintainability-closeout.md"
+  if [[ ! -f "${closeout_path}" ]]; then
+    echo "Phase 50.10 final baseline refresh requires closeout evidence: ${closeout_path}" >&2
+    exit 1
+  fi
+  closeout_required_phrases=(
+    "Phase 50.10.6"
+    "#993"
+    "\`max_lines=3003\`"
+    "\`max_effective_lines=2704\`"
+    "\`max_facade_methods=167\`"
+    "external_evidence_boundary.py lines=216"
+    "external_evidence_boundary.py effective_lines=195"
+    "external-evidence split does not require a baseline entry"
+    "silent re-growth"
+    "another decomposition decision"
+  )
+  for phrase in "${closeout_required_phrases[@]}"; do
+    if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
+      echo "Phase 50.10 final closeout evidence is missing: ${phrase}" >&2
+      exit 1
+    fi
+  done
+else
   echo "Phase 50.10 contract forbids refreshing the service.py baseline before implementation evidence exists." >&2
   exit 1
 fi

--- a/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
+++ b/scripts/verify-phase-50-8-residual-service-hotspot-contract.sh
@@ -182,8 +182,28 @@ elif [[ "${phase}" == "50.9.6" && "${issue}" == "#980" ]]; then
     "silent re-growth"
     "another decomposition decision"
   )
+elif [[ "${phase}" == "50.10.6" && "${issue}" == "#993" ]]; then
+  if [[
+    "${max_lines}" -gt 3003 ||
+    "${max_effective_lines}" -gt 2704 ||
+    "${max_facade_methods}" -gt 167
+  ]]; then
+    echo "Phase 50.10 superseding closeout baseline must remain at or below the accepted #993 ceiling." >&2
+    exit 1
+  fi
+  closeout_required_phrases=(
+    "Phase 50.10.6"
+    "#993"
+    "\`max_lines=${max_lines}\`"
+    "\`max_effective_lines=${max_effective_lines}\`"
+    "\`max_facade_methods=${max_facade_methods}\`"
+    "facade dispatch, compatibility entrypoints, and authority-boundary guard helpers"
+    "external-evidence split does not require a baseline entry"
+    "silent re-growth"
+    "another decomposition decision"
+  )
 else
-  echo "Phase 50.8 contract requires a final Phase 50.8.6 closeout baseline for #967 or a lower superseding Phase 50.9.6 closeout baseline for #980." >&2
+  echo "Phase 50.8 contract requires a final Phase 50.8.6 closeout baseline for #967, a lower superseding Phase 50.9.6 closeout baseline for #980, or a lower superseding Phase 50.10.6 closeout baseline for #993." >&2
   exit 1
 fi
 

--- a/scripts/verify-phase-50-9-residual-facade-convergence-contract.sh
+++ b/scripts/verify-phase-50-9-residual-facade-convergence-contract.sh
@@ -114,6 +114,7 @@ for phrase in "${required_phrases[@]}"; do
 done
 
 service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=3158 max_effective_lines=2853 max_facade_methods=173 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.9.6 issue=#980"
+phase50_10_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993"
 service_entry="$(grep -E '^control-plane/aegisops_control_plane/service.py[[:space:]]' "${baseline_path}" || true)"
 service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 if [[ "${service_entry_count}" -eq 0 ]]; then
@@ -124,7 +125,31 @@ if [[ "${service_entry_count}" -ne 1 ]]; then
   echo "Phase 50.9 closeout requires exactly one service.py hotspot baseline entry." >&2
   exit 1
 fi
-if [[ "${service_entry}" != "${service_baseline_entry}" ]]; then
+if [[ "${service_entry}" == "${service_baseline_entry}" ]]; then
+  :
+elif [[ "${service_entry}" == "${phase50_10_service_baseline_entry}" ]]; then
+  closeout_path="${repo_root}/docs/phase-50-maintainability-closeout.md"
+  if [[ ! -f "${closeout_path}" ]]; then
+    echo "Phase 50.9 superseding Phase 50.10 baseline requires closeout evidence: ${closeout_path}" >&2
+    exit 1
+  fi
+  closeout_required_phrases=(
+    "Phase 50.10.6"
+    "#993"
+    "\`max_lines=3003\`"
+    "\`max_effective_lines=2704\`"
+    "\`max_facade_methods=167\`"
+    "external-evidence split does not require a baseline entry"
+    "silent re-growth"
+    "another decomposition decision"
+  )
+  for phrase in "${closeout_required_phrases[@]}"; do
+    if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
+      echo "Phase 50.9 superseding Phase 50.10 closeout evidence is missing: ${phrase}" >&2
+      exit 1
+    fi
+  done
+else
   echo "Phase 50.9 closeout requires the accepted Phase 50.9.6 service.py ceiling after implementation evidence exists." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- refresh the Phase 50.10.6 maintainability hotspot baseline to the accepted `service.py` ceiling (`3003/2704/167`)
- update closeout evidence for service and external-evidence measurements without adding an external-evidence baseline entry
- add negative verifier coverage for silent regrowth beyond the Phase 50.10.6 state and allow older Phase 50 contract checks to recognize the lower superseding closeout

## Verification
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-phase-50-8-residual-service-hotspot-contract.sh && bash scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh`
- `bash scripts/verify-phase-50-9-residual-facade-convergence-contract.sh && bash scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh`
- `bash scripts/verify-phase-50-10-facade-floor-external-evidence-contract.sh && bash scripts/test-verify-phase-50-10-facade-floor-external-evidence-contract.sh`
- `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py control-plane/tests/test_phase49_service_decomposition_closeout.py`
- `python3 -m unittest control-plane/tests/test_phase28_external_evidence_boundary_refactor.py control-plane/tests/test_phase25_osquery_host_context_validation.py control-plane/tests/test_phase28_misp_enrichment_validation.py control-plane/tests/test_phase28_endpoint_evidence_pack_validation.py control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_service_persistence_ingest_case_lifecycle.py`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
- `node <codex-supervisor-root>/dist/index.js issue-lint 993 --config <supervisor-config-path>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated maintainability hotspot baseline metrics and thresholds to Phase 50.10.6
  * Added external-evidence boundary documentation requirements
  * Updated issue reference for baseline exception tracking

* **Tests**
  * Extended verification test coverage for Phase 50.10.6 baseline validation
  * Added scenarios validating external-evidence documentation requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->