### PR TITLE
Phase 50.11 residual extraction contract

### DIFF
--- a/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md
+++ b/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md
@@ -1,0 +1,147 @@
+# ADR-0008: Phase 50.11 Service Residual Extraction Contract
+
+- **Status**: Accepted
+- **Date**: 2026-04-30
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/requirements-baseline.md`
+- **Product**: AegisOps
+- **Related Issues**: #1000, #1001
+- **Depends On**: #993
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+---
+
+## 1. Context
+
+Phase 50.10.6 closed #993 and recorded the accepted residual `service.py` ceiling in `docs/maintainability-hotspot-baseline.txt`.
+
+ADR-0003 remains authoritative for the public facade-preservation exception.
+
+ADR-0004 remains authoritative for the Phase 50 ordered hotspot-reduction rule.
+
+ADR-0005 remains authoritative for the Phase 50.8 residual helper migration contract and the rule that baseline refreshes require implementation evidence.
+
+ADR-0006 remains authoritative for the Phase 50.9 residual facade convergence and projection hotspot guard.
+
+ADR-0007 remains authoritative for the Phase 50.10 facade floor and external-evidence guard.
+
+`docs/maintainability-decomposition-thresholds.md` remains the governing hotspot trigger policy.
+
+Phase 50.11 needs a repo-owned contract before residual DTO/helper extraction starts so later slices do not choose local extraction order, treat the Phase 50.10.6 ceiling as permission for facade growth, or move authority-boundary helper pressure into unchecked modules.
+
+This ADR does not refresh the baseline because Phase 50.11 implementation evidence does not exist yet and follow-on implementation slices remain.
+
+## 2. Decision
+
+Phase 50.11 will reduce the residual `service.py` hotspot by extracting DTO/snapshot shaping and helper clusters in a fixed, behavior-preserving order.
+
+The Phase 50.11 residual extraction clusters are:
+
+- DTO/snapshot extraction cluster
+- runtime auth helper cluster
+- action-review helper cluster
+- assistant linkage helper cluster
+- detection/case-linkage helper cluster
+
+Public service entrypoints, runtime behavior, configuration shape, authority semantics, response semantics, and durable-state side effects remain unchanged.
+
+AegisOps control-plane records remain authoritative workflow truth.
+
+Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, projections, snapshots, DTOs, and helper-module output remain subordinate context.
+
+## 3. Starting Measurements
+
+The Phase 50.10.6 starting ceiling for `control-plane/aegisops_control_plane/service.py` is:
+
+- `max_lines=3003`
+- `max_effective_lines=2704`
+- `max_facade_methods=167`
+- `facade_class=AegisOpsControlPlaneService`
+- `phase=50.10.6`
+- `issue=#993`
+
+The same values are the Phase 50.11 starting measurements before implementation slices begin:
+
+- `physical_lines=3003`
+- `effective_lines=2704`
+- `AegisOpsControlPlaneService methods=167`
+
+The Phase 50.11 implementation target for `control-plane/aegisops_control_plane/service.py` is:
+
+- `max_lines <= 2700`
+- `max_effective_lines <= 2450`
+- `max_facade_methods <= 150`
+
+A Phase 50.11 closeout may record a lower exception only if it names the unresolved residual cluster, records the measured line, effective-line, and facade-method counts, and keeps the exception lower than the Phase 50.10.6 ceiling.
+
+Any `service.py` baseline refresh before Phase 50.11 implementation evidence exists is forbidden.
+
+## 4. Extraction Scope
+
+The DTO/snapshot extraction cluster owns internal data shaping for response DTOs, snapshot views, and operator-facing projection assembly that is already anchored to authoritative AegisOps records.
+
+The runtime auth helper cluster owns internal helper code for principal, tenant, scope, and runtime-boundary checks without trusting forwarded headers, client-supplied identity fields, placeholder credentials, or inferred scope.
+
+The action-review helper cluster owns internal helper code that shapes approval, execution, delegation, reconciliation, mismatch, and receipt views while preserving authoritative action-review records as the source of truth.
+
+The assistant linkage helper cluster owns internal helper code that attaches assistant, advisory, recommendation, and citation context only through explicit authoritative links.
+
+The detection/case-linkage helper cluster owns internal helper code that binds detection intake, case linkage, external-evidence linkage, and evidence admission to explicit authoritative records.
+
+No extracted helper may infer tenant, repository, account, issue, case, alert, host, environment, approval, execution, reconciliation, assistant, detection, or evidence linkage from naming conventions, path shape, comments, nearby metadata, sibling records, or operator-facing summaries alone.
+
+## 5. Migration Order
+
+The Phase 50.11 migration order is:
+
+1. DTO/snapshot extraction cluster
+2. runtime auth helper cluster
+3. action-review helper cluster
+4. assistant linkage helper cluster
+5. detection/case-linkage helper cluster
+6. closeout and hotspot-baseline guard cluster
+
+DTO/snapshot helpers must move before authority-bearing helpers so read-shaping code is separated from enforcement logic before later slices touch auth, action-review, assistant, or detection linkage.
+
+Runtime auth helpers must move before action-review, assistant, and detection/case-linkage helpers so later helper boundaries keep using normalized trusted auth context instead of client-supplied hints.
+
+Action-review helpers must move before assistant linkage helpers so advisory surfaces continue to attach to directly linked authoritative approval, execution, delegation, reconciliation, and receipt records.
+
+Assistant linkage helpers must move before detection/case-linkage helpers so recommendation and citation context cannot broaden evidence or case linkage by sibling or same-parent inference.
+
+Detection/case-linkage helpers must move before closeout so any residual `service.py` baseline decision is based on implementation evidence rather than a desired target.
+
+The Phase 50.11 child issues are not parallelizable by default. A later issue may change the order only through another repo-owned decision that explicitly preserves the authority-boundary, authoritative-record, snapshot-consistency, and measurement rules in this ADR.
+
+## 6. Validation
+
+Run `bash scripts/verify-phase-50-11-service-residual-extraction-contract.sh`.
+
+Run `bash scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh`.
+
+Run `bash scripts/verify-maintainability-hotspots.sh`.
+
+Run `bash scripts/test-verify-maintainability-hotspots.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1001 --config <supervisor-config-path>`.
+
+For the Phase 50.11 Epic, run the same issue-lint command for each Phase 50.11 child issue before allowing implementation slices to proceed.
+
+## 7. Non-Goals
+
+- No production code extraction is approved by this ADR.
+- No DTO, snapshot, runtime auth, action-review, assistant linkage, detection, case-linkage, or external-evidence module split is approved by this ADR.
+- No approval, execution, reconciliation, assistant, detection, external-evidence, restore, readiness, or operator authority behavior is changed.
+- No ticket, ML, endpoint, network, browser, optional-evidence, Wazuh, Shuffle, Zammad, deployment, database, migration, credential source, HTTP surface, CLI surface, or operator UI behavior is changed.
+- No public service entrypoint, runtime behavior, configuration shape, authority semantics, response semantic, or durable-state side effect is changed.
+- No baseline refresh is approved before Phase 50.11 implementation evidence exists.
+- No subordinate source, operator-facing projection, summary, badge, counter, snapshot, DTO, recommendation, evidence snippet, reconciliation note, or helper-module output becomes authoritative workflow truth.
+- No exception may raise the Phase 50.10.6 ceiling.
+
+## 8. Approval
+
+- **Proposed By**: Codex for Issue #1001
+- **Reviewed By**: AegisOps maintainers
+- **Approved By**: AegisOps maintainers
+- **Approval Date**: 2026-04-30

--- a/scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh
+++ b/scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-50-11-service-residual-extraction-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+write_contract() {
+  local target="$1"
+  local content="$2"
+
+  mkdir -p "${target}/docs/adr"
+  printf '%s\n' "${content}" >"${target}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
+}
+
+write_baseline() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  printf '%s\n' \
+    "control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993" \
+    >"${target}/docs/maintainability-hotspot-baseline.txt"
+}
+
+create_valid_repo() {
+  local target="$1"
+
+  write_baseline "${target}"
+  write_contract "${target}" '# ADR-0008: Phase 50.11 Service Residual Extraction Contract
+
+- **Status**: Accepted
+- **Date**: 2026-04-30
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/requirements-baseline.md`
+- **Product**: AegisOps
+- **Related Issues**: #1000, #1001
+- **Depends On**: #993
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+## 1. Context
+
+Phase 50.10.6 closed #993 and recorded the accepted residual `service.py` ceiling in `docs/maintainability-hotspot-baseline.txt`.
+
+ADR-0003 remains authoritative for the public facade-preservation exception.
+
+ADR-0004 remains authoritative for the Phase 50 ordered hotspot-reduction rule.
+
+ADR-0005 remains authoritative for the Phase 50.8 residual helper migration contract and the rule that baseline refreshes require implementation evidence.
+
+ADR-0006 remains authoritative for the Phase 50.9 residual facade convergence and projection hotspot guard.
+
+ADR-0007 remains authoritative for the Phase 50.10 facade floor and external-evidence guard.
+
+`docs/maintainability-decomposition-thresholds.md` remains the governing hotspot trigger policy.
+
+This ADR does not refresh the baseline because Phase 50.11 implementation evidence does not exist yet and follow-on implementation slices remain.
+
+## 2. Decision
+
+The Phase 50.11 residual extraction clusters are:
+
+- DTO/snapshot extraction cluster
+- runtime auth helper cluster
+- action-review helper cluster
+- assistant linkage helper cluster
+- detection/case-linkage helper cluster
+
+Public service entrypoints, runtime behavior, configuration shape, authority semantics, response semantics, and durable-state side effects remain unchanged.
+
+AegisOps control-plane records remain authoritative workflow truth.
+
+Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, projections, snapshots, DTOs, and helper-module output remain subordinate context.
+
+## 3. Starting Measurements
+
+The Phase 50.10.6 starting ceiling for `control-plane/aegisops_control_plane/service.py` is:
+
+- `max_lines=3003`
+- `max_effective_lines=2704`
+- `max_facade_methods=167`
+- `facade_class=AegisOpsControlPlaneService`
+- `phase=50.10.6`
+- `issue=#993`
+
+- `physical_lines=3003`
+- `effective_lines=2704`
+- `AegisOpsControlPlaneService methods=167`
+
+The Phase 50.11 implementation target for `control-plane/aegisops_control_plane/service.py` is:
+
+- `max_lines <= 2700`
+- `max_effective_lines <= 2450`
+- `max_facade_methods <= 150`
+
+A Phase 50.11 closeout may record a lower exception only if it names the unresolved residual cluster, records the measured line, effective-line, and facade-method counts, and keeps the exception lower than the Phase 50.10.6 ceiling.
+
+Any `service.py` baseline refresh before Phase 50.11 implementation evidence exists is forbidden.
+
+## 4. Extraction Scope
+
+The DTO/snapshot extraction cluster owns internal data shaping for response DTOs, snapshot views, and operator-facing projection assembly that is already anchored to authoritative AegisOps records.
+
+The runtime auth helper cluster owns internal helper code for principal, tenant, scope, and runtime-boundary checks without trusting forwarded headers, client-supplied identity fields, placeholder credentials, or inferred scope.
+
+The action-review helper cluster owns internal helper code that shapes approval, execution, delegation, reconciliation, mismatch, and receipt views while preserving authoritative action-review records as the source of truth.
+
+The assistant linkage helper cluster owns internal helper code that attaches assistant, advisory, recommendation, and citation context only through explicit authoritative links.
+
+The detection/case-linkage helper cluster owns internal helper code that binds detection intake, case linkage, external-evidence linkage, and evidence admission to explicit authoritative records.
+
+No extracted helper may infer tenant, repository, account, issue, case, alert, host, environment, approval, execution, reconciliation, assistant, detection, or evidence linkage from naming conventions, path shape, comments, nearby metadata, sibling records, or operator-facing summaries alone.
+
+## 5. Migration Order
+
+The Phase 50.11 migration order is:
+
+1. DTO/snapshot extraction cluster
+2. runtime auth helper cluster
+3. action-review helper cluster
+4. assistant linkage helper cluster
+5. detection/case-linkage helper cluster
+6. closeout and hotspot-baseline guard cluster
+
+DTO/snapshot helpers must move before authority-bearing helpers so read-shaping code is separated from enforcement logic before later slices touch auth, action-review, assistant, or detection linkage.
+
+Runtime auth helpers must move before action-review, assistant, and detection/case-linkage helpers so later helper boundaries keep using normalized trusted auth context instead of client-supplied hints.
+
+Action-review helpers must move before assistant linkage helpers so advisory surfaces continue to attach to directly linked authoritative approval, execution, delegation, reconciliation, and receipt records.
+
+Assistant linkage helpers must move before detection/case-linkage helpers so recommendation and citation context cannot broaden evidence or case linkage by sibling or same-parent inference.
+
+Detection/case-linkage helpers must move before closeout so any residual `service.py` baseline decision is based on implementation evidence rather than a desired target.
+
+## 6. Validation
+
+Run `bash scripts/verify-phase-50-11-service-residual-extraction-contract.sh`.
+
+Run `bash scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh`.
+
+Run `bash scripts/verify-maintainability-hotspots.sh`.
+
+Run `bash scripts/test-verify-maintainability-hotspots.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1001 --config <supervisor-config-path>`.
+
+For the Phase 50.11 Epic, run the same issue-lint command for each Phase 50.11 child issue before allowing implementation slices to proceed.
+
+## 7. Non-Goals
+
+- No production code extraction is approved by this ADR.
+- No DTO, snapshot, runtime auth, action-review, assistant linkage, detection, case-linkage, or external-evidence module split is approved by this ADR.
+- No approval, execution, reconciliation, assistant, detection, external-evidence, restore, readiness, or operator authority behavior is changed.
+- No baseline refresh is approved before Phase 50.11 implementation evidence exists.
+- No subordinate source, operator-facing projection, summary, badge, counter, snapshot, DTO, recommendation, evidence snippet, reconciliation note, or helper-module output becomes authoritative workflow truth.
+- No exception may raise the Phase 50.10.6 ceiling.
+
+## 8. Approval
+
+- **Proposed By**: Codex for Issue #1001
+- **Reviewed By**: AegisOps maintainers
+- **Approved By**: AegisOps maintainers
+- **Approval Date**: 2026-04-30'
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 50.11 service residual extraction contract"
+
+missing_measurement_repo="${workdir}/missing-measurement"
+create_valid_repo "${missing_measurement_repo}"
+perl -0pi -e 's/- `effective_lines=2704`\n//g' \
+  "${missing_measurement_repo}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
+assert_fails_with \
+  "${missing_measurement_repo}" \
+  "Missing Phase 50.11 service residual extraction contract statement: - \`effective_lines=2704\`"
+
+missing_cluster_repo="${workdir}/missing-cluster"
+create_valid_repo "${missing_cluster_repo}"
+perl -0pi -e 's/- assistant linkage helper cluster\n//g' \
+  "${missing_cluster_repo}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
+assert_fails_with \
+  "${missing_cluster_repo}" \
+  "Missing Phase 50.11 service residual extraction contract statement: - assistant linkage helper cluster"
+
+missing_authority_repo="${workdir}/missing-authority"
+create_valid_repo "${missing_authority_repo}"
+perl -0pi -e 's/AegisOps control-plane records remain authoritative workflow truth\.//g' \
+  "${missing_authority_repo}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
+assert_fails_with \
+  "${missing_authority_repo}" \
+  "Missing Phase 50.11 service residual extraction contract statement: AegisOps control-plane records remain authoritative workflow truth."
+
+missing_non_goal_repo="${workdir}/missing-non-goal"
+create_valid_repo "${missing_non_goal_repo}"
+perl -0pi -e 's/No approval, execution, reconciliation, assistant, detection, external-evidence, restore, readiness, or operator authority behavior is changed\.//g' \
+  "${missing_non_goal_repo}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
+assert_fails_with \
+  "${missing_non_goal_repo}" \
+  "Missing Phase 50.11 service residual extraction contract statement: No approval, execution, reconciliation, assistant, detection, external-evidence, restore, readiness, or operator authority behavior is changed."
+
+premature_service_baseline_repo="${workdir}/premature-service-baseline"
+create_valid_repo "${premature_service_baseline_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=2700 max_effective_lines=2450 max_facade_methods=150 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0008 phase=50.11 issue=#1001" \
+  >"${premature_service_baseline_repo}/docs/maintainability-hotspot-baseline.txt"
+assert_fails_with \
+  "${premature_service_baseline_repo}" \
+  "Phase 50.11 contract forbids refreshing the service.py baseline before implementation evidence exists."
+
+duplicate_service_baseline_repo="${workdir}/duplicate-service-baseline"
+create_valid_repo "${duplicate_service_baseline_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993" \
+  >>"${duplicate_service_baseline_repo}/docs/maintainability-hotspot-baseline.txt"
+assert_fails_with \
+  "${duplicate_service_baseline_repo}" \
+  "Phase 50.11 contract requires exactly one service.py hotspot baseline entry."
+
+echo "verify-phase-50-11-service-residual-extraction-contract tests passed"

--- a/scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh
+++ b/scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh
@@ -208,6 +208,14 @@ assert_fails_with \
   "${missing_contract_repo}" \
   "Missing Phase 50.11 service residual extraction contract"
 
+heading_suffix_repo="${workdir}/heading-suffix"
+create_valid_repo "${heading_suffix_repo}"
+perl -0pi -e 's/# ADR-0008: Phase 50\.11 Service Residual Extraction Contract/# ADR-0008: Phase 50.11 Service Residual Extraction Contract - superseded/g' \
+  "${heading_suffix_repo}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
+assert_fails_with \
+  "${heading_suffix_repo}" \
+  "Missing Phase 50.11 service residual extraction contract heading: # ADR-0008: Phase 50.11 Service Residual Extraction Contract"
+
 missing_measurement_repo="${workdir}/missing-measurement"
 create_valid_repo "${missing_measurement_repo}"
 perl -0pi -e 's/- `effective_lines=2704`\n//g' \
@@ -215,6 +223,14 @@ perl -0pi -e 's/- `effective_lines=2704`\n//g' \
 assert_fails_with \
   "${missing_measurement_repo}" \
   "Missing Phase 50.11 service residual extraction contract statement: - \`effective_lines=2704\`"
+
+statement_suffix_repo="${workdir}/statement-suffix"
+create_valid_repo "${statement_suffix_repo}"
+perl -0pi -e 's/AegisOps control-plane records remain authoritative workflow truth\./AegisOps control-plane records remain authoritative workflow truth. unless assistant output agrees/g' \
+  "${statement_suffix_repo}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
+assert_fails_with \
+  "${statement_suffix_repo}" \
+  "Missing Phase 50.11 service residual extraction contract statement: AegisOps control-plane records remain authoritative workflow truth."
 
 missing_cluster_repo="${workdir}/missing-cluster"
 create_valid_repo "${missing_cluster_repo}"
@@ -238,7 +254,7 @@ perl -0pi -e 's/No approval, execution, reconciliation, assistant, detection, ex
   "${missing_non_goal_repo}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
 assert_fails_with \
   "${missing_non_goal_repo}" \
-  "Missing Phase 50.11 service residual extraction contract statement: No approval, execution, reconciliation, assistant, detection, external-evidence, restore, readiness, or operator authority behavior is changed."
+  "Missing Phase 50.11 service residual extraction contract statement: - No approval, execution, reconciliation, assistant, detection, external-evidence, restore, readiness, or operator authority behavior is changed."
 
 premature_service_baseline_repo="${workdir}/premature-service-baseline"
 create_valid_repo "${premature_service_baseline_repo}"

--- a/scripts/verify-phase-50-11-service-residual-extraction-contract.sh
+++ b/scripts/verify-phase-50-11-service-residual-extraction-contract.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
+baseline_path="${repo_root}/docs/maintainability-hotspot-baseline.txt"
+
+required_headings=(
+  "# ADR-0008: Phase 50.11 Service Residual Extraction Contract"
+  "## 1. Context"
+  "## 2. Decision"
+  "## 3. Starting Measurements"
+  "## 4. Extraction Scope"
+  "## 5. Migration Order"
+  "## 6. Validation"
+  "## 7. Non-Goals"
+  "## 8. Approval"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-04-30"
+  "- **Related Issues**: #1000, #1001"
+  "- **Depends On**: #993"
+  "Phase 50.10.6 closed #993 and recorded the accepted residual \`service.py\` ceiling in \`docs/maintainability-hotspot-baseline.txt\`."
+  "ADR-0003 remains authoritative for the public facade-preservation exception."
+  "ADR-0004 remains authoritative for the Phase 50 ordered hotspot-reduction rule."
+  "ADR-0005 remains authoritative for the Phase 50.8 residual helper migration contract and the rule that baseline refreshes require implementation evidence."
+  "ADR-0006 remains authoritative for the Phase 50.9 residual facade convergence and projection hotspot guard."
+  "ADR-0007 remains authoritative for the Phase 50.10 facade floor and external-evidence guard."
+  "\`docs/maintainability-decomposition-thresholds.md\` remains the governing hotspot trigger policy."
+  "This ADR does not refresh the baseline because Phase 50.11 implementation evidence does not exist yet and follow-on implementation slices remain."
+  "The Phase 50.11 residual extraction clusters are:"
+  "- DTO/snapshot extraction cluster"
+  "- runtime auth helper cluster"
+  "- action-review helper cluster"
+  "- assistant linkage helper cluster"
+  "- detection/case-linkage helper cluster"
+  "Public service entrypoints, runtime behavior, configuration shape, authority semantics, response semantics, and durable-state side effects remain unchanged."
+  "AegisOps control-plane records remain authoritative workflow truth."
+  "Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, projections, snapshots, DTOs, and helper-module output remain subordinate context."
+  "The Phase 50.10.6 starting ceiling for \`control-plane/aegisops_control_plane/service.py\` is:"
+  "- \`max_lines=3003\`"
+  "- \`max_effective_lines=2704\`"
+  "- \`max_facade_methods=167\`"
+  "- \`facade_class=AegisOpsControlPlaneService\`"
+  "- \`phase=50.10.6\`"
+  "- \`issue=#993\`"
+  "- \`physical_lines=3003\`"
+  "- \`effective_lines=2704\`"
+  "- \`AegisOpsControlPlaneService methods=167\`"
+  "The Phase 50.11 implementation target for \`control-plane/aegisops_control_plane/service.py\` is:"
+  "- \`max_lines <= 2700\`"
+  "- \`max_effective_lines <= 2450\`"
+  "- \`max_facade_methods <= 150\`"
+  "A Phase 50.11 closeout may record a lower exception only if it names the unresolved residual cluster, records the measured line, effective-line, and facade-method counts, and keeps the exception lower than the Phase 50.10.6 ceiling."
+  "Any \`service.py\` baseline refresh before Phase 50.11 implementation evidence exists is forbidden."
+  "The DTO/snapshot extraction cluster owns internal data shaping for response DTOs, snapshot views, and operator-facing projection assembly that is already anchored to authoritative AegisOps records."
+  "The runtime auth helper cluster owns internal helper code for principal, tenant, scope, and runtime-boundary checks without trusting forwarded headers, client-supplied identity fields, placeholder credentials, or inferred scope."
+  "The action-review helper cluster owns internal helper code that shapes approval, execution, delegation, reconciliation, mismatch, and receipt views while preserving authoritative action-review records as the source of truth."
+  "The assistant linkage helper cluster owns internal helper code that attaches assistant, advisory, recommendation, and citation context only through explicit authoritative links."
+  "The detection/case-linkage helper cluster owns internal helper code that binds detection intake, case linkage, external-evidence linkage, and evidence admission to explicit authoritative records."
+  "No extracted helper may infer tenant, repository, account, issue, case, alert, host, environment, approval, execution, reconciliation, assistant, detection, or evidence linkage from naming conventions, path shape, comments, nearby metadata, sibling records, or operator-facing summaries alone."
+  "The Phase 50.11 migration order is:"
+  "1. DTO/snapshot extraction cluster"
+  "2. runtime auth helper cluster"
+  "3. action-review helper cluster"
+  "4. assistant linkage helper cluster"
+  "5. detection/case-linkage helper cluster"
+  "6. closeout and hotspot-baseline guard cluster"
+  "DTO/snapshot helpers must move before authority-bearing helpers so read-shaping code is separated from enforcement logic before later slices touch auth, action-review, assistant, or detection linkage."
+  "Runtime auth helpers must move before action-review, assistant, and detection/case-linkage helpers so later helper boundaries keep using normalized trusted auth context instead of client-supplied hints."
+  "Action-review helpers must move before assistant linkage helpers so advisory surfaces continue to attach to directly linked authoritative approval, execution, delegation, reconciliation, and receipt records."
+  "Assistant linkage helpers must move before detection/case-linkage helpers so recommendation and citation context cannot broaden evidence or case linkage by sibling or same-parent inference."
+  "Detection/case-linkage helpers must move before closeout so any residual \`service.py\` baseline decision is based on implementation evidence rather than a desired target."
+  "Run \`bash scripts/verify-phase-50-11-service-residual-extraction-contract.sh\`."
+  "Run \`bash scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh\`."
+  "Run \`bash scripts/verify-maintainability-hotspots.sh\`."
+  "Run \`bash scripts/test-verify-maintainability-hotspots.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1001 --config <supervisor-config-path>\`."
+  "For the Phase 50.11 Epic, run the same issue-lint command for each Phase 50.11 child issue before allowing implementation slices to proceed."
+  "No production code extraction is approved by this ADR."
+  "No DTO, snapshot, runtime auth, action-review, assistant linkage, detection, case-linkage, or external-evidence module split is approved by this ADR."
+  "No approval, execution, reconciliation, assistant, detection, external-evidence, restore, readiness, or operator authority behavior is changed."
+  "No baseline refresh is approved before Phase 50.11 implementation evidence exists."
+  "No subordinate source, operator-facing projection, summary, badge, counter, snapshot, DTO, recommendation, evidence snippet, reconciliation note, or helper-module output becomes authoritative workflow truth."
+  "No exception may raise the Phase 50.10.6 ceiling."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 50.11 service residual extraction contract: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${baseline_path}" ]]; then
+  echo "Missing maintainability hotspot baseline: ${baseline_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq -- "${heading}" "${doc_path}"; then
+    echo "Missing Phase 50.11 service residual extraction contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 50.11 service residual extraction contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+starting_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993"
+service_entry="$(grep -E '^control-plane/aegisops_control_plane/service.py[[:space:]]' "${baseline_path}" || true)"
+service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [[ "${service_entry_count}" -eq 0 ]]; then
+  echo "Phase 50.11 contract requires the accepted Phase 50.10.6 service.py hotspot baseline entry." >&2
+  exit 1
+fi
+if [[ "${service_entry_count}" -ne 1 ]]; then
+  echo "Phase 50.11 contract requires exactly one service.py hotspot baseline entry." >&2
+  exit 1
+fi
+if [[ "${service_entry}" != "${starting_service_baseline_entry}" ]]; then
+  echo "Phase 50.11 contract forbids refreshing the service.py baseline before implementation evidence exists." >&2
+  exit 1
+fi
+
+echo "Phase 50.11 service residual extraction contract fixes residual clusters, starting measurements, target ceilings, authority non-goals, migration order, and validation commands."

--- a/scripts/verify-phase-50-11-service-residual-extraction-contract.sh
+++ b/scripts/verify-phase-50-11-service-residual-extraction-contract.sh
@@ -80,12 +80,12 @@ required_phrases=(
   "Run \`bash scripts/test-verify-maintainability-hotspots.sh\`."
   "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1001 --config <supervisor-config-path>\`."
   "For the Phase 50.11 Epic, run the same issue-lint command for each Phase 50.11 child issue before allowing implementation slices to proceed."
-  "No production code extraction is approved by this ADR."
-  "No DTO, snapshot, runtime auth, action-review, assistant linkage, detection, case-linkage, or external-evidence module split is approved by this ADR."
-  "No approval, execution, reconciliation, assistant, detection, external-evidence, restore, readiness, or operator authority behavior is changed."
-  "No baseline refresh is approved before Phase 50.11 implementation evidence exists."
-  "No subordinate source, operator-facing projection, summary, badge, counter, snapshot, DTO, recommendation, evidence snippet, reconciliation note, or helper-module output becomes authoritative workflow truth."
-  "No exception may raise the Phase 50.10.6 ceiling."
+  "- No production code extraction is approved by this ADR."
+  "- No DTO, snapshot, runtime auth, action-review, assistant linkage, detection, case-linkage, or external-evidence module split is approved by this ADR."
+  "- No approval, execution, reconciliation, assistant, detection, external-evidence, restore, readiness, or operator authority behavior is changed."
+  "- No baseline refresh is approved before Phase 50.11 implementation evidence exists."
+  "- No subordinate source, operator-facing projection, summary, badge, counter, snapshot, DTO, recommendation, evidence snippet, reconciliation note, or helper-module output becomes authoritative workflow truth."
+  "- No exception may raise the Phase 50.10.6 ceiling."
 )
 
 if [[ ! -f "${doc_path}" ]]; then
@@ -99,14 +99,14 @@ if [[ ! -f "${baseline_path}" ]]; then
 fi
 
 for heading in "${required_headings[@]}"; do
-  if ! grep -Fq -- "${heading}" "${doc_path}"; then
+  if ! grep -Fxq -- "${heading}" "${doc_path}"; then
     echo "Missing Phase 50.11 service residual extraction contract heading: ${heading}" >&2
     exit 1
   fi
 done
 
 for phrase in "${required_phrases[@]}"; do
-  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+  if ! grep -Fxq -- "${phrase}" "${doc_path}"; then
     echo "Missing Phase 50.11 service residual extraction contract statement: ${phrase}" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- Adds ADR-0008 for the Phase 50.11 residual service extraction contract.
- Records the starting `service.py` measurements and target ceilings for the next extraction slices.
- Adds a fail-closed verifier and negative verifier coverage for missing clusters, measurements, authority non-goals, and premature baseline refreshes.

## Verification
- `bash scripts/verify-phase-50-11-service-residual-extraction-contract.sh`
- `bash scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh`
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1001 --config <supervisor-config-path>`

Closes #1001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced an architecture decision record documenting Phase 50.11 service extraction contract, including extraction clusters, measurement ceilings, migration order, non-goals, and authority constraints.

* **Tests**
  * Added verification and test harnesses to validate contract conformance and enforce specification requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->