### PR TITLE
Phase 50.11.5: Extract assistant advisory helpers

### DIFF
--- a/control-plane/aegisops_control_plane/assistant_advisory.py
+++ b/control-plane/aegisops_control_plane/assistant_advisory.py
@@ -3,6 +3,63 @@ from __future__ import annotations
 from typing import Any, Protocol
 
 from .models import AITraceRecord, RecommendationRecord
+from .service_snapshots import (
+    AdvisoryInspectionSnapshot,
+    AnalystAssistantContextSnapshot,
+    RecommendationDraftSnapshot,
+)
+
+
+def advisory_inspection_snapshot_from_context(
+    snapshot: AnalystAssistantContextSnapshot,
+) -> AdvisoryInspectionSnapshot:
+    advisory_output = snapshot.advisory_output
+    return AdvisoryInspectionSnapshot(
+        read_only=True,
+        record_family=snapshot.record_family,
+        record_id=snapshot.record_id,
+        output_kind=str(advisory_output["output_kind"]),
+        status=str(advisory_output["status"]),
+        cited_summary=dict(advisory_output["cited_summary"]),
+        key_observations=tuple(advisory_output["key_observations"]),
+        unresolved_questions=tuple(advisory_output["unresolved_questions"]),
+        candidate_recommendations=tuple(advisory_output["candidate_recommendations"]),
+        citations=tuple(advisory_output["citations"]),
+        uncertainty_flags=tuple(advisory_output["uncertainty_flags"]),
+        reviewed_context=dict(snapshot.reviewed_context),
+        linked_alert_ids=snapshot.linked_alert_ids,
+        linked_case_ids=snapshot.linked_case_ids,
+        linked_evidence_ids=snapshot.linked_evidence_ids,
+        linked_recommendation_ids=snapshot.linked_recommendation_ids,
+        linked_reconciliation_ids=snapshot.linked_reconciliation_ids,
+    )
+
+
+def recommendation_draft_snapshot_from_context(
+    snapshot: AnalystAssistantContextSnapshot,
+) -> RecommendationDraftSnapshot:
+    advisory_output = snapshot.advisory_output
+    return RecommendationDraftSnapshot(
+        read_only=True,
+        record_family=snapshot.record_family,
+        record_id=snapshot.record_id,
+        recommendation_draft={
+            "source_output_kind": advisory_output["output_kind"],
+            "status": advisory_output["status"],
+            "review_lifecycle_state": snapshot.record.get("lifecycle_state"),
+            "cited_summary": advisory_output["cited_summary"],
+            "candidate_recommendations": advisory_output["candidate_recommendations"],
+            "unresolved_questions": advisory_output["unresolved_questions"],
+            "citations": advisory_output["citations"],
+            "uncertainty_flags": advisory_output["uncertainty_flags"],
+        },
+        reviewed_context=dict(snapshot.reviewed_context),
+        linked_alert_ids=snapshot.linked_alert_ids,
+        linked_case_ids=snapshot.linked_case_ids,
+        linked_evidence_ids=snapshot.linked_evidence_ids,
+        linked_recommendation_ids=snapshot.linked_recommendation_ids,
+        linked_reconciliation_ids=snapshot.linked_reconciliation_ids,
+    )
 
 
 class AssistantAdvisoryAssembler(Protocol):

--- a/control-plane/aegisops_control_plane/live_assistant_workflow.py
+++ b/control-plane/aegisops_control_plane/live_assistant_workflow.py
@@ -4,7 +4,8 @@ from copy import copy
 from dataclasses import replace
 from datetime import datetime, timezone
 import json
-from typing import Any, Callable, Protocol
+import re
+from typing import Any, Callable, Iterable, Protocol
 
 from .ai_trace_lifecycle import AITraceLifecycleService
 from .assistant_provider import (
@@ -15,6 +16,192 @@ from .assistant_provider import (
     provider_exception_failure_metadata,
 )
 from .models import AITraceRecord, RecommendationRecord
+from .service_snapshots import (
+    AnalystAssistantContextSnapshot,
+    LiveAssistantWorkflowSnapshot,
+)
+
+_PHASE24_WORKFLOW_FAMILY = "first_live_assistant_summary_family"
+
+
+def _dedupe_strings(values: Iterable[str]) -> tuple[str, ...]:
+    deduped: list[str] = []
+    for value in values:
+        if value not in deduped:
+            deduped.append(value)
+    return tuple(deduped)
+
+
+def phase24_live_assistant_unresolved_reasons(
+    uncertainty_flags: Iterable[str],
+) -> tuple[str, ...]:
+    mapping = {
+        "missing_supporting_citations": "required citations are missing",
+        "missing_evidence_citation": "linked evidence required for the summary is missing",
+        "conflicting_reviewed_context": (
+            "reviewed records conflict on lifecycle state, ownership, scope, or evidence-backed facts"
+        ),
+        "ambiguous_identity_alias_only": (
+            "the requested summary would require the assistant to collapse identity ambiguity"
+        ),
+        "reviewed_casework_identity_ambiguity": (
+            "reviewed multi-source casework still contains unresolved identity ambiguity"
+        ),
+        "authority_overreach": (
+            "the requested summary would widen into approval, delegation, execution, or policy interpretation"
+        ),
+        "scope_expansion_attempt": (
+            "the requested summary would widen beyond the reviewed record chain"
+        ),
+        "prompt_injection_attempt": (
+            "the requested summary would follow prompt-injection or instruction-override text instead of reviewed records"
+        ),
+        "provider_generation_failed": (
+            "the bounded live assistant did not return a trusted summary within the reviewed retry budget"
+        ),
+    }
+    reasons: list[str] = []
+    for flag in uncertainty_flags:
+        reason = mapping.get(str(flag))
+        if reason is not None and reason not in reasons:
+            reasons.append(reason)
+    return tuple(reasons)
+
+
+def phase24_live_assistant_prompt_injection_flags(text: object) -> tuple[str, ...]:
+    if not isinstance(text, str):
+        return ()
+
+    lowered = text.lower()
+    normalized = re.sub(r"[\W_]+", " ", lowered)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    flags: list[str] = []
+    prompt_injection_terms = (
+        r"\bignore(?:\s+all)?\s+previous\s+instructions\b",
+        r"\bdisregard\s+previous\s+instructions\b",
+        r"\boverride\s+previous\s+instructions\b",
+        r"\breveal\s+(?:the\s+)?hidden\s+system\s+prompt\b",
+        r"\breveal\s+(?:the\s+)?system\s+prompt\b",
+        r"\bshow\s+(?:the\s+)?system\s+prompt\b",
+        r"\breveal\s+(?:the\s+)?developer\s+message\b",
+    )
+    if any(re.search(term, normalized) for term in prompt_injection_terms):
+        flags.append("prompt_injection_attempt")
+    return _dedupe_strings(tuple(flags))
+
+
+def phase24_live_assistant_citations_from_context(
+    snapshot: AnalystAssistantContextSnapshot,
+) -> tuple[dict[str, object], ...]:
+    citations: list[dict[str, object]] = []
+    seen: set[tuple[object, ...]] = set()
+
+    def append_citation(
+        *,
+        record_family: str,
+        record_id: str,
+        claim: str,
+        evidence_id: str | None,
+        reviewed_context_field: str | None,
+    ) -> None:
+        key = (record_family, record_id, claim, evidence_id, reviewed_context_field)
+        if key in seen:
+            return
+        seen.add(key)
+        citations.append(
+            {
+                "record_family": record_family,
+                "record_id": record_id,
+                "claim": claim,
+                "evidence_id": evidence_id,
+                "reviewed_context_field": reviewed_context_field,
+            }
+        )
+
+    if snapshot.record_family == "case":
+        append_citation(
+            record_family="case",
+            record_id=snapshot.record_id,
+            claim="Reviewed case lifecycle and scope remain anchored on the case record.",
+            evidence_id=None,
+            reviewed_context_field=None,
+        )
+    elif snapshot.record_family == "alert":
+        append_citation(
+            record_family="alert",
+            record_id=snapshot.record_id,
+            claim="Reviewed alert lifecycle remains anchored on the alert record.",
+            evidence_id=None,
+            reviewed_context_field=None,
+        )
+
+    for alert_id in snapshot.linked_alert_ids:
+        append_citation(
+            record_family="alert",
+            record_id=alert_id,
+            claim="Reviewed alert linkage preserves the bounded live assistant chain.",
+            evidence_id=None,
+            reviewed_context_field=None,
+        )
+    for case_id in snapshot.linked_case_ids:
+        append_citation(
+            record_family="case",
+            record_id=case_id,
+            claim="Reviewed case linkage preserves the bounded live assistant chain.",
+            evidence_id=None,
+            reviewed_context_field=None,
+        )
+    for evidence_id in snapshot.linked_evidence_ids:
+        append_citation(
+            record_family="evidence",
+            record_id=evidence_id,
+            claim="Linked reviewed evidence supports the live assistant summary.",
+            evidence_id=evidence_id,
+            reviewed_context_field=None,
+        )
+
+    for context_field in ("asset", "identity", "privilege", "source", "provenance"):
+        if context_field in snapshot.reviewed_context:
+            append_citation(
+                record_family=snapshot.record_family,
+                record_id=snapshot.record_id,
+                claim=(
+                    f"Reviewed context field {context_field} remains within the reviewed record chain."
+                ),
+                evidence_id=None,
+                reviewed_context_field=context_field,
+            )
+
+    return tuple(citations)
+
+
+def phase24_live_assistant_snapshot(
+    *,
+    workflow_task: str,
+    summary: str,
+    citations: tuple[dict[str, object], ...],
+    unresolved_reasons: tuple[str, ...],
+) -> LiveAssistantWorkflowSnapshot:
+    status = "unresolved" if unresolved_reasons else "ready"
+    return LiveAssistantWorkflowSnapshot(
+        workflow_family=_PHASE24_WORKFLOW_FAMILY,
+        workflow_task=workflow_task,
+        status=status,
+        summary=summary,
+        citations=citations,
+        unresolved_reasons=unresolved_reasons,
+        operator_follow_up=phase24_live_assistant_follow_up(status),
+    )
+
+
+def phase24_live_assistant_follow_up(status: str) -> str:
+    if status == "ready":
+        return (
+            "Review the cited records before any approval, delegation, execution, or policy decision."
+        )
+    return (
+        "Review the unresolved reasons against the cited records before any approval, delegation, execution, or policy decision."
+    )
 
 
 class LiveAssistantWorkflowServiceDependencies(Protocol):

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 import hashlib
 import json
 import logging
-import re
 import uuid
 from typing import Iterable, Iterator, Mapping, Protocol, Type, TypeVar
 
@@ -15,6 +14,8 @@ _DATETIME_TYPE = datetime
 
 from . import action_review_projection as _action_review_projection
 from .action_policy import evaluate_action_policy_record
+from . import assistant_advisory as _assistant_advisory
+from . import live_assistant_workflow as _live_assistant_workflow
 from .assistant_provider import (
     AssistantProviderFailure,
     AssistantProviderResult,
@@ -398,231 +399,6 @@ def _normalize_admission_provenance(
     return normalized
 
 
-def _advisory_inspection_snapshot_from_context(
-    snapshot: AnalystAssistantContextSnapshot,
-) -> AdvisoryInspectionSnapshot:
-    advisory_output = snapshot.advisory_output
-    return AdvisoryInspectionSnapshot(
-        read_only=True,
-        record_family=snapshot.record_family,
-        record_id=snapshot.record_id,
-        output_kind=str(advisory_output["output_kind"]),
-        status=str(advisory_output["status"]),
-        cited_summary=dict(advisory_output["cited_summary"]),
-        key_observations=tuple(advisory_output["key_observations"]),
-        unresolved_questions=tuple(advisory_output["unresolved_questions"]),
-        candidate_recommendations=tuple(advisory_output["candidate_recommendations"]),
-        citations=tuple(advisory_output["citations"]),
-        uncertainty_flags=tuple(advisory_output["uncertainty_flags"]),
-        reviewed_context=dict(snapshot.reviewed_context),
-        linked_alert_ids=snapshot.linked_alert_ids,
-        linked_case_ids=snapshot.linked_case_ids,
-        linked_evidence_ids=snapshot.linked_evidence_ids,
-        linked_recommendation_ids=snapshot.linked_recommendation_ids,
-        linked_reconciliation_ids=snapshot.linked_reconciliation_ids,
-    )
-
-
-def _recommendation_draft_snapshot_from_context(
-    snapshot: AnalystAssistantContextSnapshot,
-) -> RecommendationDraftSnapshot:
-    advisory_output = snapshot.advisory_output
-    return RecommendationDraftSnapshot(
-        read_only=True,
-        record_family=snapshot.record_family,
-        record_id=snapshot.record_id,
-        recommendation_draft={
-            "source_output_kind": advisory_output["output_kind"],
-            "status": advisory_output["status"],
-            "review_lifecycle_state": snapshot.record.get("lifecycle_state"),
-            "cited_summary": advisory_output["cited_summary"],
-            "candidate_recommendations": advisory_output["candidate_recommendations"],
-            "unresolved_questions": advisory_output["unresolved_questions"],
-            "citations": advisory_output["citations"],
-            "uncertainty_flags": advisory_output["uncertainty_flags"],
-        },
-        reviewed_context=dict(snapshot.reviewed_context),
-        linked_alert_ids=snapshot.linked_alert_ids,
-        linked_case_ids=snapshot.linked_case_ids,
-        linked_evidence_ids=snapshot.linked_evidence_ids,
-        linked_recommendation_ids=snapshot.linked_recommendation_ids,
-        linked_reconciliation_ids=snapshot.linked_reconciliation_ids,
-    )
-
-
-def _phase24_live_assistant_unresolved_reasons(
-    uncertainty_flags: Iterable[str],
-) -> tuple[str, ...]:
-    mapping = {
-        "missing_supporting_citations": "required citations are missing",
-        "missing_evidence_citation": "linked evidence required for the summary is missing",
-        "conflicting_reviewed_context": (
-            "reviewed records conflict on lifecycle state, ownership, scope, or evidence-backed facts"
-        ),
-        "ambiguous_identity_alias_only": (
-            "the requested summary would require the assistant to collapse identity ambiguity"
-        ),
-        "reviewed_casework_identity_ambiguity": (
-            "reviewed multi-source casework still contains unresolved identity ambiguity"
-        ),
-        "authority_overreach": (
-            "the requested summary would widen into approval, delegation, execution, or policy interpretation"
-        ),
-        "scope_expansion_attempt": (
-            "the requested summary would widen beyond the reviewed record chain"
-        ),
-        "prompt_injection_attempt": (
-            "the requested summary would follow prompt-injection or instruction-override text instead of reviewed records"
-        ),
-        "provider_generation_failed": (
-            "the bounded live assistant did not return a trusted summary within the reviewed retry budget"
-        ),
-    }
-    reasons: list[str] = []
-    for flag in uncertainty_flags:
-        reason = mapping.get(str(flag))
-        if reason is not None and reason not in reasons:
-            reasons.append(reason)
-    return tuple(reasons)
-
-
-def _phase24_live_assistant_prompt_injection_flags(text: object) -> tuple[str, ...]:
-    if not isinstance(text, str):
-        return ()
-
-    lowered = text.lower()
-    normalized = re.sub(r"[\W_]+", " ", lowered)
-    normalized = re.sub(r"\s+", " ", normalized).strip()
-    flags: list[str] = []
-    prompt_injection_terms = (
-        r"\bignore(?:\s+all)?\s+previous\s+instructions\b",
-        r"\bdisregard\s+previous\s+instructions\b",
-        r"\boverride\s+previous\s+instructions\b",
-        r"\breveal\s+(?:the\s+)?hidden\s+system\s+prompt\b",
-        r"\breveal\s+(?:the\s+)?system\s+prompt\b",
-        r"\bshow\s+(?:the\s+)?system\s+prompt\b",
-        r"\breveal\s+(?:the\s+)?developer\s+message\b",
-    )
-    if any(re.search(term, normalized) for term in prompt_injection_terms):
-        flags.append("prompt_injection_attempt")
-    return _dedupe_strings(tuple(flags))
-
-
-def _phase24_live_assistant_citations_from_context(
-    snapshot: AnalystAssistantContextSnapshot,
-) -> tuple[dict[str, object], ...]:
-    citations: list[dict[str, object]] = []
-    seen: set[tuple[object, ...]] = set()
-
-    def append_citation(
-        *,
-        record_family: str,
-        record_id: str,
-        claim: str,
-        evidence_id: str | None,
-        reviewed_context_field: str | None,
-    ) -> None:
-        key = (record_family, record_id, claim, evidence_id, reviewed_context_field)
-        if key in seen:
-            return
-        seen.add(key)
-        citations.append(
-            {
-                "record_family": record_family,
-                "record_id": record_id,
-                "claim": claim,
-                "evidence_id": evidence_id,
-                "reviewed_context_field": reviewed_context_field,
-            }
-        )
-
-    lifecycle_state = snapshot.record.get("lifecycle_state")
-    if snapshot.record_family == "case":
-        append_citation(
-            record_family="case",
-            record_id=snapshot.record_id,
-            claim="Reviewed case lifecycle and scope remain anchored on the case record.",
-            evidence_id=None,
-            reviewed_context_field=None,
-        )
-    elif snapshot.record_family == "alert":
-        append_citation(
-            record_family="alert",
-            record_id=snapshot.record_id,
-            claim="Reviewed alert lifecycle remains anchored on the alert record.",
-            evidence_id=None,
-            reviewed_context_field=None,
-        )
-
-    for alert_id in snapshot.linked_alert_ids:
-        append_citation(
-            record_family="alert",
-            record_id=alert_id,
-            claim="Reviewed alert linkage preserves the bounded live assistant chain.",
-            evidence_id=None,
-            reviewed_context_field=None,
-        )
-    for case_id in snapshot.linked_case_ids:
-        append_citation(
-            record_family="case",
-            record_id=case_id,
-            claim="Reviewed case linkage preserves the bounded live assistant chain.",
-            evidence_id=None,
-            reviewed_context_field=None,
-        )
-    for evidence_id in snapshot.linked_evidence_ids:
-        append_citation(
-            record_family="evidence",
-            record_id=evidence_id,
-            claim="Linked reviewed evidence supports the live assistant summary.",
-            evidence_id=evidence_id,
-            reviewed_context_field=None,
-        )
-
-    for context_field in ("asset", "identity", "privilege", "source", "provenance"):
-        if context_field in snapshot.reviewed_context:
-            append_citation(
-                record_family=snapshot.record_family,
-                record_id=snapshot.record_id,
-                claim=(
-                    f"Reviewed context field {context_field} remains within the reviewed record chain."
-                ),
-                evidence_id=None,
-                reviewed_context_field=context_field,
-            )
-
-    return tuple(citations)
-
-
-def _phase24_live_assistant_follow_up(status: str) -> str:
-    if status == "ready":
-        return (
-            "Review the cited records before any approval, delegation, execution, or policy decision."
-        )
-    return (
-        "Review the unresolved reasons against the cited records before any approval, delegation, execution, or policy decision."
-    )
-
-
-def _phase24_live_assistant_snapshot(
-    *,
-    workflow_task: str,
-    summary: str,
-    citations: tuple[dict[str, object], ...],
-    unresolved_reasons: tuple[str, ...],
-) -> LiveAssistantWorkflowSnapshot:
-    status = "unresolved" if unresolved_reasons else "ready"
-    return LiveAssistantWorkflowSnapshot(
-        workflow_family=_PHASE24_WORKFLOW_FAMILY,
-        workflow_task=workflow_task,
-        status=status,
-        summary=summary,
-        citations=citations,
-        unresolved_reasons=unresolved_reasons,
-        operator_follow_up=_phase24_live_assistant_follow_up(status),
-    )
-
-
 class AegisOpsControlPlaneService(ExternalEvidenceFacade):
     """Minimal local runtime skeleton for the first control-plane service."""
 
@@ -670,22 +446,24 @@ class AegisOpsControlPlaneService(ExternalEvidenceFacade):
                 action_review_detail_snapshot_factory=ActionReviewDetailSnapshot,
                 assistant_context_snapshot_factory=AnalystAssistantContextSnapshot,
                 advisory_snapshot_from_context=(
-                    _advisory_inspection_snapshot_from_context
+                    _assistant_advisory.advisory_inspection_snapshot_from_context
                 ),
                 recommendation_draft_snapshot_from_context=(
-                    _recommendation_draft_snapshot_from_context
+                    _assistant_advisory.recommendation_draft_snapshot_from_context
                 ),
-                live_assistant_snapshot_factory=_phase24_live_assistant_snapshot,
+                live_assistant_snapshot_factory=(
+                    _live_assistant_workflow.phase24_live_assistant_snapshot
+                ),
                 live_assistant_citations_from_context=(
-                    lambda snapshot: _phase24_live_assistant_citations_from_context(
+                    lambda snapshot: _live_assistant_workflow.phase24_live_assistant_citations_from_context(
                         snapshot
                     )
                 ),
                 live_assistant_unresolved_reasons=(
-                    _phase24_live_assistant_unresolved_reasons
+                    _live_assistant_workflow.phase24_live_assistant_unresolved_reasons
                 ),
                 live_assistant_prompt_injection_flags=(
-                    _phase24_live_assistant_prompt_injection_flags
+                    _live_assistant_workflow.phase24_live_assistant_prompt_injection_flags
                 ),
                 startup_status_snapshot_factory=StartupStatusSnapshot,
                 readiness_diagnostics_snapshot_factory=ReadinessDiagnosticsSnapshot,

--- a/control-plane/tests/test_phase24_live_assistant_adversarial_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_adversarial_validation.py
@@ -274,7 +274,7 @@ class Phase24LiveAssistantAdversarialValidationTests(ServicePersistenceTestBase)
         )
 
         with mock.patch(
-            "aegisops_control_plane.service._phase24_live_assistant_citations_from_context",
+            "aegisops_control_plane.live_assistant_workflow.phase24_live_assistant_citations_from_context",
             return_value=(),
         ):
             snapshot = service.run_live_assistant_workflow(

--- a/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
@@ -19,7 +19,9 @@ from aegisops_control_plane.assistant_provider import (
     AssistantProviderAdapter,
     AssistantProviderResult,
 )
-from aegisops_control_plane.service import _phase24_live_assistant_citations_from_context
+from aegisops_control_plane.live_assistant_workflow import (
+    phase24_live_assistant_citations_from_context,
+)
 
 
 class Phase24LiveAssistantFeedbackLoopValidationTests(ServicePersistenceTestBase):
@@ -418,7 +420,7 @@ class Phase24LiveAssistantFeedbackLoopValidationTests(ServicePersistenceTestBase
                 "reviewed_context_conflicts": ("triage.disposition",),
             },
         )
-        expected_citations = _phase24_live_assistant_citations_from_context(
+        expected_citations = phase24_live_assistant_citations_from_context(
             unresolved_context
         )
         service._assistant_provider_adapter = mock.Mock()

--- a/control-plane/tests/test_phase24_live_assistant_surface_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_surface_validation.py
@@ -397,7 +397,7 @@ class Phase24LiveAssistantSurfaceValidationTests(ServicePersistenceTestBase):
 
         stdout = io.StringIO()
         with mock.patch(
-            "aegisops_control_plane.service._phase24_live_assistant_citations_from_context",
+            "aegisops_control_plane.live_assistant_workflow.phase24_live_assistant_citations_from_context",
             return_value=(),
         ):
             main.main(

--- a/control-plane/tests/test_service_persistence_assistant_advisory.py
+++ b/control-plane/tests/test_service_persistence_assistant_advisory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import pathlib
 import sys
 
@@ -62,6 +63,32 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
                 for authority_term in authority_terms
             )
         )
+
+    def test_assistant_snapshot_and_live_helpers_are_not_owned_by_service_facade(
+        self,
+    ) -> None:
+        service_source = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "aegisops_control_plane"
+            / "service.py"
+        ).read_text()
+        service_functions = {
+            node.name
+            for node in ast.walk(ast.parse(service_source))
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+
+        extracted_helpers = {
+            "_advisory_inspection_snapshot_from_context",
+            "_recommendation_draft_snapshot_from_context",
+            "_phase24_live_assistant_unresolved_reasons",
+            "_phase24_live_assistant_prompt_injection_flags",
+            "_phase24_live_assistant_citations_from_context",
+            "_phase24_live_assistant_follow_up",
+            "_phase24_live_assistant_snapshot",
+        }
+
+        self.assertTrue(extracted_helpers.isdisjoint(service_functions))
 
     def test_service_delegates_assistant_context_to_assembler_and_advisory_to_coordinator(
         self,


### PR DESCRIPTION
## Summary
- move advisory/recommendation snapshot builders from service.py into assistant_advisory.py
- move Phase 24 live assistant citation, unresolved-reason, prompt-injection, follow-up, and snapshot helpers into live_assistant_workflow.py
- add a focused service-facade ownership regression while preserving assistant/advisory/live workflow compatibility

Closes #1005

## Verification
- python3 -m unittest control-plane/tests/test_service_persistence_assistant_advisory.py control-plane/tests/test_phase24_live_assistant_validation.py
- python3 -m unittest discover -s control-plane/tests -p 'test_*.py'\n- bash scripts/verify-maintainability-hotspots.sh\n- bash scripts/test-verify-maintainability-hotspots.sh\n- node dist/index.js issue-lint 1005 --config supervisor.config.aegisops.json