### PR TITLE
Phase 50.11.6: Extract detection case linkage helpers

### DIFF
--- a/control-plane/aegisops_control_plane/case_workflow.py
+++ b/control-plane/aegisops_control_plane/case_workflow.py
@@ -7,14 +7,129 @@ from typing import TYPE_CHECKING, Callable, Mapping
 from .evidence_linkage import EvidenceLinkageService
 from .models import (
     AlertRecord,
+    AnalyticSignalRecord,
     CaseRecord,
+    EvidenceRecord,
     LeadRecord,
     ObservationRecord,
     RecommendationRecord,
+    ReconciliationRecord,
 )
 
 if TYPE_CHECKING:
     from .service import AegisOpsControlPlaneService
+
+
+class CaseDetectionLinkageHelper:
+    def __init__(self, service: AegisOpsControlPlaneService) -> None:
+        self._service = service
+
+    def _link_case_to_analytic_signals(
+        self,
+        analytic_signal_ids: tuple[str, ...],
+        case_id: str | None,
+    ) -> None:
+        if case_id is None:
+            return
+
+        service = self._service
+        for analytic_signal_id in analytic_signal_ids:
+            existing_signal = service._store.get(
+                AnalyticSignalRecord,
+                analytic_signal_id,
+            )
+            if existing_signal is None:
+                continue
+            linked_case_ids = service._merge_linked_ids(
+                existing_signal.case_ids,
+                case_id,
+            )
+            if linked_case_ids == existing_signal.case_ids:
+                continue
+            service.persist_record(
+                AnalyticSignalRecord(
+                    analytic_signal_id=existing_signal.analytic_signal_id,
+                    substrate_detection_record_id=(
+                        existing_signal.substrate_detection_record_id
+                    ),
+                    finding_id=existing_signal.finding_id,
+                    alert_ids=existing_signal.alert_ids,
+                    case_ids=linked_case_ids,
+                    correlation_key=existing_signal.correlation_key,
+                    first_seen_at=existing_signal.first_seen_at,
+                    last_seen_at=existing_signal.last_seen_at,
+                    lifecycle_state=existing_signal.lifecycle_state,
+                    reviewed_context=existing_signal.reviewed_context,
+                )
+            )
+
+    def _list_alert_evidence_records(
+        self,
+        *,
+        alert_id: str,
+        case_id: str | None,
+    ) -> tuple[EvidenceRecord, ...]:
+        evidence_records: list[EvidenceRecord] = []
+        for evidence in self._service._store.list(EvidenceRecord):
+            if evidence.alert_id == alert_id or (
+                case_id is not None and evidence.case_id == case_id
+            ):
+                evidence_records.append(evidence)
+        return tuple(evidence_records)
+
+    def _link_case_to_alert_reconciliations(
+        self,
+        *,
+        alert_id: str,
+        case_id: str,
+        evidence_ids: tuple[str, ...],
+    ) -> None:
+        service = self._service
+        for reconciliation in service._store.list(ReconciliationRecord):
+            if reconciliation.alert_id != alert_id:
+                continue
+            subject_linkage = dict(reconciliation.subject_linkage)
+            updated_case_ids = service._merge_linked_ids(
+                subject_linkage.get("case_ids"),
+                case_id,
+            )
+            updated_evidence_ids = service._merge_linked_ids(
+                subject_linkage.get("evidence_ids"),
+                None,
+            )
+            for evidence_id in evidence_ids:
+                updated_evidence_ids = service._merge_linked_ids(
+                    updated_evidence_ids,
+                    evidence_id,
+                )
+            if (
+                tuple(subject_linkage.get("case_ids", ())) == updated_case_ids
+                and tuple(subject_linkage.get("evidence_ids", ()))
+                == updated_evidence_ids
+            ):
+                continue
+            subject_linkage["case_ids"] = updated_case_ids
+            subject_linkage["evidence_ids"] = updated_evidence_ids
+            service.persist_record(
+                ReconciliationRecord(
+                    reconciliation_id=reconciliation.reconciliation_id,
+                    subject_linkage=subject_linkage,
+                    alert_id=reconciliation.alert_id,
+                    finding_id=reconciliation.finding_id,
+                    analytic_signal_id=reconciliation.analytic_signal_id,
+                    execution_run_id=reconciliation.execution_run_id,
+                    linked_execution_run_ids=(
+                        reconciliation.linked_execution_run_ids
+                    ),
+                    correlation_key=reconciliation.correlation_key,
+                    ingest_disposition=reconciliation.ingest_disposition,
+                    lifecycle_state=reconciliation.lifecycle_state,
+                    compared_at=reconciliation.compared_at,
+                    first_seen_at=reconciliation.first_seen_at,
+                    last_seen_at=reconciliation.last_seen_at,
+                    mismatch_summary=reconciliation.mismatch_summary,
+                )
+            )
 
 
 class CaseWorkflowService:

--- a/control-plane/aegisops_control_plane/detection_lifecycle.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle.py
@@ -8,7 +8,9 @@ from .detection_lifecycle_helpers import (
     DetectionLifecycleTransitionHelper,
     DetectionReconciliationResolver,
     LiveWazuhIntakeHandler,
+    NativeDetectionAdmissionHelper,
 )
+from .case_workflow import CaseDetectionLinkageHelper
 from .detection_native_context import NativeDetectionContextAttacher
 from .models import (
     AnalyticSignalAdmission,
@@ -76,6 +78,11 @@ class DetectionIntakeService:
             merge_reviewed_context=merge_reviewed_context,
             normalize_admission_provenance=normalize_admission_provenance,
         )
+        self._native_admission_helper = NativeDetectionAdmissionHelper(
+            service,
+            normalize_admission_provenance=normalize_admission_provenance,
+        )
+        self._case_detection_linkage_helper = CaseDetectionLinkageHelper(service)
         self.lifecycle_transition_helper = DetectionLifecycleTransitionHelper(service)
         self.reconciliation_resolver = DetectionReconciliationResolver(service)
         self.wazuh_intake_handler = LiveWazuhIntakeHandler(service, self)
@@ -159,9 +166,11 @@ class DetectionIntakeService:
                     f"Alert {alert_id!r} references missing case {resolved_case_id!r}"
                 )
 
-            evidence_records = self._list_alert_evidence_records(
-                alert_id=alert.alert_id,
-                case_id=resolved_case_id,
+            evidence_records = (
+                self._case_detection_linkage_helper._list_alert_evidence_records(
+                    alert_id=alert.alert_id,
+                    case_id=resolved_case_id,
+                )
             )
             if not evidence_records:
                 raise ValueError(
@@ -254,11 +263,11 @@ class DetectionIntakeService:
                 )
             )
             if promoted_alert.analytic_signal_id is not None:
-                self._link_case_to_analytic_signals(
+                self._case_detection_linkage_helper._link_case_to_analytic_signals(
                     (promoted_alert.analytic_signal_id,),
                     promoted_case.case_id,
                 )
-            self._link_case_to_alert_reconciliations(
+            self._case_detection_linkage_helper._link_case_to_alert_reconciliations(
                 alert_id=promoted_alert.alert_id,
                 case_id=promoted_case.case_id,
                 evidence_ids=merged_evidence_ids,
@@ -271,7 +280,7 @@ class DetectionIntakeService:
         record: NativeDetectionRecord,
     ) -> FindingAlertIngestResult:
         service = self._service
-        record = service._with_native_detection_admission_provenance(
+        record = self.with_native_detection_admission_provenance(
             record,
             admission_kind="replay",
             admission_channel="fixture_replay",
@@ -311,9 +320,11 @@ class DetectionIntakeService:
             admission.substrate_detection_record_id or record.native_record_id,
             "substrate_detection_record_id/native_record_id",
         )
-        substrate_detection_record_id = service._normalize_substrate_detection_record_id(
-            record_substrate_key,
-            raw_substrate_detection_record_id,
+        substrate_detection_record_id = (
+            self._native_admission_helper.normalize_substrate_detection_record_id(
+                record_substrate_key,
+                raw_substrate_detection_record_id,
+            )
         )
         admission = AnalyticSignalAdmission(
             finding_id=admission.finding_id,
@@ -375,7 +386,7 @@ class DetectionIntakeService:
                 alert=state.alert,
                 admission_reviewed_context=admission.reviewed_context,
             )
-            self._link_case_to_analytic_signals(
+            self._case_detection_linkage_helper._link_case_to_analytic_signals(
                 state.linked_signal_ids,
                 state.alert.case_id,
             )
@@ -760,112 +771,18 @@ class DetectionIntakeService:
             return None
         return parsed
 
-    def _link_case_to_analytic_signals(
+    def with_native_detection_admission_provenance(
         self,
-        analytic_signal_ids: tuple[str, ...],
-        case_id: str | None,
-    ) -> None:
-        if case_id is None:
-            return
-
-        service = self._service
-        for analytic_signal_id in analytic_signal_ids:
-            existing_signal = service._store.get(
-                AnalyticSignalRecord,
-                analytic_signal_id,
-            )
-            if existing_signal is None:
-                continue
-            linked_case_ids = service._merge_linked_ids(
-                existing_signal.case_ids,
-                case_id,
-            )
-            if linked_case_ids == existing_signal.case_ids:
-                continue
-            service.persist_record(
-                AnalyticSignalRecord(
-                    analytic_signal_id=existing_signal.analytic_signal_id,
-                    substrate_detection_record_id=(
-                        existing_signal.substrate_detection_record_id
-                    ),
-                    finding_id=existing_signal.finding_id,
-                    alert_ids=existing_signal.alert_ids,
-                    case_ids=linked_case_ids,
-                    correlation_key=existing_signal.correlation_key,
-                    first_seen_at=existing_signal.first_seen_at,
-                    last_seen_at=existing_signal.last_seen_at,
-                    lifecycle_state=existing_signal.lifecycle_state,
-                    reviewed_context=existing_signal.reviewed_context,
-                )
-            )
-
-    def _list_alert_evidence_records(
-        self,
+        record: NativeDetectionRecord,
         *,
-        alert_id: str,
-        case_id: str | None,
-    ) -> tuple[EvidenceRecord, ...]:
-        evidence_records: list[EvidenceRecord] = []
-        for evidence in self._service._store.list(EvidenceRecord):
-            if evidence.alert_id == alert_id or (
-                case_id is not None and evidence.case_id == case_id
-            ):
-                evidence_records.append(evidence)
-        return tuple(evidence_records)
-
-    def _link_case_to_alert_reconciliations(
-        self,
-        *,
-        alert_id: str,
-        case_id: str,
-        evidence_ids: tuple[str, ...],
-    ) -> None:
-        service = self._service
-        for reconciliation in service._store.list(ReconciliationRecord):
-            if reconciliation.alert_id != alert_id:
-                continue
-            subject_linkage = dict(reconciliation.subject_linkage)
-            updated_case_ids = service._merge_linked_ids(
-                subject_linkage.get("case_ids"),
-                case_id,
-            )
-            updated_evidence_ids = service._merge_linked_ids(
-                subject_linkage.get("evidence_ids"),
-                None,
-            )
-            for evidence_id in evidence_ids:
-                updated_evidence_ids = service._merge_linked_ids(
-                    updated_evidence_ids,
-                    evidence_id,
-                )
-            if (
-                tuple(subject_linkage.get("case_ids", ())) == updated_case_ids
-                and tuple(subject_linkage.get("evidence_ids", ()))
-                == updated_evidence_ids
-            ):
-                continue
-            subject_linkage["case_ids"] = updated_case_ids
-            subject_linkage["evidence_ids"] = updated_evidence_ids
-            service.persist_record(
-                ReconciliationRecord(
-                    reconciliation_id=reconciliation.reconciliation_id,
-                    subject_linkage=subject_linkage,
-                    alert_id=reconciliation.alert_id,
-                    finding_id=reconciliation.finding_id,
-                    analytic_signal_id=reconciliation.analytic_signal_id,
-                    execution_run_id=reconciliation.execution_run_id,
-                    linked_execution_run_ids=(
-                        reconciliation.linked_execution_run_ids
-                    ),
-                    correlation_key=reconciliation.correlation_key,
-                    first_seen_at=reconciliation.first_seen_at,
-                    last_seen_at=reconciliation.last_seen_at,
-                    ingest_disposition=reconciliation.ingest_disposition,
-                    mismatch_summary=reconciliation.mismatch_summary,
-                    compared_at=reconciliation.compared_at,
-                    lifecycle_state=reconciliation.lifecycle_state,
-                )
-            )
+        admission_kind: str,
+        admission_channel: str,
+    ) -> NativeDetectionRecord:
+        return self._native_admission_helper.with_native_detection_admission_provenance(
+            record,
+            admission_kind=admission_kind,
+            admission_channel=admission_channel,
+        )
 
     def triage_disposition_matches_current_state(
         self,

--- a/control-plane/aegisops_control_plane/detection_lifecycle_helpers.py
+++ b/control-plane/aegisops_control_plane/detection_lifecycle_helpers.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import hmac
 import logging
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Callable, Mapping
 import uuid
 
 from .adapters.wazuh import WazuhAlertAdapter
@@ -22,6 +23,7 @@ from .models import (
     HuntRunRecord,
     LeadRecord,
     LifecycleTransitionRecord,
+    NativeDetectionRecord,
     ObservationRecord,
     ReconciliationRecord,
     RecommendationRecord,
@@ -477,6 +479,48 @@ class DetectionReconciliationResolver:
         )
 
 
+class NativeDetectionAdmissionHelper:
+    def __init__(
+        self,
+        service: AegisOpsControlPlaneService,
+        *,
+        normalize_admission_provenance: Callable[[object], dict[str, str] | None],
+    ) -> None:
+        self._service = service
+        self._normalize_admission_provenance = normalize_admission_provenance
+
+    def with_native_detection_admission_provenance(
+        self,
+        record: NativeDetectionRecord,
+        *,
+        admission_kind: str,
+        admission_channel: str,
+    ) -> NativeDetectionRecord:
+        if (
+            self._normalize_admission_provenance(
+                record.metadata.get("admission_provenance")
+            )
+            is not None
+        ):
+            return record
+        metadata = dict(record.metadata)
+        metadata["admission_provenance"] = {
+            "admission_kind": admission_kind,
+            "admission_channel": admission_channel,
+        }
+        return replace(record, metadata=metadata)
+
+    def normalize_substrate_detection_record_id(
+        self,
+        substrate_key: str,
+        substrate_detection_record_id: str,
+    ) -> str:
+        namespaced_prefix = f"{substrate_key}:"
+        if substrate_detection_record_id.startswith(namespaced_prefix):
+            return substrate_detection_record_id
+        return f"{namespaced_prefix}{substrate_detection_record_id}"
+
+
 class LiveWazuhIntakeHandler:
     def __init__(
         self,
@@ -581,7 +625,7 @@ class LiveWazuhIntakeHandler:
             )
 
         adapter = WazuhAlertAdapter()
-        native_record = service._with_native_detection_admission_provenance(
+        native_record = self._intake.with_native_detection_admission_provenance(
             adapter.build_native_detection_record(native_alert),
             admission_kind="live",
             admission_channel="live_wazuh_webhook",

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -1502,43 +1502,6 @@ class AegisOpsControlPlaneService(ExternalEvidenceFacade):
             record,
         )
 
-    def _ingest_analytic_signal_admission(
-        self,
-        admission: AnalyticSignalAdmission,
-    ) -> FindingAlertIngestResult:
-        return self._detection_intake_service.ingest_analytic_signal_admission(
-            admission
-        )
-
-    def _attach_native_detection_context(
-        self,
-        *,
-        record: NativeDetectionRecord,
-        ingest_result: FindingAlertIngestResult,
-        substrate_detection_record_id: str,
-    ) -> FindingAlertIngestResult:
-        return self._detection_intake_service.attach_native_detection_context(
-            record=record,
-            ingest_result=ingest_result,
-            substrate_detection_record_id=substrate_detection_record_id,
-        )
-
-    def _with_native_detection_admission_provenance(
-        self,
-        record: NativeDetectionRecord,
-        *,
-        admission_kind: str,
-        admission_channel: str,
-    ) -> NativeDetectionRecord:
-        if _normalize_admission_provenance(record.metadata.get("admission_provenance")) is not None:
-            return record
-        metadata = dict(record.metadata)
-        metadata["admission_provenance"] = {
-            "admission_kind": admission_kind,
-            "admission_channel": admission_channel,
-        }
-        return replace(record, metadata=metadata)
-
     def reconcile_action_execution(
         self,
         *,
@@ -1575,57 +1538,6 @@ class AegisOpsControlPlaneService(ExternalEvidenceFacade):
     @staticmethod
     def _linked_id_exists(existing_values: object, candidate: str) -> bool:
         return isinstance(existing_values, (list, tuple)) and candidate in existing_values
-
-    def _link_case_to_analytic_signals(
-        self,
-        analytic_signal_ids: tuple[str, ...],
-        case_id: str | None,
-    ) -> None:
-        self._detection_intake_service._link_case_to_analytic_signals(
-            analytic_signal_ids,
-            case_id,
-        )
-
-    def _list_alert_evidence_records(
-        self,
-        *,
-        alert_id: str,
-        case_id: str | None,
-    ) -> tuple[EvidenceRecord, ...]:
-        return self._detection_intake_service._list_alert_evidence_records(
-            alert_id=alert_id,
-            case_id=case_id,
-        )
-
-    def _link_case_to_alert_reconciliations(
-        self,
-        *,
-        alert_id: str,
-        case_id: str,
-        evidence_ids: tuple[str, ...],
-    ) -> None:
-        self._detection_intake_service._link_case_to_alert_reconciliations(
-            alert_id=alert_id,
-            case_id=case_id,
-            evidence_ids=evidence_ids,
-        )
-
-    def _resolve_analytic_signal_id(
-        self,
-        *,
-        analytic_signal_id: str | None,
-        finding_id: str,
-        correlation_key: str,
-        substrate_detection_record_id: str | None,
-        latest_reconciliation: ReconciliationRecord | None,
-    ) -> str:
-        return self._detection_intake_service.resolve_analytic_signal_id(
-            analytic_signal_id=analytic_signal_id,
-            finding_id=finding_id,
-            correlation_key=correlation_key,
-            substrate_detection_record_id=substrate_detection_record_id,
-            latest_reconciliation=latest_reconciliation,
-        )
 
     def _require_empty_authoritative_restore_target(self) -> None:
         diagnostics_service = self._runtime_restore_readiness_diagnostics_service
@@ -1853,16 +1765,6 @@ class AegisOpsControlPlaneService(ExternalEvidenceFacade):
         return self._detection_intake_service.case_lifecycle_for_disposition(
             disposition
         )
-
-    @staticmethod
-    def _normalize_substrate_detection_record_id(
-        substrate_key: str,
-        substrate_detection_record_id: str,
-    ) -> str:
-        namespaced_prefix = f"{substrate_key}:"
-        if substrate_detection_record_id.startswith(namespaced_prefix):
-            return substrate_detection_record_id
-        return f"{namespaced_prefix}{substrate_detection_record_id}"
 
     @staticmethod
     def _next_identifier(prefix: str) -> str:

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -658,15 +658,17 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         self.assertIsInstance(delegate_call.func.value.value, ast.Name)
         self.assertEqual(delegate_call.func.value.value.id, "self")
 
-    def test_phase50_detection_linkage_helpers_live_with_detection_intake(
+    def test_phase50_detection_linkage_helpers_leave_service_facade(
         self,
     ) -> None:
         service_source = self._read("control-plane/aegisops_control_plane/service.py")
         detection_source = self._read(
             "control-plane/aegisops_control_plane/detection_lifecycle.py"
         )
+        case_source = self._read("control-plane/aegisops_control_plane/case_workflow.py")
         service_tree = ast.parse(service_source)
         detection_tree = ast.parse(detection_source)
+        case_tree = ast.parse(case_source)
         service_class = next(
             node
             for node in service_tree.body
@@ -679,42 +681,52 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             if isinstance(node, ast.ClassDef)
             and node.name == "DetectionIntakeService"
         )
+        case_linkage_class = next(
+            node
+            for node in case_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "CaseDetectionLinkageHelper"
+        )
 
-        moved_helper_names = {
+        case_linkage_helper_names = {
             "_link_case_to_analytic_signals",
             "_list_alert_evidence_records",
             "_link_case_to_alert_reconciliations",
+        }
+        detection_helper_names = {
+            "ingest_analytic_signal_admission",
+            "attach_native_detection_context",
+            "resolve_analytic_signal_id",
+        }
+        removed_service_helper_names = {
+            *case_linkage_helper_names,
+            "_ingest_analytic_signal_admission",
+            "_attach_native_detection_context",
+            "_with_native_detection_admission_provenance",
+            "_resolve_analytic_signal_id",
         }
         detection_method_names = {
             node.name
             for node in detection_class.body
             if isinstance(node, ast.FunctionDef)
         }
-        self.assertTrue(moved_helper_names.issubset(detection_method_names))
+        case_linkage_method_names = {
+            node.name
+            for node in case_linkage_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+        self.assertTrue(detection_helper_names.issubset(detection_method_names))
+        self.assertTrue(case_linkage_helper_names.issubset(case_linkage_method_names))
 
         service_methods = {
             node.name: node
             for node in service_class.body
             if isinstance(node, ast.FunctionDef)
         }
-        for helper_name in moved_helper_names:
-            service_method = service_methods[helper_name]
-            calls = [
-                node
-                for node in ast.walk(service_method)
-                if isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == helper_name
-                and isinstance(node.func.value, ast.Attribute)
-                and node.func.value.attr == "_detection_intake_service"
-                and isinstance(node.func.value.value, ast.Name)
-                and node.func.value.value.id == "self"
-            ]
-            self.assertEqual(
-                len(calls),
-                1,
-                f"{helper_name} should remain only as a facade compatibility delegate",
-            )
+        self.assertFalse(
+            removed_service_helper_names & service_methods.keys(),
+            "detection and case-linkage residual helpers should not remain service facade methods",
+        )
 
     def test_phase50_10_5_lifecycle_transition_callers_bypass_facade_delegates(
         self,

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -373,11 +373,13 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             native_result,
         )
         self.assertIs(
-            service._ingest_analytic_signal_admission(admission),
+            service._detection_intake_service.ingest_analytic_signal_admission(
+                admission
+            ),
             ingest_result,
         )
         self.assertIs(
-            service._attach_native_detection_context(
+            service._detection_intake_service.attach_native_detection_context(
                 record=native_record,
                 ingest_result=ingest_result,
                 substrate_detection_record_id="substrate-delegated-001",
@@ -428,7 +430,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             attribution,
         )
         self.assertEqual(
-            service._resolve_analytic_signal_id(
+            service._detection_intake_service.resolve_analytic_signal_id(
                 analytic_signal_id=None,
                 finding_id="finding-delegated-001",
                 correlation_key="claim:delegated",
@@ -833,12 +835,12 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             metadata={},
         )
 
-        linked = service._attach_native_detection_context(
+        linked = service._detection_intake_service.attach_native_detection_context(
             record=native_record,
             ingest_result=updated_result,
             substrate_detection_record_id="substrate-detection-native-link-001",
         )
-        relinked = service._attach_native_detection_context(
+        relinked = service._detection_intake_service.attach_native_detection_context(
             record=native_record,
             ingest_result=followup_result,
             substrate_detection_record_id="substrate-detection-native-link-001",
@@ -4698,7 +4700,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             RuntimeError,
             "synthetic native-context reconciliation failure",
         ):
-            failing_service._attach_native_detection_context(
+            failing_service._detection_intake_service.attach_native_detection_context(
                 record=native_record,
                 ingest_result=replace(
                     created,
@@ -4764,7 +4766,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             LookupError,
             "Alert 'alert-[^']+' references missing case 'case-missing-direct-native-001'",
         ):
-            service._attach_native_detection_context(
+            service._detection_intake_service.attach_native_detection_context(
                 record=native_record,
                 ingest_result=replace(created, alert=broken_alert),
                 substrate_detection_record_id="substrate-detection-missing-direct-native-002",


### PR DESCRIPTION
## Summary
- move case-to-signal, alert evidence listing, and alert reconciliation linkage out of service/detection residual helpers into `CaseDetectionLinkageHelper`
- move native detection admission provenance and substrate ID namespacing into `NativeDetectionAdmissionHelper`
- tighten structural regression coverage so private detection/case-linkage helpers do not remain on `AegisOpsControlPlaneService`

## Verification
- `python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py -k phase50_detection_linkage`
- `python3 -m unittest control-plane/tests/test_service_persistence_ingest_case_lifecycle.py`
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-phase-50-11-service-residual-extraction-contract.sh`
- `bash scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`\n- `node <codex-supervisor-root>/dist/index.js issue-lint 1006 --config <supervisor-config-path>`\n\nCloses #1006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of detection and case management services. Helper functionality has been restructured into dedicated utility classes for improved code maintainability and cleaner separation of concerns. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->