### PR TITLE
Refresh Phase 50.11 hotspot closeout baseline

### DIFF
--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,7 +66,8 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.10.6")
+        self.assertEqual(metadata["phase"], "50.11.7")
+        self.assertEqual(metadata["issue"], "#1007")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -50,49 +50,48 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
                 return metadata
         raise AssertionError("service.py hotspot baseline entry not found")
 
-    def test_baseline_records_phase50_10_closeout_ceiling(self) -> None:
+    def test_baseline_records_phase50_11_closeout_measurements(self) -> None:
         service_text = self._read("control-plane/aegisops_control_plane/service.py")
         metadata = self._baseline_metadata()
+        physical_lines = len(service_text.splitlines())
+        effective_lines = self._effective_line_count(service_text)
+        facade_methods = self._facade_method_count(metadata["facade_class"])
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.10.6")
-        self.assertEqual(metadata["issue"], "#993")
+        self.assertEqual(metadata["phase"], "50.11.7")
+        self.assertEqual(metadata["issue"], "#1007")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
-        self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
-        self.assertLessEqual(
-            self._effective_line_count(service_text),
-            int(metadata["max_effective_lines"]),
-        )
-        self.assertLessEqual(
-            self._facade_method_count(metadata["facade_class"]),
-            int(metadata["max_facade_methods"]),
-        )
-        self.assertLess(int(metadata["max_lines"]), 3505)
-        self.assertLess(int(metadata["max_effective_lines"]), 3182)
-        self.assertLess(int(metadata["max_facade_methods"]), 185)
+        self.assertEqual(int(metadata["max_lines"]), physical_lines)
+        self.assertEqual(int(metadata["max_effective_lines"]), effective_lines)
+        self.assertEqual(int(metadata["max_facade_methods"]), facade_methods)
+        self.assertEqual(physical_lines, 1812)
+        self.assertEqual(effective_lines, 1632)
+        self.assertEqual(facade_methods, 125)
+        self.assertLess(int(metadata["max_lines"]), 3003)
+        self.assertLess(int(metadata["max_effective_lines"]), 2704)
+        self.assertLess(int(metadata["max_facade_methods"]), 167)
 
     def test_closeout_notes_preserve_phase50_10_hotspot_and_trigger(self) -> None:
         closeout = self._read("docs/phase-50-maintainability-closeout.md")
 
         for required in (
-            "Phase 50.10.6",
+            "Phase 50.11.7",
             "control-plane/aegisops_control_plane/service.py",
             "control-plane/aegisops_control_plane/action_review_projection.py",
             "control-plane/aegisops_control_plane/external_evidence_boundary.py",
             "AegisOpsControlPlaneService",
-            "max_lines=3003",
-            "max_effective_lines=2704",
-            "max_facade_methods=167",
-            "projection lines=105",
-            "projection effective_lines=103",
-            "external_evidence_boundary.py lines=216",
-            "external_evidence_boundary.py effective_lines=195",
+            "max_lines=1812",
+            "max_effective_lines=1632",
+            "max_facade_methods=125",
+            "physical_lines=1812",
+            "effective_lines=1632",
             "ADR-0007",
+            "ADR-0008",
             "ADR-0004",
             "ADR-0003",
-            "#993",
+            "#1007",
             "remaining accepted hotspot",
-            "facade dispatch, compatibility entrypoints, and authority-boundary guard helpers",
+            "facade dispatch, compatibility entrypoints, runtime-boundary guards, and lifecycle/write-path delegates",
             "projection split does not require a baseline entry",
             "external-evidence split does not require a baseline entry",
             "silent re-growth",
@@ -125,12 +124,12 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
 
         for required in (
             "regrowth_repo",
-            "phase50_10_regrowth_repo",
+            "phase50_11_regrowth_repo",
             "Maintainability hotspot baseline limits were exceeded",
             "lines=960 exceeds max_lines=959",
             "effective_lines=960 exceeds max_effective_lines=959",
-            "lines=3004 exceeds max_lines=3003",
-            "effective_lines=3004 exceeds max_effective_lines=2704",
+            "lines=1813 exceeds max_lines=1812",
+            "effective_lines=1813 exceeds max_effective_lines=1632",
             "max_facade_methods=0",
         ):
             self.assertIn(required, verifier_test)

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,12 +1,13 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.10.6 residual exception:
-# ADR-0004 accepted ordered hotspot reduction after the ADR-0003
-# facade-preservation exception behind AegisOpsControlPlaneService.
+# Phase 50.11.7 residual exception:
+# ADR-0008 accepted ordered residual DTO/helper extraction after the
+# Phase 50.10.6 facade floor. ADR-0003 remains the public facade-preservation
+# exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 50.10.6 closeout verification, so this baseline records the
-# reduced ceiling and fails on silent re-growth. A future ADR or
-# maintainability backlog must lower or replace these limits before unrelated
-# feature expansion lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993
+# the Phase 50.11.7 closeout verification, so this baseline records the final
+# measured ceiling and fails on silent re-growth. A future ADR or maintainability
+# backlog must lower or replace these limits before unrelated feature expansion
+# lands in the facade.
+control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,10 +1,10 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.10.6 closes the ordered maintainability hotspot reduction sequence governed by ADR-0004, ADR-0005, ADR-0006, and ADR-0007.
+Phase 50.11.7 closes the ordered residual `service.py` DTO/helper extraction sequence governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, and ADR-0008.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
-ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0005 governs the Phase 50.8 residual service migration contract. ADR-0006 governs the Phase 50.9 residual facade convergence and projection guard. ADR-0007 governs the Phase 50.10 facade floor and external-evidence guard. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
+ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0005 governs the Phase 50.8 residual service migration contract. ADR-0006 governs the Phase 50.9 residual facade convergence and projection guard. ADR-0007 governs the Phase 50.10 facade floor and external-evidence guard. ADR-0008 governs the Phase 50.11 residual DTO/helper extraction order. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
 
 ## Accepted Verifier State
 
@@ -12,18 +12,39 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.10 extraction, service-facade rewiring, and internal-caller rewiring work. The final Phase 50.10.6 closeout for #993 records the accepted residual ceiling as:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work. The final Phase 50.11.7 closeout for #1007 records the accepted residual ceiling as:
 
-- `max_lines=3003`
-- `max_effective_lines=2704`
-- `max_facade_methods=167`
+- `max_lines=1812`
+- `max_effective_lines=1632`
+- `max_facade_methods=125`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.10.6`
+- `phase=50.11.7`
+- `issue=#1007`
 
-No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, operator UI route tests, `control-plane/aegisops_control_plane/action_review_projection.py`, or `control-plane/aegisops_control_plane/external_evidence_boundary.py` because the verifier does not report those areas as current responsibility-growth candidates. The Phase 50.9.6 projection measurement is `projection lines=105` and `projection effective_lines=103`, so the projection split does not require a baseline entry. The Phase 50.10.6 external-evidence measurement is `external_evidence_boundary.py lines=216` and `external_evidence_boundary.py effective_lines=195`, so the external-evidence split does not require a baseline entry.
+The measured closeout state is:
 
-The remaining accepted hotspot is not a general extension target. The residual helper pressure is concentrated in facade dispatch, compatibility entrypoints, and authority-boundary guard helpers that still sit behind the public facade. Those helpers remain review-visible because they protect action review state, detection intake linkage, external-evidence linkage, and fail-closed authoritative-state reads at the service boundary.
+- `physical_lines=1812`
+- `effective_lines=1632`
+- `AegisOpsControlPlaneService methods=125`
+
+The baseline is lower than the Phase 50.10.6 ceiling of `max_lines=3003`, `max_effective_lines=2704`, and `max_facade_methods=167`. It is also below the ADR-0008 Phase 50.11 target ceiling of `max_lines <= 2700`, `max_effective_lines <= 2450`, and `max_facade_methods <= 150`.
+
+No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, operator UI route tests, `control-plane/aegisops_control_plane/action_review_projection.py`, or `control-plane/aegisops_control_plane/external_evidence_boundary.py` because the verifier does not report those areas as current responsibility-growth candidates. The earlier Phase 50.9 projection measurement was `projection lines=105` and `projection effective_lines=103`, so the projection split does not require a baseline entry. The earlier Phase 50.10 external-evidence measurement was `external_evidence_boundary.py lines=216` and `external_evidence_boundary.py effective_lines=195`, so the external-evidence split does not require a baseline entry.
+
+The remaining accepted hotspot is not a general extension target. The residual helper pressure is concentrated in facade dispatch, compatibility entrypoints, runtime-boundary guards, and lifecycle/write-path delegates that still sit behind the public facade. Those helpers remain review-visible because they protect action review state, detection intake linkage, external-evidence linkage, authoritative restore validation, and fail-closed authoritative-state reads at the service boundary.
+
+## Phase 50.11 Extraction Evidence
+
+The final Phase 50.11 extraction sequence moved the following directly linked helper clusters out of `service.py`:
+
+- service snapshot DTO shaping into `control-plane/aegisops_control_plane/service_snapshots.py`;
+- structured runtime-event sanitization into `control-plane/aegisops_control_plane/structured_events.py`;
+- action-review inspection assembly into `control-plane/aegisops_control_plane/action_review_inspection.py`;
+- assistant advisory facade helpers into `control-plane/aegisops_control_plane/assistant_advisory.py` and `control-plane/aegisops_control_plane/live_assistant_workflow.py`;
+- detection/case-linkage helpers into `control-plane/aegisops_control_plane/case_workflow.py`, `control-plane/aegisops_control_plane/detection_lifecycle.py`, and `control-plane/aegisops_control_plane/detection_lifecycle_helpers.py`.
+
+Those extractions preserve the public service facade. AegisOps control-plane records remain authoritative workflow truth. Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, projections, snapshots, DTOs, and helper-module output remain subordinate context.
 
 ## Follow-Up Trigger
 
@@ -33,7 +54,7 @@ Any silent re-growth beyond the recorded ceiling must fail the verifier. The exp
 
 If a later extraction lowers the facade below the verifier threshold, maintainers should remove or lower the baseline only after confirming that the file no longer crosses the responsibility-growth threshold.
 
-If future work needs to add another action-review surface, intake pathway, authoritative restore/read guard, external-evidence linkage path, or cross-record projection helper to `service.py`, that is the follow-up trigger for another maintainability issue. The follow-up should extract or fence the directly linked helper cluster instead of using this exception as approval for new facade responsibility. If `action_review_projection.py` grows back toward the Phase 50.9 pre-split measurement of `max_lines=2034` or `max_effective_lines=1911`, the follow-up should split that directly linked projection cluster instead of silently recording a new projection hotspot exception. If `external_evidence_boundary.py` grows back toward the pre-Phase 50.10 measurement of `max_lines=1083` or `max_effective_lines=1033`, the follow-up should split the directly linked MISP, osquery, or endpoint-evidence helper cluster instead of recording a silent external-evidence hotspot exception.
+If future work needs to add another action-review surface, intake pathway, authoritative restore/read guard, external-evidence linkage path, runtime-boundary guard, assistant linkage path, detection/case linkage path, or cross-record projection helper to `service.py`, that is the follow-up trigger for another maintainability issue. The follow-up should extract or fence the directly linked helper cluster instead of using this exception as approval for new facade responsibility. If `action_review_projection.py` grows back toward the Phase 50.9 pre-split measurement of `max_lines=2034` or `max_effective_lines=1911`, the follow-up should split that directly linked projection cluster instead of silently recording a new projection hotspot exception. If `external_evidence_boundary.py` grows back toward the pre-Phase 50.10 measurement of `max_lines=1083` or `max_effective_lines=1033`, the follow-up should split the directly linked MISP, osquery, or endpoint-evidence helper cluster instead of recording a silent external-evidence hotspot exception.
 
 ## Verification Evidence
 
@@ -41,6 +62,8 @@ Run:
 
 - `bash scripts/verify-maintainability-hotspots.sh`
 - `bash scripts/test-verify-maintainability-hotspots.sh`
+- `bash scripts/verify-phase-50-11-service-residual-extraction-contract.sh`
+- `bash scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh`
 - `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py`
 
-The focused negative verifier coverage remains in `scripts/test-verify-maintainability-hotspots.sh` through the `regrowth_repo` fixture, which verifies that line-count, effective-line, and facade-method growth beyond the recorded ceiling still fails closed.
+The focused negative verifier coverage remains in `scripts/test-verify-maintainability-hotspots.sh` through the `regrowth_repo` fixture and the `phase50_11_regrowth_repo` fixture, which verify that line-count, effective-line, and facade-method growth beyond the recorded ceiling still fails closed.

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -162,10 +162,10 @@ if ! grep -F "RenamedControlPlaneService methods=1" "${fail_stderr}" >/dev/null;
   exit 1
 fi
 
-phase50_10_regrowth_repo="${workdir}/phase50-10-regrowth"
+phase50_11_regrowth_repo="${workdir}/phase50-11-regrowth"
 create_repo \
-  "${phase50_10_regrowth_repo}" \
-  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993" \
+  "${phase50_11_regrowth_repo}" \
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007" \
   "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
     def describe_runtime(self):
         auth_principal = 'trusted-runtime-boundary'
@@ -176,17 +176,17 @@ create_repo \
         restore_backup_export = action_reconciliation
         evidence_admission = restore_backup_export
         return evidence_admission"
-append_repeated_lines "${phase50_10_regrowth_repo}" "control-plane/aegisops_control_plane/service.py" "phase50_10_growth_line" 2994
-git -C "${phase50_10_regrowth_repo}" add .
-git -C "${phase50_10_regrowth_repo}" commit -q -m "phase 50.10 regrowth past accepted closeout"
-assert_fails_with "${phase50_10_regrowth_repo}" "Maintainability hotspot baseline limits were exceeded"
-if ! grep -F "lines=3004 exceeds max_lines=3003" "${fail_stderr}" >/dev/null; then
-  echo "Expected failure output to report the Phase 50.10 line-count limit." >&2
+append_repeated_lines "${phase50_11_regrowth_repo}" "control-plane/aegisops_control_plane/service.py" "phase50_11_growth_line" 1803
+git -C "${phase50_11_regrowth_repo}" add .
+git -C "${phase50_11_regrowth_repo}" commit -q -m "phase 50.11 regrowth past accepted closeout"
+assert_fails_with "${phase50_11_regrowth_repo}" "Maintainability hotspot baseline limits were exceeded"
+if ! grep -F "lines=1813 exceeds max_lines=1812" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the Phase 50.11 line-count limit." >&2
   cat "${fail_stderr}" >&2
   exit 1
 fi
-if ! grep -F "effective_lines=3004 exceeds max_effective_lines=2704" "${fail_stderr}" >/dev/null; then
-  echo "Expected failure output to report the Phase 50.10 effective-line limit." >&2
+if ! grep -F "effective_lines=1813 exceeds max_effective_lines=1632" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the Phase 50.11 effective-line limit." >&2
   cat "${fail_stderr}" >&2
   exit 1
 fi

--- a/scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh
+++ b/scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh
@@ -201,6 +201,24 @@ valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
 
+closeout_baseline_repo="${workdir}/closeout-baseline"
+create_valid_repo "${closeout_baseline_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007" \
+  >"${closeout_baseline_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${closeout_baseline_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.11.7 records the final #1007 closeout baseline.
+
+- `max_lines=1812`
+- `max_effective_lines=1632`
+- `max_facade_methods=125`
+- `physical_lines=1812`
+- `effective_lines=1632`
+EOF
+assert_passes "${closeout_baseline_repo}"
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
@@ -259,11 +277,20 @@ assert_fails_with \
 premature_service_baseline_repo="${workdir}/premature-service-baseline"
 create_valid_repo "${premature_service_baseline_repo}"
 printf '%s\n' \
-  "control-plane/aegisops_control_plane/service.py max_lines=2700 max_effective_lines=2450 max_facade_methods=150 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0008 phase=50.11 issue=#1001" \
+  "control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007" \
   >"${premature_service_baseline_repo}/docs/maintainability-hotspot-baseline.txt"
 assert_fails_with \
   "${premature_service_baseline_repo}" \
-  "Phase 50.11 contract forbids refreshing the service.py baseline before implementation evidence exists."
+  "Phase 50.11 closeout baseline requires docs/phase-50-maintainability-closeout.md evidence."
+
+unsupported_service_baseline_repo="${workdir}/unsupported-service-baseline"
+create_valid_repo "${unsupported_service_baseline_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=2700 max_effective_lines=2450 max_facade_methods=150 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0008 phase=50.11 issue=#1001" \
+  >"${unsupported_service_baseline_repo}/docs/maintainability-hotspot-baseline.txt"
+assert_fails_with \
+  "${unsupported_service_baseline_repo}" \
+  "Phase 50.11 contract requires either the accepted starting baseline or the verified Phase 50.11.7 closeout baseline."
 
 duplicate_service_baseline_repo="${workdir}/duplicate-service-baseline"
 create_valid_repo "${duplicate_service_baseline_repo}"

--- a/scripts/verify-phase-50-11-service-residual-extraction-contract.sh
+++ b/scripts/verify-phase-50-11-service-residual-extraction-contract.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 doc_path="${repo_root}/docs/adr/0008-phase-50-11-service-residual-extraction-contract.md"
 baseline_path="${repo_root}/docs/maintainability-hotspot-baseline.txt"
+closeout_path="${repo_root}/docs/phase-50-maintainability-closeout.md"
 
 required_headings=(
   "# ADR-0008: Phase 50.11 Service Residual Extraction Contract"
@@ -113,6 +114,7 @@ for phrase in "${required_phrases[@]}"; do
 done
 
 starting_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=3003 max_effective_lines=2704 max_facade_methods=167 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.10.6 issue=#993"
+closeout_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007"
 service_entry="$(grep -E '^control-plane/aegisops_control_plane/service.py[[:space:]]' "${baseline_path}" || true)"
 service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 if [[ "${service_entry_count}" -eq 0 ]]; then
@@ -123,9 +125,28 @@ if [[ "${service_entry_count}" -ne 1 ]]; then
   echo "Phase 50.11 contract requires exactly one service.py hotspot baseline entry." >&2
   exit 1
 fi
-if [[ "${service_entry}" != "${starting_service_baseline_entry}" ]]; then
-  echo "Phase 50.11 contract forbids refreshing the service.py baseline before implementation evidence exists." >&2
+if [[ "${service_entry}" != "${starting_service_baseline_entry}" && "${service_entry}" != "${closeout_service_baseline_entry}" ]]; then
+  echo "Phase 50.11 contract requires either the accepted starting baseline or the verified Phase 50.11.7 closeout baseline." >&2
   exit 1
+fi
+if [[ "${service_entry}" == "${closeout_service_baseline_entry}" ]]; then
+  if [[ ! -f "${closeout_path}" ]]; then
+    echo "Phase 50.11 closeout baseline requires docs/phase-50-maintainability-closeout.md evidence." >&2
+    exit 1
+  fi
+  for phrase in \
+    "Phase 50.11.7" \
+    "max_lines=1812" \
+    "max_effective_lines=1632" \
+    "max_facade_methods=125" \
+    "physical_lines=1812" \
+    "effective_lines=1632" \
+    "#1007"; do
+    if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
+      echo "Phase 50.11 closeout baseline missing closeout evidence: ${phrase}" >&2
+      exit 1
+    fi
+  done
 fi
 
 echo "Phase 50.11 service residual extraction contract fixes residual clusters, starting measurements, target ceilings, authority non-goals, migration order, and validation commands."


### PR DESCRIPTION
## Summary
- refresh the maintainability hotspot baseline to the measured Phase 50.11.7 `service.py` state: `1812` physical lines, `1632` effective lines, and `125` facade methods
- update Phase 50 closeout evidence, residual-cluster language, and follow-up triggers for #1007
- tighten verifier/unit coverage so stale baselines and silent regrowth beyond the Phase 50.11.7 ceiling fail closed

## Verification
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-phase-50-11-service-residual-extraction-contract.sh`
- `bash scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh`
- `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py`
- `python3 -m unittest control-plane/tests/test_service_snapshot_extraction.py control-plane/tests/test_structured_events.py control-plane/tests/test_service_boundary_refactor_regression_validation.py control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py control-plane/tests/test_service_persistence_assistant_advisory.py control-plane/tests/test_service_persistence_ingest_case_lifecycle.py`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1007 --config <supervisor-config-path>`

Issue: #1007


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Phase 49 and 50 maintainability closeout baselines to reflect Phase 50.11.7 standards.
  * Enhanced verification tests with tightened constraint thresholds for code maintainability metrics.

* **Documentation**
  * Updated maintainability hotspot baseline documentation with new Phase 50.11.7 measurements.
  * Expanded Phase 50 closeout documentation with extraction evidence and updated ADR governance.

* **Chores**
  * Updated verification test scripts to enforce new Phase 50.11.7 baseline requirements and associated issue tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->