### PR TITLE
Phase 50.12.2 constructor composition extraction

### DIFF
--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -58,6 +58,7 @@ from .external_evidence_facade import ExternalEvidenceFacade
 from .service_composition import (
     ControlPlaneServiceCompositionDependencies,
     build_control_plane_service_composition,
+    install_control_plane_service_composition,
 )
 from .service_snapshots import (
     ActionReviewDetailSnapshot,
@@ -118,6 +119,72 @@ _PHASE24_WORKFLOW_PROMPT_VERSIONS = {
     "case_summary": "phase24-case-summary-v1",
     "queue_triage_summary": "phase24-queue-summary-v1",
 }
+
+
+def _build_control_plane_service_composition_dependencies(
+) -> ControlPlaneServiceCompositionDependencies:
+    return ControlPlaneServiceCompositionDependencies(
+        runtime_snapshot_factory=RuntimeSnapshot,
+        authenticated_principal_factory=AuthenticatedRuntimePrincipal,
+        reviewed_summary_transport_factory=_ReviewedSummaryTransport,
+        workflow_family=_PHASE24_WORKFLOW_FAMILY,
+        workflow_prompt_versions=_PHASE24_WORKFLOW_PROMPT_VERSIONS,
+        record_types_by_family=RECORD_TYPES_BY_FAMILY,
+        authoritative_record_chain_record_types=(
+            AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES
+        ),
+        authoritative_record_chain_backup_schema_version=(
+            AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION
+        ),
+        authoritative_primary_id_field_by_family=(
+            _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY
+        ),
+        normalize_admission_provenance=_normalize_admission_provenance,
+        merge_reviewed_context=_merge_reviewed_context,
+        case_lifecycle_state_by_triage_disposition=(
+            _CASE_LIFECYCLE_STATE_BY_TRIAGE_DISPOSITION
+        ),
+        record_to_dict=_record_to_dict,
+        json_ready=_json_ready,
+        redacted_reconciliation_payload=_redacted_reconciliation_payload,
+        coordination_reference_payload=_coordination_reference_payload,
+        coordination_reference_signature=_coordination_reference_signature,
+        dedupe_strings=_dedupe_strings,
+        analyst_queue_snapshot_factory=AnalystQueueSnapshot,
+        alert_detail_snapshot_factory=AlertDetailSnapshot,
+        case_detail_snapshot_factory=CaseDetailSnapshot,
+        action_review_detail_snapshot_factory=ActionReviewDetailSnapshot,
+        assistant_context_snapshot_factory=AnalystAssistantContextSnapshot,
+        advisory_snapshot_from_context=(
+            _assistant_advisory.advisory_inspection_snapshot_from_context
+        ),
+        recommendation_draft_snapshot_from_context=(
+            _assistant_advisory.recommendation_draft_snapshot_from_context
+        ),
+        live_assistant_snapshot_factory=(
+            _live_assistant_workflow.phase24_live_assistant_snapshot
+        ),
+        live_assistant_citations_from_context=(
+            lambda snapshot: _live_assistant_workflow.phase24_live_assistant_citations_from_context(
+                snapshot
+            )
+        ),
+        live_assistant_unresolved_reasons=(
+            _live_assistant_workflow.phase24_live_assistant_unresolved_reasons
+        ),
+        live_assistant_prompt_injection_flags=(
+            _live_assistant_workflow.phase24_live_assistant_prompt_injection_flags
+        ),
+        startup_status_snapshot_factory=StartupStatusSnapshot,
+        readiness_diagnostics_snapshot_factory=ReadinessDiagnosticsSnapshot,
+        restore_drill_snapshot_factory=RestoreDrillSnapshot,
+        restore_summary_snapshot_factory=RestoreSummarySnapshot,
+        shutdown_status_snapshot_factory=ShutdownStatusSnapshot,
+        derive_readiness_status=_derive_readiness_status,
+        find_duplicate_strings=_find_duplicate_strings,
+    )
+
+
 class _ReviewedSummaryTransport(AssistantProviderTransport):
     """Deterministic reviewed-only transport for the first live workflow family."""
 
@@ -413,117 +480,11 @@ class AegisOpsControlPlaneService(ExternalEvidenceFacade):
             service=self,
             config=config,
             store=store,
-            dependencies=ControlPlaneServiceCompositionDependencies(
-                runtime_snapshot_factory=RuntimeSnapshot,
-                authenticated_principal_factory=AuthenticatedRuntimePrincipal,
-                reviewed_summary_transport_factory=_ReviewedSummaryTransport,
-                workflow_family=_PHASE24_WORKFLOW_FAMILY,
-                workflow_prompt_versions=_PHASE24_WORKFLOW_PROMPT_VERSIONS,
-                record_types_by_family=RECORD_TYPES_BY_FAMILY,
-                authoritative_record_chain_record_types=(
-                    AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES
-                ),
-                authoritative_record_chain_backup_schema_version=(
-                    AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION
-                ),
-                authoritative_primary_id_field_by_family=(
-                    _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY
-                ),
-                normalize_admission_provenance=_normalize_admission_provenance,
-                merge_reviewed_context=_merge_reviewed_context,
-                case_lifecycle_state_by_triage_disposition=(
-                    _CASE_LIFECYCLE_STATE_BY_TRIAGE_DISPOSITION
-                ),
-                record_to_dict=_record_to_dict,
-                json_ready=_json_ready,
-                redacted_reconciliation_payload=_redacted_reconciliation_payload,
-                coordination_reference_payload=_coordination_reference_payload,
-                coordination_reference_signature=_coordination_reference_signature,
-                dedupe_strings=_dedupe_strings,
-                analyst_queue_snapshot_factory=AnalystQueueSnapshot,
-                alert_detail_snapshot_factory=AlertDetailSnapshot,
-                case_detail_snapshot_factory=CaseDetailSnapshot,
-                action_review_detail_snapshot_factory=ActionReviewDetailSnapshot,
-                assistant_context_snapshot_factory=AnalystAssistantContextSnapshot,
-                advisory_snapshot_from_context=(
-                    _assistant_advisory.advisory_inspection_snapshot_from_context
-                ),
-                recommendation_draft_snapshot_from_context=(
-                    _assistant_advisory.recommendation_draft_snapshot_from_context
-                ),
-                live_assistant_snapshot_factory=(
-                    _live_assistant_workflow.phase24_live_assistant_snapshot
-                ),
-                live_assistant_citations_from_context=(
-                    lambda snapshot: _live_assistant_workflow.phase24_live_assistant_citations_from_context(
-                        snapshot
-                    )
-                ),
-                live_assistant_unresolved_reasons=(
-                    _live_assistant_workflow.phase24_live_assistant_unresolved_reasons
-                ),
-                live_assistant_prompt_injection_flags=(
-                    _live_assistant_workflow.phase24_live_assistant_prompt_injection_flags
-                ),
-                startup_status_snapshot_factory=StartupStatusSnapshot,
-                readiness_diagnostics_snapshot_factory=ReadinessDiagnosticsSnapshot,
-                restore_drill_snapshot_factory=RestoreDrillSnapshot,
-                restore_summary_snapshot_factory=RestoreSummarySnapshot,
-                shutdown_status_snapshot_factory=ShutdownStatusSnapshot,
-                derive_readiness_status=_derive_readiness_status,
-                find_duplicate_strings=_find_duplicate_strings,
-            ),
+            dependencies=_build_control_plane_service_composition_dependencies(),
         )
-        self._store = composition.store
-        self._reconciliation = composition.reconciliation
-        self._shuffle = composition.shuffle
-        self._isolated_executor = composition.isolated_executor
-        self._assistant_provider_adapter = composition.assistant_provider_adapter
-        self._reviewed_slice_policy = composition.reviewed_slice_policy
-        self._ai_trace_lifecycle_service = composition.ai_trace_lifecycle_service
-        self._assistant_context_assembler = composition.assistant_context_assembler
-        self._assistant_advisory_coordinator = (
-            composition.assistant_advisory_coordinator
-        )
-        self._live_assistant_workflow_coordinator = (
-            composition.live_assistant_workflow_coordinator
-        )
-        self._action_review_inspection_boundary = (
-            composition.action_review_inspection_boundary
-        )
-        self._operator_inspection_read_surface = (
-            composition.operator_inspection_read_surface
-        )
-        self._action_review_write_surface = composition.action_review_write_surface
-        self._evidence_linkage_service = composition.evidence_linkage_service
-        self._case_workflow_service = composition.case_workflow_service
-        self._detection_intake_service = composition.detection_intake_service
-        self._execution_coordinator = composition.execution_coordinator
-        self._action_orchestration_boundary = (
-            composition.action_orchestration_boundary
-        )
-        self._reconciliation_orchestration_boundary = (
-            composition.reconciliation_orchestration_boundary
-        )
-        self._action_lifecycle_write_coordinator = (
-            composition.action_lifecycle_write_coordinator
-        )
-        self._endpoint_evidence_pack_adapter = (
-            composition.endpoint_evidence_pack_adapter
-        )
-        self._misp_context_adapter = composition.misp_context_adapter
-        self._external_evidence_boundary = composition.external_evidence_boundary
-        self._osquery_host_context_adapter = composition.osquery_host_context_adapter
-        self._runtime_boundary_service = composition.runtime_boundary_service
-        self._readiness_operability_helper = (
-            composition.readiness_operability_helper
-        )
-        self._restore_readiness_service = composition.restore_readiness_service
-        self._runtime_restore_readiness_diagnostics_service = (
-            composition.runtime_restore_readiness_diagnostics_service
-        )
-        self._persistence_lifecycle_service = (
-            composition.persistence_lifecycle_service
+        install_control_plane_service_composition(
+            service=self,
+            composition=composition,
         )
 
     def describe_runtime(self) -> RuntimeSnapshot:

--- a/control-plane/aegisops_control_plane/service_composition.py
+++ b/control-plane/aegisops_control_plane/service_composition.py
@@ -371,8 +371,63 @@ def build_control_plane_service_composition(
     )
 
 
+def install_control_plane_service_composition(
+    *,
+    service: Any,
+    composition: ControlPlaneServiceComposition,
+) -> None:
+    assignments = {
+        "_store": composition.store,
+        "_reconciliation": composition.reconciliation,
+        "_shuffle": composition.shuffle,
+        "_isolated_executor": composition.isolated_executor,
+        "_assistant_provider_adapter": composition.assistant_provider_adapter,
+        "_reviewed_slice_policy": composition.reviewed_slice_policy,
+        "_ai_trace_lifecycle_service": composition.ai_trace_lifecycle_service,
+        "_assistant_context_assembler": composition.assistant_context_assembler,
+        "_assistant_advisory_coordinator": composition.assistant_advisory_coordinator,
+        "_live_assistant_workflow_coordinator": (
+            composition.live_assistant_workflow_coordinator
+        ),
+        "_action_review_inspection_boundary": (
+            composition.action_review_inspection_boundary
+        ),
+        "_operator_inspection_read_surface": (
+            composition.operator_inspection_read_surface
+        ),
+        "_action_review_write_surface": composition.action_review_write_surface,
+        "_evidence_linkage_service": composition.evidence_linkage_service,
+        "_case_workflow_service": composition.case_workflow_service,
+        "_detection_intake_service": composition.detection_intake_service,
+        "_execution_coordinator": composition.execution_coordinator,
+        "_action_orchestration_boundary": composition.action_orchestration_boundary,
+        "_reconciliation_orchestration_boundary": (
+            composition.reconciliation_orchestration_boundary
+        ),
+        "_action_lifecycle_write_coordinator": (
+            composition.action_lifecycle_write_coordinator
+        ),
+        "_endpoint_evidence_pack_adapter": (
+            composition.endpoint_evidence_pack_adapter
+        ),
+        "_misp_context_adapter": composition.misp_context_adapter,
+        "_external_evidence_boundary": composition.external_evidence_boundary,
+        "_osquery_host_context_adapter": composition.osquery_host_context_adapter,
+        "_runtime_boundary_service": composition.runtime_boundary_service,
+        "_readiness_operability_helper": composition.readiness_operability_helper,
+        "_restore_readiness_service": composition.restore_readiness_service,
+        "_runtime_restore_readiness_diagnostics_service": (
+            composition.runtime_restore_readiness_diagnostics_service
+        ),
+        "_persistence_lifecycle_service": composition.persistence_lifecycle_service,
+    }
+    for attribute_name, collaborator in assignments.items():
+        setattr(service, attribute_name, collaborator)
+
+
 __all__ = [
     "ControlPlaneServiceComposition",
     "ControlPlaneServiceCompositionDependencies",
     "build_control_plane_service_composition",
+    "install_control_plane_service_composition",
 ]

--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,8 +66,8 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.11.7")
-        self.assertEqual(metadata["issue"], "#1007")
+        self.assertEqual(metadata["phase"], "50.12.2")
+        self.assertEqual(metadata["issue"], "#1017")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -58,14 +58,14 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         facade_methods = self._facade_method_count(metadata["facade_class"])
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.11.7")
-        self.assertEqual(metadata["issue"], "#1007")
+        self.assertEqual(metadata["phase"], "50.12.2")
+        self.assertEqual(metadata["issue"], "#1017")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), physical_lines)
         self.assertEqual(int(metadata["max_effective_lines"]), effective_lines)
         self.assertEqual(int(metadata["max_facade_methods"]), facade_methods)
-        self.assertEqual(physical_lines, 1812)
-        self.assertEqual(effective_lines, 1632)
+        self.assertEqual(physical_lines, 1773)
+        self.assertEqual(effective_lines, 1589)
         self.assertEqual(facade_methods, 125)
         self.assertLess(int(metadata["max_lines"]), 3003)
         self.assertLess(int(metadata["max_effective_lines"]), 2704)
@@ -76,20 +76,22 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
 
         for required in (
             "Phase 50.11.7",
+            "Phase 50.12.2",
             "control-plane/aegisops_control_plane/service.py",
             "control-plane/aegisops_control_plane/action_review_projection.py",
             "control-plane/aegisops_control_plane/external_evidence_boundary.py",
             "AegisOpsControlPlaneService",
-            "max_lines=1812",
-            "max_effective_lines=1632",
+            "max_lines=1773",
+            "max_effective_lines=1589",
             "max_facade_methods=125",
-            "physical_lines=1812",
-            "effective_lines=1632",
+            "physical_lines=1773",
+            "effective_lines=1589",
             "ADR-0007",
             "ADR-0008",
             "ADR-0004",
             "ADR-0003",
             "#1007",
+            "#1017",
             "remaining accepted hotspot",
             "facade dispatch, compatibility entrypoints, runtime-boundary guards, and lifecycle/write-path delegates",
             "projection split does not require a baseline entry",
@@ -128,8 +130,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "Maintainability hotspot baseline limits were exceeded",
             "lines=960 exceeds max_lines=959",
             "effective_lines=960 exceeds max_effective_lines=959",
-            "lines=1813 exceeds max_lines=1812",
-            "effective_lines=1813 exceeds max_effective_lines=1632",
+            "lines=1774 exceeds max_lines=1773",
+            "effective_lines=1774 exceeds max_effective_lines=1589",
             "max_facade_methods=0",
         ):
             self.assertIn(required, verifier_test)

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -568,6 +568,53 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             composition_call_names,
         )
 
+    def test_phase50_12_2_constructor_keeps_composition_assignment_out_of_facade(
+        self,
+    ) -> None:
+        service_source = self._read("control-plane/aegisops_control_plane/service.py")
+        tree = ast.parse(service_source)
+        service_class = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        constructor = next(
+            node
+            for node in service_class.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "__init__"
+        )
+        self_assignments = [
+            node
+            for node in ast.walk(constructor)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+            and isinstance(getattr(node, "ctx", None), ast.Store)
+        ]
+        constructor_call_names = {
+            node.func.id
+            for node in ast.walk(constructor)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+        }
+
+        self.assertLessEqual(
+            len(self_assignments),
+            2,
+            "facade constructor should not directly assign composition collaborators",
+        )
+        self.assertNotIn(
+            "ControlPlaneServiceCompositionDependencies",
+            constructor_call_names,
+            "dependency container wiring should live outside the facade constructor",
+        )
+        self.assertIn(
+            "install_control_plane_service_composition",
+            constructor_call_names,
+        )
+
     def test_phase50_9_3_persistence_restore_and_status_helpers_leave_service_facade(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -593,6 +593,27 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             and node.value.id == "self"
             and isinstance(getattr(node, "ctx", None), ast.Store)
         ]
+        direct_setattr_calls = [
+            node
+            for node in ast.walk(constructor)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "setattr"
+            and (
+                (
+                    len(node.args) >= 1
+                    and isinstance(node.args[0], ast.Name)
+                    and node.args[0].id == "self"
+                )
+                or any(
+                    keyword.arg in {"obj", "target"}
+                    and isinstance(keyword.value, ast.Name)
+                    and keyword.value.id == "self"
+                    for keyword in node.keywords
+                )
+            )
+        ]
+        facade_self_wiring = self_assignments + direct_setattr_calls
         constructor_call_names = {
             node.func.id
             for node in ast.walk(constructor)
@@ -601,9 +622,10 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
         }
 
         self.assertLessEqual(
-            len(self_assignments),
+            len(facade_self_wiring),
             2,
-            "facade constructor should not directly assign composition collaborators",
+            "facade constructor should not directly assign or setattr "
+            "composition collaborators",
         )
         self.assertNotIn(
             "ControlPlaneServiceCompositionDependencies",

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,13 +1,13 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.11.7 residual exception:
+# Phase 50.12.2 residual exception:
 # ADR-0008 accepted ordered residual DTO/helper extraction after the
 # Phase 50.10.6 facade floor. ADR-0003 remains the public facade-preservation
 # exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 50.11.7 closeout verification, so this baseline records the final
+# the Phase 50.12.2 constructor/composition extraction, so this baseline records the
 # measured ceiling and fails on silent re-growth. A future ADR or maintainability
 # backlog must lower or replace these limits before unrelated feature expansion
 # lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007
+control-plane/aegisops_control_plane/service.py max_lines=1773 max_effective_lines=1589 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.2 issue=#1017

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -12,20 +12,20 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work. The final Phase 50.11.7 closeout for #1007 records the accepted residual ceiling as:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work accepted in #1007. Phase 50.12.2 for #1017 further extracted constructor composition assignment pressure and records the accepted residual ceiling as:
 
-- `max_lines=1812`
-- `max_effective_lines=1632`
+- `max_lines=1773`
+- `max_effective_lines=1589`
 - `max_facade_methods=125`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.11.7`
-- `issue=#1007`
+- `phase=50.12.2`
+- `issue=#1017`
 
 The measured closeout state is:
 
-- `physical_lines=1812`
-- `effective_lines=1632`
+- `physical_lines=1773`
+- `effective_lines=1589`
 - `AegisOpsControlPlaneService methods=125`
 
 The baseline is lower than the Phase 50.10.6 ceiling of `max_lines=3003`, `max_effective_lines=2704`, and `max_facade_methods=167`. It is also below the ADR-0008 Phase 50.11 target ceiling of `max_lines <= 2700`, `max_effective_lines <= 2450`, and `max_facade_methods <= 150`.

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -165,7 +165,7 @@ fi
 phase50_11_regrowth_repo="${workdir}/phase50-11-regrowth"
 create_repo \
   "${phase50_11_regrowth_repo}" \
-  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007" \
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=1773 max_effective_lines=1589 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.2 issue=#1017" \
   "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
     def describe_runtime(self):
         auth_principal = 'trusted-runtime-boundary'
@@ -176,16 +176,16 @@ create_repo \
         restore_backup_export = action_reconciliation
         evidence_admission = restore_backup_export
         return evidence_admission"
-append_repeated_lines "${phase50_11_regrowth_repo}" "control-plane/aegisops_control_plane/service.py" "phase50_11_growth_line" 1803
+append_repeated_lines "${phase50_11_regrowth_repo}" "control-plane/aegisops_control_plane/service.py" "phase50_11_growth_line" 1764
 git -C "${phase50_11_regrowth_repo}" add .
 git -C "${phase50_11_regrowth_repo}" commit -q -m "phase 50.11 regrowth past accepted closeout"
 assert_fails_with "${phase50_11_regrowth_repo}" "Maintainability hotspot baseline limits were exceeded"
-if ! grep -F "lines=1813 exceeds max_lines=1812" "${fail_stderr}" >/dev/null; then
+if ! grep -F "lines=1774 exceeds max_lines=1773" "${fail_stderr}" >/dev/null; then
   echo "Expected failure output to report the Phase 50.11 line-count limit." >&2
   cat "${fail_stderr}" >&2
   exit 1
 fi
-if ! grep -F "effective_lines=1813 exceeds max_effective_lines=1632" "${fail_stderr}" >/dev/null; then
+if ! grep -F "effective_lines=1774 exceeds max_effective_lines=1589" "${fail_stderr}" >/dev/null; then
   echo "Expected failure output to report the Phase 50.11 effective-line limit." >&2
   cat "${fail_stderr}" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Move `AegisOpsControlPlaneService.__init__` collaborator assignment fan-out behind `install_control_plane_service_composition`.
- Add a Phase 50.12.2 constructor AST regression that fails on direct composition assignment pressure.
- Lower the accepted maintainability hotspot baseline to `service.py` lines=1773 and effective_lines=1589 after extraction.

## Verification
- `python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py`
- `python3 -m unittest control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_runtime_snapshot_reports_postgresql_authoritative_persistence_mode control-plane.tests.test_service_persistence_restore_readiness.RestoreReadinessPersistenceTests.test_service_accepts_injected_store_for_runtime_snapshot`
- `python3 -m unittest control-plane/tests/test_phase49_service_decomposition_closeout.py control-plane/tests/test_phase50_maintainability_closeout.py`
- `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py`
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` (898 tests)
- `CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> node dist/index.js issue-lint 1017`

## Notes
- Draft PR for issue #1017.
- Public service construction API and runtime snapshot behavior are preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized internal composition setup to simplify service initialization and improve maintainability.

* **Tests**
  * Updated baseline expectations and added a regression-validation test to enforce the new initialization pattern.

* **Documentation**
  * Revised maintainability hotspot baselines and phase closeout docs to reflect updated thresholds and phase/issue identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->