### PR TITLE
Phase 50.12.4: reduce casework write delegate pressure

### DIFF
--- a/control-plane/aegisops_control_plane/case_workflow.py
+++ b/control-plane/aegisops_control_plane/case_workflow.py
@@ -132,6 +132,99 @@ class CaseDetectionLinkageHelper:
             )
 
 
+class CaseWorkflowFacade:
+    def record_case_observation(
+        self,
+        *,
+        case_id: str,
+        author_identity: str,
+        observed_at: datetime,
+        scope_statement: str,
+        supporting_evidence_ids: tuple[str, ...] = (),
+        observation_id: str | None = None,
+        lifecycle_state: str = "confirmed",
+    ) -> ObservationRecord:
+        return self._case_workflow_service.record_case_observation(
+            case_id=case_id,
+            author_identity=author_identity,
+            observed_at=observed_at,
+            scope_statement=scope_statement,
+            supporting_evidence_ids=supporting_evidence_ids,
+            observation_id=observation_id,
+            lifecycle_state=lifecycle_state,
+        )
+
+    def record_case_lead(
+        self,
+        *,
+        case_id: str,
+        triage_owner: str,
+        triage_rationale: str,
+        observation_id: str | None = None,
+        lead_id: str | None = None,
+        lifecycle_state: str = "triaged",
+    ) -> LeadRecord:
+        return self._case_workflow_service.record_case_lead(
+            case_id=case_id,
+            triage_owner=triage_owner,
+            triage_rationale=triage_rationale,
+            observation_id=observation_id,
+            lead_id=lead_id,
+            lifecycle_state=lifecycle_state,
+        )
+
+    def record_case_recommendation(
+        self,
+        *,
+        case_id: str,
+        review_owner: str,
+        intended_outcome: str,
+        lead_id: str | None = None,
+        recommendation_id: str | None = None,
+        lifecycle_state: str = "under_review",
+    ) -> RecommendationRecord:
+        return self._case_workflow_service.record_case_recommendation(
+            case_id=case_id,
+            review_owner=review_owner,
+            intended_outcome=intended_outcome,
+            lead_id=lead_id,
+            recommendation_id=recommendation_id,
+            lifecycle_state=lifecycle_state,
+        )
+
+    def record_case_handoff(
+        self,
+        *,
+        case_id: str,
+        handoff_at: datetime,
+        handoff_owner: str,
+        handoff_note: str,
+        follow_up_evidence_ids: tuple[str, ...] = (),
+    ) -> CaseRecord:
+        return self._case_workflow_service.record_case_handoff(
+            case_id=case_id,
+            handoff_at=handoff_at,
+            handoff_owner=handoff_owner,
+            handoff_note=handoff_note,
+            follow_up_evidence_ids=follow_up_evidence_ids,
+        )
+
+    def record_case_disposition(
+        self,
+        *,
+        case_id: str,
+        disposition: str,
+        rationale: str,
+        recorded_at: datetime,
+    ) -> CaseRecord:
+        return self._case_workflow_service.record_case_disposition(
+            case_id=case_id,
+            disposition=disposition,
+            rationale=rationale,
+            recorded_at=recorded_at,
+        )
+
+
 class CaseWorkflowService:
     def __init__(
         self,

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -53,6 +53,7 @@ from .reviewed_slice_policy import (
     REVIEWED_LIVE_SLICE_LABEL,
     ReviewedSlicePolicy,
 )
+from .case_workflow import CaseWorkflowFacade
 from .detection_lifecycle_helpers import LATEST_LIFECYCLE_TRANSITION_UNSET
 from .external_evidence_facade import ExternalEvidenceFacade
 from .service_composition import (
@@ -466,7 +467,7 @@ def _normalize_admission_provenance(
     return normalized
 
 
-class AegisOpsControlPlaneService(ExternalEvidenceFacade):
+class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
     """Minimal local runtime skeleton for the first control-plane service."""
 
     def __init__(
@@ -919,97 +920,6 @@ class AegisOpsControlPlaneService(ExternalEvidenceFacade):
     ) -> ActionReviewDetailSnapshot:
         return self._operator_inspection_read_surface.inspect_action_review_detail(
             action_request_id
-        )
-
-    def record_case_observation(
-        self,
-        *,
-        case_id: str,
-        author_identity: str,
-        observed_at: datetime,
-        scope_statement: str,
-        supporting_evidence_ids: tuple[str, ...] = (),
-        observation_id: str | None = None,
-        lifecycle_state: str = "confirmed",
-    ) -> ObservationRecord:
-        return self._case_workflow_service.record_case_observation(
-            case_id=case_id,
-            author_identity=author_identity,
-            observed_at=observed_at,
-            scope_statement=scope_statement,
-            supporting_evidence_ids=supporting_evidence_ids,
-            observation_id=observation_id,
-            lifecycle_state=lifecycle_state,
-        )
-
-    def record_case_lead(
-        self,
-        *,
-        case_id: str,
-        triage_owner: str,
-        triage_rationale: str,
-        observation_id: str | None = None,
-        lead_id: str | None = None,
-        lifecycle_state: str = "triaged",
-    ) -> LeadRecord:
-        return self._case_workflow_service.record_case_lead(
-            case_id=case_id,
-            triage_owner=triage_owner,
-            triage_rationale=triage_rationale,
-            observation_id=observation_id,
-            lead_id=lead_id,
-            lifecycle_state=lifecycle_state,
-        )
-
-    def record_case_recommendation(
-        self,
-        *,
-        case_id: str,
-        review_owner: str,
-        intended_outcome: str,
-        lead_id: str | None = None,
-        recommendation_id: str | None = None,
-        lifecycle_state: str = "under_review",
-    ) -> RecommendationRecord:
-        return self._case_workflow_service.record_case_recommendation(
-            case_id=case_id,
-            review_owner=review_owner,
-            intended_outcome=intended_outcome,
-            lead_id=lead_id,
-            recommendation_id=recommendation_id,
-            lifecycle_state=lifecycle_state,
-        )
-
-    def record_case_handoff(
-        self,
-        *,
-        case_id: str,
-        handoff_at: datetime,
-        handoff_owner: str,
-        handoff_note: str,
-        follow_up_evidence_ids: tuple[str, ...] = (),
-    ) -> CaseRecord:
-        return self._case_workflow_service.record_case_handoff(
-            case_id=case_id,
-            handoff_at=handoff_at,
-            handoff_owner=handoff_owner,
-            handoff_note=handoff_note,
-            follow_up_evidence_ids=follow_up_evidence_ids,
-        )
-
-    def record_case_disposition(
-        self,
-        *,
-        case_id: str,
-        disposition: str,
-        rationale: str,
-        recorded_at: datetime,
-    ) -> CaseRecord:
-        return self._case_workflow_service.record_case_disposition(
-            case_id=case_id,
-            disposition=disposition,
-            rationale=rationale,
-            recorded_at=recorded_at,
         )
 
     def record_action_review_manual_fallback(

--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,8 +66,8 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.12.3")
-        self.assertEqual(metadata["issue"], "#1018")
+        self.assertEqual(metadata["phase"], "50.12.4")
+        self.assertEqual(metadata["issue"], "#1019")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -58,15 +58,15 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         facade_methods = self._facade_method_count(metadata["facade_class"])
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.12.3")
-        self.assertEqual(metadata["issue"], "#1018")
+        self.assertEqual(metadata["phase"], "50.12.4")
+        self.assertEqual(metadata["issue"], "#1019")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), physical_lines)
         self.assertEqual(int(metadata["max_effective_lines"]), effective_lines)
         self.assertEqual(int(metadata["max_facade_methods"]), facade_methods)
-        self.assertEqual(physical_lines, 1709)
-        self.assertEqual(effective_lines, 1530)
-        self.assertEqual(facade_methods, 122)
+        self.assertEqual(physical_lines, 1619)
+        self.assertEqual(effective_lines, 1445)
+        self.assertEqual(facade_methods, 117)
         self.assertLess(int(metadata["max_lines"]), 3003)
         self.assertLess(int(metadata["max_effective_lines"]), 2704)
         self.assertLess(int(metadata["max_facade_methods"]), 167)
@@ -78,16 +78,18 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "Phase 50.11.7",
             "Phase 50.12.2",
             "Phase 50.12.3",
+            "Phase 50.12.4",
             "control-plane/aegisops_control_plane/service.py",
+            "control-plane/aegisops_control_plane/case_workflow.py",
             "control-plane/aegisops_control_plane/action_review_write_surface.py",
             "control-plane/aegisops_control_plane/action_review_projection.py",
             "control-plane/aegisops_control_plane/external_evidence_boundary.py",
             "AegisOpsControlPlaneService",
-            "max_lines=1709",
-            "max_effective_lines=1530",
-            "max_facade_methods=122",
-            "physical_lines=1709",
-            "effective_lines=1530",
+            "max_lines=1619",
+            "max_effective_lines=1445",
+            "max_facade_methods=117",
+            "physical_lines=1619",
+            "effective_lines=1445",
             "ADR-0007",
             "ADR-0008",
             "ADR-0004",
@@ -95,9 +97,11 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "#1007",
             "#1017",
             "#1018",
+            "#1019",
             "remaining accepted hotspot",
             "facade dispatch, compatibility entrypoints, runtime-boundary guards, and lifecycle/write-path delegates",
             "reviewed action approval policy helpers",
+            "casework write compatibility delegates",
             "projection split does not require a baseline entry",
             "external-evidence split does not require a baseline entry",
             "silent re-growth",

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from dataclasses import replace
 from datetime import timedelta
 import pathlib
@@ -11,6 +12,7 @@ if str(TESTS_ROOT) not in sys.path:
 
 import _service_persistence_support as support
 from _service_persistence_support import ServicePersistenceTestBase
+import aegisops_control_plane.service as service_module
 from aegisops_control_plane.case_workflow import CaseWorkflowService
 from aegisops_control_plane.detection_lifecycle import DetectionIntakeService
 from aegisops_control_plane.evidence_linkage import EvidenceLinkageService
@@ -264,6 +266,37 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
             rationale="Delegated disposition.",
             recorded_at=observed_at,
         )
+
+    def test_case_workflow_compatibility_delegates_are_fenced_from_service_class(
+        self,
+    ) -> None:
+        service_source = pathlib.Path(service_module.__file__).read_text(
+            encoding="utf-8",
+        )
+        service_tree = ast.parse(service_source)
+        service_class = next(
+            node
+            for node in service_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        direct_service_methods = {
+            node.name for node in service_class.body if isinstance(node, ast.FunctionDef)
+        }
+        case_workflow_write_methods = {
+            "record_case_observation",
+            "record_case_lead",
+            "record_case_recommendation",
+            "record_case_handoff",
+            "record_case_disposition",
+        }
+
+        self.assertTrue(
+            case_workflow_write_methods.issubset(
+                set(dir(support.AegisOpsControlPlaneService))
+            )
+        )
+        self.assertFalse(case_workflow_write_methods & direct_service_methods)
 
     def test_service_delegates_detection_intake_and_triage_operations(self) -> None:
         store, _ = support.make_store()

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 from dataclasses import replace
 from datetime import timedelta
 import pathlib
@@ -270,19 +269,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
     def test_case_workflow_compatibility_delegates_are_fenced_from_service_class(
         self,
     ) -> None:
-        service_source = pathlib.Path(service_module.__file__).read_text(
-            encoding="utf-8",
-        )
-        service_tree = ast.parse(service_source)
-        service_class = next(
-            node
-            for node in service_tree.body
-            if isinstance(node, ast.ClassDef)
-            and node.name == "AegisOpsControlPlaneService"
-        )
-        direct_service_methods = {
-            node.name for node in service_class.body if isinstance(node, ast.FunctionDef)
-        }
+        direct_service_attrs = set(vars(service_module.AegisOpsControlPlaneService))
         case_workflow_write_methods = {
             "record_case_observation",
             "record_case_lead",
@@ -296,7 +283,7 @@ class IngestCaseLifecyclePersistenceTests(ServicePersistenceTestBase):
                 set(dir(support.AegisOpsControlPlaneService))
             )
         )
-        self.assertFalse(case_workflow_write_methods & direct_service_methods)
+        self.assertFalse(case_workflow_write_methods & direct_service_attrs)
 
     def test_service_delegates_detection_intake_and_triage_operations(self) -> None:
         store, _ = support.make_store()

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,13 +1,13 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.12.3 residual exception:
+# Phase 50.12.4 residual exception:
 # ADR-0008 accepted ordered residual DTO/helper extraction after the
 # Phase 50.10.6 facade floor. ADR-0003 remains the public facade-preservation
 # exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 50.12.3 action approval policy helper extraction, so this baseline records the
+# the Phase 50.12.4 casework write delegate fencing, so this baseline records the
 # measured ceiling and fails on silent re-growth. A future ADR or maintainability
 # backlog must lower or replace these limits before unrelated feature expansion
 # lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=1709 max_effective_lines=1530 max_facade_methods=122 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.3 issue=#1018
+control-plane/aegisops_control_plane/service.py max_lines=1619 max_effective_lines=1445 max_facade_methods=117 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.4 issue=#1019

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,6 +1,6 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.12.3 updates the accepted `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
+Phase 50.12.4 updates the accepted `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
@@ -12,21 +12,21 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work accepted in #1007. Phase 50.12.2 for #1017 further extracted constructor composition assignment pressure, and Phase 50.12.3 for #1018 moved reviewed action approval policy helper pressure into the action-review write surface. The accepted residual ceiling is:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work accepted in #1007. Phase 50.12.2 for #1017 further extracted constructor composition assignment pressure, Phase 50.12.3 for #1018 moved reviewed action approval policy helper pressure into the action-review write surface, and Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade. The accepted residual ceiling is:
 
-- `max_lines=1709`
-- `max_effective_lines=1530`
-- `max_facade_methods=122`
+- `max_lines=1619`
+- `max_effective_lines=1445`
+- `max_facade_methods=117`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.12.3`
-- `issue=#1018`
+- `phase=50.12.4`
+- `issue=#1019`
 
 The measured closeout state is:
 
-- `physical_lines=1709`
-- `effective_lines=1530`
-- `AegisOpsControlPlaneService methods=122`
+- `physical_lines=1619`
+- `effective_lines=1445`
+- `AegisOpsControlPlaneService methods=117`
 
 The baseline is lower than the Phase 50.10.6 ceiling of `max_lines=3003`, `max_effective_lines=2704`, and `max_facade_methods=167`. It is also below the ADR-0008 Phase 50.11 target ceiling of `max_lines <= 2700`, `max_effective_lines <= 2450`, and `max_facade_methods <= 150`.
 
@@ -45,6 +45,8 @@ The final Phase 50.11 extraction sequence moved the following directly linked he
 - detection/case-linkage helpers into `control-plane/aegisops_control_plane/case_workflow.py`, `control-plane/aegisops_control_plane/detection_lifecycle.py`, and `control-plane/aegisops_control_plane/detection_lifecycle_helpers.py`.
 
 Phase 50.12.3 then moved the reviewed action approval policy helpers out of `service.py` and into `control-plane/aegisops_control_plane/action_review_write_surface.py`, preserving the public facade entrypoints for action request creation and approval decision recording.
+
+Phase 50.12.4 then moved the casework write compatibility delegates out of `AegisOpsControlPlaneService` and into `control-plane/aegisops_control_plane/case_workflow.py`, preserving the public facade entrypoints for observation, lead, recommendation, handoff, and disposition writes.
 
 Those extractions preserve the public service facade. AegisOps control-plane records remain authoritative workflow truth. Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, projections, snapshots, DTOs, and helper-module output remain subordinate context.
 

--- a/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
@@ -212,6 +212,26 @@ valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
 
+phase50_12_4_closeout_repo="${workdir}/phase50-12-4-closeout"
+create_valid_repo "${phase50_12_4_closeout_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=1619 max_effective_lines=1445 max_facade_methods=117 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.4 issue=#1019" \
+  >"${phase50_12_4_closeout_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${phase50_12_4_closeout_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade.
+
+- `max_lines=1619`
+- `max_effective_lines=1445`
+- `max_facade_methods=117`
+- `phase=50.12.4`
+- `issue=#1019`
+
+Phase 50.12.4 then moved the casework write compatibility delegates out of `AegisOpsControlPlaneService` and into `control-plane/aegisops_control_plane/case_workflow.py`, preserving the public facade entrypoints for observation, lead, recommendation, handoff, and disposition writes.
+EOF
+assert_passes "${phase50_12_4_closeout_repo}"
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/adr/0009-phase-50-12-service-facade-pressure-contract.md"

--- a/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 doc_path="${repo_root}/docs/adr/0009-phase-50-12-service-facade-pressure-contract.md"
 baseline_path="${repo_root}/docs/maintainability-hotspot-baseline.txt"
+closeout_path="${repo_root}/docs/phase-50-maintainability-closeout.md"
 
 required_headings=(
   "# ADR-0009: Phase 50.12 Service Facade Pressure Contract"
@@ -119,23 +120,53 @@ for phrase in "${required_phrases[@]}"; do
 done
 
 starting_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007"
+phase50_12_4_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1619 max_effective_lines=1445 max_facade_methods=117 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.4 issue=#1019"
 service_entry="$(grep -Fx -- "${starting_service_baseline_entry}" "${baseline_path}" || true)"
+phase50_12_4_service_entry="$(grep -Fx -- "${phase50_12_4_service_baseline_entry}" "${baseline_path}" || true)"
 service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
+phase50_12_4_service_entry_count="$(printf '%s\n' "${phase50_12_4_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 service_path_entry_count="$(
   awk -v prefix="control-plane/aegisops_control_plane/service.py " \
     'index($0, prefix) == 1 { count += 1 } END { print count + 0 }' \
     "${baseline_path}"
 )"
+if [[ "${service_path_entry_count}" -ne 1 ]]; then
+  echo "Phase 50.12 contract requires exactly one service.py hotspot baseline entry." >&2
+  exit 1
+fi
+if [[ "${service_entry_count}" -eq 1 ]]; then
+  echo "Phase 50.12 service facade pressure contract fixes residual clusters, starting measurements, sub-1500 target ceilings, fallback rules, authority non-goals, migration order, and validation commands."
+  exit 0
+fi
+if [[ "${phase50_12_4_service_entry_count}" -eq 1 ]]; then
+  if [[ ! -f "${closeout_path}" ]]; then
+    echo "Phase 50.12.4 baseline requires docs/phase-50-maintainability-closeout.md evidence." >&2
+    exit 1
+  fi
+  phase50_12_4_closeout_phrases=(
+    "Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade."
+    "- \`max_lines=1619\`"
+    "- \`max_effective_lines=1445\`"
+    "- \`max_facade_methods=117\`"
+    "- \`phase=50.12.4\`"
+    "- \`issue=#1019\`"
+    "Phase 50.12.4 then moved the casework write compatibility delegates out of \`AegisOpsControlPlaneService\` and into \`control-plane/aegisops_control_plane/case_workflow.py\`, preserving the public facade entrypoints for observation, lead, recommendation, handoff, and disposition writes."
+  )
+  for phrase in "${phase50_12_4_closeout_phrases[@]}"; do
+    if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
+      echo "Phase 50.12.4 baseline requires closeout evidence: ${phrase}" >&2
+      exit 1
+    fi
+  done
+  echo "Phase 50.12 service facade pressure contract fixes residual clusters, starting measurements, sub-1500 target ceilings, fallback rules, authority non-goals, migration order, and validation commands."
+  exit 0
+fi
 if [[ "${service_entry_count}" -eq 0 ]]; then
   if [[ "${service_path_entry_count}" -ne 0 ]]; then
     echo "Phase 50.12 contract forbids refreshing the service.py hotspot baseline before implementation evidence exists." >&2
     exit 1
   fi
   echo "Phase 50.12 contract requires the accepted Phase 50.11.7 service.py hotspot baseline entry." >&2
-  exit 1
-fi
-if [[ "${service_path_entry_count}" -ne 1 || "${service_entry_count}" -ne 1 ]]; then
-  echo "Phase 50.12 contract requires exactly one service.py hotspot baseline entry." >&2
   exit 1
 fi
 if [[ "${service_entry}" != "${starting_service_baseline_entry}" ]]; then

--- a/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
@@ -144,13 +144,12 @@ if [[ "${phase50_12_4_service_entry_count}" -eq 1 ]]; then
     exit 1
   fi
   phase50_12_4_closeout_phrases=(
-    "Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade."
+    "Phase 50.12.4 then moved the casework write compatibility delegates out of \`AegisOpsControlPlaneService\` and into \`control-plane/aegisops_control_plane/case_workflow.py\`, preserving the public facade entrypoints for observation, lead, recommendation, handoff, and disposition writes."
     "- \`max_lines=1619\`"
     "- \`max_effective_lines=1445\`"
     "- \`max_facade_methods=117\`"
     "- \`phase=50.12.4\`"
     "- \`issue=#1019\`"
-    "Phase 50.12.4 then moved the casework write compatibility delegates out of \`AegisOpsControlPlaneService\` and into \`control-plane/aegisops_control_plane/case_workflow.py\`, preserving the public facade entrypoints for observation, lead, recommendation, handoff, and disposition writes."
   )
   for phrase in "${phase50_12_4_closeout_phrases[@]}"; do
     if ! grep -Fq -- "${phrase}" "${closeout_path}"; then


### PR DESCRIPTION
## Summary
- Fence casework write compatibility delegates behind CaseWorkflowFacade while preserving public service methods.
- Refresh Phase 50.12.4 maintainability baseline and closeout evidence to the lower service.py ceiling.
- Add focused regression coverage for keeping casework write delegates out of the direct service class.

## Verification
- python3 -m unittest control-plane/tests/test_service_persistence_ingest_case_lifecycle.py -k case_workflow
- python3 -m unittest control-plane/tests/test_phase49_service_decomposition_closeout.py control-plane/tests/test_phase50_maintainability_closeout.py
- python3 -m unittest discover -s control-plane/tests -p test_*.py
- bash scripts/verify-maintainability-hotspots.sh
- bash scripts/test-verify-maintainability-hotspots.sh
- bash scripts/verify-phase-50-12-service-facade-pressure-contract.sh
- bash scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
- node dist/index.js issue-lint 1019 --config supervisor.config.aegisops.json

## Notes
- Operator UI payloads were not touched, so npm test was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal service architecture for improved code maintainability and modularity.
  * Case workflow recording functionality (observations, leads, recommendations, handoffs, dispositions) remains fully available and unchanged.
  * Service maintains full backward compatibility with existing APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->