### PR TITLE
Phase 50.12.5: Extract assistant residual helpers

### DIFF
--- a/control-plane/aegisops_control_plane/action_review_chain.py
+++ b/control-plane/aegisops_control_plane/action_review_chain.py
@@ -120,13 +120,13 @@ def _latest_action_review_reconciliation(
     ) -> bool:
         if action_execution is None:
             return False
-        subject_action_execution_ids = service._assistant_ids_from_mapping(
+        subject_action_execution_ids = service._ai_trace_lifecycle_service.ids_from_mapping(
             reconciliation.subject_linkage,
             "action_execution_ids",
         )
         if action_execution.action_execution_id in subject_action_execution_ids:
             return True
-        subject_delegation_ids = service._assistant_ids_from_mapping(
+        subject_delegation_ids = service._ai_trace_lifecycle_service.ids_from_mapping(
             reconciliation.subject_linkage,
             "delegation_ids",
         )
@@ -136,13 +136,13 @@ def _latest_action_review_reconciliation(
         if _matches_current_execution_lineage(reconciliation):
             return True
         if approval_decision is not None:
-            subject_approval_decision_ids = service._assistant_ids_from_mapping(
+            subject_approval_decision_ids = service._ai_trace_lifecycle_service.ids_from_mapping(
                 reconciliation.subject_linkage,
                 "approval_decision_ids",
             )
             if approval_decision.approval_decision_id in subject_approval_decision_ids:
                 return True
-        subject_action_request_ids = service._assistant_ids_from_mapping(
+        subject_action_request_ids = service._ai_trace_lifecycle_service.ids_from_mapping(
             reconciliation.subject_linkage,
             "action_request_ids",
         )

--- a/control-plane/aegisops_control_plane/action_review_index.py
+++ b/control-plane/aegisops_control_plane/action_review_index.py
@@ -132,28 +132,28 @@ def build_action_review_record_index(
         list[ReconciliationRecord],
     ] = defaultdict(list)
     for reconciliation in reconciliations:
-        for action_request_id in service._assistant_ids_from_mapping(
+        for action_request_id in service._ai_trace_lifecycle_service.ids_from_mapping(
             reconciliation.subject_linkage,
             "action_request_ids",
         ):
             reconciliations_by_action_request_id[action_request_id].append(
                 reconciliation
             )
-        for approval_decision_id in service._assistant_ids_from_mapping(
+        for approval_decision_id in service._ai_trace_lifecycle_service.ids_from_mapping(
             reconciliation.subject_linkage,
             "approval_decision_ids",
         ):
             reconciliations_by_approval_decision_id[approval_decision_id].append(
                 reconciliation
             )
-        for action_execution_id in service._assistant_ids_from_mapping(
+        for action_execution_id in service._ai_trace_lifecycle_service.ids_from_mapping(
             reconciliation.subject_linkage,
             "action_execution_ids",
         ):
             reconciliations_by_action_execution_id[action_execution_id].append(
                 reconciliation
             )
-        for delegation_id in service._assistant_ids_from_mapping(
+        for delegation_id in service._ai_trace_lifecycle_service.ids_from_mapping(
             reconciliation.subject_linkage,
             "delegation_ids",
         ):

--- a/control-plane/aegisops_control_plane/action_review_timeline.py
+++ b/control-plane/aegisops_control_plane/action_review_timeline.py
@@ -51,7 +51,7 @@ def action_review_timeline(
     execution_actor_identities: tuple[str, ...] = ()
     if action_execution is not None:
         delegation_details["delegation_id"] = action_execution.delegation_id
-        execution_actor_identities = service._assistant_merge_ids(
+        execution_actor_identities = service._ai_trace_lifecycle_service.merge_ids(
             action_execution.provenance.get("initiated_by"),
             action_execution.provenance.get("delegation_issuer"),
         )
@@ -137,7 +137,7 @@ def action_review_timeline(
             actor_identities=(
                 ()
                 if action_execution is None
-                else service._assistant_ids_from_mapping(
+                else service._ai_trace_lifecycle_service.ids_from_mapping(
                     action_execution.provenance,
                     "delegation_issuer",
                 )

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -72,22 +72,7 @@ class OperatorInspectionServiceDependencies(Protocol):
     def _alert_escalation_boundary(self, alert: AlertRecord) -> str:
         ...
 
-    def _assistant_evidence_records_for_context(
-        self,
-        *,
-        alert_ids: tuple[str, ...],
-        case_ids: tuple[str, ...],
-        evidence_ids: tuple[str, ...],
-        exclude_evidence_id: str | None,
-    ) -> tuple[EvidenceRecord, ...]:
-        ...
-
-    def _assistant_ids_from_mapping(
-        self,
-        mapping: Mapping[str, object],
-        key: str,
-    ) -> tuple[str, ...]:
-        ...
+    _ai_trace_lifecycle_service: Any
 
     def list_lifecycle_transitions(
         self,
@@ -692,14 +677,16 @@ class OperatorInspectionReadSurface:
             if alert.analytic_signal_id is not None
             else None
         )
-        evidence_records = self._service._assistant_evidence_records_for_context(
-            alert_ids=(alert.alert_id,),
-            case_ids=(),
-            evidence_ids=self._service._assistant_ids_from_mapping(
-                reconciliation.subject_linkage,
-                "evidence_ids",
-            ),
-            exclude_evidence_id=None,
+        evidence_records = (
+            self._service._ai_trace_lifecycle_service.evidence_records_for_context(
+                alert_ids=(alert.alert_id,),
+                case_ids=(),
+                evidence_ids=self._service._ai_trace_lifecycle_service.ids_from_mapping(
+                    reconciliation.subject_linkage,
+                    "evidence_ids",
+                ),
+                exclude_evidence_id=None,
+            )
         )
         source_systems = self._service._merge_linked_ids(
             reconciliation.subject_linkage.get("source_systems"),

--- a/control-plane/aegisops_control_plane/readiness_operability.py
+++ b/control-plane/aegisops_control_plane/readiness_operability.py
@@ -38,11 +38,13 @@ class ReadinessOperabilityHelper:
         config: Any,
         store: Any,
         action_review_inspection_boundary: Any,
+        ai_trace_lifecycle: Any,
     ) -> None:
         self._service = service
         self._config = config
         self._store = store
         self._action_review_inspection_boundary = action_review_inspection_boundary
+        self._ai_trace_lifecycle = ai_trace_lifecycle
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._service, name)
@@ -151,12 +153,12 @@ class ReadinessOperabilityHelper:
             if reconciliation is None:
                 continue
             candidate_action_request_ids.update(
-                self._assistant_ids_from_mapping(
+                self._ai_trace_lifecycle.ids_from_mapping(
                     reconciliation.subject_linkage,
                     "action_request_ids",
                 )
             )
-            for approval_decision_id in self._assistant_ids_from_mapping(
+            for approval_decision_id in self._ai_trace_lifecycle.ids_from_mapping(
                 reconciliation.subject_linkage,
                 "approval_decision_ids",
             ):
@@ -167,13 +169,13 @@ class ReadinessOperabilityHelper:
                 if approval_decision is not None:
                     candidate_action_request_ids.add(approval_decision.action_request_id)
             execution_ids.update(
-                self._assistant_ids_from_mapping(
+                self._ai_trace_lifecycle.ids_from_mapping(
                     reconciliation.subject_linkage,
                     "action_execution_ids",
                 )
             )
             unresolved_delegation_ids.update(
-                self._assistant_ids_from_mapping(
+                self._ai_trace_lifecycle.ids_from_mapping(
                     reconciliation.subject_linkage,
                     "delegation_ids",
                 )
@@ -295,7 +297,7 @@ class ReadinessOperabilityHelper:
             for reconciliation in self._store.list(ReconciliationRecord):
                 matched_action_request_ids = {
                     action_request_id
-                    for action_request_id in self._assistant_ids_from_mapping(
+                    for action_request_id in self._ai_trace_lifecycle.ids_from_mapping(
                         reconciliation.subject_linkage,
                         "action_request_ids",
                     )
@@ -303,7 +305,7 @@ class ReadinessOperabilityHelper:
                 }
                 matched_action_request_ids.update(
                     approval_action_request_ids_by_id[approval_decision_id]
-                    for approval_decision_id in self._assistant_ids_from_mapping(
+                    for approval_decision_id in self._ai_trace_lifecycle.ids_from_mapping(
                         reconciliation.subject_linkage,
                         "approval_decision_ids",
                     )
@@ -311,7 +313,7 @@ class ReadinessOperabilityHelper:
                 )
                 matched_action_request_ids.update(
                     current_execution_request_ids_by_execution_id[action_execution_id]
-                    for action_execution_id in self._assistant_ids_from_mapping(
+                    for action_execution_id in self._ai_trace_lifecycle.ids_from_mapping(
                         reconciliation.subject_linkage,
                         "action_execution_ids",
                     )
@@ -319,7 +321,7 @@ class ReadinessOperabilityHelper:
                 )
                 matched_action_request_ids.update(
                     current_execution_request_ids_by_delegation_id[delegation_id]
-                    for delegation_id in self._assistant_ids_from_mapping(
+                    for delegation_id in self._ai_trace_lifecycle.ids_from_mapping(
                         reconciliation.subject_linkage,
                         "delegation_ids",
                     )
@@ -920,28 +922,28 @@ class ReadinessOperabilityHelper:
             list[ReconciliationRecord],
         ] = defaultdict(list)
         for reconciliation in readiness_records.reconciliations:
-            for action_request_id in self._assistant_ids_from_mapping(
+            for action_request_id in self._ai_trace_lifecycle.ids_from_mapping(
                 reconciliation.subject_linkage,
                 "action_request_ids",
             ):
                 reconciliations_by_action_request_id[action_request_id].append(
                     reconciliation
                 )
-            for approval_decision_id in self._assistant_ids_from_mapping(
+            for approval_decision_id in self._ai_trace_lifecycle.ids_from_mapping(
                 reconciliation.subject_linkage,
                 "approval_decision_ids",
             ):
                 reconciliations_by_approval_decision_id[approval_decision_id].append(
                     reconciliation
                 )
-            for action_execution_id in self._assistant_ids_from_mapping(
+            for action_execution_id in self._ai_trace_lifecycle.ids_from_mapping(
                 reconciliation.subject_linkage,
                 "action_execution_ids",
             ):
                 reconciliations_by_action_execution_id[action_execution_id].append(
                     reconciliation
                 )
-            for delegation_id in self._assistant_ids_from_mapping(
+            for delegation_id in self._ai_trace_lifecycle.ids_from_mapping(
                 reconciliation.subject_linkage,
                 "delegation_ids",
             ):

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -995,9 +995,6 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
             record_id=record_id,
         )
 
-    def _assistant_primary_linked_id(self, linked_ids: tuple[str, ...]) -> str | None:
-        return self._ai_trace_lifecycle_service.primary_linked_id(linked_ids)
-
     def create_reviewed_action_request_from_advisory(
         self,
         *,
@@ -1102,124 +1099,6 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
     def _reconciliation_is_wazuh_origin(self, record: ReconciliationRecord) -> bool:
         return self._detection_intake_service.reconciliation_resolver.reconciliation_is_wazuh_origin(
             record
-        )
-
-    def _assistant_ids_from_value(self, value: object) -> tuple[str, ...]:
-        return self._ai_trace_lifecycle_service.ids_from_value(value)
-
-    def _assistant_ids_from_mapping(
-        self,
-        mapping: Mapping[str, object],
-        key: str,
-    ) -> tuple[str, ...]:
-        return self._ai_trace_lifecycle_service.ids_from_mapping(mapping, key)
-
-    def _assistant_merge_ids(
-        self,
-        existing_values: object,
-        incoming_values: object,
-    ) -> tuple[str, ...]:
-        return self._ai_trace_lifecycle_service.merge_ids(
-            existing_values,
-            incoming_values,
-        )
-
-    def _assistant_action_lineage_ids(
-        self,
-        record: ControlPlaneRecord,
-    ) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
-        return self._ai_trace_lifecycle_service.action_lineage_ids(record)
-
-    def _assistant_merge_action_request_linkage(
-        self,
-        *,
-        linked_alert_ids: tuple[str, ...],
-        linked_case_ids: tuple[str, ...],
-        linked_finding_ids: tuple[str, ...],
-        action_request: ActionRequestRecord,
-    ) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
-        return self._ai_trace_lifecycle_service.merge_action_request_linkage(
-            linked_alert_ids=linked_alert_ids,
-            linked_case_ids=linked_case_ids,
-            linked_finding_ids=linked_finding_ids,
-            action_request=action_request,
-        )
-
-    def _assistant_action_execution_for_delegation_id(
-        self,
-        delegation_id: str,
-    ) -> ActionExecutionRecord | None:
-        return self._ai_trace_lifecycle_service.action_execution_for_delegation_id(
-            delegation_id
-        )
-
-    def _assistant_ai_trace_records_for_context(
-        self,
-        record: ControlPlaneRecord,
-    ) -> tuple[AITraceRecord, ...]:
-        return self._ai_trace_lifecycle_service.ai_trace_records_for_context(record)
-
-    def _assistant_ai_trace_evidence_ids(
-        self,
-        ai_trace_record: AITraceRecord,
-    ) -> tuple[str, ...]:
-        return self._ai_trace_lifecycle_service.ai_trace_evidence_ids(ai_trace_record)
-
-    def _assistant_linked_evidence_ids(self, record: ControlPlaneRecord) -> tuple[str, ...]:
-        return self._ai_trace_lifecycle_service.linked_evidence_ids(record)
-
-    def _assistant_evidence_siblings(self, record: EvidenceRecord) -> tuple[str, ...]:
-        return self._ai_trace_lifecycle_service.evidence_siblings(record)
-
-    def _assistant_evidence_records_for_context(
-        self,
-        *,
-        alert_ids: tuple[str, ...],
-        case_ids: tuple[str, ...],
-        evidence_ids: tuple[str, ...],
-        exclude_evidence_id: str | None,
-    ) -> tuple[EvidenceRecord, ...]:
-        return self._ai_trace_lifecycle_service.evidence_records_for_context(
-            alert_ids=alert_ids,
-            case_ids=case_ids,
-            evidence_ids=evidence_ids,
-            exclude_evidence_id=exclude_evidence_id,
-        )
-
-    def _assistant_recommendation_records_for_context(
-        self,
-        *,
-        record: ControlPlaneRecord,
-        alert_ids: tuple[str, ...],
-        case_ids: tuple[str, ...],
-        ai_trace_records: tuple[AITraceRecord, ...],
-        exclude_recommendation_id: str | None,
-    ) -> tuple[RecommendationRecord, ...]:
-        return self._ai_trace_lifecycle_service.recommendation_records_for_context(
-            record=record,
-            alert_ids=alert_ids,
-            case_ids=case_ids,
-            ai_trace_records=ai_trace_records,
-            exclude_recommendation_id=exclude_recommendation_id,
-        )
-
-    def _assistant_reconciliation_records_for_context(
-        self,
-        *,
-        record: ControlPlaneRecord,
-        alert_ids: tuple[str, ...],
-        case_ids: tuple[str, ...],
-        finding_ids: tuple[str, ...],
-        evidence_ids: tuple[str, ...],
-        exclude_reconciliation_id: str | None,
-    ) -> tuple[ReconciliationRecord, ...]:
-        return self._ai_trace_lifecycle_service.reconciliation_records_for_context(
-            record=record,
-            alert_ids=alert_ids,
-            case_ids=case_ids,
-            finding_ids=finding_ids,
-            evidence_ids=evidence_ids,
-            exclude_reconciliation_id=exclude_reconciliation_id,
         )
 
     @staticmethod

--- a/control-plane/aegisops_control_plane/service_composition.py
+++ b/control-plane/aegisops_control_plane/service_composition.py
@@ -265,6 +265,7 @@ def build_control_plane_service_composition(
         config=config,
         store=resolved_store,
         action_review_inspection_boundary=action_review_inspection_boundary,
+        ai_trace_lifecycle=ai_trace_lifecycle_service,
     )
     lifecycle_transition_helper = (
         detection_intake_service.lifecycle_transition_helper
@@ -312,7 +313,7 @@ def build_control_plane_service_composition(
         record_types_by_family=dependencies.record_types_by_family,
         find_duplicate_strings=dependencies.find_duplicate_strings,
         synthesize_lifecycle_transition_record=synthesize_lifecycle_transition_record,
-        assistant_ids_from_mapping=service._assistant_ids_from_mapping,
+        assistant_ids_from_mapping=ai_trace_lifecycle_service.ids_from_mapping,
         inspect_case_detail=lambda case_id: service.inspect_case_detail(case_id),
         inspect_assistant_context=(
             lambda record_family, record_id: service.inspect_assistant_context(

--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,8 +66,8 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.12.4")
-        self.assertEqual(metadata["issue"], "#1019")
+        self.assertEqual(metadata["phase"], "50.12.5")
+        self.assertEqual(metadata["issue"], "#1020")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(
@@ -78,7 +78,7 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
             self._facade_method_count(metadata["facade_class"]),
             int(metadata["max_facade_methods"]),
         )
-        self.assertGreater(int(metadata["max_lines"]), 1500)
+        self.assertLessEqual(int(metadata["max_lines"]), 1500)
         self.assertGreater(int(metadata["max_facade_methods"]), 50)
 
         adr = self._read("docs/adr/0003-phase-49-service-decomposition-boundaries.md")

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -58,15 +58,15 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         facade_methods = self._facade_method_count(metadata["facade_class"])
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.12.4")
-        self.assertEqual(metadata["issue"], "#1019")
+        self.assertEqual(metadata["phase"], "50.12.5")
+        self.assertEqual(metadata["issue"], "#1020")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), physical_lines)
         self.assertEqual(int(metadata["max_effective_lines"]), effective_lines)
         self.assertEqual(int(metadata["max_facade_methods"]), facade_methods)
-        self.assertEqual(physical_lines, 1619)
-        self.assertEqual(effective_lines, 1445)
-        self.assertEqual(facade_methods, 117)
+        self.assertEqual(physical_lines, 1498)
+        self.assertEqual(effective_lines, 1338)
+        self.assertEqual(facade_methods, 103)
         self.assertLess(int(metadata["max_lines"]), 3003)
         self.assertLess(int(metadata["max_effective_lines"]), 2704)
         self.assertLess(int(metadata["max_facade_methods"]), 167)
@@ -79,17 +79,19 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "Phase 50.12.2",
             "Phase 50.12.3",
             "Phase 50.12.4",
+            "Phase 50.12.5",
             "control-plane/aegisops_control_plane/service.py",
             "control-plane/aegisops_control_plane/case_workflow.py",
             "control-plane/aegisops_control_plane/action_review_write_surface.py",
             "control-plane/aegisops_control_plane/action_review_projection.py",
             "control-plane/aegisops_control_plane/external_evidence_boundary.py",
+            "control-plane/aegisops_control_plane/ai_trace_lifecycle.py",
             "AegisOpsControlPlaneService",
-            "max_lines=1619",
-            "max_effective_lines=1445",
-            "max_facade_methods=117",
-            "physical_lines=1619",
-            "effective_lines=1445",
+            "max_lines=1498",
+            "max_effective_lines=1338",
+            "max_facade_methods=103",
+            "physical_lines=1498",
+            "effective_lines=1338",
             "ADR-0007",
             "ADR-0008",
             "ADR-0004",
@@ -98,6 +100,7 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "#1017",
             "#1018",
             "#1019",
+            "#1020",
             "remaining accepted hotspot",
             "facade dispatch, compatibility entrypoints, runtime-boundary guards, and lifecycle/write-path delegates",
             "reviewed action approval policy helpers",

--- a/control-plane/tests/test_service_persistence_assistant_advisory.py
+++ b/control-plane/tests/test_service_persistence_assistant_advisory.py
@@ -108,7 +108,7 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
         service_method_names = {
             node.name
             for node in service_class.body
-            if isinstance(node, ast.FunctionDef)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         }
 
         residual_assistant_helpers = {

--- a/control-plane/tests/test_service_persistence_assistant_advisory.py
+++ b/control-plane/tests/test_service_persistence_assistant_advisory.py
@@ -90,6 +90,46 @@ class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):
 
         self.assertTrue(extracted_helpers.isdisjoint(service_functions))
 
+    def test_assistant_lifecycle_helpers_are_not_service_facade_methods(
+        self,
+    ) -> None:
+        service_source = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "aegisops_control_plane"
+            / "service.py"
+        ).read_text()
+        service_tree = ast.parse(service_source)
+        service_class = next(
+            node
+            for node in service_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        service_method_names = {
+            node.name
+            for node in service_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+
+        residual_assistant_helpers = {
+            "_assistant_primary_linked_id",
+            "_assistant_ids_from_value",
+            "_assistant_ids_from_mapping",
+            "_assistant_merge_ids",
+            "_assistant_action_lineage_ids",
+            "_assistant_merge_action_request_linkage",
+            "_assistant_action_execution_for_delegation_id",
+            "_assistant_ai_trace_records_for_context",
+            "_assistant_ai_trace_evidence_ids",
+            "_assistant_linked_evidence_ids",
+            "_assistant_evidence_siblings",
+            "_assistant_evidence_records_for_context",
+            "_assistant_recommendation_records_for_context",
+            "_assistant_reconciliation_records_for_context",
+        }
+
+        self.assertTrue(residual_assistant_helpers.isdisjoint(service_method_names))
+
     def test_service_delegates_assistant_context_to_assembler_and_advisory_to_coordinator(
         self,
     ) -> None:

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,13 +1,13 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.12.4 residual exception:
+# Phase 50.12.5 residual exception:
 # ADR-0008 accepted ordered residual DTO/helper extraction after the
 # Phase 50.10.6 facade floor. ADR-0003 remains the public facade-preservation
 # exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 50.12.4 casework write delegate fencing, so this baseline records the
+# the Phase 50.12.5 assistant residual helper extraction, so this baseline records the
 # measured ceiling and fails on silent re-growth. A future ADR or maintainability
 # backlog must lower or replace these limits before unrelated feature expansion
 # lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=1619 max_effective_lines=1445 max_facade_methods=117 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.4 issue=#1019
+control-plane/aegisops_control_plane/service.py max_lines=1498 max_effective_lines=1338 max_facade_methods=103 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.5 issue=#1020

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,6 +1,6 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.12.4 updates the accepted `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
+Phase 50.12.5 updates the accepted `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4/50.12.5 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
@@ -12,21 +12,21 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work accepted in #1007. Phase 50.12.2 for #1017 further extracted constructor composition assignment pressure, Phase 50.12.3 for #1018 moved reviewed action approval policy helper pressure into the action-review write surface, and Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade. The accepted residual ceiling is:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work accepted in #1007. Phase 50.12.2 for #1017 further extracted constructor composition assignment pressure, Phase 50.12.3 for #1018 moved reviewed action approval policy helper pressure into the action-review write surface, Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade, and Phase 50.12.5 for #1020 moved assistant residual lifecycle helper delegates out of the service facade and onto the extracted AI trace lifecycle boundary. The accepted residual ceiling is:
 
-- `max_lines=1619`
-- `max_effective_lines=1445`
-- `max_facade_methods=117`
+- `max_lines=1498`
+- `max_effective_lines=1338`
+- `max_facade_methods=103`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.12.4`
-- `issue=#1019`
+- `phase=50.12.5`
+- `issue=#1020`
 
 The measured closeout state is:
 
-- `physical_lines=1619`
-- `effective_lines=1445`
-- `AegisOpsControlPlaneService methods=117`
+- `physical_lines=1498`
+- `effective_lines=1338`
+- `AegisOpsControlPlaneService methods=103`
 
 The baseline is lower than the Phase 50.10.6 ceiling of `max_lines=3003`, `max_effective_lines=2704`, and `max_facade_methods=167`. It is also below the ADR-0008 Phase 50.11 target ceiling of `max_lines <= 2700`, `max_effective_lines <= 2450`, and `max_facade_methods <= 150`.
 
@@ -47,6 +47,8 @@ The final Phase 50.11 extraction sequence moved the following directly linked he
 Phase 50.12.3 then moved the reviewed action approval policy helpers out of `service.py` and into `control-plane/aegisops_control_plane/action_review_write_surface.py`, preserving the public facade entrypoints for action request creation and approval decision recording.
 
 Phase 50.12.4 then moved the casework write compatibility delegates out of `AegisOpsControlPlaneService` and into `control-plane/aegisops_control_plane/case_workflow.py`, preserving the public facade entrypoints for observation, lead, recommendation, handoff, and disposition writes.
+
+Phase 50.12.5 then removed the remaining assistant residual lifecycle helper delegates from `AegisOpsControlPlaneService` and routed direct consumers through `control-plane/aegisops_control_plane/ai_trace_lifecycle.py`, preserving assistant context, advisory output, recommendation draft, live assistant workflow, readiness, and action-review linkage behavior.
 
 Those extractions preserve the public service facade. AegisOps control-plane records remain authoritative workflow truth. Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, projections, snapshots, DTOs, and helper-module output remain subordinate context.
 

--- a/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
@@ -232,6 +232,26 @@ Phase 50.12.4 then moved the casework write compatibility delegates out of `Aegi
 EOF
 assert_passes "${phase50_12_4_closeout_repo}"
 
+phase50_12_5_closeout_repo="${workdir}/phase50-12-5-closeout"
+create_valid_repo "${phase50_12_5_closeout_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=1498 max_effective_lines=1338 max_facade_methods=103 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.5 issue=#1020" \
+  >"${phase50_12_5_closeout_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${phase50_12_5_closeout_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.12.5 for #1020 moved assistant residual lifecycle helper delegates onto the AI trace lifecycle boundary.
+
+- `max_lines=1498`
+- `max_effective_lines=1338`
+- `max_facade_methods=103`
+- `phase=50.12.5`
+- `issue=#1020`
+
+Phase 50.12.5 then removed the remaining assistant residual lifecycle helper delegates from `AegisOpsControlPlaneService` and routed direct consumers through `control-plane/aegisops_control_plane/ai_trace_lifecycle.py`, preserving assistant context, advisory output, recommendation draft, live assistant workflow, readiness, and action-review linkage behavior.
+EOF
+assert_passes "${phase50_12_5_closeout_repo}"
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/adr/0009-phase-50-12-service-facade-pressure-contract.md"

--- a/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
@@ -121,10 +121,13 @@ done
 
 starting_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007"
 phase50_12_4_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1619 max_effective_lines=1445 max_facade_methods=117 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.4 issue=#1019"
+phase50_12_5_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1498 max_effective_lines=1338 max_facade_methods=103 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.5 issue=#1020"
 service_entry="$(grep -Fx -- "${starting_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_4_service_entry="$(grep -Fx -- "${phase50_12_4_service_baseline_entry}" "${baseline_path}" || true)"
+phase50_12_5_service_entry="$(grep -Fx -- "${phase50_12_5_service_baseline_entry}" "${baseline_path}" || true)"
 service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_4_service_entry_count="$(printf '%s\n' "${phase50_12_4_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
+phase50_12_5_service_entry_count="$(printf '%s\n' "${phase50_12_5_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 service_path_entry_count="$(
   awk -v prefix="control-plane/aegisops_control_plane/service.py " \
     'index($0, prefix) == 1 { count += 1 } END { print count + 0 }' \
@@ -154,6 +157,28 @@ if [[ "${phase50_12_4_service_entry_count}" -eq 1 ]]; then
   for phrase in "${phase50_12_4_closeout_phrases[@]}"; do
     if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
       echo "Phase 50.12.4 baseline requires closeout evidence: ${phrase}" >&2
+      exit 1
+    fi
+  done
+  echo "Phase 50.12 service facade pressure contract fixes residual clusters, starting measurements, sub-1500 target ceilings, fallback rules, authority non-goals, migration order, and validation commands."
+  exit 0
+fi
+if [[ "${phase50_12_5_service_entry_count}" -eq 1 ]]; then
+  if [[ ! -f "${closeout_path}" ]]; then
+    echo "Phase 50.12.5 baseline requires docs/phase-50-maintainability-closeout.md evidence." >&2
+    exit 1
+  fi
+  phase50_12_5_closeout_phrases=(
+    "Phase 50.12.5 then removed the remaining assistant residual lifecycle helper delegates from \`AegisOpsControlPlaneService\` and routed direct consumers through \`control-plane/aegisops_control_plane/ai_trace_lifecycle.py\`, preserving assistant context, advisory output, recommendation draft, live assistant workflow, readiness, and action-review linkage behavior."
+    "- \`max_lines=1498\`"
+    "- \`max_effective_lines=1338\`"
+    "- \`max_facade_methods=103\`"
+    "- \`phase=50.12.5\`"
+    "- \`issue=#1020\`"
+  )
+  for phrase in "${phase50_12_5_closeout_phrases[@]}"; do
+    if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
+      echo "Phase 50.12.5 baseline requires closeout evidence: ${phrase}" >&2
       exit 1
     fi
   done


### PR DESCRIPTION
## Summary
- Remove remaining assistant lifecycle helper delegates from `AegisOpsControlPlaneService`.
- Rewire action-review, operator inspection, readiness, and restore composition consumers to `AITraceLifecycleService`.
- Add a focused facade regression and refresh Phase 50.12.5 maintainability closeout evidence.

## Verification
- `python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory`
- `python3 -m unittest control-plane.tests.test_phase24_live_assistant_validation`
- `python3 -m unittest control-plane.tests.test_service_boundary_refactor_regression_validation`
- `python3 -m unittest control-plane.tests.test_phase49_service_decomposition_closeout control-plane.tests.test_phase50_maintainability_closeout`
- `bash scripts/verify-phase-50-12-service-facade-pressure-contract.sh`
- `bash scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh`
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
- `CODEX_SUPERVISOR_CONFIG=supervisor.config.aegisops.coderabbit.json node dist/index.js issue-lint 1020`

Closes #1020


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal lifecycle and linkage logic centralized into a dedicated lifecycle component; redundant facade helpers removed to streamline service composition.

* **Tests**
  * Updated and added unit tests to reflect the new composition and to assert the facade no longer exposes deprecated helper behavior; baselines adjusted accordingly.

* **Documentation**
  * Maintainability closeout and hotspot baselines advanced to Phase 50.12.5 with revised thresholds and updated closeout narrative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->