### PR TITLE
Phase 50.12.6 action visibility helper cleanup

### DIFF
--- a/control-plane/aegisops_control_plane/action_review_write_surface.py
+++ b/control-plane/aegisops_control_plane/action_review_write_surface.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import datetime, timezone
 import logging
-from typing import TYPE_CHECKING, Protocol
+from typing import Callable, Mapping, TYPE_CHECKING, Protocol
 
 from . import action_review_projection as _action_review_projection
 from .action_policy import evaluate_action_policy_record
@@ -41,16 +41,7 @@ class ActionReviewWriteSurfaceDependencies(Protocol):
     ) -> str | None:
         ...
 
-    def _require_review_bound_action_request(
-        self,
-        action_request_id: str,
-    ) -> ActionRequestRecord:
-        ...
-
-    def _require_action_review_visibility_context_record(
-        self,
-        action_request: ActionRequestRecord,
-    ) -> CaseRecord | AlertRecord:
+    def _require_reviewed_operator_case(self, case_id: str) -> CaseRecord:
         ...
 
     def _validate_case_evidence_linkage(
@@ -69,14 +60,6 @@ class ActionReviewWriteSurfaceDependencies(Protocol):
         evidence_ids: tuple[str, ...],
         field_name: str,
     ) -> None:
-        ...
-
-    def _persist_action_review_visibility_context_record(
-        self,
-        *,
-        context_record: CaseRecord | AlertRecord,
-        reviewed_context_update: dict[str, object],
-    ) -> CaseRecord | AlertRecord:
         ...
 
     def _resolve_new_record_identifier(
@@ -106,8 +89,71 @@ class ActionReviewWriteSurfaceDependencies(Protocol):
 
 
 class ActionReviewWriteSurface:
-    def __init__(self, service: ActionReviewWriteSurfaceDependencies) -> None:
+    def __init__(
+        self,
+        service: ActionReviewWriteSurfaceDependencies,
+        *,
+        merge_reviewed_context: Callable[
+            [Mapping[str, object] | None, Mapping[str, object] | None],
+            dict[str, object],
+        ],
+    ) -> None:
         self._service = service
+        self._merge_reviewed_context = merge_reviewed_context
+
+    def _require_review_bound_action_request(
+        self,
+        action_request_id: str,
+    ) -> ActionRequestRecord:
+        service = self._service
+        action_request_id = service._require_non_empty_string(
+            action_request_id,
+            "action_request_id",
+        )
+        action_request = service._store.get(ActionRequestRecord, action_request_id)
+        if action_request is None:
+            raise LookupError(f"Missing action request {action_request_id!r}")
+        if not _action_review_projection._action_request_is_review_bound(
+            action_request
+        ):
+            raise ValueError(
+                "action_request_id must reference a reviewed action request"
+            )
+        return action_request
+
+    def _require_action_review_visibility_context_record(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> CaseRecord | AlertRecord:
+        service = self._service
+        if action_request.case_id is not None:
+            return service._require_reviewed_operator_case(action_request.case_id)
+        if action_request.alert_id is None:
+            raise ValueError(
+                "reviewed action request must be linked to a case or alert before "
+                "recording runtime visibility"
+            )
+        alert = service._store.get(AlertRecord, action_request.alert_id)
+        if alert is None:
+            raise LookupError(f"Missing alert {action_request.alert_id!r}")
+        return alert
+
+    def _persist_action_review_visibility_context_record(
+        self,
+        *,
+        context_record: CaseRecord | AlertRecord,
+        reviewed_context_update: Mapping[str, object],
+    ) -> CaseRecord | AlertRecord:
+        updated_reviewed_context = self._merge_reviewed_context(
+            context_record.reviewed_context,
+            reviewed_context_update,
+        )
+        return self._service.persist_record(
+            replace(
+                context_record,
+                reviewed_context=updated_reviewed_context,
+            )
+        )
 
     def record_action_review_manual_fallback(
         self,
@@ -142,7 +188,7 @@ class ActionReviewWriteSurface:
             "residual_uncertainty",
         )
         with service._store.transaction():
-            action_request = service._require_review_bound_action_request(
+            action_request = self._require_review_bound_action_request(
                 action_request_id
             )
             approval_decision = (
@@ -175,7 +221,7 @@ class ActionReviewWriteSurface:
                     "manual fallback requires an approved action review in a live "
                     "post-approval state"
                 )
-            context_record = service._require_action_review_visibility_context_record(
+            context_record = self._require_action_review_visibility_context_record(
                 action_request
             )
             if isinstance(context_record, CaseRecord):
@@ -204,7 +250,7 @@ class ActionReviewWriteSurface:
                 manual_fallback_context["residual_uncertainty"] = (
                     normalized_residual_uncertainty
                 )
-            return service._persist_action_review_visibility_context_record(
+            return self._persist_action_review_visibility_context_record(
                 context_record=context_record,
                 reviewed_context_update=(
                     _action_review_projection._action_review_visibility_update(
@@ -236,7 +282,7 @@ class ActionReviewWriteSurface:
         )
         note = service._require_non_empty_string(note, "note")
         with service._store.transaction():
-            action_request = service._require_review_bound_action_request(
+            action_request = self._require_review_bound_action_request(
                 action_request_id
             )
             approval_decision = (
@@ -260,7 +306,7 @@ class ActionReviewWriteSurface:
                 approval_state=approval_state,
                 action_execution=action_execution,
             )
-            context_record = service._require_action_review_visibility_context_record(
+            context_record = self._require_action_review_visibility_context_record(
                 action_request
             )
             escalation_context: dict[str, object] = {
@@ -275,7 +321,7 @@ class ActionReviewWriteSurface:
                 escalation_context["approval_decision_id"] = (
                     approval_decision.approval_decision_id
                 )
-            return service._persist_action_review_visibility_context_record(
+            return self._persist_action_review_visibility_context_record(
                 context_record=context_record,
                 reviewed_context_update=(
                     _action_review_projection._action_review_visibility_update(
@@ -326,7 +372,9 @@ class ActionReviewWriteSurface:
         approval_decision: ApprovalDecisionRecord | None = None
         request_expired = False
         with service._store.transaction(isolation_level="SERIALIZABLE"):
-            action_request = service._require_review_bound_action_request(action_request_id)
+            action_request = self._require_review_bound_action_request(
+                action_request_id
+            )
             if action_request.lifecycle_state != "pending_approval":
                 raise ValueError(
                     "approval decisions can only be recorded for pending reviewed action requests"

--- a/control-plane/aegisops_control_plane/service.py
+++ b/control-plane/aegisops_control_plane/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import AbstractContextManager, contextmanager
 from collections import Counter
-from dataclasses import fields, replace
+from dataclasses import fields
 from datetime import datetime, timezone
 import hashlib
 import json
@@ -12,7 +12,6 @@ from typing import Iterable, Iterator, Mapping, Protocol, Type, TypeVar
 
 _DATETIME_TYPE = datetime
 
-from . import action_review_projection as _action_review_projection
 from .action_policy import evaluate_action_policy_record
 from . import assistant_advisory as _assistant_advisory
 from . import live_assistant_workflow as _live_assistant_workflow
@@ -1257,52 +1256,6 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
         if action_request is None:
             raise LookupError(f"Missing action request {action_request_id!r}")
         return action_request
-
-    def _require_review_bound_action_request(
-        self,
-        action_request_id: str,
-    ) -> ActionRequestRecord:
-        action_request = self._require_action_request_record(action_request_id)
-        if not _action_review_projection._action_request_is_review_bound(
-            action_request
-        ):
-            raise ValueError(
-                "action_request_id must reference a reviewed action request"
-            )
-        return action_request
-
-    def _require_action_review_visibility_context_record(
-        self,
-        action_request: ActionRequestRecord,
-    ) -> CaseRecord | AlertRecord:
-        if action_request.case_id is not None:
-            return self._require_reviewed_operator_case(action_request.case_id)
-        if action_request.alert_id is None:
-            raise ValueError(
-                "reviewed action request must be linked to a case or alert before "
-                "recording runtime visibility"
-            )
-        alert = self._store.get(AlertRecord, action_request.alert_id)
-        if alert is None:
-            raise LookupError(f"Missing alert {action_request.alert_id!r}")
-        return alert
-
-    def _persist_action_review_visibility_context_record(
-        self,
-        *,
-        context_record: CaseRecord | AlertRecord,
-        reviewed_context_update: Mapping[str, object],
-    ) -> CaseRecord | AlertRecord:
-        updated_reviewed_context = _merge_reviewed_context(
-            context_record.reviewed_context,
-            reviewed_context_update,
-        )
-        return self.persist_record(
-            replace(
-                context_record,
-                reviewed_context=updated_reviewed_context,
-            )
-        )
 
     def _require_reviewed_operator_case(self, case_id: str) -> CaseRecord:
         return self._reviewed_slice_policy.require_operator_case(case_id)

--- a/control-plane/aegisops_control_plane/service_composition.py
+++ b/control-plane/aegisops_control_plane/service_composition.py
@@ -214,7 +214,10 @@ def build_control_plane_service_composition(
         coordination_reference_signature=dependencies.coordination_reference_signature,
         dedupe_strings=dependencies.dedupe_strings,
     )
-    action_review_write_surface = ActionReviewWriteSurface(service)
+    action_review_write_surface = ActionReviewWriteSurface(
+        service,
+        merge_reviewed_context=dependencies.merge_reviewed_context,
+    )
     evidence_linkage_service = EvidenceLinkageService(
         store=resolved_store,
         require_non_empty_string=service._require_non_empty_string,

--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,8 +66,8 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.12.5")
-        self.assertEqual(metadata["issue"], "#1020")
+        self.assertEqual(metadata["phase"], "50.12.6")
+        self.assertEqual(metadata["issue"], "#1021")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -58,15 +58,15 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         facade_methods = self._facade_method_count(metadata["facade_class"])
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.12.5")
-        self.assertEqual(metadata["issue"], "#1020")
+        self.assertEqual(metadata["phase"], "50.12.6")
+        self.assertEqual(metadata["issue"], "#1021")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), physical_lines)
         self.assertEqual(int(metadata["max_effective_lines"]), effective_lines)
         self.assertEqual(int(metadata["max_facade_methods"]), facade_methods)
-        self.assertEqual(physical_lines, 1498)
-        self.assertEqual(effective_lines, 1338)
-        self.assertEqual(facade_methods, 103)
+        self.assertEqual(physical_lines, 1451)
+        self.assertEqual(effective_lines, 1294)
+        self.assertEqual(facade_methods, 100)
         self.assertLess(int(metadata["max_lines"]), 3003)
         self.assertLess(int(metadata["max_effective_lines"]), 2704)
         self.assertLess(int(metadata["max_facade_methods"]), 167)
@@ -80,6 +80,7 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "Phase 50.12.3",
             "Phase 50.12.4",
             "Phase 50.12.5",
+            "Phase 50.12.6",
             "control-plane/aegisops_control_plane/service.py",
             "control-plane/aegisops_control_plane/case_workflow.py",
             "control-plane/aegisops_control_plane/action_review_write_surface.py",
@@ -87,17 +88,18 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "control-plane/aegisops_control_plane/external_evidence_boundary.py",
             "control-plane/aegisops_control_plane/ai_trace_lifecycle.py",
             "AegisOpsControlPlaneService",
-            "max_lines=1498",
-            "max_effective_lines=1338",
-            "max_facade_methods=103",
-            "physical_lines=1498",
-            "effective_lines=1338",
+            "max_lines=1451",
+            "max_effective_lines=1294",
+            "max_facade_methods=100",
+            "physical_lines=1451",
+            "effective_lines=1294",
             "ADR-0007",
             "ADR-0008",
             "ADR-0004",
             "ADR-0003",
             "#1007",
             "#1017",
+            "#1021",
             "#1018",
             "#1019",
             "#1020",

--- a/control-plane/tests/test_service_boundary_refactor_regression_validation.py
+++ b/control-plane/tests/test_service_boundary_refactor_regression_validation.py
@@ -685,6 +685,54 @@ class ServiceBoundaryRefactorRegressionValidationTests(unittest.TestCase):
             "reviewed action approval policy helpers should live with the approval write surface",
         )
 
+    def test_phase50_12_6_action_review_visibility_helpers_leave_service_facade(
+        self,
+    ) -> None:
+        service_source = self._read("control-plane/aegisops_control_plane/service.py")
+        write_surface_source = self._read(
+            "control-plane/aegisops_control_plane/action_review_write_surface.py"
+        )
+        service_tree = ast.parse(service_source)
+        write_surface_tree = ast.parse(write_surface_source)
+        service_class = next(
+            node
+            for node in service_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "AegisOpsControlPlaneService"
+        )
+        write_surface_class = next(
+            node
+            for node in write_surface_tree.body
+            if isinstance(node, ast.ClassDef)
+            and node.name == "ActionReviewWriteSurface"
+        )
+        service_method_names = {
+            node.name
+            for node in service_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+        write_surface_method_names = {
+            node.name
+            for node in write_surface_class.body
+            if isinstance(node, ast.FunctionDef)
+        }
+
+        visibility_helper_names = {
+            "_require_review_bound_action_request",
+            "_require_action_review_visibility_context_record",
+            "_persist_action_review_visibility_context_record",
+        }
+        self.assertFalse(
+            visibility_helper_names & service_method_names,
+            "action review visibility persistence helpers should not remain "
+            "service facade methods",
+        )
+        self.assertTrue(
+            visibility_helper_names.issubset(write_surface_method_names),
+            "action review visibility persistence helpers should live with the "
+            "write surface that records the reviewed context",
+        )
+
     def test_phase50_9_3_persistence_restore_and_status_helpers_leave_service_facade(
         self,
     ) -> None:

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,13 +1,13 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.12.5 residual exception:
+# Phase 50.12.6 residual exception:
 # ADR-0008 accepted ordered residual DTO/helper extraction after the
 # Phase 50.10.6 facade floor. ADR-0003 remains the public facade-preservation
 # exception behind AegisOpsControlPlaneService.
 # The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 50.12.5 assistant residual helper extraction, so this baseline records the
+# the Phase 50.12.6 detection/action residual helper cleanup, so this baseline records the
 # measured ceiling and fails on silent re-growth. A future ADR or maintainability
 # backlog must lower or replace these limits before unrelated feature expansion
 # lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=1498 max_effective_lines=1338 max_facade_methods=103 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.5 issue=#1020
+control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.6 issue=#1021

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,6 +1,6 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.12.5 updates the accepted `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4/50.12.5 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
+Phase 50.12.6 updates the accepted `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
@@ -12,21 +12,21 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work accepted in #1007. Phase 50.12.2 for #1017 further extracted constructor composition assignment pressure, Phase 50.12.3 for #1018 moved reviewed action approval policy helper pressure into the action-review write surface, Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade, and Phase 50.12.5 for #1020 moved assistant residual lifecycle helper delegates out of the service facade and onto the extracted AI trace lifecycle boundary. The accepted residual ceiling is:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work accepted in #1007. Phase 50.12.2 for #1017 further extracted constructor composition assignment pressure, Phase 50.12.3 for #1018 moved reviewed action approval policy helper pressure into the action-review write surface, Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade, Phase 50.12.5 for #1020 moved assistant residual lifecycle helper delegates out of the service facade and onto the extracted AI trace lifecycle boundary, and Phase 50.12.6 for #1021 moved reviewed action visibility persistence helpers into the action-review write surface while retaining public detection intake and action reconciliation facade delegates. The accepted residual ceiling is:
 
-- `max_lines=1498`
-- `max_effective_lines=1338`
-- `max_facade_methods=103`
+- `max_lines=1451`
+- `max_effective_lines=1294`
+- `max_facade_methods=100`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.12.5`
-- `issue=#1020`
+- `phase=50.12.6`
+- `issue=#1021`
 
 The measured closeout state is:
 
-- `physical_lines=1498`
-- `effective_lines=1338`
-- `AegisOpsControlPlaneService methods=103`
+- `physical_lines=1451`
+- `effective_lines=1294`
+- `AegisOpsControlPlaneService methods=100`
 
 The baseline is lower than the Phase 50.10.6 ceiling of `max_lines=3003`, `max_effective_lines=2704`, and `max_facade_methods=167`. It is also below the ADR-0008 Phase 50.11 target ceiling of `max_lines <= 2700`, `max_effective_lines <= 2450`, and `max_facade_methods <= 150`.
 
@@ -49,6 +49,8 @@ Phase 50.12.3 then moved the reviewed action approval policy helpers out of `ser
 Phase 50.12.4 then moved the casework write compatibility delegates out of `AegisOpsControlPlaneService` and into `control-plane/aegisops_control_plane/case_workflow.py`, preserving the public facade entrypoints for observation, lead, recommendation, handoff, and disposition writes.
 
 Phase 50.12.5 then removed the remaining assistant residual lifecycle helper delegates from `AegisOpsControlPlaneService` and routed direct consumers through `control-plane/aegisops_control_plane/ai_trace_lifecycle.py`, preserving assistant context, advisory output, recommendation draft, live assistant workflow, readiness, and action-review linkage behavior.
+
+Phase 50.12.6 then moved the remaining reviewed action visibility persistence helpers out of `AegisOpsControlPlaneService` and into `control-plane/aegisops_control_plane/action_review_write_surface.py`, preserving manual fallback, escalation-note, approval-decision, detection intake, and action execution reconciliation behavior. `ingest_finding_alert` and `reconcile_action_execution` remain public facade delegates because callers rely on those compatibility entrypoints; their implementation bodies remain single-hop delegates to the extracted detection intake and action lifecycle boundaries.
 
 Those extractions preserve the public service facade. AegisOps control-plane records remain authoritative workflow truth. Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, projections, snapshots, DTOs, and helper-module output remain subordinate context.
 

--- a/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
@@ -252,6 +252,26 @@ Phase 50.12.5 then removed the remaining assistant residual lifecycle helper del
 EOF
 assert_passes "${phase50_12_5_closeout_repo}"
 
+phase50_12_6_closeout_repo="${workdir}/phase50-12-6-closeout"
+create_valid_repo "${phase50_12_6_closeout_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.6 issue=#1021" \
+  >"${phase50_12_6_closeout_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${phase50_12_6_closeout_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.12.6 for #1021 moved reviewed action visibility persistence helpers onto the action-review write surface.
+
+- `max_lines=1451`
+- `max_effective_lines=1294`
+- `max_facade_methods=100`
+- `phase=50.12.6`
+- `issue=#1021`
+
+Phase 50.12.6 then moved the remaining reviewed action visibility persistence helpers out of `AegisOpsControlPlaneService` and into `control-plane/aegisops_control_plane/action_review_write_surface.py`, preserving manual fallback, escalation-note, approval-decision, detection intake, and action execution reconciliation behavior. `ingest_finding_alert` and `reconcile_action_execution` remain public facade delegates because callers rely on those compatibility entrypoints; their implementation bodies remain single-hop delegates to the extracted detection intake and action lifecycle boundaries.
+EOF
+assert_passes "${phase50_12_6_closeout_repo}"
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/adr/0009-phase-50-12-service-facade-pressure-contract.md"

--- a/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
@@ -122,12 +122,15 @@ done
 starting_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1812 max_effective_lines=1632 max_facade_methods=125 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.11.7 issue=#1007"
 phase50_12_4_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1619 max_effective_lines=1445 max_facade_methods=117 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.4 issue=#1019"
 phase50_12_5_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1498 max_effective_lines=1338 max_facade_methods=103 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.5 issue=#1020"
+phase50_12_6_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.6 issue=#1021"
 service_entry="$(grep -Fx -- "${starting_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_4_service_entry="$(grep -Fx -- "${phase50_12_4_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_5_service_entry="$(grep -Fx -- "${phase50_12_5_service_baseline_entry}" "${baseline_path}" || true)"
+phase50_12_6_service_entry="$(grep -Fx -- "${phase50_12_6_service_baseline_entry}" "${baseline_path}" || true)"
 service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_4_service_entry_count="$(printf '%s\n' "${phase50_12_4_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_5_service_entry_count="$(printf '%s\n' "${phase50_12_5_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
+phase50_12_6_service_entry_count="$(printf '%s\n' "${phase50_12_6_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 service_path_entry_count="$(
   awk -v prefix="control-plane/aegisops_control_plane/service.py " \
     'index($0, prefix) == 1 { count += 1 } END { print count + 0 }' \
@@ -179,6 +182,28 @@ if [[ "${phase50_12_5_service_entry_count}" -eq 1 ]]; then
   for phrase in "${phase50_12_5_closeout_phrases[@]}"; do
     if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
       echo "Phase 50.12.5 baseline requires closeout evidence: ${phrase}" >&2
+      exit 1
+    fi
+  done
+  echo "Phase 50.12 service facade pressure contract fixes residual clusters, starting measurements, sub-1500 target ceilings, fallback rules, authority non-goals, migration order, and validation commands."
+  exit 0
+fi
+if [[ "${phase50_12_6_service_entry_count}" -eq 1 ]]; then
+  if [[ ! -f "${closeout_path}" ]]; then
+    echo "Phase 50.12.6 baseline requires docs/phase-50-maintainability-closeout.md evidence." >&2
+    exit 1
+  fi
+  phase50_12_6_closeout_phrases=(
+    "Phase 50.12.6 then moved the remaining reviewed action visibility persistence helpers out of \`AegisOpsControlPlaneService\` and into \`control-plane/aegisops_control_plane/action_review_write_surface.py\`, preserving manual fallback, escalation-note, approval-decision, detection intake, and action execution reconciliation behavior. \`ingest_finding_alert\` and \`reconcile_action_execution\` remain public facade delegates because callers rely on those compatibility entrypoints; their implementation bodies remain single-hop delegates to the extracted detection intake and action lifecycle boundaries."
+    "- \`max_lines=1451\`"
+    "- \`max_effective_lines=1294\`"
+    "- \`max_facade_methods=100\`"
+    "- \`phase=50.12.6\`"
+    "- \`issue=#1021\`"
+  )
+  for phrase in "${phase50_12_6_closeout_phrases[@]}"; do
+    if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
+      echo "Phase 50.12.6 baseline requires closeout evidence: ${phrase}" >&2
       exit 1
     fi
   done


### PR DESCRIPTION
## Summary
- Move reviewed action visibility persistence helpers from service.py into ActionReviewWriteSurface.
- Keep detection intake and action reconciliation as public single-hop facade delegates.
- Lower the service.py maintainability baseline to Phase 50.12.6 measurements and update closeout/contract evidence.

## Verification
- python3 -m unittest control-plane/tests/test_service_boundary_refactor_regression_validation.py
- python3 -m unittest control-plane/tests/test_action_review_write_boundary.py control-plane/tests/test_phase22_end_to_end_validation.py control-plane/tests/test_phase26_end_to_end_validation.py
- python3 -m unittest control-plane/tests/test_service_persistence_ingest_case_lifecycle.py control-plane/tests/test_service_persistence_action_reconciliation_reconciliation.py control-plane/tests/test_execution_coordinator_boundary.py control-plane/tests/test_action_review_write_boundary.py
- python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py control-plane/tests/test_phase49_service_decomposition_closeout.py
- python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
- bash scripts/verify-maintainability-hotspots.sh && bash scripts/test-verify-maintainability-hotspots.sh
- bash scripts/verify-phase-50-12-service-facade-pressure-contract.sh
- bash scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
- node dist/index.js issue-lint 1021 --config <supervisor-config-path>

Closes #1021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized action review processing logic to improve code organization and maintainability.

* **Tests**
  * Added new validation tests to enforce proper architectural boundaries and separation of concerns.

* **Chores**
  * Updated documentation and maintainability metrics reflecting improvements to code structure and quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->