### PR TITLE
Refresh Phase 50.12 closeout baseline

### DIFF
--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,8 +66,8 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.12.6")
-        self.assertEqual(metadata["issue"], "#1021")
+        self.assertEqual(metadata["phase"], "50.12.7")
+        self.assertEqual(metadata["issue"], "#1022")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -58,8 +58,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         facade_methods = self._facade_method_count(metadata["facade_class"])
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.12.6")
-        self.assertEqual(metadata["issue"], "#1021")
+        self.assertEqual(metadata["phase"], "50.12.7")
+        self.assertEqual(metadata["issue"], "#1022")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), physical_lines)
         self.assertEqual(int(metadata["max_effective_lines"]), effective_lines)
@@ -67,9 +67,12 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         self.assertEqual(physical_lines, 1451)
         self.assertEqual(effective_lines, 1294)
         self.assertEqual(facade_methods, 100)
-        self.assertLess(int(metadata["max_lines"]), 3003)
-        self.assertLess(int(metadata["max_effective_lines"]), 2704)
-        self.assertLess(int(metadata["max_facade_methods"]), 167)
+        self.assertLess(int(metadata["max_lines"]), 1812)
+        self.assertLess(int(metadata["max_effective_lines"]), 1632)
+        self.assertLess(int(metadata["max_facade_methods"]), 125)
+        self.assertLessEqual(int(metadata["max_lines"]), 1500)
+        self.assertLessEqual(int(metadata["max_effective_lines"]), 1350)
+        self.assertGreater(int(metadata["max_facade_methods"]), 95)
 
     def test_closeout_notes_preserve_phase50_10_hotspot_and_trigger(self) -> None:
         closeout = self._read("docs/phase-50-maintainability-closeout.md")
@@ -81,6 +84,7 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "Phase 50.12.4",
             "Phase 50.12.5",
             "Phase 50.12.6",
+            "Phase 50.12.7",
             "control-plane/aegisops_control_plane/service.py",
             "control-plane/aegisops_control_plane/case_workflow.py",
             "control-plane/aegisops_control_plane/action_review_write_surface.py",
@@ -93,13 +97,18 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "max_facade_methods=100",
             "physical_lines=1451",
             "effective_lines=1294",
+            "max_lines <= 1500",
+            "max_effective_lines <= 1350",
+            "max_facade_methods <= 95",
             "ADR-0007",
             "ADR-0008",
+            "ADR-0009",
             "ADR-0004",
             "ADR-0003",
             "#1007",
             "#1017",
             "#1021",
+            "#1022",
             "#1018",
             "#1019",
             "#1020",
@@ -113,6 +122,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "another decomposition decision",
             "bash scripts/verify-maintainability-hotspots.sh",
             "bash scripts/test-verify-maintainability-hotspots.sh",
+            "bash scripts/verify-phase-50-12-service-facade-pressure-contract.sh",
+            "bash scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh",
         ):
             self.assertIn(required, closeout)
 
@@ -140,11 +151,14 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         for required in (
             "regrowth_repo",
             "phase50_11_regrowth_repo",
+            "phase50_12_final_regrowth_repo",
             "Maintainability hotspot baseline limits were exceeded",
             "lines=960 exceeds max_lines=959",
             "effective_lines=960 exceeds max_effective_lines=959",
             "lines=1774 exceeds max_lines=1773",
             "effective_lines=1774 exceeds max_effective_lines=1589",
+            "lines=1452 exceeds max_lines=1451",
+            "effective_lines=1452 exceeds max_effective_lines=1294",
             "max_facade_methods=0",
         ):
             self.assertIn(required, verifier_test)

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,13 +1,13 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.12.6 residual exception:
+# Phase 50.12.7 residual exception:
 # ADR-0008 accepted ordered residual DTO/helper extraction after the
 # Phase 50.10.6 facade floor. ADR-0003 remains the public facade-preservation
 # exception behind AegisOpsControlPlaneService.
-# The facade remains above the long-term 1,500-line and 50-method targets after
-# the Phase 50.12.6 detection/action residual helper cleanup, so this baseline records the
-# measured ceiling and fails on silent re-growth. A future ADR or maintainability
-# backlog must lower or replace these limits before unrelated feature expansion
-# lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.6 issue=#1021
+# The facade is now below the long-term 1,500-line target, but it remains above
+# the long-term 50-method target after the Phase 50.12 final facade-pressure
+# sequence, so this baseline records the accepted closeout ceiling and fails on
+# silent re-growth. A future ADR or maintainability backlog must lower or
+# replace these limits before unrelated feature expansion lands in the facade.
+control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.7 issue=#1022

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,6 +1,6 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.12.6 updates the accepted `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
+Phase 50.12.7 records the accepted final `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
@@ -19,16 +19,16 @@ That result is expected because `AegisOpsControlPlaneService` remains the public
 - `max_facade_methods=100`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.12.6`
-- `issue=#1021`
+- `phase=50.12.7`
+- `issue=#1022`
 
-The measured closeout state is:
+The measured Phase 50.12.7 closeout state is:
 
 - `physical_lines=1451`
 - `effective_lines=1294`
 - `AegisOpsControlPlaneService methods=100`
 
-The baseline is lower than the Phase 50.10.6 ceiling of `max_lines=3003`, `max_effective_lines=2704`, and `max_facade_methods=167`. It is also below the ADR-0008 Phase 50.11 target ceiling of `max_lines <= 2700`, `max_effective_lines <= 2450`, and `max_facade_methods <= 150`.
+The baseline is lower than the Phase 50.11.7 ceiling of `max_lines=1812`, `max_effective_lines=1632`, and `max_facade_methods=125`. It also reached the ADR-0009 Phase 50.12 physical-line and effective-line targets of `max_lines <= 1500` and `max_effective_lines <= 1350`, but it did not reach the `max_facade_methods <= 95` target. The retained `100` facade methods are accepted only as an ADR-0003 facade-preservation exception because the remaining public compatibility entrypoints continue to protect existing callers while delegating into extracted boundaries.
 
 No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, operator UI route tests, `control-plane/aegisops_control_plane/action_review_projection.py`, or `control-plane/aegisops_control_plane/external_evidence_boundary.py` because the verifier does not report those areas as current responsibility-growth candidates. The earlier Phase 50.9 projection measurement was `projection lines=105` and `projection effective_lines=103`, so the projection split does not require a baseline entry. The earlier Phase 50.10 external-evidence measurement was `external_evidence_boundary.py lines=216` and `external_evidence_boundary.py effective_lines=195`, so the external-evidence split does not require a baseline entry.
 
@@ -56,7 +56,7 @@ Those extractions preserve the public service facade. AegisOps control-plane rec
 
 ## Follow-Up Trigger
 
-The service facade remains above the long-term 1,500-line and 50-method targets. It is therefore an accepted exception, not a success target.
+The service facade is below the long-term 1,500-line target, but it remains above the long-term 50-method target. The retained method-count ceiling is therefore an accepted exception, not a success target.
 
 Any silent re-growth beyond the recorded ceiling must fail the verifier. The expected response is another decomposition decision or maintainability backlog before unrelated feature expansion lands in the facade.
 
@@ -70,8 +70,8 @@ Run:
 
 - `bash scripts/verify-maintainability-hotspots.sh`
 - `bash scripts/test-verify-maintainability-hotspots.sh`
-- `bash scripts/verify-phase-50-11-service-residual-extraction-contract.sh`
-- `bash scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh`
+- `bash scripts/verify-phase-50-12-service-facade-pressure-contract.sh`
+- `bash scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh`
 - `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py`
 
-The focused negative verifier coverage remains in `scripts/test-verify-maintainability-hotspots.sh` through the `regrowth_repo` fixture and the `phase50_11_regrowth_repo` fixture, which verify that line-count, effective-line, and facade-method growth beyond the recorded ceiling still fails closed.
+The focused negative verifier coverage remains in `scripts/test-verify-maintainability-hotspots.sh` through the `regrowth_repo`, `phase50_11_regrowth_repo`, and `phase50_12_final_regrowth_repo` fixtures, which verify that line-count, effective-line, and facade-method growth beyond the recorded ceiling still fails closed.

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -191,6 +191,35 @@ if ! grep -F "effective_lines=1774 exceeds max_effective_lines=1589" "${fail_std
   exit 1
 fi
 
+phase50_12_final_regrowth_repo="${workdir}/phase50-12-final-regrowth"
+create_repo \
+  "${phase50_12_final_regrowth_repo}" \
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.7 issue=#1022" \
+  "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
+    def describe_runtime(self):
+        auth_principal = 'trusted-runtime-boundary'
+        queue_status = {'operator': auth_principal}
+        case_transition = queue_status
+        assistant_recommendation = case_transition
+        action_reconciliation = assistant_recommendation
+        restore_backup_export = action_reconciliation
+        evidence_admission = restore_backup_export
+        return evidence_admission"
+append_repeated_lines "${phase50_12_final_regrowth_repo}" "control-plane/aegisops_control_plane/service.py" "phase50_12_growth_line" 1442
+git -C "${phase50_12_final_regrowth_repo}" add .
+git -C "${phase50_12_final_regrowth_repo}" commit -q -m "phase 50.12 final regrowth past accepted closeout"
+assert_fails_with "${phase50_12_final_regrowth_repo}" "Maintainability hotspot baseline limits were exceeded"
+if ! grep -F "lines=1452 exceeds max_lines=1451" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the Phase 50.12 final line-count limit." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
+if ! grep -F "effective_lines=1452 exceeds max_effective_lines=1294" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the Phase 50.12 final effective-line limit." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
+
 new_hotspot_repo="${workdir}/new-hotspot"
 create_repo \
   "${new_hotspot_repo}" \

--- a/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
@@ -272,6 +272,28 @@ Phase 50.12.6 then moved the remaining reviewed action visibility persistence he
 EOF
 assert_passes "${phase50_12_6_closeout_repo}"
 
+phase50_12_7_closeout_repo="${workdir}/phase50-12-7-closeout"
+create_valid_repo "${phase50_12_7_closeout_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.7 issue=#1022" \
+  >"${phase50_12_7_closeout_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${phase50_12_7_closeout_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.12.7 records the accepted final `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
+
+- `max_lines=1451`
+- `max_effective_lines=1294`
+- `max_facade_methods=100`
+- `phase=50.12.7`
+- `issue=#1022`
+
+The measured Phase 50.12.7 closeout state is:
+
+The baseline is lower than the Phase 50.11.7 ceiling of `max_lines=1812`, `max_effective_lines=1632`, and `max_facade_methods=125`. It also reached the ADR-0009 Phase 50.12 physical-line and effective-line targets of `max_lines <= 1500` and `max_effective_lines <= 1350`, but it did not reach the `max_facade_methods <= 95` target. The retained `100` facade methods are accepted only as an ADR-0003 facade-preservation exception because the remaining public compatibility entrypoints continue to protect existing callers while delegating into extracted boundaries.
+EOF
+assert_passes "${phase50_12_7_closeout_repo}"
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/adr/0009-phase-50-12-service-facade-pressure-contract.md"

--- a/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
@@ -123,14 +123,17 @@ starting_service_baseline_entry="control-plane/aegisops_control_plane/service.py
 phase50_12_4_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1619 max_effective_lines=1445 max_facade_methods=117 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.4 issue=#1019"
 phase50_12_5_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1498 max_effective_lines=1338 max_facade_methods=103 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.5 issue=#1020"
 phase50_12_6_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.6 issue=#1021"
+phase50_12_7_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.7 issue=#1022"
 service_entry="$(grep -Fx -- "${starting_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_4_service_entry="$(grep -Fx -- "${phase50_12_4_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_5_service_entry="$(grep -Fx -- "${phase50_12_5_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_6_service_entry="$(grep -Fx -- "${phase50_12_6_service_baseline_entry}" "${baseline_path}" || true)"
+phase50_12_7_service_entry="$(grep -Fx -- "${phase50_12_7_service_baseline_entry}" "${baseline_path}" || true)"
 service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_4_service_entry_count="$(printf '%s\n' "${phase50_12_4_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_5_service_entry_count="$(printf '%s\n' "${phase50_12_5_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_6_service_entry_count="$(printf '%s\n' "${phase50_12_6_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
+phase50_12_7_service_entry_count="$(printf '%s\n' "${phase50_12_7_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 service_path_entry_count="$(
   awk -v prefix="control-plane/aegisops_control_plane/service.py " \
     'index($0, prefix) == 1 { count += 1 } END { print count + 0 }' \
@@ -204,6 +207,30 @@ if [[ "${phase50_12_6_service_entry_count}" -eq 1 ]]; then
   for phrase in "${phase50_12_6_closeout_phrases[@]}"; do
     if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
       echo "Phase 50.12.6 baseline requires closeout evidence: ${phrase}" >&2
+      exit 1
+    fi
+  done
+  echo "Phase 50.12 service facade pressure contract fixes residual clusters, starting measurements, sub-1500 target ceilings, fallback rules, authority non-goals, migration order, and validation commands."
+  exit 0
+fi
+if [[ "${phase50_12_7_service_entry_count}" -eq 1 ]]; then
+  if [[ ! -f "${closeout_path}" ]]; then
+    echo "Phase 50.12.7 baseline requires docs/phase-50-maintainability-closeout.md evidence." >&2
+    exit 1
+  fi
+  phase50_12_7_closeout_phrases=(
+    "Phase 50.12.7 records the accepted final \`service.py\` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009."
+    "The measured Phase 50.12.7 closeout state is:"
+    "The baseline is lower than the Phase 50.11.7 ceiling of \`max_lines=1812\`, \`max_effective_lines=1632\`, and \`max_facade_methods=125\`. It also reached the ADR-0009 Phase 50.12 physical-line and effective-line targets of \`max_lines <= 1500\` and \`max_effective_lines <= 1350\`, but it did not reach the \`max_facade_methods <= 95\` target. The retained \`100\` facade methods are accepted only as an ADR-0003 facade-preservation exception because the remaining public compatibility entrypoints continue to protect existing callers while delegating into extracted boundaries."
+    "- \`max_lines=1451\`"
+    "- \`max_effective_lines=1294\`"
+    "- \`max_facade_methods=100\`"
+    "- \`phase=50.12.7\`"
+    "- \`issue=#1022\`"
+  )
+  for phrase in "${phase50_12_7_closeout_phrases[@]}"; do
+    if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
+      echo "Phase 50.12.7 baseline requires closeout evidence: ${phrase}" >&2
       exit 1
     fi
   done


### PR DESCRIPTION
## Summary
- refresh the maintainability hotspot baseline to the final Phase 50.12.7/#1022 closeout marker
- record the measured final service facade state: 1451 physical lines, 1294 effective lines, 100 facade methods
- add Phase 50.12 final regrowth coverage and teach the Phase 50.12 contract verifier about the #1022 closeout entry

## Verification
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-phase-50-12-service-facade-pressure-contract.sh`
- `bash scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh`
- `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py control-plane/tests/test_phase49_service_decomposition_closeout.py`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` (902 tests)
- `node dist/index.js issue-lint 1022 --config supervisor.config.aegisops.json` from `<codex-supervisor-root>`

Closes #1022


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated maintainability baseline test assertions and verification procedures
  * Added enhanced test fixtures for service facade pressure contract validation

* **Documentation**
  * Updated maintainability hotspot baseline documentation with new phase closure metadata
  * Updated phase closure documentation with revised metrics and verification procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->