### PR TITLE
Phase 50.13.2 internal caller facade rewiring

### DIFF
--- a/control-plane/aegisops_control_plane/assistant_context.py
+++ b/control-plane/aegisops_control_plane/assistant_context.py
@@ -1198,7 +1198,7 @@ class AssistantContextAssembler:
             ),
             lifecycle_transitions=tuple(
                 self._record_to_dict(transition)
-                for transition in self._service.list_lifecycle_transitions(
+                for transition in self._service._store.list_lifecycle_transitions(
                     record_family,
                     record_id,
                 )

--- a/control-plane/aegisops_control_plane/execution_coordinator.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator.py
@@ -15,15 +15,11 @@ _PHASE26_REVIEWED_COORDINATION_TARGET_TYPES = frozenset(("zammad", "glpi"))
 
 
 class ExecutionCoordinatorServiceDependencies(Protocol):
+    _assistant_advisory_coordinator: object
+    _assistant_context_assembler: object
     _store: object
     _shuffle: object
     _isolated_executor: object
-
-    def inspect_assistant_context(self, record_family: str, record_id: str) -> object:
-        ...
-
-    def render_recommendation_draft(self, record_family: str, record_id: str) -> object:
-        ...
 
     def persist_record(
         self,

--- a/control-plane/aegisops_control_plane/execution_coordinator_action_requests.py
+++ b/control-plane/aegisops_control_plane/execution_coordinator_action_requests.py
@@ -51,14 +51,18 @@ class ReviewedActionRequestCoordinator:
         expires_at = self._service._require_aware_datetime(expires_at, "expires_at")
 
         with self._service._store.transaction():
-            context_snapshot = self._service.inspect_assistant_context(
-                record_family,
-                record_id,
+            context_snapshot = (
+                self._service._assistant_context_assembler.inspect_assistant_context(
+                    record_family,
+                    record_id,
+                )
             )
             self._service._require_reviewed_case_scoped_advisory_read(context_snapshot)
-            recommendation_draft = self._service.render_recommendation_draft(
-                record_family,
-                record_id,
+            recommendation_draft = (
+                self._service._assistant_advisory_coordinator.render_recommendation_draft(
+                    record_family,
+                    record_id,
+                )
             )
             if recommendation_draft.recommendation_draft.get("status") != "ready":
                 raise ValueError(
@@ -241,14 +245,18 @@ class ReviewedActionRequestCoordinator:
         expires_at = self._service._require_aware_datetime(expires_at, "expires_at")
 
         with self._service._store.transaction():
-            context_snapshot = self._service.inspect_assistant_context(
-                record_family,
-                record_id,
+            context_snapshot = (
+                self._service._assistant_context_assembler.inspect_assistant_context(
+                    record_family,
+                    record_id,
+                )
             )
             self._service._require_reviewed_case_scoped_advisory_read(context_snapshot)
-            recommendation_draft = self._service.render_recommendation_draft(
-                record_family,
-                record_id,
+            recommendation_draft = (
+                self._service._assistant_advisory_coordinator.render_recommendation_draft(
+                    record_family,
+                    record_id,
+                )
             )
             if recommendation_draft.recommendation_draft.get("status") != "ready":
                 raise ValueError(

--- a/control-plane/aegisops_control_plane/live_assistant_workflow.py
+++ b/control-plane/aegisops_control_plane/live_assistant_workflow.py
@@ -205,11 +205,9 @@ def phase24_live_assistant_follow_up(status: str) -> str:
 
 
 class LiveAssistantWorkflowServiceDependencies(Protocol):
+    _assistant_context_assembler: object
     _assistant_provider_adapter: object
     _store: object
-
-    def inspect_assistant_context(self, record_family: str, record_id: str) -> object:
-        ...
 
     def persist_record(
         self,
@@ -301,7 +299,12 @@ class LiveAssistantWorkflowCoordinator:
                 f"workflow_task {workflow_task!r} requires record_family {expected_record_family!r}"
             )
 
-        context_snapshot = self._service.inspect_assistant_context(record_family, record_id)
+        context_snapshot = (
+            self._service._assistant_context_assembler.inspect_assistant_context(
+                record_family,
+                record_id,
+            )
+        )
         if workflow_task == "queue_triage_summary":
             self._service._require_reviewed_alert_scoped_queue_summary_read(
                 context_snapshot

--- a/control-plane/aegisops_control_plane/operator_inspection.py
+++ b/control-plane/aegisops_control_plane/operator_inspection.py
@@ -38,8 +38,16 @@ class InspectionStore(Protocol):
     def list(self, record_type: Type[RecordT]) -> tuple[RecordT, ...]:
         ...
 
+    def list_lifecycle_transitions(
+        self,
+        record_family: str,
+        record_id: str,
+    ) -> tuple[LifecycleTransitionRecord, ...]:
+        ...
+
 
 class OperatorInspectionServiceDependencies(Protocol):
+    _assistant_context_assembler: Any
     _store: InspectionStore
 
     def _require_reviewed_operator_alert_record(self, alert: AlertRecord) -> AlertRecord:
@@ -74,21 +82,7 @@ class OperatorInspectionServiceDependencies(Protocol):
 
     _ai_trace_lifecycle_service: Any
 
-    def list_lifecycle_transitions(
-        self,
-        record_family: str,
-        record_id: str,
-    ) -> tuple[LifecycleTransitionRecord, ...]:
-        ...
-
     def _require_non_empty_string(self, value: str, field_name: str) -> str:
-        ...
-
-    def inspect_assistant_context(
-        self,
-        record_family: str,
-        record_id: str,
-    ) -> object:
         ...
 
     def _require_reviewed_operator_case(self, case_id: str) -> CaseRecord:
@@ -764,7 +758,7 @@ class OperatorInspectionReadSurface:
             lineage=lineage,
             lifecycle_transitions=tuple(
                 self._record_to_dict(transition)
-                for transition in self._service.list_lifecycle_transitions(
+                for transition in self._service._store.list_lifecycle_transitions(
                     "alert", alert.alert_id
                 )
             ),
@@ -779,7 +773,12 @@ class OperatorInspectionReadSurface:
     def inspect_case_detail(self, case_id: str) -> object:
         case = self._service._require_reviewed_operator_case(case_id)
         case_id = case.case_id
-        context_snapshot = self._service.inspect_assistant_context("case", case_id)
+        context_snapshot = (
+            self._service._assistant_context_assembler.inspect_assistant_context(
+                "case",
+                case_id,
+            )
+        )
         observation_records = tuple(
             self._record_to_dict(record)
             for record in self._service._observations_for_case(case_id)

--- a/control-plane/tests/test_phase24_live_assistant_fallback_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_fallback_validation.py
@@ -43,7 +43,7 @@ class Phase24LiveAssistantFallbackValidationTests(ServicePersistenceTestBase):
         service._assistant_provider_adapter = mock.Mock()
 
         with mock.patch.object(
-            service,
+            service._assistant_context_assembler,
             "inspect_assistant_context",
             return_value=unresolved_context,
         ):
@@ -124,7 +124,7 @@ class Phase24LiveAssistantFallbackValidationTests(ServicePersistenceTestBase):
         service._assistant_provider_adapter = mock.Mock()
 
         with mock.patch.object(
-            service,
+            service._assistant_context_assembler,
             "inspect_assistant_context",
             return_value=unresolved_context,
         ):
@@ -171,7 +171,7 @@ class Phase24LiveAssistantFallbackValidationTests(ServicePersistenceTestBase):
         service._assistant_provider_adapter = mock.Mock()
 
         with mock.patch.object(
-            service,
+            service._assistant_context_assembler,
             "inspect_assistant_context",
             return_value=unresolved_context,
         ):

--- a/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
@@ -566,7 +566,7 @@ class Phase24LiveAssistantFeedbackLoopValidationTests(ServicePersistenceTestBase
         )
 
         with mock.patch.object(
-            service,
+            service._assistant_context_assembler,
             "inspect_assistant_context",
             return_value=unresolved_context,
         ):
@@ -671,7 +671,7 @@ class Phase24LiveAssistantFeedbackLoopValidationTests(ServicePersistenceTestBase
         )
 
         with mock.patch.object(
-            service,
+            service._assistant_context_assembler,
             "inspect_assistant_context",
             return_value=linked_context,
         ):

--- a/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
@@ -429,7 +429,7 @@ class Phase24LiveAssistantFeedbackLoopValidationTests(ServicePersistenceTestBase
         service._assistant_provider_adapter._prompt_version = "phase24-case-summary-v1"
 
         with mock.patch.object(
-            service,
+            service._assistant_context_assembler,
             "inspect_assistant_context",
             return_value=unresolved_context,
         ):

--- a/control-plane/tests/test_phase50_13_internal_caller_rewiring.py
+++ b/control-plane/tests/test_phase50_13_internal_caller_rewiring.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import ast
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class Phase5013InternalCallerRewiringTests(unittest.TestCase):
+    def _service_facade_delegate_calls(
+        self,
+        relative_path: str,
+        forbidden_methods: set[str],
+    ) -> list[str]:
+        source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=relative_path)
+        calls: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            function = node.func
+            if not isinstance(function, ast.Attribute):
+                continue
+            value = function.value
+            if (
+                isinstance(value, ast.Attribute)
+                and value.attr == "_service"
+                and isinstance(value.value, ast.Name)
+                and value.value.id == "self"
+                and function.attr in forbidden_methods
+            ):
+                calls.append(f"{relative_path}:{node.lineno}:{function.attr}")
+        return calls
+
+    def test_internal_focus_modules_do_not_call_public_facade_delegates(self) -> None:
+        forbidden_methods = {
+            "inspect_assistant_context",
+            "list_lifecycle_transitions",
+            "render_recommendation_draft",
+        }
+        focused_modules = (
+            "control-plane/aegisops_control_plane/assistant_context.py",
+            "control-plane/aegisops_control_plane/execution_coordinator_action_requests.py",
+            "control-plane/aegisops_control_plane/live_assistant_workflow.py",
+            "control-plane/aegisops_control_plane/operator_inspection.py",
+        )
+
+        calls = [
+            call
+            for relative_path in focused_modules
+            for call in self._service_facade_delegate_calls(
+                relative_path,
+                forbidden_methods,
+            )
+        ]
+
+        self.assertEqual(
+            calls,
+            [],
+            "focused internal services must call owning collaborators or stores directly",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Rewire focused internal services away from service facade delegates for assistant context, recommendation drafts, and lifecycle transition reads.
- Add a Phase 50.13 regression that blocks focused modules from calling those public facade delegates internally.
- Keep public facade methods intact where ADR-0010 marks them as external API or CLI dependencies.

## Verification
- python3 -m unittest control-plane/tests/test_phase50_13_internal_caller_rewiring.py control-plane/tests/test_service_persistence_assistant_advisory.py
- python3 -m unittest control-plane/tests/test_execution_coordinator_boundary.py control-plane/tests/test_phase24_live_assistant_surface_validation.py
- python3 -m unittest control-plane/tests/test_cli_inspection_action_reviews.py control-plane/tests/test_cli_inspection_runtime_surface.py
- python3 -m unittest control-plane/tests/test_phase24_live_assistant_fallback_validation.py control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py control-plane/tests/test_phase50_13_internal_caller_rewiring.py
- python3 -m unittest discover -s control-plane/tests -p 'test_*.py'\n- bash scripts/verify-maintainability-hotspots.sh\n- bash scripts/test-verify-maintainability-hotspots.sh\n- npm ci\n- npm test\n- node <codex-supervisor-root>/dist/index.js issue-lint 1032 --config <supervisor-config-path>\n\nCloses #1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal control-plane services now delegate responsibilities to specialized collaborators and the underlying store (e.g., lifecycle transition retrieval), instead of using aggregated service façade methods. User-facing behavior and control flow are unchanged.

* **Tests**
  * Added a static analysis test to enforce architectural boundaries.
  * Updated unit tests to mock the new collaborator interception points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->