### PR TITLE
Phase 50.13.4 compatibility delegate docs

### DIFF
--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -182,6 +182,26 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
                 "reconcile_action_execution",
             ),
         }
+        expected_forwarded_keywords = {
+            "ingest_finding_alert": (
+                "finding_id",
+                "analytic_signal_id",
+                "substrate_detection_record_id",
+                "correlation_key",
+                "first_seen_at",
+                "last_seen_at",
+                "materially_new_work",
+                "reviewed_context",
+            ),
+            "reconcile_action_execution": (
+                "action_request_id",
+                "execution_surface_type",
+                "execution_surface_id",
+                "observed_executions",
+                "compared_at",
+                "stale_after",
+            ),
+        }
 
         for method_name, (attribute_name, target_method_name) in expected_delegates.items():
             with self.subTest(method_name=method_name):
@@ -199,6 +219,17 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
                 self.assertEqual(target.attr, attribute_name)
                 self.assertIsInstance(target.value, ast.Name)
                 self.assertEqual(target.value.id, "self")
+                self.assertEqual(return_value.args, [])
+                forwarded_keywords: list[tuple[str | None, str]] = []
+                for keyword in return_value.keywords:
+                    self.assertIsNotNone(keyword.arg)
+                    self.assertIsInstance(keyword.value, ast.Name)
+                    forwarded_keywords.append((keyword.arg, keyword.value.id))
+                expected_keywords = expected_forwarded_keywords[method_name]
+                self.assertEqual(
+                    forwarded_keywords,
+                    [(keyword, keyword) for keyword in expected_keywords],
+                )
 
     def test_verifier_reports_only_phase50_accepted_hotspot(self) -> None:
         bash_executable = shutil.which("bash")

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -39,6 +39,28 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
                 )
         raise AssertionError(f"{class_name} class not found")
 
+    def _facade_method(self, method_name: str) -> ast.FunctionDef:
+        service_text = self._read("control-plane/aegisops_control_plane/service.py")
+        tree = ast.parse(
+            service_text,
+            filename="control-plane/aegisops_control_plane/service.py",
+        )
+        service_class = next(
+            (
+                node
+                for node in tree.body
+                if isinstance(node, ast.ClassDef)
+                and node.name == "AegisOpsControlPlaneService"
+            ),
+            None,
+        )
+        if service_class is None:
+            raise AssertionError("AegisOpsControlPlaneService class not found")
+        for child in service_class.body:
+            if isinstance(child, ast.FunctionDef) and child.name == method_name:
+                return child
+        raise AssertionError(f"{method_name} method not found")
+
     def _baseline_metadata(self) -> dict[str, str]:
         for line in self._read("docs/maintainability-hotspot-baseline.txt").splitlines():
             stripped = line.strip()
@@ -131,6 +153,52 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "bash scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh",
         ):
             self.assertIn(required, closeout)
+
+    def test_closeout_lists_retained_public_compatibility_delegates(self) -> None:
+        closeout = self._read("docs/phase-50-maintainability-closeout.md")
+
+        for required in (
+            "## Retained Compatibility Delegates",
+            "| `ingest_finding_alert` | `DetectionIntakeService.ingest_finding_alert` |",
+            "| `reconcile_action_execution` | `ActionLifecycleWriteCoordinator.reconcile_action_execution` |",
+            "Both retained delegates must remain narrow single-hop facade methods.",
+            "Remove or reclassify only after every documented caller is rewired to `DetectionIntakeService`",
+            "Remove or reclassify only after every documented caller is rewired to the action lifecycle write boundary",
+            "rejected reconciliation paths still prove durable state stays clean",
+            "must not grow local authorization, provenance, scope, reconciliation, detection, projection, persistence, or durable-state side effects in `service.py`",
+        ):
+            self.assertIn(required, closeout)
+
+    def test_retained_compatibility_delegates_are_single_hop_facade_methods(
+        self,
+    ) -> None:
+        expected_delegates = {
+            "ingest_finding_alert": (
+                "_detection_intake_service",
+                "ingest_finding_alert",
+            ),
+            "reconcile_action_execution": (
+                "_action_lifecycle_write_coordinator",
+                "reconcile_action_execution",
+            ),
+        }
+
+        for method_name, (attribute_name, target_method_name) in expected_delegates.items():
+            with self.subTest(method_name=method_name):
+                method = self._facade_method(method_name)
+                self.assertEqual(len(method.body), 1)
+                statement = method.body[0]
+                self.assertIsInstance(statement, ast.Return)
+                return_value = statement.value
+                self.assertIsInstance(return_value, ast.Call)
+                callee = return_value.func
+                self.assertIsInstance(callee, ast.Attribute)
+                self.assertEqual(callee.attr, target_method_name)
+                target = callee.value
+                self.assertIsInstance(target, ast.Attribute)
+                self.assertEqual(target.attr, attribute_name)
+                self.assertIsInstance(target.value, ast.Name)
+                self.assertEqual(target.value.id, "self")
 
     def test_verifier_reports_only_phase50_accepted_hotspot(self) -> None:
         bash_executable = shutil.which("bash")

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -56,6 +56,17 @@ Phase 50.13.3 then moved owned private guard helpers out of `AegisOpsControlPlan
 
 Those extractions preserve the public service facade. AegisOps control-plane records remain authoritative workflow truth. Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, projections, snapshots, DTOs, and helper-module output remain subordinate context.
 
+## Retained Compatibility Delegates
+
+Phase 50.13.4 consolidates the retained public compatibility delegates that intentionally remain defined directly on `AegisOpsControlPlaneService` after the Phase 50.12 and Phase 50.13 internal rewiring:
+
+| Delegate | Extracted boundary | Retention rationale | Follow-up trigger |
+| --- | --- | --- | --- |
+| `ingest_finding_alert` | `DetectionIntakeService.ingest_finding_alert` | Preserves the public detection-intake facade for existing tests, workflows, and callers while detection intake ownership lives behind `control-plane/aegisops_control_plane/detection_lifecycle.py`. | Remove or reclassify only after every documented caller is rewired to `DetectionIntakeService` or another explicit public detection-intake boundary. |
+| `reconcile_action_execution` | `ActionLifecycleWriteCoordinator.reconcile_action_execution` | Preserves the public action-reconciliation facade for existing reviewed action workflows while reconciliation write authority lives behind the action lifecycle write boundary. | Remove or reclassify only after every documented caller is rewired to the action lifecycle write boundary and rejected reconciliation paths still prove durable state stays clean. |
+
+Both retained delegates must remain narrow single-hop facade methods. They must not grow local authorization, provenance, scope, reconciliation, detection, projection, persistence, or durable-state side effects in `service.py`; those responsibilities belong to the extracted authoritative boundaries. If either delegate needs local logic beyond argument forwarding, the follow-up is a maintainability issue that names the owning boundary instead of silently expanding the facade exception.
+
 ## Follow-Up Trigger
 
 The service facade is below the long-term 1,500-line target, but it remains above the long-term 50-method target. The retained method-count ceiling is therefore an accepted exception, not a success target.


### PR DESCRIPTION
## Summary
- document retained public compatibility delegates in the Phase 50 maintainability closeout
- add focused closeout tests for the retained delegate list and single-hop facade shape

## Verification
- python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py
- bash scripts/verify-phase-50-13-public-facade-inventory-contract.sh
- bash scripts/test-verify-phase-50-13-public-facade-inventory-contract.sh
- bash scripts/verify-maintainability-hotspots.sh
- bash scripts/test-verify-maintainability-hotspots.sh
- python3 -m unittest discover -s control-plane/tests -p 'test_*.py'\n- node <codex-supervisor-root>/dist/index.js issue-lint 1034 --config <supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance listing which compatibility delegate methods remain after Phase 50 closeout and the conditions and constraints for their removal or reclassification.

* **Tests**
  * Strengthened tests to verify retained delegate methods conform to the documented narrow forwarding pattern and adhere to the specified argument and behavior constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->