### PR TITLE
Phase 50.13.5 closeout baseline refresh

### DIFF
--- a/control-plane/tests/test_phase49_service_decomposition_closeout.py
+++ b/control-plane/tests/test_phase49_service_decomposition_closeout.py
@@ -66,8 +66,8 @@ class Phase49ServiceDecompositionCloseoutTests(unittest.TestCase):
         metadata = self._baseline_metadata()
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.13.3")
-        self.assertEqual(metadata["issue"], "#1033")
+        self.assertEqual(metadata["phase"], "50.13.5")
+        self.assertEqual(metadata["issue"], "#1035")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertLessEqual(len(service_text.splitlines()), int(metadata["max_lines"]))
         self.assertLessEqual(

--- a/control-plane/tests/test_phase50_maintainability_closeout.py
+++ b/control-plane/tests/test_phase50_maintainability_closeout.py
@@ -80,8 +80,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
         facade_methods = self._facade_method_count(metadata["facade_class"])
 
         self.assertEqual(metadata["adr_exception"], "ADR-0003")
-        self.assertEqual(metadata["phase"], "50.13.3")
-        self.assertEqual(metadata["issue"], "#1033")
+        self.assertEqual(metadata["phase"], "50.13.5")
+        self.assertEqual(metadata["issue"], "#1035")
         self.assertEqual(metadata["facade_class"], "AegisOpsControlPlaneService")
         self.assertEqual(int(metadata["max_lines"]), physical_lines)
         self.assertEqual(int(metadata["max_effective_lines"]), effective_lines)
@@ -108,6 +108,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "Phase 50.12.6",
             "Phase 50.12.7",
             "Phase 50.13.3",
+            "Phase 50.13.4",
+            "Phase 50.13.5",
             "control-plane/aegisops_control_plane/service.py",
             "control-plane/aegisops_control_plane/case_workflow.py",
             "control-plane/aegisops_control_plane/action_review_write_surface.py",
@@ -120,11 +122,14 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "max_lines=1393",
             "max_effective_lines=1241",
             "max_facade_methods=95",
+            "phase=50.13.5",
+            "issue=#1035",
             "physical_lines=1393",
             "effective_lines=1241",
             "max_lines <= 1500",
             "max_effective_lines <= 1350",
             "max_facade_methods <= 95",
+            "Phase 50.13 target of `AegisOpsControlPlaneService <= 85` methods was not reached",
             "ADR-0007",
             "ADR-0008",
             "ADR-0009",
@@ -138,6 +143,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "#1018",
             "#1019",
             "#1020",
+            "#1034",
+            "#1035",
             "remaining accepted hotspot",
             "facade dispatch, compatibility entrypoints, runtime-boundary guards, and lifecycle/write-path delegates",
             "reviewed action approval policy helpers",
@@ -256,6 +263,7 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "regrowth_repo",
             "phase50_11_regrowth_repo",
             "phase50_12_final_regrowth_repo",
+            "phase50_13_final_regrowth_repo",
             "Maintainability hotspot baseline limits were exceeded",
             "lines=960 exceeds max_lines=959",
             "effective_lines=960 exceeds max_effective_lines=959",
@@ -263,6 +271,8 @@ class Phase50MaintainabilityCloseoutTests(unittest.TestCase):
             "effective_lines=1774 exceeds max_effective_lines=1589",
             "lines=1452 exceeds max_lines=1451",
             "effective_lines=1452 exceeds max_effective_lines=1294",
+            "lines=1394 exceeds max_lines=1393",
+            "effective_lines=1394 exceeds max_effective_lines=1241",
             "max_facade_methods=0",
         ):
             self.assertIn(required, verifier_test)

--- a/docs/maintainability-hotspot-baseline.txt
+++ b/docs/maintainability-hotspot-baseline.txt
@@ -1,13 +1,13 @@
 # Reviewed maintainability hotspot baseline for scripts/verify-maintainability-hotspots.sh.
 # One repo-relative Python path per line. Entries are not exemptions for new responsibility growth.
 #
-# Phase 50.13.3 residual exception:
+# Phase 50.13.5 residual exception:
 # ADR-0008 accepted ordered residual DTO/helper extraction after the
 # Phase 50.10.6 facade floor. ADR-0003 remains the public facade-preservation
 # exception behind AegisOpsControlPlaneService.
 # The facade is now below the long-term 1,500-line target, but it remains above
-# the long-term 50-method target after the Phase 50.13.3 private guard
+# the long-term 50-method target after the Phase 50.13 final private guard
 # relocation slice, so this baseline records the accepted current ceiling and
 # fails on silent re-growth. A future ADR or maintainability backlog must lower
 # or replace these limits before unrelated feature expansion lands in the facade.
-control-plane/aegisops_control_plane/service.py max_lines=1393 max_effective_lines=1241 max_facade_methods=95 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.13.3 issue=#1033
+control-plane/aegisops_control_plane/service.py max_lines=1393 max_effective_lines=1241 max_facade_methods=95 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.13.5 issue=#1035

--- a/docs/phase-50-maintainability-closeout.md
+++ b/docs/phase-50-maintainability-closeout.md
@@ -1,10 +1,10 @@
 # Phase 50 Maintainability Closeout
 
-Phase 50.12.7 records the accepted final `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence and the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, and ADR-0009.
+Phase 50.13.5 records the accepted final `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence, the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions, and the Phase 50.13 facade inventory, internal rewiring, private guard relocation, and compatibility delegate consolidation work governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, ADR-0009, and ADR-0010.
 
 This closeout is validation and documentation only. It does not change runtime behavior, public APIs, approval, execution, reconciliation, assistant, ticket, ML, endpoint, network, browser, optional-evidence, restore, readiness, or operator authority.
 
-ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0005 governs the Phase 50.8 residual service migration contract. ADR-0006 governs the Phase 50.9 residual facade convergence and projection guard. ADR-0007 governs the Phase 50.10 facade floor and external-evidence guard. ADR-0008 governs the Phase 50.11 residual DTO/helper extraction order. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
+ADR-0004 governs the Phase 50 migration order and closeout validation. ADR-0005 governs the Phase 50.8 residual service migration contract. ADR-0006 governs the Phase 50.9 residual facade convergence and projection guard. ADR-0007 governs the Phase 50.10 facade floor and external-evidence guard. ADR-0008 governs the Phase 50.11 residual DTO/helper extraction order. ADR-0010 governs the Phase 50.13 public facade inventory and compatibility policy. ADR-0003 remains the facade-preservation exception authority for the remaining `service.py` baseline entry.
 
 ## Accepted Verifier State
 
@@ -12,23 +12,23 @@ The maintainability verifier still reports one remaining accepted hotspot:
 
 - `control-plane/aegisops_control_plane/service.py`
 
-That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work accepted in #1007. Phase 50.12.2 for #1017 further extracted constructor composition assignment pressure, Phase 50.12.3 for #1018 moved reviewed action approval policy helper pressure into the action-review write surface, Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade, Phase 50.12.5 for #1020 moved assistant residual lifecycle helper delegates out of the service facade and onto the extracted AI trace lifecycle boundary, and Phase 50.12.6 for #1021 moved reviewed action visibility persistence helpers into the action-review write surface while retaining public detection intake and action reconciliation facade delegates. Phase 50.13.3 for #1033 moved the remaining owned case-detail, alert-projection, and reviewed action-request binding guards into `control-plane/aegisops_control_plane/operator_inspection.py` and `control-plane/aegisops_control_plane/execution_coordinator_action_requests.py`. The accepted residual ceiling is:
+That result is expected because `AegisOpsControlPlaneService` remains the public facade after the Phase 50.11 DTO/snapshot, runtime-event, action-review inspection, assistant-advisory, and detection/case-linkage helper extraction work accepted in #1007. Phase 50.12.2 for #1017 further extracted constructor composition assignment pressure, Phase 50.12.3 for #1018 moved reviewed action approval policy helper pressure into the action-review write surface, Phase 50.12.4 for #1019 fenced casework write compatibility delegates behind the case workflow facade, Phase 50.12.5 for #1020 moved assistant residual lifecycle helper delegates out of the service facade and onto the extracted AI trace lifecycle boundary, and Phase 50.12.6 for #1021 moved reviewed action visibility persistence helpers into the action-review write surface while retaining public detection intake and action reconciliation facade delegates. Phase 50.13.3 for #1033 moved the remaining owned case-detail, alert-projection, and reviewed action-request binding guards into `control-plane/aegisops_control_plane/operator_inspection.py` and `control-plane/aegisops_control_plane/execution_coordinator_action_requests.py`. Phase 50.13.4 for #1034 then consolidated the retained public compatibility delegate evidence without changing the final measured facade size. Phase 50.13.5 for #1035 records that final accepted Phase 50.13 state. The accepted residual ceiling is:
 
 - `max_lines=1393`
 - `max_effective_lines=1241`
 - `max_facade_methods=95`
 - `facade_class=AegisOpsControlPlaneService`
 - `adr_exception=ADR-0003`
-- `phase=50.13.3`
-- `issue=#1033`
+- `phase=50.13.5`
+- `issue=#1035`
 
-The measured Phase 50.13.3 closeout state is:
+The measured Phase 50.13.5 closeout state is:
 
 - `physical_lines=1393`
 - `effective_lines=1241`
 - `AegisOpsControlPlaneService methods=95`
 
-The baseline is lower than the Phase 50.11.7 ceiling of `max_lines=1812`, `max_effective_lines=1632`, and `max_facade_methods=125`. It also reached the ADR-0009 Phase 50.12 physical-line, effective-line, and method-count targets of `max_lines <= 1500`, `max_effective_lines <= 1350`, and `max_facade_methods <= 95`. The retained `95` facade methods are accepted only as an ADR-0003 facade-preservation exception because the remaining public compatibility entrypoints continue to protect existing callers while delegating into extracted boundaries.
+The baseline is lower than the Phase 50.11.7 ceiling of `max_lines=1812`, `max_effective_lines=1632`, and `max_facade_methods=125`. It also reached the ADR-0009 Phase 50.12 physical-line, effective-line, and method-count targets of `max_lines <= 1500`, `max_effective_lines <= 1350`, and `max_facade_methods <= 95`. The Phase 50.13 target of `AegisOpsControlPlaneService <= 85` methods was not reached safely; the retained `95` facade methods are accepted only as an ADR-0003 facade-preservation exception because the remaining public compatibility entrypoints continue to protect existing callers while delegating into extracted boundaries.
 
 No additional baseline entry is recorded for restore validation, HTTP surface, assistant, detection, operator inspection, operator UI route tests, `control-plane/aegisops_control_plane/action_review_projection.py`, or `control-plane/aegisops_control_plane/external_evidence_boundary.py` because the verifier does not report those areas as current responsibility-growth candidates. The earlier Phase 50.9 projection measurement was `projection lines=105` and `projection effective_lines=103`, so the projection split does not require a baseline entry. The earlier Phase 50.10 external-evidence measurement was `external_evidence_boundary.py lines=216` and `external_evidence_boundary.py effective_lines=195`, so the external-evidence split does not require a baseline entry.
 
@@ -53,6 +53,8 @@ Phase 50.12.5 then removed the remaining assistant residual lifecycle helper del
 Phase 50.12.6 then moved the remaining reviewed action visibility persistence helpers out of `AegisOpsControlPlaneService` and into `control-plane/aegisops_control_plane/action_review_write_surface.py`, preserving manual fallback, escalation-note, approval-decision, detection intake, and action execution reconciliation behavior. `ingest_finding_alert` and `reconcile_action_execution` remain public facade delegates because callers rely on those compatibility entrypoints; their implementation bodies remain single-hop delegates to the extracted detection intake and action lifecycle boundaries.
 
 Phase 50.13.3 then moved owned private guard helpers out of `AegisOpsControlPlaneService`: `_observations_for_case`, `_leads_for_case`, and `_alert_review_state` now live with `OperatorInspectionReadSurface`; `_require_single_linked_case_id` and `_require_single_recommendation_binding` now live with `ReviewedActionRequestCoordinator`. This lowers the previous #1022 Phase 50.12.7 ceiling without changing public facade behavior. The relocation preserves exception text and keeps shared facade-boundary guards such as identifier allocation and reviewed-slice policy checks on the service until their direct caller evidence supports a narrower owner.
+
+Phase 50.13.4 then documented the retained public compatibility delegates for #1034. It did not reduce the facade below 95 methods, but it closed the caller-evidence question by identifying `ingest_finding_alert` and `reconcile_action_execution` as intentionally retained delegates rather than unresolved extraction misses.
 
 Those extractions preserve the public service facade. AegisOps control-plane records remain authoritative workflow truth. Tickets, assistant output, ML, endpoint evidence, network evidence, browser state, receipts, optional extension status, Wazuh, Shuffle, Zammad, operator-facing summaries, badges, counters, projections, snapshots, DTOs, and helper-module output remain subordinate context.
 
@@ -87,4 +89,4 @@ Run:
 - `bash scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh`
 - `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py`
 
-The focused negative verifier coverage remains in `scripts/test-verify-maintainability-hotspots.sh` through the `regrowth_repo`, `phase50_11_regrowth_repo`, and `phase50_12_final_regrowth_repo` fixtures, which verify that line-count, effective-line, and facade-method growth beyond the recorded ceiling still fails closed.
+The focused negative verifier coverage remains in `scripts/test-verify-maintainability-hotspots.sh` through the `regrowth_repo`, `phase50_11_regrowth_repo`, `phase50_12_final_regrowth_repo`, and `phase50_13_final_regrowth_repo` fixtures, which verify that line-count, effective-line, and facade-method growth beyond the recorded ceiling still fails closed.

--- a/scripts/test-verify-maintainability-hotspots.sh
+++ b/scripts/test-verify-maintainability-hotspots.sh
@@ -220,6 +220,35 @@ if ! grep -F "effective_lines=1452 exceeds max_effective_lines=1294" "${fail_std
   exit 1
 fi
 
+phase50_13_final_regrowth_repo="${workdir}/phase50-13-final-regrowth"
+create_repo \
+  "${phase50_13_final_regrowth_repo}" \
+  "docs/maintainability-hotspot-baseline.txt" "control-plane/aegisops_control_plane/service.py max_lines=1393 max_effective_lines=1241 max_facade_methods=95 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.13.5 issue=#1035" \
+  "control-plane/aegisops_control_plane/service.py" "class AegisOpsControlPlaneService:
+    def describe_runtime(self):
+        auth_principal = 'trusted-runtime-boundary'
+        queue_status = {'operator': auth_principal}
+        case_transition = queue_status
+        assistant_recommendation = case_transition
+        action_reconciliation = assistant_recommendation
+        restore_backup_export = action_reconciliation
+        evidence_admission = restore_backup_export
+        return evidence_admission"
+append_repeated_lines "${phase50_13_final_regrowth_repo}" "control-plane/aegisops_control_plane/service.py" "phase50_13_growth_line" 1384
+git -C "${phase50_13_final_regrowth_repo}" add .
+git -C "${phase50_13_final_regrowth_repo}" commit -q -m "phase 50.13 final regrowth past accepted closeout"
+assert_fails_with "${phase50_13_final_regrowth_repo}" "Maintainability hotspot baseline limits were exceeded"
+if ! grep -F "lines=1394 exceeds max_lines=1393" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the Phase 50.13 final line-count limit." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
+if ! grep -F "effective_lines=1394 exceeds max_effective_lines=1241" "${fail_stderr}" >/dev/null; then
+  echo "Expected failure output to report the Phase 50.13 final effective-line limit." >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
+
 new_hotspot_repo="${workdir}/new-hotspot"
 create_repo \
   "${new_hotspot_repo}" \

--- a/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
@@ -312,9 +312,21 @@ Phase 50.13.5 records the accepted final `service.py` residual closeout after th
 
 The measured Phase 50.13.5 closeout state is:
 
+- `physical_lines=1393`
+- `effective_lines=1241`
+- `AegisOpsControlPlaneService methods=95`
+
 The Phase 50.13 target of `AegisOpsControlPlaneService <= 85` methods was not reached safely; the retained `95` facade methods are accepted only as an ADR-0003 facade-preservation exception because the remaining public compatibility entrypoints continue to protect existing callers while delegating into extracted boundaries.
 EOF
 assert_passes "${phase50_13_5_closeout_repo}"
+
+phase50_13_5_missing_measured_evidence_repo="${workdir}/phase50-13-5-missing-measured-evidence"
+cp -R "${phase50_13_5_closeout_repo}" "${phase50_13_5_missing_measured_evidence_repo}"
+perl -0pi -e 's/- `AegisOpsControlPlaneService methods=95`\n//g' \
+  "${phase50_13_5_missing_measured_evidence_repo}/docs/phase-50-maintainability-closeout.md"
+assert_fails_with \
+  "${phase50_13_5_missing_measured_evidence_repo}" \
+  "Phase 50.13.5 baseline requires closeout evidence: - \`AegisOpsControlPlaneService methods=95\`"
 
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"

--- a/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh
@@ -294,6 +294,28 @@ The baseline is lower than the Phase 50.11.7 ceiling of `max_lines=1812`, `max_e
 EOF
 assert_passes "${phase50_12_7_closeout_repo}"
 
+phase50_13_5_closeout_repo="${workdir}/phase50-13-5-closeout"
+create_valid_repo "${phase50_13_5_closeout_repo}"
+printf '%s\n' \
+  "control-plane/aegisops_control_plane/service.py max_lines=1393 max_effective_lines=1241 max_facade_methods=95 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.13.5 issue=#1035" \
+  >"${phase50_13_5_closeout_repo}/docs/maintainability-hotspot-baseline.txt"
+cat >"${phase50_13_5_closeout_repo}/docs/phase-50-maintainability-closeout.md" <<'EOF'
+# Phase 50 Maintainability Closeout
+
+Phase 50.13.5 records the accepted final `service.py` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence, the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions, and the Phase 50.13 facade inventory, internal rewiring, private guard relocation, and compatibility delegate consolidation work governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, ADR-0009, and ADR-0010.
+
+- `max_lines=1393`
+- `max_effective_lines=1241`
+- `max_facade_methods=95`
+- `phase=50.13.5`
+- `issue=#1035`
+
+The measured Phase 50.13.5 closeout state is:
+
+The Phase 50.13 target of `AegisOpsControlPlaneService <= 85` methods was not reached safely; the retained `95` facade methods are accepted only as an ADR-0003 facade-preservation exception because the remaining public compatibility entrypoints continue to protect existing callers while delegating into extracted boundaries.
+EOF
+assert_passes "${phase50_13_5_closeout_repo}"
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/adr/0009-phase-50-12-service-facade-pressure-contract.md"

--- a/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
@@ -124,16 +124,19 @@ phase50_12_4_service_baseline_entry="control-plane/aegisops_control_plane/servic
 phase50_12_5_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1498 max_effective_lines=1338 max_facade_methods=103 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.5 issue=#1020"
 phase50_12_6_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.6 issue=#1021"
 phase50_12_7_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1451 max_effective_lines=1294 max_facade_methods=100 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.12.7 issue=#1022"
+phase50_13_5_service_baseline_entry="control-plane/aegisops_control_plane/service.py max_lines=1393 max_effective_lines=1241 max_facade_methods=95 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.13.5 issue=#1035"
 service_entry="$(grep -Fx -- "${starting_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_4_service_entry="$(grep -Fx -- "${phase50_12_4_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_5_service_entry="$(grep -Fx -- "${phase50_12_5_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_6_service_entry="$(grep -Fx -- "${phase50_12_6_service_baseline_entry}" "${baseline_path}" || true)"
 phase50_12_7_service_entry="$(grep -Fx -- "${phase50_12_7_service_baseline_entry}" "${baseline_path}" || true)"
+phase50_13_5_service_entry="$(grep -Fx -- "${phase50_13_5_service_baseline_entry}" "${baseline_path}" || true)"
 service_entry_count="$(printf '%s\n' "${service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_4_service_entry_count="$(printf '%s\n' "${phase50_12_4_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_5_service_entry_count="$(printf '%s\n' "${phase50_12_5_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_6_service_entry_count="$(printf '%s\n' "${phase50_12_6_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 phase50_12_7_service_entry_count="$(printf '%s\n' "${phase50_12_7_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
+phase50_13_5_service_entry_count="$(printf '%s\n' "${phase50_13_5_service_entry}" | sed '/^$/d' | wc -l | tr -d ' ')"
 service_path_entry_count="$(
   awk -v prefix="control-plane/aegisops_control_plane/service.py " \
     'index($0, prefix) == 1 { count += 1 } END { print count + 0 }' \
@@ -231,6 +234,30 @@ if [[ "${phase50_12_7_service_entry_count}" -eq 1 ]]; then
   for phrase in "${phase50_12_7_closeout_phrases[@]}"; do
     if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
       echo "Phase 50.12.7 baseline requires closeout evidence: ${phrase}" >&2
+      exit 1
+    fi
+  done
+  echo "Phase 50.12 service facade pressure contract fixes residual clusters, starting measurements, sub-1500 target ceilings, fallback rules, authority non-goals, migration order, and validation commands."
+  exit 0
+fi
+if [[ "${phase50_13_5_service_entry_count}" -eq 1 ]]; then
+  if [[ ! -f "${closeout_path}" ]]; then
+    echo "Phase 50.13.5 baseline requires docs/phase-50-maintainability-closeout.md evidence." >&2
+    exit 1
+  fi
+  phase50_13_5_closeout_phrases=(
+    "Phase 50.13.5 records the accepted final \`service.py\` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence, the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions, and the Phase 50.13 facade inventory, internal rewiring, private guard relocation, and compatibility delegate consolidation work governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, ADR-0009, and ADR-0010."
+    "The measured Phase 50.13.5 closeout state is:"
+    "The Phase 50.13 target of \`AegisOpsControlPlaneService <= 85\` methods was not reached safely; the retained \`95\` facade methods are accepted only as an ADR-0003 facade-preservation exception because the remaining public compatibility entrypoints continue to protect existing callers while delegating into extracted boundaries."
+    "- \`max_lines=1393\`"
+    "- \`max_effective_lines=1241\`"
+    "- \`max_facade_methods=95\`"
+    "- \`phase=50.13.5\`"
+    "- \`issue=#1035\`"
+  )
+  for phrase in "${phase50_13_5_closeout_phrases[@]}"; do
+    if ! grep -Fq -- "${phrase}" "${closeout_path}"; then
+      echo "Phase 50.13.5 baseline requires closeout evidence: ${phrase}" >&2
       exit 1
     fi
   done

--- a/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
+++ b/scripts/verify-phase-50-12-service-facade-pressure-contract.sh
@@ -248,6 +248,9 @@ if [[ "${phase50_13_5_service_entry_count}" -eq 1 ]]; then
   phase50_13_5_closeout_phrases=(
     "Phase 50.13.5 records the accepted final \`service.py\` residual closeout after the Phase 50.11.7 ordered DTO/helper extraction sequence, the Phase 50.12.2/50.12.3/50.12.4/50.12.5/50.12.6 facade-pressure reductions, and the Phase 50.13 facade inventory, internal rewiring, private guard relocation, and compatibility delegate consolidation work governed by ADR-0004, ADR-0005, ADR-0006, ADR-0007, ADR-0008, ADR-0009, and ADR-0010."
     "The measured Phase 50.13.5 closeout state is:"
+    "- \`physical_lines=1393\`"
+    "- \`effective_lines=1241\`"
+    "- \`AegisOpsControlPlaneService methods=95\`"
     "The Phase 50.13 target of \`AegisOpsControlPlaneService <= 85\` methods was not reached safely; the retained \`95\` facade methods are accepted only as an ADR-0003 facade-preservation exception because the remaining public compatibility entrypoints continue to protect existing callers while delegating into extracted boundaries."
     "- \`max_lines=1393\`"
     "- \`max_effective_lines=1241\`"


### PR DESCRIPTION
## Summary
- refresh the maintainability hotspot baseline to the accepted Phase 50.13.5/#1035 state: `service.py` remains 1393 physical lines, 1241 effective lines, and 95 facade methods
- update closeout evidence to state the Phase 50.13 <=85-method target was not safely reached and document retained compatibility delegates as the accepted residual exception
- add Phase 50.13 final regrowth coverage and update legacy Phase 50.12 verifier/tests to accept the later closeout only with explicit evidence

## Verification
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-phase-50-12-service-facade-pressure-contract.sh`
- `bash scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh`
- `bash scripts/verify-phase-50-13-public-facade-inventory-contract.sh`
- `bash scripts/test-verify-phase-50-13-public-facade-inventory-contract.sh`
- `python3 -m unittest control-plane/tests/test_phase49_service_decomposition_closeout.py`
- `python3 -m unittest control-plane/tests/test_phase50_maintainability_closeout.py`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` (906 tests)
- `node dist/index.js issue-lint 1035 --config supervisor.config.aegisops.json` from `<codex-supervisor-root>`

Closes #1035


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated expectations to reference Phase 50.13.5 (issue #1035) and added regression/negative cases to validate hotspot threshold and closeout evidence.
* **Documentation**
  * Revised maintainability baseline and closeout docs to record Phase 50.13.5 and related phase compatibility notes (including Phase 50.13.4/#1034).
* **Chores**
  * Enhanced verification scripts to detect Phase 50.13.5 baselines and enforce closeout evidence and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->