### PR TITLE
Phase 51.1 replacement boundary ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Current scope:
 Canonical cross-phase boundary reference:
 
 - `docs/non-goals-and-expansion-guardrails.md`
+- `docs/adr/0011-phase-51-1-replacement-boundary.md` defines the Phase 51.1 SMB SecOps replacement boundary: AegisOps replaces the operating experience above Wazuh and Shuffle, not their internals or every SIEM/SOAR capability.
 
 Phase 44-47 closure contracts:
 

--- a/docs/adr/0011-phase-51-1-replacement-boundary.md
+++ b/docs/adr/0011-phase-51-1-replacement-boundary.md
@@ -1,0 +1,128 @@
+# ADR-0011: Phase 51.1 SMB SecOps Replacement Boundary
+
+- **Status**: Accepted
+- **Date**: 2026-04-30
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/requirements-baseline.md`, `docs/adr/0002-wazuh-shuffle-control-plane-thesis.md`
+- **Product**: AegisOps
+- **Related Issues**: #1041, #1042
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+---
+
+## 1. Context
+
+ADR-0002 defines AegisOps as a governed SecOps decision and execution control plane above Wazuh and Shuffle. Phase 51 needs sharper replacement wording so README positioning and follow-on materials can say what AegisOps replaces without weakening that authority boundary.
+
+The risk is two-sided:
+
+- under-claiming leaves SMB buyers and operators with no clear operating-experience replacement story; and
+- over-claiming makes AegisOps sound like it reimplements Wazuh, Shuffle, or every SIEM/SOAR capability.
+
+This ADR fixes the product-language boundary only. It does not change runtime behavior, substrate integrations, approval policy, reconciliation policy, packaging, release state, or general availability scope.
+
+## 2. Decision
+
+AegisOps replaces the SMB SecOps operating experience, not Wazuh internals, Shuffle internals, or every SIEM and SOAR capability.
+
+Replacement means the reviewed operator experience for daily SMB SOC work: Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
+
+The replacement boundary is the working surface and record chain used by an SMB security operator to review signals, manage alerts and cases, attach evidence, approve actions, delegate routine execution, reconcile results, audit the work, and prove release readiness.
+
+AegisOps must not use replacement language to claim control over detection engines, correlation internals, workflow-engine internals, or unimplemented breadth.
+
+## 3. Allowed Replacement Claims
+
+- Allowed claim: AegisOps can replace the daily SMB SOC operating experience above Wazuh and Shuffle.
+- Allowed claim: AegisOps can replace ad hoc ticket-and-script coordination with authoritative alert, case, approval, action request, receipt, reconciliation, audit, and release records.
+- Allowed claim: AegisOps can provide a governed SIEM/SOAR operating layer for SMB teams when Wazuh and Shuffle provide the reviewed substrate capabilities.
+
+The allowed wording may describe an SMB SOC/SIEM/SOAR replacement experience only when the sentence keeps Wazuh and Shuffle in their substrate roles and keeps AegisOps records as workflow truth.
+
+## 4. Disallowed Replacement Claims
+
+- Disallowed claim: AegisOps already replaces every SIEM capability.
+- Disallowed claim: AegisOps already replaces every SOAR capability.
+- Disallowed claim: AegisOps reimplements Wazuh detection internals.
+- Disallowed claim: AegisOps reimplements Shuffle workflow internals.
+
+The disallowed wording also includes claims that AegisOps makes external substrate state authoritative, that the assistant can operate as an autonomous SOC, or that pilot artifacts imply release-candidate or general-availability breadth.
+
+## 5. Authority Boundary
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, and release truth.
+
+AI must not approve actions, execute actions, reconcile execution, close cases, activate detectors, or become source truth.
+
+Wazuh alert status is not AegisOps case truth.
+
+Shuffle workflow success is not AegisOps reconciliation truth.
+
+Tickets, evidence systems, browser state, UI cache, downstream receipts, demo data, Wazuh, Shuffle, and AI output remain subordinate context.
+
+This ADR rejects any shortcut that promotes subordinate surfaces into AegisOps workflow truth.
+
+Derived summaries, status badges, projections, dashboards, detail DTOs, operator-facing text, and downstream receipts must be recalculated from or linked back to authoritative AegisOps records. If they drift, the projection must be repaired; the authoritative record chain must not be redefined around the projection.
+
+## 6. Substrate Responsibilities
+
+Wazuh is the detection substrate.
+
+Shuffle is the routine automation substrate.
+
+Wazuh may detect, classify, and expose upstream security signal state. AegisOps must admit that signal through reviewed intake and explicit linkage before it becomes AegisOps alert, case, evidence, audit, release, or reconciliation truth.
+
+Shuffle may execute reviewed delegated routine work. AegisOps must record action intent, approval, delegation, execution receipt, reconciliation, and mismatch handling as its own authoritative workflow records.
+
+Future substrate changes may replace Wazuh or Shuffle only through a later accepted ADR or scoped implementation issue. A substrate change must not change the replacement boundary by implication.
+
+## 7. Implementation Impact
+
+This ADR does not implement CLI behavior, Wazuh profile generation, Shuffle profile generation, AI daily operations, SIEM breadth, SOAR breadth, packaging, release-candidate behavior, or general-availability behavior.
+
+Phase 51.2 may update README positioning against this ADR, but it must preserve this boundary: AegisOps replaces the SMB SecOps operating experience above Wazuh and Shuffle, not their internals or every SIEM/SOAR capability.
+
+Follow-on docs may cite this ADR when they need allowed replacement wording, disallowed replacement wording, or authority-boundary language for product positioning.
+
+## 8. Security Impact
+
+The security posture is unchanged by this documentation contract. The ADR narrows language that could otherwise become unsafe implementation pressure.
+
+Approval, execution, reconciliation, case closure, detector activation, source truth, and release truth remain explicit AegisOps control-plane responsibilities. External products and AI assistance remain untrusted or subordinate until admitted through the reviewed boundary that owns the authoritative record.
+
+This ADR reinforces fail-closed review: missing, malformed, or partial signals from AI, Wazuh, Shuffle, tickets, evidence systems, browser state, UI cache, downstream receipts, or demo data must not be promoted into workflow truth.
+
+## 9. Rollback / Exit Strategy
+
+Rollback is required if replacement wording causes reviewers or operators to treat AegisOps as a reimplementation of Wazuh, Shuffle, or every SIEM/SOAR capability.
+
+The rollback path is to supersede this ADR with a narrower accepted ADR and remove README or roadmap language that cites the broader replacement boundary.
+
+Rollback does not require runtime migration because this ADR does not change runtime behavior or write durable records.
+
+## 10. Validation
+
+Run `bash scripts/verify-phase-51-1-replacement-boundary-adr.sh`.
+
+Run `bash scripts/test-verify-phase-51-1-replacement-boundary-adr.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1042 --config <supervisor-config-path>`.
+
+The verifier must fail when allowed or disallowed claim wording is missing, when the ADR claims AegisOps already replaces every SIEM/SOAR capability, or when the ADR promotes AI, Wazuh, Shuffle, tickets, evidence systems, browser state, UI cache, downstream receipts, or demo data into authority.
+
+## 11. Non-Goals
+
+- No runtime behavior changes are approved by this ADR.
+- No CLI, Wazuh profile generation, Shuffle profile generation, AI daily operations, SIEM breadth, SOAR breadth, packaging, release-candidate, or general-availability behavior is implemented or approved.
+- No Wazuh internals, Shuffle internals, detector engine behavior, workflow engine behavior, ticket behavior, evidence-system behavior, browser behavior, UI cache behavior, downstream receipt behavior, or demo-data behavior becomes authoritative workflow truth.
+- No AI approval, AI execution, AI reconciliation, AI case closure, AI detector activation, or AI source-truth authority is approved.
+- No Wazuh alert status becomes case truth.
+- No Shuffle workflow success becomes reconciliation truth.
+
+## 12. Approval
+
+- **Proposed By**: Codex for Issue #1042
+- **Reviewed By**: AegisOps maintainers
+- **Approved By**: AegisOps maintainers
+- **Approval Date**: 2026-04-30

--- a/scripts/test-verify-phase-51-1-replacement-boundary-adr.sh
+++ b/scripts/test-verify-phase-51-1-replacement-boundary-adr.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-51-1-replacement-boundary-adr.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+write_phase511_adr() {
+  local target="$1"
+  local content="$2"
+
+  mkdir -p "${target}/docs/adr"
+  printf '%s\n' "${content}" >"${target}/docs/adr/0011-phase-51-1-replacement-boundary.md"
+}
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}"
+  printf '%s\n' "# AegisOps" "See docs/adr/0011-phase-51-1-replacement-boundary.md." >"${target}/README.md"
+
+  write_phase511_adr "${target}" '# ADR-0011: Phase 51.1 SMB SecOps Replacement Boundary
+
+- **Status**: Accepted
+- **Date**: 2026-04-30
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/requirements-baseline.md`
+- **Product**: AegisOps
+- **Related Issues**: #1041, #1042
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+## 1. Context
+
+Phase 51 needs replacement wording that preserves the AegisOps control-plane authority boundary.
+
+## 2. Decision
+
+AegisOps replaces the SMB SecOps operating experience, not Wazuh internals, Shuffle internals, or every SIEM and SOAR capability.
+
+Replacement means the reviewed operator experience for daily SMB SOC work: Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
+
+## 3. Allowed Replacement Claims
+
+- Allowed claim: AegisOps can replace the daily SMB SOC operating experience above Wazuh and Shuffle.
+- Allowed claim: AegisOps can replace ad hoc ticket-and-script coordination with authoritative alert, case, approval, action request, receipt, reconciliation, audit, and release records.
+- Allowed claim: AegisOps can provide a governed SIEM/SOAR operating layer for SMB teams when Wazuh and Shuffle provide the reviewed substrate capabilities.
+
+## 4. Disallowed Replacement Claims
+
+- Disallowed claim: AegisOps already replaces every SIEM capability.
+- Disallowed claim: AegisOps already replaces every SOAR capability.
+- Disallowed claim: AegisOps reimplements Wazuh detection internals.
+- Disallowed claim: AegisOps reimplements Shuffle workflow internals.
+
+## 5. Authority Boundary
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, and release truth.
+
+AI must not approve actions, execute actions, reconcile execution, close cases, activate detectors, or become source truth.
+
+Wazuh alert status is not AegisOps case truth.
+
+Shuffle workflow success is not AegisOps reconciliation truth.
+
+Tickets, evidence systems, browser state, UI cache, downstream receipts, demo data, Wazuh, Shuffle, and AI output remain subordinate context.
+
+This ADR rejects any shortcut that promotes subordinate surfaces into AegisOps workflow truth.
+
+## 6. Substrate Responsibilities
+
+Wazuh is the detection substrate.
+
+Shuffle is the routine automation substrate.
+
+## 7. Implementation Impact
+
+This ADR does not implement CLI behavior, Wazuh profile generation, Shuffle profile generation, AI daily operations, SIEM breadth, SOAR breadth, packaging, release-candidate behavior, or general-availability behavior.
+
+## 8. Security Impact
+
+Authority remains in AegisOps records.
+
+## 9. Rollback / Exit Strategy
+
+Supersede this ADR if replacement wording changes.
+
+## 10. Validation
+
+Run `bash scripts/verify-phase-51-1-replacement-boundary-adr.sh`.
+Run `bash scripts/test-verify-phase-51-1-replacement-boundary-adr.sh`.
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1042 --config <supervisor-config-path>`.
+
+## 11. Non-Goals
+
+No runtime behavior changes are approved by this ADR.
+
+## 12. Approval
+
+- **Proposed By**: Codex for Issue #1042
+- **Reviewed By**: AegisOps maintainers
+- **Approved By**: AegisOps maintainers
+- **Approval Date**: 2026-04-30'
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_adr_repo="${workdir}/missing-adr"
+create_valid_repo "${missing_adr_repo}"
+rm "${missing_adr_repo}/docs/adr/0011-phase-51-1-replacement-boundary.md"
+assert_fails_with \
+  "${missing_adr_repo}" \
+  "Missing Phase 51.1 replacement boundary ADR"
+
+missing_allowed_claim_repo="${workdir}/missing-allowed-claim"
+create_valid_repo "${missing_allowed_claim_repo}"
+perl -0pi -e 's#- Allowed claim: AegisOps can provide a governed SIEM/SOAR operating layer for SMB teams when Wazuh and Shuffle provide the reviewed substrate capabilities\.\n##' \
+  "${missing_allowed_claim_repo}/docs/adr/0011-phase-51-1-replacement-boundary.md"
+assert_fails_with \
+  "${missing_allowed_claim_repo}" \
+  "Missing Phase 51.1 replacement boundary ADR statement: Allowed claim: AegisOps can provide a governed SIEM/SOAR operating layer for SMB teams when Wazuh and Shuffle provide the reviewed substrate capabilities."
+
+missing_disallowed_claim_repo="${workdir}/missing-disallowed-claim"
+create_valid_repo "${missing_disallowed_claim_repo}"
+perl -0pi -e 's#- Disallowed claim: AegisOps already replaces every SOAR capability\.\n##' \
+  "${missing_disallowed_claim_repo}/docs/adr/0011-phase-51-1-replacement-boundary.md"
+assert_fails_with \
+  "${missing_disallowed_claim_repo}" \
+  "Missing Phase 51.1 replacement boundary ADR statement: Disallowed claim: AegisOps already replaces every SOAR capability."
+
+forbidden_claim_repo="${workdir}/forbidden-claim"
+create_valid_repo "${forbidden_claim_repo}"
+printf '%s\n' "Allowed claim: AegisOps already replaces every SIEM capability" >>"${forbidden_claim_repo}/docs/adr/0011-phase-51-1-replacement-boundary.md"
+assert_fails_with \
+  "${forbidden_claim_repo}" \
+  "Forbidden Phase 51.1 replacement boundary ADR claim: Allowed claim: AegisOps already replaces every SIEM capability"
+
+missing_authority_repo="${workdir}/missing-authority"
+create_valid_repo "${missing_authority_repo}"
+perl -0pi -e 's#Wazuh alert status is not AegisOps case truth\.\n##' \
+  "${missing_authority_repo}/docs/adr/0011-phase-51-1-replacement-boundary.md"
+assert_fails_with \
+  "${missing_authority_repo}" \
+  "Missing Phase 51.1 replacement boundary ADR statement: Wazuh alert status is not AegisOps case truth."
+
+missing_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_link_repo}/README.md"
+assert_fails_with \
+  "${missing_link_repo}" \
+  "README must link the Phase 51.1 replacement boundary ADR."
+
+echo "verify-phase-51-1-replacement-boundary-adr tests passed"

--- a/scripts/verify-phase-51-1-replacement-boundary-adr.sh
+++ b/scripts/verify-phase-51-1-replacement-boundary-adr.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0011-phase-51-1-replacement-boundary.md"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# ADR-0011: Phase 51.1 SMB SecOps Replacement Boundary"
+  "## 1. Context"
+  "## 2. Decision"
+  "## 3. Allowed Replacement Claims"
+  "## 4. Disallowed Replacement Claims"
+  "## 5. Authority Boundary"
+  "## 6. Substrate Responsibilities"
+  "## 7. Implementation Impact"
+  "## 8. Security Impact"
+  "## 9. Rollback / Exit Strategy"
+  "## 10. Validation"
+  "## 11. Non-Goals"
+  "## 12. Approval"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-04-30"
+  "- **Related Issues**: #1041, #1042"
+  "AegisOps replaces the SMB SecOps operating experience, not Wazuh internals, Shuffle internals, or every SIEM and SOAR capability."
+  "Replacement means the reviewed operator experience for daily SMB SOC work: Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work."
+  "Wazuh is the detection substrate."
+  "Shuffle is the routine automation substrate."
+  "Allowed claim: AegisOps can replace the daily SMB SOC operating experience above Wazuh and Shuffle."
+  "Allowed claim: AegisOps can replace ad hoc ticket-and-script coordination with authoritative alert, case, approval, action request, receipt, reconciliation, audit, and release records."
+  "Allowed claim: AegisOps can provide a governed SIEM/SOAR operating layer for SMB teams when Wazuh and Shuffle provide the reviewed substrate capabilities."
+  "Disallowed claim: AegisOps already replaces every SIEM capability."
+  "Disallowed claim: AegisOps already replaces every SOAR capability."
+  "Disallowed claim: AegisOps reimplements Wazuh detection internals."
+  "Disallowed claim: AegisOps reimplements Shuffle workflow internals."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, and release truth."
+  "AI must not approve actions, execute actions, reconcile execution, close cases, activate detectors, or become source truth."
+  "Wazuh alert status is not AegisOps case truth."
+  "Shuffle workflow success is not AegisOps reconciliation truth."
+  "Tickets, evidence systems, browser state, UI cache, downstream receipts, demo data, Wazuh, Shuffle, and AI output remain subordinate context."
+  "This ADR rejects any shortcut that promotes subordinate surfaces into AegisOps workflow truth."
+  "This ADR does not implement CLI behavior, Wazuh profile generation, Shuffle profile generation, AI daily operations, SIEM breadth, SOAR breadth, packaging, release-candidate behavior, or general-availability behavior."
+  "Run \`bash scripts/verify-phase-51-1-replacement-boundary-adr.sh\`."
+  "Run \`bash scripts/test-verify-phase-51-1-replacement-boundary-adr.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1042 --config <supervisor-config-path>\`."
+)
+
+forbidden_phrases=(
+  "Allowed claim: AegisOps already replaces every SIEM capability"
+  "Allowed claim: AegisOps already replaces every SOAR capability"
+  "AegisOps is a complete replacement for every SIEM capability"
+  "AegisOps is a complete replacement for every SOAR capability"
+  "AI may approve actions"
+  "AI may execute actions"
+  "AI may reconcile execution"
+  "AI may close cases"
+  "AI may activate detectors"
+  "AI may become source truth"
+  "Wazuh alert status is AegisOps case truth"
+  "Shuffle workflow success is AegisOps reconciliation truth"
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 51.1 replacement boundary ADR: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fq -- "${heading}" "${doc_path}"; then
+    echo "Missing Phase 51.1 replacement boundary ADR heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 51.1 replacement boundary ADR statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${forbidden_phrases[@]}"; do
+  if grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Forbidden Phase 51.1 replacement boundary ADR claim: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 51.1 ADR link check: ${readme_path}" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- "docs/adr/0011-phase-51-1-replacement-boundary.md" "${readme_path}"; then
+  echo "README must link the Phase 51.1 replacement boundary ADR." >&2
+  exit 1
+fi
+
+echo "Phase 51.1 replacement boundary ADR is present and fixes replacement claims, substrate roles, authority boundaries, and validation commands."


### PR DESCRIPTION
## Summary
- Add ADR-0011 for the Phase 51.1 SMB SecOps replacement boundary.
- Define allowed/disallowed replacement claims and preserve AegisOps control-plane authority over Wazuh, Shuffle, AI, tickets, evidence systems, browser state, UI cache, downstream receipts, and demo data.
- Link the ADR from README and add focused verifier coverage with negative tests.

## Verification
- bash scripts/verify-phase-51-1-replacement-boundary-adr.sh
- bash scripts/test-verify-phase-51-1-replacement-boundary-adr.sh
- bash scripts/verify-adr-review-path-doc.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1042 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json

Phase 51.2 can safely update README positioning against ADR-0011.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Architecture Decision Record documenting Phase 51.1 replacement boundaries and operational scope.
  * Updated README to reference boundary documentation.

* **Tests**
  * Added verification scripts to validate replacement boundary documentation compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->