### PR TITLE
Phase 51.4 SMB personas and JTBD matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Canonical cross-phase boundary reference:
 - `docs/non-goals-and-expansion-guardrails.md`
 - `docs/adr/0011-phase-51-1-replacement-boundary.md` defines the Phase 51.1 SMB SecOps replacement boundary: AegisOps replaces the operating experience above Wazuh and Shuffle, not their internals or every SIEM/SOAR capability.
 - [Phase 51.3 pilot beta RC GA gate contract](docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md) defines the Pilot, Beta, RC, and GA evidence gates for replacement-readiness materialization.
+- [Phase 51.4 SMB personas and jobs-to-be-done matrix](docs/phase-51-4-smb-personas-jobs-to-be-done.md) defines the internal IT manager, part-time security operator, approver/escalation owner, platform admin, and bounded external support collaborator personas for later replacement-roadmap work.
 
 ## Product positioning
 
@@ -31,6 +32,8 @@ Replacement means the operating experience and authoritative record chain for da
 The Phase 51 replacement boundary is defined by `docs/adr/0011-phase-51-1-replacement-boundary.md`.
 
 The Phase 51.3 Pilot, Beta, RC, and GA gate contract is defined by the [Phase 51.3 pilot beta RC GA gate contract](docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md); Phase 66 is RC and Phase 67 is GA.
+
+The Phase 51.4 SMB personas and jobs-to-be-done matrix is defined by the [Phase 51.4 SMB personas and jobs-to-be-done matrix](docs/phase-51-4-smb-personas-jobs-to-be-done.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-51-4-smb-personas-jobs-to-be-done.md
+++ b/docs/phase-51-4-smb-personas-jobs-to-be-done.md
@@ -1,0 +1,100 @@
+# Phase 51.4 SMB Personas and Jobs-to-Be-Done Matrix
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/adr/0011-phase-51-1-replacement-boundary.md`, `docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md`, `docs/smb-footprint-and-deployment-profile-baseline.md`
+- **Related Issues**: #1041, #1042, #1045
+
+This document defines product-planning personas and jobs-to-be-done for the post-Phase50 SMB replacement roadmap.
+
+This document changes documentation and verification only. It does not implement RBAC, UI, support, AI, admin, Wazuh, Shuffle, ticketing, or evidence-system behavior.
+
+## 1. Purpose
+
+The Phase 51 replacement roadmap needs concrete SMB users so setup, operator UI, administration, supportability, reporting, AI advisory, and release-gate work can target real jobs without widening authority.
+
+These personas describe who the later roadmap serves, what each person needs to get done during normal business-hours security work, what each person is anxious about, where handoffs break down, and which authority limits must remain explicit.
+
+The matrix is planning input only. Runtime roles, permissions, workflow implementation, support access, AI behavior, and admin behavior still require separately reviewed implementation work.
+
+## 2. Shared Operating Assumptions
+
+The default staffing model is business-hours security work with explicit after-hours escalation, not a 24x7 staffed SOC.
+
+The target customer is a single-company or single-business-unit SMB deployment where a small team splits security operations across IT, part-time security work, named approvers, and platform administration.
+
+AegisOps replaces the daily SMB SecOps operating experience above Wazuh and Shuffle. It does not replace Wazuh internals, Shuffle internals, every SIEM/SOAR capability, or customer accountability for approval and escalation decisions.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, and limitation truth.
+
+External support collaborators, AI, Wazuh, Shuffle, tickets, evidence systems, dashboards, report exports, and operator-facing summaries remain subordinate context.
+
+## 3. Personas and Jobs-to-Be-Done Matrix
+
+| Persona | Primary job-to-be-done | Daily jobs | Anxieties | Handoff needs | Authority limits | Later roadmap phases |
+| --- | --- | --- | --- | --- | --- | --- |
+| Internal IT Manager | Keep daily security work understandable while also owning normal IT operations. | Review prioritized alerts, confirm business impact, decide which issues need operator follow-up, coordinate with approvers, and keep leadership aware of limitations. | Fear that AegisOps becomes another broad SIEM/SOAR program, requires 24x7 staffing, hides risky automation behind AI, or leaves unclear ownership after a failed action. | Needs concise business-hours queue summaries, clear evidence links, explicit escalation owner handoff, and release-gate or limitation summaries that can be shared internally. | May request investigation, update non-approval case context, and coordinate follow-up within assigned scope. Must not approve their own approval-sensitive requests, use IT ownership as platform-admin authority, or treat Wazuh, Shuffle, AI, tickets, or support advice as authoritative AegisOps truth. | Phase 52 setup and guided onboarding, Phase 55 daily operator queue, Phase 62 report export, Phase 66 RC evidence packet, Phase 67 GA launch evidence. |
+| Part-Time Security Operator | Triage real signals efficiently without becoming a full-time SOC analyst. | Review admitted Wazuh signals, group related evidence, create or update AegisOps cases, draft action requests, check delegated Shuffle receipts, and prepare handoff notes before returning to other work. | Fear missing critical context, being blamed for automation they did not approve, losing the thread across shifts, or having AI produce confident but unaudited guidance. | Needs saved investigation state, next-step prompts, evidence anchors, explicit approval status, failed-delegation cleanup notes, and handoff text that a later operator can resume. | May investigate, annotate, and request approval-bound actions within assigned scope. Must not self-approve sensitive actions, execute destructive actions outside reviewed delegation, close cases from AI advice alone, or promote raw Wazuh or Shuffle state into AegisOps reconciliation truth. | Phase 54 Wazuh signal intake, Phase 55 daily queue, Phase 57 AI advisory trace, Phase 59 Shuffle delegated execution, Phase 61 restore dry-run evidence. |
+| Approver / Escalation Owner | Make accountable decisions on actions that need human authority or after-hours escalation. | Review requester identity, evidence, risk, blast radius, proposed action, rollback owner, and timing; approve or reject within delegated authority; decide when after-hours escalation is justified. | Fear rubber-stamp approvals, unclear separation from the requester, missing rollback context, or hidden support or AI pressure to approve an unsafe action. | Needs immutable approval context, requester separation, explicit action intent, rollback and mismatch handling notes, and after-hours escalation reason captured in the AegisOps record. | May approve or reject approval-bound requests within delegated scope and own escalation decisions. Must remain distinct from the requester where required, must not rely on side-channel approvals alone, and must not let support, AI, tickets, Wazuh, or Shuffle approve actions by proxy. | Phase 56 approval ergonomics, Phase 59 delegated execution, Phase 60 reconciliation, Phase 64 limitation ownership, Phase 66 RC evidence packet. |
+| Platform Admin | Keep AegisOps deployable, recoverable, connected, and auditable for the SMB footprint. | Configure reviewed runtime settings, maintain identity and secret boundaries, run install or upgrade preflights, collect support bundles, rehearse restore and rollback, and repair platform connectivity without changing case truth. | Fear brittle installs, hidden credential drift, backup or restore gaps, unclear ownership of service accounts, or being asked to bypass approvals during an incident. | Needs deterministic preflight output, repo-relative runbooks, secret-custody checks, backup and restore manifests, support-bundle redaction guidance, and clear separation from approver authority. | May administer platform components, service-account plumbing, recovery procedures, and approved configuration paths. Must not use platform-admin access as a substitute approval path, mutate authoritative case or reconciliation outcomes outside reviewed controls, or grant external support direct backend or substrate authority. | Phase 52 setup, Phase 53 install profile, Phase 58 admin and secret custody, Phase 61 restore dry-run, Phase 63 support bundle, Phase 65 upgrade plan. |
+| Bounded External Support Collaborator | Help diagnose platform or product issues without becoming an operator, approver, administrator, or source of truth. | Review redacted support bundles, ask clarifying questions, suggest documented remediation steps, and identify product defects or known limitations for the customer-owned team to accept or reject. | Fear receiving private production data, being expected to provide 24x7 coverage, being blamed for customer decisions, or accidentally becoming an authority path through informal advice. | Needs redacted bundles, explicit customer owner, limitation owner, reproduction steps, environment class, retained evidence references, and a written boundary for what support may not do. | May provide advisory diagnosis from redacted evidence and documented product knowledge only. Must not access customer-private production systems directly, approve actions, execute actions, mutate AegisOps records, operate Wazuh or Shuffle, close cases, or make AI, tickets, or support notes authoritative. | Phase 63 support bundle, Phase 64 known limitations ownership, Phase 66 RC supportability evidence, Phase 67 GA support-readiness evidence. |
+
+### 3.1 Internal IT Manager
+
+The internal IT manager is often the person accountable for keeping the security program understandable to the business. This persona needs AegisOps to compress security work into clear queues, explicit escalation choices, and evidence-backed status without asking the IT manager to become a full-time analyst or platform administrator.
+
+### 3.2 Part-Time Security Operator
+
+The part-time security operator performs real triage in bounded windows. This persona needs durable state, clear next actions, and handoff notes because the same operator may leave the queue for ordinary IT work and return later.
+
+### 3.3 Approver / Escalation Owner
+
+The approver or escalation owner carries the accountable decision. This persona needs complete context, requester separation, and a recorded decision path so approval-sensitive work does not collapse into chat, support advice, AI output, or automation success.
+
+### 3.4 Platform Admin
+
+The platform admin keeps AegisOps installed, configured, backed up, upgraded, and recoverable. This persona can operate infrastructure but does not gain approval authority or case-truth authority by administering the platform.
+
+### 3.5 Bounded External Support Collaborator
+
+The bounded external support collaborator helps from redacted, customer-approved evidence. This persona is intentionally not an operator, approver, administrator, substrate owner, or authoritative record owner.
+
+## 4. Later Roadmap Usage
+
+| Persona | Primary later phases | Usage |
+| --- | --- | --- |
+| Internal IT Manager | Phase 52, Phase 55, Phase 62, Phase 66, Phase 67 | Shapes setup language, daily summaries, leadership-ready reports, RC evidence, and GA launch evidence around narrow SMB ownership. |
+| Part-Time Security Operator | Phase 54, Phase 55, Phase 57, Phase 59, Phase 61 | Shapes signal triage, queue ergonomics, advisory AI traces, delegated execution review, and restore-readiness handoffs. |
+| Approver / Escalation Owner | Phase 56, Phase 59, Phase 60, Phase 64, Phase 66 | Shapes approval context, separation-of-duties proof, reconciliation ownership, limitations decisions, and RC gate packets. |
+| Platform Admin | Phase 52, Phase 53, Phase 58, Phase 61, Phase 63, Phase 65 | Shapes install, configuration, secret custody, restore rehearsal, support-bundle, and upgrade-plan requirements. |
+| Bounded External Support Collaborator | Phase 63, Phase 64, Phase 66, Phase 67 | Shapes redacted support-bundle evidence, limitation ownership, supportability proof, and GA support-readiness boundaries. |
+
+Later roadmap issues may cite this matrix when defining user-facing setup, operator queue, approval, admin, support, AI advisory, reporting, release-gate, and launch-readiness work.
+
+## 5. Authority Boundary
+
+These personas do not grant external support, AI, Wazuh, Shuffle, tickets, evidence systems, dashboards, reports, or operator-facing summaries authority over AegisOps records.
+
+Support collaborators provide advisory diagnosis only from redacted evidence and documented product knowledge. Customer-owned AegisOps operators, approvers, and platform administrators remain responsible for admitting evidence, approving actions, changing platform state, and recording durable outcomes.
+
+AI remains advisory-only and must stay attached to reviewed recommendation, evidence, and human decision records. AI output must not approve, execute, reconcile, close, activate, administer, or define source truth.
+
+Wazuh remains the detection substrate. Shuffle remains the routine automation substrate. Their outputs become AegisOps workflow evidence only through reviewed admission, approval, execution receipt, and reconciliation records.
+
+## 6. Validation
+
+Run `bash scripts/verify-phase-51-4-smb-personas-jtbd.sh`.
+
+Run `bash scripts/test-verify-phase-51-4-smb-personas-jtbd.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1045 --config <supervisor-config-path>`.
+
+The verifier must fail when the bounded external support collaborator is missing, when persona text grants external support or AI authority over AegisOps records, or when the document assumes 24x7 SOC staffing as the default.
+
+## 7. Non-Goals
+
+- No RBAC implementation, permission assignment, UI implementation, support workflow, AI workflow, admin workflow, Wazuh behavior, Shuffle behavior, ticketing behavior, or evidence-system behavior changes.
+- No support collaborator receives direct customer-private production access, backend access, approval authority, execution authority, substrate authority, or authority over AegisOps records.
+- No AI, ticket, Wazuh, Shuffle, support note, report, dashboard, export, or operator-facing summary becomes authoritative workflow truth.
+- No 24x7 staffed SOC promise, formal SLA, self-service GA claim, or broad SIEM/SOAR replacement claim is created by this matrix.

--- a/scripts/test-verify-phase-51-4-smb-personas-jtbd.sh
+++ b/scripts/test-verify-phase-51-4-smb-personas-jtbd.sh
@@ -69,6 +69,24 @@ valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
 
+alternate_date_repo="${workdir}/alternate-date"
+create_valid_repo "${alternate_date_repo}"
+replace_text_in_doc \
+  "${alternate_date_repo}" \
+  "- **Date**: 2026-05-01" \
+  "- **Date**: 2026-04-30"
+assert_passes "${alternate_date_repo}"
+
+invalid_date_repo="${workdir}/invalid-date"
+create_valid_repo "${invalid_date_repo}"
+replace_text_in_doc \
+  "${invalid_date_repo}" \
+  "- **Date**: 2026-05-01" \
+  "- **Date**: May 1, 2026"
+assert_fails_with \
+  "${invalid_date_repo}" \
+  "Missing or invalid Phase 51.4 personas date line (- **Date**: YYYY-MM-DD)."
+
 missing_doc_repo="${workdir}/missing-doc"
 create_valid_repo "${missing_doc_repo}"
 rm "${missing_doc_repo}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"

--- a/scripts/test-verify-phase-51-4-smb-personas-jtbd.sh
+++ b/scripts/test-verify-phase-51-4-smb-personas-jtbd.sh
@@ -121,6 +121,14 @@ assert_fails_with \
   "${external_support_authority_repo}" \
   "Forbidden Phase 51.4 personas authority or staffing claim: External support may approve AegisOps actions."
 
+external_support_authoritative_reworded_repo="${workdir}/external-support-authoritative-reworded"
+create_valid_repo "${external_support_authoritative_reworded_repo}"
+printf '%s\n' "External Support may be authoritative for AegisOps records." \
+  >>"${external_support_authoritative_reworded_repo}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+assert_fails_with \
+  "${external_support_authoritative_reworded_repo}" \
+  "Forbidden Phase 51.4 personas authority or staffing claim matched: external[[:space:]-]+support[^.]*(is|are|becomes|become|remains|may[[:space:]]+be|can[[:space:]]+be|serves[[:space:]]+as|acts[[:space:]]+as)[^.]*authoritative[^.]*aegisops"
+
 ai_authority_repo="${workdir}/ai-authority"
 create_valid_repo "${ai_authority_repo}"
 printf '%s\n' "AI is authoritative for AegisOps records." \
@@ -129,6 +137,14 @@ assert_fails_with \
   "${ai_authority_repo}" \
   "Forbidden Phase 51.4 personas authority or staffing claim: AI is authoritative for AegisOps records."
 
+ai_execution_reworded_repo="${workdir}/ai-execution-reworded"
+create_valid_repo "${ai_execution_reworded_repo}"
+printf '%s\n' "ai can execute AegisOps actions." \
+  >>"${ai_execution_reworded_repo}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+assert_fails_with \
+  "${ai_execution_reworded_repo}" \
+  "Forbidden Phase 51.4 personas authority or staffing claim matched: (^|[^[:alnum:]_])ai[^.]*((can|could)[[:space:]]+|(is|are)[[:space:]]+(authorized|allowed)[[:space:]]+to[[:space:]]+|has[[:space:]]+authority[[:space:]]+to[[:space:]]+)(approve|execute)[^.]*aegisops"
+
 staffing_drift_repo="${workdir}/staffing-drift"
 create_valid_repo "${staffing_drift_repo}"
 printf '%s\n' "24x7 staffed SOC is the default operating model." \
@@ -136,6 +152,14 @@ printf '%s\n' "24x7 staffed SOC is the default operating model." \
 assert_fails_with \
   "${staffing_drift_repo}" \
   "Forbidden Phase 51.4 personas authority or staffing claim: 24x7 staffed SOC is the default operating model."
+
+staffing_case_drift_repo="${workdir}/staffing-case-drift"
+create_valid_repo "${staffing_case_drift_repo}"
+printf '%s\n' "AegisOps uses a 24x7 staffed soc as the default model." \
+  >>"${staffing_case_drift_repo}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+assert_fails_with \
+  "${staffing_case_drift_repo}" \
+  "Forbidden Phase 51.4 personas authority or staffing claim matched: 24x7[[:space:]-]+staffed[[:space:]-]+soc[[:space:]]+(is|as|becomes|become|remains)[^.]*default"
 
 workstation_path_repo="${workdir}/workstation-local-path"
 create_valid_repo "${workstation_path_repo}"

--- a/scripts/test-verify-phase-51-4-smb-personas-jtbd.sh
+++ b/scripts/test-verify-phase-51-4-smb-personas-jtbd.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-51-4-smb-personas-jtbd.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  printf '%s\n' "# AegisOps" "See [Phase 51.4 SMB personas](docs/phase-51-4-smb-personas-jobs-to-be-done.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/phase-51-4-smb-personas-jobs-to-be-done.md" \
+    "${target}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+}
+
+replace_text_in_doc() {
+  local target="$1"
+  local old_text="$2"
+  local new_text="$3"
+
+  OLD_TEXT="${old_text}" NEW_TEXT="${new_text}" perl -0pi -e 's/\Q$ENV{OLD_TEXT}\E/$ENV{NEW_TEXT}/g' \
+    "${target}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 51.4 SMB personas and jobs-to-be-done document"
+
+missing_support_repo="${workdir}/missing-support-collaborator"
+create_valid_repo "${missing_support_repo}"
+replace_text_in_doc \
+  "${missing_support_repo}" \
+  "### 3.5 Bounded External Support Collaborator" \
+  "### 3.5 Support Notes"
+assert_fails_with \
+  "${missing_support_repo}" \
+  "Missing Phase 51.4 personas heading: ### 3.5 Bounded External Support Collaborator"
+
+missing_authority_limits_repo="${workdir}/missing-support-authority-limits"
+create_valid_repo "${missing_authority_limits_repo}"
+remove_text_from_doc \
+  "${missing_authority_limits_repo}" \
+  "| Bounded External Support Collaborator | Help diagnose platform or product issues without becoming an operator, approver, administrator, or source of truth. | Review redacted support bundles, ask clarifying questions, suggest documented remediation steps, and identify product defects or known limitations for the customer-owned team to accept or reject. | Fear receiving private production data, being expected to provide 24x7 coverage, being blamed for customer decisions, or accidentally becoming an authority path through informal advice. | Needs redacted bundles, explicit customer owner, limitation owner, reproduction steps, environment class, retained evidence references, and a written boundary for what support may not do. | May provide advisory diagnosis from redacted evidence and documented product knowledge only. Must not access customer-private production systems directly, approve actions, execute actions, mutate AegisOps records, operate Wazuh or Shuffle, close cases, or make AI, tickets, or support notes authoritative. | Phase 63 support bundle, Phase 64 known limitations ownership, Phase 66 RC supportability evidence, Phase 67 GA support-readiness evidence. |"
+assert_fails_with \
+  "${missing_authority_limits_repo}" \
+  "Missing Phase 51.4 personas statement: | Bounded External Support Collaborator |"
+
+external_support_authority_repo="${workdir}/external-support-authority"
+create_valid_repo "${external_support_authority_repo}"
+printf '%s\n' "External support may approve AegisOps actions." \
+  >>"${external_support_authority_repo}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+assert_fails_with \
+  "${external_support_authority_repo}" \
+  "Forbidden Phase 51.4 personas authority or staffing claim: External support may approve AegisOps actions."
+
+ai_authority_repo="${workdir}/ai-authority"
+create_valid_repo "${ai_authority_repo}"
+printf '%s\n' "AI is authoritative for AegisOps records." \
+  >>"${ai_authority_repo}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+assert_fails_with \
+  "${ai_authority_repo}" \
+  "Forbidden Phase 51.4 personas authority or staffing claim: AI is authoritative for AegisOps records."
+
+staffing_drift_repo="${workdir}/staffing-drift"
+create_valid_repo "${staffing_drift_repo}"
+printf '%s\n' "24x7 staffed SOC is the default operating model." \
+  >>"${staffing_drift_repo}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+assert_fails_with \
+  "${staffing_drift_repo}" \
+  "Forbidden Phase 51.4 personas authority or staffing claim: 24x7 staffed SOC is the default operating model."
+
+workstation_path_repo="${workdir}/workstation-local-path"
+create_valid_repo "${workstation_path_repo}"
+workstation_path="$(printf '/%s/%s/support-bundle.md' "Users" "example")"
+printf '%s\n' "Support bundle path:file://${workstation_path}" \
+  >>"${workstation_path_repo}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+assert_fails_with \
+  "${workstation_path_repo}" \
+  "Forbidden Phase 51.4 personas document: workstation-local absolute path detected"
+
+raw_readme_path_repo="${workdir}/raw-readme-path"
+create_valid_repo "${raw_readme_path_repo}"
+printf '%s\n' "# AegisOps" "See docs/phase-51-4-smb-personas-jobs-to-be-done.md." >"${raw_readme_path_repo}/README.md"
+assert_fails_with \
+  "${raw_readme_path_repo}" \
+  "README must link the Phase 51.4 SMB personas and jobs-to-be-done document."
+
+echo "Phase 51.4 SMB personas and jobs-to-be-done verifier tests passed."

--- a/scripts/verify-phase-51-4-smb-personas-jtbd.sh
+++ b/scripts/verify-phase-51-4-smb-personas-jtbd.sh
@@ -62,6 +62,25 @@ forbidden_lines=(
   "tickets are authoritative for AegisOps records."
 )
 
+authority_verb_pattern="(is|are|becomes|become|remains|may[[:space:]]+be|can[[:space:]]+be|serves[[:space:]]+as|acts[[:space:]]+as)"
+
+forbidden_patterns=(
+  "24x7[[:space:]-]+staffed[[:space:]-]+soc[[:space:]]+(is|as|becomes|become|remains)[^.]*default"
+  "aegisops[[:space:]]+(assumes|uses|requires|defaults[[:space:]]+to)[^.]*24x7[[:space:]-]+staffed[[:space:]-]+soc"
+  "external[[:space:]-]+support[^.]*${authority_verb_pattern}[^.]*authoritative[^.]*aegisops"
+  "external[[:space:]-]+support[^.]*aegisops[^.]*${authority_verb_pattern}[^.]*authoritative"
+  "external[[:space:]-]+support[^.]*((can|could)[[:space:]]+|(is|are)[[:space:]]+(authorized|allowed)[[:space:]]+to[[:space:]]+|has[[:space:]]+authority[[:space:]]+to[[:space:]]+)(approve|execute|mutate)[^.]*aegisops"
+  "(^|[^[:alnum:]_])ai[^.]*${authority_verb_pattern}[^.]*authoritative[^.]*aegisops"
+  "(^|[^[:alnum:]_])ai[^.]*aegisops[^.]*${authority_verb_pattern}[^.]*authoritative"
+  "(^|[^[:alnum:]_])ai[^.]*((can|could)[[:space:]]+|(is|are)[[:space:]]+(authorized|allowed)[[:space:]]+to[[:space:]]+|has[[:space:]]+authority[[:space:]]+to[[:space:]]+)(approve|execute)[^.]*aegisops"
+  "(^|[^[:alnum:]_])wazuh[^.]*${authority_verb_pattern}[^.]*authoritative[^.]*aegisops"
+  "(^|[^[:alnum:]_])wazuh[^.]*aegisops[^.]*${authority_verb_pattern}[^.]*authoritative"
+  "(^|[^[:alnum:]_])shuffle[^.]*${authority_verb_pattern}[^.]*authoritative[^.]*aegisops"
+  "(^|[^[:alnum:]_])shuffle[^.]*aegisops[^.]*${authority_verb_pattern}[^.]*authoritative"
+  "(^|[^[:alnum:]_])tickets?[^.]*${authority_verb_pattern}[^.]*authoritative[^.]*aegisops"
+  "(^|[^[:alnum:]_])tickets?[^.]*aegisops[^.]*${authority_verb_pattern}[^.]*authoritative"
+)
+
 if [[ ! -f "${doc_path}" ]]; then
   echo "Missing Phase 51.4 SMB personas and jobs-to-be-done document: ${doc_path}" >&2
   exit 1
@@ -87,8 +106,15 @@ if ! grep -Eq '^- \*\*Date\*\*: [0-9]{4}-[0-9]{2}-[0-9]{2}$' "${doc_path}"; then
 fi
 
 for line in "${forbidden_lines[@]}"; do
-  if grep -Fq -- "${line}" "${doc_path}"; then
+  if grep -Fiq -- "${line}" "${doc_path}"; then
     echo "Forbidden Phase 51.4 personas authority or staffing claim: ${line}" >&2
+    exit 1
+  fi
+done
+
+for pattern in "${forbidden_patterns[@]}"; do
+  if grep -Eiq -- "${pattern}" "${doc_path}"; then
+    echo "Forbidden Phase 51.4 personas authority or staffing claim matched: ${pattern}" >&2
     exit 1
   fi
 done

--- a/scripts/verify-phase-51-4-smb-personas-jtbd.sh
+++ b/scripts/verify-phase-51-4-smb-personas-jtbd.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-51-4-smb-personas-jobs-to-be-done.md"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 51.4 SMB Personas and Jobs-to-Be-Done Matrix"
+  "## 1. Purpose"
+  "## 2. Shared Operating Assumptions"
+  "## 3. Personas and Jobs-to-Be-Done Matrix"
+  "### 3.1 Internal IT Manager"
+  "### 3.2 Part-Time Security Operator"
+  "### 3.3 Approver / Escalation Owner"
+  "### 3.4 Platform Admin"
+  "### 3.5 Bounded External Support Collaborator"
+  "## 4. Later Roadmap Usage"
+  "## 5. Authority Boundary"
+  "## 6. Validation"
+  "## 7. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1041, #1042, #1045"
+  "This document defines product-planning personas and jobs-to-be-done for the post-Phase50 SMB replacement roadmap."
+  "This document changes documentation and verification only. It does not implement RBAC, UI, support, AI, admin, Wazuh, Shuffle, ticketing, or evidence-system behavior."
+  "The default staffing model is business-hours security work with explicit after-hours escalation, not a 24x7 staffed SOC."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, and limitation truth."
+  "External support collaborators, AI, Wazuh, Shuffle, tickets, evidence systems, dashboards, report exports, and operator-facing summaries remain subordinate context."
+  "| Internal IT Manager | Keep daily security work understandable while also owning normal IT operations. | Review prioritized alerts, confirm business impact, decide which issues need operator follow-up, coordinate with approvers, and keep leadership aware of limitations. | Fear that AegisOps becomes another broad SIEM/SOAR program, requires 24x7 staffing, hides risky automation behind AI, or leaves unclear ownership after a failed action. | Needs concise business-hours queue summaries, clear evidence links, explicit escalation owner handoff, and release-gate or limitation summaries that can be shared internally. | May request investigation, update non-approval case context, and coordinate follow-up within assigned scope. Must not approve their own approval-sensitive requests, use IT ownership as platform-admin authority, or treat Wazuh, Shuffle, AI, tickets, or support advice as authoritative AegisOps truth. | Phase 52 setup and guided onboarding, Phase 55 daily operator queue, Phase 62 report export, Phase 66 RC evidence packet, Phase 67 GA launch evidence. |"
+  "| Part-Time Security Operator | Triage real signals efficiently without becoming a full-time SOC analyst. | Review admitted Wazuh signals, group related evidence, create or update AegisOps cases, draft action requests, check delegated Shuffle receipts, and prepare handoff notes before returning to other work. | Fear missing critical context, being blamed for automation they did not approve, losing the thread across shifts, or having AI produce confident but unaudited guidance. | Needs saved investigation state, next-step prompts, evidence anchors, explicit approval status, failed-delegation cleanup notes, and handoff text that a later operator can resume. | May investigate, annotate, and request approval-bound actions within assigned scope. Must not self-approve sensitive actions, execute destructive actions outside reviewed delegation, close cases from AI advice alone, or promote raw Wazuh or Shuffle state into AegisOps reconciliation truth. | Phase 54 Wazuh signal intake, Phase 55 daily queue, Phase 57 AI advisory trace, Phase 59 Shuffle delegated execution, Phase 61 restore dry-run evidence. |"
+  "| Approver / Escalation Owner | Make accountable decisions on actions that need human authority or after-hours escalation. | Review requester identity, evidence, risk, blast radius, proposed action, rollback owner, and timing; approve or reject within delegated authority; decide when after-hours escalation is justified. | Fear rubber-stamp approvals, unclear separation from the requester, missing rollback context, or hidden support or AI pressure to approve an unsafe action. | Needs immutable approval context, requester separation, explicit action intent, rollback and mismatch handling notes, and after-hours escalation reason captured in the AegisOps record. | May approve or reject approval-bound requests within delegated scope and own escalation decisions. Must remain distinct from the requester where required, must not rely on side-channel approvals alone, and must not let support, AI, tickets, Wazuh, or Shuffle approve actions by proxy. | Phase 56 approval ergonomics, Phase 59 delegated execution, Phase 60 reconciliation, Phase 64 limitation ownership, Phase 66 RC evidence packet. |"
+  "| Platform Admin | Keep AegisOps deployable, recoverable, connected, and auditable for the SMB footprint. | Configure reviewed runtime settings, maintain identity and secret boundaries, run install or upgrade preflights, collect support bundles, rehearse restore and rollback, and repair platform connectivity without changing case truth. | Fear brittle installs, hidden credential drift, backup or restore gaps, unclear ownership of service accounts, or being asked to bypass approvals during an incident. | Needs deterministic preflight output, repo-relative runbooks, secret-custody checks, backup and restore manifests, support-bundle redaction guidance, and clear separation from approver authority. | May administer platform components, service-account plumbing, recovery procedures, and approved configuration paths. Must not use platform-admin access as a substitute approval path, mutate authoritative case or reconciliation outcomes outside reviewed controls, or grant external support direct backend or substrate authority. | Phase 52 setup, Phase 53 install profile, Phase 58 admin and secret custody, Phase 61 restore dry-run, Phase 63 support bundle, Phase 65 upgrade plan. |"
+  "| Bounded External Support Collaborator | Help diagnose platform or product issues without becoming an operator, approver, administrator, or source of truth. | Review redacted support bundles, ask clarifying questions, suggest documented remediation steps, and identify product defects or known limitations for the customer-owned team to accept or reject. | Fear receiving private production data, being expected to provide 24x7 coverage, being blamed for customer decisions, or accidentally becoming an authority path through informal advice. | Needs redacted bundles, explicit customer owner, limitation owner, reproduction steps, environment class, retained evidence references, and a written boundary for what support may not do. | May provide advisory diagnosis from redacted evidence and documented product knowledge only. Must not access customer-private production systems directly, approve actions, execute actions, mutate AegisOps records, operate Wazuh or Shuffle, close cases, or make AI, tickets, or support notes authoritative. | Phase 63 support bundle, Phase 64 known limitations ownership, Phase 66 RC supportability evidence, Phase 67 GA support-readiness evidence. |"
+  "| Persona | Primary later phases | Usage |"
+  "| Internal IT Manager | Phase 52, Phase 55, Phase 62, Phase 66, Phase 67 | Shapes setup language, daily summaries, leadership-ready reports, RC evidence, and GA launch evidence around narrow SMB ownership. |"
+  "| Part-Time Security Operator | Phase 54, Phase 55, Phase 57, Phase 59, Phase 61 | Shapes signal triage, queue ergonomics, advisory AI traces, delegated execution review, and restore-readiness handoffs. |"
+  "| Approver / Escalation Owner | Phase 56, Phase 59, Phase 60, Phase 64, Phase 66 | Shapes approval context, separation-of-duties proof, reconciliation ownership, limitations decisions, and RC gate packets. |"
+  "| Platform Admin | Phase 52, Phase 53, Phase 58, Phase 61, Phase 63, Phase 65 | Shapes install, configuration, secret custody, restore rehearsal, support-bundle, and upgrade-plan requirements. |"
+  "| Bounded External Support Collaborator | Phase 63, Phase 64, Phase 66, Phase 67 | Shapes redacted support-bundle evidence, limitation ownership, supportability proof, and GA support-readiness boundaries. |"
+  "These personas do not grant external support, AI, Wazuh, Shuffle, tickets, evidence systems, dashboards, reports, or operator-facing summaries authority over AegisOps records."
+  'Run `bash scripts/verify-phase-51-4-smb-personas-jtbd.sh`.'
+  'Run `bash scripts/test-verify-phase-51-4-smb-personas-jtbd.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1045 --config <supervisor-config-path>`.'
+)
+
+forbidden_lines=(
+  "AegisOps assumes a 24x7 staffed SOC by default."
+  "24x7 staffed SOC is the default operating model."
+  "External support may approve AegisOps actions."
+  "External support may execute AegisOps actions."
+  "External support may mutate AegisOps records."
+  "External support is authoritative for AegisOps records."
+  "AI may approve AegisOps actions."
+  "AI may execute AegisOps actions."
+  "AI is authoritative for AegisOps records."
+  "Wazuh is authoritative for AegisOps records."
+  "Shuffle is authoritative for AegisOps records."
+  "tickets are authoritative for AegisOps records."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 51.4 SMB personas and jobs-to-be-done document: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" "${doc_path}"; then
+    echo "Missing Phase 51.4 personas heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fxq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 51.4 personas statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for line in "${forbidden_lines[@]}"; do
+  if grep -Fq -- "${line}" "${doc_path}"; then
+    echo "Forbidden Phase 51.4 personas authority or staffing claim: ${line}" >&2
+    exit 1
+  fi
+done
+
+mac_user_home="$(printf '/%s/' 'Users')"
+unix_user_home="$(printf '/%s/' 'home')"
+windows_user_profile_backslash="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_user_profile_slash="$(printf '[A-Za-z]:/%s/' 'Users')"
+
+if grep -Eq "(${mac_user_home}[^[:space:]]*|${unix_user_home}[^[:space:]]*|${windows_user_profile_backslash}[^[:space:]]*|${windows_user_profile_slash}[^[:space:]]*)" "${doc_path}"; then
+  echo "Forbidden Phase 51.4 personas document: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 51.4 personas link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    !in_fenced_block { print }
+  ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/phase-51-4-smb-personas-jobs-to-be-done\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 51.4 SMB personas and jobs-to-be-done document." >&2
+  exit 1
+fi
+
+echo "Phase 51.4 SMB personas and jobs-to-be-done matrix is present and preserves SMB staffing and authority boundaries."

--- a/scripts/verify-phase-51-4-smb-personas-jtbd.sh
+++ b/scripts/verify-phase-51-4-smb-personas-jtbd.sh
@@ -24,7 +24,6 @@ required_headings=(
 
 required_phrases=(
   "- **Status**: Accepted"
-  "- **Date**: 2026-05-01"
   "- **Related Issues**: #1041, #1042, #1045"
   "This document defines product-planning personas and jobs-to-be-done for the post-Phase50 SMB replacement roadmap."
   "This document changes documentation and verification only. It does not implement RBAC, UI, support, AI, admin, Wazuh, Shuffle, ticketing, or evidence-system behavior."
@@ -81,6 +80,11 @@ for phrase in "${required_phrases[@]}"; do
     exit 1
   fi
 done
+
+if ! grep -Eq '^- \*\*Date\*\*: [0-9]{4}-[0-9]{2}-[0-9]{2}$' "${doc_path}"; then
+  echo "Missing or invalid Phase 51.4 personas date line (- **Date**: YYYY-MM-DD)." >&2
+  exit 1
+fi
 
 for line in "${forbidden_lines[@]}"; do
   if grep -Fq -- "${line}" "${doc_path}"; then


### PR DESCRIPTION
## Summary
- add the Phase 51.4 SMB personas and jobs-to-be-done matrix
- cover internal IT manager, part-time security operator, approver/escalation owner, platform admin, and bounded external support collaborator
- add focused verifier coverage for missing support collaborator, authority drift, 24x7 staffing drift, README discovery, and path hygiene

## Verification
- `bash scripts/verify-phase-51-4-smb-personas-jtbd.sh`
- `bash scripts/test-verify-phase-51-4-smb-personas-jtbd.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1045 --config <supervisor-config-path>`
- `git diff --check`
- `bash scripts/verify-publishable-path-hygiene.sh`

Closes #1045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 51.4 SMB personas and jobs-to-be-done planning doc covering five personas, jobs, daily tasks, anxieties, handoff needs, authority limits, operating assumptions, non-goals, and a README cross-reference.
* **Tests**
  * Added verification tooling and a test harness to assert doc presence, required headings/statements and date format, detect forbidden claims and local workstation paths, and confirm README links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->