### PR TITLE
Phase 51 closeout evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           bash scripts/verify-roadmap-materialization-preflight-contract.sh
           bash scripts/test-verify-roadmap-materialization-preflight-contract.sh
           bash scripts/test-verify-roadmap-materialization-preflight.sh
+          bash scripts/verify-phase-51-closeout-evaluation.sh
+          bash scripts/test-verify-phase-51-closeout-evaluation.sh
           bash scripts/verify-support-playbook-break-glass-rehearsal.sh
           bash scripts/verify-response-action-safety-model-doc.sh
           bash scripts/verify-requirements-baseline-control-plane-thesis.sh

--- a/docs/phase-51-closeout-evaluation.md
+++ b/docs/phase-51-closeout-evaluation.md
@@ -1,0 +1,91 @@
+# Phase 51 Closeout Evaluation
+
+- **Status**: Accepted with lifecycle closeout pending
+- **Date**: 2026-05-01
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1041, #1042, #1043, #1044, #1045, #1046, #1047, #1048, #1049
+
+## Verdict
+
+Phase 51 is accepted as a repo-owned replacement-readiness contract. The Phase 51 docs, ADR, focused verifiers, and materialization guard agree that AegisOps is a governed SMB SecOps operating-experience control plane above Wazuh and Shuffle, not a broad GA replacement for every SIEM or SOAR capability.
+
+Phase 52 is the next materialization target after this closeout is made authoritative by closing or explicitly owner-accepting the Phase 51 Epic and closeout issue. Until that lifecycle state is recorded, the Phase 52 preflight must continue to fail closed with `phase_classification["51"] = "materialized_open"`.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1042 | Phase 51.1 replacement boundary ADR | Closed. `docs/adr/0011-phase-51-1-replacement-boundary.md` is accepted and cited from README. |
+| #1043 | Phase 51.2 README product positioning | Closed. README states current pre-GA status, replacement target, forbidden overclaims, and authority boundary. |
+| #1044 | Phase 51.3 Pilot, Beta, RC, and GA gate contract | Closed. `docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md` defines evidence gates and keeps Phase 66 as RC and Phase 67 as GA. |
+| #1045 | Phase 51.4 SMB personas and jobs-to-be-done | Closed. `docs/phase-51-4-smb-personas-jobs-to-be-done.md` defines SMB personas without granting authority to support, AI, Wazuh, Shuffle, or tickets. |
+| #1046 | Phase 51.5 competitive gap matrix | Closed. `docs/phase-51-5-competitive-gap-matrix.md` maps P0/P1 gaps to Phase 52-67 or explicit deferral. |
+| #1047 | Phase 51.6 authority-boundary negative-test policy | Closed. `docs/phase-51-6-authority-boundary-negative-test-policy.md` covers AI, Wazuh, Shuffle, tickets, evidence, browser state, UI cache, downstream receipts, and demo data. |
+| #1048 | Phase 51.7 roadmap materialization guard | Closed. `docs/roadmap-materialization-preflight-contract.md`, `docs/automation/roadmap-materialization-phase-graph.json`, and preflight fixtures bind Phase 51 before Phase 52+. |
+| #1049 | Phase 51.8 closeout evaluation | Open while this evaluation is under review. This issue is the remaining lifecycle item before Phase 52 may be materialized. |
+
+## Verification Summary
+
+Focused Phase 51 verifiers passed:
+
+- `bash scripts/verify-phase-51-1-replacement-boundary-adr.sh`
+- `bash scripts/test-verify-phase-51-1-replacement-boundary-adr.sh`
+- `bash scripts/verify-readme-product-positioning.sh`
+- `bash scripts/test-verify-readme-product-positioning.sh`
+- `bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh`
+- `bash scripts/test-verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh`
+- `bash scripts/verify-phase-51-4-smb-personas-jtbd.sh`
+- `bash scripts/test-verify-phase-51-4-smb-personas-jtbd.sh`
+- `bash scripts/verify-phase-51-5-competitive-gap-matrix.sh`
+- `bash scripts/test-verify-phase-51-5-competitive-gap-matrix.sh`
+- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
+- `bash scripts/test-verify-phase-51-6-authority-boundary-negative-test-policy.sh`
+- `bash scripts/verify-roadmap-materialization-preflight-contract.sh`
+- `bash scripts/test-verify-roadmap-materialization-preflight-contract.sh`
+- `bash scripts/test-verify-roadmap-materialization-preflight.sh`
+
+Issue-lint passed for #1041 through #1049 with:
+
+- `execution_ready=yes`
+- `missing_required=none`
+- `missing_recommended=none`
+- `metadata_errors=none`
+- `high_risk_blocking_ambiguity=none`
+
+The live Phase 52 preflight was also run with:
+
+```sh
+CODEX_SUPERVISOR_ROOT=<codex-supervisor-root> \
+CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> \
+bash scripts/roadmap-materialization-preflight.sh --graph docs/automation/roadmap-materialization-phase-graph.json --target-phase 52 --issue-source github
+```
+
+That check correctly failed while #1041 and #1049 remain open:
+
+- `pass=false`
+- `invalid_phase_id="51"`
+- `invalid_field="issue_state"`
+- `invalid_issue_number=1041`
+- `phase_classification["51"]="materialized_open"`
+- `suggested_next_safe_action="close or explicitly accept every predecessor Epic and child issue before dependent scheduling"`
+
+## Alignment Check
+
+- Replacement boundary ADR exists and is cited from README.
+- README keeps current state as pre-GA and rejects already-GA, broad enterprise SIEM/SOAR parity, and autonomous SOC overclaims.
+- Gate contract keeps Pilot, Beta, RC, and GA evidence distinct and requires real-user or design-partner evidence before GA.
+- Personas and competitive matrix target SMB operator jobs and P0/P1 gaps without broad 24x7 SOC or enterprise parity assumptions.
+- Authority-boundary policy requires later breadth issues to cite fail-closed negative-test expectations before AI, Wazuh, Shuffle, ticket, evidence, browser, UI cache, receipt, or demo-data behavior is added.
+- Materialization guard resolves Phase 51 from explicit issue graph records and lint output, not roadmap prose, naming conventions, or derived status text.
+
+## Accepted Limitations
+
+- Phase 51 does not implement Phase 52 setup, guided onboarding, executable stack, Wazuh profile, Shuffle profile, AI daily operations, SIEM breadth, SOAR breadth, packaging, RC, or GA work.
+- Phase 51 does not prove GA replacement readiness. It proves the repo-owned replacement boundary, gate vocabulary, personas, competitive gaps, negative-test policy, and materialization guard needed before Phase 52+ work starts.
+- Phase 52 materialization remains blocked until the Phase 51 Epic and this closeout issue are closed or explicitly owner-accepted. This is the expected fail-closed lifecycle guard, not a verifier failure.
+
+## Phase 52 Recommendation
+
+Materialize Phase 52 next after closing or explicitly owner-accepting #1041 and #1049, then rerun the Phase 52 preflight command above. Phase 52 must remain scoped to setup and guided onboarding and must cite the Phase 51 replacement boundary, gate contract, persona matrix, competitive gap matrix, authority-boundary negative-test policy, and materialization guard.
+
+Do not materialize Phase 52 while the live preflight reports Phase 51 as `materialized_open`.

--- a/scripts/test-verify-phase-51-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-51-closeout-evaluation.sh
@@ -79,6 +79,22 @@ assert_fails_with \
   "${absolute_path_repo}" \
   "Forbidden Phase 51 closeout evaluation: workstation-local absolute path detected"
 
+linux_home_path_repo="${workdir}/linux-home-path"
+copy_valid_repo "${linux_home_path_repo}"
+linux_home_prefix="/""home/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${linux_home_prefix}" >>"${linux_home_path_repo}/docs/phase-51-closeout-evaluation.md"
+assert_fails_with \
+  "${linux_home_path_repo}" \
+  "Forbidden Phase 51 closeout evaluation: workstation-local absolute path detected"
+
+windows_slash_path_repo="${workdir}/windows-slash-path"
+copy_valid_repo "${windows_slash_path_repo}"
+windows_slash_path="C:""/""Users/example/repo/file.md"
+printf 'Run %s.\n' "${windows_slash_path}" >>"${windows_slash_path_repo}/docs/phase-51-closeout-evaluation.md"
+assert_fails_with \
+  "${windows_slash_path_repo}" \
+  "Forbidden Phase 51 closeout evaluation: workstation-local absolute path detected"
+
 windows_backslash_path_repo="${workdir}/windows-backslash-path"
 copy_valid_repo "${windows_backslash_path_repo}"
 windows_backslash_path="$(printf 'C:%bUsers%bexample%brepo%bfile.md' '\\' '\\' '\\' '\\')"

--- a/scripts/test-verify-phase-51-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-51-closeout-evaluation.sh
@@ -79,4 +79,12 @@ assert_fails_with \
   "${absolute_path_repo}" \
   "Forbidden Phase 51 closeout evaluation: workstation-local absolute path detected"
 
+windows_backslash_path_repo="${workdir}/windows-backslash-path"
+copy_valid_repo "${windows_backslash_path_repo}"
+windows_backslash_path="$(printf 'C:%bUsers%bexample%brepo%bfile.md' '\\' '\\' '\\' '\\')"
+printf 'Run %s.\n' "${windows_backslash_path}" >>"${windows_backslash_path_repo}/docs/phase-51-closeout-evaluation.md"
+assert_fails_with \
+  "${windows_backslash_path_repo}" \
+  "Forbidden Phase 51 closeout evaluation: workstation-local absolute path detected"
+
 echo "Phase 51 closeout evaluation verifier tests passed."

--- a/scripts/test-verify-phase-51-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-51-closeout-evaluation.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-51-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-51-closeout-evaluation.md" "${target}/docs/phase-51-closeout-evaluation.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 51 closeout evaluation: docs/phase-51-closeout-evaluation.md"
+
+missing_phase52_guard_repo="${workdir}/missing-phase52-guard"
+copy_valid_repo "${missing_phase52_guard_repo}"
+perl -0pi -e 's/Do not materialize Phase 52 while the live preflight reports Phase 51 as `materialized_open`\.//' \
+  "${missing_phase52_guard_repo}/docs/phase-51-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_phase52_guard_repo}" \
+  'Missing required closeout term in docs/phase-51-closeout-evaluation.md: Do not materialize Phase 52 while the live preflight reports Phase 51 as `materialized_open`.'
+
+ga_overclaim_repo="${workdir}/ga-overclaim"
+copy_valid_repo "${ga_overclaim_repo}"
+printf '%s\n' "AegisOps is already GA" >>"${ga_overclaim_repo}/docs/phase-51-closeout-evaluation.md"
+assert_fails_with \
+  "${ga_overclaim_repo}" \
+  "Forbidden Phase 51 closeout evaluation claim: AegisOps is already GA"
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+mac_home_prefix="/""Users/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${mac_home_prefix}" >>"${absolute_path_repo}/docs/phase-51-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 51 closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 51 closeout evaluation verifier tests passed."

--- a/scripts/verify-phase-51-closeout-evaluation.sh
+++ b/scripts/verify-phase-51-closeout-evaluation.sh
@@ -76,11 +76,12 @@ for phrase in "${required_phrases[@]}"; do
   require_phrase "${phrase}" "required closeout term"
 done
 
-unix_home_prefix="/""home/"
-mac_home_prefix="/""Users/"
-windows_backslash_prefix="C:""\\Users\\"
-windows_slash_prefix="C:""/""Users/"
-if grep -Eq "(${mac_home_prefix}|${unix_home_prefix}[^ <\`]+|${windows_backslash_prefix}|${windows_slash_prefix})" "${absolute_doc_path}"; then
+mac_home_prefix="$(printf '/%s/' 'Users')"
+unix_home_prefix="$(printf '/%s/' 'home')"
+windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
+absolute_path_pattern="(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}"; then
   echo "Forbidden Phase 51 closeout evaluation: workstation-local absolute path detected" >&2
   exit 1
 fi

--- a/scripts/verify-phase-51-closeout-evaluation.sh
+++ b/scripts/verify-phase-51-closeout-evaluation.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-51-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+
+require_phrase() {
+  local phrase="$1"
+  local description="$2"
+
+  if ! grep -Fq -- "${phrase}" "${absolute_doc_path}"; then
+    echo "Missing ${description} in ${doc_path}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 51 closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+required_phrases=(
+  "# Phase 51 Closeout Evaluation"
+  "**Status**: Accepted with lifecycle closeout pending"
+  "**Related Issues**: #1041, #1042, #1043, #1044, #1045, #1046, #1047, #1048, #1049"
+  "Phase 51 is accepted as a repo-owned replacement-readiness contract."
+  "Phase 52 is the next materialization target after this closeout is made authoritative by closing or explicitly owner-accepting the Phase 51 Epic and closeout issue."
+  'phase_classification["51"] = "materialized_open"'
+  "| #1042 | Phase 51.1 replacement boundary ADR | Closed."
+  "| #1043 | Phase 51.2 README product positioning | Closed."
+  "| #1044 | Phase 51.3 Pilot, Beta, RC, and GA gate contract | Closed."
+  "| #1045 | Phase 51.4 SMB personas and jobs-to-be-done | Closed."
+  "| #1046 | Phase 51.5 competitive gap matrix | Closed."
+  "| #1047 | Phase 51.6 authority-boundary negative-test policy | Closed."
+  "| #1048 | Phase 51.7 roadmap materialization guard | Closed."
+  "| #1049 | Phase 51.8 closeout evaluation | Open while this evaluation is under review."
+  "bash scripts/verify-phase-51-1-replacement-boundary-adr.sh"
+  "bash scripts/test-verify-phase-51-1-replacement-boundary-adr.sh"
+  "bash scripts/verify-readme-product-positioning.sh"
+  "bash scripts/test-verify-readme-product-positioning.sh"
+  "bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh"
+  "bash scripts/test-verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh"
+  "bash scripts/verify-phase-51-4-smb-personas-jtbd.sh"
+  "bash scripts/test-verify-phase-51-4-smb-personas-jtbd.sh"
+  "bash scripts/verify-phase-51-5-competitive-gap-matrix.sh"
+  "bash scripts/test-verify-phase-51-5-competitive-gap-matrix.sh"
+  "bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh"
+  "bash scripts/test-verify-phase-51-6-authority-boundary-negative-test-policy.sh"
+  "bash scripts/verify-roadmap-materialization-preflight-contract.sh"
+  "bash scripts/test-verify-roadmap-materialization-preflight-contract.sh"
+  "bash scripts/test-verify-roadmap-materialization-preflight.sh"
+  "execution_ready=yes"
+  "missing_required=none"
+  "missing_recommended=none"
+  "metadata_errors=none"
+  "high_risk_blocking_ambiguity=none"
+  "CODEX_SUPERVISOR_ROOT=<codex-supervisor-root>"
+  "CODEX_SUPERVISOR_CONFIG=<supervisor-config-path>"
+  "bash scripts/roadmap-materialization-preflight.sh --graph docs/automation/roadmap-materialization-phase-graph.json --target-phase 52 --issue-source github"
+  'invalid_phase_id="51"'
+  'invalid_field="issue_state"'
+  'invalid_issue_number=1041'
+  'phase_classification["51"]="materialized_open"'
+  "Replacement boundary ADR exists and is cited from README."
+  "Authority-boundary policy requires later breadth issues to cite fail-closed negative-test expectations"
+  "Phase 51 does not implement Phase 52 setup"
+  "Phase 51 does not prove GA replacement readiness."
+  'Do not materialize Phase 52 while the live preflight reports Phase 51 as `materialized_open`.'
+)
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${phrase}" "required closeout term"
+done
+
+unix_home_prefix="/""home/"
+mac_home_prefix="/""Users/"
+windows_backslash_prefix="C:""\\Users\\"
+windows_slash_prefix="C:""/""Users/"
+if grep -Eq "(${mac_home_prefix}|${unix_home_prefix}[^ <\`]+|${windows_backslash_prefix}|${windows_slash_prefix})" "${absolute_doc_path}"; then
+  echo "Forbidden Phase 51 closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+for forbidden in \
+  "Phase 51 proves GA replacement readiness" \
+  "Phase 52 may be materialized while Phase 51 is open" \
+  "AegisOps is already GA" \
+  "AI is authoritative" \
+  "Wazuh is authoritative for AegisOps records" \
+  "Shuffle workflow success is AegisOps reconciliation truth"; do
+  if grep -Fq -- "${forbidden}" "${absolute_doc_path}"; then
+    echo "Forbidden Phase 51 closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 51 closeout evaluation records verifier evidence, lifecycle limitation, authority boundary, and Phase 52 materialization recommendation."


### PR DESCRIPTION
## Summary

- Add `docs/phase-51-closeout-evaluation.md` with Phase 51 child issue outcomes, verifier evidence, issue-lint summary, accepted limitations, and Phase 52 recommendation.
- Add a focused closeout verifier and negative fixture test, then wire them into CI.

## Verification

- `bash scripts/verify-phase-51-1-replacement-boundary-adr.sh && bash scripts/test-verify-phase-51-1-replacement-boundary-adr.sh && bash scripts/verify-readme-product-positioning.sh && bash scripts/test-verify-readme-product-positioning.sh && bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh && bash scripts/test-verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh && bash scripts/verify-phase-51-4-smb-personas-jtbd.sh && bash scripts/test-verify-phase-51-4-smb-personas-jtbd.sh && bash scripts/verify-phase-51-5-competitive-gap-matrix.sh && bash scripts/test-verify-phase-51-5-competitive-gap-matrix.sh && bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh && bash scripts/test-verify-phase-51-6-authority-boundary-negative-test-policy.sh && bash scripts/verify-roadmap-materialization-preflight-contract.sh && bash scripts/test-verify-roadmap-materialization-preflight-contract.sh && bash scripts/test-verify-roadmap-materialization-preflight.sh && bash scripts/verify-phase-51-closeout-evaluation.sh && bash scripts/test-verify-phase-51-closeout-evaluation.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `git diff --check`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1041..1049 --config <supervisor-config-path>`
- Live Phase 52 preflight currently fails closed with `phase_classification["51"]="materialized_open"` because #1041 and #1049 remain open during closeout review.

Closes #1049


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 51 closeout evaluation page with outcomes, verification evidence, limitations, and an alignment checklist.

* **Chores**
  * CI now runs closeout verification steps as part of documentation checks.

* **Tests**
  * Added an automated verifier and test-runner to validate the closeout documentation and enforce guardrails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->