### PR TITLE
Phase 51 graph completion preflight

### DIFF
--- a/docs/automation/roadmap-materialization-phase-graph.json
+++ b/docs/automation/roadmap-materialization-phase-graph.json
@@ -32,9 +32,9 @@
     {
       "phase_id": "51",
       "phase_title": "Replacement Thesis, Gates, Boundary ADR",
-      "phase_status": "materialized",
-      "phase_completion_state": "open",
-      "phase_evaluation_state": "open",
+      "phase_status": "done",
+      "phase_completion_state": "done",
+      "phase_evaluation_state": "evaluated",
       "predecessor_phase_ids": [],
       "epic_issue_number": 1041,
       "child_issue_numbers": [1042, 1043, 1044, 1045, 1046, 1047, 1048, 1049]

--- a/docs/phase-51-closeout-evaluation.md
+++ b/docs/phase-51-closeout-evaluation.md
@@ -1,6 +1,6 @@
 # Phase 51 Closeout Evaluation
 
-- **Status**: Accepted with lifecycle closed; Phase 52 preflight reconciliation pending
+- **Status**: Accepted with lifecycle closed; Phase 52 preflight unblocked by Phase 51 graph state
 - **Date**: 2026-05-01
 - **Owner**: AegisOps maintainers
 - **Related Issues**: #1041, #1042, #1043, #1044, #1045, #1046, #1047, #1048, #1049
@@ -9,7 +9,7 @@
 
 Phase 51 is accepted as a repo-owned replacement-readiness contract. The Phase 51 docs, ADR, focused verifiers, and materialization guard agree that AegisOps is a governed SMB SecOps operating-experience control plane above Wazuh and Shuffle, not a broad GA replacement for every SIEM or SOAR capability.
 
-Phase 52 is the next materialization target after repo-owned graph and preflight state are reconciled with the now-closed Phase 51 issue lifecycle. Until that reconciliation is recorded in the repo-owned materialization graph and proven by the Phase 52 preflight, the preflight must continue to fail closed with `phase_classification["51"] = "materialized_open"`.
+Phase 52 is the next materialization target after repo-owned graph and preflight state were reconciled with the now-closed Phase 51 issue lifecycle. The Phase 52 preflight now records `phase_classification["51"] = "done"` and no longer fails on stale Phase 51 lifecycle state. Phase 52 issue materialization still requires explicit owner direction.
 
 ## Child Issue Outcomes
 
@@ -60,14 +60,15 @@ CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> \
 bash scripts/roadmap-materialization-preflight.sh --graph docs/automation/roadmap-materialization-phase-graph.json --target-phase 52 --issue-source github
 ```
 
-That check now fails after #1041 and #1049 closed because the repo-owned graph still records Phase 51 as open. The remaining Phase 52 preflight blocker is repo-owned graph reconciliation, not GitHub issue lifecycle.
+That check now passes after the repo-owned graph recorded Phase 51 as complete and evaluated. It verifies the Phase 51 predecessor gate only; it does not create or authorize Phase 52 issues.
 
-- `pass=false`
-- `invalid_phase_id="51"`
-- `invalid_field="phase_completion_state"`
+- `pass=true`
+- `fail=false`
+- `invalid_phase_id=null`
+- `invalid_field=null`
 - `invalid_issue_number=null`
-- `phase_classification["51"]="materialized_open"`
-- `suggested_next_safe_action="complete and evaluate the materialized predecessor phase before dependent scheduling"`
+- `phase_classification["51"]="done"`
+- `suggested_next_safe_action="evaluate next phase gate"`
 
 ## Alignment Check
 
@@ -82,10 +83,10 @@ That check now fails after #1041 and #1049 closed because the repo-owned graph s
 
 - Phase 51 does not implement Phase 52 setup, guided onboarding, executable stack, Wazuh profile, Shuffle profile, AI daily operations, SIEM breadth, SOAR breadth, packaging, RC, or GA work.
 - Phase 51 does not prove GA replacement readiness. It proves the repo-owned replacement boundary, gate vocabulary, personas, competitive gaps, negative-test policy, and materialization guard needed before Phase 52+ work starts.
-- Phase 52 materialization remains blocked until the repo-owned graph and preflight output are reconciled with the closed Phase 51 issue lifecycle. This is the expected fail-closed graph/preflight guard, not a GitHub lifecycle blocker.
+- Phase 52 materialization remains a separate owner-directed action. The repo-owned graph and live preflight no longer report stale Phase 51 lifecycle state.
 
 ## Phase 52 Recommendation
 
-Materialize Phase 52 next after the repo-owned materialization graph records Phase 51 as complete and evaluated, then rerun the Phase 52 preflight command above. Phase 52 must remain scoped to setup and guided onboarding and must cite the Phase 51 replacement boundary, gate contract, persona matrix, competitive gap matrix, authority-boundary negative-test policy, and materialization guard.
+Materialize Phase 52 next only after explicit owner direction. Phase 52 must remain scoped to setup and guided onboarding and must cite the Phase 51 replacement boundary, gate contract, persona matrix, competitive gap matrix, authority-boundary negative-test policy, and materialization guard.
 
-Do not materialize Phase 52 while repo-owned graph or preflight state still reports Phase 51 as `materialized_open`, stale, missing, or otherwise unreconciled.
+Do not materialize Phase 52 solely because the graph and preflight now classify Phase 51 as done; Phase 52 issue materialization still requires explicit owner direction.

--- a/scripts/test-verify-phase-51-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-51-closeout-evaluation.sh
@@ -56,13 +56,13 @@ assert_fails_with \
   "${missing_doc_repo}" \
   "Missing Phase 51 closeout evaluation: docs/phase-51-closeout-evaluation.md"
 
-missing_phase52_guard_repo="${workdir}/missing-phase52-guard"
-copy_valid_repo "${missing_phase52_guard_repo}"
-perl -0pi -e 's/Do not materialize Phase 52 while repo-owned graph or preflight state still reports Phase 51 as `materialized_open`, stale, missing, or otherwise unreconciled\.//' \
-  "${missing_phase52_guard_repo}/docs/phase-51-closeout-evaluation.md"
+missing_owner_direction_repo="${workdir}/missing-owner-direction"
+copy_valid_repo "${missing_owner_direction_repo}"
+perl -0pi -e 's/Do not materialize Phase 52 solely because the graph and preflight now classify Phase 51 as done; Phase 52 issue materialization still requires explicit owner direction\.//' \
+  "${missing_owner_direction_repo}/docs/phase-51-closeout-evaluation.md"
 assert_fails_with \
-  "${missing_phase52_guard_repo}" \
-  'Missing required closeout term in docs/phase-51-closeout-evaluation.md: Do not materialize Phase 52 while repo-owned graph or preflight state still reports Phase 51 as `materialized_open`, stale, missing, or otherwise unreconciled.'
+  "${missing_owner_direction_repo}" \
+  "Missing required closeout term in docs/phase-51-closeout-evaluation.md: Do not materialize Phase 52 solely because the graph and preflight now classify Phase 51 as done; Phase 52 issue materialization still requires explicit owner direction."
 
 ga_overclaim_repo="${workdir}/ga-overclaim"
 copy_valid_repo "${ga_overclaim_repo}"

--- a/scripts/verify-phase-51-closeout-evaluation.sh
+++ b/scripts/verify-phase-51-closeout-evaluation.sh
@@ -25,11 +25,12 @@ fi
 
 required_phrases=(
   "# Phase 51 Closeout Evaluation"
-  "**Status**: Accepted with lifecycle closed; Phase 52 preflight reconciliation pending"
+  "**Status**: Accepted with lifecycle closed; Phase 52 preflight unblocked by Phase 51 graph state"
   "**Related Issues**: #1041, #1042, #1043, #1044, #1045, #1046, #1047, #1048, #1049"
   "Phase 51 is accepted as a repo-owned replacement-readiness contract."
-  "Phase 52 is the next materialization target after repo-owned graph and preflight state are reconciled with the now-closed Phase 51 issue lifecycle."
-  'phase_classification["51"] = "materialized_open"'
+  "Phase 52 is the next materialization target after repo-owned graph and preflight state were reconciled with the now-closed Phase 51 issue lifecycle."
+  'phase_classification["51"] = "done"'
+  "Phase 52 issue materialization still requires explicit owner direction."
   "| #1042 | Phase 51.1 replacement boundary ADR | Closed."
   "| #1043 | Phase 51.2 README product positioning | Closed."
   "| #1044 | Phase 51.3 Pilot, Beta, RC, and GA gate contract | Closed."
@@ -61,16 +62,20 @@ required_phrases=(
   "CODEX_SUPERVISOR_ROOT=<codex-supervisor-root>"
   "CODEX_SUPERVISOR_CONFIG=<supervisor-config-path>"
   "bash scripts/roadmap-materialization-preflight.sh --graph docs/automation/roadmap-materialization-phase-graph.json --target-phase 52 --issue-source github"
-  'invalid_phase_id="51"'
-  'invalid_field="phase_completion_state"'
+  "That check now passes after the repo-owned graph recorded Phase 51 as complete and evaluated."
+  "It verifies the Phase 51 predecessor gate only; it does not create or authorize Phase 52 issues."
+  "pass=true"
+  "fail=false"
+  "invalid_phase_id=null"
+  "invalid_field=null"
   'invalid_issue_number=null'
-  'phase_classification["51"]="materialized_open"'
-  "The remaining Phase 52 preflight blocker is repo-owned graph reconciliation, not GitHub issue lifecycle."
+  'phase_classification["51"]="done"'
+  'suggested_next_safe_action="evaluate next phase gate"'
   "Replacement boundary ADR exists and is cited from README."
   "Authority-boundary policy requires later breadth issues to cite fail-closed negative-test expectations"
   "Phase 51 does not implement Phase 52 setup"
   "Phase 51 does not prove GA replacement readiness."
-  'Do not materialize Phase 52 while repo-owned graph or preflight state still reports Phase 51 as `materialized_open`, stale, missing, or otherwise unreconciled.'
+  "Do not materialize Phase 52 solely because the graph and preflight now classify Phase 51 as done; Phase 52 issue materialization still requires explicit owner direction."
 )
 
 for phrase in "${required_phrases[@]}"; do
@@ -91,6 +96,7 @@ for forbidden in \
   "Phase 51 proves GA replacement readiness" \
   "Phase 52 may be materialized while Phase 51 is open" \
   "Phase 52 is blocked because #1041 or #1049 are open" \
+  "The remaining Phase 52 preflight blocker is repo-owned graph reconciliation" \
   "while #1041 and #1049 remain open" \
   "#1049 | Phase 51.8 closeout evaluation | Open" \
   "Accepted with lifecycle closeout pending" \


### PR DESCRIPTION
## Summary
- Mark Phase 51 complete/evaluated in the roadmap materialization graph after live issue lifecycle verification.
- Update Phase 51 closeout evidence and verifier expectations to record the passing Phase 52 preflight.
- Keep Phase 52 issue materialization gated on explicit owner direction.

## Verification
- `jq . docs/automation/roadmap-materialization-phase-graph.json`
- `bash scripts/verify-phase-51-closeout-evaluation.sh`
- `bash scripts/test-verify-phase-51-closeout-evaluation.sh`
- `bash scripts/verify-roadmap-materialization-preflight-contract.sh`
- `bash scripts/test-verify-roadmap-materialization-preflight-contract.sh`
- `bash scripts/test-verify-roadmap-materialization-preflight.sh`
- Live GitHub-backed Phase 52 preflight with `CODEX_SUPERVISOR_ROOT`, `CODEX_SUPERVISOR_CONFIG`, `--target-phase 52`, and `--issue-source github`
- `git diff --check`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1060 --config <supervisor-config-path>`

Closes #1060


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Phase 51 lifecycle completion status and closeout evaluation semantics
  * Clarified Phase 52 materialization requirements to require explicit owner direction

* **Tests**
  * Updated verification tests to validate Phase 51 completion state transitions
  * Adjusted validation assertions to reflect updated phase lifecycle semantics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->