### PR TITLE
Phase 52.1 CLI command contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Canonical cross-phase boundary reference:
 - [Phase 51.4 SMB personas and jobs-to-be-done matrix](docs/phase-51-4-smb-personas-jobs-to-be-done.md) defines the internal IT manager, part-time security operator, approver/escalation owner, platform admin, and bounded external support collaborator personas for later replacement-roadmap work.
 - [Phase 51.5 competitive gap matrix](docs/phase-51-5-competitive-gap-matrix.md) compares the replacement operating-experience target against standalone Wazuh, standalone Shuffle, manual SOC/ticket workflow, and common SMB SIEM/SOAR expectations.
 - [Phase 51.6 authority-boundary negative-test policy](docs/phase-51-6-authority-boundary-negative-test-policy.md) defines the fail-closed negative-test classes later AI, Wazuh, Shuffle, ticket, evidence, browser, UI cache, downstream receipt, and demo-data work must cite.
+- [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md) defines the first-user stack command contract for `init`, `up`, `doctor`, `seed-demo`, `status`, `open`, `logs`, and `down`.
 
 ## Product positioning
 
@@ -40,6 +41,8 @@ The Phase 51.4 SMB personas and jobs-to-be-done matrix is defined by the [Phase 
 The Phase 51.5 competitive gap matrix is defined by the [Phase 51.5 competitive gap matrix](docs/phase-51-5-competitive-gap-matrix.md).
 
 The Phase 51.6 authority-boundary negative-test policy is defined by the [Phase 51.6 authority-boundary negative-test policy](docs/phase-51-6-authority-boundary-negative-test-policy.md).
+
+The Phase 52.1 first-user CLI command contract is defined by the [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-52-1-cli-command-contract.md
+++ b/docs/phase-52-1-cli-command-contract.md
@@ -1,0 +1,92 @@
+# Phase 52.1 CLI Command Contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/adr/0011-phase-51-1-replacement-boundary.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1063, #1064
+
+This contract defines the first-user CLI command contract only. It does not implement installer behavior, Wazuh profile generation, Shuffle profile generation, first-user UI flows, AI operations, SIEM breadth, SOAR breadth, packaging, release-candidate behavior, or general-availability behavior.
+
+## 1. Purpose
+
+Phase 52.1 gives later executable-stack issues one stable contract for the first-user CLI surface. The CLI may guide an operator through setup, startup, readiness review, demo seeding, status inspection, browser opening, log inspection, and shutdown.
+
+The approved command names are `init`, `up`, `doctor`, `seed-demo`, `status`, `open`, `logs`, and `down`.
+
+## 2. Authority Boundary
+
+CLI output is operator guidance and readiness evidence only. CLI output is not alert, case, evidence, approval, execution, reconciliation, gate, release, or production truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.
+
+This command contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. The CLI must preserve the Phase 51.6 rule that subordinate surfaces, including Wazuh, Shuffle, tickets, AI, browser state, UI cache, downstream receipts, and demo data, cannot become workflow truth.
+
+## 3. Shared Output Contract
+
+Every command must emit structured operator-facing output with:
+
+- `command`: the invoked command name.
+- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.
+- `summary`: a short human-readable operator summary.
+- `next_actions`: zero or more safe follow-up commands or prerequisite actions.
+- `evidence`: zero or more readiness evidence references, never authoritative workflow truth.
+
+The CLI must use repo-relative commands, documented environment variables, and placeholders such as `<runtime-env-file>`, `<profile-name>`, `<log-selector>`, `<evidence-dir>`, `<supervisor-config-path>`, and `<codex-supervisor-root>` in publishable guidance.
+
+## 4. Command Contract
+
+| Command | Purpose | Required inputs | Expected outputs | Failure behavior | Safe retry guidance |
+| --- | --- | --- | --- | --- | --- |
+| `init` | Create or validate the local first-user AegisOps workspace skeleton and runtime configuration placeholders. | Repository checkout; writable working directory; optional `<runtime-env-file>`; selected `<profile-name>`. | `result=ok` when placeholders are present; generated or reused config paths; explicit next action `aegisops up`; readiness evidence references only. | Fail closed if the target directory is not writable, required templates are missing, or an existing config conflicts with the selected profile. Do not overwrite operator-owned files without an explicit reviewed flag. | Safe to retry after fixing permissions, restoring templates, or choosing a non-conflicting profile. Retry must be idempotent and preserve existing operator-owned values. |
+| `up` | Start the reviewed first-user stack components that are available for the selected profile. | Initialized workspace; `<runtime-env-file>`; selected `<profile-name>`; available container or process runtime. | `result=ok` only for components actually started or already healthy; `result=skipped` or `result=mocked` for unavailable Wazuh or Shuffle profiles; service endpoints and next action `aegisops doctor`. | Fail closed when required control-plane prerequisites are missing, startup exits non-zero, readiness cannot be checked, or profile binding is ambiguous. Do not claim Wazuh or Shuffle profile completion when those profiles are absent. | Safe to retry after `doctor` identifies the missing prerequisite. Retry may reuse already-running components and must surface any skipped or mocked state again. |
+| `doctor` | Inspect local prerequisites, profile selection, readiness probes, and authority-boundary warnings. | Repository checkout; optional `<runtime-env-file>`; selected or discoverable `<profile-name>`. | Readiness checklist with `ok`, `skipped`, `mocked`, `degraded`, or `failed` per check; explicit prerequisite follow-ups; evidence references only. | Fail closed when required readiness checks cannot run, snapshots are mixed, profile identity is missing, or a subordinate surface is presented as authoritative truth. | Safe to retry after resolving prerequisites. Retry must recompute checks from current state instead of trusting stale output. |
+| `seed-demo` | Seed reviewed demo-only records and fixtures for first-user evaluation without production claims. | Initialized workspace; explicit demo mode flag; selected `<profile-name>`; demo fixture bundle. | `result=ok` only for demo fixture admission; demo record identifiers; warning that demo data is not production truth; next action `aegisops status`. | Fail closed if demo mode is not explicit, fixture provenance is missing, fake credentials are treated as real, or seed data would overwrite production-bound records. | Safe to retry after cleaning partial demo state or supplying a reviewed fixture bundle. Retry must not duplicate authoritative records silently. |
+| `status` | Summarize local stack health and first-user readiness from current checks. | Initialized workspace; optional `<runtime-env-file>`; selected or discoverable `<profile-name>`. | Current component health; skipped or mocked Wazuh and Shuffle states; links to AegisOps record identifiers when available; operator guidance only. | Fail closed when the status read mixes snapshots, cannot bind to the selected profile, or attempts to treat CLI status as workflow truth. | Safe to retry at any time. Retry must refresh from current checks and must not promote cached summaries to authoritative state. |
+| `open` | Open or print the reviewed operator access URL for the local stack. | Initialized workspace; selected `<profile-name>`; reviewed access URL or route. | Operator URL or browser-open result; warning that browser state is not workflow truth; next action `aegisops doctor` if readiness is unknown. | Fail closed if the URL is missing, unreviewed, points outside the approved access path, or would bypass the reviewed reverse proxy boundary. | Safe to retry after fixing access configuration. Retry must not infer tenant, profile, or readiness from browser state. |
+| `logs` | Show bounded logs for selected first-user stack components. | Initialized workspace; `<log-selector>` or default selector; optional time window. | Bounded log stream or retained log path; redaction and truncation notice; evidence references only. | Fail closed if the selector is ambiguous, logs cannot be bounded, redaction cannot run, or log text is used as authoritative workflow truth. | Safe to retry with a narrower selector or time window. Retry must not require destructive cleanup. |
+| `down` | Stop the local first-user stack without deleting authoritative or operator-owned state. | Initialized workspace; selected `<profile-name>`; optional reviewed cleanup flag. | `result=ok` when managed components are stopped or already stopped; retained state paths; next actions for restart or cleanup. | Fail closed if component ownership is ambiguous, cleanup would delete operator-owned state, or shutdown cannot verify component identity. | Safe to retry. Retry may treat already-stopped managed components as `ok`, while preserving retained state and surfacing unmanaged components. |
+
+## 5. Mocked and Skipped States
+
+Before reviewed Wazuh and Shuffle product profiles exist, commands must report unavailable substrate work as explicit `skipped` or `mocked` states. `skipped` means the command intentionally did not attempt a profile-backed operation because the reviewed profile is absent or disabled. `mocked` means the command used a reviewed demo or placeholder path that is not production-capable.
+
+`skipped` and `mocked` states must not be reported as false success. They must include the missing prerequisite, the affected command, and the later profile issue that must replace the placeholder path before production use.
+
+Wazuh alert status is not AegisOps workflow truth. Shuffle workflow success is not AegisOps workflow truth. Demo data is not production truth. Browser state, UI cache, logs, tickets, downstream receipts, and CLI summaries are not AegisOps workflow truth.
+
+## 6. Failure and Retry Rules
+
+All commands fail closed when provenance, profile binding, runtime scope, auth context, snapshot consistency, or authority-boundary signals are missing, malformed, stale, mixed, or only partially trusted.
+
+Safe retry means a command can be rerun after the stated prerequisite is repaired without destructive cleanup, duplicate authoritative writes, hidden state promotion, or widened product scope.
+
+Failed, rejected, skipped, mocked, and degraded paths must leave durable state clean. If a command writes multiple records in later implementation work, that logical change must be atomic and later verification must prove no orphan record or partial durable write survives a failed path.
+
+## 7. Forbidden Claims
+
+- CLI status is workflow truth.
+- CLI output is authoritative for AegisOps records.
+- Phase 52 completes Wazuh profiles.
+- Phase 52 completes Shuffle profiles.
+- Wazuh alert status is AegisOps workflow truth.
+- Shuffle workflow success is AegisOps workflow truth.
+- Demo data is production truth.
+- Browser state is workflow truth.
+- Logs are authoritative workflow truth.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-52-1-cli-command-contract.sh`.
+
+Run `bash scripts/test-verify-phase-52-1-cli-command-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1064 --config <supervisor-config-path>`.
+
+The verifier must fail when any required command is missing, when command purpose, inputs, outputs, failure behavior, or safe retry guidance is missing, when CLI status is claimed as workflow truth, when Phase 52 is claimed to complete Wazuh or Shuffle profiles, when mocked or skipped states can be false success, when the Phase 51.6 policy citation is missing, or when publishable guidance uses workstation-local absolute paths.
+
+## 9. Non-Goals
+
+- No runtime CLI implementation is approved by this contract.
+- No installer, Wazuh profile, Shuffle profile, first-user UI journey, AI operation, SIEM breadth, SOAR breadth, packaging, RC, or GA behavior is implemented here.
+- No CLI output, browser state, UI cache, log text, demo data, Wazuh state, Shuffle state, ticket state, downstream receipt, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/test-verify-phase-52-1-cli-command-contract.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-1-cli-command-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  printf '%s\n' "# AegisOps" "See [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/phase-52-1-cli-command-contract.md" \
+    "${target}/docs/phase-52-1-cli-command-contract.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-52-1-cli-command-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 52.1 CLI command contract"
+
+missing_command_repo="${workdir}/missing-seed-demo"
+create_valid_repo "${missing_command_repo}"
+remove_text_from_contract "${missing_command_repo}" \
+  '| `seed-demo` | Seed reviewed demo-only records and fixtures for first-user evaluation without production claims. | Initialized workspace; explicit demo mode flag; selected `<profile-name>`; demo fixture bundle. | `result=ok` only for demo fixture admission; demo record identifiers; warning that demo data is not production truth; next action `aegisops status`. | Fail closed if demo mode is not explicit, fixture provenance is missing, fake credentials are treated as real, or seed data would overwrite production-bound records. | Safe to retry after cleaning partial demo state or supplying a reviewed fixture bundle. Retry must not duplicate authoritative records silently. |'
+assert_fails_with \
+  "${missing_command_repo}" \
+  "Missing complete Phase 52.1 CLI command row: seed-demo"
+
+missing_retry_repo="${workdir}/missing-retry"
+create_valid_repo "${missing_retry_repo}"
+remove_text_from_contract "${missing_retry_repo}" \
+  "Safe retry means a command can be rerun after the stated prerequisite is repaired without destructive cleanup, duplicate authoritative writes, hidden state promotion, or widened product scope."
+assert_fails_with \
+  "${missing_retry_repo}" \
+  "Missing Phase 52.1 CLI command contract statement: Safe retry means"
+
+missing_mocked_repo="${workdir}/missing-mocked"
+create_valid_repo "${missing_mocked_repo}"
+remove_text_from_contract "${missing_mocked_repo}" \
+  '`skipped` and `mocked` states must not be reported as false success.'
+assert_fails_with \
+  "${missing_mocked_repo}" \
+  "Missing Phase 52.1 CLI command contract statement: \`skipped\` and \`mocked\` states must not be reported as false success."
+
+missing_phase51_citation_repo="${workdir}/missing-phase51-citation"
+create_valid_repo "${missing_phase51_citation_repo}"
+remove_text_from_contract "${missing_phase51_citation_repo}" \
+  'This command contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+assert_fails_with \
+  "${missing_phase51_citation_repo}" \
+  "Missing Phase 52.1 CLI command contract statement: This command contract cites the Phase 51.6 authority-boundary negative-test policy"
+
+cli_truth_repo="${workdir}/cli-truth"
+create_valid_repo "${cli_truth_repo}"
+printf '%s\n' "CLI status is workflow truth." \
+  >>"${cli_truth_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${cli_truth_repo}" \
+  "Forbidden Phase 52.1 CLI command contract claim: CLI status is workflow truth"
+
+wazuh_complete_repo="${workdir}/wazuh-complete"
+create_valid_repo "${wazuh_complete_repo}"
+printf '%s\n' "Phase 52 completes Wazuh profiles." \
+  >>"${wazuh_complete_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${wazuh_complete_repo}" \
+  "Forbidden Phase 52.1 CLI command contract claim: Phase 52 completes Wazuh profiles"
+
+shuffle_complete_repo="${workdir}/shuffle-complete"
+create_valid_repo "${shuffle_complete_repo}"
+printf '%s\n' "Phase 52 completes Shuffle profiles." \
+  >>"${shuffle_complete_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${shuffle_complete_repo}" \
+  "Forbidden Phase 52.1 CLI command contract claim: Phase 52 completes Shuffle profiles"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" "Phase 52.1 CLI command contract exists." >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 52.1 CLI command contract."
+
+echo "Phase 52.1 CLI command contract verifier tests passed."

--- a/scripts/test-verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/test-verify-phase-52-1-cli-command-contract.sh
@@ -99,6 +99,54 @@ assert_fails_with \
   "${missing_phase51_citation_repo}" \
   "Missing Phase 52.1 CLI command contract statement: This command contract cites the Phase 51.6 authority-boundary negative-test policy"
 
+missing_command_field_repo="${workdir}/missing-command-field"
+create_valid_repo "${missing_command_field_repo}"
+remove_text_from_contract "${missing_command_field_repo}" \
+  '- `command`: the invoked command name.'
+assert_fails_with \
+  "${missing_command_field_repo}" \
+  "Missing or empty Phase 52.1 shared output field: command"
+
+missing_summary_field_repo="${workdir}/missing-summary-field"
+create_valid_repo "${missing_summary_field_repo}"
+remove_text_from_contract "${missing_summary_field_repo}" \
+  '- `summary`: a short human-readable operator summary.'
+assert_fails_with \
+  "${missing_summary_field_repo}" \
+  "Missing or empty Phase 52.1 shared output field: summary"
+
+missing_next_actions_field_repo="${workdir}/missing-next-actions-field"
+create_valid_repo "${missing_next_actions_field_repo}"
+remove_text_from_contract "${missing_next_actions_field_repo}" \
+  '- `next_actions`: zero or more safe follow-up commands or prerequisite actions.'
+assert_fails_with \
+  "${missing_next_actions_field_repo}" \
+  "Missing or empty Phase 52.1 shared output field: next_actions"
+
+missing_evidence_field_repo="${workdir}/missing-evidence-field"
+create_valid_repo "${missing_evidence_field_repo}"
+remove_text_from_contract "${missing_evidence_field_repo}" \
+  '- `evidence`: zero or more readiness evidence references, never authoritative workflow truth.'
+assert_fails_with \
+  "${missing_evidence_field_repo}" \
+  "Missing or empty Phase 52.1 shared output field: evidence"
+
+missing_result_field_repo="${workdir}/missing-result-field"
+create_valid_repo "${missing_result_field_repo}"
+remove_text_from_contract "${missing_result_field_repo}" \
+  '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.'
+assert_fails_with \
+  "${missing_result_field_repo}" \
+  "Missing or empty Phase 52.1 shared output field: result"
+
+invalid_result_field_repo="${workdir}/invalid-result-field"
+create_valid_repo "${invalid_result_field_repo}"
+perl -0pi -e 's/- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`\./- `result`: one of `ok` or `failed`./g' \
+  "${invalid_result_field_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${invalid_result_field_repo}" \
+  "Invalid Phase 52.1 shared output result field"
+
 cli_truth_repo="${workdir}/cli-truth"
 create_valid_repo "${cli_truth_repo}"
 printf '%s\n' "CLI status is workflow truth." \
@@ -136,6 +184,16 @@ create_valid_repo "${missing_readme_link_repo}"
 printf '%s\n' "# AegisOps" "Phase 52.1 CLI command contract exists." >"${missing_readme_link_repo}/README.md"
 assert_fails_with \
   "${missing_readme_link_repo}" \
+  "README must link the Phase 52.1 CLI command contract."
+
+commented_readme_link_repo="${workdir}/commented-readme-link"
+create_valid_repo "${commented_readme_link_repo}"
+printf '%s\n' \
+  "# AegisOps" \
+  "<!-- [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md) -->" \
+  >"${commented_readme_link_repo}/README.md"
+assert_fails_with \
+  "${commented_readme_link_repo}" \
   "README must link the Phase 52.1 CLI command contract."
 
 echo "Phase 52.1 CLI command contract verifier tests passed."

--- a/scripts/test-verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/test-verify-phase-52-1-cli-command-contract.sh
@@ -75,6 +75,14 @@ assert_fails_with \
   "${missing_command_repo}" \
   "Missing complete Phase 52.1 CLI command row: seed-demo"
 
+whitespace_command_cell_repo="${workdir}/whitespace-command-cell"
+create_valid_repo "${whitespace_command_cell_repo}"
+perl -0pi -e 's/\| `status` \| [^|]+ \|/| `status` |     |/g' \
+  "${whitespace_command_cell_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${whitespace_command_cell_repo}" \
+  "Missing complete Phase 52.1 CLI command row: status"
+
 missing_retry_repo="${workdir}/missing-retry"
 create_valid_repo "${missing_retry_repo}"
 remove_text_from_contract "${missing_retry_repo}" \

--- a/scripts/test-verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/test-verify-phase-52-1-cli-command-contract.sh
@@ -99,6 +99,16 @@ assert_fails_with \
   "${missing_phase51_citation_repo}" \
   "Missing Phase 52.1 CLI command contract statement: This command contract cites the Phase 51.6 authority-boundary negative-test policy"
 
+commented_heading_repo="${workdir}/commented-heading"
+create_valid_repo "${commented_heading_repo}"
+remove_text_from_contract "${commented_heading_repo}" \
+  '# Phase 52.1 CLI Command Contract'
+printf '%s\n' '<!-- # Phase 52.1 CLI Command Contract -->' \
+  >>"${commented_heading_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${commented_heading_repo}" \
+  "Missing Phase 52.1 CLI command contract heading: # Phase 52.1 CLI Command Contract"
+
 missing_command_field_repo="${workdir}/missing-command-field"
 create_valid_repo "${missing_command_field_repo}"
 remove_text_from_contract "${missing_command_field_repo}" \
@@ -139,6 +149,19 @@ assert_fails_with \
   "${missing_result_field_repo}" \
   "Missing or empty Phase 52.1 shared output field: result"
 
+fenced_result_field_repo="${workdir}/fenced-result-field"
+create_valid_repo "${fenced_result_field_repo}"
+remove_text_from_contract "${fenced_result_field_repo}" \
+  '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.'
+printf '%s\n' \
+  '```markdown' \
+  '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.' \
+  '```' \
+  >>"${fenced_result_field_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${fenced_result_field_repo}" \
+  "Missing or empty Phase 52.1 shared output field: result"
+
 invalid_result_field_repo="${workdir}/invalid-result-field"
 create_valid_repo "${invalid_result_field_repo}"
 perl -0pi -e 's/- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`\./- `result`: one of `ok` or `failed`./g' \
@@ -170,6 +193,19 @@ printf '%s\n' "Phase 52 completes Shuffle profiles." \
 assert_fails_with \
   "${shuffle_complete_repo}" \
   "Forbidden Phase 52.1 CLI command contract claim: Phase 52 completes Shuffle profiles"
+
+fenced_command_row_repo="${workdir}/fenced-command-row"
+create_valid_repo "${fenced_command_row_repo}"
+remove_text_from_contract "${fenced_command_row_repo}" \
+  '| `logs` | Show bounded logs for selected first-user stack components. | Initialized workspace; `<log-selector>` or default selector; optional time window. | Bounded log stream or retained log path; redaction and truncation notice; evidence references only. | Fail closed if the selector is ambiguous, logs cannot be bounded, redaction cannot run, or log text is used as authoritative workflow truth. | Safe to retry with a narrower selector or time window. Retry must not require destructive cleanup. |'
+printf '%s\n' \
+  '```markdown' \
+  '| `logs` | Show bounded logs for selected first-user stack components. | Initialized workspace; `<log-selector>` or default selector; optional time window. | Bounded log stream or retained log path; redaction and truncation notice; evidence references only. | Fail closed if the selector is ambiguous, logs cannot be bounded, redaction cannot run, or log text is used as authoritative workflow truth. | Safe to retry with a narrower selector or time window. Retry must not require destructive cleanup. |' \
+  '```' \
+  >>"${fenced_command_row_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${fenced_command_row_repo}" \
+  "Missing complete Phase 52.1 CLI command row: logs"
 
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"

--- a/scripts/test-verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/test-verify-phase-52-1-cli-command-contract.sh
@@ -260,12 +260,28 @@ assert_fails_with \
   "${file_uri_path_repo}" \
   "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected"
 
+inline_code_path_repo="${workdir}/inline-code-path"
+create_valid_repo "${inline_code_path_repo}"
+printf 'Use `%s%s/aegisops` for setup.\n' "/" "tmp" \
+  >>"${inline_code_path_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${inline_code_path_repo}" \
+  "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected"
+
 windows_drive_path_repo="${workdir}/windows-drive-path"
 create_valid_repo "${windows_drive_path_repo}"
 printf 'Use %s:%s%s for setup.\n' "D" "\\" "aegisops" \
   >>"${windows_drive_path_repo}/docs/phase-52-1-cli-command-contract.md"
 assert_fails_with \
   "${windows_drive_path_repo}" \
+  "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected"
+
+inline_code_windows_drive_path_repo="${workdir}/inline-code-windows-drive-path"
+create_valid_repo "${inline_code_windows_drive_path_repo}"
+printf 'Use `%s:%s%s` for setup.\n' "D" "\\" "aegisops" \
+  >>"${inline_code_windows_drive_path_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${inline_code_windows_drive_path_repo}" \
   "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected"
 
 missing_readme_link_repo="${workdir}/missing-readme-link"

--- a/scripts/test-verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/test-verify-phase-52-1-cli-command-contract.sh
@@ -117,6 +117,16 @@ assert_fails_with \
   "${commented_heading_repo}" \
   "Missing Phase 52.1 CLI command contract heading: # Phase 52.1 CLI Command Contract"
 
+indented_heading_repo="${workdir}/indented-heading"
+create_valid_repo "${indented_heading_repo}"
+remove_text_from_contract "${indented_heading_repo}" \
+  '# Phase 52.1 CLI Command Contract'
+printf '%s\n' '    # Phase 52.1 CLI Command Contract' \
+  >>"${indented_heading_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${indented_heading_repo}" \
+  "Missing Phase 52.1 CLI command contract heading: # Phase 52.1 CLI Command Contract"
+
 missing_command_field_repo="${workdir}/missing-command-field"
 create_valid_repo "${missing_command_field_repo}"
 remove_text_from_contract "${missing_command_field_repo}" \
@@ -215,12 +225,47 @@ assert_fails_with \
   "${fenced_command_row_repo}" \
   "Missing complete Phase 52.1 CLI command row: logs"
 
+indented_command_row_repo="${workdir}/indented-command-row"
+create_valid_repo "${indented_command_row_repo}"
+remove_text_from_contract "${indented_command_row_repo}" \
+  '| `logs` | Show bounded logs for selected first-user stack components. | Initialized workspace; `<log-selector>` or default selector; optional time window. | Bounded log stream or retained log path; redaction and truncation notice; evidence references only. | Fail closed if the selector is ambiguous, logs cannot be bounded, redaction cannot run, or log text is used as authoritative workflow truth. | Safe to retry with a narrower selector or time window. Retry must not require destructive cleanup. |'
+printf '%s\n' \
+  '    | `logs` | Show bounded logs for selected first-user stack components. | Initialized workspace; `<log-selector>` or default selector; optional time window. | Bounded log stream or retained log path; redaction and truncation notice; evidence references only. | Fail closed if the selector is ambiguous, logs cannot be bounded, redaction cannot run, or log text is used as authoritative workflow truth. | Safe to retry with a narrower selector or time window. Retry must not require destructive cleanup. |' \
+  >>"${indented_command_row_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${indented_command_row_repo}" \
+  "Missing complete Phase 52.1 CLI command row: logs"
+
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"
 printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
   >>"${local_path_repo}/docs/phase-52-1-cli-command-contract.md"
 assert_fails_with \
   "${local_path_repo}" \
+  "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected"
+
+temp_path_repo="${workdir}/temp-path"
+create_valid_repo "${temp_path_repo}"
+printf 'Use /%s/aegisops for setup.\n' "tmp" \
+  >>"${temp_path_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${temp_path_repo}" \
+  "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected"
+
+file_uri_path_repo="${workdir}/file-uri-path"
+create_valid_repo "${file_uri_path_repo}"
+printf 'Use file:///%s/aegisops for setup.\n' "tmp" \
+  >>"${file_uri_path_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${file_uri_path_repo}" \
+  "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected"
+
+windows_drive_path_repo="${workdir}/windows-drive-path"
+create_valid_repo "${windows_drive_path_repo}"
+printf 'Use %s:%s%s for setup.\n' "D" "\\" "aegisops" \
+  >>"${windows_drive_path_repo}/docs/phase-52-1-cli-command-contract.md"
+assert_fails_with \
+  "${windows_drive_path_repo}" \
   "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected"
 
 missing_readme_link_repo="${workdir}/missing-readme-link"
@@ -238,6 +283,16 @@ printf '%s\n' \
   >"${commented_readme_link_repo}/README.md"
 assert_fails_with \
   "${commented_readme_link_repo}" \
+  "README must link the Phase 52.1 CLI command contract."
+
+indented_readme_link_repo="${workdir}/indented-readme-link"
+create_valid_repo "${indented_readme_link_repo}"
+printf '%s\n' \
+  "# AegisOps" \
+  "    [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md)" \
+  >"${indented_readme_link_repo}/README.md"
+assert_fails_with \
+  "${indented_readme_link_repo}" \
   "README must link the Phase 52.1 CLI command contract."
 
 echo "Phase 52.1 CLI command contract verifier tests passed."

--- a/scripts/verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/verify-phase-52-1-cli-command-contract.sh
@@ -106,7 +106,7 @@ for phrase in "${required_phrases[@]}"; do
 done
 
 for command in "${commands[@]}"; do
-  if ! grep -Eq "^\| \`${command}\` \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \|$" <<<"${doc_rendered_markdown}"; then
+  if ! grep -Eq "^\| \`${command}\` \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
     echo "Missing complete Phase 52.1 CLI command row: ${command}" >&2
     exit 1
   fi

--- a/scripts/verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/verify-phase-52-1-cli-command-contract.sh
@@ -29,6 +29,11 @@ required_phrases=(
   "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth."
   'This command contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
   'Every command must emit structured operator-facing output with:'
+  '- `command`: the invoked command name.'
+  '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.'
+  '- `summary`: a short human-readable operator summary.'
+  '- `next_actions`: zero or more safe follow-up commands or prerequisite actions.'
+  '- `evidence`: zero or more readiness evidence references, never authoritative workflow truth.'
   "| Command | Purpose | Required inputs | Expected outputs | Failure behavior | Safe retry guidance |"
   'Before reviewed Wazuh and Shuffle product profiles exist, commands must report unavailable substrate work as explicit `skipped` or `mocked` states.'
   '`skipped` and `mocked` states must not be reported as false success.'
@@ -71,13 +76,6 @@ for heading in "${required_headings[@]}"; do
   fi
 done
 
-for phrase in "${required_phrases[@]}"; do
-  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
-    echo "Missing Phase 52.1 CLI command contract statement: ${phrase}" >&2
-    exit 1
-  fi
-done
-
 for field in "${shared_output_fields[@]}"; do
   if ! grep -Eq -- "^- \`${field}\`: [^[:space:]].+$" "${doc_path}"; then
     echo "Missing or empty Phase 52.1 shared output field: ${field}" >&2
@@ -89,6 +87,13 @@ if ! grep -Fxq -- '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or 
   echo "Invalid Phase 52.1 shared output result field: expected one of ok, skipped, mocked, degraded, or failed." >&2
   exit 1
 fi
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 52.1 CLI command contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
 
 for command in "${commands[@]}"; do
   if ! grep -Eq "^\| \`${command}\` \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \|$" "${doc_path}"; then

--- a/scripts/verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/verify-phase-52-1-cli-command-contract.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-52-1-cli-command-contract.md"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 52.1 CLI Command Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Shared Output Contract"
+  "## 4. Command Contract"
+  "## 5. Mocked and Skipped States"
+  "## 6. Failure and Retry Rules"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1063, #1064"
+  "This contract defines the first-user CLI command contract only. It does not implement installer behavior, Wazuh profile generation, Shuffle profile generation, first-user UI flows, AI operations, SIEM breadth, SOAR breadth, packaging, release-candidate behavior, or general-availability behavior."
+  'The approved command names are `init`, `up`, `doctor`, `seed-demo`, `status`, `open`, `logs`, and `down`.'
+  "CLI output is operator guidance and readiness evidence only. CLI output is not alert, case, evidence, approval, execution, reconciliation, gate, release, or production truth."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth."
+  'This command contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+  'Every command must emit structured operator-facing output with:'
+  '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.'
+  "| Command | Purpose | Required inputs | Expected outputs | Failure behavior | Safe retry guidance |"
+  'Before reviewed Wazuh and Shuffle product profiles exist, commands must report unavailable substrate work as explicit `skipped` or `mocked` states.'
+  '`skipped` and `mocked` states must not be reported as false success.'
+  "Wazuh alert status is not AegisOps workflow truth. Shuffle workflow success is not AegisOps workflow truth. Demo data is not production truth. Browser state, UI cache, logs, tickets, downstream receipts, and CLI summaries are not AegisOps workflow truth."
+  "All commands fail closed when provenance, profile binding, runtime scope, auth context, snapshot consistency, or authority-boundary signals are missing, malformed, stale, mixed, or only partially trusted."
+  "Safe retry means a command can be rerun after the stated prerequisite is repaired without destructive cleanup, duplicate authoritative writes, hidden state promotion, or widened product scope."
+  "Failed, rejected, skipped, mocked, and degraded paths must leave durable state clean."
+  "- CLI status is workflow truth."
+  "- Phase 52 completes Wazuh profiles."
+  "- Phase 52 completes Shuffle profiles."
+  'Run `bash scripts/verify-phase-52-1-cli-command-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-52-1-cli-command-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1064 --config <supervisor-config-path>`.'
+)
+
+commands=(init up doctor seed-demo status open logs down)
+
+forbidden_claims=(
+  "CLI status is workflow truth"
+  "CLI output is authoritative for AegisOps records"
+  "Phase 52 completes Wazuh profiles"
+  "Phase 52 completes Shuffle profiles"
+  "Wazuh alert status is AegisOps workflow truth"
+  "Shuffle workflow success is AegisOps workflow truth"
+  "Demo data is production truth"
+  "Browser state is workflow truth"
+  "Logs are authoritative workflow truth"
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.1 CLI command contract: ${doc_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" "${doc_path}"; then
+    echo "Missing Phase 52.1 CLI command contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 52.1 CLI command contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for command in "${commands[@]}"; do
+  if ! grep -Eq "^\| \`${command}\` \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \|$" "${doc_path}"; then
+    echo "Missing complete Phase 52.1 CLI command row: ${command}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index($0, claim) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.1 CLI command contract claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+mac_user_home="$(printf '/%s/' 'Users')"
+unix_user_home="$(printf '/%s/' 'home')"
+windows_user_profile_backslash="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_user_profile_slash="$(printf '[A-Za-z]:/%s/' 'Users')"
+path_token_boundary="(^|[[:space:]'\"(<{=])"
+local_path_token="(${mac_user_home}|${unix_user_home}|${windows_user_profile_backslash}|${windows_user_profile_slash})[^[:space:]'\" )>}]*"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 52.1 CLI command contract link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    !in_fenced_block { print }
+  ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/phase-52-1-cli-command-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 52.1 CLI command contract." >&2
+  exit 1
+fi
+
+echo "Phase 52.1 CLI command contract is present and preserves command coverage, skipped or mocked state handling, and authority boundaries."

--- a/scripts/verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/verify-phase-52-1-cli-command-contract.sh
@@ -29,7 +29,6 @@ required_phrases=(
   "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth."
   'This command contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
   'Every command must emit structured operator-facing output with:'
-  '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.'
   "| Command | Purpose | Required inputs | Expected outputs | Failure behavior | Safe retry guidance |"
   'Before reviewed Wazuh and Shuffle product profiles exist, commands must report unavailable substrate work as explicit `skipped` or `mocked` states.'
   '`skipped` and `mocked` states must not be reported as false success.'
@@ -46,6 +45,7 @@ required_phrases=(
 )
 
 commands=(init up doctor seed-demo status open logs down)
+shared_output_fields=(command result summary next_actions evidence)
 
 forbidden_claims=(
   "CLI status is workflow truth"
@@ -77,6 +77,18 @@ for phrase in "${required_phrases[@]}"; do
     exit 1
   fi
 done
+
+for field in "${shared_output_fields[@]}"; do
+  if ! grep -Eq -- "^- \`${field}\`: [^[:space:]].+$" "${doc_path}"; then
+    echo "Missing or empty Phase 52.1 shared output field: ${field}" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Fxq -- '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.' "${doc_path}"; then
+  echo "Invalid Phase 52.1 shared output result field: expected one of ok, skipped, mocked, degraded, or failed." >&2
+  exit 1
+fi
 
 for command in "${commands[@]}"; do
   if ! grep -Eq "^\| \`${command}\` \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \|$" "${doc_path}"; then
@@ -128,6 +140,10 @@ readme_rendered_markdown="$(
     }
     !in_fenced_block { print }
   ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+readme_rendered_markdown="$(
+  perl -0pe 's/<!--.*?-->//gs' <<<"${readme_rendered_markdown}"
 )"
 
 if ! grep -Eq '\[[^]]+\]\(docs/phase-52-1-cli-command-contract\.md\)' <<<"${readme_rendered_markdown}"; then

--- a/scripts/verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/verify-phase-52-1-cli-command-contract.sh
@@ -139,8 +139,8 @@ for claim in "${forbidden_claims[@]}"; do
   fi
 done
 
-path_token_boundary="(^|[[:space:]'\"(<{=])"
-path_token_chars="[^[:space:]'\" )>}|]"
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
 unix_absolute_path="/${path_token_chars}+"
 windows_drive_path="[A-Za-z]:[\\\\/]${path_token_chars}*"
 local_path_token="(${unix_absolute_path}|${windows_drive_path})"

--- a/scripts/verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/verify-phase-52-1-cli-command-contract.sh
@@ -69,34 +69,44 @@ if [[ ! -f "${doc_path}" ]]; then
   exit 1
 fi
 
+doc_rendered_markdown="$(
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    !in_fenced_block { print }
+  ' "${doc_path}" | perl -0pe 's/<!--.*?-->//gs'
+)"
+
 for heading in "${required_headings[@]}"; do
-  if ! grep -Fxq -- "${heading}" "${doc_path}"; then
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
     echo "Missing Phase 52.1 CLI command contract heading: ${heading}" >&2
     exit 1
   fi
 done
 
 for field in "${shared_output_fields[@]}"; do
-  if ! grep -Eq -- "^- \`${field}\`: [^[:space:]].+$" "${doc_path}"; then
+  if ! grep -Eq -- "^- \`${field}\`: [^[:space:]].+$" <<<"${doc_rendered_markdown}"; then
     echo "Missing or empty Phase 52.1 shared output field: ${field}" >&2
     exit 1
   fi
 done
 
-if ! grep -Fxq -- '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.' "${doc_path}"; then
+if ! grep -Fxq -- '- `result`: one of `ok`, `skipped`, `mocked`, `degraded`, or `failed`.' <<<"${doc_rendered_markdown}"; then
   echo "Invalid Phase 52.1 shared output result field: expected one of ok, skipped, mocked, degraded, or failed." >&2
   exit 1
 fi
 
 for phrase in "${required_phrases[@]}"; do
-  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
     echo "Missing Phase 52.1 CLI command contract statement: ${phrase}" >&2
     exit 1
   fi
 done
 
 for command in "${commands[@]}"; do
-  if ! grep -Eq "^\| \`${command}\` \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \|$" "${doc_path}"; then
+  if ! grep -Eq "^\| \`${command}\` \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \| [^|]+ \|$" <<<"${doc_rendered_markdown}"; then
     echo "Missing complete Phase 52.1 CLI command row: ${command}" >&2
     exit 1
   fi

--- a/scripts/verify-phase-52-1-cli-command-contract.sh
+++ b/scripts/verify-phase-52-1-cli-command-contract.sh
@@ -64,19 +64,28 @@ forbidden_claims=(
   "Logs are authoritative workflow truth"
 )
 
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
 if [[ ! -f "${doc_path}" ]]; then
   echo "Missing Phase 52.1 CLI command contract: ${doc_path}" >&2
   exit 1
 fi
 
 doc_rendered_markdown="$(
-  awk '
-    /^[[:space:]]*(```|~~~)/ {
-      in_fenced_block = !in_fenced_block
-      next
-    }
-    !in_fenced_block { print }
-  ' "${doc_path}" | perl -0pe 's/<!--.*?-->//gs'
+  rendered_markdown_without_code_blocks "${doc_path}"
 )"
 
 for heading in "${required_headings[@]}"; do
@@ -130,12 +139,11 @@ for claim in "${forbidden_claims[@]}"; do
   fi
 done
 
-mac_user_home="$(printf '/%s/' 'Users')"
-unix_user_home="$(printf '/%s/' 'home')"
-windows_user_profile_backslash="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
-windows_user_profile_slash="$(printf '[A-Za-z]:/%s/' 'Users')"
 path_token_boundary="(^|[[:space:]'\"(<{=])"
-local_path_token="(${mac_user_home}|${unix_user_home}|${windows_user_profile_backslash}|${windows_user_profile_slash})[^[:space:]'\" )>}]*"
+path_token_chars="[^[:space:]'\" )>}|]"
+unix_absolute_path="/${path_token_chars}+"
+windows_drive_path="[A-Za-z]:[\\\\/]${path_token_chars}*"
+local_path_token="(${unix_absolute_path}|${windows_drive_path})"
 
 if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
   echo "Forbidden Phase 52.1 CLI command contract: workstation-local absolute path detected" >&2
@@ -148,17 +156,7 @@ if [[ ! -f "${readme_path}" ]]; then
 fi
 
 readme_rendered_markdown="$(
-  awk '
-    /^[[:space:]]*(```|~~~)/ {
-      in_fenced_block = !in_fenced_block
-      next
-    }
-    !in_fenced_block { print }
-  ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
-)"
-
-readme_rendered_markdown="$(
-  perl -0pe 's/<!--.*?-->//gs' <<<"${readme_rendered_markdown}"
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
 )"
 
 if ! grep -Eq '\[[^]]+\]\(docs/phase-52-1-cli-command-contract\.md\)' <<<"${readme_rendered_markdown}"; then


### PR DESCRIPTION
## Summary
- Defines the Phase 52.1 first-user CLI command contract for `init`, `up`, `doctor`, `seed-demo`, `status`, `open`, `logs`, and `down`.
- Adds a focused verifier and self-test for required command coverage, skipped/mocked state handling, authority-boundary language, negative claims, and path hygiene.
- Links the contract from the README canonical boundary references.

Part of #1063
Closes #1064

## Verification
- `bash scripts/verify-phase-52-1-cli-command-contract.sh`
- `bash scripts/test-verify-phase-52-1-cli-command-contract.sh`
- `git diff --check`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1064 --config <supervisor-config-path>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 52.1 CLI command contract and linked it from the README.

* **New Features**
  * Formalized eight core CLI commands (init, up, doctor, seed-demo, status, open, logs, down) and standardized structured output fields: command, result, summary, next_actions, evidence; includes per-command I/O, idempotency, and failure/retry guidance.

* **Tests**
  * Added verifier and end-to-end checks to validate the contract and reject missing or forbidden claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->