### PR TITLE
Phase 52.2: Define smb-single-node profile model

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Canonical cross-phase boundary reference:
 - [Phase 51.5 competitive gap matrix](docs/phase-51-5-competitive-gap-matrix.md) compares the replacement operating-experience target against standalone Wazuh, standalone Shuffle, manual SOC/ticket workflow, and common SMB SIEM/SOAR expectations.
 - [Phase 51.6 authority-boundary negative-test policy](docs/phase-51-6-authority-boundary-negative-test-policy.md) defines the fail-closed negative-test classes later AI, Wazuh, Shuffle, ticket, evidence, browser, UI cache, downstream receipt, and demo-data work must cite.
 - [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md) defines the first-user stack command contract for `init`, `up`, `doctor`, `seed-demo`, `status`, `open`, `logs`, and `down`.
+- [Phase 52.2 SMB single-node profile model](docs/phase-52-2-smb-single-node-profile-model.md) defines the `smb-single-node` setup profile sections, mode labels, generated-config expectations, validation rules, and authority boundary.
 
 ## Product positioning
 
@@ -43,6 +44,8 @@ The Phase 51.5 competitive gap matrix is defined by the [Phase 51.5 competitive 
 The Phase 51.6 authority-boundary negative-test policy is defined by the [Phase 51.6 authority-boundary negative-test policy](docs/phase-51-6-authority-boundary-negative-test-policy.md).
 
 The Phase 52.1 first-user CLI command contract is defined by the [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md).
+
+The Phase 52.2 first-user SMB single-node profile model is defined by the [Phase 52.2 SMB single-node profile model](docs/phase-52-2-smb-single-node-profile-model.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-52-2-smb-single-node-profile-model.md
+++ b/docs/phase-52-2-smb-single-node-profile-model.md
@@ -1,0 +1,103 @@
+# Phase 52.2 SMB Single-Node Profile Model
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/adr/0011-phase-51-1-replacement-boundary.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`, `docs/phase-52-1-cli-command-contract.md`
+- **Related Issues**: #1063, #1064, #1065
+
+This contract defines the repo-owned `smb-single-node` profile model only. It does not implement full profile generation, compose generation, Wazuh product profiles, Shuffle product profiles, installer UX, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+## 1. Purpose
+
+The `smb-single-node` profile is the first executable-stack model for a first-user SMB deployment shape. It names the required setup inputs, generated configuration expectations, validation rules, and mode labels that later profile-generation issues must preserve.
+
+The approved profile identifier is `smb-single-node`.
+
+## 2. Authority Boundary
+
+Profile config is setup input only. Profile config is not alert, case, evidence, approval, execution, reconciliation, source, workflow, gate, release, production, or closeout truth.
+
+Generated config is operator setup output and readiness evidence only. Generated config is not production truth and must not become AegisOps workflow truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.
+
+This profile model cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. The profile must preserve the Phase 51.6 rule that Wazuh, Shuffle, demo data, generated config, placeholders, tickets, AI, browser state, UI cache, and downstream receipts cannot become workflow truth or production truth.
+
+## 3. Mode Labels
+
+The profile model uses the following mode labels:
+
+| Mode label | Purpose | Production meaning |
+| --- | --- | --- |
+| `required` | The section is required for a valid `smb-single-node` profile contract. | Missing required sections fail validation. |
+| `deferred` | The section is named and bounded now, but full product-profile generation is owned by a later issue. | Deferred sections remain explicit `skipped` or `mocked` setup surfaces until reviewed implementation exists. |
+| `demo-only` | The section may seed reviewed demonstration fixtures for first-user evaluation. | Demo-only data is not production truth and must not satisfy production credential, source, approval, execution, or reconciliation requirements. |
+
+## 4. Required Profile Sections
+
+Every valid `smb-single-node` profile must include these sections:
+
+| Section | Mode label | Required fields | Generated config expectations | Validation rules |
+| --- | --- | --- | --- | --- |
+| AegisOps | `required` | `service_name`, `control_plane_url`, `operator_url`, `runtime_env_file`, `admin_bootstrap_secret_ref`, `evidence_dir`, `profile_id` | Control-plane runtime env placeholders, operator access URL, readiness evidence path, and profile binding metadata. | `profile_id` must equal `smb-single-node`; URLs must use the reviewed proxy access path; secret refs must point to trusted custody instead of inline or placeholder secrets. |
+| PostgreSQL | `required` | `service_name`, `database_name`, `credential_ref`, `data_volume`, `backup_volume`, `migration_mode` | Database connection placeholders, persistent data volume, backup volume, and migration mode for the control-plane store. | Credential source must be explicit; data and backup volumes must be distinct; placeholder passwords, sample DSNs, or TODO credentials are invalid. |
+| Proxy | `required` | `service_name`, `public_base_url`, `protected_routes`, `wazuh_ingest_route`, `tls_mode`, `trusted_proxy_cidrs`, `boundary_secret_ref` | Reverse-proxy route map for operator, readiness, runtime inspection, and Wazuh-facing intake admission. | The proxy is the only reviewed user-facing ingress; forwarded headers, host, proto, tenant, or user hints are untrusted unless already normalized by the trusted boundary. |
+| Wazuh | `deferred` | `service_name`, `manager_url`, `ingest_route`, `ingest_secret_ref`, `alert_contract`, `source_binding` | Wazuh-facing intake placeholders and binding metadata for later reviewed Wazuh product-profile generation. | Missing Wazuh section fails validation; Wazuh status, rule, manager, decoder, alert, or timestamp state must not become AegisOps source, workflow, release, or gate truth without explicit AegisOps admission and linkage. |
+| Shuffle | `deferred` | `service_name`, `api_url`, `credential_ref`, `workflow_catalog_ref`, `callback_route`, `delegation_scope` | Shuffle delegation placeholders and callback binding metadata for later reviewed Shuffle product-profile generation. | Missing Shuffle section fails validation; Shuffle workflow success, failure, retry, payload, or callback state must not become AegisOps execution, reconciliation, release, gate, or closeout truth without AegisOps approval, action intent, receipt, and reconciliation records. |
+| Demo source | `demo-only` | `fixture_bundle`, `demo_mode_flag`, `source_family`, `seed_scope`, `credential_policy`, `cleanup_policy` | Demo fixture references, explicit demo-mode flag, and cleanup guidance for first-user evaluation. | Demo mode must be explicit; demo data, fake secrets, sample credentials, TODO values, or placeholder credentials must not satisfy production readiness or credential validation. |
+
+## 5. Shared Required Fields
+
+Each profile section must define:
+
+- `section_id`: stable section key from the required profile sections table.
+- `mode_label`: one of `required`, `deferred`, or `demo-only`.
+- `required_fields`: the section-specific input fields that must be present.
+- `generated_config_expectations`: the config files, placeholders, routes, or evidence references later generators may create.
+- `validation_rules`: fail-closed validation requirements for missing, malformed, placeholder-backed, ambiguous, inferred, or untrusted fields.
+- `authority_boundary`: the explicit statement that the section remains setup input or subordinate context and cannot become authoritative AegisOps truth.
+
+## 6. Validation Rules
+
+Profile validation must fail closed when:
+
+- the profile identifier is missing or is not `smb-single-node`;
+- any required profile section is missing, including Wazuh or Shuffle;
+- a required field is missing, empty, malformed, placeholder-backed, inferred from naming conventions, or only partially trusted;
+- generated config is described as production truth or workflow truth;
+- placeholder secrets, fake secrets, sample credentials, TODO values, or inline credentials are treated as valid values;
+- Wazuh, Shuffle, demo data, browser state, UI cache, tickets, AI, generated config, downstream receipts, or logs are treated as AegisOps workflow truth or production truth;
+- proxy boundary checks depend on raw `X-Forwarded-*`, `Forwarded`, host, proto, tenant, or user-id hints without a trusted normalized boundary; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<runtime-env-file>`, `<profile-name>`, `<supervisor-config-path>`, and `<codex-supervisor-root>`.
+
+Validation may produce readiness evidence, but readiness evidence remains derived evidence only and must not overwrite or redefine authoritative AegisOps records.
+
+## 7. Forbidden Claims
+
+- Generated config is production truth.
+- Generated config is workflow truth.
+- Profile config is authoritative for AegisOps records.
+- Wazuh profile status is AegisOps source truth.
+- Shuffle workflow success is AegisOps reconciliation truth.
+- Demo data is production truth.
+- Placeholder secrets are valid credentials.
+- Raw forwarded headers are trusted identity.
+- Phase 52.2 implements Wazuh product profiles.
+- Phase 52.2 implements Shuffle product profiles.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-52-2-smb-single-node-profile-model.sh`.
+
+Run `bash scripts/test-verify-phase-52-2-smb-single-node-profile-model.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1065 --config <supervisor-config-path>`.
+
+The verifier must fail when the contract is missing, when AegisOps, PostgreSQL, proxy, Wazuh, Shuffle, or demo source coverage is missing, when required fields or mode labels are missing, when generated config is treated as production truth or workflow truth, when placeholder secrets are accepted as valid credentials, when the Phase 51.6 policy citation is missing, or when publishable guidance uses workstation-local absolute paths.
+
+## 9. Non-Goals
+
+- No runtime profile generation is implemented here.
+- No compose generation, installer UX, Wazuh product profile, Shuffle product profile, RC behavior, GA behavior, or production deployment behavior is implemented here.
+- No profile config, generated config, Wazuh state, Shuffle state, demo data, placeholder, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-52-2-smb-single-node-profile-model.sh
+++ b/scripts/test-verify-phase-52-2-smb-single-node-profile-model.sh
@@ -91,6 +91,14 @@ assert_fails_with \
   "${missing_mode_repo}" \
   "Missing complete Phase 52.2 profile section row: Proxy"
 
+wrong_mode_repo="${workdir}/wrong-mode"
+create_valid_repo "${wrong_mode_repo}"
+perl -0pi -e 's/\| Proxy \| `required` \|/\| Proxy \| `deferred` \|/g' \
+  "${wrong_mode_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${wrong_mode_repo}" \
+  "Missing complete Phase 52.2 profile section row: Proxy"
+
 missing_field_repo="${workdir}/missing-authority-field"
 create_valid_repo "${missing_field_repo}"
 remove_text_from_contract "${missing_field_repo}" \
@@ -115,6 +123,14 @@ assert_fails_with \
   "${generated_truth_repo}" \
   "Forbidden Phase 52.2 SMB single-node profile model claim: Generated config is production truth"
 
+generated_truth_variant_repo="${workdir}/generated-truth-variant"
+create_valid_repo "${generated_truth_variant_repo}"
+printf '%s\n' "- generated config is production truth." \
+  >>"${generated_truth_variant_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${generated_truth_variant_repo}" \
+  "Forbidden Phase 52.2 SMB single-node profile model claim: Generated config is production truth"
+
 workflow_truth_repo="${workdir}/workflow-truth"
 create_valid_repo "${workflow_truth_repo}"
 printf '%s\n' "Generated config is workflow truth." \
@@ -137,6 +153,14 @@ printf '%s\n' "placeholder secret can be trusted production credentials." \
   >>"${placeholder_secret_variant_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
 assert_fails_with \
   "${placeholder_secret_variant_repo}" \
+  "Forbidden Phase 52.2 SMB single-node profile model claim: placeholder secrets accepted as valid credentials"
+
+placeholder_secret_bullet_repo="${workdir}/placeholder-secret-bullet"
+create_valid_repo "${placeholder_secret_bullet_repo}"
+printf '%s\n' "- Placeholder secrets may be accepted." \
+  >>"${placeholder_secret_bullet_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${placeholder_secret_bullet_repo}" \
   "Forbidden Phase 52.2 SMB single-node profile model claim: placeholder secrets accepted as valid credentials"
 
 local_path_repo="${workdir}/local-path"

--- a/scripts/test-verify-phase-52-2-smb-single-node-profile-model.sh
+++ b/scripts/test-verify-phase-52-2-smb-single-node-profile-model.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-2-smb-single-node-profile-model.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  printf '%s\n' "# AegisOps" "See [Phase 52.2 SMB single-node profile model](docs/phase-52-2-smb-single-node-profile-model.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/phase-52-2-smb-single-node-profile-model.md" \
+    "${target}/docs/phase-52-2-smb-single-node-profile-model.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-52-2-smb-single-node-profile-model.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 52.2 SMB single-node profile model"
+
+missing_wazuh_repo="${workdir}/missing-wazuh"
+create_valid_repo "${missing_wazuh_repo}"
+remove_text_from_contract "${missing_wazuh_repo}" \
+  "| Wazuh | \`deferred\` | \`service_name\`, \`manager_url\`, \`ingest_route\`, \`ingest_secret_ref\`, \`alert_contract\`, \`source_binding\` | Wazuh-facing intake placeholders and binding metadata for later reviewed Wazuh product-profile generation. | Missing Wazuh section fails validation; Wazuh status, rule, manager, decoder, alert, or timestamp state must not become AegisOps source, workflow, release, or gate truth without explicit AegisOps admission and linkage. |"
+assert_fails_with \
+  "${missing_wazuh_repo}" \
+  "Missing complete Phase 52.2 profile section row: Wazuh"
+
+missing_shuffle_repo="${workdir}/missing-shuffle"
+create_valid_repo "${missing_shuffle_repo}"
+remove_text_from_contract "${missing_shuffle_repo}" \
+  "| Shuffle | \`deferred\` | \`service_name\`, \`api_url\`, \`credential_ref\`, \`workflow_catalog_ref\`, \`callback_route\`, \`delegation_scope\` | Shuffle delegation placeholders and callback binding metadata for later reviewed Shuffle product-profile generation. | Missing Shuffle section fails validation; Shuffle workflow success, failure, retry, payload, or callback state must not become AegisOps execution, reconciliation, release, gate, or closeout truth without AegisOps approval, action intent, receipt, and reconciliation records. |"
+assert_fails_with \
+  "${missing_shuffle_repo}" \
+  "Missing complete Phase 52.2 profile section row: Shuffle"
+
+missing_mode_repo="${workdir}/missing-mode"
+create_valid_repo "${missing_mode_repo}"
+perl -0pi -e 's/\| Proxy \| `required` \|/\| Proxy \|  \|/g' \
+  "${missing_mode_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${missing_mode_repo}" \
+  "Missing complete Phase 52.2 profile section row: Proxy"
+
+missing_field_repo="${workdir}/missing-authority-field"
+create_valid_repo "${missing_field_repo}"
+remove_text_from_contract "${missing_field_repo}" \
+  "- \`authority_boundary\`: the explicit statement that the section remains setup input or subordinate context and cannot become authoritative AegisOps truth."
+assert_fails_with \
+  "${missing_field_repo}" \
+  "Missing Phase 52.2 SMB single-node profile model statement: - \`authority_boundary\`:"
+
+missing_phase51_citation_repo="${workdir}/missing-phase51-citation"
+create_valid_repo "${missing_phase51_citation_repo}"
+remove_text_from_contract "${missing_phase51_citation_repo}" \
+  "This profile model cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`."
+assert_fails_with \
+  "${missing_phase51_citation_repo}" \
+  "Missing Phase 52.2 SMB single-node profile model statement: This profile model cites the Phase 51.6 authority-boundary negative-test policy"
+
+generated_truth_repo="${workdir}/generated-truth"
+create_valid_repo "${generated_truth_repo}"
+printf '%s\n' "Generated config is production truth." \
+  >>"${generated_truth_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${generated_truth_repo}" \
+  "Forbidden Phase 52.2 SMB single-node profile model claim: Generated config is production truth"
+
+workflow_truth_repo="${workdir}/workflow-truth"
+create_valid_repo "${workflow_truth_repo}"
+printf '%s\n' "Generated config is workflow truth." \
+  >>"${workflow_truth_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${workflow_truth_repo}" \
+  "Forbidden Phase 52.2 SMB single-node profile model claim: Generated config is workflow truth"
+
+placeholder_secret_repo="${workdir}/placeholder-secret"
+create_valid_repo "${placeholder_secret_repo}"
+printf '%s\n' "Placeholder secrets are valid credentials." \
+  >>"${placeholder_secret_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${placeholder_secret_repo}" \
+  "Forbidden Phase 52.2 SMB single-node profile model claim: Placeholder secrets are valid credentials"
+
+placeholder_secret_variant_repo="${workdir}/placeholder-secret-variant"
+create_valid_repo "${placeholder_secret_variant_repo}"
+printf '%s\n' "placeholder secret can be trusted production credentials." \
+  >>"${placeholder_secret_variant_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${placeholder_secret_variant_repo}" \
+  "Forbidden Phase 52.2 SMB single-node profile model claim: placeholder secrets accepted as valid credentials"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.2 SMB single-node profile model: workstation-local absolute path detected"
+
+file_uri_path_repo="${workdir}/file-uri-path"
+create_valid_repo "${file_uri_path_repo}"
+printf 'Use file:///%s/aegisops for setup.\n' "tmp" \
+  >>"${file_uri_path_repo}/docs/phase-52-2-smb-single-node-profile-model.md"
+assert_fails_with \
+  "${file_uri_path_repo}" \
+  "Forbidden Phase 52.2 SMB single-node profile model: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 52.2 SMB single-node profile model."
+
+echo "Phase 52.2 SMB single-node profile model verifier tests passed."

--- a/scripts/verify-phase-52-2-smb-single-node-profile-model.sh
+++ b/scripts/verify-phase-52-2-smb-single-node-profile-model.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-52-2-smb-single-node-profile-model.md"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 52.2 SMB Single-Node Profile Model"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Mode Labels"
+  "## 4. Required Profile Sections"
+  "## 5. Shared Required Fields"
+  "## 6. Validation Rules"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1063, #1064, #1065"
+  'This contract defines the repo-owned `smb-single-node` profile model only. It does not implement full profile generation, compose generation, Wazuh product profiles, Shuffle product profiles, installer UX, release-candidate behavior, general-availability behavior, or runtime behavior.'
+  'The approved profile identifier is `smb-single-node`.'
+  "Profile config is setup input only. Profile config is not alert, case, evidence, approval, execution, reconciliation, source, workflow, gate, release, production, or closeout truth."
+  "Generated config is operator setup output and readiness evidence only. Generated config is not production truth and must not become AegisOps workflow truth."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth."
+  'This profile model cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+  "| Mode label | Purpose | Production meaning |"
+  '| `required` | The section is required for a valid `smb-single-node` profile contract. | Missing required sections fail validation. |'
+  '| `deferred` | The section is named and bounded now, but full product-profile generation is owned by a later issue. | Deferred sections remain explicit `skipped` or `mocked` setup surfaces until reviewed implementation exists. |'
+  '| `demo-only` | The section may seed reviewed demonstration fixtures for first-user evaluation. | Demo-only data is not production truth and must not satisfy production credential, source, approval, execution, or reconciliation requirements. |'
+  "| Section | Mode label | Required fields | Generated config expectations | Validation rules |"
+  '- `section_id`: stable section key from the required profile sections table.'
+  '- `mode_label`: one of `required`, `deferred`, or `demo-only`.'
+  '- `required_fields`: the section-specific input fields that must be present.'
+  '- `generated_config_expectations`: the config files, placeholders, routes, or evidence references later generators may create.'
+  '- `validation_rules`: fail-closed validation requirements for missing, malformed, placeholder-backed, ambiguous, inferred, or untrusted fields.'
+  '- `authority_boundary`: the explicit statement that the section remains setup input or subordinate context and cannot become authoritative AegisOps truth.'
+  'the profile identifier is missing or is not `smb-single-node`;'
+  "any required profile section is missing, including Wazuh or Shuffle;"
+  "generated config is described as production truth or workflow truth;"
+  "placeholder secrets, fake secrets, sample credentials, TODO values, or inline credentials are treated as valid values;"
+  'Run `bash scripts/verify-phase-52-2-smb-single-node-profile-model.sh`.'
+  'Run `bash scripts/test-verify-phase-52-2-smb-single-node-profile-model.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1065 --config <supervisor-config-path>`.'
+)
+
+sections=("AegisOps" "PostgreSQL" "Proxy" "Wazuh" "Shuffle" "Demo source")
+shared_fields=(
+  "section_id"
+  "mode_label"
+  "required_fields"
+  "generated_config_expectations"
+  "validation_rules"
+  "authority_boundary"
+)
+
+forbidden_claims=(
+  "Generated config is production truth"
+  "Generated config is workflow truth"
+  "Profile config is authoritative for AegisOps records"
+  "Wazuh profile status is AegisOps source truth"
+  "Shuffle workflow success is AegisOps reconciliation truth"
+  "Demo data is production truth"
+  "Placeholder secrets are valid credentials"
+  "Raw forwarded headers are trusted identity"
+  "Phase 52.2 implements Wazuh product profiles"
+  "Phase 52.2 implements Shuffle product profiles"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.2 SMB single-node profile model: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.2 SMB single-node profile model heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.2 SMB single-node profile model statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for field in "${shared_fields[@]}"; do
+  if ! grep -Eq -- "^- \`${field}\`: [^[:space:]].+$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing or empty Phase 52.2 shared profile field: ${field}" >&2
+    exit 1
+  fi
+done
+
+for section in "${sections[@]}"; do
+  if ! grep -Eq "^\| ${section} \| \`(required|deferred|demo-only)\` \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.2 profile section row: ${section}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index($0, claim) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.2 SMB single-node profile model claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if grep -Eiq "^placeholder secrets? (are|is|count as|counts as|may be|can be|remain|stays) (valid|trusted|accepted|production)" <<<"${doc_rendered_markdown}"; then
+  echo "Forbidden Phase 52.2 SMB single-node profile model claim: placeholder secrets accepted as valid credentials" >&2
+  exit 1
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+unix_absolute_path="/${path_token_chars}+"
+windows_drive_path="[A-Za-z]:[\\\\/]${path_token_chars}*"
+local_path_token="(${unix_absolute_path}|${windows_drive_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.2 SMB single-node profile model: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 52.2 SMB single-node profile model link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/phase-52-2-smb-single-node-profile-model\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 52.2 SMB single-node profile model." >&2
+  exit 1
+fi
+
+echo "Phase 52.2 SMB single-node profile model is present and preserves required section coverage, mode labels, validation rules, and authority boundaries."

--- a/scripts/verify-phase-52-2-smb-single-node-profile-model.sh
+++ b/scripts/verify-phase-52-2-smb-single-node-profile-model.sh
@@ -59,6 +59,26 @@ shared_fields=(
   "authority_boundary"
 )
 
+expected_mode_for_section() {
+  local section="$1"
+
+  case "${section}" in
+    "AegisOps" | "PostgreSQL" | "Proxy")
+      printf '%s\n' "required"
+      ;;
+    "Wazuh" | "Shuffle")
+      printf '%s\n' "deferred"
+      ;;
+    "Demo source")
+      printf '%s\n' "demo-only"
+      ;;
+    *)
+      echo "Unknown Phase 52.2 profile section: ${section}" >&2
+      return 1
+      ;;
+  esac
+}
+
 forbidden_claims=(
   "Generated config is production truth"
   "Generated config is workflow truth"
@@ -118,7 +138,8 @@ for field in "${shared_fields[@]}"; do
 done
 
 for section in "${sections[@]}"; do
-  if ! grep -Eq "^\| ${section} \| \`(required|deferred|demo-only)\` \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+  mode="$(expected_mode_for_section "${section}")"
+  if ! grep -Eq "^\| ${section} \| \`${mode}\` \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
     echo "Missing complete Phase 52.2 profile section row: ${section}" >&2
     exit 1
   fi
@@ -128,11 +149,27 @@ contains_forbidden_outside_forbidden_section() {
   local claim="$1"
 
   awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
     /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
     /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
-    !in_forbidden_claims && index($0, claim) { found = 1 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
     END { exit(found ? 0 : 1) }
   ' "${doc_path}"
+}
+
+contains_placeholder_secret_valid_claim() {
+  awk '
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    {
+      line = tolower($0)
+      negative_context = line ~ /(must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy)/
+      if (!in_forbidden_claims && !negative_context && line ~ /(^|[^[:alnum:]_])placeholder secrets?[[:space:]]+(are|is|count as|counts as|may be|can be|remain|stays)[[:space:]]+([^.]*[^[:alnum:]_])?(valid|trusted|accepted|production)([^[:alnum:]_]|$)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${doc_rendered_markdown}"
 }
 
 for claim in "${forbidden_claims[@]}"; do
@@ -142,7 +179,7 @@ for claim in "${forbidden_claims[@]}"; do
   fi
 done
 
-if grep -Eiq "^placeholder secrets? (are|is|count as|counts as|may be|can be|remain|stays) (valid|trusted|accepted|production)" <<<"${doc_rendered_markdown}"; then
+if contains_placeholder_secret_valid_claim; then
   echo "Forbidden Phase 52.2 SMB single-node profile model claim: placeholder secrets accepted as valid credentials" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Adds the Phase 52.2 `smb-single-node` profile model contract.
- Covers AegisOps, PostgreSQL, proxy, Wazuh, Shuffle, and demo source sections with mode labels, generated-config expectations, validation rules, and Phase 51.6 authority-boundary citation.
- Adds a focused verifier and mutation-style verifier tests for missing sections, generated-config truth claims, placeholder secrets, README linkage, and path hygiene.

## Verification
- `bash scripts/verify-phase-52-2-smb-single-node-profile-model.sh`
- `bash scripts/test-verify-phase-52-2-smb-single-node-profile-model.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1065 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`
- `bash scripts/verify-readme-product-positioning.sh`
- `bash scripts/test-verify-readme-product-positioning.sh`
- `bash scripts/verify-readme-and-repository-structure-control-plane-thesis.sh`
- `bash -n scripts/verify-phase-52-2-smb-single-node-profile-model.sh scripts/test-verify-phase-52-2-smb-single-node-profile-model.sh`

Part of #1063.
Depends on #1064.
Closes #1065.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Phase 52.2 SMB Single-Node Profile Model documentation specifying setup inputs, required coverage areas, and validation requirements.

* **Tests**
  * Added verification tools to validate Phase 52.2 profile model configuration compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->