### PR TITLE
Phase 52.3 add combined dependency matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Canonical cross-phase boundary reference:
 - [Phase 51.6 authority-boundary negative-test policy](docs/phase-51-6-authority-boundary-negative-test-policy.md) defines the fail-closed negative-test classes later AI, Wazuh, Shuffle, ticket, evidence, browser, UI cache, downstream receipt, and demo-data work must cite.
 - [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md) defines the first-user stack command contract for `init`, `up`, `doctor`, `seed-demo`, `status`, `open`, `logs`, and `down`.
 - [Phase 52.2 SMB single-node profile model](docs/phase-52-2-smb-single-node-profile-model.md) defines the `smb-single-node` setup profile sections, mode labels, generated-config expectations, validation rules, and authority boundary.
+- [Phase 52.3 combined dependency matrix](docs/deployment/combined-dependency-matrix.md) defines first-user stack dependency expectations, host footprint, ports, volumes, certificate requirements, incompatibilities, and host-preflight follow-up fields.
 
 ## Product positioning
 
@@ -46,6 +47,8 @@ The Phase 51.6 authority-boundary negative-test policy is defined by the [Phase 
 The Phase 52.1 first-user CLI command contract is defined by the [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md).
 
 The Phase 52.2 first-user SMB single-node profile model is defined by the [Phase 52.2 SMB single-node profile model](docs/phase-52-2-smb-single-node-profile-model.md).
+
+The Phase 52.3 first-user combined dependency matrix is defined by the [Phase 52.3 combined dependency matrix](docs/deployment/combined-dependency-matrix.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/combined-dependency-matrix.md
+++ b/docs/deployment/combined-dependency-matrix.md
@@ -1,0 +1,95 @@
+# Phase 52.3 Combined Dependency Matrix
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-52-1-cli-command-contract.md`, `docs/phase-52-2-smb-single-node-profile-model.md`, `docs/deployment/single-customer-profile.md`, `docs/network-exposure-and-access-path-policy.md`, `docs/storage-layout-and-mount-policy.md`
+- **Related Issues**: #1063, #1065, #1066
+
+This matrix defines dependency documentation and verifier expectations for the executable first-user stack only. It does not implement an installer, compose generation, Wazuh product-profile runtime behavior, Shuffle product-profile runtime behavior, a full host preflight engine, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+## 1. Purpose
+
+The combined dependency matrix gives platform admins one repo-owned place to review expected component versions, host footprint, ports, volumes, certificate requirements, incompatible versions, and the fields a later host preflight contract must consume.
+
+The matrix covers the first-user executable stack shape: AegisOps, Wazuh, Shuffle, PostgreSQL, proxy, Docker, and Docker Compose.
+
+## 2. Authority Boundary
+
+Dependency expectations are setup readiness evidence only. Docker, Docker Compose, Wazuh, Shuffle, PostgreSQL, proxy, port, certificate, volume, host sizing, or version state is not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+This matrix cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. Dependency checks must preserve the Phase 51.6 rule that Wazuh, Shuffle, generated config, placeholders, tickets, AI, browser state, UI cache, logs, and downstream receipts cannot become workflow truth or production truth.
+
+## 3. Host Footprint
+
+The first-user stack baseline assumes one SMB single-node host profile before any HA, multi-customer, or managed-service deployment work exists.
+
+| Host tier | CPU | RAM | Disk | Notes |
+| --- | --- | --- | --- | --- |
+| Minimum rehearsal | 4 vCPU | 16 GB RAM | 250 GB durable disk plus separate backup capacity | Sufficient for disposable rehearsal and verifier-driven setup review only. |
+| Recommended first-user | 8 vCPU | 32 GB RAM | 500 GB durable disk plus separate backup capacity | Recommended for one named customer environment with Wazuh intake, PostgreSQL state, proxy ingress, and bounded Shuffle delegation. |
+| Out of scope | Cluster sizing | HA memory sizing | Multi-node storage sizing | Enterprise cluster, MSSP, zero-downtime, and vendor-managed HA sizing are later scope. |
+
+## 4. Dependency Matrix
+
+| Component | Version expectation | Host CPU/RAM/disk expectation | Ports | Volumes | Certificate requirements | Known incompatibilities | Host preflight follow-up fields | Authority boundary |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| AegisOps | Reviewed repository revision plus Python/runtime dependencies from the repo-owned control-plane package; image tags or source revisions must be release-bound, not floating latest. | Included in recommended 8 vCPU, 32 GB RAM, 500 GB disk host; control-plane logs and evidence must not share mutable database storage. | Proxy-published operator, readiness, runtime inspection, and Wazuh intake routes only; backend port remains internal. | Runtime env reference, evidence directory, log directory, and control-plane migration assets. | Protected-surface reverse-proxy secret, admin bootstrap token, break-glass token, and reviewed identity-provider binding must come from trusted custody. | Floating image tags, placeholder secrets, unsigned identity hints, direct backend exposure, raw forwarded-header trust, or skipped migration bootstrap are incompatible. | `AEGISOPS_PREFLIGHT_AEGISOPS_REVISION`, `AEGISOPS_PREFLIGHT_AEGISOPS_IMAGE_TAG`, `AEGISOPS_PREFLIGHT_CONTROL_PLANE_PORT`, `AEGISOPS_PREFLIGHT_AEGISOPS_EVIDENCE_VOLUME`, `AEGISOPS_PREFLIGHT_AEGISOPS_SECRET_REFS` | AegisOps dependency state is setup readiness evidence only and cannot replace AegisOps-owned workflow records. |
+| Wazuh | Reviewed Wazuh 4.x manager profile for the first-user intake path; exact product-profile pin is deferred to the Wazuh profile issue. | Included in recommended host sizing unless deployed as an external reviewed substrate; retention growth must be accounted for separately from PostgreSQL. | Wazuh manager/API ports stay internal or substrate-owned; only the reviewed Wazuh intake route reaches AegisOps through the proxy. | Wazuh manager data, rules, decoder, and log volumes must be separate from AegisOps PostgreSQL state. | Wazuh ingest shared secret and Wazuh ingest reverse-proxy secret must come from trusted custody. | Wazuh 3.x, unreviewed Wazuh 5.x, direct Wazuh-to-automation routing, treating Wazuh alert status as AegisOps case truth, and placeholder ingest secrets are incompatible. | `AEGISOPS_PREFLIGHT_WAZUH_VERSION`, `AEGISOPS_PREFLIGHT_WAZUH_INGEST_ROUTE`, `AEGISOPS_PREFLIGHT_WAZUH_SECRET_REFS`, `AEGISOPS_PREFLIGHT_WAZUH_VOLUME_REFS` | Wazuh detects and provides subordinate upstream signal context; Wazuh state is not AegisOps workflow truth. |
+| Shuffle | Reviewed Shuffle deployment profile for delegated low-risk automation; exact product-profile pin is deferred to the Shuffle profile issue. | Included in recommended host sizing only when bounded delegated execution is enabled; workflow execution artifacts must not share authoritative AegisOps state storage. | Shuffle API, webhook, and callback ports stay internal or proxy-mediated through reviewed callback routes. | Shuffle app data and workflow catalog volumes must be separated from PostgreSQL and AegisOps evidence custody. | Shuffle API credential, callback secret, and workflow-catalog custody must come from trusted secret references. | Unreviewed workflow packs, placeholder API keys, direct Wazuh-to-Shuffle execution, and treating Shuffle workflow success as AegisOps reconciliation truth are incompatible. | `AEGISOPS_PREFLIGHT_SHUFFLE_VERSION`, `AEGISOPS_PREFLIGHT_SHUFFLE_API_ROUTE`, `AEGISOPS_PREFLIGHT_SHUFFLE_CALLBACK_ROUTE`, `AEGISOPS_PREFLIGHT_SHUFFLE_SECRET_REFS`, `AEGISOPS_PREFLIGHT_SHUFFLE_VOLUME_REFS` | Shuffle executes reviewed delegated routine work only; Shuffle state is not AegisOps execution or reconciliation truth. |
+| PostgreSQL | PostgreSQL 15 or 16 until a later migration compatibility review changes the pin. | Requires durable disk with backup capacity separate from data capacity; database memory pressure must not starve the control-plane process. | Database port remains internal to the Compose or host service boundary and must not be published as a user-facing ingress path. | PostgreSQL data volume and PostgreSQL backup volume must be distinct. | PostgreSQL credential source must come from trusted custody; direct DSNs with secret material are incompatible. | PostgreSQL below 15, unreviewed PostgreSQL 17+, destructive schema recreation, placeholder DSNs, shared data and backup volumes, and external write access outside the control plane are incompatible. | `AEGISOPS_PREFLIGHT_POSTGRES_VERSION`, `AEGISOPS_PREFLIGHT_POSTGRES_PORT`, `AEGISOPS_PREFLIGHT_POSTGRES_DATA_VOLUME`, `AEGISOPS_PREFLIGHT_POSTGRES_BACKUP_VOLUME`, `AEGISOPS_PREFLIGHT_POSTGRES_SECRET_REFS` | PostgreSQL stores AegisOps-owned records, but PostgreSQL process state alone is not workflow truth. |
+| Proxy | Reviewed reverse-proxy implementation selected by the deployment package; proxy config revision must be release-bound. | Included in recommended host sizing; TLS material and access logs require bounded storage and rotation. | Public HTTPS port, optional HTTP redirect port, protected-surface routes, readiness route, runtime inspection route, and Wazuh intake route. | Proxy config, TLS certificate chain reference, TLS private-key reference, and bounded access-log storage. | Ingress TLS certificate chain, ingress TLS private key, protected-surface boundary secret, Wazuh reverse-proxy secret, trusted proxy CIDR binding, and reviewed identity-provider binding are required. | Raw `X-Forwarded-*`, `Forwarded`, host, proto, tenant, or user-id trust without normalized proxy boundary; direct backend exposure; placeholder TLS material; and expired certificate custody are incompatible. | `AEGISOPS_PREFLIGHT_PROXY_VERSION`, `AEGISOPS_PREFLIGHT_PROXY_PUBLIC_PORTS`, `AEGISOPS_PREFLIGHT_PROXY_TLS_REFS`, `AEGISOPS_PREFLIGHT_PROXY_TRUSTED_CIDRS`, `AEGISOPS_PREFLIGHT_PROXY_ROUTE_MAP` | The proxy enforces ingress and normalization boundaries; proxy header or port state is not AegisOps workflow truth. |
+| Docker | Docker Engine 24 or 25 for first-user stack rehearsal and setup verification until a later runtime support review changes the expectation. | Host must satisfy the recommended first-user CPU, RAM, and disk tier before dependency checks are accepted. | Docker daemon socket or service endpoint must not be exposed as a user-facing AegisOps port. | Docker image cache, named volumes, and logs must preserve separation between AegisOps state, PostgreSQL data, backups, and optional substrate data. | No Docker daemon certificate requirement is approved for the local single-node profile; if remote daemon TLS is introduced later it needs a separate reviewed certificate custody contract. | Docker Engine below 24, rootless or remote-daemon profiles not covered by the deployment package, daemon socket exposure to untrusted users, and floating image pulls are incompatible. | `AEGISOPS_PREFLIGHT_DOCKER_ENGINE_VERSION`, `AEGISOPS_PREFLIGHT_DOCKER_CONTEXT`, `AEGISOPS_PREFLIGHT_DOCKER_ROOTLESS_MODE`, `AEGISOPS_PREFLIGHT_DOCKER_VOLUME_DRIVER`, `AEGISOPS_PREFLIGHT_DOCKER_SOCKET_EXPOSURE` | Docker health or container state is setup readiness evidence only and cannot become AegisOps workflow truth. |
+| Docker Compose | Docker Compose plugin v2.24 or newer; legacy standalone `docker-compose` v1 is not an accepted first-user stack interface. | Compose must run on a host that satisfies the recommended first-user CPU, RAM, and disk tier and preserves named-volume separation. | Compose-published ports must match the reviewed proxy and internal-service exposure policy. | Compose project name, named volumes, env-file reference, and bind-mount policy must be explicit and repo-relative or placeholder-backed. | Compose must reference secret and certificate files through trusted secret refs or documented placeholders; inline secret material is incompatible. | Standalone Compose v1, unreviewed Compose v3-only semantics that change health dependency behavior, host absolute path guidance in publishable docs, inline secrets, and published database/backend ports are incompatible. | `AEGISOPS_PREFLIGHT_COMPOSE_VERSION`, `AEGISOPS_PREFLIGHT_COMPOSE_PROJECT_NAME`, `AEGISOPS_PREFLIGHT_COMPOSE_FILE`, `AEGISOPS_PREFLIGHT_COMPOSE_ENV_FILE`, `AEGISOPS_PREFLIGHT_COMPOSE_PUBLISHED_PORTS`, `AEGISOPS_PREFLIGHT_COMPOSE_VOLUME_REFS` | Compose orchestration result is setup readiness evidence only and cannot become AegisOps workflow truth. |
+
+Known incompatible versions must be explicit and must fail host preflight follow-up until reviewed.
+
+## 5. Host Preflight Follow-Up Contract
+
+This issue does not implement the full host preflight engine. A later host preflight issue must consume the `AEGISOPS_PREFLIGHT_*` fields named in this matrix and fail closed when a required field is missing, malformed, placeholder-backed, stale, incompatible, inferred from naming conventions, or only partially trusted.
+
+The existing install preflight remains the current verifier for runtime input, secret custody, storage separation, migration bootstrap, and optional-extension non-blocking behavior. The dependency-matrix follow-up must link back to that contract instead of redefining runtime authority.
+
+Host preflight output may report readiness evidence, incompatibility findings, missing prerequisites, and safe next actions. It must not promote Docker, Compose, Wazuh, Shuffle, port, certificate, or version state into AegisOps workflow truth.
+
+## 6. Validation Rules
+
+Matrix validation must fail closed when:
+
+- any required component row is missing, including AegisOps, Wazuh, Shuffle, PostgreSQL, proxy, Docker, or Docker Compose;
+- CPU, RAM, disk, ports, volumes, certificate requirements, known incompatibilities, or preflight follow-up fields are missing;
+- known incompatible versions are omitted or described as warnings only;
+- substrate version state, port state, certificate state, Docker state, Compose state, Wazuh state, or Shuffle state is described as workflow truth;
+- placeholder secrets, sample credentials, TODO values, inline secrets, raw forwarded headers, or unreviewed scope inference are treated as valid setup state; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<supervisor-config-path>`, `<codex-supervisor-root>`, `<compose-file>`, and `<runtime-env-file>`.
+
+## 7. Forbidden Claims
+
+- Substrate version state is AegisOps workflow truth.
+- Docker status is AegisOps workflow truth.
+- Docker Compose status is AegisOps workflow truth.
+- Wazuh alert status is AegisOps case truth.
+- Shuffle workflow success is AegisOps reconciliation truth.
+- Placeholder secrets are valid credentials.
+- Raw forwarded headers are trusted identity.
+- This matrix implements the host preflight engine.
+- This matrix implements Wazuh product-profile runtime behavior.
+- This matrix implements Shuffle product-profile runtime behavior.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-52-3-combined-dependency-matrix.sh`.
+
+Run `bash scripts/test-verify-phase-52-3-combined-dependency-matrix.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1066 --config <supervisor-config-path>`.
+
+The verifier must fail when the matrix is missing, when AegisOps, Wazuh, Shuffle, PostgreSQL, proxy, Docker, or Docker Compose coverage is missing, when CPU, RAM, disk, ports, volumes, certificate requirements, known incompatibilities, or preflight follow-up fields are missing, when dependency state is treated as workflow truth, or when publishable guidance uses workstation-local absolute paths.
+
+## 9. Non-Goals
+
+- No installer, compose generation, profile generation, host probing, or runtime behavior is implemented here.
+- No Wazuh product-profile runtime behavior or Shuffle product-profile runtime behavior is implemented here.
+- No Docker, Docker Compose, Wazuh, Shuffle, PostgreSQL, proxy, port, certificate, volume, host sizing, preflight, setup, generated-config, placeholder, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-52-3-combined-dependency-matrix.sh
+++ b/scripts/test-verify-phase-52-3-combined-dependency-matrix.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-3-combined-dependency-matrix.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment"
+  printf '%s\n' "# AegisOps" "See [Phase 52.3 combined dependency matrix](docs/deployment/combined-dependency-matrix.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/combined-dependency-matrix.md" \
+    "${target}/docs/deployment/combined-dependency-matrix.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_matrix() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/combined-dependency-matrix.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_matrix_repo="${workdir}/missing-matrix"
+create_valid_repo "${missing_matrix_repo}"
+rm "${missing_matrix_repo}/docs/deployment/combined-dependency-matrix.md"
+assert_fails_with \
+  "${missing_matrix_repo}" \
+  "Missing Phase 52.3 combined dependency matrix"
+
+missing_aegisops_repo="${workdir}/missing-aegisops"
+create_valid_repo "${missing_aegisops_repo}"
+remove_text_from_matrix "${missing_aegisops_repo}" \
+  "| AegisOps |"
+assert_fails_with \
+  "${missing_aegisops_repo}" \
+  "Missing complete Phase 52.3 dependency row: AegisOps"
+
+missing_wazuh_repo="${workdir}/missing-wazuh"
+create_valid_repo "${missing_wazuh_repo}"
+remove_text_from_matrix "${missing_wazuh_repo}" \
+  "| Wazuh |"
+assert_fails_with \
+  "${missing_wazuh_repo}" \
+  "Missing complete Phase 52.3 dependency row: Wazuh"
+
+missing_shuffle_repo="${workdir}/missing-shuffle"
+create_valid_repo "${missing_shuffle_repo}"
+remove_text_from_matrix "${missing_shuffle_repo}" \
+  "| Shuffle |"
+assert_fails_with \
+  "${missing_shuffle_repo}" \
+  "Missing complete Phase 52.3 dependency row: Shuffle"
+
+missing_postgresql_repo="${workdir}/missing-postgresql"
+create_valid_repo "${missing_postgresql_repo}"
+remove_text_from_matrix "${missing_postgresql_repo}" \
+  "| PostgreSQL |"
+assert_fails_with \
+  "${missing_postgresql_repo}" \
+  "Missing complete Phase 52.3 dependency row: PostgreSQL"
+
+missing_proxy_repo="${workdir}/missing-proxy"
+create_valid_repo "${missing_proxy_repo}"
+remove_text_from_matrix "${missing_proxy_repo}" \
+  "| Proxy |"
+assert_fails_with \
+  "${missing_proxy_repo}" \
+  "Missing complete Phase 52.3 dependency row: Proxy"
+
+missing_incompat_repo="${workdir}/missing-incompatibility"
+create_valid_repo "${missing_incompat_repo}"
+remove_text_from_matrix "${missing_incompat_repo}" \
+  "Known incompatible versions must be explicit and must fail host preflight follow-up until reviewed."
+assert_fails_with \
+  "${missing_incompat_repo}" \
+  "Missing Phase 52.3 combined dependency matrix statement: Known incompatible versions must be explicit"
+
+workflow_truth_repo="${workdir}/workflow-truth"
+create_valid_repo "${workflow_truth_repo}"
+printf '%s\n' "Substrate version state is AegisOps workflow truth." \
+  >>"${workflow_truth_repo}/docs/deployment/combined-dependency-matrix.md"
+assert_fails_with \
+  "${workflow_truth_repo}" \
+  "Forbidden Phase 52.3 combined dependency matrix claim: Substrate version state is AegisOps workflow truth"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/combined-dependency-matrix.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.3 combined dependency matrix: workstation-local absolute path detected"
+
+echo "Phase 52.3 combined dependency matrix negative and valid fixtures passed."

--- a/scripts/verify-phase-52-3-combined-dependency-matrix.sh
+++ b/scripts/verify-phase-52-3-combined-dependency-matrix.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/combined-dependency-matrix.md"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 52.3 Combined Dependency Matrix"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Host Footprint"
+  "## 4. Dependency Matrix"
+  "## 5. Host Preflight Follow-Up Contract"
+  "## 6. Validation Rules"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1063, #1065, #1066"
+  "This matrix defines dependency documentation and verifier expectations for the executable first-user stack only. It does not implement an installer, compose generation, Wazuh product-profile runtime behavior, Shuffle product-profile runtime behavior, a full host preflight engine, release-candidate behavior, general-availability behavior, or runtime behavior."
+  "The matrix covers the first-user executable stack shape: AegisOps, Wazuh, Shuffle, PostgreSQL, proxy, Docker, and Docker Compose."
+  "Dependency expectations are setup readiness evidence only. Docker, Docker Compose, Wazuh, Shuffle, PostgreSQL, proxy, port, certificate, volume, host sizing, or version state is not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, or closeout truth."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  'This matrix cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+  "| Host tier | CPU | RAM | Disk | Notes |"
+  "| Minimum rehearsal | 4 vCPU | 16 GB RAM | 250 GB durable disk plus separate backup capacity | Sufficient for disposable rehearsal and verifier-driven setup review only. |"
+  "| Recommended first-user | 8 vCPU | 32 GB RAM | 500 GB durable disk plus separate backup capacity | Recommended for one named customer environment with Wazuh intake, PostgreSQL state, proxy ingress, and bounded Shuffle delegation. |"
+  "| Component | Version expectation | Host CPU/RAM/disk expectation | Ports | Volumes | Certificate requirements | Known incompatibilities | Host preflight follow-up fields | Authority boundary |"
+  "Known incompatible versions must be explicit and must fail host preflight follow-up until reviewed."
+  'A later host preflight issue must consume the `AEGISOPS_PREFLIGHT_*` fields named in this matrix and fail closed when a required field is missing, malformed, placeholder-backed, stale, incompatible, inferred from naming conventions, or only partially trusted.'
+  "The existing install preflight remains the current verifier for runtime input, secret custody, storage separation, migration bootstrap, and optional-extension non-blocking behavior."
+  "Host preflight output may report readiness evidence, incompatibility findings, missing prerequisites, and safe next actions. It must not promote Docker, Compose, Wazuh, Shuffle, port, certificate, or version state into AegisOps workflow truth."
+  "any required component row is missing, including AegisOps, Wazuh, Shuffle, PostgreSQL, proxy, Docker, or Docker Compose;"
+  "CPU, RAM, disk, ports, volumes, certificate requirements, known incompatibilities, or preflight follow-up fields are missing;"
+  "known incompatible versions are omitted or described as warnings only;"
+  "substrate version state, port state, certificate state, Docker state, Compose state, Wazuh state, or Shuffle state is described as workflow truth;"
+  "- Substrate version state is AegisOps workflow truth."
+  "- Docker status is AegisOps workflow truth."
+  "- Docker Compose status is AegisOps workflow truth."
+  "- Wazuh alert status is AegisOps case truth."
+  "- Shuffle workflow success is AegisOps reconciliation truth."
+  "- This matrix implements the host preflight engine."
+  'Run `bash scripts/verify-phase-52-3-combined-dependency-matrix.sh`.'
+  'Run `bash scripts/test-verify-phase-52-3-combined-dependency-matrix.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1066 --config <supervisor-config-path>`.'
+)
+
+components=(
+  "AegisOps"
+  "Wazuh"
+  "Shuffle"
+  "PostgreSQL"
+  "Proxy"
+  "Docker"
+  "Docker Compose"
+)
+
+forbidden_claims=(
+  "Substrate version state is AegisOps workflow truth"
+  "Docker status is AegisOps workflow truth"
+  "Docker Compose status is AegisOps workflow truth"
+  "Wazuh alert status is AegisOps case truth"
+  "Shuffle workflow success is AegisOps reconciliation truth"
+  "Placeholder secrets are valid credentials"
+  "Raw forwarded headers are trusted identity"
+  "This matrix implements the host preflight engine"
+  "This matrix implements Wazuh product-profile runtime behavior"
+  "This matrix implements Shuffle product-profile runtime behavior"
+)
+
+required_preflight_fields=(
+  "AEGISOPS_PREFLIGHT_AEGISOPS_REVISION"
+  "AEGISOPS_PREFLIGHT_WAZUH_VERSION"
+  "AEGISOPS_PREFLIGHT_SHUFFLE_VERSION"
+  "AEGISOPS_PREFLIGHT_POSTGRES_VERSION"
+  "AEGISOPS_PREFLIGHT_PROXY_VERSION"
+  "AEGISOPS_PREFLIGHT_DOCKER_ENGINE_VERSION"
+  "AEGISOPS_PREFLIGHT_COMPOSE_VERSION"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.3 combined dependency matrix: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.3 combined dependency matrix heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.3 combined dependency matrix statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for component in "${components[@]}"; do
+  if ! grep -Eq "^\| ${component} \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.3 dependency row: ${component}" >&2
+    exit 1
+  fi
+done
+
+for field in "${required_preflight_fields[@]}"; do
+  if ! grep -Fq -- "\`${field}\`" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.3 host preflight follow-up field: ${field}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+contains_placeholder_secret_valid_claim() {
+  awk '
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    {
+      line = tolower($0)
+      negative_context = line ~ /(must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|incompatible)/
+      if (!in_forbidden_claims && !negative_context && line ~ /(^|[^[:alnum:]_])placeholder secrets?[[:space:]]+(are|is|count as|counts as|may be|can be|remain|stays)[[:space:]]+([^.]*[^[:alnum:]_])?(valid|trusted|accepted|production)([^[:alnum:]_]|$)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${doc_rendered_markdown}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.3 combined dependency matrix claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if contains_placeholder_secret_valid_claim; then
+  echo "Forbidden Phase 52.3 combined dependency matrix claim: placeholder secrets accepted as valid credentials" >&2
+  exit 1
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+unix_absolute_path="/${path_token_chars}+"
+windows_drive_path="[A-Za-z]:[\\\\/]${path_token_chars}*"
+local_path_token="(${unix_absolute_path}|${windows_drive_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.3 combined dependency matrix: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 52.3 combined dependency matrix link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/combined-dependency-matrix\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 52.3 combined dependency matrix." >&2
+  exit 1
+fi
+
+echo "Phase 52.3 combined dependency matrix is present and preserves component coverage, host footprint, incompatibility handling, preflight follow-up fields, and authority boundaries."


### PR DESCRIPTION
## Summary
- Add the Phase 52.3 combined dependency matrix for AegisOps, Wazuh, Shuffle, PostgreSQL, proxy, Docker, and Docker Compose.
- Add focused verifier coverage for host footprint, ports, volumes, certificates, known incompatibilities, preflight follow-up fields, authority-boundary claims, path hygiene, and required negative cases.
- Link the matrix from README.

## Verification
- bash scripts/verify-phase-52-3-combined-dependency-matrix.sh
- bash scripts/test-verify-phase-52-3-combined-dependency-matrix.sh
- bash scripts/test-verify-publishable-path-hygiene.sh
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1066 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json

Part of #1063
Depends on #1065
Closes #1066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive deployment dependency matrix documentation specifying system requirements, component versions, host resources, ports, volume requirements, and known compatibility constraints for initial deployment.

* **Tests**
  * Added automated verification scripts and test harness to validate deployment documentation against structural requirements, policy constraints, and configuration specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->