### PR TITLE
Phase 52.4 compose generator contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md) defines the first-user stack command contract for `init`, `up`, `doctor`, `seed-demo`, `status`, `open`, `logs`, and `down`.
 - [Phase 52.2 SMB single-node profile model](docs/phase-52-2-smb-single-node-profile-model.md) defines the `smb-single-node` setup profile sections, mode labels, generated-config expectations, validation rules, and authority boundary.
 - [Phase 52.3 combined dependency matrix](docs/deployment/combined-dependency-matrix.md) defines first-user stack dependency expectations, host footprint, ports, volumes, certificate requirements, incompatibilities, and host-preflight follow-up fields.
+- [Phase 52.4 compose generator contract](docs/deployment/compose-generator-contract.md) defines generated Compose shape, proxy-only ingress, snapshot expectations, and manual-editing rejection for the executable first-user stack.
 
 ## Product positioning
 
@@ -49,6 +50,8 @@ The Phase 52.1 first-user CLI command contract is defined by the [Phase 52.1 CLI
 The Phase 52.2 first-user SMB single-node profile model is defined by the [Phase 52.2 SMB single-node profile model](docs/phase-52-2-smb-single-node-profile-model.md).
 
 The Phase 52.3 first-user combined dependency matrix is defined by the [Phase 52.3 combined dependency matrix](docs/deployment/combined-dependency-matrix.md).
+
+The Phase 52.4 first-user compose generator contract is defined by the [Phase 52.4 compose generator contract](docs/deployment/compose-generator-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/compose-generator-contract.md
+++ b/docs/deployment/compose-generator-contract.md
@@ -1,0 +1,99 @@
+# Phase 52.4 Compose Generator Contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-52-1-cli-command-contract.md`, `docs/phase-52-2-smb-single-node-profile-model.md`, `docs/deployment/combined-dependency-matrix.md`, `docs/network-exposure-and-access-path-policy.md`
+- **Related Issues**: #1063, #1065, #1066, #1067
+
+This contract defines generated Docker Compose shape and snapshot-test expectations for the executable first-user stack only. It does not implement the installer, compose generator runtime, Wazuh product profile, Shuffle product profile, production hardening, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+## 1. Purpose
+
+The compose generator contract gives later setup issues one stable output shape for the `smb-single-node` first-user stack. The generator may produce a Compose file from reviewed profile input, but the generated file is setup/runtime posture evidence only.
+
+Manual editing of generated Compose output is not the product path. Operators may supply reviewed profile input, env files, secret references, and documented overrides through later installer or profile surfaces, but hand-edited Compose files must not become the supported configuration workflow.
+
+## 2. Authority Boundary
+
+Generated compose state is setup/runtime posture evidence only. Generated compose state is not alert, case, evidence, approval, execution, reconciliation, source, workflow, gate, release, production, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. The generator must preserve the Phase 51.6 rule that Wazuh, Shuffle, generated config, placeholders, tickets, AI, browser state, UI cache, logs, and downstream receipts cannot become workflow truth or production truth.
+
+## 3. Generated Compose Shape
+
+The generated `smb-single-node` Compose output must include these service keys and boundaries:
+
+| Service | Mode label | Generated shape | Boundary requirement |
+| --- | --- | --- | --- |
+| AegisOps | `required` | Control-plane service built from a release-bound image or repository revision, joined only to internal and proxy networks, with env-file and secret-reference placeholders. | Backend port remains internal; no direct host `ports` publication is allowed. |
+| PostgreSQL | `required` | PostgreSQL 15 or 16 service with named data and backup volumes, explicit credential reference, and healthcheck dependency for AegisOps startup. | Database port remains internal; state backs AegisOps records but process state alone is not workflow truth. |
+| Proxy | `required` | Reviewed reverse-proxy service with the only host-published user-facing ports, route map for operator, readiness, runtime inspection, and Wazuh intake paths, and trusted boundary secret references. | Proxy is the only approved ingress boundary; raw forwarded headers and direct backend access are not trusted. |
+| Wazuh | `deferred` | Deferred product-profile placeholder service or external-substrate binding with explicit intake route, source binding, and secret-reference placeholders. | Wazuh status, alerts, timestamps, and rule state remain subordinate signal context, not AegisOps workflow truth. |
+| Shuffle | `deferred` | Deferred product-profile placeholder service or external-substrate binding with callback route, workflow catalog reference, and credential-reference placeholders. | Shuffle workflow success, failure, retry, payload, and callback state remain subordinate execution context until admitted through AegisOps records. |
+| Demo source | `demo-only` | Demo fixture source with explicit demo mode, reviewed fixture bundle reference, seed scope, and cleanup policy. | Demo data, fake secrets, and sample credentials are not production truth and must not satisfy production readiness. |
+
+Generated Compose output must use named volumes, repo-relative references, documented environment variables, or placeholders such as `<runtime-env-file>`, `<compose-output-path>`, `<profile-name>`, `<supervisor-config-path>`, and `<codex-supervisor-root>` in publishable guidance.
+
+## 4. Snapshot Expectations
+
+The required snapshot fixture is `docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml`.
+
+Snapshot tests must verify:
+
+- service keys for AegisOps, PostgreSQL, proxy, Wazuh, Shuffle, and demo source are present;
+- the proxy service is the only service with host-published `ports`;
+- AegisOps, PostgreSQL, Wazuh, Shuffle, and demo source do not publish direct host ports;
+- AegisOps and PostgreSQL share an internal network, and AegisOps reaches users only through the proxy network;
+- PostgreSQL data and backup volumes are separate named volumes;
+- Wazuh, Shuffle, and demo source are explicit deferred or demo-only surfaces instead of hidden product-profile completion claims;
+- secret, certificate, and credential values are represented as trusted references or placeholders, not inline secrets; and
+- the snapshot carries an authority-boundary note that generated Compose output is setup/runtime posture evidence only.
+
+## 5. Validation Rules
+
+Compose generator contract validation must fail closed when:
+
+- the contract document is missing;
+- any required service row is missing, including AegisOps, PostgreSQL, proxy, Wazuh, Shuffle, or demo source;
+- the generated snapshot fixture is missing;
+- the generated snapshot omits any required service;
+- any non-proxy service publishes host ports directly;
+- the proxy boundary is missing or is not the only approved ingress;
+- manual Compose editing is described as the product path;
+- generated compose state is described as AegisOps workflow truth, production truth, release truth, gate truth, or closeout truth;
+- placeholder secrets, sample credentials, TODO values, inline secrets, raw forwarded headers, or unreviewed scope inference are treated as valid setup state; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders.
+
+## 6. Forbidden Claims
+
+- Compose state is AegisOps workflow truth.
+- Generated compose state is production truth.
+- Generated compose state is release truth.
+- Generated compose state is closeout truth.
+- Manual Compose editing is the product path.
+- Direct backend exposure is approved.
+- Proxy boundary is optional.
+- Placeholder secrets are valid credentials.
+- Raw forwarded headers are trusted identity.
+- Phase 52.4 implements the compose generator runtime.
+- Phase 52.4 implements Wazuh product profiles.
+- Phase 52.4 implements Shuffle product profiles.
+
+## 7. Validation
+
+Run `bash scripts/verify-phase-52-4-compose-generator-contract.sh`.
+
+Run `bash scripts/test-verify-phase-52-4-compose-generator-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1067 --config <supervisor-config-path>`.
+
+The verifier must fail when the contract is missing, when the snapshot is missing, when any expected service is absent, when a non-proxy service exposes backend ports directly, when the proxy boundary is missing, when manual Compose editing is treated as the product path, when generated compose state is treated as workflow truth, or when publishable guidance uses workstation-local absolute paths.
+
+## 8. Non-Goals
+
+- No compose generator implementation is approved by this contract.
+- No installer, Wazuh product profile, Shuffle product profile, production hardening, release-candidate behavior, general-availability behavior, or runtime behavior is implemented here.
+- No generated compose output, generated config, Wazuh state, Shuffle state, demo data, placeholder, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml
+++ b/docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml
@@ -1,0 +1,102 @@
+name: aegisops-smb-single-node
+
+x-aegisops-authority-boundary: generated-compose-output-is-setup-runtime-posture-evidence-only
+
+services:
+  aegisops:
+    image: ${AEGISOPS_IMAGE_REF:?set-reviewed-release-bound-image}
+    env_file:
+      - ${AEGISOPS_RUNTIME_ENV_FILE:-<runtime-env-file>}
+    environment:
+      AEGISOPS_PROFILE_ID: smb-single-node
+      AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_REF: ${AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_REF:?set-trusted-secret-ref}
+      AEGISOPS_PROXY_BOUNDARY_SECRET_REF: ${AEGISOPS_PROXY_BOUNDARY_SECRET_REF:?set-trusted-secret-ref}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    expose:
+      - "8080"
+    networks:
+      - internal
+      - proxy
+
+  postgres:
+    image: postgres:16.4
+    environment:
+      POSTGRES_DB: ${AEGISOPS_POSTGRES_DB:-aegisops_control_plane}
+      POSTGRES_USER: ${AEGISOPS_POSTGRES_USER:-aegisops_control_plane}
+      POSTGRES_PASSWORD_FILE: ${AEGISOPS_POSTGRES_PASSWORD_FILE:?set-trusted-secret-file}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - postgres-backup:/aegisops/postgres-backup
+    expose:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - internal
+
+  proxy:
+    image: nginx:1.27.0
+    depends_on:
+      - aegisops
+    ports:
+      - "${AEGISOPS_PROXY_HTTP_PORT:-80}:80"
+      - "${AEGISOPS_PROXY_HTTPS_PORT:-443}:443"
+    environment:
+      AEGISOPS_PROXY_ROUTE_MAP_REF: ${AEGISOPS_PROXY_ROUTE_MAP_REF:?set-reviewed-route-map-ref}
+      AEGISOPS_PROXY_TLS_CERT_REF: ${AEGISOPS_PROXY_TLS_CERT_REF:?set-trusted-cert-ref}
+      AEGISOPS_PROXY_TLS_KEY_REF: ${AEGISOPS_PROXY_TLS_KEY_REF:?set-trusted-key-ref}
+      AEGISOPS_PROXY_BOUNDARY_SECRET_REF: ${AEGISOPS_PROXY_BOUNDARY_SECRET_REF:?set-trusted-secret-ref}
+    networks:
+      - proxy
+      - internal
+
+  wazuh:
+    image: ${AEGISOPS_WAZUH_IMAGE_REF:-deferred-wazuh-profile-placeholder}
+    profiles:
+      - deferred-wazuh
+    environment:
+      AEGISOPS_WAZUH_MODE: deferred
+      AEGISOPS_WAZUH_INGEST_ROUTE: ${AEGISOPS_WAZUH_INGEST_ROUTE:-/wazuh/ingest}
+      AEGISOPS_WAZUH_INGEST_SECRET_REF: ${AEGISOPS_WAZUH_INGEST_SECRET_REF:?set-trusted-secret-ref}
+    expose:
+      - "55000"
+    networks:
+      - internal
+
+  shuffle:
+    image: ${AEGISOPS_SHUFFLE_IMAGE_REF:-deferred-shuffle-profile-placeholder}
+    profiles:
+      - deferred-shuffle
+    environment:
+      AEGISOPS_SHUFFLE_MODE: deferred
+      AEGISOPS_SHUFFLE_CALLBACK_ROUTE: ${AEGISOPS_SHUFFLE_CALLBACK_ROUTE:-/shuffle/callback}
+      AEGISOPS_SHUFFLE_CREDENTIAL_REF: ${AEGISOPS_SHUFFLE_CREDENTIAL_REF:?set-trusted-secret-ref}
+    expose:
+      - "3001"
+    networks:
+      - internal
+
+  demo-source:
+    image: ${AEGISOPS_DEMO_SOURCE_IMAGE_REF:-demo-source-placeholder}
+    profiles:
+      - demo
+    environment:
+      AEGISOPS_DEMO_MODE: "true"
+      AEGISOPS_DEMO_FIXTURE_BUNDLE_REF: ${AEGISOPS_DEMO_FIXTURE_BUNDLE_REF:-<demo-fixture-bundle>}
+      AEGISOPS_DEMO_CREDENTIAL_POLICY: no-production-credentials
+    networks:
+      - internal
+
+networks:
+  internal:
+    internal: true
+  proxy:
+
+volumes:
+  postgres-data:
+  postgres-backup:

--- a/scripts/test-verify-phase-52-4-compose-generator-contract.sh
+++ b/scripts/test-verify-phase-52-4-compose-generator-contract.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-4-compose-generator-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/fixtures/compose-generator"
+  printf '%s\n' "# AegisOps" "See [Phase 52.4 compose generator contract](docs/deployment/compose-generator-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/compose-generator-contract.md" \
+    "${target}/docs/deployment/compose-generator-contract.md"
+  cp "${repo_root}/docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml" \
+    "${target}/docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/compose-generator-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/compose-generator-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 52.4 compose generator contract"
+
+missing_snapshot_repo="${workdir}/missing-snapshot"
+create_valid_repo "${missing_snapshot_repo}"
+rm "${missing_snapshot_repo}/docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml"
+assert_fails_with \
+  "${missing_snapshot_repo}" \
+  "Missing Phase 52.4 generated compose snapshot fixture"
+
+missing_proxy_repo="${workdir}/missing-proxy"
+create_valid_repo "${missing_proxy_repo}"
+perl -0pi -e 's/\n  proxy:\n    image: nginx:1\.27\.0.*?(?=\n  wazuh:)/\n/s' \
+  "${missing_proxy_repo}/docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml"
+assert_fails_with \
+  "${missing_proxy_repo}" \
+  "Missing generated compose snapshot service: proxy"
+
+direct_backend_repo="${workdir}/direct-backend"
+create_valid_repo "${direct_backend_repo}"
+perl -0pi -e 's/    expose:\n      - "8080"/    ports:\n      - "8080:8080"/' \
+  "${direct_backend_repo}/docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml"
+assert_fails_with \
+  "${direct_backend_repo}" \
+  "Generated compose snapshot must not publish host ports for service: aegisops"
+
+missing_wazuh_row_repo="${workdir}/missing-wazuh-row"
+create_valid_repo "${missing_wazuh_row_repo}"
+remove_text_from_contract "${missing_wazuh_row_repo}" \
+  "| Wazuh | \`deferred\` | Deferred product-profile placeholder service or external-substrate binding with explicit intake route, source binding, and secret-reference placeholders. | Wazuh status, alerts, timestamps, and rule state remain subordinate signal context, not AegisOps workflow truth. |"
+assert_fails_with \
+  "${missing_wazuh_row_repo}" \
+  "Missing complete Phase 52.4 compose service row: Wazuh"
+
+manual_editing_repo="${workdir}/manual-editing"
+create_valid_repo "${manual_editing_repo}"
+remove_text_from_contract "${manual_editing_repo}" \
+  "Manual editing of generated Compose output is not the product path."
+assert_fails_with \
+  "${manual_editing_repo}" \
+  "Missing Phase 52.4 compose generator contract statement: Manual editing of generated Compose output is not the product path."
+
+workflow_truth_repo="${workdir}/workflow-truth"
+create_valid_repo "${workflow_truth_repo}"
+printf '%s\n' "Compose state is AegisOps workflow truth." \
+  >>"${workflow_truth_repo}/docs/deployment/compose-generator-contract.md"
+assert_fails_with \
+  "${workflow_truth_repo}" \
+  "Forbidden Phase 52.4 compose generator contract claim: Compose state is AegisOps workflow truth"
+
+direct_exposure_claim_repo="${workdir}/direct-exposure-claim"
+create_valid_repo "${direct_exposure_claim_repo}"
+printf '%s\n' "Direct backend exposure is approved." \
+  >>"${direct_exposure_claim_repo}/docs/deployment/compose-generator-contract.md"
+assert_fails_with \
+  "${direct_exposure_claim_repo}" \
+  "Forbidden Phase 52.4 compose generator contract claim: Direct backend exposure is approved"
+
+placeholder_secret_repo="${workdir}/placeholder-secret"
+create_valid_repo "${placeholder_secret_repo}"
+printf '%s\n' "Placeholder secrets are valid credentials." \
+  >>"${placeholder_secret_repo}/docs/deployment/compose-generator-contract.md"
+assert_fails_with \
+  "${placeholder_secret_repo}" \
+  "Forbidden Phase 52.4 compose generator contract claim: Placeholder secrets are valid credentials"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/compose-generator-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.4 compose generator contract: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 52.4 compose generator contract."
+
+echo "Phase 52.4 compose generator contract verifier tests passed."

--- a/scripts/verify-phase-52-4-compose-generator-contract.sh
+++ b/scripts/verify-phase-52-4-compose-generator-contract.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/compose-generator-contract.md"
+snapshot_path="${repo_root}/docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 52.4 Compose Generator Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Generated Compose Shape"
+  "## 4. Snapshot Expectations"
+  "## 5. Validation Rules"
+  "## 6. Forbidden Claims"
+  "## 7. Validation"
+  "## 8. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1063, #1065, #1066, #1067"
+  "This contract defines generated Docker Compose shape and snapshot-test expectations for the executable first-user stack only. It does not implement the installer, compose generator runtime, Wazuh product profile, Shuffle product profile, production hardening, release-candidate behavior, general-availability behavior, or runtime behavior."
+  'The compose generator contract gives later setup issues one stable output shape for the `smb-single-node` first-user stack.'
+  "Manual editing of generated Compose output is not the product path."
+  "Generated compose state is setup/runtime posture evidence only. Generated compose state is not alert, case, evidence, approval, execution, reconciliation, source, workflow, gate, release, production, or closeout truth."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  'This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+  "| Service | Mode label | Generated shape | Boundary requirement |"
+  'The required snapshot fixture is `docs/deployment/fixtures/compose-generator/smb-single-node.compose.snapshot.yml`.'
+  'the proxy service is the only service with host-published `ports`;'
+  "AegisOps, PostgreSQL, Wazuh, Shuffle, and demo source do not publish direct host ports;"
+  "the proxy boundary is missing or is not the only approved ingress;"
+  "manual Compose editing is described as the product path;"
+  'Run `bash scripts/verify-phase-52-4-compose-generator-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-52-4-compose-generator-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1067 --config <supervisor-config-path>`.'
+)
+
+services=(
+  "AegisOps|required"
+  "PostgreSQL|required"
+  "Proxy|required"
+  "Wazuh|deferred"
+  "Shuffle|deferred"
+  "Demo source|demo-only"
+)
+
+snapshot_services=(
+  "aegisops"
+  "postgres"
+  "proxy"
+  "wazuh"
+  "shuffle"
+  "demo-source"
+)
+
+forbidden_claims=(
+  "Compose state is AegisOps workflow truth"
+  "Generated compose state is production truth"
+  "Generated compose state is release truth"
+  "Generated compose state is closeout truth"
+  "Manual Compose editing is the product path"
+  "Direct backend exposure is approved"
+  "Proxy boundary is optional"
+  "Placeholder secrets are valid credentials"
+  "Raw forwarded headers are trusted identity"
+  "Phase 52.4 implements the compose generator runtime"
+  "Phase 52.4 implements Wazuh product profiles"
+  "Phase 52.4 implements Shuffle product profiles"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.4 compose generator contract: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.4 compose generator contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.4 compose generator contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for service_entry in "${services[@]}"; do
+  service="${service_entry%%|*}"
+  mode="${service_entry##*|}"
+  if ! grep -Eq "^\| ${service} \| \`${mode}\` \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.4 compose service row: ${service}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 6\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+contains_placeholder_secret_valid_claim() {
+  awk '
+    /^## 6\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    {
+      line = tolower($0)
+      negative_context = line ~ /(must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|incompatible|not inline|not the product path)/
+      if (!in_forbidden_claims && !negative_context && line ~ /(^|[^[:alnum:]_])placeholder secrets?[[:space:]]+(are|is|count as|counts as|may be|can be|remain|stays)[[:space:]]+([^.]*[^[:alnum:]_])?(valid|trusted|accepted|production)([^[:alnum:]_]|$)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${doc_rendered_markdown}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.4 compose generator contract claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if contains_placeholder_secret_valid_claim; then
+  echo "Forbidden Phase 52.4 compose generator contract claim: placeholder secrets accepted as valid credentials" >&2
+  exit 1
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.4 compose generator contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${snapshot_path}" ]]; then
+  echo "Missing Phase 52.4 generated compose snapshot fixture: ${snapshot_path}" >&2
+  exit 1
+fi
+
+for service in "${snapshot_services[@]}"; do
+  if ! awk -v service="${service}" '
+    /^services:[[:space:]]*$/ { in_services = 1; next }
+    /^[A-Za-z0-9_-]+:[[:space:]]*$/ && in_services { in_services = 0 }
+    in_services && $0 ~ "^  " service ":[[:space:]]*$" { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${snapshot_path}"; then
+    echo "Missing generated compose snapshot service: ${service}" >&2
+    exit 1
+  fi
+done
+
+for required in \
+  "name: aegisops-smb-single-node" \
+  "x-aegisops-authority-boundary: generated-compose-output-is-setup-runtime-posture-evidence-only" \
+  "postgres-data:" \
+  "postgres-backup:" \
+  "internal: true"; do
+  if ! grep -Fq -- "${required}" "${snapshot_path}"; then
+    echo "Missing generated compose snapshot statement: ${required}" >&2
+    exit 1
+  fi
+done
+
+non_proxy_ports="$(
+  awk '
+    /^services:[[:space:]]*$/ { in_services = 1; next }
+    /^[A-Za-z0-9_-]+:[[:space:]]*$/ && in_services { in_services = 0 }
+    !in_services { next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+      service = $1
+      sub(/:$/, "", service)
+      next
+    }
+    /^[[:space:]]{4}ports:[[:space:]]*$/ && service != "" && service != "proxy" {
+      print service
+    }
+  ' "${snapshot_path}" | sort -u
+)"
+
+if [[ -n "${non_proxy_ports}" ]]; then
+  while IFS= read -r service; do
+    [[ -z "${service}" ]] && continue
+    echo "Generated compose snapshot must not publish host ports for service: ${service}" >&2
+  done <<<"${non_proxy_ports}"
+  exit 1
+fi
+
+if ! awk '
+  /^  proxy:[[:space:]]*$/ { in_proxy = 1; next }
+  /^  [A-Za-z0-9_-]+:[[:space:]]*$/ && in_proxy { in_proxy = 0 }
+  in_proxy && /^[[:space:]]{4}ports:[[:space:]]*$/ { found = 1 }
+  END { exit(found ? 0 : 1) }
+' "${snapshot_path}"; then
+  echo "Generated compose snapshot proxy service must publish the reviewed ingress ports." >&2
+  exit 1
+fi
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${snapshot_path}"; then
+  echo "Forbidden Phase 52.4 generated compose snapshot: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 52.4 compose generator contract link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/compose-generator-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 52.4 compose generator contract." >&2
+  exit 1
+fi
+
+echo "Phase 52.4 compose generator contract is present and preserves service shape, proxy-only ingress, snapshot expectations, and authority boundaries."


### PR DESCRIPTION
## Summary
- define the Phase 52.4 compose generator contract for the executable first-user stack
- add a generated compose snapshot fixture covering AegisOps, PostgreSQL, proxy, Wazuh, Shuffle, and demo source
- add verifier coverage for proxy-only ingress, no direct backend exposure, manual-editing rejection, authority-boundary claims, README linkage, and path-literal hygiene

## Verification
- bash scripts/verify-phase-52-4-compose-generator-contract.sh
- bash scripts/test-verify-phase-52-4-compose-generator-contract.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1067 --config <supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 52.4 cross-phase boundary reference to deployment documentation
  * Introduced compose generator contract documentation specifying generated Docker Compose structure, service configuration, networking rules, security boundaries, and validation assertions for single-node deployments

* **Tests**
  * Added validation infrastructure and testing scripts for compose generator contract compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->