### PR TITLE
Phase 52.5 env secrets certs contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,12 @@ Thumbs.db
 docker-compose.override.yml
 docker-compose.local.yml
 
+# Generated first-user runtime config, secrets, and certificates
+control-plane/deployment/first-boot/generated/
+control-plane/deployment/first-boot/runtime/
+control-plane/deployment/first-boot/secrets/
+control-plane/deployment/first-boot/certs/
+
 # Rendered Wazuh integration artifacts may contain live bearer material
 ossec.integration.rendered.xml
 *.ossec.integration.rendered.xml

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.2 SMB single-node profile model](docs/phase-52-2-smb-single-node-profile-model.md) defines the `smb-single-node` setup profile sections, mode labels, generated-config expectations, validation rules, and authority boundary.
 - [Phase 52.3 combined dependency matrix](docs/deployment/combined-dependency-matrix.md) defines first-user stack dependency expectations, host footprint, ports, volumes, certificate requirements, incompatibilities, and host-preflight follow-up fields.
 - [Phase 52.4 compose generator contract](docs/deployment/compose-generator-contract.md) defines generated Compose shape, proxy-only ingress, snapshot expectations, and manual-editing rejection for the executable first-user stack.
+- [Phase 52.5 env secrets certs contract](docs/deployment/env-secrets-certs-contract.md) defines generated runtime env config, ignored secret/cert paths, demo token/cert posture, and fail-closed secret validation for the executable first-user stack.
 
 ## Product positioning
 
@@ -52,6 +53,8 @@ The Phase 52.2 first-user SMB single-node profile model is defined by the [Phase
 The Phase 52.3 first-user combined dependency matrix is defined by the [Phase 52.3 combined dependency matrix](docs/deployment/combined-dependency-matrix.md).
 
 The Phase 52.4 first-user compose generator contract is defined by the [Phase 52.4 compose generator contract](docs/deployment/compose-generator-contract.md).
+
+The Phase 52.5 first-user env secrets certs contract is defined by the [Phase 52.5 env secrets certs contract](docs/deployment/env-secrets-certs-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/control-plane/deployment/first-boot/bootstrap.env.sample
+++ b/control-plane/deployment/first-boot/bootstrap.env.sample
@@ -1,6 +1,8 @@
 # Reviewed bootstrap sample for the Phase 16 first-boot skeleton only.
 # Copy reviewed values into an untracked runtime env file before use.
 # Do not commit live credentials, DSNs, or secret material to this repository.
+# Runtime env, secret, and certificate generation expectations are defined in
+# docs/deployment/env-secrets-certs-contract.md.
 # Release-bundle ownership and handoff expectations are inventoried in
 # docs/deployment/single-customer-release-bundle-inventory.md.
 

--- a/docs/deployment/env-secrets-certs-contract.md
+++ b/docs/deployment/env-secrets-certs-contract.md
@@ -1,0 +1,124 @@
+# Phase 52.5 Env, Secrets, and Cert Generation Contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-52-1-cli-command-contract.md`, `docs/phase-52-2-smb-single-node-profile-model.md`, `docs/deployment/combined-dependency-matrix.md`, `docs/deployment/compose-generator-contract.md`, `control-plane/deployment/first-boot/bootstrap.env.sample`
+- **Related Issues**: #1063, #1065, #1066, #1067, #1068
+
+This contract defines generated runtime env config, secret-reference, and certificate-generation expectations for the executable first-user stack only. It does not implement full secret backend integration, Wazuh product-profile generation, Shuffle product-profile generation, installer UX, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+## 1. Purpose
+
+The first-user stack needs one reviewed contract for the files and references that later setup commands may generate before `up`, `doctor`, or rehearsal smoke checks run.
+
+Generated runtime config is a setup prerequisite. It may prove that required inputs are present, named, ignored, and bound to reviewed custody, but it is not a source of AegisOps workflow authority.
+
+## 2. Authority Boundary
+
+Env files, generated secret files, generated demo tokens, generated certificates, certificate paths, OpenBao bindings, and custody checklists are setup/security prerequisites only. Their presence, freshness, generated status, file ownership, or validation status cannot become AegisOps workflow truth, approval truth, execution truth, reconciliation truth, source truth, gate truth, release truth, production truth, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. The Phase 52.5 verifier must preserve the Phase 51.6 rule that generated config, placeholders, demo data, tickets, AI, browser state, UI cache, downstream receipts, logs, Wazuh state, and Shuffle state cannot become workflow truth or production truth.
+
+## 3. Generated Runtime Config
+
+Later setup commands may generate an untracked runtime env file from `control-plane/deployment/first-boot/bootstrap.env.sample`.
+
+The reviewed runtime env contract uses these setup bindings:
+
+| Binding | Expected form | Production posture | Validation rule |
+| --- | --- | --- | --- |
+| `AEGISOPS_RUNTIME_ENV_FILE` | Path to an untracked env file such as `<runtime-env-file>`. | Required setup input; not committed evidence or workflow truth. | Must not point at `.env.sample`, a tracked file, or a workstation-local publishable path. |
+| `AEGISOPS_GENERATED_CONFIG_DIR` | Untracked generated config directory such as `control-plane/deployment/first-boot/generated/`. | Generated setup output only. | Directory must be ignored or outside Git-tracked paths before writing generated files. |
+| `AEGISOPS_SECRETS_DIR` | Mounted secret-file directory such as `control-plane/deployment/first-boot/secrets/` for local rehearsal or `/run/aegisops-secrets` in containers. | Secret custody source or mount point, never product truth. | Missing, empty, placeholder, sample, fake, TODO, unsigned, inline, guessed, or committed secret-looking values fail validation. |
+| `AEGISOPS_CERTS_DIR` | Generated certificate directory such as `control-plane/deployment/first-boot/certs/` for local rehearsal. | Certificate custody source or mount point, never production truth by itself. | Demo certificates must be explicitly marked demo-only and cannot satisfy production TLS custody. |
+| `AEGISOPS_DEMO_TOKEN_FILE` | File reference for a generated demo token when demo mode is explicitly enabled. | Demo-only setup convenience. | Must not satisfy admin bootstrap, break-glass, Wazuh ingest, proxy boundary, OpenBao, or production credential checks. |
+| `AEGISOPS_DEMO_TLS_CERT_FILE` | File reference for a generated demo certificate when demo mode is explicitly enabled. | Demo-only local rehearsal certificate. | Must not satisfy production ingress TLS certificate-chain custody, private-key custody, expiry review, or reload evidence. |
+
+Generated config must use repo-relative paths, documented env vars, or placeholders such as `<runtime-env-file>`, `<generated-config-dir>`, `<secrets-dir>`, `<certs-dir>`, `<evidence-dir>`, `<supervisor-config-path>`, and `<codex-supervisor-root>` in publishable guidance.
+
+## 4. Secret File Custody
+
+Secret values must be supplied through reviewed file bindings or reviewed OpenBao bindings. Inline secrets, sample credentials, placeholder values, fake values, TODO values, unsigned tokens, guessed scope, and values copied from comments are invalid.
+
+The required secret custody classes are:
+
+| Secret class | Accepted reference forms | Demo posture | Rejection rule |
+| --- | --- | --- | --- |
+| PostgreSQL DSN | `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_FILE` or `AEGISOPS_CONTROL_PLANE_POSTGRES_DSN_OPENBAO_PATH`. | Demo DSNs are not production readiness. | Inline DSNs in committed docs or fixtures are rejected unless they are placeholder-safe samples in `.sample` files. |
+| Wazuh ingest shared secret | `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE` or `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH`. | Demo token files must be separate and demo-labeled. | Placeholder, sample, fake, TODO, unsigned, or committed bearer values are rejected. |
+| Wazuh reverse-proxy secret | `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET_FILE` or `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_REVERSE_PROXY_SECRET_OPENBAO_PATH`. | Demo proxy tokens cannot become trusted boundary secrets. | Missing trusted proxy boundary custody fails closed. |
+| Protected-surface proxy secret | `AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET_FILE` or `AEGISOPS_CONTROL_PLANE_PROTECTED_SURFACE_REVERSE_PROXY_SECRET_OPENBAO_PATH`. | Demo values cannot satisfy protected-surface custody. | Raw forwarded headers, host, proto, tenant, or user-id hints are not trusted identity. |
+| Admin bootstrap token | `AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN_FILE` or `AEGISOPS_CONTROL_PLANE_ADMIN_BOOTSTRAP_TOKEN_OPENBAO_PATH`. | Demo tokens are separate from bootstrap tokens. | Placeholder or demo token files must not unlock admin bootstrap. |
+| Break-glass token | `AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_FILE` or `AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_OPENBAO_PATH`. | Demo tokens are separate from break-glass tokens. | Missing custody owner, trigger, and follow-up rotation evidence fails closed. |
+| OpenBao token | `AEGISOPS_OPENBAO_TOKEN_FILE` or a runtime-injected `AEGISOPS_OPENBAO_TOKEN`. | Demo-only OpenBao tokens are invalid. | Committed OpenBao tokens, TODO values, and sample tokens are rejected. |
+
+## 5. Certificate Generation
+
+Later setup commands may generate demo TLS material only when demo mode is explicit. Generated demo certificate material must be written to an ignored or untracked certificate directory and labeled as demo-only.
+
+Production posture requires reviewed certificate-chain custody, private-key custody, expiry review horizon, reload evidence, approved proxy artifact revision, and trusted-header normalization. The existing first-boot sample names these production custody fields through `AEGISOPS_INGRESS_TLS_CERT_CHAIN_FILE`, `AEGISOPS_INGRESS_TLS_PRIVATE_KEY_FILE`, `AEGISOPS_INGRESS_TLS_CERT_CUSTODY_OWNER`, `AEGISOPS_INGRESS_TLS_PRIVATE_KEY_CUSTODIAN`, `AEGISOPS_INGRESS_TLS_EXPIRY_REVIEW_HORIZON`, `AEGISOPS_INGRESS_TLS_RELOAD_EVIDENCE_REF`, `AEGISOPS_INGRESS_APPROVED_PROXY_ARTIFACT_REVISION`, and `AEGISOPS_INGRESS_TRUSTED_HEADER_NORMALIZATION`.
+
+Demo certificates, self-signed local certificates, generated key pairs, or certificate path existence are not production truth and must not satisfy production ingress TLS custody.
+
+## 6. Ignored Generated Paths
+
+Generated runtime config, generated secret files, and generated certificates must be untracked or explicitly ignored before setup commands write them.
+
+The repository ignore contract includes:
+
+| Ignored path | Purpose | Tracking rule |
+| --- | --- | --- |
+| `control-plane/deployment/first-boot/generated/` | Generated compose/env/profile output for first-user setup. | Must remain ignored. |
+| `control-plane/deployment/first-boot/runtime/` | Local runtime env files and generated runtime state. | Must remain ignored. |
+| `control-plane/deployment/first-boot/secrets/` | Local rehearsal secret-file bindings. | Must remain ignored. |
+| `control-plane/deployment/first-boot/certs/` | Local rehearsal certificate material. | Must remain ignored. |
+
+Tracked `.sample` files may document names and placeholder-safe structure only. Real env files, live DSNs, live tokens, private keys, certificate material, and customer-private credentials must not be committed.
+
+## 7. Validation Rules
+
+Env, secrets, and cert contract validation must fail closed when:
+
+- the contract document is missing;
+- runtime env, generated config, secret, demo token, or cert binding coverage is missing;
+- generated secret or certificate paths are not ignored;
+- demo token or demo certificate posture is not separated from production posture;
+- a placeholder, TODO, sample, fake, guessed, unsigned, inline, or committed secret-looking value is accepted as valid;
+- generated env, secret, certificate, demo token, or certificate path state is described as AegisOps workflow truth, production truth, gate truth, release truth, approval truth, execution truth, reconciliation truth, or closeout truth;
+- raw forwarded headers, host, proto, tenant, or user-id hints are trusted as identity without the reviewed proxy boundary; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders.
+
+## 8. Forbidden Claims
+
+- Placeholder secrets are valid credentials.
+- Committed secret-looking values are acceptable.
+- Demo token is production truth.
+- Demo certificate is production truth.
+- Generated certificate path is production truth.
+- Env config is AegisOps workflow truth.
+- Secret file presence is AegisOps approval truth.
+- Certificate freshness is AegisOps release truth.
+- Raw forwarded headers are trusted identity.
+- Phase 52.5 implements secret backend integration.
+- Phase 52.5 implements production certificate automation.
+- Phase 52.5 implements Wazuh product profiles.
+- Phase 52.5 implements Shuffle product profiles.
+
+## 9. Validation
+
+Run `bash scripts/verify-phase-52-5-env-secrets-certs-contract.sh`.
+
+Run `bash scripts/test-verify-phase-52-5-env-secrets-certs-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1068 --config <supervisor-config-path>`.
+
+The verifier must fail when the contract is missing, when generated runtime paths are not ignored, when placeholder secrets are accepted as valid, when committed secret-looking values appear outside approved placeholder-safe sample context, when demo token or demo certificate posture is treated as production truth, when the Phase 51.6 policy citation is missing, or when publishable guidance uses workstation-local absolute paths.
+
+## 10. Non-Goals
+
+- No secret backend integration is implemented here.
+- No Wazuh product profile generation, Shuffle product profile generation, installer UX, release-candidate behavior, general-availability behavior, or runtime behavior is implemented here.
+- No env file, generated config, generated secret, generated certificate, demo token, certificate path, OpenBao binding, custody checklist, Wazuh state, Shuffle state, placeholder, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-51-5-competitive-gap-matrix.sh
+++ b/scripts/test-verify-phase-51-5-competitive-gap-matrix.sh
@@ -192,7 +192,7 @@ assert_fails_with \
 workstation_path_repo="${workdir}/workstation-local-path"
 create_valid_repo "${workstation_path_repo}"
 workstation_path="$(printf '/%s/%s/gap-matrix.md' "Users" "example")"
-printf '%s\n' "Matrix path:file://${workstation_path}" \
+printf '%s%s%s\n' "Matrix path:" "file:" "//${workstation_path}" \
   >>"${workstation_path_repo}/docs/phase-51-5-competitive-gap-matrix.md"
 assert_fails_with \
   "${workstation_path_repo}" \

--- a/scripts/test-verify-phase-52-5-env-secrets-certs-contract.sh
+++ b/scripts/test-verify-phase-52-5-env-secrets-certs-contract.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-5-env-secrets-certs-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment" "${target}/control-plane/deployment/first-boot"
+  printf '%s\n' "# AegisOps" "See [Phase 52.5 env secrets certs contract](docs/deployment/env-secrets-certs-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/env-secrets-certs-contract.md" \
+    "${target}/docs/deployment/env-secrets-certs-contract.md"
+  cp "${repo_root}/control-plane/deployment/first-boot/bootstrap.env.sample" \
+    "${target}/control-plane/deployment/first-boot/bootstrap.env.sample"
+  printf '%s\n' \
+    "control-plane/deployment/first-boot/generated/" \
+    "control-plane/deployment/first-boot/runtime/" \
+    "control-plane/deployment/first-boot/secrets/" \
+    "control-plane/deployment/first-boot/certs/" \
+    >"${target}/.gitignore"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/env-secrets-certs-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/env-secrets-certs-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 52.5 env secrets certs contract"
+
+missing_ignore_repo="${workdir}/missing-ignore"
+create_valid_repo "${missing_ignore_repo}"
+perl -0pi -e 's/control-plane\/deployment\/first-boot\/secrets\/\n//' \
+  "${missing_ignore_repo}/.gitignore"
+assert_fails_with \
+  "${missing_ignore_repo}" \
+  "Missing Phase 52.5 generated runtime ignore pattern: control-plane/deployment/first-boot/secrets/"
+
+missing_binding_repo="${workdir}/missing-demo-token-binding"
+create_valid_repo "${missing_binding_repo}"
+remove_text_from_contract "${missing_binding_repo}" \
+  "| \`AEGISOPS_DEMO_TOKEN_FILE\` | File reference for a generated demo token when demo mode is explicitly enabled. | Demo-only setup convenience. | Must not satisfy admin bootstrap, break-glass, Wazuh ingest, proxy boundary, OpenBao, or production credential checks. |"
+assert_fails_with \
+  "${missing_binding_repo}" \
+  "Missing complete Phase 52.5 runtime binding row: AEGISOPS_DEMO_TOKEN_FILE"
+
+missing_secret_class_repo="${workdir}/missing-break-glass-secret"
+create_valid_repo "${missing_secret_class_repo}"
+remove_text_from_contract "${missing_secret_class_repo}" \
+  "| Break-glass token | \`AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_FILE\` or \`AEGISOPS_CONTROL_PLANE_BREAK_GLASS_TOKEN_OPENBAO_PATH\`. | Demo tokens are separate from break-glass tokens. | Missing custody owner, trigger, and follow-up rotation evidence fails closed. |"
+assert_fails_with \
+  "${missing_secret_class_repo}" \
+  "Missing complete Phase 52.5 secret custody row: Break-glass token"
+
+placeholder_secret_repo="${workdir}/placeholder-secret"
+create_valid_repo "${placeholder_secret_repo}"
+printf '%s\n' "Placeholder secrets are valid credentials." \
+  >>"${placeholder_secret_repo}/docs/deployment/env-secrets-certs-contract.md"
+assert_fails_with \
+  "${placeholder_secret_repo}" \
+  "Forbidden Phase 52.5 env secrets certs contract claim: Placeholder secrets are valid credentials"
+
+secret_looking_repo="${workdir}/secret-looking-value"
+create_valid_repo "${secret_looking_repo}"
+printf '%s\n' "admin_token = syntheticsecretvalue1234567890" \
+  >>"${secret_looking_repo}/docs/deployment/env-secrets-certs-contract.md"
+assert_fails_with \
+  "${secret_looking_repo}" \
+  "Forbidden Phase 52.5 env secrets certs contract: committed secret-looking value detected"
+
+demo_token_truth_repo="${workdir}/demo-token-production-truth"
+create_valid_repo "${demo_token_truth_repo}"
+printf '%s\n' "Demo token is production truth." \
+  >>"${demo_token_truth_repo}/docs/deployment/env-secrets-certs-contract.md"
+assert_fails_with \
+  "${demo_token_truth_repo}" \
+  "Forbidden Phase 52.5 env secrets certs contract claim: Demo token is production truth"
+
+demo_cert_truth_repo="${workdir}/demo-cert-production-truth"
+create_valid_repo "${demo_cert_truth_repo}"
+printf '%s\n' "Demo certificate is production truth." \
+  >>"${demo_cert_truth_repo}/docs/deployment/env-secrets-certs-contract.md"
+assert_fails_with \
+  "${demo_cert_truth_repo}" \
+  "Forbidden Phase 52.5 env secrets certs contract claim: Demo certificate is production truth"
+
+missing_phase51_repo="${workdir}/missing-phase51-citation"
+create_valid_repo "${missing_phase51_repo}"
+remove_text_from_contract "${missing_phase51_repo}" \
+  'This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+assert_fails_with \
+  "${missing_phase51_repo}" \
+  'Missing Phase 52.5 env secrets certs contract statement: This contract cites the Phase 51.6 authority-boundary negative-test policy'
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/env-secrets-certs-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.5 env secrets certs contract: workstation-local absolute path detected"
+
+missing_env_sample_link_repo="${workdir}/missing-env-sample-link"
+create_valid_repo "${missing_env_sample_link_repo}"
+perl -0pi -e 's/docs\/deployment\/env-secrets-certs-contract\.md/docs\/deployment\/single-customer-release-bundle-inventory.md/' \
+  "${missing_env_sample_link_repo}/control-plane/deployment/first-boot/bootstrap.env.sample"
+assert_fails_with \
+  "${missing_env_sample_link_repo}" \
+  "First-boot bootstrap env sample must link the Phase 52.5 env secrets certs contract."
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 52.5 env secrets certs contract."
+
+echo "Phase 52.5 env secrets certs contract negative and valid fixtures passed."

--- a/scripts/verify-phase-52-5-env-secrets-certs-contract.sh
+++ b/scripts/verify-phase-52-5-env-secrets-certs-contract.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/env-secrets-certs-contract.md"
+readme_path="${repo_root}/README.md"
+gitignore_path="${repo_root}/.gitignore"
+env_sample_path="${repo_root}/control-plane/deployment/first-boot/bootstrap.env.sample"
+
+required_headings=(
+  "# Phase 52.5 Env, Secrets, and Cert Generation Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Generated Runtime Config"
+  "## 4. Secret File Custody"
+  "## 5. Certificate Generation"
+  "## 6. Ignored Generated Paths"
+  "## 7. Validation Rules"
+  "## 8. Forbidden Claims"
+  "## 9. Validation"
+  "## 10. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1063, #1065, #1066, #1067, #1068"
+  "This contract defines generated runtime env config, secret-reference, and certificate-generation expectations for the executable first-user stack only. It does not implement full secret backend integration, Wazuh product-profile generation, Shuffle product-profile generation, installer UX, release-candidate behavior, general-availability behavior, or runtime behavior."
+  "Generated runtime config is a setup prerequisite."
+  "Env files, generated secret files, generated demo tokens, generated certificates, certificate paths, OpenBao bindings, and custody checklists are setup/security prerequisites only."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  'This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+  'Later setup commands may generate an untracked runtime env file from `control-plane/deployment/first-boot/bootstrap.env.sample`.'
+  "| Binding | Expected form | Production posture | Validation rule |"
+  "| Secret class | Accepted reference forms | Demo posture | Rejection rule |"
+  "Secret values must be supplied through reviewed file bindings or reviewed OpenBao bindings."
+  "Later setup commands may generate demo TLS material only when demo mode is explicit."
+  "Demo certificates, self-signed local certificates, generated key pairs, or certificate path existence are not production truth and must not satisfy production ingress TLS custody."
+  "Generated runtime config, generated secret files, and generated certificates must be untracked or explicitly ignored before setup commands write them."
+  "| Ignored path | Purpose | Tracking rule |"
+  "placeholder, TODO, sample, fake, guessed, unsigned, inline, or committed secret-looking value is accepted as valid;"
+  "demo token or demo certificate posture is treated as production truth"
+  'Run `bash scripts/verify-phase-52-5-env-secrets-certs-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-52-5-env-secrets-certs-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1068 --config <supervisor-config-path>`.'
+)
+
+bindings=(
+  "AEGISOPS_RUNTIME_ENV_FILE"
+  "AEGISOPS_GENERATED_CONFIG_DIR"
+  "AEGISOPS_SECRETS_DIR"
+  "AEGISOPS_CERTS_DIR"
+  "AEGISOPS_DEMO_TOKEN_FILE"
+  "AEGISOPS_DEMO_TLS_CERT_FILE"
+)
+
+secret_classes=(
+  "PostgreSQL DSN"
+  "Wazuh ingest shared secret"
+  "Wazuh reverse-proxy secret"
+  "Protected-surface proxy secret"
+  "Admin bootstrap token"
+  "Break-glass token"
+  "OpenBao token"
+)
+
+ignored_paths=(
+  "control-plane/deployment/first-boot/generated/"
+  "control-plane/deployment/first-boot/runtime/"
+  "control-plane/deployment/first-boot/secrets/"
+  "control-plane/deployment/first-boot/certs/"
+)
+
+forbidden_claims=(
+  "Placeholder secrets are valid credentials"
+  "Committed secret-looking values are acceptable"
+  "Demo token is production truth"
+  "Demo certificate is production truth"
+  "Generated certificate path is production truth"
+  "Env config is AegisOps workflow truth"
+  "Secret file presence is AegisOps approval truth"
+  "Certificate freshness is AegisOps release truth"
+  "Raw forwarded headers are trusted identity"
+  "Phase 52.5 implements secret backend integration"
+  "Phase 52.5 implements production certificate automation"
+  "Phase 52.5 implements Wazuh product profiles"
+  "Phase 52.5 implements Shuffle product profiles"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.5 env secrets certs contract: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.5 env secrets certs contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.5 env secrets certs contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for binding in "${bindings[@]}"; do
+  if ! grep -Eq "^\| \`${binding}\` \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.5 runtime binding row: ${binding}" >&2
+    exit 1
+  fi
+done
+
+for secret_class in "${secret_classes[@]}"; do
+  if ! grep -Eq "^\| ${secret_class} \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.5 secret custody row: ${secret_class}" >&2
+    exit 1
+  fi
+done
+
+for ignored_path in "${ignored_paths[@]}"; do
+  if ! grep -Eq "^\| \`${ignored_path//\//\\/}\` \| [^|[:space:]][^|]* \| Must remain ignored\. \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.5 ignored path row: ${ignored_path}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 8\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+contains_placeholder_secret_valid_claim() {
+  awk '
+    /^## 8\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    {
+      line = tolower($0)
+      negative_context = line ~ /(must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|separate from|rejected|not valid|not production|not product truth)/
+      if (!in_forbidden_claims && !negative_context && line ~ /(^|[^[:alnum:]_])placeholder secrets?[[:space:]]+(are|is|count as|counts as|may be|can be|remain|stays)[[:space:]]+([^.]*[^[:alnum:]_])?(valid|trusted|accepted|production)([^[:alnum:]_]|$)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${doc_rendered_markdown}"
+}
+
+contains_committed_secret_looking_value() {
+  grep -Ein \
+    '(^|[^A-Z0-9_])[A-Z0-9_-]*(token|secret|password|private[_-]?key|dsn)[A-Z0-9_-]*[[:space:]]*[:=][[:space:]]*["'\'']?[A-Za-z0-9_./+=:@-]{20,}["'\'']?($|[^A-Za-z0-9_./+=:@-])' \
+    "${doc_path}" |
+    grep -Eiv '(<[^>]+>|placeholder|sample|demo-only|runtime-injected|OPENBAO_PATH|_FILE|`[^`]+`|forbidden claims)' || true
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.5 env secrets certs contract claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if contains_placeholder_secret_valid_claim; then
+  echo "Forbidden Phase 52.5 env secrets certs contract claim: placeholder secrets accepted as valid credentials" >&2
+  exit 1
+fi
+
+secret_looking_matches="$(contains_committed_secret_looking_value)"
+if [[ -n "${secret_looking_matches}" ]]; then
+  echo "Forbidden Phase 52.5 env secrets certs contract: committed secret-looking value detected" >&2
+  echo "${secret_looking_matches}" >&2
+  exit 1
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.5 env secrets certs contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${gitignore_path}" ]]; then
+  echo "Missing .gitignore for Phase 52.5 generated runtime path checks: ${gitignore_path}" >&2
+  exit 1
+fi
+
+for ignored_path in "${ignored_paths[@]}"; do
+  if ! grep -Fxq -- "${ignored_path}" "${gitignore_path}"; then
+    echo "Missing Phase 52.5 generated runtime ignore pattern: ${ignored_path}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "${env_sample_path}" ]]; then
+  echo "Missing first-boot bootstrap env sample: ${env_sample_path}" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- "docs/deployment/env-secrets-certs-contract.md" "${env_sample_path}"; then
+  echo "First-boot bootstrap env sample must link the Phase 52.5 env secrets certs contract." >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 52.5 env secrets certs contract link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/env-secrets-certs-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 52.5 env secrets certs contract." >&2
+  exit 1
+fi
+
+echo "Phase 52.5 env secrets certs contract is present and preserves ignored generated paths, demo/prod separation, fail-closed secret validation, and authority boundaries."


### PR DESCRIPTION
## Summary
- define the Phase 52.5 env/secrets/certs contract for generated first-user runtime config
- add ignored generated runtime config, secrets, and cert paths
- add focused verifier plus negative fixtures for placeholder secrets, committed secret-looking values, and demo/prod confusion

## Verification
- bash scripts/verify-phase-52-5-env-secrets-certs-contract.sh
- bash scripts/test-verify-phase-52-5-env-secrets-certs-contract.sh
- bash scripts/test-verify-publishable-path-hygiene.sh
- bash scripts/verify-phase-52-4-compose-generator-contract.sh
- bash scripts/test-verify-phase-52-4-compose-generator-contract.sh
- git diff --check
- CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> node <codex-supervisor-root>/dist/index.js issue-lint 1068 --config <supervisor-config-path>

Closes #1068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a new environment, secrets, and certificates contract document specifying first-boot deployment requirements and validation expectations.
  * Updated README and deployment configuration to reference the new contract documentation.

* **Tests**
  * Added verification scripts to validate compliance with the environment, secrets, and certificates contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->