### PR TITLE
Phase 52.6: Add host preflight contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
           bash scripts/test-verify-roadmap-materialization-preflight.sh
           bash scripts/verify-phase-51-closeout-evaluation.sh
           bash scripts/test-verify-phase-51-closeout-evaluation.sh
+          bash scripts/verify-phase-52-6-host-preflight-contract.sh
+          bash scripts/test-verify-phase-52-6-host-preflight-contract.sh
           bash scripts/verify-support-playbook-break-glass-rehearsal.sh
           bash scripts/verify-response-action-safety-model-doc.sh
           bash scripts/verify-requirements-baseline-control-plane-thesis.sh

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.3 combined dependency matrix](docs/deployment/combined-dependency-matrix.md) defines first-user stack dependency expectations, host footprint, ports, volumes, certificate requirements, incompatibilities, and host-preflight follow-up fields.
 - [Phase 52.4 compose generator contract](docs/deployment/compose-generator-contract.md) defines generated Compose shape, proxy-only ingress, snapshot expectations, and manual-editing rejection for the executable first-user stack.
 - [Phase 52.5 env secrets certs contract](docs/deployment/env-secrets-certs-contract.md) defines generated runtime env config, ignored secret/cert paths, demo token/cert posture, and fail-closed secret validation for the executable first-user stack.
+- [Phase 52.6 host preflight contract](docs/deployment/host-preflight-contract.md) defines Docker, Compose, RAM, disk, port, `vm.max_map_count`, and profile-validity readiness checks and fixture expectations for the executable first-user stack.
 
 ## Product positioning
 
@@ -55,6 +56,8 @@ The Phase 52.3 first-user combined dependency matrix is defined by the [Phase 52
 The Phase 52.4 first-user compose generator contract is defined by the [Phase 52.4 compose generator contract](docs/deployment/compose-generator-contract.md).
 
 The Phase 52.5 first-user env secrets certs contract is defined by the [Phase 52.5 env secrets certs contract](docs/deployment/env-secrets-certs-contract.md).
+
+The Phase 52.6 first-user host preflight contract is defined by the [Phase 52.6 host preflight contract](docs/deployment/host-preflight-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/fixtures/host-preflight/bad-ports.json
+++ b/docs/deployment/fixtures/host-preflight/bad-ports.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "bad-ports",
+  "overall_state": "fail",
+  "mocked": false,
+  "results": [
+    {
+      "check": "Ports",
+      "state": "fail",
+      "source": "fixture",
+      "summary": "A reviewed proxy-public port is already bound or a backend/database port is directly published.",
+      "safe_next_action": "free the conflicting port and keep backend/database ports internal"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/host-preflight/invalid-profile.json
+++ b/docs/deployment/fixtures/host-preflight/invalid-profile.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "invalid-profile",
+  "overall_state": "fail",
+  "mocked": false,
+  "results": [
+    {
+      "check": "Profile validity",
+      "state": "fail",
+      "source": "fixture",
+      "summary": "Profile is missing, unknown, placeholder-backed, inferred, or not release-bound.",
+      "safe_next_action": "select a reviewed smb-single-node profile and release-bound revision"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/host-preflight/low-ram.json
+++ b/docs/deployment/fixtures/host-preflight/low-ram.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "low-ram",
+  "overall_state": "fail",
+  "mocked": false,
+  "results": [
+    {
+      "check": "RAM",
+      "state": "fail",
+      "source": "fixture",
+      "summary": "Host reports less than 16 GB RAM.",
+      "safe_next_action": "move setup to a host that satisfies the minimum rehearsal RAM tier"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/host-preflight/missing-compose.json
+++ b/docs/deployment/fixtures/host-preflight/missing-compose.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "missing-compose",
+  "overall_state": "fail",
+  "mocked": false,
+  "results": [
+    {
+      "check": "Docker Compose",
+      "state": "fail",
+      "source": "fixture",
+      "summary": "Docker Compose plugin is missing.",
+      "safe_next_action": "install Docker Compose plugin v2.24 or newer before setup"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/host-preflight/missing-docker.json
+++ b/docs/deployment/fixtures/host-preflight/missing-docker.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "missing-docker",
+  "overall_state": "fail",
+  "mocked": false,
+  "results": [
+    {
+      "check": "Docker engine",
+      "state": "fail",
+      "source": "fixture",
+      "summary": "Docker Engine is missing.",
+      "safe_next_action": "install a reviewed Docker Engine before setup"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/host-preflight/missing-vm-max-map-count.json
+++ b/docs/deployment/fixtures/host-preflight/missing-vm-max-map-count.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "missing-vm-max-map-count",
+  "overall_state": "fail",
+  "mocked": false,
+  "results": [
+    {
+      "check": "vm.max_map_count",
+      "state": "fail",
+      "source": "fixture",
+      "summary": "Linux host did not report vm.max_map_count.",
+      "safe_next_action": "set and verify vm.max_map_count before setup"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/host-preflight/mocked-pass.json
+++ b/docs/deployment/fixtures/host-preflight/mocked-pass.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "mocked-pass",
+  "overall_state": "mocked",
+  "mocked": true,
+  "results": [
+    {
+      "check": "Docker engine",
+      "state": "mocked",
+      "source": "test-double",
+      "summary": "Fixture simulates Docker Engine 24 without claiming live host readiness.",
+      "safe_next_action": "rerun against live host before setup"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/host-preflight/non-linux-vm-max-map-count-skip.json
+++ b/docs/deployment/fixtures/host-preflight/non-linux-vm-max-map-count-skip.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "non-linux-vm-max-map-count-skip",
+  "overall_state": "skip",
+  "mocked": false,
+  "results": [
+    {
+      "check": "vm.max_map_count",
+      "state": "skip",
+      "source": "fixture",
+      "summary": "Non-Linux host class does not expose vm.max_map_count.",
+      "safe_next_action": "record the platform-specific skip reason before setup"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/host-preflight/valid-pass.json
+++ b/docs/deployment/fixtures/host-preflight/valid-pass.json
@@ -1,0 +1,56 @@
+{
+  "fixture": "valid-pass",
+  "overall_state": "pass",
+  "mocked": false,
+  "results": [
+    {
+      "check": "Docker engine",
+      "state": "pass",
+      "source": "fixture",
+      "summary": "Docker Engine 24 is present on the reviewed local context.",
+      "safe_next_action": "continue setup readiness review"
+    },
+    {
+      "check": "Docker Compose",
+      "state": "pass",
+      "source": "fixture",
+      "summary": "Docker Compose plugin v2.24 or newer is present.",
+      "safe_next_action": "continue setup readiness review"
+    },
+    {
+      "check": "RAM",
+      "state": "pass",
+      "source": "fixture",
+      "summary": "Host reports at least 16 GB RAM.",
+      "safe_next_action": "continue setup readiness review"
+    },
+    {
+      "check": "Disk",
+      "state": "pass",
+      "source": "fixture",
+      "summary": "Host reports at least 250 GB disk and separate backup capacity.",
+      "safe_next_action": "continue setup readiness review"
+    },
+    {
+      "check": "Ports",
+      "state": "pass",
+      "source": "fixture",
+      "summary": "Only reviewed proxy-public ports are host-published.",
+      "safe_next_action": "continue setup readiness review"
+    },
+    {
+      "check": "vm.max_map_count",
+      "state": "pass",
+      "source": "fixture",
+      "summary": "Linux host reports vm.max_map_count at or above 262144.",
+      "safe_next_action": "continue setup readiness review"
+    },
+    {
+      "check": "Profile validity",
+      "state": "pass",
+      "source": "fixture",
+      "summary": "Profile is smb-single-node with a reviewed mode and release-bound revision.",
+      "safe_next_action": "continue setup readiness review"
+    }
+  ]
+}

--- a/docs/deployment/host-preflight-contract.md
+++ b/docs/deployment/host-preflight-contract.md
@@ -1,0 +1,123 @@
+# Phase 52.6 Host Preflight Contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-52-1-cli-command-contract.md`, `docs/phase-52-2-smb-single-node-profile-model.md`, `docs/deployment/combined-dependency-matrix.md`, `docs/deployment/compose-generator-contract.md`, `docs/deployment/env-secrets-certs-contract.md`
+- **Related Issues**: #1063, #1066, #1069
+
+This contract defines host preflight input and output expectations for the executable first-user stack only. It does not implement the installer, stack startup, live host probing, Wazuh product profiles, Shuffle product profiles, production supportability, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+## 1. Purpose
+
+The host preflight contract gives later setup commands one fail-closed checklist for host prerequisites before the executable first-user stack is started.
+
+The contract covers Docker, Docker Compose, RAM, disk, ports, `vm.max_map_count`, and setup profile validity.
+
+The contract consumes the Phase 52.3 dependency matrix fields in `docs/deployment/combined-dependency-matrix.md` and must not redefine dependency authority outside that matrix.
+
+## 2. Authority Boundary
+
+Host preflight output is setup readiness evidence only.
+
+Docker state, Docker Compose state, RAM, disk, port state, `vm.max_map_count`, generated config, setup profile selection, fixture output, or preflight status is not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.
+
+## 3. Checked Inputs
+
+| Check | Required input | Pass condition | Fail-closed condition |
+| --- | --- | --- | --- |
+| Docker engine | `AEGISOPS_PREFLIGHT_DOCKER_ENGINE_VERSION`, `AEGISOPS_PREFLIGHT_DOCKER_CONTEXT`, `AEGISOPS_PREFLIGHT_DOCKER_SOCKET_EXPOSURE` | Docker Engine 24 or 25 is present on a reviewed local context with no untrusted socket exposure. | Missing Docker, unsupported major version, remote or rootless profile outside the reviewed package, or untrusted socket exposure fails. |
+| Docker Compose | `AEGISOPS_PREFLIGHT_COMPOSE_VERSION`, `AEGISOPS_PREFLIGHT_COMPOSE_FILE`, `AEGISOPS_PREFLIGHT_COMPOSE_ENV_FILE` | Docker Compose plugin v2.24 or newer is present and references reviewed repo-relative or placeholder-backed compose and env files. | Missing Compose, standalone Compose v1, malformed version, or host-local absolute path guidance fails. |
+| RAM | `AEGISOPS_PREFLIGHT_HOST_RAM_GB` | At least 16 GB is present for minimum rehearsal; 32 GB remains the recommended first-user target. | Missing RAM signal, nonnumeric RAM, or RAM below 16 GB fails. |
+| Disk | `AEGISOPS_PREFLIGHT_HOST_DISK_GB`, `AEGISOPS_PREFLIGHT_HOST_BACKUP_DISK_GB` | At least 250 GB durable disk plus separate backup capacity is present for minimum rehearsal. | Missing disk signal, nonnumeric disk, disk below 250 GB, or backup storage not represented separately fails. |
+| Ports | `AEGISOPS_PREFLIGHT_PROXY_PUBLIC_PORTS`, `AEGISOPS_PREFLIGHT_COMPOSE_PUBLISHED_PORTS`, `AEGISOPS_PREFLIGHT_CONTROL_PLANE_PORT`, `AEGISOPS_PREFLIGHT_POSTGRES_PORT` | Only reviewed proxy-public ports are host-published; backend and database ports remain internal. | Port conflict, direct backend publication, direct database publication, malformed port value, or inferred port ownership fails. |
+| `vm.max_map_count` | `AEGISOPS_PREFLIGHT_VM_MAX_MAP_COUNT` | Linux hosts report `vm.max_map_count` at or above `262144`; non-Linux hosts may return a documented `skip` with reason. | Missing Linux `vm.max_map_count`, nonnumeric value, or value below `262144` fails. |
+| Profile validity | `AEGISOPS_PREFLIGHT_PROFILE`, `AEGISOPS_PREFLIGHT_PROFILE_MODE`, `AEGISOPS_PREFLIGHT_PROFILE_REVISION` | The profile is `smb-single-node`, mode is `demo` or `production-dry-run`, and the profile revision is release-bound. | Missing profile, unknown profile, TODO/sample placeholder, inferred profile name, or floating revision fails. |
+
+## 4. Output States
+
+| State | Meaning | Accepted use |
+| --- | --- | --- |
+| `pass` | The check satisfied the reviewed input contract. | May contribute readiness evidence for setup. |
+| `fail` | The check is missing, malformed, incompatible, conflicting, or untrusted. | Blocks setup until repaired or explicitly retained as a failed prerequisite. |
+| `skip` | The check is not applicable to the current reviewed host class and includes a reason. | May appear only for documented platform differences such as non-Linux `vm.max_map_count`. |
+| `mocked` | The result came from a fixture or test double, not live host state. | Valid only in fixture expectations and tests; it is not setup readiness evidence. |
+
+Every preflight result must include the check name, state, source, summary, and safe next action. Failed results must not be reported as success. Mocked results must not be promoted to live readiness evidence.
+
+## 5. Fixture Expectations
+
+Fixture expectations live under `docs/deployment/fixtures/host-preflight/`.
+
+| Fixture | Required state | Required failing check |
+| --- | --- | --- |
+| `valid-pass.json` | `pass` | None |
+| `mocked-pass.json` | `mocked` | None |
+| `non-linux-vm-max-map-count-skip.json` | `skip` | None |
+| `missing-docker.json` | `fail` | Docker engine |
+| `missing-compose.json` | `fail` | Docker Compose |
+| `bad-ports.json` | `fail` | Ports |
+| `low-ram.json` | `fail` | RAM |
+| `missing-vm-max-map-count.json` | `fail` | `vm.max_map_count` |
+| `invalid-profile.json` | `fail` | Profile validity |
+
+Negative fixtures must fail closed when a missing Docker engine, missing Docker Compose plugin, bad port conflict, low RAM, missing Linux `vm.max_map_count`, or invalid profile is reported as `pass`, `skip`, or `mocked`.
+
+## 6. Dependency Matrix Link
+
+The host preflight contract must consume the Phase 52.3 dependency matrix instead of duplicating product-support truth.
+
+Required references from this contract include `AEGISOPS_PREFLIGHT_DOCKER_ENGINE_VERSION`, `AEGISOPS_PREFLIGHT_COMPOSE_VERSION`, `AEGISOPS_PREFLIGHT_HOST_RAM_GB`, `AEGISOPS_PREFLIGHT_HOST_DISK_GB`, `AEGISOPS_PREFLIGHT_PROXY_PUBLIC_PORTS`, `AEGISOPS_PREFLIGHT_VM_MAX_MAP_COUNT`, and `AEGISOPS_PREFLIGHT_PROFILE`.
+
+Known incompatible versions, missing prerequisites, malformed fields, placeholder-backed credentials, direct backend exposure, raw forwarded-header trust, and inferred scope bindings must fail closed.
+
+## 7. Validation Rules
+
+Validation must fail closed when:
+
+- Docker or Docker Compose coverage is missing;
+- RAM, disk, ports, `vm.max_map_count`, or profile validity coverage is missing;
+- fixture expectations for missing Docker, missing Compose, bad ports, low RAM, missing `vm.max_map_count`, or invalid profile are missing;
+- any negative fixture reports `pass`, `skip`, or `mocked` instead of `fail`;
+- `pass`, `fail`, `skip`, and `mocked` output states are not distinguished;
+- preflight readiness evidence is described as AegisOps workflow truth;
+- placeholder credentials, sample secrets, TODO values, raw forwarded headers, direct backend ports, direct database ports, or inferred profile names are treated as valid; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<compose-file>`, `<runtime-env-file>`, and `<preflight-output>`.
+
+## 8. Forbidden Claims
+
+- Host preflight status is AegisOps workflow truth.
+- Docker status is AegisOps workflow truth.
+- Docker Compose status is AegisOps workflow truth.
+- Port state is AegisOps release truth.
+- Mocked preflight output is live readiness evidence.
+- Skipped `vm.max_map_count` is valid on Linux.
+- Missing Docker reported as success.
+- Bad port conflict reported as success.
+- Low RAM reported as success.
+- Missing `vm.max_map_count` reported as success.
+- Invalid profile reported as success.
+- This contract implements the installer.
+- This contract starts the stack.
+- This contract implements Wazuh product profiles.
+- This contract implements Shuffle product profiles.
+
+## 9. Validation
+
+Run `bash scripts/verify-phase-52-6-host-preflight-contract.sh`.
+
+Run `bash scripts/test-verify-phase-52-6-host-preflight-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1069 --config <supervisor-config-path>`.
+
+The verifier must fail when the host preflight contract is missing, when checked inputs or output states are incomplete, when fixture expectations are missing or falsely successful, when dependency-matrix linkage is absent, when preflight evidence is treated as workflow truth, or when publishable guidance uses workstation-local absolute paths.
+
+## 10. Non-Goals
+
+- No installer, stack startup, compose generation, profile generation, live host probing, runtime behavior, RC behavior, or GA behavior is implemented here.
+- No Wazuh product profile or Shuffle product profile is implemented here.
+- No Docker, Docker Compose, RAM, disk, port, `vm.max_map_count`, profile, fixture, generated config, mocked output, skipped check, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-52-6-host-preflight-contract.sh
+++ b/scripts/test-verify-phase-52-6-host-preflight-contract.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-6-host-preflight-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/fixtures/host-preflight"
+  printf '%s\n' "# AegisOps" "See [Phase 52.6 host preflight contract](docs/deployment/host-preflight-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/host-preflight-contract.md" \
+    "${target}/docs/deployment/host-preflight-contract.md"
+  cp "${repo_root}/docs/deployment/combined-dependency-matrix.md" \
+    "${target}/docs/deployment/combined-dependency-matrix.md"
+  cp "${repo_root}/docs/deployment/fixtures/host-preflight/"*.json \
+    "${target}/docs/deployment/fixtures/host-preflight/"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/host-preflight-contract.md"
+}
+
+set_fixture_state() {
+  local target="$1"
+  local fixture="$2"
+  local state="$3"
+
+  python3 - "$target/docs/deployment/fixtures/host-preflight/${fixture}" "${state}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+state = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["overall_state"] = state
+for result in payload["results"]:
+    result["state"] = state
+path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/host-preflight-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 52.6 host preflight contract"
+
+missing_docker_coverage_repo="${workdir}/missing-docker-coverage"
+create_valid_repo "${missing_docker_coverage_repo}"
+remove_text_from_contract "${missing_docker_coverage_repo}" \
+  "| Docker engine |"
+assert_fails_with \
+  "${missing_docker_coverage_repo}" \
+  "Missing complete Phase 52.6 checked input row: Docker engine"
+
+missing_compose_coverage_repo="${workdir}/missing-compose-coverage"
+create_valid_repo "${missing_compose_coverage_repo}"
+remove_text_from_contract "${missing_compose_coverage_repo}" \
+  "| Docker Compose |"
+assert_fails_with \
+  "${missing_compose_coverage_repo}" \
+  "Missing complete Phase 52.6 checked input row: Docker Compose"
+
+missing_ports_coverage_repo="${workdir}/missing-ports-coverage"
+create_valid_repo "${missing_ports_coverage_repo}"
+remove_text_from_contract "${missing_ports_coverage_repo}" \
+  "| Ports |"
+assert_fails_with \
+  "${missing_ports_coverage_repo}" \
+  "Missing complete Phase 52.6 checked input row: Ports"
+
+missing_vm_coverage_repo="${workdir}/missing-vm-coverage"
+create_valid_repo "${missing_vm_coverage_repo}"
+remove_text_from_contract "${missing_vm_coverage_repo}" \
+  "| \`vm.max_map_count\` |"
+assert_fails_with \
+  "${missing_vm_coverage_repo}" \
+  "Missing complete Phase 52.6 checked input row: vm.max_map_count"
+
+missing_mocked_state_repo="${workdir}/missing-mocked-state"
+create_valid_repo "${missing_mocked_state_repo}"
+remove_text_from_contract "${missing_mocked_state_repo}" \
+  "| \`mocked\` | The result came from a fixture or test double, not live host state. | Valid only in fixture expectations and tests; it is not setup readiness evidence. |"
+assert_fails_with \
+  "${missing_mocked_state_repo}" \
+  "Missing complete Phase 52.6 output state row: mocked"
+
+missing_docker_fixture_repo="${workdir}/missing-docker-fixture"
+create_valid_repo "${missing_docker_fixture_repo}"
+rm "${missing_docker_fixture_repo}/docs/deployment/fixtures/host-preflight/missing-docker.json"
+assert_fails_with \
+  "${missing_docker_fixture_repo}" \
+  "Missing Phase 52.6 host preflight fixture: missing-docker.json"
+
+docker_false_success_repo="${workdir}/docker-false-success"
+create_valid_repo "${docker_false_success_repo}"
+set_fixture_state "${docker_false_success_repo}" "missing-docker.json" "pass"
+assert_fails_with \
+  "${docker_false_success_repo}" \
+  "Invalid Phase 52.6 host preflight fixture state for missing-docker.json: expected fail"
+
+compose_false_success_repo="${workdir}/compose-false-success"
+create_valid_repo "${compose_false_success_repo}"
+set_fixture_state "${compose_false_success_repo}" "missing-compose.json" "mocked"
+assert_fails_with \
+  "${compose_false_success_repo}" \
+  "Invalid Phase 52.6 host preflight fixture state for missing-compose.json: expected fail"
+
+bad_ports_false_success_repo="${workdir}/bad-ports-false-success"
+create_valid_repo "${bad_ports_false_success_repo}"
+set_fixture_state "${bad_ports_false_success_repo}" "bad-ports.json" "pass"
+assert_fails_with \
+  "${bad_ports_false_success_repo}" \
+  "Invalid Phase 52.6 host preflight fixture state for bad-ports.json: expected fail"
+
+low_ram_false_success_repo="${workdir}/low-ram-false-success"
+create_valid_repo "${low_ram_false_success_repo}"
+set_fixture_state "${low_ram_false_success_repo}" "low-ram.json" "skip"
+assert_fails_with \
+  "${low_ram_false_success_repo}" \
+  "Invalid Phase 52.6 host preflight fixture state for low-ram.json: expected fail"
+
+vm_false_success_repo="${workdir}/vm-false-success"
+create_valid_repo "${vm_false_success_repo}"
+set_fixture_state "${vm_false_success_repo}" "missing-vm-max-map-count.json" "pass"
+assert_fails_with \
+  "${vm_false_success_repo}" \
+  "Invalid Phase 52.6 host preflight fixture state for missing-vm-max-map-count.json: expected fail"
+
+profile_false_success_repo="${workdir}/profile-false-success"
+create_valid_repo "${profile_false_success_repo}"
+set_fixture_state "${profile_false_success_repo}" "invalid-profile.json" "pass"
+assert_fails_with \
+  "${profile_false_success_repo}" \
+  "Invalid Phase 52.6 host preflight fixture state for invalid-profile.json: expected fail"
+
+workflow_truth_repo="${workdir}/workflow-truth"
+create_valid_repo "${workflow_truth_repo}"
+printf '%s\n' "Host preflight status is AegisOps workflow truth." \
+  >>"${workflow_truth_repo}/docs/deployment/host-preflight-contract.md"
+assert_fails_with \
+  "${workflow_truth_repo}" \
+  "Forbidden Phase 52.6 host preflight contract claim: Host preflight status is AegisOps workflow truth"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/host-preflight-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.6 host preflight contract: workstation-local absolute path detected"
+
+missing_matrix_repo="${workdir}/missing-matrix"
+create_valid_repo "${missing_matrix_repo}"
+rm "${missing_matrix_repo}/docs/deployment/combined-dependency-matrix.md"
+assert_fails_with \
+  "${missing_matrix_repo}" \
+  "Missing Phase 52.3 dependency matrix for Phase 52.6 link check"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 52.6 host preflight contract."
+
+echo "Phase 52.6 host preflight negative and valid fixtures passed."

--- a/scripts/test-verify-phase-52-6-host-preflight-contract.sh
+++ b/scripts/test-verify-phase-52-6-host-preflight-contract.sh
@@ -80,9 +80,34 @@ path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 PY
 }
 
+set_first_fixture_result_state() {
+  local target="$1"
+  local fixture="$2"
+  local state="$3"
+
+  python3 - "$target/docs/deployment/fixtures/host-preflight/${fixture}" "${state}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+state = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["results"][0]["state"] = state
+path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
 valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
+
+mixed_positive_fixture_repo="${workdir}/mixed-positive-fixture"
+create_valid_repo "${mixed_positive_fixture_repo}"
+set_first_fixture_result_state "${mixed_positive_fixture_repo}" "valid-pass.json" "fail"
+assert_fails_with \
+  "${mixed_positive_fixture_repo}" \
+  "Invalid Phase 52.6 host preflight fixture state for valid-pass.json: expected all results to be pass"
 
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"

--- a/scripts/verify-phase-52-6-host-preflight-contract.sh
+++ b/scripts/verify-phase-52-6-host-preflight-contract.sh
@@ -290,6 +290,13 @@ for expectation in expectations:
         if result["state"] not in allowed_states:
             print(f"Unknown Phase 52.6 result state in {filename}", file=sys.stderr)
             sys.exit(1)
+    if expected_state != "fail" and any(result["state"] != expected_state for result in results):
+        print(
+            f"Invalid Phase 52.6 host preflight fixture state for {filename}: "
+            f"expected all results to be {expected_state}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if expected_state == "fail":
         if not any(
             result.get("check") == required_check and result.get("state") == "fail"

--- a/scripts/verify-phase-52-6-host-preflight-contract.sh
+++ b/scripts/verify-phase-52-6-host-preflight-contract.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -gt 0 ]]; then
+  repo_root="$1"
+else
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+doc_path="${repo_root}/docs/deployment/host-preflight-contract.md"
+matrix_path="${repo_root}/docs/deployment/combined-dependency-matrix.md"
+readme_path="${repo_root}/README.md"
+fixtures_dir="${repo_root}/docs/deployment/fixtures/host-preflight"
+
+required_headings=(
+  "# Phase 52.6 Host Preflight Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Checked Inputs"
+  "## 4. Output States"
+  "## 5. Fixture Expectations"
+  "## 6. Dependency Matrix Link"
+  "## 7. Validation Rules"
+  "## 8. Forbidden Claims"
+  "## 9. Validation"
+  "## 10. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1063, #1066, #1069"
+  "This contract defines host preflight input and output expectations for the executable first-user stack only. It does not implement the installer, stack startup, live host probing, Wazuh product profiles, Shuffle product profiles, production supportability, release-candidate behavior, general-availability behavior, or runtime behavior."
+  'The contract covers Docker, Docker Compose, RAM, disk, ports, `vm.max_map_count`, and setup profile validity.'
+  'The contract consumes the Phase 52.3 dependency matrix fields in `docs/deployment/combined-dependency-matrix.md` and must not redefine dependency authority outside that matrix.'
+  "Host preflight output is setup readiness evidence only."
+  'Docker state, Docker Compose state, RAM, disk, port state, `vm.max_map_count`, generated config, setup profile selection, fixture output, or preflight status is not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, or closeout truth.'
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  'This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+  "| Check | Required input | Pass condition | Fail-closed condition |"
+  "| State | Meaning | Accepted use |"
+  "| Fixture | Required state | Required failing check |"
+  'Negative fixtures must fail closed when a missing Docker engine, missing Docker Compose plugin, bad port conflict, low RAM, missing Linux `vm.max_map_count`, or invalid profile is reported as `pass`, `skip`, or `mocked`.'
+  "Known incompatible versions, missing prerequisites, malformed fields, placeholder-backed credentials, direct backend exposure, raw forwarded-header trust, and inferred scope bindings must fail closed."
+  '`pass`, `fail`, `skip`, and `mocked` output states are not distinguished;'
+  'Run `bash scripts/verify-phase-52-6-host-preflight-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-52-6-host-preflight-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1069 --config <supervisor-config-path>`.'
+)
+
+checks=(
+  "Docker engine"
+  "Docker Compose"
+  "RAM"
+  "Disk"
+  "Ports"
+  "vm.max_map_count"
+  "Profile validity"
+)
+
+states=(
+  "pass"
+  "fail"
+  "skip"
+  "mocked"
+)
+
+required_preflight_fields=(
+  "AEGISOPS_PREFLIGHT_DOCKER_ENGINE_VERSION"
+  "AEGISOPS_PREFLIGHT_COMPOSE_VERSION"
+  "AEGISOPS_PREFLIGHT_HOST_RAM_GB"
+  "AEGISOPS_PREFLIGHT_HOST_DISK_GB"
+  "AEGISOPS_PREFLIGHT_PROXY_PUBLIC_PORTS"
+  "AEGISOPS_PREFLIGHT_VM_MAX_MAP_COUNT"
+  "AEGISOPS_PREFLIGHT_PROFILE"
+)
+
+fixture_expectations=(
+  "valid-pass.json|pass|"
+  "mocked-pass.json|mocked|"
+  "non-linux-vm-max-map-count-skip.json|skip|"
+  "missing-docker.json|fail|Docker engine"
+  "missing-compose.json|fail|Docker Compose"
+  "bad-ports.json|fail|Ports"
+  "low-ram.json|fail|RAM"
+  "missing-vm-max-map-count.json|fail|vm.max_map_count"
+  "invalid-profile.json|fail|Profile validity"
+)
+
+forbidden_claims=(
+  "Host preflight status is AegisOps workflow truth"
+  "Docker status is AegisOps workflow truth"
+  "Docker Compose status is AegisOps workflow truth"
+  "Port state is AegisOps release truth"
+  "Mocked preflight output is live readiness evidence"
+  "Skipped vm.max_map_count is valid on Linux"
+  "Missing Docker reported as success"
+  "Bad port conflict reported as success"
+  "Low RAM reported as success"
+  "Missing vm.max_map_count reported as success"
+  "Invalid profile reported as success"
+  "This contract implements the installer"
+  "This contract starts the stack"
+  "This contract implements Wazuh product profiles"
+  "This contract implements Shuffle product profiles"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.6 host preflight contract: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.6 host preflight contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.6 host preflight contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for check in "${checks[@]}"; do
+  if ! grep -Fq -- "| ${check} |" <<<"${doc_rendered_markdown}" && \
+      ! grep -Fq -- "| \`${check}\` |" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.6 checked input row: ${check}" >&2
+    exit 1
+  fi
+done
+
+for state in "${states[@]}"; do
+  if ! grep -Eq "^\\| \`${state}\` \\| [^|]+ \\| [^|]+ \\|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.6 output state row: ${state}" >&2
+    exit 1
+  fi
+done
+
+for field in "${required_preflight_fields[@]}"; do
+  if ! grep -Fq -- "\`${field}\`" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.6 host preflight field: ${field}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 8\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+contains_false_success_claim() {
+  awk '
+    /^## 8\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    {
+      line = tolower($0)
+      negative_context = line ~ /(must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|blocks setup|reported as `pass`, `skip`, or `mocked`)/
+      if (!in_forbidden_claims && !negative_context && line ~ /(missing docker|bad port|low ram|missing.*vm\.max_map_count|invalid profile).*reported as success/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${doc_rendered_markdown}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.6 host preflight contract claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if contains_false_success_claim; then
+  echo "Forbidden Phase 52.6 host preflight contract claim: failed prerequisite reported as success" >&2
+  exit 1
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -REq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}" "${fixtures_dir}" 2>/dev/null; then
+  echo "Forbidden Phase 52.6 host preflight contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${matrix_path}" ]]; then
+  echo "Missing Phase 52.3 dependency matrix for Phase 52.6 link check: ${matrix_path}" >&2
+  exit 1
+fi
+
+for field in AEGISOPS_PREFLIGHT_DOCKER_ENGINE_VERSION AEGISOPS_PREFLIGHT_COMPOSE_VERSION AEGISOPS_PREFLIGHT_PROXY_PUBLIC_PORTS; do
+  if ! grep -Fq -- "\`${field}\`" "${matrix_path}"; then
+    echo "Phase 52.6 dependency matrix link missing matrix field: ${field}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 52.6 host preflight contract link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/host-preflight-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 52.6 host preflight contract." >&2
+  exit 1
+fi
+
+if [[ ! -d "${fixtures_dir}" ]]; then
+  echo "Missing Phase 52.6 host preflight fixture directory: ${fixtures_dir}" >&2
+  exit 1
+fi
+
+python3 - "$fixtures_dir" "${fixture_expectations[@]}" <<'PY'
+import json
+import pathlib
+import sys
+
+fixtures_dir = pathlib.Path(sys.argv[1])
+expectations = sys.argv[2:]
+allowed_states = {"pass", "fail", "skip", "mocked"}
+required_result_fields = {"check", "state", "source", "summary", "safe_next_action"}
+
+for expectation in expectations:
+    filename, expected_state, required_check = expectation.split("|", 2)
+    path = fixtures_dir / filename
+    if not path.is_file():
+        print(f"Missing Phase 52.6 host preflight fixture: {filename}", file=sys.stderr)
+        sys.exit(1)
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if payload.get("overall_state") != expected_state:
+        print(
+            f"Invalid Phase 52.6 host preflight fixture state for {filename}: "
+            f"expected {expected_state}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if payload.get("overall_state") not in allowed_states:
+        print(f"Unknown Phase 52.6 fixture state in {filename}", file=sys.stderr)
+        sys.exit(1)
+    results = payload.get("results")
+    if not isinstance(results, list) or not results:
+        print(f"Missing Phase 52.6 fixture results: {filename}", file=sys.stderr)
+        sys.exit(1)
+    for result in results:
+        missing = required_result_fields.difference(result)
+        if missing:
+            print(
+                f"Missing Phase 52.6 fixture result fields in {filename}: "
+                f"{', '.join(sorted(missing))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if result["state"] not in allowed_states:
+            print(f"Unknown Phase 52.6 result state in {filename}", file=sys.stderr)
+            sys.exit(1)
+    if expected_state == "fail":
+        if not any(
+            result.get("check") == required_check and result.get("state") == "fail"
+            for result in results
+        ):
+            print(
+                f"Missing Phase 52.6 failing fixture check for {filename}: {required_check}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    elif required_check:
+        print(f"Unexpected Phase 52.6 required failing check for {filename}", file=sys.stderr)
+        sys.exit(1)
+PY
+
+echo "Phase 52.6 host preflight contract is present and preserves checked inputs, output states, negative fixtures, dependency-matrix linkage, and authority boundaries."


### PR DESCRIPTION
## Summary
- Add the Phase 52.6 host preflight contract for Docker, Docker Compose, RAM, disk, ports, vm.max_map_count, and profile validity.
- Add host-preflight JSON fixtures covering pass, fail, skip, mocked, and required negative cases.
- Add verifier/test scripts plus README and CI wiring.

## Verification
- bash scripts/test-verify-phase-52-6-host-preflight-contract.sh
- bash scripts/verify-phase-52-6-host-preflight-contract.sh
- bash scripts/test-verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1069 --config <supervisor-config-path>

Closes #1069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Host Preflight Contract for Phase 52.6 and updated README to reference it
  * Added detailed host-preflight documentation and guidance

* **New Content**
  * Added multiple host-preflight fixture examples covering pass, fail, skip, mocked, and common negative scenarios

* **Chores / Tests**
  * Added automated contract verification checks and test harnesses to validate contract, fixtures, and README linkage in CI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->