### PR TITLE
Phase 52.7 demo seed contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.4 compose generator contract](docs/deployment/compose-generator-contract.md) defines generated Compose shape, proxy-only ingress, snapshot expectations, and manual-editing rejection for the executable first-user stack.
 - [Phase 52.5 env secrets certs contract](docs/deployment/env-secrets-certs-contract.md) defines generated runtime env config, ignored secret/cert paths, demo token/cert posture, and fail-closed secret validation for the executable first-user stack.
 - [Phase 52.6 host preflight contract](docs/deployment/host-preflight-contract.md) defines Docker, Compose, RAM, disk, port, `vm.max_map_count`, and profile-validity readiness checks and fixture expectations for the executable first-user stack.
+- [Phase 52.7 demo seed contract](docs/deployment/demo-seed-contract.md) defines demo-only seed records, required labels, reset boundaries, and production-exclusion fixtures for the executable first-user stack.
 
 ## Product positioning
 
@@ -58,6 +59,8 @@ The Phase 52.4 first-user compose generator contract is defined by the [Phase 52
 The Phase 52.5 first-user env secrets certs contract is defined by the [Phase 52.5 env secrets certs contract](docs/deployment/env-secrets-certs-contract.md).
 
 The Phase 52.6 first-user host preflight contract is defined by the [Phase 52.6 host preflight contract](docs/deployment/host-preflight-contract.md).
+
+The Phase 52.7 first-user demo seed contract is defined by the [Phase 52.7 demo seed contract](docs/deployment/demo-seed-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/demo-seed-contract.md
+++ b/docs/deployment/demo-seed-contract.md
@@ -56,6 +56,8 @@ Rendered operator surfaces must show these labels directly or through an equival
 
 Reset output is operator guidance and cleanup evidence for the demo bundle only.
 
+Reset selectors must be structured as `{"bundle":"phase-52-7-demo-seed","labels":["demo-only","first-user-rehearsal","not-production-truth"]}` or an equivalent object with the same bundle and label constraints.
+
 ## 6. Production Exclusion Rules
 
 Demo seed validation must reject any record, bundle, reset plan, or presentation that:

--- a/docs/deployment/demo-seed-contract.md
+++ b/docs/deployment/demo-seed-contract.md
@@ -63,7 +63,7 @@ Reset selectors must be structured as `{"bundle":"phase-52-7-demo-seed","labels"
 Demo seed validation must reject any record, bundle, reset plan, or presentation that:
 
 - omits the required demo labels;
-- sets `production_claim=true` or attaches production, gate, customer-evidence, approval, execution, or reconciliation truth surfaces;
+- sets `production_claim=true` or attaches production, gate, customer-evidence, approval, execution, reconciliation, or closeout truth surfaces;
 - treats fake credentials, sample credentials, demo tokens, demo certificates, demo source state, or fixture provenance as valid production credentials or production readiness;
 - allows reset selectors to delete production, imported, customer-private, or unlabeled records;
 - infers tenant, account, repository, issue, environment, customer, source, approval, execution, or reconciliation linkage from naming convention, path shape, comments, or nearby metadata; or

--- a/docs/deployment/demo-seed-contract.md
+++ b/docs/deployment/demo-seed-contract.md
@@ -1,0 +1,131 @@
+# Phase 52.7 Demo Seed Contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-52-1-cli-command-contract.md`, `docs/phase-52-2-smb-single-node-profile-model.md`, `docs/deployment/compose-generator-contract.md`, `docs/deployment/env-secrets-certs-contract.md`, `docs/deployment/host-preflight-contract.md`
+- **Related Issues**: #1063, #1065, #1070
+
+This contract defines demo seed records and demo/prod separation expectations for the executable first-user stack only. It does not implement the full first-user UI journey, production data import, Wazuh product profiles, Shuffle product profiles, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+## 1. Purpose
+
+The demo seed contract gives later setup and `seed-demo` work one reviewed bundle shape for first-user workflow rehearsal. The bundle may create demo alerts, cases, evidence, action requests, approvals, execution receipts, and reconciliation notes, but every seeded record remains demo-only rehearsal state.
+
+Demo seed output is workflow rehearsal evidence only.
+
+## 2. Authority Boundary
+
+Demo records, demo labels, fixture provenance, reset output, fake secrets, sample credentials, demo source state, and operator-facing seed summaries are not production truth, gate truth, customer evidence, approval truth, execution truth, or reconciliation truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.
+
+## 3. Seed Record Contract
+
+| Record type | Required demo fields | Presentation rule | Production exclusion |
+| --- | --- | --- | --- |
+| Demo alert | Stable demo alert identifier, fixture provenance, demo source family, demo labels, and reviewed timestamp placeholder. | Must render as demo-only alert rehearsal. | Must not satisfy production alert admission, customer evidence, release gate, or detector activation truth. |
+| Demo case | Stable demo case identifier, linked demo alert, analyst owner placeholder, demo labels, and rehearsal status. | Must render as demo-only case rehearsal. | Must not satisfy production case ownership, customer queue state, release gate, or closeout truth. |
+| Demo evidence | Stable demo evidence identifier, linked demo case, fixture path, demo labels, and provenance note. | Must render as demo-only evidence rehearsal. | Must not satisfy customer evidence, audit evidence, production detection proof, or release evidence truth. |
+| Demo action request | Stable demo action-request identifier, linked demo case, requested action placeholder, demo labels, and non-production scope. | Must render as demo-only action rehearsal. | Must not authorize production action, substrate mutation, approval gate, or execution truth. |
+| Demo approval | Explicit demo approval identifier, demo labels, linked demo action request, and reviewer placeholder. | Must render as demo-only approval rehearsal. | Must not satisfy real approval truth, release gate truth, execution authorization, or customer evidence. |
+| Demo execution receipt | Stable demo execution receipt identifier, linked demo action request, mocked executor note, and demo labels. | Must render as demo-only execution rehearsal. | Must not satisfy real execution truth, Shuffle truth, substrate mutation proof, or customer evidence. |
+| Demo reconciliation note | Stable demo reconciliation identifier, linked demo execution receipt, outcome placeholder, and demo labels. | Must render as demo-only reconciliation rehearsal. | Must not satisfy production reconciliation truth, closeout truth, customer evidence, or release gate truth. |
+
+Every seeded record must include `production_claim=false`, `authority=demo_rehearsal_only`, and an empty `truth_surfaces` list.
+
+## 4. Demo Labels
+
+| Label | Required value | Validation rule |
+| --- | --- | --- |
+| `demo-only` | Required on every demo seed record. | Missing label fails because the record cannot be separated from production-bound state. |
+| `first-user-rehearsal` | Required on every demo seed record. | Missing label fails because the record cannot be bound to the executable first-user rehearsal scope. |
+| `not-production-truth` | Required on every demo seed record. | Missing label fails because demo data must never be presented as production truth. |
+
+Rendered operator surfaces must show these labels directly or through an equivalent demo-only badge. Hidden metadata alone is not enough for operator-facing presentation.
+
+## 5. Reset Behavior
+
+| Reset boundary | Required behavior | Rejection rule |
+| --- | --- | --- |
+| Selector scope | Reset must target only records in the reviewed demo bundle with all required demo labels. | Any selector based on name shape, timestamps alone, profile name alone, or parent lineage inference fails. |
+| Production guard | Reset must prove `deletes_production_records=false` and must not touch records outside the demo bundle. | Any reset plan that can delete production, imported, customer-private, or unlabeled records fails. |
+| Failure cleanup | Failed seed or reset attempts must leave durable production and non-demo state unchanged. | Any partial write, orphan record, half-reset state, or untracked cleanup result fails. |
+
+Reset output is operator guidance and cleanup evidence for the demo bundle only.
+
+## 6. Production Exclusion Rules
+
+Demo seed validation must reject any record, bundle, reset plan, or presentation that:
+
+- omits the required demo labels;
+- sets `production_claim=true` or attaches production, gate, customer-evidence, approval, execution, or reconciliation truth surfaces;
+- treats fake credentials, sample credentials, demo tokens, demo certificates, demo source state, or fixture provenance as valid production credentials or production readiness;
+- allows reset selectors to delete production, imported, customer-private, or unlabeled records;
+- infers tenant, account, repository, issue, environment, customer, source, approval, execution, or reconciliation linkage from naming convention, path shape, comments, or nearby metadata; or
+- presents demo records as customer truth, gate truth, production truth, approval truth, execution truth, reconciliation truth, or closeout truth.
+
+## 7. Fixture Expectations
+
+Fixture expectations live under `docs/deployment/fixtures/demo-seed/`.
+
+| Fixture | Expected validity | Required rejection |
+| --- | --- | --- |
+| `valid-demo-seed.json` | `valid` | None |
+| `missing-label.json` | `invalid` | missing required demo label |
+| `destructive-reset.json` | `invalid` | reset deletes production records |
+| `production-claim.json` | `invalid` | demo record claims production truth |
+
+Negative fixtures must fail closed when a demo record lacks required labels, when reset can delete production records, or when a demo record is used as production truth.
+
+## 8. Validation Rules
+
+Validation must fail closed when:
+
+- the demo seed contract is missing;
+- any seed record type row is incomplete;
+- any required demo label row is missing;
+- reset selector, production guard, or failure cleanup coverage is missing;
+- fixture expectations are missing;
+- a negative fixture becomes valid;
+- a valid fixture lacks required labels, demo mode, production exclusion, or reset safety;
+- demo records are described as production truth, gate truth, customer evidence, approval truth, execution truth, reconciliation truth, or closeout truth;
+- placeholder credentials, sample secrets, fake credentials, raw forwarded headers, or inferred scope bindings are treated as valid; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<demo-fixture-bundle>`, `<profile-name>`, `<supervisor-config-path>`, and `<codex-supervisor-root>`.
+
+## 9. Forbidden Claims
+
+- Demo data is production truth.
+- Demo record is production truth.
+- Demo seed output is gate truth.
+- Demo reset may delete production records.
+- Demo labels are optional.
+- Fake credentials are valid credentials.
+- Sample credentials are valid credentials.
+- Demo source state is customer evidence.
+- Demo approval is approval truth.
+- Demo execution receipt is execution truth.
+- Demo reconciliation note is reconciliation truth.
+- This contract implements production data import.
+- This contract implements Wazuh product profiles.
+- This contract implements Shuffle product profiles.
+
+## 10. Validation
+
+Run `bash scripts/verify-phase-52-7-demo-seed-contract.sh`.
+
+Run `bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1070 --config <supervisor-config-path>`.
+
+The verifier must fail when the demo seed contract is missing, when label, reset, fixture, production exclusion, or authority-boundary coverage is incomplete, when negative fixtures falsely pass, when demo records are treated as production truth, or when publishable guidance uses workstation-local absolute paths.
+
+## 11. Non-Goals
+
+- No first-user UI journey is implemented here.
+- No production data import is implemented here.
+- No Wazuh product profile or Shuffle product profile is implemented here.
+- No RC behavior or GA behavior is implemented here.
+- No demo record, demo label, fixture, reset output, fake secret, sample credential, demo source state, or operator-facing seed summary becomes production truth, gate truth, customer evidence, approval truth, execution truth, reconciliation truth, or closeout truth.

--- a/docs/deployment/fixtures/demo-seed/destructive-reset.json
+++ b/docs/deployment/fixtures/demo-seed/destructive-reset.json
@@ -14,6 +14,9 @@
       "authority": "demo_rehearsal_only",
       "production_claim": false,
       "truth_surfaces": [],
+      "fixture_provenance": "docs/deployment/fixtures/demo-seed/destructive-reset.json",
+      "demo_source_family": "demo-fixture",
+      "reviewed_at": null,
       "presentation": "demo-only alert rehearsal"
     }
   ],
@@ -30,7 +33,8 @@
       "customer_evidence",
       "approval",
       "execution",
-      "reconciliation"
+      "reconciliation",
+      "closeout"
     ]
   }
 }

--- a/docs/deployment/fixtures/demo-seed/destructive-reset.json
+++ b/docs/deployment/fixtures/demo-seed/destructive-reset.json
@@ -1,0 +1,36 @@
+{
+  "bundle": "phase-52-7-demo-seed",
+  "mode": "demo",
+  "profile": "smb-single-node",
+  "records": [
+    {
+      "id": "demo-alert-destructive-reset",
+      "type": "demo-alert",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "presentation": "demo-only alert rehearsal"
+    }
+  ],
+  "reset": {
+    "scope": "all-records",
+    "selector": "profile=smb-single-node",
+    "deletes_production_records": true
+  },
+  "production_exclusion": {
+    "may_satisfy_production_truth": false,
+    "blocked_truth_surfaces": [
+      "production",
+      "gate",
+      "customer_evidence",
+      "approval",
+      "execution",
+      "reconciliation"
+    ]
+  }
+}

--- a/docs/deployment/fixtures/demo-seed/missing-label.json
+++ b/docs/deployment/fixtures/demo-seed/missing-label.json
@@ -1,0 +1,35 @@
+{
+  "bundle": "phase-52-7-demo-seed",
+  "mode": "demo",
+  "profile": "smb-single-node",
+  "records": [
+    {
+      "id": "demo-alert-missing-label",
+      "type": "demo-alert",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "presentation": "demo-only alert rehearsal"
+    }
+  ],
+  "reset": {
+    "scope": "demo-bundle-only",
+    "selector": "bundle=phase-52-7-demo-seed AND label=demo-only AND label=first-user-rehearsal",
+    "deletes_production_records": false
+  },
+  "production_exclusion": {
+    "may_satisfy_production_truth": false,
+    "blocked_truth_surfaces": [
+      "production",
+      "gate",
+      "customer_evidence",
+      "approval",
+      "execution",
+      "reconciliation"
+    ]
+  }
+}

--- a/docs/deployment/fixtures/demo-seed/missing-label.json
+++ b/docs/deployment/fixtures/demo-seed/missing-label.json
@@ -13,6 +13,9 @@
       "authority": "demo_rehearsal_only",
       "production_claim": false,
       "truth_surfaces": [],
+      "fixture_provenance": "docs/deployment/fixtures/demo-seed/missing-label.json",
+      "demo_source_family": "demo-fixture",
+      "reviewed_at": null,
       "presentation": "demo-only alert rehearsal"
     }
   ],
@@ -36,7 +39,8 @@
       "customer_evidence",
       "approval",
       "execution",
-      "reconciliation"
+      "reconciliation",
+      "closeout"
     ]
   }
 }

--- a/docs/deployment/fixtures/demo-seed/missing-label.json
+++ b/docs/deployment/fixtures/demo-seed/missing-label.json
@@ -18,7 +18,14 @@
   ],
   "reset": {
     "scope": "demo-bundle-only",
-    "selector": "bundle=phase-52-7-demo-seed AND label=demo-only AND label=first-user-rehearsal",
+    "selector": {
+      "bundle": "phase-52-7-demo-seed",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ]
+    },
     "deletes_production_records": false
   },
   "production_exclusion": {

--- a/docs/deployment/fixtures/demo-seed/production-claim.json
+++ b/docs/deployment/fixtures/demo-seed/production-claim.json
@@ -1,0 +1,37 @@
+{
+  "bundle": "phase-52-7-demo-seed",
+  "mode": "demo",
+  "profile": "smb-single-node",
+  "records": [
+    {
+      "id": "demo-alert-production-claim",
+      "type": "demo-alert",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "production",
+      "production_claim": true,
+      "truth_surfaces": [
+        "production"
+      ],
+      "presentation": "production alert"
+    }
+  ],
+  "reset": {
+    "scope": "demo-bundle-only",
+    "selector": "bundle=phase-52-7-demo-seed AND label=demo-only AND label=first-user-rehearsal AND label=not-production-truth",
+    "deletes_production_records": false
+  },
+  "production_exclusion": {
+    "may_satisfy_production_truth": true,
+    "blocked_truth_surfaces": [
+      "gate",
+      "customer_evidence",
+      "approval",
+      "execution",
+      "reconciliation"
+    ]
+  }
+}

--- a/docs/deployment/fixtures/demo-seed/production-claim.json
+++ b/docs/deployment/fixtures/demo-seed/production-claim.json
@@ -16,6 +16,9 @@
       "truth_surfaces": [
         "production"
       ],
+      "fixture_provenance": "docs/deployment/fixtures/demo-seed/production-claim.json",
+      "demo_source_family": "demo-fixture",
+      "reviewed_at": null,
       "presentation": "production alert"
     }
   ],

--- a/docs/deployment/fixtures/demo-seed/production-claim.json
+++ b/docs/deployment/fixtures/demo-seed/production-claim.json
@@ -21,7 +21,14 @@
   ],
   "reset": {
     "scope": "demo-bundle-only",
-    "selector": "bundle=phase-52-7-demo-seed AND label=demo-only AND label=first-user-rehearsal AND label=not-production-truth",
+    "selector": {
+      "bundle": "phase-52-7-demo-seed",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ]
+    },
     "deletes_production_records": false
   },
   "production_exclusion": {

--- a/docs/deployment/fixtures/demo-seed/valid-demo-seed.json
+++ b/docs/deployment/fixtures/demo-seed/valid-demo-seed.json
@@ -14,6 +14,9 @@
       "authority": "demo_rehearsal_only",
       "production_claim": false,
       "truth_surfaces": [],
+      "fixture_provenance": "docs/deployment/fixtures/demo-seed/valid-demo-seed.json",
+      "demo_source_family": "demo-fixture",
+      "reviewed_at": null,
       "presentation": "demo-only alert rehearsal"
     },
     {
@@ -27,6 +30,9 @@
       "authority": "demo_rehearsal_only",
       "production_claim": false,
       "truth_surfaces": [],
+      "linked_demo_alert_id": "demo-alert-001",
+      "analyst_owner": null,
+      "rehearsal_status": "rehearsal",
       "presentation": "demo-only case rehearsal"
     }
   ],
@@ -50,7 +56,8 @@
       "customer_evidence",
       "approval",
       "execution",
-      "reconciliation"
+      "reconciliation",
+      "closeout"
     ]
   }
 }

--- a/docs/deployment/fixtures/demo-seed/valid-demo-seed.json
+++ b/docs/deployment/fixtures/demo-seed/valid-demo-seed.json
@@ -1,0 +1,49 @@
+{
+  "bundle": "phase-52-7-demo-seed",
+  "mode": "demo",
+  "profile": "smb-single-node",
+  "records": [
+    {
+      "id": "demo-alert-001",
+      "type": "demo-alert",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "presentation": "demo-only alert rehearsal"
+    },
+    {
+      "id": "demo-case-001",
+      "type": "demo-case",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "presentation": "demo-only case rehearsal"
+    }
+  ],
+  "reset": {
+    "scope": "demo-bundle-only",
+    "selector": "bundle=phase-52-7-demo-seed AND label=demo-only AND label=first-user-rehearsal AND label=not-production-truth",
+    "deletes_production_records": false
+  },
+  "production_exclusion": {
+    "may_satisfy_production_truth": false,
+    "blocked_truth_surfaces": [
+      "production",
+      "gate",
+      "customer_evidence",
+      "approval",
+      "execution",
+      "reconciliation"
+    ]
+  }
+}

--- a/docs/deployment/fixtures/demo-seed/valid-demo-seed.json
+++ b/docs/deployment/fixtures/demo-seed/valid-demo-seed.json
@@ -32,7 +32,14 @@
   ],
   "reset": {
     "scope": "demo-bundle-only",
-    "selector": "bundle=phase-52-7-demo-seed AND label=demo-only AND label=first-user-rehearsal AND label=not-production-truth",
+    "selector": {
+      "bundle": "phase-52-7-demo-seed",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ]
+    },
     "deletes_production_records": false
   },
   "production_exclusion": {

--- a/scripts/test-verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/test-verify-phase-52-7-demo-seed-contract.sh
@@ -128,6 +128,16 @@ assert_fails_with \
   "${valid_missing_label_repo}" \
   "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
 
+valid_missing_demo_alert_field_repo="${workdir}/valid-missing-demo-alert-field"
+create_valid_repo "${valid_missing_demo_alert_field_repo}"
+set_fixture_json_value \
+  "${valid_missing_demo_alert_field_repo}" \
+  "valid-demo-seed.json" \
+  "del payload['records'][0]['fixture_provenance']"
+assert_fails_with \
+  "${valid_missing_demo_alert_field_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
 negative_label_false_pass_repo="${workdir}/negative-label-false-pass"
 create_valid_repo "${negative_label_false_pass_repo}"
 set_fixture_json_value \
@@ -173,7 +183,7 @@ create_valid_repo "${production_claim_false_pass_repo}"
 set_fixture_json_value \
   "${production_claim_false_pass_repo}" \
   "production-claim.json" \
-  "payload['records'][0]['production_claim'] = False; payload['records'][0]['truth_surfaces'] = []; payload['records'][0]['authority'] = 'demo_rehearsal_only'; payload['production_exclusion']['may_satisfy_production_truth'] = False; payload['production_exclusion']['blocked_truth_surfaces'] = ['production', 'gate', 'customer_evidence', 'approval', 'execution', 'reconciliation']"
+  "payload['records'][0]['production_claim'] = False; payload['records'][0]['truth_surfaces'] = []; payload['records'][0]['authority'] = 'demo_rehearsal_only'; payload['records'][0]['presentation'] = 'demo-only alert rehearsal'; payload['production_exclusion']['may_satisfy_production_truth'] = False; payload['production_exclusion']['blocked_truth_surfaces'] = ['production', 'gate', 'customer_evidence', 'approval', 'execution', 'reconciliation', 'closeout']"
 assert_fails_with \
   "${production_claim_false_pass_repo}" \
   "Invalid Phase 52.7 demo seed fixture state for production-claim.json: expected rejection"

--- a/scripts/test-verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/test-verify-phase-52-7-demo-seed-contract.sh
@@ -143,10 +143,30 @@ create_valid_repo "${destructive_reset_false_pass_repo}"
 set_fixture_json_value \
   "${destructive_reset_false_pass_repo}" \
   "destructive-reset.json" \
-  "payload['reset']['deletes_production_records'] = False; payload['reset']['scope'] = 'demo-bundle-only'"
+  "payload['reset']['deletes_production_records'] = False; payload['reset']['scope'] = 'demo-bundle-only'; payload['reset']['selector'] = {'bundle': 'phase-52-7-demo-seed', 'labels': ['demo-only', 'first-user-rehearsal', 'not-production-truth']}"
 assert_fails_with \
   "${destructive_reset_false_pass_repo}" \
   "Invalid Phase 52.7 demo seed fixture state for destructive-reset.json: expected rejection"
+
+valid_broad_reset_selector_repo="${workdir}/valid-broad-reset-selector"
+create_valid_repo "${valid_broad_reset_selector_repo}"
+set_fixture_json_value \
+  "${valid_broad_reset_selector_repo}" \
+  "valid-demo-seed.json" \
+  "payload['reset']['selector'] = {'bundle': 'phase-52-7-demo-seed', 'labels': ['demo-only', 'first-user-rehearsal']}"
+assert_fails_with \
+  "${valid_broad_reset_selector_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
+valid_string_reset_selector_repo="${workdir}/valid-string-reset-selector"
+create_valid_repo "${valid_string_reset_selector_repo}"
+set_fixture_json_value \
+  "${valid_string_reset_selector_repo}" \
+  "valid-demo-seed.json" \
+  "payload['reset']['selector'] = 'bundle=phase-52-7-demo-seed AND label=demo-only AND label=first-user-rehearsal AND label=not-production-truth'"
+assert_fails_with \
+  "${valid_string_reset_selector_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
 
 production_claim_false_pass_repo="${workdir}/production-claim-false-pass"
 create_valid_repo "${production_claim_false_pass_repo}"
@@ -157,6 +177,16 @@ set_fixture_json_value \
 assert_fails_with \
   "${production_claim_false_pass_repo}" \
   "Invalid Phase 52.7 demo seed fixture state for production-claim.json: expected rejection"
+
+valid_custom_truth_surface_repo="${workdir}/valid-custom-truth-surface"
+create_valid_repo "${valid_custom_truth_surface_repo}"
+set_fixture_json_value \
+  "${valid_custom_truth_surface_repo}" \
+  "valid-demo-seed.json" \
+  "payload['records'][0]['truth_surfaces'] = ['demo_only_projection']"
+assert_fails_with \
+  "${valid_custom_truth_surface_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
 
 demo_truth_repo="${workdir}/demo-production-truth"
 create_valid_repo "${demo_truth_repo}"

--- a/scripts/test-verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/test-verify-phase-52-7-demo-seed-contract.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-7-demo-seed-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/fixtures/demo-seed"
+  printf '%s\n' "# AegisOps" "See [Phase 52.7 demo seed contract](docs/deployment/demo-seed-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/demo-seed-contract.md" \
+    "${target}/docs/deployment/demo-seed-contract.md"
+  cp "${repo_root}/docs/deployment/fixtures/demo-seed/"*.json \
+    "${target}/docs/deployment/fixtures/demo-seed/"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/demo-seed-contract.md"
+}
+
+set_fixture_json_value() {
+  local target="$1"
+  local fixture="$2"
+  local expression="$3"
+
+  python3 - "${target}/docs/deployment/fixtures/demo-seed/${fixture}" "${expression}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+expression = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+exec(expression, {"payload": payload})
+path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/demo-seed-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 52.7 demo seed contract"
+
+missing_record_row_repo="${workdir}/missing-record-row"
+create_valid_repo "${missing_record_row_repo}"
+remove_text_from_contract "${missing_record_row_repo}" \
+  "| Demo approval | Explicit demo approval identifier, demo labels, linked demo action request, and reviewer placeholder. | Must render as demo-only approval rehearsal. | Must not satisfy real approval truth, release gate truth, execution authorization, or customer evidence. |"
+assert_fails_with \
+  "${missing_record_row_repo}" \
+  "Missing complete Phase 52.7 seed record row: Demo approval"
+
+missing_label_row_repo="${workdir}/missing-label-row"
+create_valid_repo "${missing_label_row_repo}"
+remove_text_from_contract "${missing_label_row_repo}" \
+  '| `not-production-truth` | Required on every demo seed record. | Missing label fails because demo data must never be presented as production truth. |'
+assert_fails_with \
+  "${missing_label_row_repo}" \
+  "Missing complete Phase 52.7 demo label row: not-production-truth"
+
+missing_reset_row_repo="${workdir}/missing-reset-row"
+create_valid_repo "${missing_reset_row_repo}"
+remove_text_from_contract "${missing_reset_row_repo}" \
+  '| Production guard | Reset must prove `deletes_production_records=false` and must not touch records outside the demo bundle. | Any reset plan that can delete production, imported, customer-private, or unlabeled records fails. |'
+assert_fails_with \
+  "${missing_reset_row_repo}" \
+  "Missing complete Phase 52.7 reset boundary row: Production guard"
+
+missing_fixture_repo="${workdir}/missing-fixture"
+create_valid_repo "${missing_fixture_repo}"
+rm "${missing_fixture_repo}/docs/deployment/fixtures/demo-seed/missing-label.json"
+assert_fails_with \
+  "${missing_fixture_repo}" \
+  "Missing Phase 52.7 demo seed fixture: missing-label.json"
+
+valid_missing_label_repo="${workdir}/valid-missing-label"
+create_valid_repo "${valid_missing_label_repo}"
+set_fixture_json_value \
+  "${valid_missing_label_repo}" \
+  "valid-demo-seed.json" \
+  "payload['records'][0]['labels'].remove('not-production-truth')"
+assert_fails_with \
+  "${valid_missing_label_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
+negative_label_false_pass_repo="${workdir}/negative-label-false-pass"
+create_valid_repo "${negative_label_false_pass_repo}"
+set_fixture_json_value \
+  "${negative_label_false_pass_repo}" \
+  "missing-label.json" \
+  "payload['records'][0]['labels'] = ['demo-only', 'first-user-rehearsal', 'not-production-truth']"
+assert_fails_with \
+  "${negative_label_false_pass_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for missing-label.json: expected rejection"
+
+destructive_reset_false_pass_repo="${workdir}/destructive-reset-false-pass"
+create_valid_repo "${destructive_reset_false_pass_repo}"
+set_fixture_json_value \
+  "${destructive_reset_false_pass_repo}" \
+  "destructive-reset.json" \
+  "payload['reset']['deletes_production_records'] = False; payload['reset']['scope'] = 'demo-bundle-only'"
+assert_fails_with \
+  "${destructive_reset_false_pass_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for destructive-reset.json: expected rejection"
+
+production_claim_false_pass_repo="${workdir}/production-claim-false-pass"
+create_valid_repo "${production_claim_false_pass_repo}"
+set_fixture_json_value \
+  "${production_claim_false_pass_repo}" \
+  "production-claim.json" \
+  "payload['records'][0]['production_claim'] = False; payload['records'][0]['truth_surfaces'] = []; payload['records'][0]['authority'] = 'demo_rehearsal_only'; payload['production_exclusion']['may_satisfy_production_truth'] = False; payload['production_exclusion']['blocked_truth_surfaces'] = ['production', 'gate', 'customer_evidence', 'approval', 'execution', 'reconciliation']"
+assert_fails_with \
+  "${production_claim_false_pass_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for production-claim.json: expected rejection"
+
+demo_truth_repo="${workdir}/demo-production-truth"
+create_valid_repo "${demo_truth_repo}"
+printf '%s\n' "Demo data is production truth." \
+  >>"${demo_truth_repo}/docs/deployment/demo-seed-contract.md"
+assert_fails_with \
+  "${demo_truth_repo}" \
+  "Forbidden Phase 52.7 demo seed contract claim: Demo data is production truth"
+
+destructive_reset_claim_repo="${workdir}/destructive-reset-claim"
+create_valid_repo "${destructive_reset_claim_repo}"
+printf '%s\n' "Demo reset may delete production records." \
+  >>"${destructive_reset_claim_repo}/docs/deployment/demo-seed-contract.md"
+assert_fails_with \
+  "${destructive_reset_claim_repo}" \
+  "Forbidden Phase 52.7 demo seed contract claim: Demo reset may delete production records"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/demo-seed-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.7 demo seed contract: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 52.7 demo seed contract."
+
+echo "Phase 52.7 demo seed contract negative and valid fixtures passed."

--- a/scripts/verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/verify-phase-52-7-demo-seed-contract.sh
@@ -34,6 +34,7 @@ required_phrases=(
   "| Record type | Required demo fields | Presentation rule | Production exclusion |"
   "| Label | Required value | Validation rule |"
   "| Reset boundary | Required behavior | Rejection rule |"
+  'Reset selectors must be structured as `{"bundle":"phase-52-7-demo-seed","labels":["demo-only","first-user-rehearsal","not-production-truth"]}` or an equivalent object with the same bundle and label constraints.'
   "| Fixture | Expected validity | Required rejection |"
   'Run `bash scripts/verify-phase-52-7-demo-seed-contract.sh`.'
   'Run `bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`.'
@@ -211,7 +212,7 @@ def rejection_reasons(payload):
             reasons.append("missing required demo label")
         if record.get("production_claim") is not False:
             reasons.append("demo record claims production truth")
-        if any(surface in set(record.get("truth_surfaces") or []) for surface in truth_surfaces):
+        if record.get("truth_surfaces") != []:
             reasons.append("demo record claims production truth")
         if record.get("authority") != "demo_rehearsal_only":
             reasons.append("demo record claims production truth")
@@ -220,6 +221,16 @@ def rejection_reasons(payload):
     if reset.get("deletes_production_records") is not False:
         reasons.append("reset deletes production records")
     if reset.get("scope") != "demo-bundle-only":
+        reasons.append("reset deletes production records")
+    selector = reset.get("selector")
+    selector_labels = set()
+    if isinstance(selector, dict) and isinstance(selector.get("labels"), list):
+        selector_labels = set(selector.get("labels") or [])
+    if (
+        not isinstance(selector, dict)
+        or selector.get("bundle") != "phase-52-7-demo-seed"
+        or not required_labels.issubset(selector_labels)
+    ):
         reasons.append("reset deletes production records")
 
     exclusion = payload.get("production_exclusion") or {}

--- a/scripts/verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/verify-phase-52-7-demo-seed-contract.sh
@@ -196,6 +196,54 @@ truth_surfaces = {
     "approval",
     "execution",
     "reconciliation",
+    "closeout",
+}
+
+
+def has_non_empty_string(record, field):
+    return isinstance(record.get(field), str) and bool(record.get(field).strip())
+
+
+def has_field(record, field):
+    return field in record
+
+
+type_requirements = {
+    "demo-alert": {
+        "presentation": "demo-only alert rehearsal",
+        "non_empty": ("id", "fixture_provenance", "demo_source_family"),
+        "present": ("reviewed_at",),
+    },
+    "demo-case": {
+        "presentation": "demo-only case rehearsal",
+        "non_empty": ("id", "linked_demo_alert_id", "rehearsal_status"),
+        "present": ("analyst_owner",),
+    },
+    "demo-evidence": {
+        "presentation": "demo-only evidence rehearsal",
+        "non_empty": ("id", "linked_demo_case_id", "fixture_path", "provenance_note"),
+        "present": (),
+    },
+    "demo-action-request": {
+        "presentation": "demo-only action rehearsal",
+        "non_empty": ("id", "linked_demo_case_id", "requested_action"),
+        "present": ("non_production_scope",),
+    },
+    "demo-approval": {
+        "presentation": "demo-only approval rehearsal",
+        "non_empty": ("id", "linked_demo_action_request_id"),
+        "present": ("reviewer_placeholder",),
+    },
+    "demo-execution-receipt": {
+        "presentation": "demo-only execution rehearsal",
+        "non_empty": ("id", "linked_demo_action_request_id", "mocked_executor_note"),
+        "present": (),
+    },
+    "demo-reconciliation-note": {
+        "presentation": "demo-only reconciliation rehearsal",
+        "non_empty": ("id", "linked_demo_execution_receipt_id", "outcome_placeholder"),
+        "present": (),
+    },
 }
 
 
@@ -207,6 +255,20 @@ def rejection_reasons(payload):
         return reasons
 
     for record in records:
+        record_type = record.get("type")
+        requirements = type_requirements.get(record_type)
+        if requirements is None:
+            reasons.append("missing demo record type contract")
+        else:
+            for field in requirements["non_empty"]:
+                if not has_non_empty_string(record, field):
+                    reasons.append(f"missing {record_type} field {field}")
+            for field in requirements["present"]:
+                if not has_field(record, field):
+                    reasons.append(f"missing {record_type} field {field}")
+            if record.get("presentation") != requirements["presentation"]:
+                reasons.append(f"missing {record_type} presentation")
+
         labels = set(record.get("labels") or [])
         if not required_labels.issubset(labels):
             reasons.append("missing required demo label")

--- a/scripts/verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/verify-phase-52-7-demo-seed-contract.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/demo-seed-contract.md"
+readme_path="${repo_root}/README.md"
+fixtures_dir="${repo_root}/docs/deployment/fixtures/demo-seed"
+
+required_headings=(
+  "# Phase 52.7 Demo Seed Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Seed Record Contract"
+  "## 4. Demo Labels"
+  "## 5. Reset Behavior"
+  "## 6. Production Exclusion Rules"
+  "## 7. Fixture Expectations"
+  "## 8. Validation Rules"
+  "## 9. Forbidden Claims"
+  "## 10. Validation"
+  "## 11. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1063, #1065, #1070"
+  "This contract defines demo seed records and demo/prod separation expectations for the executable first-user stack only. It does not implement the full first-user UI journey, production data import, Wazuh product profiles, Shuffle product profiles, release-candidate behavior, general-availability behavior, or runtime behavior."
+  "Demo seed output is workflow rehearsal evidence only."
+  "Demo records, demo labels, fixture provenance, reset output, fake secrets, sample credentials, demo source state, and operator-facing seed summaries are not production truth, gate truth, customer evidence, approval truth, execution truth, or reconciliation truth."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  'This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+  "| Record type | Required demo fields | Presentation rule | Production exclusion |"
+  "| Label | Required value | Validation rule |"
+  "| Reset boundary | Required behavior | Rejection rule |"
+  "| Fixture | Expected validity | Required rejection |"
+  'Run `bash scripts/verify-phase-52-7-demo-seed-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1070 --config <supervisor-config-path>`.'
+)
+
+record_types=(
+  "Demo alert"
+  "Demo case"
+  "Demo evidence"
+  "Demo action request"
+  "Demo approval"
+  "Demo execution receipt"
+  "Demo reconciliation note"
+)
+
+labels=(
+  "demo-only"
+  "first-user-rehearsal"
+  "not-production-truth"
+)
+
+reset_boundaries=(
+  "Selector scope"
+  "Production guard"
+  "Failure cleanup"
+)
+
+fixture_expectations=(
+  "valid-demo-seed.json|valid|"
+  "missing-label.json|invalid|missing required demo label"
+  "destructive-reset.json|invalid|reset deletes production records"
+  "production-claim.json|invalid|demo record claims production truth"
+)
+
+forbidden_claims=(
+  "Demo data is production truth"
+  "Demo record is production truth"
+  "Demo seed output is gate truth"
+  "Demo reset may delete production records"
+  "Demo labels are optional"
+  "Fake credentials are valid credentials"
+  "Sample credentials are valid credentials"
+  "Demo source state is customer evidence"
+  "Demo approval is approval truth"
+  "Demo execution receipt is execution truth"
+  "Demo reconciliation note is reconciliation truth"
+  "This contract implements production data import"
+  "This contract implements Wazuh product profiles"
+  "This contract implements Shuffle product profiles"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.7 demo seed contract: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.7 demo seed contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.7 demo seed contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for record_type in "${record_types[@]}"; do
+  if ! grep -Eq "^\| ${record_type} \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.7 seed record row: ${record_type}" >&2
+    exit 1
+  fi
+done
+
+for label in "${labels[@]}"; do
+  if ! grep -Eq "^\| \`${label}\` \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.7 demo label row: ${label}" >&2
+    exit 1
+  fi
+done
+
+for reset_boundary in "${reset_boundaries[@]}"; do
+  if ! grep -Eq "^\| ${reset_boundary} \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.7 reset boundary row: ${reset_boundary}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 9\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.7 demo seed contract claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -REq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}" "${fixtures_dir}" 2>/dev/null; then
+  echo "Forbidden Phase 52.7 demo seed contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+python3 - "${fixtures_dir}" "${fixture_expectations[@]}" <<'PY'
+import json
+import pathlib
+import sys
+
+fixtures_dir = pathlib.Path(sys.argv[1])
+expectations = [item.split("|", 2) for item in sys.argv[2:]]
+
+if not fixtures_dir.is_dir():
+    print(f"Missing Phase 52.7 demo seed fixtures directory: {fixtures_dir}", file=sys.stderr)
+    sys.exit(1)
+
+required_labels = {"demo-only", "first-user-rehearsal", "not-production-truth"}
+truth_surfaces = {
+    "production",
+    "gate",
+    "customer_evidence",
+    "approval",
+    "execution",
+    "reconciliation",
+}
+
+
+def rejection_reasons(payload):
+    reasons = []
+    records = payload.get("records")
+    if not isinstance(records, list) or not records:
+        reasons.append("missing records")
+        return reasons
+
+    for record in records:
+        labels = set(record.get("labels") or [])
+        if not required_labels.issubset(labels):
+            reasons.append("missing required demo label")
+        if record.get("production_claim") is not False:
+            reasons.append("demo record claims production truth")
+        if any(surface in set(record.get("truth_surfaces") or []) for surface in truth_surfaces):
+            reasons.append("demo record claims production truth")
+        if record.get("authority") != "demo_rehearsal_only":
+            reasons.append("demo record claims production truth")
+
+    reset = payload.get("reset") or {}
+    if reset.get("deletes_production_records") is not False:
+        reasons.append("reset deletes production records")
+    if reset.get("scope") != "demo-bundle-only":
+        reasons.append("reset deletes production records")
+
+    exclusion = payload.get("production_exclusion") or {}
+    if exclusion.get("may_satisfy_production_truth") is not False:
+        reasons.append("demo record claims production truth")
+    blocked = set(exclusion.get("blocked_truth_surfaces") or [])
+    if not truth_surfaces.issubset(blocked):
+        reasons.append("demo record claims production truth")
+
+    if payload.get("mode") != "demo":
+        reasons.append("missing required demo label")
+
+    return reasons
+
+
+for fixture, expected_validity, required_rejection in expectations:
+    path = fixtures_dir / fixture
+    if not path.is_file():
+        print(f"Missing Phase 52.7 demo seed fixture: {fixture}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"Invalid Phase 52.7 demo seed fixture JSON for {fixture}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    reasons = rejection_reasons(payload)
+    if expected_validity == "valid" and reasons:
+        print(
+            f"Invalid Phase 52.7 demo seed fixture state for {fixture}: expected valid, got {sorted(set(reasons))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if expected_validity == "invalid":
+        if not reasons:
+            print(f"Invalid Phase 52.7 demo seed fixture state for {fixture}: expected rejection", file=sys.stderr)
+            sys.exit(1)
+        if required_rejection not in reasons:
+            print(
+                f"Invalid Phase 52.7 demo seed fixture state for {fixture}: expected {required_rejection}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+PY
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 52.7 demo seed contract link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/demo-seed-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 52.7 demo seed contract." >&2
+  exit 1
+fi
+
+echo "Phase 52.7 demo seed contract verified."


### PR DESCRIPTION
## Summary
- Add the Phase 52.7 demo seed contract for demo-only records, required labels, reset behavior, and production exclusion.
- Add valid and negative demo seed fixtures for missing labels, destructive reset, and demo-as-production claims.
- Add focused verifier and negative fixture harness, plus README links.

## Verification
- `bash scripts/verify-phase-52-7-demo-seed-contract.sh`
- `bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`
- `bash scripts/test-verify-publishable-path-hygiene.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1070 --config <supervisor-config-path>`

Closes #1070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new demo-seed contract describing required demo-record fields, labels, authority boundaries, reset constraints, validation rules, and guidance; updated README to reference Phase 52.7.

* **Tests**
  * Added demo-seed fixtures covering valid and negative scenarios.
  * Added verification and test harnesses to enforce contract rules, negative-case failures, and file/path checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->