### PR TITLE
Phase 52.8: Add clean-host smoke skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.5 env secrets certs contract](docs/deployment/env-secrets-certs-contract.md) defines generated runtime env config, ignored secret/cert paths, demo token/cert posture, and fail-closed secret validation for the executable first-user stack.
 - [Phase 52.6 host preflight contract](docs/deployment/host-preflight-contract.md) defines Docker, Compose, RAM, disk, port, `vm.max_map_count`, and profile-validity readiness checks and fixture expectations for the executable first-user stack.
 - [Phase 52.7 demo seed contract](docs/deployment/demo-seed-contract.md) defines demo-only seed records, required labels, reset boundaries, and production-exclusion fixtures for the executable first-user stack.
+- [Phase 52.8 clean-host smoke skeleton](docs/deployment/clean-host-smoke-skeleton.md) defines the mocked/skipped `init -> up -> doctor -> seed-demo` fixture path and false-success rejection rules for the executable first-user stack.
 
 ## Product positioning
 
@@ -61,6 +62,8 @@ The Phase 52.5 first-user env secrets certs contract is defined by the [Phase 52
 The Phase 52.6 first-user host preflight contract is defined by the [Phase 52.6 host preflight contract](docs/deployment/host-preflight-contract.md).
 
 The Phase 52.7 first-user demo seed contract is defined by the [Phase 52.7 demo seed contract](docs/deployment/demo-seed-contract.md).
+
+The Phase 52.8 first-user clean-host smoke skeleton is defined by the [Phase 52.8 clean-host smoke skeleton](docs/deployment/clean-host-smoke-skeleton.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/clean-host-smoke-skeleton.md
+++ b/docs/deployment/clean-host-smoke-skeleton.md
@@ -1,0 +1,119 @@
+# Phase 52.8 Clean-Host Smoke Skeleton
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-52-1-cli-command-contract.md`, `docs/deployment/compose-generator-contract.md`, `docs/deployment/env-secrets-certs-contract.md`, `docs/deployment/host-preflight-contract.md`, `docs/deployment/demo-seed-contract.md`
+- **Related Issues**: #1063, #1064, #1067, #1068, #1069, #1070, #1071
+
+This contract defines a clean-host smoke skeleton for the executable first-user stack only. It does not implement full stack startup, Wazuh product profiles, Shuffle product profiles, the first-user guided UI journey, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+## 1. Purpose
+
+Phase 52.8 gives later executable-stack work one repo-owned smoke shape for the first user path:
+
+`init -> up -> doctor -> seed-demo`
+
+The smoke may run entirely from reviewed fixtures until actual profile-backed commands exist. Mocked and skipped states are expected in this phase, but the smoke must surface them as incomplete prerequisites instead of reporting a successful full stack.
+
+## 2. Authority Boundary
+
+Smoke output is validation evidence only. Smoke output, fixture output, Docker state, Docker Compose state, generated config state, host preflight state, demo seed output, Wazuh state, Shuffle state, browser state, UI cache, logs, tickets, downstream receipts, or operator-facing summaries cannot become workflow truth, source truth, approval truth, execution truth, reconciliation truth, gate truth, release truth, production truth, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.
+
+## 3. Smoke Sequence
+
+| Step | Command | Required contract reference | Expected skeleton state | Required evidence role |
+| --- | --- | --- | --- | --- |
+| 1 | `init` | Phase 52.1 CLI command contract and Phase 52.5 env/secrets/certs contract. | `mocked` or `skipped` until generated runtime config is implemented. | Setup fixture evidence only. |
+| 2 | `up` | Phase 52.1 CLI command contract and Phase 52.4 compose generator contract. | `mocked` or `skipped` until stack startup and product profiles are implemented. | Compose/runtime posture fixture evidence only. |
+| 3 | `doctor` | Phase 52.1 CLI command contract and Phase 52.6 host preflight contract. | `mocked` or `skipped` until live host preflight is implemented. | Host preflight fixture evidence only. |
+| 4 | `seed-demo` | Phase 52.1 CLI command contract and Phase 52.7 demo seed contract. | `mocked` or `skipped` until demo seed command execution is implemented. | Demo rehearsal fixture evidence only. |
+
+The sequence order is fixed. A fixture that omits a command, repeats a command, reorders commands, or runs `seed-demo` before `doctor` fails validation.
+
+## 4. Mocked and Skipped States
+
+| State | Meaning | Required follow-up |
+| --- | --- | --- |
+| `mocked` | The smoke used a reviewed fixture or test double instead of a live clean host. | Replace the mocked step with a real implementation in the later owning phase named by the fixture. |
+| `skipped` | The smoke intentionally did not attempt a profile-backed operation because a reviewed prerequisite is absent. | Close the missing prerequisite before claiming full stack startup or production readiness. |
+
+Each mocked or skipped step must include the command, the missing prerequisite, the later closing phase, and a safe next action. A mocked or skipped step cannot be summarized as `ok`, full-stack success, production readiness, RC readiness, GA readiness, gate truth, release truth, or closeout truth.
+
+## 5. Required Contract References
+
+The smoke skeleton must reference:
+
+- Phase 52.1 CLI command contract: `docs/phase-52-1-cli-command-contract.md`.
+- Phase 52.4 compose generator contract: `docs/deployment/compose-generator-contract.md`.
+- Phase 52.5 env secrets certs contract: `docs/deployment/env-secrets-certs-contract.md`.
+- Phase 52.6 host preflight contract: `docs/deployment/host-preflight-contract.md`.
+- Phase 52.7 demo seed contract: `docs/deployment/demo-seed-contract.md`.
+
+The smoke skeleton must also name compose, env/secrets/certs, host preflight, and demo seed contract coverage in fixture output.
+
+## 6. Fixture Expectations
+
+The required fixture directory is `docs/deployment/fixtures/clean-host-smoke`.
+
+| Fixture | Expected validity | Required rejection |
+| --- | --- | --- |
+| `valid-clean-host-smoke.json` | valid | None. |
+| `profile-skipped-clean-host-smoke.json` | valid | None. |
+| `false-success.json` | invalid | Smoke reports skipped or mocked profile work as successful full stack. |
+| `compose-truth.json` | invalid | Smoke treats Docker or Compose status as workflow truth. |
+| `phase-53-54-required.json` | invalid | Smoke requires Phase 53 or Phase 54 profile completion. |
+
+## 7. Validation Rules
+
+Clean-host smoke skeleton validation must fail closed when:
+
+- the contract document is missing;
+- the README link is missing;
+- any required command is missing, repeated, or out of order;
+- mocked or skipped states are missing from the document or fixture set;
+- a mocked or skipped step is treated as full-stack success;
+- Docker status or Docker Compose status is treated as workflow truth;
+- the smoke requires Phase 53 or Phase 54 profile completion;
+- compose, env/secrets/certs, host preflight, or demo seed contract references are missing;
+- fixture output omits missing prerequisites, later closing phases, or safe next actions for mocked or skipped steps;
+- any fixture uses workstation-local absolute paths; or
+- the smoke claims RC, GA, production readiness, release truth, gate truth, closeout truth, workflow truth, approval truth, execution truth, or reconciliation truth.
+
+## 8. Forbidden Claims
+
+- Clean-host smoke success is workflow truth.
+- Clean-host smoke output is source truth.
+- Clean-host smoke output is approval truth.
+- Clean-host smoke output is execution truth.
+- Clean-host smoke output is reconciliation truth.
+- Docker status is AegisOps workflow truth.
+- Docker Compose status is AegisOps workflow truth.
+- Mocked profile work is successful full stack startup.
+- Skipped profile work is successful full stack startup.
+- Phase 52.8 requires Phase 53 profile completion.
+- Phase 52.8 requires Phase 54 profile completion.
+- Phase 52.8 implements Wazuh product profiles.
+- Phase 52.8 implements Shuffle product profiles.
+- Phase 52.8 completes RC behavior.
+- Phase 52.8 completes GA behavior.
+
+## 9. Validation
+
+Run `bash scripts/verify-phase-52-8-clean-host-smoke-skeleton.sh`.
+
+Run `bash scripts/test-verify-phase-52-8-clean-host-smoke-skeleton.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1071 --config <supervisor-config-path>`.
+
+The verifier must fail when skipped or mocked profile work is reported as successful full stack startup, when Docker or Docker Compose state is treated as workflow truth, when Phase 53 or Phase 54 profile completion is required, when required contract references are missing, or when publishable guidance uses workstation-local absolute paths.
+
+## 10. Non-Goals
+
+- No full stack startup implementation is approved by this contract.
+- No Wazuh product profile, Shuffle product profile, guided UI journey, RC behavior, GA behavior, production readiness, release gate, or runtime behavior is implemented here.
+- No smoke output, fixture output, Docker state, Docker Compose state, generated config state, host preflight state, demo seed output, Wazuh state, Shuffle state, browser state, UI cache, logs, tickets, downstream receipts, or operator-facing summary becomes authoritative AegisOps truth.

--- a/docs/deployment/fixtures/clean-host-smoke/compose-truth.json
+++ b/docs/deployment/fixtures/clean-host-smoke/compose-truth.json
@@ -1,0 +1,68 @@
+{
+  "fixture": "compose-truth",
+  "phase": "52.8",
+  "overall_state": "mocked",
+  "full_stack_success": false,
+  "requires_phase_53_or_54_completion": false,
+  "authority_boundary": "Docker Compose status is AegisOps workflow truth",
+  "contract_coverage": [
+    "compose",
+    "env/secrets/certs",
+    "host preflight",
+    "demo seed"
+  ],
+  "sequence": [
+    {
+      "step": 1,
+      "command": "init",
+      "state": "mocked",
+      "missing_prerequisite": "runtime config generator implementation",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "replace fixture-backed init later",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/env-secrets-certs-contract.md"
+      ],
+      "evidence_role": "setup fixture evidence only"
+    },
+    {
+      "step": 2,
+      "command": "up",
+      "state": "mocked",
+      "missing_prerequisite": "compose-backed stack startup implementation",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "replace fixture-backed up later",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/compose-generator-contract.md"
+      ],
+      "evidence_role": "Compose workflow truth"
+    },
+    {
+      "step": 3,
+      "command": "doctor",
+      "state": "mocked",
+      "missing_prerequisite": "live host preflight implementation",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "replace fixture-backed doctor later",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/host-preflight-contract.md"
+      ],
+      "evidence_role": "host preflight fixture evidence only"
+    },
+    {
+      "step": 4,
+      "command": "seed-demo",
+      "state": "mocked",
+      "missing_prerequisite": "demo seed command implementation",
+      "closing_phase": "Phase 54",
+      "safe_next_action": "replace fixture-backed seed-demo later",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/demo-seed-contract.md"
+      ],
+      "evidence_role": "demo rehearsal fixture evidence only"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/clean-host-smoke/false-success.json
+++ b/docs/deployment/fixtures/clean-host-smoke/false-success.json
@@ -1,0 +1,68 @@
+{
+  "fixture": "false-success",
+  "phase": "52.8",
+  "overall_state": "ok",
+  "full_stack_success": true,
+  "requires_phase_53_or_54_completion": false,
+  "authority_boundary": "clean-host smoke output is validation evidence only",
+  "contract_coverage": [
+    "compose",
+    "env/secrets/certs",
+    "host preflight",
+    "demo seed"
+  ],
+  "sequence": [
+    {
+      "step": 1,
+      "command": "init",
+      "state": "mocked",
+      "missing_prerequisite": "runtime config generator implementation",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "replace fixture-backed init later",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/env-secrets-certs-contract.md"
+      ],
+      "evidence_role": "setup fixture evidence only"
+    },
+    {
+      "step": 2,
+      "command": "up",
+      "state": "skipped",
+      "missing_prerequisite": "Wazuh and Shuffle product profiles are not implemented",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "replace skipped startup later",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/compose-generator-contract.md"
+      ],
+      "evidence_role": "startup skip evidence only"
+    },
+    {
+      "step": 3,
+      "command": "doctor",
+      "state": "mocked",
+      "missing_prerequisite": "live host preflight implementation",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "replace fixture-backed doctor later",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/host-preflight-contract.md"
+      ],
+      "evidence_role": "host preflight fixture evidence only"
+    },
+    {
+      "step": 4,
+      "command": "seed-demo",
+      "state": "mocked",
+      "missing_prerequisite": "demo seed command implementation",
+      "closing_phase": "Phase 54",
+      "safe_next_action": "replace fixture-backed seed-demo later",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/demo-seed-contract.md"
+      ],
+      "evidence_role": "demo rehearsal fixture evidence only"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/clean-host-smoke/phase-53-54-required.json
+++ b/docs/deployment/fixtures/clean-host-smoke/phase-53-54-required.json
@@ -1,0 +1,68 @@
+{
+  "fixture": "phase-53-54-required",
+  "phase": "52.8",
+  "overall_state": "skipped",
+  "full_stack_success": false,
+  "requires_phase_53_or_54_completion": true,
+  "authority_boundary": "clean-host smoke output is validation evidence only",
+  "contract_coverage": [
+    "compose",
+    "env/secrets/certs",
+    "host preflight",
+    "demo seed"
+  ],
+  "sequence": [
+    {
+      "step": 1,
+      "command": "init",
+      "state": "skipped",
+      "missing_prerequisite": "profile-backed init is not implemented",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "keep init skipped until profile-backed setup exists",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/env-secrets-certs-contract.md"
+      ],
+      "evidence_role": "setup skip evidence only"
+    },
+    {
+      "step": 2,
+      "command": "up",
+      "state": "skipped",
+      "missing_prerequisite": "Wazuh and Shuffle product profiles are not implemented",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "keep profile startup skipped until the owning profile phase replaces this skeleton",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/compose-generator-contract.md"
+      ],
+      "evidence_role": "startup skip evidence only"
+    },
+    {
+      "step": 3,
+      "command": "doctor",
+      "state": "skipped",
+      "missing_prerequisite": "live clean-host preflight is not implemented",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "keep doctor skipped until live preflight exists",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/host-preflight-contract.md"
+      ],
+      "evidence_role": "preflight skip evidence only"
+    },
+    {
+      "step": 4,
+      "command": "seed-demo",
+      "state": "skipped",
+      "missing_prerequisite": "demo seed command is not implemented",
+      "closing_phase": "Phase 54",
+      "safe_next_action": "keep seed-demo skipped until demo seed execution exists",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/demo-seed-contract.md"
+      ],
+      "evidence_role": "demo seed skip evidence only"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/clean-host-smoke/profile-skipped-clean-host-smoke.json
+++ b/docs/deployment/fixtures/clean-host-smoke/profile-skipped-clean-host-smoke.json
@@ -1,0 +1,68 @@
+{
+  "fixture": "profile-skipped-clean-host-smoke",
+  "phase": "52.8",
+  "overall_state": "skipped",
+  "full_stack_success": false,
+  "requires_phase_53_or_54_completion": false,
+  "authority_boundary": "clean-host smoke output is validation evidence only",
+  "contract_coverage": [
+    "compose",
+    "env/secrets/certs",
+    "host preflight",
+    "demo seed"
+  ],
+  "sequence": [
+    {
+      "step": 1,
+      "command": "init",
+      "state": "skipped",
+      "missing_prerequisite": "profile-backed init is not implemented",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "keep init skipped until profile-backed setup exists",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/env-secrets-certs-contract.md"
+      ],
+      "evidence_role": "setup skip evidence only"
+    },
+    {
+      "step": 2,
+      "command": "up",
+      "state": "skipped",
+      "missing_prerequisite": "Wazuh and Shuffle product profiles are not implemented",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "keep profile startup skipped until the owning profile phase replaces this skeleton",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/compose-generator-contract.md"
+      ],
+      "evidence_role": "startup skip evidence only"
+    },
+    {
+      "step": 3,
+      "command": "doctor",
+      "state": "skipped",
+      "missing_prerequisite": "live clean-host preflight is not implemented",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "keep doctor skipped until live preflight exists",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/host-preflight-contract.md"
+      ],
+      "evidence_role": "preflight skip evidence only"
+    },
+    {
+      "step": 4,
+      "command": "seed-demo",
+      "state": "skipped",
+      "missing_prerequisite": "demo seed command is not implemented",
+      "closing_phase": "Phase 54",
+      "safe_next_action": "keep seed-demo skipped until demo seed execution exists",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/demo-seed-contract.md"
+      ],
+      "evidence_role": "demo seed skip evidence only"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/clean-host-smoke/valid-clean-host-smoke.json
+++ b/docs/deployment/fixtures/clean-host-smoke/valid-clean-host-smoke.json
@@ -1,0 +1,68 @@
+{
+  "fixture": "valid-clean-host-smoke",
+  "phase": "52.8",
+  "overall_state": "mocked",
+  "full_stack_success": false,
+  "requires_phase_53_or_54_completion": false,
+  "authority_boundary": "clean-host smoke output is validation evidence only",
+  "contract_coverage": [
+    "compose",
+    "env/secrets/certs",
+    "host preflight",
+    "demo seed"
+  ],
+  "sequence": [
+    {
+      "step": 1,
+      "command": "init",
+      "state": "mocked",
+      "missing_prerequisite": "runtime config generator implementation",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "replace fixture-backed init with profile-backed init when Phase 53 owns the implementation",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/env-secrets-certs-contract.md"
+      ],
+      "evidence_role": "setup fixture evidence only"
+    },
+    {
+      "step": 2,
+      "command": "up",
+      "state": "mocked",
+      "missing_prerequisite": "compose-backed stack startup implementation",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "replace fixture-backed up with compose-backed startup when Phase 53 owns the implementation",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/compose-generator-contract.md"
+      ],
+      "evidence_role": "compose fixture evidence only"
+    },
+    {
+      "step": 3,
+      "command": "doctor",
+      "state": "mocked",
+      "missing_prerequisite": "live host preflight implementation",
+      "closing_phase": "Phase 53",
+      "safe_next_action": "replace fixture-backed doctor with live host preflight when Phase 53 owns the implementation",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/host-preflight-contract.md"
+      ],
+      "evidence_role": "host preflight fixture evidence only"
+    },
+    {
+      "step": 4,
+      "command": "seed-demo",
+      "state": "mocked",
+      "missing_prerequisite": "demo seed command implementation",
+      "closing_phase": "Phase 54",
+      "safe_next_action": "replace fixture-backed seed-demo with demo seed execution when Phase 54 owns the implementation",
+      "contract_refs": [
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/demo-seed-contract.md"
+      ],
+      "evidence_role": "demo rehearsal fixture evidence only"
+    }
+  ]
+}

--- a/scripts/test-verify-phase-52-8-clean-host-smoke-skeleton.sh
+++ b/scripts/test-verify-phase-52-8-clean-host-smoke-skeleton.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-8-clean-host-smoke-skeleton.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/fixtures/clean-host-smoke"
+  printf '%s\n' "# AegisOps" "See [Phase 52.8 clean-host smoke skeleton](docs/deployment/clean-host-smoke-skeleton.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/clean-host-smoke-skeleton.md" \
+    "${target}/docs/deployment/clean-host-smoke-skeleton.md"
+  cp "${repo_root}/docs/deployment/fixtures/clean-host-smoke/"*.json \
+    "${target}/docs/deployment/fixtures/clean-host-smoke/"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/clean-host-smoke-skeleton.md"
+}
+
+set_fixture_json_value() {
+  local target="$1"
+  local fixture="$2"
+  local expression="$3"
+
+  python3 - "${target}/docs/deployment/fixtures/clean-host-smoke/${fixture}" "${expression}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+expression = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+exec(expression, {"payload": payload})
+path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/clean-host-smoke-skeleton.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 52.8 clean-host smoke skeleton"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 52.8 clean-host smoke skeleton."
+
+missing_sequence_row_repo="${workdir}/missing-sequence-row"
+create_valid_repo "${missing_sequence_row_repo}"
+remove_text_from_contract "${missing_sequence_row_repo}" \
+  "| 4 | \`seed-demo\` | Phase 52.1 CLI command contract and Phase 52.7 demo seed contract. | \`mocked\` or \`skipped\` until demo seed command execution is implemented. | Demo rehearsal fixture evidence only. |"
+assert_fails_with \
+  "${missing_sequence_row_repo}" \
+  "Missing complete Phase 52.8 smoke sequence row: seed-demo"
+
+missing_mocked_state_repo="${workdir}/missing-mocked-state"
+create_valid_repo "${missing_mocked_state_repo}"
+remove_text_from_contract "${missing_mocked_state_repo}" \
+  "| \`mocked\` | The smoke used a reviewed fixture or test double instead of a live clean host. | Replace the mocked step with a real implementation in the later owning phase named by the fixture. |"
+assert_fails_with \
+  "${missing_mocked_state_repo}" \
+  "Missing complete Phase 52.8 state row: mocked"
+
+missing_contract_ref_repo="${workdir}/missing-contract-ref"
+create_valid_repo "${missing_contract_ref_repo}"
+remove_text_from_contract "${missing_contract_ref_repo}" \
+  'Phase 52.6 host preflight contract: `docs/deployment/host-preflight-contract.md`.'
+assert_fails_with \
+  "${missing_contract_ref_repo}" \
+  "Missing Phase 52.8 clean-host smoke skeleton statement: Phase 52.6 host preflight contract"
+
+missing_fixture_repo="${workdir}/missing-fixture"
+create_valid_repo "${missing_fixture_repo}"
+rm "${missing_fixture_repo}/docs/deployment/fixtures/clean-host-smoke/false-success.json"
+assert_fails_with \
+  "${missing_fixture_repo}" \
+  "Missing Phase 52.8 clean-host smoke fixture: false-success.json"
+
+reordered_fixture_repo="${workdir}/reordered-fixture"
+create_valid_repo "${reordered_fixture_repo}"
+set_fixture_json_value \
+  "${reordered_fixture_repo}" \
+  "valid-clean-host-smoke.json" \
+  "payload['sequence'][2], payload['sequence'][3] = payload['sequence'][3], payload['sequence'][2]"
+assert_fails_with \
+  "${reordered_fixture_repo}" \
+  "Invalid Phase 52.8 clean-host smoke fixture state for valid-clean-host-smoke.json: expected valid"
+
+false_success_not_rejected_repo="${workdir}/false-success-not-rejected"
+create_valid_repo "${false_success_not_rejected_repo}"
+set_fixture_json_value \
+  "${false_success_not_rejected_repo}" \
+  "false-success.json" \
+  "payload['overall_state'] = 'mocked'; payload['full_stack_success'] = False"
+assert_fails_with \
+  "${false_success_not_rejected_repo}" \
+  "Invalid Phase 52.8 clean-host smoke fixture state for false-success.json: expected rejection"
+
+compose_truth_not_rejected_repo="${workdir}/compose-truth-not-rejected"
+create_valid_repo "${compose_truth_not_rejected_repo}"
+set_fixture_json_value \
+  "${compose_truth_not_rejected_repo}" \
+  "compose-truth.json" \
+  "payload['authority_boundary'] = 'clean-host smoke output is validation evidence only'; payload['sequence'][1]['evidence_role'] = 'compose fixture evidence only'"
+assert_fails_with \
+  "${compose_truth_not_rejected_repo}" \
+  "Invalid Phase 52.8 clean-host smoke fixture state for compose-truth.json: expected rejection"
+
+phase_required_not_rejected_repo="${workdir}/phase-required-not-rejected"
+create_valid_repo "${phase_required_not_rejected_repo}"
+set_fixture_json_value \
+  "${phase_required_not_rejected_repo}" \
+  "phase-53-54-required.json" \
+  "payload['requires_phase_53_or_54_completion'] = False"
+assert_fails_with \
+  "${phase_required_not_rejected_repo}" \
+  "Invalid Phase 52.8 clean-host smoke fixture state for phase-53-54-required.json: expected rejection"
+
+workflow_truth_doc_repo="${workdir}/workflow-truth-doc"
+create_valid_repo "${workflow_truth_doc_repo}"
+printf '%s\n' "Clean-host smoke success is workflow truth." \
+  >>"${workflow_truth_doc_repo}/docs/deployment/clean-host-smoke-skeleton.md"
+assert_fails_with \
+  "${workflow_truth_doc_repo}" \
+  "Forbidden Phase 52.8 clean-host smoke skeleton claim: Clean-host smoke success is workflow truth"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/clean-host-smoke-skeleton.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.8 clean-host smoke skeleton: workstation-local absolute path detected"
+
+echo "Phase 52.8 clean-host smoke skeleton negative and valid fixtures passed."

--- a/scripts/test-verify-phase-52-8-clean-host-smoke-skeleton.sh
+++ b/scripts/test-verify-phase-52-8-clean-host-smoke-skeleton.sh
@@ -135,6 +135,16 @@ assert_fails_with \
   "${reordered_fixture_repo}" \
   "Invalid Phase 52.8 clean-host smoke fixture state for valid-clean-host-smoke.json: expected valid"
 
+misassigned_contract_refs_repo="${workdir}/misassigned-contract-refs"
+create_valid_repo "${misassigned_contract_refs_repo}"
+set_fixture_json_value \
+  "${misassigned_contract_refs_repo}" \
+  "valid-clean-host-smoke.json" \
+  "payload['sequence'][1]['contract_refs'], payload['sequence'][2]['contract_refs'] = payload['sequence'][2]['contract_refs'], payload['sequence'][1]['contract_refs']"
+assert_fails_with \
+  "${misassigned_contract_refs_repo}" \
+  "Invalid Phase 52.8 clean-host smoke fixture state for valid-clean-host-smoke.json: expected valid"
+
 false_success_not_rejected_repo="${workdir}/false-success-not-rejected"
 create_valid_repo "${false_success_not_rejected_repo}"
 set_fixture_json_value \

--- a/scripts/verify-phase-52-8-clean-host-smoke-skeleton.sh
+++ b/scripts/verify-phase-52-8-clean-host-smoke-skeleton.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/clean-host-smoke-skeleton.md"
+readme_path="${repo_root}/README.md"
+fixtures_dir="${repo_root}/docs/deployment/fixtures/clean-host-smoke"
+
+required_headings=(
+  "# Phase 52.8 Clean-Host Smoke Skeleton"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Smoke Sequence"
+  "## 4. Mocked and Skipped States"
+  "## 5. Required Contract References"
+  "## 6. Fixture Expectations"
+  "## 7. Validation Rules"
+  "## 8. Forbidden Claims"
+  "## 9. Validation"
+  "## 10. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1063, #1064, #1067, #1068, #1069, #1070, #1071"
+  "This contract defines a clean-host smoke skeleton for the executable first-user stack only. It does not implement full stack startup, Wazuh product profiles, Shuffle product profiles, the first-user guided UI journey, release-candidate behavior, general-availability behavior, or runtime behavior."
+  '`init -> up -> doctor -> seed-demo`'
+  "Smoke output is validation evidence only."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  'This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+  "| Step | Command | Required contract reference | Expected skeleton state | Required evidence role |"
+  "| State | Meaning | Required follow-up |"
+  "| Fixture | Expected validity | Required rejection |"
+  'Phase 52.1 CLI command contract: `docs/phase-52-1-cli-command-contract.md`.'
+  'Phase 52.4 compose generator contract: `docs/deployment/compose-generator-contract.md`.'
+  'Phase 52.5 env secrets certs contract: `docs/deployment/env-secrets-certs-contract.md`.'
+  'Phase 52.6 host preflight contract: `docs/deployment/host-preflight-contract.md`.'
+  'Phase 52.7 demo seed contract: `docs/deployment/demo-seed-contract.md`.'
+  "The smoke skeleton must also name compose, env/secrets/certs, host preflight, and demo seed contract coverage in fixture output."
+  'Run `bash scripts/verify-phase-52-8-clean-host-smoke-skeleton.sh`.'
+  'Run `bash scripts/test-verify-phase-52-8-clean-host-smoke-skeleton.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1071 --config <supervisor-config-path>`.'
+)
+
+command_order=(
+  "init"
+  "up"
+  "doctor"
+  "seed-demo"
+)
+
+states=(
+  "mocked"
+  "skipped"
+)
+
+coverage_terms=(
+  "compose"
+  "env/secrets/certs"
+  "host preflight"
+  "demo seed"
+)
+
+required_contract_refs=(
+  "docs/phase-52-1-cli-command-contract.md"
+  "docs/deployment/compose-generator-contract.md"
+  "docs/deployment/env-secrets-certs-contract.md"
+  "docs/deployment/host-preflight-contract.md"
+  "docs/deployment/demo-seed-contract.md"
+)
+
+fixture_expectations=(
+  "valid-clean-host-smoke.json|valid|"
+  "profile-skipped-clean-host-smoke.json|valid|"
+  "false-success.json|invalid|successful full stack"
+  "compose-truth.json|invalid|workflow truth"
+  "phase-53-54-required.json|invalid|requires Phase 53 or Phase 54 completion"
+)
+
+forbidden_claims=(
+  "Clean-host smoke success is workflow truth"
+  "Clean-host smoke output is source truth"
+  "Clean-host smoke output is approval truth"
+  "Clean-host smoke output is execution truth"
+  "Clean-host smoke output is reconciliation truth"
+  "Docker status is AegisOps workflow truth"
+  "Docker Compose status is AegisOps workflow truth"
+  "Mocked profile work is successful full stack startup"
+  "Skipped profile work is successful full stack startup"
+  "Phase 52.8 requires Phase 53 profile completion"
+  "Phase 52.8 requires Phase 54 profile completion"
+  "Phase 52.8 implements Wazuh product profiles"
+  "Phase 52.8 implements Shuffle product profiles"
+  "Phase 52.8 completes RC behavior"
+  "Phase 52.8 completes GA behavior"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.8 clean-host smoke skeleton: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.8 clean-host smoke skeleton heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.8 clean-host smoke skeleton statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for index in "${!command_order[@]}"; do
+  step=$((index + 1))
+  command="${command_order[$index]}"
+  if ! grep -Eq "^\\| ${step} \\| \`${command}\` \\| [^|]+ \\| [^|]+ \\| [^|]+ \\|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.8 smoke sequence row: ${command}" >&2
+    exit 1
+  fi
+done
+
+for state in "${states[@]}"; do
+  if ! grep -Eq "^\\| \`${state}\` \\| [^|]+ \\| [^|]+ \\|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.8 state row: ${state}" >&2
+    exit 1
+  fi
+done
+
+for coverage_term in "${coverage_terms[@]}"; do
+  if ! grep -Fq -- "${coverage_term}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.8 coverage term: ${coverage_term}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 8\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+contains_false_success_claim() {
+  awk '
+    /^## 8\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    {
+      line = tolower($0)
+      negative_context = line ~ /(cannot|must not|fail|fails|invalid|rejected|required rejection|forbidden|instead of reporting|not implement|before claiming|treated as)/
+      if (!in_forbidden_claims && !negative_context && line ~ /((mocked|skipped).*(successful full stack|full-stack success|production readiness|rc readiness|ga readiness)|(docker|docker compose).*workflow truth)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${doc_rendered_markdown}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.8 clean-host smoke skeleton claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if contains_false_success_claim; then
+  echo "Forbidden Phase 52.8 clean-host smoke skeleton claim: false success or workflow truth" >&2
+  exit 1
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -REq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}" "${fixtures_dir}" 2>/dev/null; then
+  echo "Forbidden Phase 52.8 clean-host smoke skeleton: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 52.8 clean-host smoke skeleton link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/clean-host-smoke-skeleton\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 52.8 clean-host smoke skeleton." >&2
+  exit 1
+fi
+
+python3 - "${fixtures_dir}" "${fixture_expectations[@]}" "${required_contract_refs[@]}" <<'PY'
+import json
+import pathlib
+import sys
+
+fixtures_dir = pathlib.Path(sys.argv[1])
+expectations = [item.split("|", 2) for item in sys.argv[2:7]]
+required_contract_refs = set(sys.argv[7:])
+required_order = ["init", "up", "doctor", "seed-demo"]
+allowed_states = {"mocked", "skipped"}
+required_coverage = {"compose", "env/secrets/certs", "host preflight", "demo seed"}
+truth_markers = (
+    "workflow truth",
+    "source truth",
+    "approval truth",
+    "execution truth",
+    "reconciliation truth",
+    "gate truth",
+    "release truth",
+    "production truth",
+    "closeout truth",
+)
+
+if not fixtures_dir.is_dir():
+    print(f"Missing Phase 52.8 clean-host smoke fixture directory: {fixtures_dir}", file=sys.stderr)
+    sys.exit(1)
+
+
+def text_contains_truth_claim(value):
+    if isinstance(value, str):
+        lowered = value.lower()
+        return any(marker in lowered for marker in truth_markers)
+    if isinstance(value, list):
+        return any(text_contains_truth_claim(item) for item in value)
+    if isinstance(value, dict):
+        return any(text_contains_truth_claim(item) for item in value.values())
+    return False
+
+
+def rejection_reasons(payload):
+    reasons = []
+    sequence = payload.get("sequence")
+    if not isinstance(sequence, list) or len(sequence) != len(required_order):
+        reasons.append("missing smoke sequence")
+        return reasons
+
+    commands = [step.get("command") for step in sequence]
+    if commands != required_order:
+        reasons.append("invalid command order")
+
+    if payload.get("overall_state") not in allowed_states:
+        reasons.append("invalid overall state")
+
+    coverage = payload.get("contract_coverage")
+    if not isinstance(coverage, list) or set(coverage) != required_coverage:
+        reasons.append("missing contract coverage")
+
+    if payload.get("full_stack_success") is True:
+        reasons.append("successful full stack")
+
+    if payload.get("requires_phase_53_or_54_completion") is True:
+        reasons.append("requires Phase 53 or Phase 54 completion")
+
+    if text_contains_truth_claim(payload):
+        reasons.append("workflow truth")
+
+    seen_states = set()
+    seen_contract_refs = set()
+    for expected_step, step in enumerate(sequence, start=1):
+        if step.get("step") != expected_step:
+            reasons.append("invalid step number")
+        state = step.get("state")
+        if state not in allowed_states:
+            reasons.append("invalid step state")
+        else:
+            seen_states.add(state)
+        for field in ("missing_prerequisite", "closing_phase", "safe_next_action", "evidence_role"):
+            if not isinstance(step.get(field), str) or not step[field].strip():
+                reasons.append(f"missing {field}")
+        contract_refs = step.get("contract_refs")
+        if not isinstance(contract_refs, list) or not contract_refs:
+            reasons.append("missing contract refs")
+        else:
+            seen_contract_refs.update(contract_refs)
+
+    if not seen_states.intersection(allowed_states):
+        reasons.append("missing mocked or skipped states")
+
+    missing_refs = required_contract_refs.difference(seen_contract_refs)
+    if missing_refs:
+        reasons.append("missing contract refs")
+
+    return reasons
+
+
+for filename, expected_validity, required_rejection in expectations:
+    path = fixtures_dir / filename
+    if not path.is_file():
+        print(f"Missing Phase 52.8 clean-host smoke fixture: {filename}", file=sys.stderr)
+        sys.exit(1)
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    reasons = rejection_reasons(payload)
+    if expected_validity == "valid" and reasons:
+        print(
+            f"Invalid Phase 52.8 clean-host smoke fixture state for {filename}: "
+            f"expected valid; got {', '.join(sorted(set(reasons)))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if expected_validity == "invalid":
+        if not reasons:
+            print(
+                f"Invalid Phase 52.8 clean-host smoke fixture state for {filename}: "
+                "expected rejection",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if required_rejection and required_rejection not in reasons:
+            print(
+                f"Missing Phase 52.8 clean-host smoke fixture rejection for {filename}: "
+                f"{required_rejection}; got {', '.join(sorted(set(reasons)))}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+PY
+
+echo "Phase 52.8 clean-host smoke skeleton preserves sequence order, mocked/skipped states, contract references, and false-success rejection."

--- a/scripts/verify-phase-52-8-clean-host-smoke-skeleton.sh
+++ b/scripts/verify-phase-52-8-clean-host-smoke-skeleton.sh
@@ -233,6 +233,24 @@ required_contract_refs = set(sys.argv[7:])
 required_order = ["init", "up", "doctor", "seed-demo"]
 allowed_states = {"mocked", "skipped"}
 required_coverage = {"compose", "env/secrets/certs", "host preflight", "demo seed"}
+required_refs_by_command = {
+    "init": {
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/env-secrets-certs-contract.md",
+    },
+    "up": {
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/compose-generator-contract.md",
+    },
+    "doctor": {
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/host-preflight-contract.md",
+    },
+    "seed-demo": {
+        "docs/phase-52-1-cli-command-contract.md",
+        "docs/deployment/demo-seed-contract.md",
+    },
+}
 truth_markers = (
     "workflow truth",
     "source truth",
@@ -293,6 +311,7 @@ def rejection_reasons(payload):
     for expected_step, step in enumerate(sequence, start=1):
         if step.get("step") != expected_step:
             reasons.append("invalid step number")
+        command = step.get("command")
         state = step.get("state")
         if state not in allowed_states:
             reasons.append("invalid step state")
@@ -306,6 +325,11 @@ def rejection_reasons(payload):
             reasons.append("missing contract refs")
         else:
             seen_contract_refs.update(contract_refs)
+            expected_refs = required_refs_by_command.get(command)
+            if expected_refs is None:
+                reasons.append("invalid command")
+            elif expected_refs.difference(contract_refs):
+                reasons.append("missing contract refs")
 
     if not seen_states.intersection(allowed_states):
         reasons.append("missing mocked or skipped states")


### PR DESCRIPTION
## Summary
- Add the Phase 52.8 clean-host smoke skeleton for `init -> up -> doctor -> seed-demo`.
- Add mocked/skipped smoke fixtures plus negative fixtures for false full-stack success, Docker/Compose-as-truth, and Phase 53/54 hard dependencies.
- Add a repo-owned verifier/test script and README links.

## Mocked/skipped states Phase 53/54 must close
- `init`: mocked/skipped until runtime config generator and profile-backed setup exist.
- `up`: mocked/skipped until compose-backed startup and Wazuh/Shuffle profile handling exist.
- `doctor`: mocked/skipped until live host preflight exists.
- `seed-demo`: mocked/skipped until demo seed command execution exists.

## Verification
- `bash scripts/verify-phase-52-8-clean-host-smoke-skeleton.sh`
- `bash scripts/test-verify-phase-52-8-clean-host-smoke-skeleton.sh`
- `bash scripts/verify-phase-52-1-cli-command-contract.sh && bash scripts/test-verify-phase-52-1-cli-command-contract.sh`
- `bash scripts/verify-phase-52-4-compose-generator-contract.sh && bash scripts/test-verify-phase-52-4-compose-generator-contract.sh`
- `bash scripts/verify-phase-52-5-env-secrets-certs-contract.sh && bash scripts/test-verify-phase-52-5-env-secrets-certs-contract.sh`
- `bash scripts/verify-phase-52-6-host-preflight-contract.sh && bash scripts/test-verify-phase-52-6-host-preflight-contract.sh`
- `bash scripts/verify-phase-52-7-demo-seed-contract.sh && bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1071 --config <supervisor-config-path>`

Closes #1071


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 52.8 clean-host smoke skeleton specification with deployment guidance and contract references.
  * Defined test fixture scenarios documenting expected behaviors across mocked, skipped, and validation states.

* **Tests**
  * Added verification scripts to validate documentation structure and fixture compliance with defined rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->