### PR TITLE
Phase 52.9: Add first-user stack docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.6 host preflight contract](docs/deployment/host-preflight-contract.md) defines Docker, Compose, RAM, disk, port, `vm.max_map_count`, and profile-validity readiness checks and fixture expectations for the executable first-user stack.
 - [Phase 52.7 demo seed contract](docs/deployment/demo-seed-contract.md) defines demo-only seed records, required labels, reset boundaries, and production-exclusion fixtures for the executable first-user stack.
 - [Phase 52.8 clean-host smoke skeleton](docs/deployment/clean-host-smoke-skeleton.md) defines the mocked/skipped `init -> up -> doctor -> seed-demo` fixture path and false-success rejection rules for the executable first-user stack.
+- [Phase 52.9 first-user stack overview](docs/deployment/first-user-stack.md) defines the few-command first-user path, troubleshooting links, pre-GA status, and authority boundary for the executable first-user stack.
 
 ## Product positioning
 
@@ -64,6 +65,8 @@ The Phase 52.6 first-user host preflight contract is defined by the [Phase 52.6 
 The Phase 52.7 first-user demo seed contract is defined by the [Phase 52.7 demo seed contract](docs/deployment/demo-seed-contract.md).
 
 The Phase 52.8 first-user clean-host smoke skeleton is defined by the [Phase 52.8 clean-host smoke skeleton](docs/deployment/clean-host-smoke-skeleton.md).
+
+The Phase 52.9 first-user stack overview is defined by the [Phase 52.9 first-user stack overview](docs/deployment/first-user-stack.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/first-user-stack.md
+++ b/docs/deployment/first-user-stack.md
@@ -1,0 +1,97 @@
+# Phase 52.9 First-User Stack Overview
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-52-1-cli-command-contract.md`, `docs/deployment/combined-dependency-matrix.md`, `docs/deployment/compose-generator-contract.md`, `docs/deployment/env-secrets-certs-contract.md`, `docs/deployment/host-preflight-contract.md`, `docs/deployment/demo-seed-contract.md`, `docs/deployment/clean-host-smoke-skeleton.md`, `docs/adr/0011-phase-51-1-replacement-boundary.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1063, #1064, #1065, #1068, #1069, #1070, #1071, #1072
+
+This overview is the operator-facing first-user path for the executable Phase 52 stack. It is workflow guidance only. It does not implement installer behavior, Wazuh product profiles, Shuffle product profiles, first-login UI, AI operations, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+## 1. Purpose and Status
+
+Phase 52.9 gives a first user one few-command path through setup, startup, readiness review, demo rehearsal, status inspection, browser access, log review, and shutdown.
+
+AegisOps remains pre-GA. The Phase 52 path is not self-service commercial readiness and is not GA readiness. It is a reviewed setup and rehearsal path that later Phase 53 and Phase 54 work must close for product profiles and operational completeness.
+
+The replacement boundary remains the Phase 51.1 boundary in `docs/adr/0011-phase-51-1-replacement-boundary.md`: AegisOps replaces the SMB operating experience and authoritative record chain above Wazuh and Shuffle, not Wazuh internals, Shuffle internals, or every SIEM/SOAR capability.
+
+## 2. Few-Command Path
+
+Run the first-user stack from a repository checkout with reviewed profile input and documented placeholders. Commands are shown at overview level; later executable issues own the concrete runtime implementation.
+
+| Step | Command | Operator intent | Expected outcome | Troubleshooting link |
+| --- | --- | --- | --- | --- |
+| 1 | `aegisops init --profile smb-single-node --runtime-env <runtime-env-file>` | Create or validate local first-user setup placeholders. | Runtime config placeholders are present and safe next actions are shown. | [Env, secrets, and certs](env-secrets-certs-contract.md). |
+| 2 | `aegisops up --profile smb-single-node --runtime-env <runtime-env-file>` | Start the reviewed stack components available for the selected profile. | Available components start or report explicit `skipped` or `mocked` prerequisites. | [Compose generation](compose-generator-contract.md). |
+| 3 | `aegisops doctor --profile smb-single-node --runtime-env <runtime-env-file>` | Check host prerequisites, profile binding, readiness, and boundary warnings. | Docker, Compose, RAM, disk, ports, `vm.max_map_count`, and profile validity are reported as setup evidence. | [Host preflight](host-preflight-contract.md). |
+| 4 | `aegisops seed-demo --profile smb-single-node --demo-mode explicit` | Seed reviewed demo-only records for workflow rehearsal. | Demo records are labeled as demo-only and not production truth. | [Demo seed separation](demo-seed-contract.md). |
+| 5 | `aegisops status --profile smb-single-node` | Inspect current local stack and first-user readiness. | Current setup state, skipped or mocked profile gaps, and safe next actions are shown. | [Host preflight](host-preflight-contract.md). |
+| 6 | `aegisops open --profile smb-single-node` | Print or open the reviewed operator access URL. | The reviewed access path is surfaced without using browser state as workflow truth. | [Compose generation](compose-generator-contract.md). |
+| 7 | `aegisops logs --selector <log-selector>` | Review bounded setup logs for the selected stack component. | Redacted, bounded logs are shown as evidence only. | [Env, secrets, and certs](env-secrets-certs-contract.md). |
+| 8 | `aegisops down --profile smb-single-node` | Stop managed local components without deleting operator-owned state. | Managed components stop or are already stopped, with retained state paths surfaced. | [Clean-host smoke skeleton](clean-host-smoke-skeleton.md). |
+
+## 3. Troubleshooting Index
+
+Use the scoped troubleshooting contracts before widening the investigation:
+
+- Host preflight failures: `docs/deployment/host-preflight-contract.md` covers missing Docker, missing Compose, low RAM, low disk, port conflicts, Linux `vm.max_map_count`, invalid profile identity, and safe next actions.
+- Env, secrets, and cert failures: `docs/deployment/env-secrets-certs-contract.md` covers runtime env files, generated config directories, ignored secret and cert paths, demo token posture, production TLS custody, and placeholder-secret rejection.
+- Compose generation failures: `docs/deployment/compose-generator-contract.md` covers generated Compose shape, proxy-only ingress, internal ports, manual-edit rejection, snapshot expectations, and subordinate Docker or Compose state.
+- Demo seed separation failures: `docs/deployment/demo-seed-contract.md` covers demo-only labels, fixture provenance, reset boundaries, production exclusion, and fake credential rejection.
+
+## 4. Authority Boundary
+
+First-user docs are operator guidance only. CLI output, generated config, demo data, Docker state, Docker Compose state, host preflight state, Wazuh state, Shuffle state, browser state, UI cache, AI output, tickets, logs, downstream receipts, or operator-facing summaries cannot become workflow truth, source truth, approval truth, execution truth, reconciliation truth, gate truth, release truth, production truth, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+This overview cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.
+
+## 5. Validation Rules
+
+Validation must fail closed when:
+
+- the first-user docs page is missing;
+- the README link is missing;
+- any required command is missing or out of order;
+- troubleshooting links for host preflight, env/secrets/certs, compose generation, or demo seed separation are missing;
+- the docs claim self-service commercial readiness, RC readiness, GA readiness, or production readiness;
+- demo state, CLI status, Docker state, Compose state, Wazuh state, Shuffle state, AI output, tickets, logs, downstream receipts, browser state, or UI cache is promoted to AegisOps workflow truth;
+- the Phase 51.1 replacement boundary and Phase 51.6 authority-boundary policy citations are missing; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders.
+
+## 6. Forbidden Claims
+
+- AegisOps is GA ready.
+- AegisOps is self-service commercial ready.
+- Phase 52 completes RC readiness.
+- Phase 52 completes GA readiness.
+- Demo data is workflow truth.
+- Demo data is production truth.
+- CLI status is workflow truth.
+- Docker status is AegisOps workflow truth.
+- Docker Compose status is AegisOps workflow truth.
+- Wazuh state is AegisOps workflow truth.
+- Shuffle state is AegisOps workflow truth.
+- AI output is AegisOps workflow truth.
+- Tickets are AegisOps workflow truth.
+- Logs are authoritative workflow truth.
+- This overview implements Wazuh product profiles.
+- This overview implements Shuffle product profiles.
+
+## 7. Validation
+
+Run `bash scripts/verify-phase-52-9-first-user-stack-docs.sh`.
+
+Run `bash scripts/test-verify-phase-52-9-first-user-stack-docs.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1072 --config <supervisor-config-path>`.
+
+The verifier must fail when first-user docs are missing, when the few-command path omits a command, when troubleshooting links are absent, when Phase 52 is described as self-service commercial, RC, or GA readiness, when demo data or CLI status is promoted to workflow truth, when Phase 51 boundary citations are missing, or when publishable guidance uses workstation-local absolute paths.
+
+## 8. Non-Goals
+
+- No Phase 52 runtime behavior is implemented by this overview.
+- No Wazuh product profile, Shuffle product profile, guided first-login UI, AI operation, RC behavior, GA behavior, production supportability, or commercial launch claim is approved here.
+- No CLI output, generated config, demo data, Docker state, Docker Compose state, host preflight output, Wazuh state, Shuffle state, AI output, ticket, log text, downstream receipt, browser state, UI cache, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-52-9-first-user-stack-docs.sh
+++ b/scripts/test-verify-phase-52-9-first-user-stack-docs.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-9-first-user-stack-docs.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment"
+  printf '%s\n' "# AegisOps" "See [Phase 52.9 first-user stack docs](docs/deployment/first-user-stack.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/first-user-stack.md" \
+    "${target}/docs/deployment/first-user-stack.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/first-user-stack.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/deployment/first-user-stack.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 52.9 first-user stack docs"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 52.9 first-user stack docs."
+
+missing_command_repo="${workdir}/missing-command"
+create_valid_repo "${missing_command_repo}"
+remove_text_from_doc "${missing_command_repo}" \
+  "| 4 | \`aegisops seed-demo --profile smb-single-node --demo-mode explicit\` | Seed reviewed demo-only records for workflow rehearsal. | Demo records are labeled as demo-only and not production truth. | [Demo seed separation](demo-seed-contract.md). |"
+assert_fails_with \
+  "${missing_command_repo}" \
+  "Missing complete Phase 52.9 first-user command row: seed-demo"
+
+missing_troubleshooting_repo="${workdir}/missing-troubleshooting"
+create_valid_repo "${missing_troubleshooting_repo}"
+remove_text_from_doc "${missing_troubleshooting_repo}" \
+  "Demo seed separation failures: \`docs/deployment/demo-seed-contract.md\` covers demo-only labels, fixture provenance, reset boundaries, production exclusion, and fake credential rejection."
+assert_fails_with \
+  "${missing_troubleshooting_repo}" \
+  "Missing Phase 52.9 first-user stack docs statement: Demo seed separation failures"
+
+missing_phase51_boundary_repo="${workdir}/missing-phase51-boundary"
+create_valid_repo "${missing_phase51_boundary_repo}"
+remove_text_from_doc "${missing_phase51_boundary_repo}" \
+  "The replacement boundary remains the Phase 51.1 boundary in \`docs/adr/0011-phase-51-1-replacement-boundary.md\`: AegisOps replaces the SMB operating experience and authoritative record chain above Wazuh and Shuffle, not Wazuh internals, Shuffle internals, or every SIEM/SOAR capability."
+assert_fails_with \
+  "${missing_phase51_boundary_repo}" \
+  "Missing Phase 52.9 first-user stack docs statement: The replacement boundary remains the Phase 51.1 boundary"
+
+self_service_claim_repo="${workdir}/self-service-claim"
+create_valid_repo "${self_service_claim_repo}"
+printf '%s\n' "AegisOps is self-service commercial ready." \
+  >>"${self_service_claim_repo}/docs/deployment/first-user-stack.md"
+assert_fails_with \
+  "${self_service_claim_repo}" \
+  "Forbidden Phase 52.9 first-user stack docs claim: AegisOps is self-service commercial ready"
+
+ga_claim_repo="${workdir}/ga-claim"
+create_valid_repo "${ga_claim_repo}"
+printf '%s\n' "Phase 52 completes GA readiness." \
+  >>"${ga_claim_repo}/docs/deployment/first-user-stack.md"
+assert_fails_with \
+  "${ga_claim_repo}" \
+  "Forbidden Phase 52.9 first-user stack docs claim: Phase 52 completes GA readiness"
+
+authority_claim_repo="${workdir}/authority-claim"
+create_valid_repo "${authority_claim_repo}"
+printf '%s\n' "CLI status is workflow truth." \
+  >>"${authority_claim_repo}/docs/deployment/first-user-stack.md"
+assert_fails_with \
+  "${authority_claim_repo}" \
+  "Forbidden Phase 52.9 first-user stack docs claim: CLI status is workflow truth"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/first-user-stack.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.9 first-user stack docs: workstation-local absolute path detected"
+
+echo "Phase 52.9 first-user stack docs negative and valid checks passed."

--- a/scripts/verify-phase-52-9-first-user-stack-docs.sh
+++ b/scripts/verify-phase-52-9-first-user-stack-docs.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/first-user-stack.md"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 52.9 First-User Stack Overview"
+  "## 1. Purpose and Status"
+  "## 2. Few-Command Path"
+  "## 3. Troubleshooting Index"
+  "## 4. Authority Boundary"
+  "## 5. Validation Rules"
+  "## 6. Forbidden Claims"
+  "## 7. Validation"
+  "## 8. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1063, #1064, #1065, #1068, #1069, #1070, #1071, #1072"
+  "This overview is the operator-facing first-user path for the executable Phase 52 stack."
+  "AegisOps remains pre-GA."
+  "The Phase 52 path is not self-service commercial readiness and is not GA readiness."
+  'The replacement boundary remains the Phase 51.1 boundary in `docs/adr/0011-phase-51-1-replacement-boundary.md`'
+  "| Step | Command | Operator intent | Expected outcome | Troubleshooting link |"
+  'Host preflight failures: `docs/deployment/host-preflight-contract.md`'
+  'Env, secrets, and cert failures: `docs/deployment/env-secrets-certs-contract.md`'
+  'Compose generation failures: `docs/deployment/compose-generator-contract.md`'
+  'Demo seed separation failures: `docs/deployment/demo-seed-contract.md`'
+  "First-user docs are operator guidance only."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  'This overview cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.'
+  'Run `bash scripts/verify-phase-52-9-first-user-stack-docs.sh`.'
+  'Run `bash scripts/test-verify-phase-52-9-first-user-stack-docs.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1072 --config <supervisor-config-path>`.'
+)
+
+commands=(
+  "init"
+  "up"
+  "doctor"
+  "seed-demo"
+  "status"
+  "open"
+  "logs"
+  "down"
+)
+
+troubleshooting_targets=(
+  "env-secrets-certs-contract.md"
+  "compose-generator-contract.md"
+  "host-preflight-contract.md"
+  "demo-seed-contract.md"
+  "clean-host-smoke-skeleton.md"
+)
+
+forbidden_claims=(
+  "AegisOps is GA ready"
+  "AegisOps is self-service commercial ready"
+  "Phase 52 completes RC readiness"
+  "Phase 52 completes GA readiness"
+  "Demo data is workflow truth"
+  "Demo data is production truth"
+  "CLI status is workflow truth"
+  "Docker status is AegisOps workflow truth"
+  "Docker Compose status is AegisOps workflow truth"
+  "Wazuh state is AegisOps workflow truth"
+  "Shuffle state is AegisOps workflow truth"
+  "AI output is AegisOps workflow truth"
+  "Tickets are AegisOps workflow truth"
+  "Logs are authoritative workflow truth"
+  "This overview implements Wazuh product profiles"
+  "This overview implements Shuffle product profiles"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.9 first-user stack docs: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.9 first-user stack docs heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.9 first-user stack docs statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for index in "${!commands[@]}"; do
+  step=$((index + 1))
+  command="${commands[$index]}"
+  if ! grep -Eq "^\\| ${step} \\| \`aegisops ${command}([[:space:]][^\`]+)?\` \\| [^|]+ \\| [^|]+ \\| \\[[^]]+\\]\\([^)]*\\.md\\)\\. \\|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 52.9 first-user command row: ${command}" >&2
+    exit 1
+  fi
+done
+
+for target in "${troubleshooting_targets[@]}"; do
+  if ! grep -Fq -- "${target}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.9 troubleshooting link: ${target}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 6\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+contains_readiness_overclaim() {
+  awk '
+    /^## 6\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    {
+      line = tolower($0)
+      negative_context = line ~ /(not|cannot|must not|fail|fails|invalid|rejected|forbidden|non-goal|no |claim|described as|promoted to)/
+      if (!in_forbidden_claims && !negative_context && line ~ /(self-service commercial ready|self-service commercial readiness|ga ready|ga readiness|rc readiness|production readiness)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${doc_rendered_markdown}"
+}
+
+contains_authority_promotion() {
+  awk '
+    /^## 6\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    {
+      line = tolower($0)
+      negative_context = line ~ /(not|cannot|must not|fail|fails|invalid|rejected|forbidden|non-goal|no |claim|described as|promoted to)/
+      if (!in_forbidden_claims && !negative_context && line ~ /(demo data|cli status|docker status|docker compose status|wazuh state|shuffle state|ai output|tickets|logs).*(workflow truth|production truth|authoritative workflow truth|aegisops workflow truth)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${doc_rendered_markdown}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.9 first-user stack docs claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if contains_readiness_overclaim; then
+  echo "Forbidden Phase 52.9 first-user stack docs claim: readiness overclaim" >&2
+  exit 1
+fi
+
+if contains_authority_promotion; then
+  echo "Forbidden Phase 52.9 first-user stack docs claim: subordinate state promoted to workflow truth" >&2
+  exit 1
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.9 first-user stack docs: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 52.9 first-user stack docs link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/first-user-stack\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 52.9 first-user stack docs." >&2
+  exit 1
+fi
+
+echo "Phase 52.9 first-user stack docs preserve the few-command path, troubleshooting links, pre-GA status, Phase 51 citations, and authority boundaries."


### PR DESCRIPTION
## Summary
- Add Phase 52.9 first-user stack overview at `docs/deployment/first-user-stack.md` covering init, up, doctor, seed-demo, status, open, logs, and down.
- Link troubleshooting for host preflight, env/secrets/certs, compose generation, demo seed separation, and clean-host smoke guidance.
- Add focused verifier and negative harness for pre-GA status, Phase 51 citations, authority boundary, troubleshooting links, and workstation-local path hygiene.

## Verification
- `test -f scripts/verify-phase-52-9-first-user-stack-docs.sh` reproduced the initial missing-verifier failure.
- `bash scripts/verify-phase-52-9-first-user-stack-docs.sh`
- `bash scripts/test-verify-phase-52-9-first-user-stack-docs.sh`
- `for script in scripts/verify-phase-52-{1-cli-command-contract,2-smb-single-node-profile-model,3-combined-dependency-matrix,4-compose-generator-contract,5-env-secrets-certs-contract,6-host-preflight-contract,7-demo-seed-contract,8-clean-host-smoke-skeleton,9-first-user-stack-docs}.sh; do bash "$script"; done`
- `node dist/index.js issue-lint 1072 --config supervisor.config.aegisops.coderabbit.json` from `<codex-supervisor-root>`

## Remaining blockers
- Phase 53/54 still need to close product profile/setup blockers before the first-user stack can claim product-profile completeness or commercial readiness.

Closes #1072