### PR TITLE
Phase 52.5.1 control-plane layout inventory contract

### DIFF
--- a/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
+++ b/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
@@ -1,0 +1,171 @@
+# ADR-0012: Phase 52.5.1 Control-Plane Layout Inventory and Migration Contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/repository-structure-baseline.md`
+- **Product**: AegisOps
+- **Related Issues**: #1084, #1085
+- **Depends On**: #1073
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+---
+
+## 1. Purpose
+
+Phase 52.5.1 records the current `control-plane/aegisops_control_plane/` Python package layout before any package moves happen.
+
+The inventory assigns every current Python file in the package to a target package family so later child issues can move modules deliberately instead of inferring ownership from filename shape or nearby metadata.
+
+This contract is documentation and verification only.
+
+## 2. Authority Boundary
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, and operator-facing text remain subordinate context.
+
+The layout inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, or action-execution behavior.
+
+## 3. Target Package Families
+
+| Family | Target responsibility |
+| --- | --- |
+| `core` | Authoritative record model, persistence, lifecycle-neutral service composition, validation, and shared control-plane primitives. |
+| `api` | HTTP, protected surface, CLI, and other public process entry surfaces. |
+| `runtime` | Startup, configuration, readiness, restore, runtime boundary, operations, and runtime diagnostics. |
+| `ingestion` | Detection and alert intake lifecycle modules before records become broader workflow state. |
+| `actions` | Action policy, action lifecycle writes, delegation, receipts, reconciliation, and execution coordination. |
+| `actions.review` | Reviewed action queue, chain, projection, visibility, inspection, path health, and write surfaces. |
+| `evidence` | Evidence linkage, external evidence boundaries, and evidence facade modules. |
+| `assistant` | Assistant context, advisory, provider, AI trace, and live assistant workflow modules. |
+| `ml_shadow` | Reviewed ML shadow-mode datasets, scoring, registry, and drift visibility modules. |
+| `reporting` | Audit export, pilot reporting, and operator inspection surfaces that summarize authoritative state. |
+| `adapters` | Substrate adapters for Wazuh, Shuffle, n8n, OpenSearch, PostgreSQL, osquery, MISP, executors, and endpoint evidence. |
+
+## 4. Module Inventory
+
+| Module | Target family | Migration contract |
+| --- | --- | --- |
+| `__init__.py` | `core` | Keep the public package marker stable while compatibility shims exist. |
+| `action_lifecycle_write_coordinator.py` | `actions` | Move only with action lifecycle write ownership and atomic durable write tests. |
+| `action_policy.py` | `actions` | Move only with reviewed action policy caller evidence and unchanged fail-closed decisions. |
+| `action_receipt_validation.py` | `actions` | Move only with receipt validation ownership and rejected-receipt state-cleanliness tests. |
+| `action_reconciliation_orchestration.py` | `actions` | Move only with direct reconciliation linkage and snapshot-consistent read guarantees. |
+| `action_review_chain.py` | `actions.review` | Move only with reviewed action chain authority and legacy import coverage. |
+| `action_review_coordination.py` | `actions.review` | Move only with reviewed action coordination ownership and queue-state regression tests. |
+| `action_review_index.py` | `actions.review` | Move only with reviewed index ownership and authoritative record selection tests. |
+| `action_review_inspection.py` | `actions.review` | Move only with reviewed inspection ownership and direct-link context constraints. |
+| `action_review_path_health.py` | `actions.review` | Move only with reviewed path health ownership and fail-closed missing-signal tests. |
+| `action_review_projection.py` | `actions.review` | Move only with reviewed projection derivation tests from authoritative records. |
+| `action_review_timeline.py` | `actions.review` | Move only with reviewed timeline derivation and no timeline-as-truth regression tests. |
+| `action_review_visibility.py` | `actions.review` | Move only with reviewed visibility ownership and scope-boundary tests. |
+| `action_review_write_surface.py` | `actions.review` | Move only with reviewed write-surface ownership and atomic write tests. |
+| `adapters/__init__.py` | `adapters` | Keep adapter package marker stable while adapter imports transition. |
+| `adapters/endpoint_evidence.py` | `adapters` | Move only within adapter family while endpoint evidence remains subordinate. |
+| `adapters/executor.py` | `adapters` | Move only within adapter family while execution authority remains in control-plane records. |
+| `adapters/misp.py` | `adapters` | Move only within adapter family while MISP evidence remains subordinate. |
+| `adapters/n8n.py` | `adapters` | Move only within adapter family while n8n remains a routine automation substrate. |
+| `adapters/opensearch.py` | `adapters` | Move only within adapter family while OpenSearch remains a substrate, not authority. |
+| `adapters/osquery.py` | `adapters` | Move only within adapter family while endpoint evidence remains subordinate. |
+| `adapters/postgres.py` | `adapters` | Move only within adapter family with unchanged persistence semantics. |
+| `adapters/shuffle.py` | `adapters` | Move only within adapter family while Shuffle remains subordinate execution context. |
+| `adapters/wazuh.py` | `adapters` | Move only within adapter family while Wazuh remains subordinate detection context. |
+| `ai_trace_lifecycle.py` | `assistant` | Move only with assistant trace lifecycle ownership and subordinate-output checks. |
+| `assistant_advisory.py` | `assistant` | Move only with advisory ownership and no advisory-as-authority regression tests. |
+| `assistant_context.py` | `assistant` | Move only with direct anchored-context read rules. |
+| `assistant_provider.py` | `assistant` | Move only with provider boundary ownership and no placeholder credential acceptance. |
+| `audit_export.py` | `reporting` | Move only with export snapshot consistency and no partial durable write on failure. |
+| `case_workflow.py` | `core` | Move only with authoritative case workflow ownership and lifecycle state tests. |
+| `cli.py` | `api` | Move only after CLI import compatibility and command behavior are preserved. |
+| `config.py` | `runtime` | Move only with runtime config ownership and no sample secret acceptance. |
+| `detection_lifecycle.py` | `ingestion` | Move only with detection lifecycle authority and lifecycle transition tests. |
+| `detection_lifecycle_helpers.py` | `ingestion` | Move only with detection helper ownership and unchanged authoritative selection rules. |
+| `detection_native_context.py` | `ingestion` | Move only with native detection context ownership and provenance tests. |
+| `entrypoint_support.py` | `runtime` | Move only with startup entrypoint ownership and unchanged boot semantics. |
+| `evidence_linkage.py` | `evidence` | Move only with evidence linkage ownership and direct-link constraints. |
+| `execution_coordinator.py` | `actions` | Move only with execution coordination ownership and authoritative receipt linkage. |
+| `execution_coordinator_action_requests.py` | `actions` | Move only with action request ownership and fail-closed scope tests. |
+| `execution_coordinator_delegation.py` | `actions` | Move only with delegation ownership and no substrate-as-authority regression. |
+| `execution_coordinator_reconciliation.py` | `actions` | Move only with reconciliation ownership and snapshot-consistent read tests. |
+| `external_evidence_boundary.py` | `evidence` | Move only with external evidence boundary ownership and subordinate evidence checks. |
+| `external_evidence_endpoint.py` | `api` | Move only with endpoint routing ownership and unchanged protected-surface behavior. |
+| `external_evidence_facade.py` | `evidence` | Move only with evidence facade compatibility and legacy import shims. |
+| `external_evidence_misp.py` | `evidence` | Move only with MISP evidence ownership and no broadened lineage inference. |
+| `external_evidence_osquery.py` | `evidence` | Move only with osquery evidence ownership and no endpoint evidence authority drift. |
+| `http_protected_surface.py` | `api` | Move only with protected HTTP surface ownership and trusted-boundary tests. |
+| `http_runtime_surface.py` | `api` | Move only with runtime HTTP surface ownership and unchanged readiness behavior. |
+| `http_surface.py` | `api` | Move only with public HTTP surface ownership and route compatibility tests. |
+| `live_assistant_workflow.py` | `assistant` | Move only with live assistant workflow ownership and subordinate output checks. |
+| `models.py` | `core` | Move only with authoritative model import compatibility and schema regression tests. |
+| `operations.py` | `runtime` | Move only with operations boundary ownership and unchanged operator command behavior. |
+| `operator_inspection.py` | `reporting` | Move only with operator inspection derivation tests from authoritative records. |
+| `persistence_lifecycle.py` | `core` | Move only with persistence lifecycle ownership and all-or-nothing mutation tests. |
+| `phase29_evidently_drift_visibility.py` | `ml_shadow` | Move only with ML shadow drift visibility ownership and subordinate ML posture. |
+| `phase29_mlflow_shadow_model_registry.py` | `ml_shadow` | Move only with shadow registry ownership and no model-as-authority regression. |
+| `phase29_shadow_dataset.py` | `ml_shadow` | Move only with shadow dataset ownership and reviewed dataset lineage checks. |
+| `phase29_shadow_scoring.py` | `ml_shadow` | Move only with shadow scoring ownership and subordinate recommendation checks. |
+| `pilot_reporting_export.py` | `reporting` | Move only with pilot reporting ownership and snapshot-consistent export tests. |
+| `publishable_paths.py` | `core` | Move only with publishable path hygiene ownership and workstation-local path tests. |
+| `readiness_contracts.py` | `runtime` | Move only with readiness contract ownership and unchanged fail-closed readiness checks. |
+| `readiness_operability.py` | `runtime` | Move only with readiness operability ownership and no status-as-truth drift. |
+| `record_validation.py` | `core` | Move only with authoritative record validation ownership and malformed input tests. |
+| `restore_readiness.py` | `runtime` | Move only with restore readiness ownership and clean failed-restore state tests. |
+| `restore_readiness_backup_restore.py` | `runtime` | Move only with backup/restore ownership and all-or-nothing restore tests. |
+| `restore_readiness_projection.py` | `runtime` | Move only with restore projection derivation tests from authoritative state. |
+| `reviewed_slice_policy.py` | `core` | Move only with reviewed-slice policy ownership and direct scope binding tests. |
+| `runtime_boundary.py` | `runtime` | Move only with runtime trust boundary ownership and untrusted-header tests. |
+| `runtime_restore_readiness_diagnostics.py` | `runtime` | Move only with diagnostics ownership and no mixed-snapshot aggregation. |
+| `service.py` | `core` | Keep the public facade import path stable until facade compatibility policy is superseded. |
+| `service_composition.py` | `core` | Move only with service composition ownership and unchanged facade construction. |
+| `service_snapshots.py` | `core` | Move only with snapshot ownership and snapshot-consistent read tests. |
+| `structured_events.py` | `core` | Move only with structured event ownership and unchanged event payload semantics. |
+
+## 5. Compatibility Shim Expectations
+
+The public Python package name `aegisops_control_plane` remains unchanged throughout Phase 52.5.1 and later child issues unless a later accepted ADR explicitly approves a rename.
+
+The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.
+
+Legacy import paths remain available during migration through compatibility shims or direct re-export modules until all documented internal, CLI, HTTP, test, and operator callers have migrated.
+
+Removing a legacy import path requires a later transition policy that lists the affected import path, replacement import path, caller evidence, deprecation window, focused regression test, and rollback path.
+
+Compatibility shims must be narrow: they may re-export or delegate to the new owner, but they must not make Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, projections, summaries, or adapter state authoritative.
+
+If caller evidence is incomplete, malformed, or ambiguous, the old import path stays available.
+
+## 6. Deferred Renames
+
+The public package rename is deferred because external and internal callers currently import `aegisops_control_plane`, and renaming it before compatibility evidence would create avoidable runtime and test breakage.
+
+The outer directory rename is deferred because `control-plane/` is already the approved repository-structure baseline for live control-plane code and must stay distinct from `postgres/control-plane/` persistence-contract assets.
+
+Phase 52.5.1 does not approve production module moves, import rewrites, package renames, directory renames, Wazuh profile work, Shuffle profile work, runtime behavior changes, deployment behavior changes, or authority-boundary changes.
+
+## 7. Forbidden Claims
+
+The verifier rejects this contract if it asserts any of these claims outside this section:
+
+- This contract changes runtime behavior.
+- This contract implements Wazuh product profiles.
+- This contract implements Shuffle product profiles.
+- Legacy imports may be removed immediately.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`.
+
+Run `bash scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1085 --config <supervisor-config-path>`.
+
+## 9. Non-Goals
+
+- No production module is moved.
+- No production import path is changed.
+- No public package name is changed.
+- No outer repository directory is changed.
+- No runtime behavior, HTTP behavior, CLI behavior, deployment behavior, Wazuh behavior, Shuffle behavior, ticket behavior, assistant behavior, evidence behavior, ML behavior, reporting behavior, backup behavior, restore behavior, readiness behavior, or durable-state side effect is changed.
+- No subordinate source becomes authoritative workflow truth.

--- a/scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
+++ b/scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh"
+contract_path="docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/adr" "${target}/control-plane"
+  cp "${repo_root}/${contract_path}" "${target}/${contract_path}"
+  cp -R "${repo_root}/control-plane/aegisops_control_plane" \
+    "${target}/control-plane/aegisops_control_plane"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/${contract_path}"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+unclassified_repo="${workdir}/unclassified-module"
+create_valid_repo "${unclassified_repo}"
+printf '%s\n' "\"\"\"Fixture module intentionally missing from the layout inventory.\"\"\"" \
+  >"${unclassified_repo}/control-plane/aegisops_control_plane/new_unclassified_module.py"
+assert_fails_with \
+  "${unclassified_repo}" \
+  "Phase 52.5.1 layout inventory is missing module rows: new_unclassified_module.py"
+
+behavior_change_repo="${workdir}/behavior-change-claim"
+create_valid_repo "${behavior_change_repo}"
+printf '%s\n' "This contract changes runtime behavior." \
+  >>"${behavior_change_repo}/${contract_path}"
+assert_fails_with \
+  "${behavior_change_repo}" \
+  "Forbidden Phase 52.5.1 layout contract claim: This contract changes runtime behavior."
+
+wazuh_profile_repo="${workdir}/wazuh-profile-claim"
+create_valid_repo "${wazuh_profile_repo}"
+printf '%s\n' "This contract implements Wazuh product profiles." \
+  >>"${wazuh_profile_repo}/${contract_path}"
+assert_fails_with \
+  "${wazuh_profile_repo}" \
+  "Forbidden Phase 52.5.1 layout contract claim: This contract implements Wazuh product profiles."
+
+shuffle_profile_repo="${workdir}/shuffle-profile-claim"
+create_valid_repo "${shuffle_profile_repo}"
+printf '%s\n' "This contract implements Shuffle product profiles." \
+  >>"${shuffle_profile_repo}/${contract_path}"
+assert_fails_with \
+  "${shuffle_profile_repo}" \
+  "Forbidden Phase 52.5.1 layout contract claim: This contract implements Shuffle product profiles."
+
+legacy_import_removal_repo="${workdir}/legacy-import-removal"
+create_valid_repo "${legacy_import_removal_repo}"
+printf '%s\n' "Legacy imports may be removed immediately." \
+  >>"${legacy_import_removal_repo}/${contract_path}"
+assert_fails_with \
+  "${legacy_import_removal_repo}" \
+  "Forbidden Phase 52.5.1 layout contract claim: Legacy imports may be removed immediately."
+
+missing_transition_policy_repo="${workdir}/missing-transition-policy"
+create_valid_repo "${missing_transition_policy_repo}"
+remove_text_from_contract "${missing_transition_policy_repo}" \
+  "Removing a legacy import path requires a later transition policy that lists the affected import path, replacement import path, caller evidence, deprecation window, focused regression test, and rollback path."
+assert_fails_with \
+  "${missing_transition_policy_repo}" \
+  "Missing Phase 52.5.1 layout contract statement: Removing a legacy import path requires a later transition policy"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/${contract_path}"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.5.1 layout contract: workstation-local absolute path detected"
+
+echo "Phase 52.5.1 control-plane layout inventory verifier negative and valid fixtures passed."

--- a/scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
+++ b/scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
@@ -77,6 +77,25 @@ assert_fails_with \
   "${behavior_change_repo}" \
   "Forbidden Phase 52.5.1 layout contract claim: This contract changes runtime behavior."
 
+fenced_behavior_change_repo="${workdir}/fenced-behavior-change-claim"
+create_valid_repo "${fenced_behavior_change_repo}"
+{
+  printf '%s\n' '```'
+  printf '%s\n' "This contract changes runtime behavior."
+  printf '%s\n' '```'
+} >>"${fenced_behavior_change_repo}/${contract_path}"
+assert_fails_with \
+  "${fenced_behavior_change_repo}" \
+  "Forbidden Phase 52.5.1 layout contract claim: This contract changes runtime behavior."
+
+commented_behavior_change_repo="${workdir}/commented-behavior-change-claim"
+create_valid_repo "${commented_behavior_change_repo}"
+printf '%s\n' "<!-- This contract changes runtime behavior. -->" \
+  >>"${commented_behavior_change_repo}/${contract_path}"
+assert_fails_with \
+  "${commented_behavior_change_repo}" \
+  "Forbidden Phase 52.5.1 layout contract claim: This contract changes runtime behavior."
+
 wazuh_profile_repo="${workdir}/wazuh-profile-claim"
 create_valid_repo "${wazuh_profile_repo}"
 printf '%s\n' "This contract implements Wazuh product profiles." \

--- a/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
+++ b/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
@@ -88,6 +88,7 @@ fi
 doc_rendered_markdown="$(
   rendered_markdown_without_code_blocks "${doc_path}"
 )"
+doc_raw_markdown="$(cat "${doc_path}")"
 
 for heading in "${required_headings[@]}"; do
   if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
@@ -105,6 +106,7 @@ done
 
 contains_forbidden_outside_forbidden_section() {
   local claim="$1"
+  local markdown="$2"
 
   awk -v claim="${claim}" '
     BEGIN { claim_lower = tolower(claim) }
@@ -112,11 +114,11 @@ contains_forbidden_outside_forbidden_section() {
     /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
     !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
     END { exit(found ? 0 : 1) }
-  ' <<<"${doc_rendered_markdown}"
+  ' <<<"${markdown}"
 }
 
 for claim in "${forbidden_claims[@]}"; do
-  if contains_forbidden_outside_forbidden_section "${claim}"; then
+  if contains_forbidden_outside_forbidden_section "${claim}" "${doc_raw_markdown}"; then
     echo "Forbidden Phase 52.5.1 layout contract claim: ${claim}" >&2
     exit 1
   fi

--- a/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
+++ b/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md"
+package_root="${repo_root}/control-plane/aegisops_control_plane"
+
+required_headings=(
+  "# ADR-0012: Phase 52.5.1 Control-Plane Layout Inventory and Migration Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Target Package Families"
+  "## 4. Module Inventory"
+  "## 5. Compatibility Shim Expectations"
+  "## 6. Deferred Renames"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1084, #1085"
+  "- **Depends On**: #1073"
+  "This contract is documentation and verification only."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  "Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, and operator-facing text remain subordinate context."
+  "The layout inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, or action-execution behavior."
+  'The public Python package name `aegisops_control_plane` remains unchanged throughout Phase 52.5.1 and later child issues unless a later accepted ADR explicitly approves a rename.'
+  'The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.'
+  "Legacy import paths remain available during migration through compatibility shims or direct re-export modules until all documented internal, CLI, HTTP, test, and operator callers have migrated."
+  "Removing a legacy import path requires a later transition policy that lists the affected import path, replacement import path, caller evidence, deprecation window, focused regression test, and rollback path."
+  "If caller evidence is incomplete, malformed, or ambiguous, the old import path stays available."
+  "Phase 52.5.1 does not approve production module moves, import rewrites, package renames, directory renames, Wazuh profile work, Shuffle profile work, runtime behavior changes, deployment behavior changes, or authority-boundary changes."
+  'Run `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1085 --config <supervisor-config-path>`.'
+)
+
+allowed_families=(
+  "core"
+  "api"
+  "runtime"
+  "ingestion"
+  "actions"
+  "actions.review"
+  "evidence"
+  "assistant"
+  "ml_shadow"
+  "reporting"
+  "adapters"
+)
+
+forbidden_claims=(
+  "This contract changes runtime behavior."
+  "This contract implements Wazuh product profiles."
+  "This contract implements Shuffle product profiles."
+  "Legacy imports may be removed immediately."
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.5.1 control-plane layout inventory contract: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${package_root}" ]]; then
+  echo "Missing control-plane package root: ${package_root}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.5.1 layout contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.5.1 layout contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${doc_rendered_markdown}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 52.5.1 layout contract claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.5.1 layout contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+allowed_pattern="$(printf '%s\n' "${allowed_families[@]}" | paste -sd '|' -)"
+
+export PHASE52_5_1_DOC_PATH="${doc_path}"
+export PHASE52_5_1_PACKAGE_ROOT="${package_root}"
+export PHASE52_5_1_ALLOWED_PATTERN="${allowed_pattern}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import sys
+
+doc_path = pathlib.Path(os.environ["PHASE52_5_1_DOC_PATH"])
+package_root = pathlib.Path(os.environ["PHASE52_5_1_PACKAGE_ROOT"])
+allowed = frozenset(os.environ["PHASE52_5_1_ALLOWED_PATTERN"].split("|"))
+
+doc_text = doc_path.read_text(encoding="utf-8")
+row_pattern = re.compile(
+    r"^\| `(?P<module>[^`]+\.py)` \| `(?P<family>[^`]+)` \| (?P<contract>[^|][^|]*) \|$",
+    re.MULTILINE,
+)
+
+rows: dict[str, str] = {}
+duplicates: set[str] = set()
+invalid_families: list[str] = []
+empty_contracts: list[str] = []
+for match in row_pattern.finditer(doc_text):
+    module = match.group("module")
+    family = match.group("family").strip()
+    contract = match.group("contract").strip()
+    if module in rows:
+        duplicates.add(module)
+    rows[module] = family
+    if family not in allowed:
+        invalid_families.append(f"{module}: {family}")
+    if not contract:
+        empty_contracts.append(module)
+
+actual_modules = sorted(
+    path.relative_to(package_root).as_posix()
+    for path in package_root.rglob("*.py")
+    if path.is_file()
+)
+
+if duplicates:
+    print(
+        "Phase 52.5.1 layout inventory has duplicate module rows: "
+        + ", ".join(sorted(duplicates)),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+missing = [module for module in actual_modules if module not in rows]
+extra = sorted(set(rows) - set(actual_modules))
+if missing:
+    print(
+        "Phase 52.5.1 layout inventory is missing module rows: "
+        + ", ".join(missing),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if extra:
+    print(
+        "Phase 52.5.1 layout inventory lists modules not present under control-plane/aegisops_control_plane: "
+        + ", ".join(extra),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if invalid_families:
+    print(
+        "Phase 52.5.1 layout inventory uses unsupported target families: "
+        + "; ".join(invalid_families),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if empty_contracts:
+    print(
+        "Phase 52.5.1 layout inventory has empty migration contract rows: "
+        + ", ".join(empty_contracts),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+missing_families = sorted(allowed - set(rows.values()))
+if missing_families:
+    print(
+        "Phase 52.5.1 layout inventory does not use required target families: "
+        + ", ".join(missing_families),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(
+    "Phase 52.5.1 control-plane layout inventory classifies "
+    f"{len(actual_modules)} current Python files across "
+    f"{len(allowed)} target package families and records migration compatibility policy."
+)
+PY


### PR DESCRIPTION
## Summary
- add ADR-0012 for the Phase 52.5.1 control-plane package layout inventory and migration contract
- classify all 73 current Python files under `control-plane/aegisops_control_plane/` across the approved target package families
- add a verifier plus negative fixtures for unclassified modules, forbidden behavior/profile claims, legacy import removal without a transition policy, and workstation-local absolute paths

## Verification
- `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`
- `bash scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `git diff --check`
- `node dist/index.js issue-lint 1085 --config supervisor.config.aegisops.coderabbit.json` from `<codex-supervisor-root>`

## Follow-up blockers
- no production module move is approved until later child issues provide caller evidence and compatibility-shim coverage
- public package rename and outer `control-plane/` directory rename remain deferred unless a later accepted ADR approves them
- Wazuh and Shuffle product-profile implementation remains out of scope for this contract

Part of #1084
Closes #1085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an ADR documenting the control-plane package layout, module inventory, authority boundaries, and migration contracts with explicit validation rules and non-goals.

* **Tests**
  * Added verification scripts and fixtures that validate the ADR and module inventory, asserting required policy text, forbidding disallowed claims/paths, and ensuring ADR/module consistency and regression checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->