### PR TITLE
Phase 52.5.2 package scaffold compatibility guardrails

### DIFF
--- a/control-plane/aegisops_control_plane/actions/__init__.py
+++ b/control-plane/aegisops_control_plane/actions/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future action lifecycle modules."""

--- a/control-plane/aegisops_control_plane/actions/review/__init__.py
+++ b/control-plane/aegisops_control_plane/actions/review/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future reviewed-action modules."""

--- a/control-plane/aegisops_control_plane/api/__init__.py
+++ b/control-plane/aegisops_control_plane/api/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future API and entry-surface modules."""

--- a/control-plane/aegisops_control_plane/assistant/__init__.py
+++ b/control-plane/aegisops_control_plane/assistant/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future assistant modules."""

--- a/control-plane/aegisops_control_plane/core/__init__.py
+++ b/control-plane/aegisops_control_plane/core/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future core control-plane modules."""

--- a/control-plane/aegisops_control_plane/evidence/__init__.py
+++ b/control-plane/aegisops_control_plane/evidence/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future evidence boundary modules."""

--- a/control-plane/aegisops_control_plane/ingestion/__init__.py
+++ b/control-plane/aegisops_control_plane/ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future ingestion lifecycle modules."""

--- a/control-plane/aegisops_control_plane/ml_shadow/__init__.py
+++ b/control-plane/aegisops_control_plane/ml_shadow/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future reviewed ML shadow-mode modules."""

--- a/control-plane/aegisops_control_plane/reporting/__init__.py
+++ b/control-plane/aegisops_control_plane/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future reporting and inspection modules."""

--- a/control-plane/aegisops_control_plane/runtime/__init__.py
+++ b/control-plane/aegisops_control_plane/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Package scaffold only for future runtime and readiness modules."""

--- a/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
+++ b/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
@@ -49,6 +49,8 @@ The layout inventory does not change authorization, provenance, reconciliation, 
 | Module | Target family | Migration contract |
 | --- | --- | --- |
 | `__init__.py` | `core` | Keep the public package marker stable while compatibility shims exist. |
+| `actions/__init__.py` | `actions` | Package scaffold marker only; no action lifecycle module moves are approved by the marker. |
+| `actions/review/__init__.py` | `actions.review` | Package scaffold marker only; no reviewed-action module moves are approved by the marker. |
 | `action_lifecycle_write_coordinator.py` | `actions` | Move only with action lifecycle write ownership and atomic durable write tests. |
 | `action_policy.py` | `actions` | Move only with reviewed action policy caller evidence and unchanged fail-closed decisions. |
 | `action_receipt_validation.py` | `actions` | Move only with receipt validation ownership and rejected-receipt state-cleanliness tests. |
@@ -72,7 +74,9 @@ The layout inventory does not change authorization, provenance, reconciliation, 
 | `adapters/postgres.py` | `adapters` | Move only within adapter family with unchanged persistence semantics. |
 | `adapters/shuffle.py` | `adapters` | Move only within adapter family while Shuffle remains subordinate execution context. |
 | `adapters/wazuh.py` | `adapters` | Move only within adapter family while Wazuh remains subordinate detection context. |
+| `api/__init__.py` | `api` | Package scaffold marker only; no HTTP, CLI, endpoint, or protected-surface module moves are approved by the marker. |
 | `ai_trace_lifecycle.py` | `assistant` | Move only with assistant trace lifecycle ownership and subordinate-output checks. |
+| `assistant/__init__.py` | `assistant` | Package scaffold marker only; no assistant module moves are approved by the marker. |
 | `assistant_advisory.py` | `assistant` | Move only with advisory ownership and no advisory-as-authority regression tests. |
 | `assistant_context.py` | `assistant` | Move only with direct anchored-context read rules. |
 | `assistant_provider.py` | `assistant` | Move only with provider boundary ownership and no placeholder credential acceptance. |
@@ -80,10 +84,12 @@ The layout inventory does not change authorization, provenance, reconciliation, 
 | `case_workflow.py` | `core` | Move only with authoritative case workflow ownership and lifecycle state tests. |
 | `cli.py` | `api` | Move only after CLI import compatibility and command behavior are preserved. |
 | `config.py` | `runtime` | Move only with runtime config ownership and no sample secret acceptance. |
+| `core/__init__.py` | `core` | Package scaffold marker only; no authoritative model, persistence, service, or validation module moves are approved by the marker. |
 | `detection_lifecycle.py` | `ingestion` | Move only with detection lifecycle authority and lifecycle transition tests. |
 | `detection_lifecycle_helpers.py` | `ingestion` | Move only with detection helper ownership and unchanged authoritative selection rules. |
 | `detection_native_context.py` | `ingestion` | Move only with native detection context ownership and provenance tests. |
 | `entrypoint_support.py` | `runtime` | Move only with startup entrypoint ownership and unchanged boot semantics. |
+| `evidence/__init__.py` | `evidence` | Package scaffold marker only; no evidence boundary or facade module moves are approved by the marker. |
 | `evidence_linkage.py` | `evidence` | Move only with evidence linkage ownership and direct-link constraints. |
 | `execution_coordinator.py` | `actions` | Move only with execution coordination ownership and authoritative receipt linkage. |
 | `execution_coordinator_action_requests.py` | `actions` | Move only with action request ownership and fail-closed scope tests. |
@@ -97,7 +103,9 @@ The layout inventory does not change authorization, provenance, reconciliation, 
 | `http_protected_surface.py` | `api` | Move only with protected HTTP surface ownership and trusted-boundary tests. |
 | `http_runtime_surface.py` | `api` | Move only with runtime HTTP surface ownership and unchanged readiness behavior. |
 | `http_surface.py` | `api` | Move only with public HTTP surface ownership and route compatibility tests. |
+| `ingestion/__init__.py` | `ingestion` | Package scaffold marker only; no detection intake module moves are approved by the marker. |
 | `live_assistant_workflow.py` | `assistant` | Move only with live assistant workflow ownership and subordinate output checks. |
+| `ml_shadow/__init__.py` | `ml_shadow` | Package scaffold marker only; no ML shadow-mode module moves are approved by the marker. |
 | `models.py` | `core` | Move only with authoritative model import compatibility and schema regression tests. |
 | `operations.py` | `runtime` | Move only with operations boundary ownership and unchanged operator command behavior. |
 | `operator_inspection.py` | `reporting` | Move only with operator inspection derivation tests from authoritative records. |
@@ -111,10 +119,12 @@ The layout inventory does not change authorization, provenance, reconciliation, 
 | `readiness_contracts.py` | `runtime` | Move only with readiness contract ownership and unchanged fail-closed readiness checks. |
 | `readiness_operability.py` | `runtime` | Move only with readiness operability ownership and no status-as-truth drift. |
 | `record_validation.py` | `core` | Move only with authoritative record validation ownership and malformed input tests. |
+| `reporting/__init__.py` | `reporting` | Package scaffold marker only; no audit, pilot reporting, or operator inspection module moves are approved by the marker. |
 | `restore_readiness.py` | `runtime` | Move only with restore readiness ownership and clean failed-restore state tests. |
 | `restore_readiness_backup_restore.py` | `runtime` | Move only with backup/restore ownership and all-or-nothing restore tests. |
 | `restore_readiness_projection.py` | `runtime` | Move only with restore projection derivation tests from authoritative state. |
 | `reviewed_slice_policy.py` | `core` | Move only with reviewed-slice policy ownership and direct scope binding tests. |
+| `runtime/__init__.py` | `runtime` | Package scaffold marker only; no runtime, readiness, restore, operation, or config module moves are approved by the marker. |
 | `runtime_boundary.py` | `runtime` | Move only with runtime trust boundary ownership and untrusted-header tests. |
 | `runtime_restore_readiness_diagnostics.py` | `runtime` | Move only with diagnostics ownership and no mixed-snapshot aggregation. |
 | `service.py` | `core` | Keep the public facade import path stable until facade compatibility policy is superseded. |

--- a/docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md
+++ b/docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md
@@ -1,0 +1,99 @@
+# ADR-0013: Phase 52.5.2 Package Scaffolding and Compatibility-Shim Policy
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md`
+- **Product**: AegisOps
+- **Related Issues**: #1084, #1086
+- **Depends On**: #1085
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+---
+
+## 1. Purpose
+
+Phase 52.5.2 creates package markers for the target package families accepted in ADR-0012 before later child issues move modules.
+
+The scaffolds are package markers only; they do not move production modules, rename `aegisops_control_plane`, or rename the outer `control-plane/` directory.
+
+This policy records the compatibility-shim posture and layout guardrail skeleton that later package-migration issues must extend.
+
+## 2. Target Package Scaffolds
+
+The approved scaffold packages under `control-plane/aegisops_control_plane/` are:
+
+| Package | ADR-0012 family | Posture |
+| --- | --- | --- |
+| `core/` | `core` | Package scaffold only; no production ownership move yet. |
+| `api/` | `api` | Package scaffold only; no HTTP, CLI, or protected-surface move yet. |
+| `runtime/` | `runtime` | Package scaffold only; no startup, config, readiness, or restore move yet. |
+| `ingestion/` | `ingestion` | Package scaffold only; no detection lifecycle move yet. |
+| `actions/` | `actions` | Package scaffold only; no action lifecycle or coordination move yet. |
+| `actions/review/` | `actions.review` | Package scaffold only; no reviewed-action surface move yet. |
+| `evidence/` | `evidence` | Package scaffold only; no evidence boundary or facade move yet. |
+| `assistant/` | `assistant` | Package scaffold only; no assistant context, advisory, provider, or workflow move yet. |
+| `ml_shadow/` | `ml_shadow` | Package scaffold only; no reviewed ML shadow-mode move yet. |
+| `reporting/` | `reporting` | Package scaffold only; no audit, pilot reporting, or inspection move yet. |
+
+The existing `adapters/` package remains the approved adapter package marker from earlier phases.
+
+## 3. Compatibility-Shim Policy
+
+Legacy imports remain the stable public compatibility surface until a later child issue documents caller evidence, replacement imports, deprecation window, focused regression tests, and rollback path.
+
+Compatibility shims may re-export from a new owner after a module move, but they must stay narrow and cannot introduce runtime behavior, durable-state side effects, or authority-boundary changes.
+
+When caller evidence is missing, malformed, ambiguous, or only inferred from path shape, the legacy import path stays available.
+
+Compatibility shims cannot make Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, operator-facing text, or nearby metadata authoritative workflow truth.
+
+Removing a legacy import path requires explicit caller evidence that covers internal imports, CLI imports, HTTP imports, tests, operator runbooks, and documented external usage where applicable.
+
+## 4. Initial Import Compatibility Checks
+
+The initial import compatibility verifier covers `aegisops_control_plane.service:AegisOpsControlPlaneService` and `aegisops_control_plane.models:AlertRecord` as stable legacy imports.
+
+Later child issues that move modules must add at least one legacy import check for each moved module before changing internal callers.
+
+An import compatibility check that bypasses the legacy path and validates only the new package path is incomplete because it does not prove existing callers keep working.
+
+## 5. Layout Guardrail Skeleton
+
+The layout guardrail skeleton rejects new flat root-level Python modules unless the Phase 52.5.1 inventory or the Phase 52.5.2 approved scaffold package set classifies them.
+
+The guardrail intentionally accepts the current repository baseline after the scaffold markers are classified in ADR-0012.
+
+Later child issues may extend the guardrail with package-family-specific rules only after the corresponding module moves and legacy import shims are verified.
+
+## 6. Authority Boundary
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+Package scaffolding, compatibility shims, import verifiers, and layout guardrails are maintainability infrastructure only.
+
+They do not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, action-execution, HTTP, CLI, deployment, Wazuh, Shuffle, ticket, ML, reporting, or durable-state behavior.
+
+## 7. Validation
+
+Run `bash scripts/verify-phase-52-5-2-package-scaffolding.sh`.
+
+Run `bash scripts/verify-phase-52-5-2-import-compatibility.sh`.
+
+Run `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`.
+
+Run `bash scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh`.
+
+Run `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1086 --config <supervisor-config-path>`.
+
+## 8. Non-Goals
+
+- No production module is moved.
+- No production import is rewritten.
+- No public package name is changed.
+- No outer repository directory is changed.
+- No public API, runtime endpoint, CLI command, operator UI behavior, deployment behavior, or durable-state side effect is changed.
+- No subordinate source, projection, DTO, summary, helper-module output, or nearby metadata becomes authoritative workflow truth.

--- a/scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh
+++ b/scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+scaffold_verifier="${repo_root}/scripts/verify-phase-52-5-2-package-scaffolding.sh"
+import_verifier="${repo_root}/scripts/verify-phase-52-5-2-import-compatibility.sh"
+guardrail_verifier="${repo_root}/scripts/verify-phase-52-5-2-layout-guardrail.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/adr" "${target}/control-plane"
+  cp "${repo_root}/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md" \
+    "${target}/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md"
+  cp "${repo_root}/docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md" \
+    "${target}/docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md"
+  cp -R "${repo_root}/control-plane/aegisops_control_plane" \
+    "${target}/control-plane/aegisops_control_plane"
+}
+
+assert_passes() {
+  local verifier="$1"
+  local target="$2"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local verifier="$1"
+  local target="$2"
+  local expected="$3"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${scaffold_verifier}" "${valid_repo}"
+assert_passes "${import_verifier}" "${valid_repo}"
+assert_passes "${guardrail_verifier}" "${valid_repo}"
+
+missing_scaffold_repo="${workdir}/missing-scaffold"
+create_valid_repo "${missing_scaffold_repo}"
+rm -rf "${missing_scaffold_repo}/control-plane/aegisops_control_plane/evidence"
+assert_fails_with \
+  "${scaffold_verifier}" \
+  "${missing_scaffold_repo}" \
+  "Missing Phase 52.5.2 target package scaffold: control-plane/aegisops_control_plane/evidence"
+
+bypassed_legacy_import_repo="${workdir}/bypassed-legacy-import"
+create_valid_repo "${bypassed_legacy_import_repo}"
+perl -0pi -e 's/aegisops_control_plane\.service:AegisOpsControlPlaneService/aegisops_control_plane.core.service:AegisOpsControlPlaneService/g' \
+  "${bypassed_legacy_import_repo}/docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md"
+assert_fails_with \
+  "${import_verifier}" \
+  "${bypassed_legacy_import_repo}" \
+  "Missing Phase 52.5.2 documented legacy import compatibility check: aegisops_control_plane.service:AegisOpsControlPlaneService"
+
+unclassified_flat_module_repo="${workdir}/unclassified-flat-module"
+create_valid_repo "${unclassified_flat_module_repo}"
+printf '%s\n' "\"\"\"Unclassified root-level fixture module.\"\"\"" \
+  >"${unclassified_flat_module_repo}/control-plane/aegisops_control_plane/new_flat_module.py"
+assert_fails_with \
+  "${guardrail_verifier}" \
+  "${unclassified_flat_module_repo}" \
+  "Phase 52.5.2 layout guardrail found unclassified flat root-level modules: new_flat_module.py"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Evidence: /%s/example/AegisOps/package-policy.md\n' "Users" \
+  >>"${local_path_repo}/docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md"
+assert_fails_with \
+  "${scaffold_verifier}" \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.5.2 package scaffolding policy: workstation-local absolute path detected"
+
+echo "Phase 52.5.2 package scaffolding, import compatibility, and layout guardrail verifier tests passed."

--- a/scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh
+++ b/scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh
@@ -78,6 +78,14 @@ assert_fails_with \
   "${bypassed_legacy_import_repo}" \
   "Missing Phase 52.5.2 documented legacy import compatibility check: aegisops_control_plane.service:AegisOpsControlPlaneService"
 
+missing_control_plane_root_repo="${workdir}/missing-control-plane-root"
+create_valid_repo "${missing_control_plane_root_repo}"
+rm -rf "${missing_control_plane_root_repo}/control-plane"
+assert_fails_with \
+  "${import_verifier}" \
+  "${missing_control_plane_root_repo}" \
+  "Missing or unreadable Phase 52.5.2 control-plane root for import compatibility verifier:"
+
 unclassified_flat_module_repo="${workdir}/unclassified-flat-module"
 create_valid_repo "${unclassified_flat_module_repo}"
 printf '%s\n' "\"\"\"Unclassified root-level fixture module.\"\"\"" \

--- a/scripts/verify-phase-52-5-2-import-compatibility.sh
+++ b/scripts/verify-phase-52-5-2-import-compatibility.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md"
+control_plane_root="${repo_root}/control-plane"
+
+required_imports=(
+  "aegisops_control_plane.service:AegisOpsControlPlaneService"
+  "aegisops_control_plane.models:AlertRecord"
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.5.2 compatibility-shim policy: ${doc_path}" >&2
+  exit 1
+fi
+
+for import_spec in "${required_imports[@]}"; do
+  if ! grep -Fq -- "${import_spec}" "${doc_path}"; then
+    echo "Missing Phase 52.5.2 documented legacy import compatibility check: ${import_spec}" >&2
+    exit 1
+  fi
+done
+
+export PHASE52_5_2_CONTROL_PLANE_ROOT="${control_plane_root}"
+export PHASE52_5_2_REQUIRED_IMPORTS="$(printf '%s\n' "${required_imports[@]}")"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import importlib
+import os
+import pathlib
+import sys
+
+control_plane_root = pathlib.Path(os.environ["PHASE52_5_2_CONTROL_PLANE_ROOT"])
+if str(control_plane_root) not in sys.path:
+    sys.path.insert(0, str(control_plane_root))
+
+required_imports = [
+    line
+    for line in os.environ["PHASE52_5_2_REQUIRED_IMPORTS"].splitlines()
+    if line.strip()
+]
+
+for import_spec in required_imports:
+    module_name, attribute_name = import_spec.split(":", 1)
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:  # pragma: no cover - shell verifier reports detail.
+        print(
+            f"Phase 52.5.2 legacy import failed: {module_name}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not hasattr(module, attribute_name):
+        print(
+            f"Phase 52.5.2 legacy import missing attribute: {import_spec}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+print(
+    "Phase 52.5.2 import compatibility verifier preserved stable legacy imports: "
+    + ", ".join(required_imports)
+)
+PY

--- a/scripts/verify-phase-52-5-2-import-compatibility.sh
+++ b/scripts/verify-phase-52-5-2-import-compatibility.sh
@@ -16,6 +16,11 @@ if [[ ! -f "${doc_path}" ]]; then
   exit 1
 fi
 
+if [[ ! -d "${control_plane_root}" || ! -r "${control_plane_root}" || ! -x "${control_plane_root}" ]]; then
+  echo "Missing or unreadable Phase 52.5.2 control-plane root for import compatibility verifier: ${control_plane_root}" >&2
+  exit 1
+fi
+
 for import_spec in "${required_imports[@]}"; do
   if ! grep -Fq -- "${import_spec}" "${doc_path}"; then
     echo "Missing Phase 52.5.2 documented legacy import compatibility check: ${import_spec}" >&2

--- a/scripts/verify-phase-52-5-2-layout-guardrail.sh
+++ b/scripts/verify-phase-52-5-2-layout-guardrail.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+inventory_doc="${repo_root}/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md"
+package_root="${repo_root}/control-plane/aegisops_control_plane"
+
+approved_scaffold_roots=(
+  "core"
+  "api"
+  "runtime"
+  "ingestion"
+  "actions"
+  "evidence"
+  "assistant"
+  "ml_shadow"
+  "reporting"
+)
+
+if [[ ! -f "${inventory_doc}" ]]; then
+  echo "Missing Phase 52.5.1 layout inventory for guardrail: ${inventory_doc}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${package_root}" ]]; then
+  echo "Missing control-plane package root for guardrail: ${package_root}" >&2
+  exit 1
+fi
+
+export PHASE52_5_2_INVENTORY_DOC="${inventory_doc}"
+export PHASE52_5_2_PACKAGE_ROOT="${package_root}"
+export PHASE52_5_2_SCAFFOLD_ROOTS="$(printf '%s\n' "${approved_scaffold_roots[@]}")"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import sys
+
+inventory_doc = pathlib.Path(os.environ["PHASE52_5_2_INVENTORY_DOC"])
+package_root = pathlib.Path(os.environ["PHASE52_5_2_PACKAGE_ROOT"])
+approved_scaffold_roots = {
+    line
+    for line in os.environ["PHASE52_5_2_SCAFFOLD_ROOTS"].splitlines()
+    if line.strip()
+}
+
+doc_text = inventory_doc.read_text(encoding="utf-8")
+row_pattern = re.compile(
+    r"^\| `(?P<module>[^`]+\.py)` \| `(?P<family>[^`]+)` \| (?P<contract>[^|][^|]*) \|$",
+    re.MULTILINE,
+)
+classified_modules = {match.group("module") for match in row_pattern.finditer(doc_text)}
+
+unclassified_flat_modules: list[str] = []
+for path in package_root.glob("*.py"):
+    relative = path.relative_to(package_root).as_posix()
+    if relative not in classified_modules:
+        unclassified_flat_modules.append(relative)
+
+missing_scaffold_markers = []
+for scaffold_root in approved_scaffold_roots:
+    init_relative = f"{scaffold_root}/__init__.py"
+    init_path = package_root / init_relative
+    if not init_path.is_file():
+        missing_scaffold_markers.append(init_relative)
+    elif init_relative not in classified_modules:
+        missing_scaffold_markers.append(f"{init_relative} (not classified)")
+
+review_marker = package_root / "actions" / "review" / "__init__.py"
+if not review_marker.is_file():
+    missing_scaffold_markers.append("actions/review/__init__.py")
+elif "actions/review/__init__.py" not in classified_modules:
+    missing_scaffold_markers.append("actions/review/__init__.py (not classified)")
+
+if unclassified_flat_modules:
+    print(
+        "Phase 52.5.2 layout guardrail found unclassified flat root-level modules: "
+        + ", ".join(sorted(unclassified_flat_modules)),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if missing_scaffold_markers:
+    print(
+        "Phase 52.5.2 layout guardrail found unclassified package scaffolds: "
+        + ", ".join(sorted(missing_scaffold_markers)),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(
+    "Phase 52.5.2 layout guardrail accepts the current classified baseline and rejects new unclassified flat root-level modules."
+)
+PY

--- a/scripts/verify-phase-52-5-2-package-scaffolding.sh
+++ b/scripts/verify-phase-52-5-2-package-scaffolding.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md"
+package_root="${repo_root}/control-plane/aegisops_control_plane"
+
+required_packages=(
+  "core"
+  "api"
+  "runtime"
+  "ingestion"
+  "actions"
+  "actions/review"
+  "evidence"
+  "assistant"
+  "ml_shadow"
+  "reporting"
+)
+
+required_doc_phrases=(
+  "# ADR-0013: Phase 52.5.2 Package Scaffolding and Compatibility-Shim Policy"
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-01"
+  "- **Related Issues**: #1084, #1086"
+  "- **Depends On**: #1085"
+  'The scaffolds are package markers only; they do not move production modules, rename `aegisops_control_plane`, or rename the outer `control-plane/` directory.'
+  "Legacy imports remain the stable public compatibility surface until a later child issue documents caller evidence, replacement imports, deprecation window, focused regression tests, and rollback path."
+  "Compatibility shims may re-export from a new owner after a module move, but they must stay narrow and cannot introduce runtime behavior, durable-state side effects, or authority-boundary changes."
+  "When caller evidence is missing, malformed, ambiguous, or only inferred from path shape, the legacy import path stays available."
+  'The initial import compatibility verifier covers `aegisops_control_plane.service:AegisOpsControlPlaneService` and `aegisops_control_plane.models:AlertRecord` as stable legacy imports.'
+  "The layout guardrail skeleton rejects new flat root-level Python modules unless the Phase 52.5.1 inventory or the Phase 52.5.2 approved scaffold package set classifies them."
+  'Run `bash scripts/verify-phase-52-5-2-package-scaffolding.sh`.'
+  'Run `bash scripts/verify-phase-52-5-2-import-compatibility.sh`.'
+  'Run `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`.'
+  'Run `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1086 --config <supervisor-config-path>`.'
+)
+
+if [[ ! -d "${package_root}" ]]; then
+  echo "Missing control-plane package root: ${package_root}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.5.2 package scaffolding policy: ${doc_path}" >&2
+  exit 1
+fi
+
+for package in "${required_packages[@]}"; do
+  package_path="${package_root}/${package}"
+  init_path="${package_path}/__init__.py"
+  if [[ ! -d "${package_path}" ]]; then
+    echo "Missing Phase 52.5.2 target package scaffold: control-plane/aegisops_control_plane/${package}" >&2
+    exit 1
+  fi
+  if [[ ! -f "${init_path}" ]]; then
+    echo "Missing Phase 52.5.2 target package marker: control-plane/aegisops_control_plane/${package}/__init__.py" >&2
+    exit 1
+  fi
+  if [[ -s "${init_path}" ]] && ! grep -Fq "Package scaffold only" "${init_path}"; then
+    echo "Phase 52.5.2 package marker must state scaffold-only posture: control-plane/aegisops_control_plane/${package}/__init__.py" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_doc_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 52.5.2 package scaffolding policy statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.5.2 package scaffolding policy: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+echo "Phase 52.5.2 package scaffolds and compatibility-shim policy are present."


### PR DESCRIPTION
## Summary
- add Phase 52.5.2 package scaffold markers for target control-plane package families
- document compatibility-shim policy in ADR-0013 and classify scaffold markers in ADR-0012
- add package scaffold, import compatibility, layout guardrail, and negative verifier harness scripts

## Verification
- `bash scripts/verify-phase-52-5-2-package-scaffolding.sh`
- `bash scripts/verify-phase-52-5-2-import-compatibility.sh`
- `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`
- `bash scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh`
- `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1086 --config <supervisor-config-path>`

Closes #1086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new architecture decision records defining package-scaffolding and compatibility policies for the control-plane layout.

* **Tests**
  * Added end-to-end and targeted verification scripts to validate scaffolding policy, legacy import compatibility, and layout guardrails.

* **Chores**
  * Initialized multiple control-plane package directories with scaffold marker files to prepare for future module organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->