### PR TITLE
Phase 52.5.9: Freeze service facade growth

### DIFF
--- a/control-plane/aegisops_control_plane/actions/review/action_review_write_surface.py
+++ b/control-plane/aegisops_control_plane/actions/review/action_review_write_surface.py
@@ -6,7 +6,7 @@ import logging
 from typing import Callable, Mapping, TYPE_CHECKING, Protocol
 
 from . import action_review_projection as _action_review_projection
-from ...action_policy import evaluate_action_policy_record
+from ..action_policy import evaluate_action_policy_record
 from ...models import (
     ActionRequestRecord,
     AlertRecord,

--- a/docs/control-plane-service-internal-boundaries.md
+++ b/docs/control-plane-service-internal-boundaries.md
@@ -353,3 +353,33 @@ Each follow-up extraction issue should:
 - verify that the resulting slice still aligns with the reviewed Phase 19-21 documents before merging.
 
 This document is the decomposition contract for future `service.py` extraction work. Later issues may rename internal classes during implementation if the resulting ownership and dependency direction remain materially identical to the boundaries defined here.
+
+## 11. Phase 52.5 Facade Freeze And Package Import Rule
+
+No new implementation-heavy behavior belongs in `service.py` after Phase 52.5.
+The accepted Phase 50.13.5 facade ceiling remains the freeze line: `1393` physical lines, `1241` effective lines, and `95` `AegisOpsControlPlaneService` methods under the ADR-0003 facade-preservation exception.
+New workflow logic, policy decisions, adapter orchestration, DTO shaping, readiness or restore behavior, evidence handling, action governance, assistant assembly, ingestion logic, and API or CLI transport handling belong in the package owner for that domain rather than in the public service facade.
+
+`service.py` may retain public compatibility entrypoints when existing callers still rely on them, but those methods should stay narrow delegates into collaborators or package-owned helpers.
+If a future issue needs more than delegation, the expected response is a new decomposition decision or a package-owned implementation slice, not silent facade growth.
+
+Internal control-plane modules must import moved implementation owners from their domain packages:
+
+- `assistant/` owns assistant context, advisory, provider, trace lifecycle, and live workflow implementations.
+- `reporting/` owns audit and pilot reporting export implementations.
+- `actions/` and `actions/review/` own action policy, lifecycle, execution, reconciliation, and reviewed-action implementations.
+- `runtime/` owns runtime boundary, readiness, restore, operations, diagnostics, and service snapshot implementations.
+- `api/` owns CLI, entrypoint, protected-surface, runtime-surface, and HTTP-surface implementations.
+- `ingestion/` owns detection lifecycle, native detection context, case workflow, and evidence linkage implementations.
+- `evidence/` owns external evidence boundary, facade, MISP, osquery, and endpoint helper implementations.
+- `ml_shadow/` owns Phase 29 shadow dataset, scoring, registry, and drift visibility implementations.
+
+Compatibility shims are for public or legacy callers, not for package-internal dependency direction.
+Package-owned modules must not reach through root-level moved-module shims such as `aegisops_control_plane.action_policy` when a package owner such as `aegisops_control_plane.actions.action_policy` exists.
+Legacy imports remain available where promised by ADR-0013, but internal dependency direction should now point at the owning package unless the import is an intentional public facade boundary such as `AegisOpsControlPlaneService`.
+
+The focused guardrail for this freeze is:
+
+`bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`
+
+Run it with `bash scripts/verify-maintainability-hotspots.sh` and `bash scripts/verify-phase-52-5-2-import-compatibility.sh` when closing a package-migration or service-facade issue.

--- a/scripts/test-verify-phase-52-5-9-service-facade-freeze.sh
+++ b/scripts/test-verify-phase-52-5-9-service-facade-freeze.sh
@@ -118,6 +118,17 @@ for index in $(seq 1 1393); do
 done
 assert_fails_with "${service_growth_repo}" "rejects service.py growth beyond the accepted Phase 50.13.5 ceiling"
 
+method_growth_repo="${workdir}/method-growth"
+create_fixture "${method_growth_repo}"
+{
+  echo "class AegisOpsControlPlaneService:"
+  for index in $(seq 1 96); do
+    printf '    def method_%04d(self):\n' "${index}"
+    printf '        return %d\n' "${index}"
+  done
+} >"${method_growth_repo}/control-plane/aegisops_control_plane/service.py"
+assert_fails_with "${method_growth_repo}" "facade_methods=96 exceeds 95"
+
 missing_doc_repo="${workdir}/missing-doc"
 create_fixture "${missing_doc_repo}"
 perl -0pi -e 's/Compatibility shims are for public or legacy callers, not for package-internal dependency direction\.\n//' \

--- a/scripts/test-verify-phase-52-5-9-service-facade-freeze.sh
+++ b/scripts/test-verify-phase-52-5-9-service-facade-freeze.sh
@@ -110,6 +110,25 @@ def evaluate(record):
 EOF
 assert_fails_with "${plain_legacy_import_repo}" "imports aegisops_control_plane.action_policy; use aegisops_control_plane.actions.action_policy"
 
+root_shim_from_import_repo="${workdir}/root-shim-from-import"
+create_fixture "${root_shim_from_import_repo}"
+cat >"${root_shim_from_import_repo}/control-plane/aegisops_control_plane/actions/review/action_review_write_surface.py" <<'EOF'
+from aegisops_control_plane import action_policy
+
+def evaluate(record):
+    return action_policy.evaluate_action_policy_record(record)
+EOF
+assert_fails_with "${root_shim_from_import_repo}" "imports aegisops_control_plane.action_policy; use aegisops_control_plane.actions.action_policy"
+
+package_init_legacy_import_repo="${workdir}/package-init-legacy-import"
+create_fixture "${package_init_legacy_import_repo}"
+cat >"${package_init_legacy_import_repo}/control-plane/aegisops_control_plane/actions/__init__.py" <<'EOF'
+from ..action_policy import evaluate_action_policy_record
+
+__all__ = ["evaluate_action_policy_record"]
+EOF
+assert_fails_with "${package_init_legacy_import_repo}" "imports aegisops_control_plane.action_policy; use aegisops_control_plane.actions.action_policy"
+
 service_growth_repo="${workdir}/service-growth"
 create_fixture "${service_growth_repo}"
 for index in $(seq 1 1393); do

--- a/scripts/test-verify-phase-52-5-9-service-facade-freeze.sh
+++ b/scripts/test-verify-phase-52-5-9-service-facade-freeze.sh
@@ -100,6 +100,16 @@ perl -0pi -e 's/from \.\.action_policy import evaluate_action_policy_record/from
   "${legacy_import_repo}/control-plane/aegisops_control_plane/actions/review/action_review_write_surface.py"
 assert_fails_with "${legacy_import_repo}" "imports aegisops_control_plane.action_policy; use aegisops_control_plane.actions.action_policy"
 
+plain_legacy_import_repo="${workdir}/plain-legacy-import"
+create_fixture "${plain_legacy_import_repo}"
+cat >"${plain_legacy_import_repo}/control-plane/aegisops_control_plane/actions/review/action_review_write_surface.py" <<'EOF'
+import aegisops_control_plane.action_policy as action_policy
+
+def evaluate(record):
+    return action_policy.evaluate_action_policy_record(record)
+EOF
+assert_fails_with "${plain_legacy_import_repo}" "imports aegisops_control_plane.action_policy; use aegisops_control_plane.actions.action_policy"
+
 service_growth_repo="${workdir}/service-growth"
 create_fixture "${service_growth_repo}"
 for index in $(seq 1 1393); do

--- a/scripts/test-verify-phase-52-5-9-service-facade-freeze.sh
+++ b/scripts/test-verify-phase-52-5-9-service-facade-freeze.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-5-9-service-facade-freeze.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_fixture() {
+  local target="$1"
+
+  mkdir -p \
+    "${target}/control-plane/aegisops_control_plane/actions/review" \
+    "${target}/control-plane/aegisops_control_plane/actions" \
+    "${target}/docs"
+
+  cat >"${target}/docs/maintainability-hotspot-baseline.txt" <<'EOF'
+control-plane/aegisops_control_plane/service.py max_lines=1393 max_effective_lines=1241 max_facade_methods=95 facade_class=AegisOpsControlPlaneService adr_exception=ADR-0003 phase=50.13.5 issue=#1035
+EOF
+
+  cat >"${target}/docs/control-plane-service-internal-boundaries.md" <<'EOF'
+## 11. Phase 52.5 Facade Freeze And Package Import Rule
+
+No new implementation-heavy behavior belongs in `service.py` after Phase 52.5.
+Internal control-plane modules must import moved implementation owners from their domain packages.
+Compatibility shims are for public or legacy callers, not for package-internal dependency direction.
+Run `bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`.
+EOF
+
+  cat >"${target}/control-plane/aegisops_control_plane/service.py" <<'EOF'
+class AegisOpsControlPlaneService:
+    def describe_runtime(self):
+        return "ok"
+EOF
+
+  cat >"${target}/control-plane/aegisops_control_plane/actions/action_policy.py" <<'EOF'
+def evaluate_action_policy_record(record):
+    return record
+EOF
+
+  cat >"${target}/control-plane/aegisops_control_plane/action_policy.py" <<'EOF'
+from .actions.action_policy import evaluate_action_policy_record
+
+__all__ = ["evaluate_action_policy_record"]
+EOF
+
+  cat >"${target}/control-plane/aegisops_control_plane/actions/review/action_review_write_surface.py" <<'EOF'
+from ..action_policy import evaluate_action_policy_record
+
+def evaluate(record):
+    return evaluate_action_policy_record(record)
+EOF
+}
+
+assert_passes() {
+  local target="$1"
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+passing_repo="${workdir}/passing"
+create_fixture "${passing_repo}"
+assert_passes "${passing_repo}"
+if ! grep -F "domain package internals avoid legacy compatibility shims" "${pass_stdout}" >/dev/null; then
+  echo "Expected passing output to report internal import cleanup." >&2
+  cat "${pass_stdout}" >&2
+  exit 1
+fi
+
+legacy_import_repo="${workdir}/legacy-import"
+create_fixture "${legacy_import_repo}"
+perl -0pi -e 's/from \.\.action_policy import evaluate_action_policy_record/from ...action_policy import evaluate_action_policy_record/' \
+  "${legacy_import_repo}/control-plane/aegisops_control_plane/actions/review/action_review_write_surface.py"
+assert_fails_with "${legacy_import_repo}" "imports aegisops_control_plane.action_policy; use aegisops_control_plane.actions.action_policy"
+
+service_growth_repo="${workdir}/service-growth"
+create_fixture "${service_growth_repo}"
+for index in $(seq 1 1393); do
+  printf 'growth_line_%04d = %d\n' "${index}" "${index}" \
+    >>"${service_growth_repo}/control-plane/aegisops_control_plane/service.py"
+done
+assert_fails_with "${service_growth_repo}" "rejects service.py growth beyond the accepted Phase 50.13.5 ceiling"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_fixture "${missing_doc_repo}"
+perl -0pi -e 's/Compatibility shims are for public or legacy callers, not for package-internal dependency direction\.\n//' \
+  "${missing_doc_repo}/docs/control-plane-service-internal-boundaries.md"
+assert_fails_with "${missing_doc_repo}" "Missing Phase 52.5.9 service facade freeze guidance"
+
+echo "verify-phase-52-5-9-service-facade-freeze tests passed"

--- a/scripts/verify-phase-52-5-9-service-facade-freeze.sh
+++ b/scripts/verify-phase-52-5-9-service-facade-freeze.sh
@@ -170,19 +170,50 @@ def service_baseline_metadata() -> dict[str, str]:
 
 def module_name_for(path: pathlib.Path) -> str:
     relative = path.relative_to(package_root).with_suffix("")
-    return "aegisops_control_plane." + ".".join(relative.parts)
+    parts = list(relative.parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    if not parts:
+        return "aegisops_control_plane"
+    return "aegisops_control_plane." + ".".join(parts)
 
 
-def resolved_import_module(current_module: str, node: ast.ImportFrom) -> str | None:
+def is_domain_module(current_module: str) -> bool:
+    return any(
+        current_module == domain_root[:-1] or current_module.startswith(domain_root)
+        for domain_root in domain_roots
+    )
+
+
+def resolved_import_module(
+    current_module: str,
+    node: ast.ImportFrom,
+    *,
+    from_package_init: bool,
+) -> str | None:
     if node.level == 0:
         return node.module
-    package_parts = current_module.split(".")[:-1]
+    package_parts = current_module.split(".")
+    if not from_package_init:
+        package_parts = package_parts[:-1]
     if node.level > len(package_parts) + 1:
         return None
     anchor = package_parts[: len(package_parts) - node.level + 1]
     if node.module:
         anchor.extend(node.module.split("."))
     return ".".join(anchor)
+
+
+def legacy_import_violations(
+    imported_module: str | None,
+    node: ast.ImportFrom,
+) -> list[str]:
+    if imported_module is None:
+        return []
+    candidates = [imported_module]
+    if imported_module:
+        candidates.extend(f"{imported_module}.{alias.name}" for alias in node.names)
+    return [candidate for candidate in candidates if candidate in legacy_owner_modules]
 
 
 metadata = service_baseline_metadata()
@@ -235,7 +266,7 @@ if exceeded:
 violations: list[str] = []
 for path in sorted(package_root.rglob("*.py")):
     current_module = module_name_for(path)
-    if not current_module.startswith(domain_roots):
+    if not is_domain_module(current_module):
         continue
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -244,8 +275,12 @@ for path in sorted(package_root.rglob("*.py")):
         sys.exit(1)
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
-            imported_module = resolved_import_module(current_module, node)
-            if imported_module in legacy_owner_modules:
+            imported_module = resolved_import_module(
+                current_module,
+                node,
+                from_package_init=path.name == "__init__.py",
+            )
+            for imported_module in legacy_import_violations(imported_module, node):
                 relative_path = path.relative_to(repo_root).as_posix()
                 owner = legacy_owner_modules[imported_module]
                 violations.append(

--- a/scripts/verify-phase-52-5-9-service-facade-freeze.sh
+++ b/scripts/verify-phase-52-5-9-service-facade-freeze.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+package_root="${repo_root}/control-plane/aegisops_control_plane"
+service_path="${package_root}/service.py"
+baseline_path="${repo_root}/docs/maintainability-hotspot-baseline.txt"
+boundary_doc="${repo_root}/docs/control-plane-service-internal-boundaries.md"
+
+if [[ ! -f "${service_path}" ]]; then
+  echo "Missing service facade file: control-plane/aegisops_control_plane/service.py" >&2
+  exit 1
+fi
+
+if [[ ! -f "${baseline_path}" ]]; then
+  echo "Missing maintainability hotspot baseline: docs/maintainability-hotspot-baseline.txt" >&2
+  exit 1
+fi
+
+if [[ ! -f "${boundary_doc}" ]]; then
+  echo "Missing service boundary document: docs/control-plane-service-internal-boundaries.md" >&2
+  exit 1
+fi
+
+required_doc_terms=(
+  "## 11. Phase 52.5 Facade Freeze And Package Import Rule"
+  'No new implementation-heavy behavior belongs in `service.py` after Phase 52.5.'
+  "Internal control-plane modules must import moved implementation owners from their domain packages"
+  "Compatibility shims are for public or legacy callers, not for package-internal dependency direction."
+  "bash scripts/verify-phase-52-5-9-service-facade-freeze.sh"
+)
+
+for required in "${required_doc_terms[@]}"; do
+  if ! grep -Fq -- "${required}" "${boundary_doc}"; then
+    echo "Missing Phase 52.5.9 service facade freeze guidance in docs/control-plane-service-internal-boundaries.md: ${required}" >&2
+    exit 1
+  fi
+done
+
+export PHASE52_5_9_REPO_ROOT="${repo_root}"
+export PHASE52_5_9_PACKAGE_ROOT="${package_root}"
+export PHASE52_5_9_SERVICE_PATH="${service_path}"
+export PHASE52_5_9_BASELINE_PATH="${baseline_path}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import sys
+
+repo_root = pathlib.Path(os.environ["PHASE52_5_9_REPO_ROOT"])
+package_root = pathlib.Path(os.environ["PHASE52_5_9_PACKAGE_ROOT"])
+service_path = pathlib.Path(os.environ["PHASE52_5_9_SERVICE_PATH"])
+baseline_path = pathlib.Path(os.environ["PHASE52_5_9_BASELINE_PATH"])
+
+expected_baseline = {
+    "path": "control-plane/aegisops_control_plane/service.py",
+    "max_lines": "1393",
+    "max_effective_lines": "1241",
+    "max_facade_methods": "95",
+    "facade_class": "AegisOpsControlPlaneService",
+    "adr_exception": "ADR-0003",
+    "phase": "50.13.5",
+    "issue": "#1035",
+}
+
+legacy_owner_modules = {
+    "aegisops_control_plane.ai_trace_lifecycle": "aegisops_control_plane.assistant.ai_trace_lifecycle",
+    "aegisops_control_plane.assistant_advisory": "aegisops_control_plane.assistant.assistant_advisory",
+    "aegisops_control_plane.assistant_context": "aegisops_control_plane.assistant.assistant_context",
+    "aegisops_control_plane.assistant_provider": "aegisops_control_plane.assistant.assistant_provider",
+    "aegisops_control_plane.live_assistant_workflow": "aegisops_control_plane.assistant.live_assistant_workflow",
+    "aegisops_control_plane.audit_export": "aegisops_control_plane.reporting.audit_export",
+    "aegisops_control_plane.pilot_reporting_export": "aegisops_control_plane.reporting.pilot_reporting_export",
+    "aegisops_control_plane.action_review_chain": "aegisops_control_plane.actions.review.action_review_chain",
+    "aegisops_control_plane.action_review_coordination": "aegisops_control_plane.actions.review.action_review_coordination",
+    "aegisops_control_plane.action_review_index": "aegisops_control_plane.actions.review.action_review_index",
+    "aegisops_control_plane.action_review_inspection": "aegisops_control_plane.actions.review.action_review_inspection",
+    "aegisops_control_plane.action_review_path_health": "aegisops_control_plane.actions.review.action_review_path_health",
+    "aegisops_control_plane.action_review_projection": "aegisops_control_plane.actions.review.action_review_projection",
+    "aegisops_control_plane.action_review_timeline": "aegisops_control_plane.actions.review.action_review_timeline",
+    "aegisops_control_plane.action_review_visibility": "aegisops_control_plane.actions.review.action_review_visibility",
+    "aegisops_control_plane.action_review_write_surface": "aegisops_control_plane.actions.review.action_review_write_surface",
+    "aegisops_control_plane.action_lifecycle_write_coordinator": "aegisops_control_plane.actions.action_lifecycle_write_coordinator",
+    "aegisops_control_plane.action_policy": "aegisops_control_plane.actions.action_policy",
+    "aegisops_control_plane.action_receipt_validation": "aegisops_control_plane.actions.action_receipt_validation",
+    "aegisops_control_plane.action_reconciliation_orchestration": "aegisops_control_plane.actions.action_reconciliation_orchestration",
+    "aegisops_control_plane.execution_coordinator": "aegisops_control_plane.actions.execution_coordinator",
+    "aegisops_control_plane.execution_coordinator_action_requests": "aegisops_control_plane.actions.execution_coordinator_action_requests",
+    "aegisops_control_plane.execution_coordinator_delegation": "aegisops_control_plane.actions.execution_coordinator_delegation",
+    "aegisops_control_plane.execution_coordinator_reconciliation": "aegisops_control_plane.actions.execution_coordinator_reconciliation",
+    "aegisops_control_plane.runtime_boundary": "aegisops_control_plane.runtime.runtime_boundary",
+    "aegisops_control_plane.readiness_contracts": "aegisops_control_plane.runtime.readiness_contracts",
+    "aegisops_control_plane.readiness_operability": "aegisops_control_plane.runtime.readiness_operability",
+    "aegisops_control_plane.restore_readiness": "aegisops_control_plane.runtime.restore_readiness",
+    "aegisops_control_plane.restore_readiness_projection": "aegisops_control_plane.runtime.restore_readiness_projection",
+    "aegisops_control_plane.restore_readiness_backup_restore": "aegisops_control_plane.runtime.restore_readiness_backup_restore",
+    "aegisops_control_plane.runtime_restore_readiness_diagnostics": "aegisops_control_plane.runtime.runtime_restore_readiness_diagnostics",
+    "aegisops_control_plane.service_snapshots": "aegisops_control_plane.runtime.service_snapshots",
+    "aegisops_control_plane.operations": "aegisops_control_plane.runtime.operations",
+    "aegisops_control_plane.cli": "aegisops_control_plane.api.cli",
+    "aegisops_control_plane.entrypoint_support": "aegisops_control_plane.api.entrypoint_support",
+    "aegisops_control_plane.http_surface": "aegisops_control_plane.api.http_surface",
+    "aegisops_control_plane.http_protected_surface": "aegisops_control_plane.api.http_protected_surface",
+    "aegisops_control_plane.http_runtime_surface": "aegisops_control_plane.api.http_runtime_surface",
+    "aegisops_control_plane.detection_lifecycle": "aegisops_control_plane.ingestion.detection_lifecycle",
+    "aegisops_control_plane.detection_lifecycle_helpers": "aegisops_control_plane.ingestion.detection_lifecycle_helpers",
+    "aegisops_control_plane.detection_native_context": "aegisops_control_plane.ingestion.detection_native_context",
+    "aegisops_control_plane.case_workflow": "aegisops_control_plane.ingestion.case_workflow",
+    "aegisops_control_plane.evidence_linkage": "aegisops_control_plane.ingestion.evidence_linkage",
+    "aegisops_control_plane.external_evidence_boundary": "aegisops_control_plane.evidence.external_evidence_boundary",
+    "aegisops_control_plane.external_evidence_facade": "aegisops_control_plane.evidence.external_evidence_facade",
+    "aegisops_control_plane.external_evidence_misp": "aegisops_control_plane.evidence.external_evidence_misp",
+    "aegisops_control_plane.external_evidence_osquery": "aegisops_control_plane.evidence.external_evidence_osquery",
+    "aegisops_control_plane.external_evidence_endpoint": "aegisops_control_plane.evidence.external_evidence_endpoint",
+    "aegisops_control_plane.phase29_shadow_dataset": "aegisops_control_plane.ml_shadow.dataset",
+    "aegisops_control_plane.phase29_shadow_scoring": "aegisops_control_plane.ml_shadow.scoring",
+    "aegisops_control_plane.phase29_evidently_drift_visibility": "aegisops_control_plane.ml_shadow.drift_visibility",
+    "aegisops_control_plane.phase29_mlflow_shadow_model_registry": "aegisops_control_plane.ml_shadow.mlflow_registry",
+}
+
+domain_roots = (
+    "aegisops_control_plane.actions.",
+    "aegisops_control_plane.api.",
+    "aegisops_control_plane.assistant.",
+    "aegisops_control_plane.evidence.",
+    "aegisops_control_plane.ingestion.",
+    "aegisops_control_plane.ml_shadow.",
+    "aegisops_control_plane.reporting.",
+    "aegisops_control_plane.runtime.",
+)
+
+
+def effective_line_count(text: str) -> int:
+    return sum(1 for line in text.splitlines() if line.strip() and not line.strip().startswith("#"))
+
+
+def facade_method_count(text: str, class_name: str) -> int | None:
+    tree = ast.parse(text, filename="control-plane/aegisops_control_plane/service.py")
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return sum(
+                1
+                for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
+    return None
+
+
+def service_baseline_metadata() -> dict[str, str]:
+    for line in baseline_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split()
+        if parts[0] != expected_baseline["path"]:
+            continue
+        metadata = {"path": parts[0]}
+        for part in parts[1:]:
+            if "=" not in part:
+                continue
+            key, value = part.split("=", 1)
+            metadata[key] = value
+        return metadata
+    return {}
+
+
+def module_name_for(path: pathlib.Path) -> str:
+    relative = path.relative_to(package_root).with_suffix("")
+    return "aegisops_control_plane." + ".".join(relative.parts)
+
+
+def resolved_import_module(current_module: str, node: ast.ImportFrom) -> str | None:
+    if node.level == 0:
+        return node.module
+    package_parts = current_module.split(".")[:-1]
+    if node.level > len(package_parts) + 1:
+        return None
+    anchor = package_parts[: len(package_parts) - node.level + 1]
+    if node.module:
+        anchor.extend(node.module.split("."))
+    return ".".join(anchor)
+
+
+metadata = service_baseline_metadata()
+missing_or_changed = [
+    f"{key}={value}"
+    for key, value in expected_baseline.items()
+    if metadata.get(key) != value
+]
+if missing_or_changed:
+    print(
+        "Phase 52.5.9 service facade freeze requires the accepted Phase 50.13.5 "
+        "service.py baseline entry; missing or changed fields: "
+        + ", ".join(missing_or_changed),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+service_text = service_path.read_text(encoding="utf-8")
+physical_lines = len(service_text.splitlines())
+effective_lines = effective_line_count(service_text)
+facade_methods = facade_method_count(service_text, expected_baseline["facade_class"])
+
+if facade_methods is None:
+    print(
+        "Phase 52.5.9 service facade freeze could not find "
+        f"{expected_baseline['facade_class']} in service.py",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+limits = {
+    "lines": (physical_lines, int(expected_baseline["max_lines"])),
+    "effective_lines": (effective_lines, int(expected_baseline["max_effective_lines"])),
+    "facade_methods": (facade_methods, int(expected_baseline["max_facade_methods"])),
+}
+exceeded = [
+    f"{name}={actual} exceeds {limit}"
+    for name, (actual, limit) in limits.items()
+    if actual > limit
+]
+if exceeded:
+    print(
+        "Phase 52.5.9 service facade freeze rejects service.py growth beyond the "
+        "accepted Phase 50.13.5 ceiling: "
+        + ", ".join(exceeded),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+violations: list[str] = []
+for path in sorted(package_root.rglob("*.py")):
+    current_module = module_name_for(path)
+    if not current_module.startswith(domain_roots):
+        continue
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:
+        print(f"Could not parse {path.relative_to(repo_root).as_posix()}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        imported_module = resolved_import_module(current_module, node)
+        if imported_module in legacy_owner_modules:
+            relative_path = path.relative_to(repo_root).as_posix()
+            owner = legacy_owner_modules[imported_module]
+            violations.append(
+                f"{relative_path}:{node.lineno} imports {imported_module}; use {owner}"
+            )
+
+if violations:
+    print(
+        "Phase 52.5.9 internal import cleanup found domain modules importing "
+        "compatibility shims:",
+        file=sys.stderr,
+    )
+    for violation in violations:
+        print(f"- {violation}", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    "Phase 52.5.9 service facade freeze passed: "
+    f"service.py lines={physical_lines}, effective_lines={effective_lines}, "
+    f"AegisOpsControlPlaneService methods={facade_methods}; "
+    "domain package internals avoid legacy compatibility shims."
+)
+PY

--- a/scripts/verify-phase-52-5-9-service-facade-freeze.sh
+++ b/scripts/verify-phase-52-5-9-service-facade-freeze.sh
@@ -243,15 +243,22 @@ for path in sorted(package_root.rglob("*.py")):
         print(f"Could not parse {path.relative_to(repo_root).as_posix()}: {exc}", file=sys.stderr)
         sys.exit(1)
     for node in ast.walk(tree):
-        if not isinstance(node, ast.ImportFrom):
-            continue
-        imported_module = resolved_import_module(current_module, node)
-        if imported_module in legacy_owner_modules:
-            relative_path = path.relative_to(repo_root).as_posix()
-            owner = legacy_owner_modules[imported_module]
-            violations.append(
-                f"{relative_path}:{node.lineno} imports {imported_module}; use {owner}"
-            )
+        if isinstance(node, ast.ImportFrom):
+            imported_module = resolved_import_module(current_module, node)
+            if imported_module in legacy_owner_modules:
+                relative_path = path.relative_to(repo_root).as_posix()
+                owner = legacy_owner_modules[imported_module]
+                violations.append(
+                    f"{relative_path}:{node.lineno} imports {imported_module}; use {owner}"
+                )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in legacy_owner_modules:
+                    relative_path = path.relative_to(repo_root).as_posix()
+                    owner = legacy_owner_modules[alias.name]
+                    violations.append(
+                        f"{relative_path}:{node.lineno} imports {alias.name}; use {owner}"
+                    )
 
 if violations:
     print(


### PR DESCRIPTION
## Summary
- add a Phase 52.5.9 service facade freeze verifier that pins the accepted `service.py` ceiling and rejects internal domain-package imports through moved compatibility shims
- update reviewed-action write surface to import action policy from `actions.action_policy` directly
- document the post-Phase 52.5 rule for what remains in `service.py` versus package-owned modules

## Closeout Evidence
- `service.py` facade metrics: 1393 physical lines, 1241 effective lines, 95 `AegisOpsControlPlaneService` methods
- import cleanup: `actions/review/action_review_write_surface.py` no longer reaches through the root `action_policy` compatibility shim
- compatibility status: legacy import verifier still preserves promised root and package imports
- deferred cleanup: public service facade APIs and legacy shims remain in place; future implementation-heavy behavior should land in package owners or a new decomposition issue

## Verification
- `bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`
- `bash scripts/test-verify-phase-52-5-9-service-facade-freeze.sh`
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/test-verify-maintainability-hotspots.sh`
- `bash scripts/verify-phase-52-5-2-import-compatibility.sh`
- `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `python3 -m unittest discover control-plane/tests`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1093 --config <supervisor-config-path>`

Closes #1093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added internal service-boundary guidance enforcing a narrow service facade and prescribing where workflows, policies, adapters, DTOs, evidence handling, and transport logic must reside.

* **Tests**
  * Added verification scripts and a test runner to enforce the facade freeze, structural ceilings, and import-compatibility checks with pass/fail diagnostics.

* **Chores**
  * Adjusted an internal import reference for consistent module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->