### PR TITLE
Phase 52.5 closeout evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.8 clean-host smoke skeleton](docs/deployment/clean-host-smoke-skeleton.md) defines the mocked/skipped `init -> up -> doctor -> seed-demo` fixture path and false-success rejection rules for the executable first-user stack.
 - [Phase 52.9 first-user stack overview](docs/deployment/first-user-stack.md) defines the few-command first-user path, troubleshooting links, pre-GA status, and authority boundary for the executable first-user stack.
 - [Phase 52.10 closeout evaluation](docs/phase-52-closeout-evaluation.md) records the Phase 52 child issue outcomes, focused verifier results, issue-lint summary, accepted limitations, and Phase 53/54 materialization recommendation.
+- [Phase 52.5 closeout evaluation](docs/phase-52-5-closeout-evaluation.md) records the Phase 52.5 package-layout hardening outcomes, moved modules, compatibility shims, verifier results, accepted limitations, and bounded Phase 53 readiness recommendation.
 
 ## Product positioning
 
@@ -70,6 +71,8 @@ The Phase 52.8 first-user clean-host smoke skeleton is defined by the [Phase 52.
 The Phase 52.9 first-user stack overview is defined by the [Phase 52.9 first-user stack overview](docs/deployment/first-user-stack.md).
 
 The Phase 52.10 closeout evaluation is defined by the [Phase 52.10 closeout evaluation](docs/phase-52-closeout-evaluation.md).
+
+The Phase 52.5 package-layout hardening closeout is defined by the [Phase 52.5 closeout evaluation](docs/phase-52-5-closeout-evaluation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-52-5-closeout-evaluation.md
+++ b/docs/phase-52-5-closeout-evaluation.md
@@ -1,0 +1,151 @@
+# Phase 52.5 Closeout Evaluation
+
+**Status**: Accepted as control-plane package layout hardening; Phase 53 Wazuh product profile work can start after this closeout lands.
+
+**Related Issues**: #1084, #1085, #1086, #1087, #1088, #1089, #1090, #1091, #1092, #1093, #1094
+
+**Authority Boundary**: This closeout is release and planning evidence only. AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth. Package layout, compatibility shims, import verifiers, layout guardrails, issue-lint output, and this document do not change runtime workflow truth.
+
+Phase 52.5 is accepted as the package-layout hardening phase that keeps the public `aegisops_control_plane` package name, the outer `control-plane/` repository directory, and existing runtime/product behavior unchanged while moving implementation owners into domain packages behind compatibility shims.
+
+This closeout does not claim that Wazuh product profiles are complete, Shuffle product profiles are complete, AegisOps is GA, RC, Beta, or self-service commercially ready, or that runtime behavior changed during Phase 52.5.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1084 | Epic: Phase 52.5 Control-Plane Package Layout Hardening | Open until #1094 lands; accepted when this closeout, verifiers, and issue-lint pass. |
+| #1085 | Phase 52.5.1 control-plane layout inventory and migration contract | Closed. ADR-0012 records the module inventory, target package families, compatibility-shim expectations, deferred renames, and non-goals. PR #1095. |
+| #1086 | Phase 52.5.2 package scaffolding and compatibility-shim policy | Closed. ADR-0013 records package scaffolds, compatibility-shim policy, import compatibility checks, and layout guardrails. PR #1096. |
+| #1087 | Phase 52.5.3 assistant and reporting package moves | Closed. Assistant and reporting implementation owners moved under `assistant/` and `reporting/` with root compatibility shims preserved. PR #1097. |
+| #1088 | Phase 52.5.4 action-review package moves | Closed. Reviewed-action surface implementation owners moved under `actions/review/` with root compatibility shims preserved. PR #1098. |
+| #1089 | Phase 52.5.5 execution and action lifecycle package moves | Closed. Execution coordinator, action lifecycle, policy, receipt, and reconciliation owners moved under `actions/` with root compatibility shims preserved. PR #1099. |
+| #1090 | Phase 52.5.6 runtime, readiness, restore, and API package moves | Closed. Runtime/readiness/restore owners moved under `runtime/`; CLI and HTTP owners moved under `api/`; root compatibility shims preserved. PR #1100. |
+| #1091 | Phase 52.5.7 ingestion and external-evidence package moves | Closed. Ingestion owners moved under `ingestion/`; external-evidence owners moved under `evidence/`; root compatibility shims preserved. PR #1101. |
+| #1092 | Phase 52.5.8 Phase 29 shadow-ML module rename | Closed. Domain-owned ML shadow implementations moved to non-phase-numbered names under `ml_shadow/`; Phase 29 root import shims preserved. PR #1102. |
+| #1093 | Phase 52.5.9 service facade freeze and internal import cleanup | Closed. `service.py` growth remains capped at the accepted Phase 50.13.5 baseline and domain internals avoid legacy compatibility shims. PR #1103. |
+| #1094 | Phase 52.5.10 closeout evaluation | Open until this closeout lands; accepted when this document and focused verifier pass. |
+
+## Final Module Map
+
+| Package family | Final owner posture |
+| --- | --- |
+| `core` | Scaffold package only. No Phase 52.5 production owner moved into `core/`. |
+| `api` | Owns CLI, entrypoint support, HTTP surface, protected HTTP surface, and runtime HTTP response helpers. |
+| `runtime` | Owns runtime boundary, operations, readiness contracts, readiness operability, restore readiness, restore projections, backup/restore helpers, diagnostics, and service snapshots. |
+| `ingestion` | Owns detection lifecycle, detection helpers, native detection context, case workflow, and evidence linkage. |
+| `actions` | Owns action lifecycle write coordination, action policy, receipt validation, reconciliation orchestration, and execution coordinators. |
+| `actions.review` | Owns action review chain, coordination, index, inspection, path health, projection, timeline, visibility, and write surface. |
+| `evidence` | Owns external evidence boundary, facade, MISP, osquery, and endpoint helpers. |
+| `assistant` | Owns AI trace lifecycle, assistant advisory, assistant context, assistant provider, and live assistant workflow. |
+| `ml_shadow` | Owns non-phase-numbered ML shadow dataset, scoring, drift visibility, and MLflow registry implementations. |
+| `reporting` | Owns audit export and pilot reporting export. |
+| `adapters` | Existing adapter package remains unchanged. |
+
+## Moved Modules And Compatibility Shims
+
+Each moved implementation keeps a root compatibility shim unless a later accepted transition policy proves caller coverage and approves removal.
+
+| Legacy import path | Owner import path |
+| --- | --- |
+| `aegisops_control_plane.ai_trace_lifecycle` | `aegisops_control_plane.assistant.ai_trace_lifecycle` |
+| `aegisops_control_plane.assistant_advisory` | `aegisops_control_plane.assistant.assistant_advisory` |
+| `aegisops_control_plane.assistant_context` | `aegisops_control_plane.assistant.assistant_context` |
+| `aegisops_control_plane.assistant_provider` | `aegisops_control_plane.assistant.assistant_provider` |
+| `aegisops_control_plane.live_assistant_workflow` | `aegisops_control_plane.assistant.live_assistant_workflow` |
+| `aegisops_control_plane.audit_export` | `aegisops_control_plane.reporting.audit_export` |
+| `aegisops_control_plane.pilot_reporting_export` | `aegisops_control_plane.reporting.pilot_reporting_export` |
+| `aegisops_control_plane.action_review_chain` | `aegisops_control_plane.actions.review.action_review_chain` |
+| `aegisops_control_plane.action_review_coordination` | `aegisops_control_plane.actions.review.action_review_coordination` |
+| `aegisops_control_plane.action_review_index` | `aegisops_control_plane.actions.review.action_review_index` |
+| `aegisops_control_plane.action_review_inspection` | `aegisops_control_plane.actions.review.action_review_inspection` |
+| `aegisops_control_plane.action_review_path_health` | `aegisops_control_plane.actions.review.action_review_path_health` |
+| `aegisops_control_plane.action_review_projection` | `aegisops_control_plane.actions.review.action_review_projection` |
+| `aegisops_control_plane.action_review_timeline` | `aegisops_control_plane.actions.review.action_review_timeline` |
+| `aegisops_control_plane.action_review_visibility` | `aegisops_control_plane.actions.review.action_review_visibility` |
+| `aegisops_control_plane.action_review_write_surface` | `aegisops_control_plane.actions.review.action_review_write_surface` |
+| `aegisops_control_plane.action_lifecycle_write_coordinator` | `aegisops_control_plane.actions.action_lifecycle_write_coordinator` |
+| `aegisops_control_plane.action_policy` | `aegisops_control_plane.actions.action_policy` |
+| `aegisops_control_plane.action_receipt_validation` | `aegisops_control_plane.actions.action_receipt_validation` |
+| `aegisops_control_plane.action_reconciliation_orchestration` | `aegisops_control_plane.actions.action_reconciliation_orchestration` |
+| `aegisops_control_plane.execution_coordinator` | `aegisops_control_plane.actions.execution_coordinator` |
+| `aegisops_control_plane.execution_coordinator_action_requests` | `aegisops_control_plane.actions.execution_coordinator_action_requests` |
+| `aegisops_control_plane.execution_coordinator_delegation` | `aegisops_control_plane.actions.execution_coordinator_delegation` |
+| `aegisops_control_plane.execution_coordinator_reconciliation` | `aegisops_control_plane.actions.execution_coordinator_reconciliation` |
+| `aegisops_control_plane.runtime_boundary` | `aegisops_control_plane.runtime.runtime_boundary` |
+| `aegisops_control_plane.readiness_contracts` | `aegisops_control_plane.runtime.readiness_contracts` |
+| `aegisops_control_plane.readiness_operability` | `aegisops_control_plane.runtime.readiness_operability` |
+| `aegisops_control_plane.restore_readiness` | `aegisops_control_plane.runtime.restore_readiness` |
+| `aegisops_control_plane.restore_readiness_projection` | `aegisops_control_plane.runtime.restore_readiness_projection` |
+| `aegisops_control_plane.restore_readiness_backup_restore` | `aegisops_control_plane.runtime.restore_readiness_backup_restore` |
+| `aegisops_control_plane.runtime_restore_readiness_diagnostics` | `aegisops_control_plane.runtime.runtime_restore_readiness_diagnostics` |
+| `aegisops_control_plane.service_snapshots` | `aegisops_control_plane.runtime.service_snapshots` |
+| `aegisops_control_plane.operations` | `aegisops_control_plane.runtime.operations` |
+| `aegisops_control_plane.cli` | `aegisops_control_plane.api.cli` |
+| `aegisops_control_plane.entrypoint_support` | `aegisops_control_plane.api.entrypoint_support` |
+| `aegisops_control_plane.http_surface` | `aegisops_control_plane.api.http_surface` |
+| `aegisops_control_plane.http_protected_surface` | `aegisops_control_plane.api.http_protected_surface` |
+| `aegisops_control_plane.http_runtime_surface` | `aegisops_control_plane.api.http_runtime_surface` |
+| `aegisops_control_plane.detection_lifecycle` | `aegisops_control_plane.ingestion.detection_lifecycle` |
+| `aegisops_control_plane.detection_lifecycle_helpers` | `aegisops_control_plane.ingestion.detection_lifecycle_helpers` |
+| `aegisops_control_plane.detection_native_context` | `aegisops_control_plane.ingestion.detection_native_context` |
+| `aegisops_control_plane.case_workflow` | `aegisops_control_plane.ingestion.case_workflow` |
+| `aegisops_control_plane.evidence_linkage` | `aegisops_control_plane.ingestion.evidence_linkage` |
+| `aegisops_control_plane.external_evidence_boundary` | `aegisops_control_plane.evidence.external_evidence_boundary` |
+| `aegisops_control_plane.external_evidence_facade` | `aegisops_control_plane.evidence.external_evidence_facade` |
+| `aegisops_control_plane.external_evidence_misp` | `aegisops_control_plane.evidence.external_evidence_misp` |
+| `aegisops_control_plane.external_evidence_osquery` | `aegisops_control_plane.evidence.external_evidence_osquery` |
+| `aegisops_control_plane.external_evidence_endpoint` | `aegisops_control_plane.evidence.external_evidence_endpoint` |
+| `aegisops_control_plane.phase29_shadow_dataset` | `aegisops_control_plane.ml_shadow.dataset` |
+| `aegisops_control_plane.phase29_shadow_scoring` | `aegisops_control_plane.ml_shadow.scoring` |
+| `aegisops_control_plane.phase29_evidently_drift_visibility` | `aegisops_control_plane.ml_shadow.drift_visibility` |
+| `aegisops_control_plane.phase29_mlflow_shadow_model_registry` | `aegisops_control_plane.ml_shadow.mlflow_registry` |
+
+## Verifier Evidence
+
+Focused Phase 52.5 verifiers passed:
+
+- `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`: classified 135 current Python files across 11 target package families.
+- `bash scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`: negative and valid fixtures passed.
+- `bash scripts/verify-phase-52-5-2-package-scaffolding.sh`: package scaffolds and compatibility-shim policy are present.
+- `bash scripts/verify-phase-52-5-2-import-compatibility.sh`: stable legacy imports and target imports are preserved for moved modules and the service/model baseline.
+- `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`: current classified baseline passes and new unclassified or phase-numbered production modules are rejected.
+- `bash scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh`: package, import, layout, and path-hygiene negative fixtures passed.
+- `bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`: `service.py` remains at 1393 lines, 1241 effective lines, and 95 `AegisOpsControlPlaneService` methods; domain package internals avoid legacy compatibility shims.
+- `bash scripts/test-verify-phase-52-5-9-service-facade-freeze.sh`: service-growth, method-growth, missing-doc, and internal legacy-import negative fixtures passed.
+- `bash scripts/verify-publishable-path-hygiene.sh`: publishable tracked content does not contain workstation-local absolute paths.
+- `bash scripts/verify-phase-52-5-closeout-evaluation.sh`: this closeout records child outcomes, moved modules, compatibility shim status, accepted limitations, verifier evidence, issue-lint summary, and bounded Phase 53 recommendation.
+- `bash scripts/test-verify-phase-52-5-closeout-evaluation.sh`: closeout negative fixtures reject Wazuh/Shuffle completion overclaims, missing compatibility shim status, missing service facade status, and workstation-local absolute paths.
+- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`: 934 broad control-plane tests passed.
+
+Issue-lint evidence for #1084 through #1094:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1084 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1085 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1086 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1087 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1088 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1089 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1090 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1091 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1092 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1093 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1094 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+
+## Accepted Limitations And Deferred Rename Blockers
+
+- The public package name remains `aegisops_control_plane`; a rename requires a later accepted ADR, caller evidence, operator migration plan, focused regression tests, and rollback path.
+- The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.
+- Root compatibility shims remain until a later transition policy documents affected import paths, replacement imports, caller evidence, deprecation window, focused regression tests, and rollback path.
+- Phase-numbered production filenames are rejected for new owner implementations by the layout guardrail, but existing Phase 29 root import paths remain as compatibility shims for ML shadow callers.
+- `service.py` remains an ADR-governed facade hotspot at the accepted Phase 50.13.5 ceiling; Phase 52.5 freezes growth but does not complete all future facade decomposition.
+- `core/` remains a package scaffold without a production owner move in this phase.
+- Phase 52.5 does not implement Wazuh product profiles, Shuffle product profiles, public package rename, outer directory rename, product behavior changes, deployment behavior changes, authorization changes, provenance changes, snapshot semantics changes, backup/restore changes, export changes, readiness changes, assistant behavior changes, evidence behavior changes, action-execution behavior changes, HTTP behavior changes, CLI behavior changes, or durable-state changes.
+
+## Phase 53 Recommendation
+
+Phase 53 can start after #1094 lands and the closeout verifier remains green.
+
+The recommendation is bounded to Wazuh product profile materialization. Phase 53 should consume the hardened package layout, keep compatibility shims intact, and avoid package rename or outer directory rename work unless a later accepted ADR explicitly changes that boundary.
+
+Do not treat this recommendation as a claim that the Wazuh product profile is complete, Shuffle product profile work is complete, or Phase 52.5 changed runtime product behavior.

--- a/scripts/test-verify-phase-52-5-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-52-5-closeout-evaluation.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-5-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-52-5-closeout-evaluation.md" "${target}/docs/phase-52-5-closeout-evaluation.md"
+  cp "${repo_root}/README.md" "${target}/README.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+cp "${repo_root}/README.md" "${missing_doc_repo}/README.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 52.5 closeout evaluation: docs/phase-52-5-closeout-evaluation.md"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+copy_valid_repo "${missing_readme_link_repo}"
+perl -0pi -e 's/\[Phase 52\.5 closeout evaluation\]\(docs\/phase-52-5-closeout-evaluation\.md\)/Phase 52.5 closeout evaluation/g' \
+  "${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "Missing README Phase 52.5 closeout link: [Phase 52.5 closeout evaluation](docs/phase-52-5-closeout-evaluation.md)"
+
+missing_shim_status_repo="${workdir}/missing-shim-status"
+copy_valid_repo "${missing_shim_status_repo}"
+perl -0pi -e 's/Root compatibility shims remain until a later transition policy documents affected import paths, replacement imports, caller evidence, deprecation window, focused regression tests, and rollback path\.//' \
+  "${missing_shim_status_repo}/docs/phase-52-5-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_shim_status_repo}" \
+  "Missing required Phase 52.5 closeout term in docs/phase-52-5-closeout-evaluation.md: Root compatibility shims remain until a later transition policy documents affected import paths, replacement imports, caller evidence, deprecation window, focused regression tests, and rollback path."
+
+missing_service_facade_repo="${workdir}/missing-service-facade"
+copy_valid_repo "${missing_service_facade_repo}"
+perl -0pi -e 's/`service\.py` remains an ADR-governed facade hotspot at the accepted Phase 50\.13\.5 ceiling; Phase 52\.5 freezes growth but does not complete all future facade decomposition\.//' \
+  "${missing_service_facade_repo}/docs/phase-52-5-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_service_facade_repo}" \
+  'Missing required Phase 52.5 closeout term in docs/phase-52-5-closeout-evaluation.md: `service.py` remains an ADR-governed facade hotspot at the accepted Phase 50.13.5 ceiling; Phase 52.5 freezes growth but does not complete all future facade decomposition.'
+
+wazuh_overclaim_repo="${workdir}/wazuh-overclaim"
+copy_valid_repo "${wazuh_overclaim_repo}"
+printf '%s\n' "The Wazuh product profile is complete" >>"${wazuh_overclaim_repo}/docs/phase-52-5-closeout-evaluation.md"
+assert_fails_with \
+  "${wazuh_overclaim_repo}" \
+  "Forbidden Phase 52.5 closeout evaluation claim: The Wazuh product profile is complete"
+
+shuffle_overclaim_repo="${workdir}/shuffle-overclaim"
+copy_valid_repo "${shuffle_overclaim_repo}"
+printf '%s\n' "The Shuffle product profile work is complete" >>"${shuffle_overclaim_repo}/docs/phase-52-5-closeout-evaluation.md"
+assert_fails_with \
+  "${shuffle_overclaim_repo}" \
+  "Forbidden Phase 52.5 closeout evaluation claim: The Shuffle product profile work is complete"
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+mac_home_prefix="/""Users/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${mac_home_prefix}" >>"${absolute_path_repo}/docs/phase-52-5-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 52.5 closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 52.5 closeout evaluation verifier tests passed."

--- a/scripts/verify-phase-52-5-closeout-evaluation.sh
+++ b/scripts/verify-phase-52-5-closeout-evaluation.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-52-5-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${file}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 52.5 closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+require_phrase "${readme_path}" "[Phase 52.5 closeout evaluation](docs/phase-52-5-closeout-evaluation.md)" "README Phase 52.5 closeout link"
+
+required_phrases=(
+  "# Phase 52.5 Closeout Evaluation"
+  "**Status**: Accepted as control-plane package layout hardening; Phase 53 Wazuh product profile work can start after this closeout lands."
+  "**Related Issues**: #1084, #1085, #1086, #1087, #1088, #1089, #1090, #1091, #1092, #1093, #1094"
+  "Package layout, compatibility shims, import verifiers, layout guardrails, issue-lint output, and this document do not change runtime workflow truth."
+  "This closeout does not claim that Wazuh product profiles are complete, Shuffle product profiles are complete, AegisOps is GA, RC, Beta, or self-service commercially ready, or that runtime behavior changed during Phase 52.5."
+  '| #1084 | Epic: Phase 52.5 Control-Plane Package Layout Hardening | Open until #1094 lands; accepted when this closeout, verifiers, and issue-lint pass. |'
+  '| #1085 | Phase 52.5.1 control-plane layout inventory and migration contract | Closed.'
+  '| #1086 | Phase 52.5.2 package scaffolding and compatibility-shim policy | Closed.'
+  '| #1087 | Phase 52.5.3 assistant and reporting package moves | Closed.'
+  '| #1088 | Phase 52.5.4 action-review package moves | Closed.'
+  '| #1089 | Phase 52.5.5 execution and action lifecycle package moves | Closed.'
+  '| #1090 | Phase 52.5.6 runtime, readiness, restore, and API package moves | Closed.'
+  '| #1091 | Phase 52.5.7 ingestion and external-evidence package moves | Closed.'
+  '| #1092 | Phase 52.5.8 Phase 29 shadow-ML module rename | Closed.'
+  '| #1093 | Phase 52.5.9 service facade freeze and internal import cleanup | Closed.'
+  '| #1094 | Phase 52.5.10 closeout evaluation | Open until this closeout lands; accepted when this document and focused verifier pass. |'
+  'Each moved implementation keeps a root compatibility shim unless a later accepted transition policy proves caller coverage and approves removal.'
+  '| `aegisops_control_plane.ai_trace_lifecycle` | `aegisops_control_plane.assistant.ai_trace_lifecycle` |'
+  '| `aegisops_control_plane.action_review_write_surface` | `aegisops_control_plane.actions.review.action_review_write_surface` |'
+  '| `aegisops_control_plane.execution_coordinator_reconciliation` | `aegisops_control_plane.actions.execution_coordinator_reconciliation` |'
+  '| `aegisops_control_plane.http_runtime_surface` | `aegisops_control_plane.api.http_runtime_surface` |'
+  '| `aegisops_control_plane.external_evidence_endpoint` | `aegisops_control_plane.evidence.external_evidence_endpoint` |'
+  '| `aegisops_control_plane.phase29_mlflow_shadow_model_registry` | `aegisops_control_plane.ml_shadow.mlflow_registry` |'
+  '`bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`: classified 135 current Python files across 11 target package families.'
+  '`bash scripts/verify-phase-52-5-2-import-compatibility.sh`: stable legacy imports and target imports are preserved for moved modules and the service/model baseline.'
+  '`bash scripts/verify-phase-52-5-2-layout-guardrail.sh`: current classified baseline passes and new unclassified or phase-numbered production modules are rejected.'
+  '`bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`: `service.py` remains at 1393 lines, 1241 effective lines, and 95 `AegisOpsControlPlaneService` methods; domain package internals avoid legacy compatibility shims.'
+  '`bash scripts/verify-publishable-path-hygiene.sh`: publishable tracked content does not contain workstation-local absolute paths.'
+  '`bash scripts/verify-phase-52-5-closeout-evaluation.sh`: this closeout records child outcomes, moved modules, compatibility shim status, accepted limitations, verifier evidence, issue-lint summary, and bounded Phase 53 recommendation.'
+  '`python3 -m unittest discover -s control-plane/tests -p '"'"'test_*.py'"'"'`: 934 broad control-plane tests passed.'
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1084 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1085 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1086 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1087 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1088 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1089 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1090 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1091 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1092 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1093 --config <supervisor-config-path>"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1094 --config <supervisor-config-path>"
+  "execution_ready=yes"
+  "missing_required=none"
+  "missing_recommended=none"
+  "metadata_errors=none"
+  "high_risk_blocking_ambiguity=none"
+  'The public package name remains `aegisops_control_plane`; a rename requires a later accepted ADR, caller evidence, operator migration plan, focused regression tests, and rollback path.'
+  'The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.'
+  'Root compatibility shims remain until a later transition policy documents affected import paths, replacement imports, caller evidence, deprecation window, focused regression tests, and rollback path.'
+  'Phase-numbered production filenames are rejected for new owner implementations by the layout guardrail, but existing Phase 29 root import paths remain as compatibility shims for ML shadow callers.'
+  '`service.py` remains an ADR-governed facade hotspot at the accepted Phase 50.13.5 ceiling; Phase 52.5 freezes growth but does not complete all future facade decomposition.'
+  "Phase 53 can start after #1094 lands and the closeout verifier remains green."
+  "The recommendation is bounded to Wazuh product profile materialization."
+  "Do not treat this recommendation as a claim that the Wazuh product profile is complete, Shuffle product profile work is complete, or Phase 52.5 changed runtime product behavior."
+)
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 52.5 closeout term in ${doc_path}"
+done
+
+mac_home_prefix="$(printf '/%s/' 'Users')"
+unix_home_prefix="$(printf '/%s/' 'home')"
+windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
+absolute_path_pattern="(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}" "${readme_path}"; then
+  echo "Forbidden Phase 52.5 closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+for forbidden in \
+  "Phase 52.5 proves GA readiness" \
+  "Phase 52.5 proves RC readiness" \
+  "Phase 52.5 proves Beta readiness" \
+  "Phase 52.5 proves self-service commercial readiness" \
+  "The Wazuh product profile is complete" \
+  "The Shuffle product profile work is complete" \
+  "Phase 52.5 proves runtime product behavior changed" \
+  "Compatibility shims may be removed immediately" \
+  "service.py can grow beyond the accepted facade ceiling" \
+  "Wazuh state is AegisOps workflow truth" \
+  "Shuffle state is AegisOps workflow truth"; do
+  if grep -Fq -- "${forbidden}" "${absolute_doc_path}"; then
+    echo "Forbidden Phase 52.5 closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 52.5 closeout evaluation records child outcomes, moved modules, compatibility shim status, accepted limitations, verifier evidence, issue-lint summary, and bounded Phase 53 recommendation."


### PR DESCRIPTION
## Summary
- Adds the Phase 52.5 closeout evaluation document for issue #1094.
- Records child issue outcomes, moved module/shim map, verifier and issue-lint evidence, accepted limitations, and bounded Phase 53 readiness recommendation.
- Adds a focused closeout verifier plus negative fixture tests for overclaims, missing shim/facade status, and publishable path hygiene.

## Verification
- bash scripts/verify-phase-52-5-closeout-evaluation.sh
- bash scripts/test-verify-phase-52-5-closeout-evaluation.sh
- bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh && bash scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
- bash scripts/verify-phase-52-5-2-package-scaffolding.sh && bash scripts/verify-phase-52-5-2-import-compatibility.sh && bash scripts/verify-phase-52-5-2-layout-guardrail.sh && bash scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh
- bash scripts/verify-phase-52-5-9-service-facade-freeze.sh && bash scripts/test-verify-phase-52-5-9-service-facade-freeze.sh
- bash scripts/verify-publishable-path-hygiene.sh && bash scripts/test-verify-publishable-path-hygiene.sh
- python3 -m unittest discover -s control-plane/tests -p 'test_*.py'\n- node <codex-supervisor-root>/dist/index.js issue-lint 1084..1094 --config <supervisor-config-path>\n\nCloses #1094\nPart of #1084