### PR TITLE
Phase 52.6.1 root shim inventory contract

### DIFF
--- a/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
+++ b/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
@@ -144,6 +144,8 @@ Run `bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh`.
 
 Run `bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh`.
 
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
 Run `node <codex-supervisor-root>/dist/index.js issue-lint 1106 --config <supervisor-config-path>`.
 
 ## 10. Non-Goals

--- a/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
+++ b/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
@@ -1,0 +1,157 @@
+# ADR-0014: Phase 52.6.1 Root Shim Inventory and Deprecation Contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md`
+- **Product**: AegisOps
+- **Related Issues**: #1105, #1106
+- **Depends On**: #1094
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+---
+
+## 1. Purpose
+
+Phase 52.6.1 records the root-level compatibility surface under `control-plane/aegisops_control_plane/` before any physical root shim deletion is approved.
+
+This contract is documentation and verification only. It does not delete shims, change imports, rename the public package, change the outer `control-plane/` directory, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior.
+
+## 2. Authority Boundary
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, compatibility shims, alias rows, inventory rows, and operator-facing text remain subordinate context.
+
+The root shim inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, action-execution, Wazuh, Shuffle, ticket, CLI, HTTP, or deployment behavior.
+
+## 3. Phase 52.5 Root File Baseline
+
+The Phase 52.5 closeout baseline for root-level Python files under `control-plane/aegisops_control_plane/` is `63`.
+
+The baseline counts only direct `.py` files in `control-plane/aegisops_control_plane/`; package-owned files below subdirectories are tracked by ADR-0012 and stay outside this root shim baseline.
+
+## 4. Classification Rules
+
+Root files are classified with one of these roles:
+
+| Classification | Meaning |
+| --- | --- |
+| retained owner | A root file still owns live behavior or package identity and is not a deletion candidate in Phase 52.6.1. |
+| simple shim | A root file re-exports moved owner symbols and may be deleted only after caller evidence, deprecation window, import regression test, and rollback path exist. |
+| compatibility adapter | A root file adapts a legacy API shape to a moved domain owner and must stay until adapter-specific caller evidence and regression tests prove safe removal. |
+| alias candidate | A root file currently aliases a moved owner module and may be deleted only after direct-owner imports, alias-preservation expectations, and rollback are documented. |
+| retained compatibility blocker | A root file must stay because existing public compatibility policy still requires the root import path. |
+
+If caller evidence is incomplete, malformed, ambiguous, or inferred only from naming, path shape, nearby metadata, comments, or summary text, the root file stays available.
+
+## 5. Root File Inventory
+
+| Root file | Target family | Classification | Deprecation decision |
+| --- | --- | --- | --- |
+| `__init__.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+| `action_lifecycle_write_coordinator.py` | `actions` | simple shim | Candidate for later deletion only after caller evidence, deprecation window, focused import regression, and rollback path are recorded. |
+| `action_policy.py` | `actions` | simple shim | Candidate for later deletion only after caller evidence, deprecation window, focused import regression, and rollback path are recorded. |
+| `action_receipt_validation.py` | `actions` | simple shim | Candidate for later deletion only after caller evidence, deprecation window, focused import regression, and rollback path are recorded. |
+| `action_reconciliation_orchestration.py` | `actions` | simple shim | Candidate for later deletion only after caller evidence, deprecation window, focused import regression, and rollback path are recorded. |
+| `action_review_chain.py` | `actions.review` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `action_review_coordination.py` | `actions.review` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `action_review_index.py` | `actions.review` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `action_review_inspection.py` | `actions.review` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `action_review_path_health.py` | `actions.review` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `action_review_projection.py` | `actions.review` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `action_review_timeline.py` | `actions.review` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `action_review_visibility.py` | `actions.review` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `action_review_write_surface.py` | `actions.review` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `ai_trace_lifecycle.py` | `assistant` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `assistant_advisory.py` | `assistant` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `assistant_context.py` | `assistant` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `assistant_provider.py` | `assistant` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `audit_export.py` | `reporting` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `case_workflow.py` | `ingestion` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `cli.py` | `api` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `config.py` | `runtime` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+| `detection_lifecycle.py` | `ingestion` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `detection_lifecycle_helpers.py` | `ingestion` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `detection_native_context.py` | `ingestion` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `entrypoint_support.py` | `api` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `evidence_linkage.py` | `ingestion` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `execution_coordinator.py` | `actions` | simple shim | Candidate for later deletion only after caller evidence, deprecation window, focused import regression, and rollback path are recorded. |
+| `execution_coordinator_action_requests.py` | `actions` | simple shim | Candidate for later deletion only after caller evidence, deprecation window, focused import regression, and rollback path are recorded. |
+| `execution_coordinator_delegation.py` | `actions` | simple shim | Candidate for later deletion only after caller evidence, deprecation window, focused import regression, and rollback path are recorded. |
+| `execution_coordinator_reconciliation.py` | `actions` | simple shim | Candidate for later deletion only after caller evidence, deprecation window, focused import regression, and rollback path are recorded. |
+| `external_evidence_boundary.py` | `evidence` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `external_evidence_endpoint.py` | `evidence` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `external_evidence_facade.py` | `evidence` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `external_evidence_misp.py` | `evidence` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `external_evidence_osquery.py` | `evidence` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `http_protected_surface.py` | `api` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `http_runtime_surface.py` | `api` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `http_surface.py` | `api` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `live_assistant_workflow.py` | `assistant` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `models.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+| `operations.py` | `runtime` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `operator_inspection.py` | `reporting` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+| `persistence_lifecycle.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+| `phase29_evidently_drift_visibility.py` | `ml_shadow` | compatibility adapter | Retain as a Phase29 legacy adapter; `ml_shadow/drift_visibility.py` is the domain-owned `ml_shadow` implementation. |
+| `phase29_mlflow_shadow_model_registry.py` | `ml_shadow` | compatibility adapter | Retain as a Phase29 legacy adapter; `ml_shadow/mlflow_registry.py` is the domain-owned `ml_shadow` implementation. |
+| `phase29_shadow_dataset.py` | `ml_shadow` | compatibility adapter | Retain as a Phase29 legacy adapter; `ml_shadow/dataset.py` is the domain-owned `ml_shadow` implementation. |
+| `phase29_shadow_scoring.py` | `ml_shadow` | compatibility adapter | Retain as a Phase29 legacy adapter; `ml_shadow/scoring.py` is the domain-owned `ml_shadow` implementation. |
+| `pilot_reporting_export.py` | `reporting` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `publishable_paths.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+| `readiness_contracts.py` | `runtime` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `readiness_operability.py` | `runtime` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `record_validation.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+| `restore_readiness.py` | `runtime` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `restore_readiness_backup_restore.py` | `runtime` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `restore_readiness_projection.py` | `runtime` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `reviewed_slice_policy.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+| `runtime_boundary.py` | `runtime` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `runtime_restore_readiness_diagnostics.py` | `runtime` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `service.py` | `core` | retained compatibility blocker | Retain physically until ADR-0003, ADR-0010, and a later facade transition issue prove the public facade import path can change safely. |
+| `service_composition.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+| `service_snapshots.py` | `runtime` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
+| `structured_events.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
+
+## 6. Phase29 Boundary
+
+The Phase29 root files are legacy compatibility adapters only. They are not production owners.
+
+The domain-owned implementations are the directly linked `ml_shadow` modules listed in the inventory. Any later removal plan must test both the legacy `phase29_*` import path and the domain-owned `ml_shadow` import path before deleting a root adapter.
+
+## 7. Deprecation Decision Rules
+
+Physical root shim deletion is allowed only when a later issue records the exact root file, replacement owner import path, caller evidence, deprecation window, focused legacy-import regression, rollback path, and authority-boundary impact.
+
+Alias preservation is allowed only when the alias remains a narrow reference to the moved owner and does not make compatibility state, summary text, or module identity authoritative workflow truth.
+
+Retained blockers stay physically present until the referenced compatibility policy is superseded by a later accepted ADR or issue-specific contract.
+
+If a prerequisite signal is missing, malformed, ambiguous, or only partially trusted, the deletion path fails closed and the root file stays available.
+
+## 8. Forbidden Claims
+
+The verifier rejects this contract if it asserts any of these claims outside this section:
+
+- This contract changes runtime behavior.
+- This contract allows Phase29 root files as production owners.
+- Legacy root shims may be deleted immediately.
+
+## 9. Validation
+
+Run `bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh`.
+
+Run `bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1106 --config <supervisor-config-path>`.
+
+## 10. Non-Goals
+
+- No root-level shim is deleted.
+- No import path is changed.
+- No public package name is changed.
+- No outer repository directory is changed.
+- No runtime behavior, HTTP behavior, CLI behavior, deployment behavior, Wazuh behavior, Shuffle behavior, ticket behavior, assistant behavior, evidence behavior, ML behavior, reporting behavior, backup behavior, restore behavior, readiness behavior, or durable-state side effect is changed.
+- No Phase29 root file is promoted to production owner.
+- No subordinate source becomes authoritative workflow truth.

--- a/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
+++ b/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
@@ -22,7 +22,7 @@ This contract is documentation and verification only. It does not delete shims, 
 
 AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
 
-Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, compatibility shims, alias rows, inventory rows, and operator-facing text remain subordinate context.
+Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, compatibility shims, alias rows, and operator-facing text remain subordinate context.
 
 The root shim inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, action-execution, Wazuh, Shuffle, ticket, CLI, HTTP, or deployment behavior.
 

--- a/scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -101,4 +101,12 @@ assert_fails_with \
   "${missing_publishable_hygiene_repo}" \
   "Missing Phase 52.6.1 root shim inventory statement: Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
 
+subordinate_inventory_rows_repo="${workdir}/subordinate-inventory-rows"
+create_valid_repo "${subordinate_inventory_rows_repo}"
+perl -0pi -e 's/alias rows, and operator-facing text remain subordinate context/alias rows, inventory rows, and operator-facing text remain subordinate context/' \
+  "${subordinate_inventory_rows_repo}/${contract_path}"
+assert_fails_with \
+  "${subordinate_inventory_rows_repo}" \
+  "Missing Phase 52.6.1 root shim inventory statement: Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, compatibility shims, alias rows, and operator-facing text remain subordinate context."
+
 echo "Phase 52.6.1 root shim inventory verifier negative and valid fixtures passed."

--- a/scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -93,4 +93,12 @@ assert_fails_with \
   "${local_path_repo}" \
   "Forbidden Phase 52.6.1 root shim inventory: workstation-local absolute path detected"
 
+missing_publishable_hygiene_repo="${workdir}/missing-publishable-hygiene"
+create_valid_repo "${missing_publishable_hygiene_repo}"
+perl -0pi -e 's/\nRun `bash scripts\/verify-publishable-path-hygiene\.sh`\.\n//' \
+  "${missing_publishable_hygiene_repo}/${contract_path}"
+assert_fails_with \
+  "${missing_publishable_hygiene_repo}" \
+  "Missing Phase 52.6.1 root shim inventory statement: Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
+
 echo "Phase 52.6.1 root shim inventory verifier negative and valid fixtures passed."

--- a/scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh"
+contract_path="docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/adr" "${target}/control-plane"
+  cp "${repo_root}/${contract_path}" "${target}/${contract_path}"
+  cp -R "${repo_root}/control-plane/aegisops_control_plane" \
+    "${target}/control-plane/aegisops_control_plane"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+unclassified_repo="${workdir}/unclassified-root-file"
+create_valid_repo "${unclassified_repo}"
+printf '%s\n' "\"\"\"Fixture root file intentionally missing from the shim inventory.\"\"\"" \
+  >"${unclassified_repo}/control-plane/aegisops_control_plane/new_root_shim.py"
+assert_fails_with \
+  "${unclassified_repo}" \
+  "Phase 52.6.1 root shim inventory is missing root file rows: new_root_shim.py"
+
+behavior_change_repo="${workdir}/behavior-change-claim"
+create_valid_repo "${behavior_change_repo}"
+printf '%s\n' "This contract changes runtime behavior." \
+  >>"${behavior_change_repo}/${contract_path}"
+assert_fails_with \
+  "${behavior_change_repo}" \
+  "Forbidden Phase 52.6.1 root shim inventory claim: This contract changes runtime behavior."
+
+phase29_owner_repo="${workdir}/phase29-production-owner"
+create_valid_repo "${phase29_owner_repo}"
+perl -0pi -e 's/\| `phase29_shadow_dataset\.py` \| `ml_shadow` \| compatibility adapter \| Retain as a Phase29 legacy adapter; `ml_shadow\/dataset\.py` is the domain-owned `ml_shadow` implementation\. \|/\| `phase29_shadow_dataset.py` \| `ml_shadow` \| retained owner \| Retain as a Phase29 production owner. \|/' \
+  "${phase29_owner_repo}/${contract_path}"
+assert_fails_with \
+  "${phase29_owner_repo}" \
+  "Phase 52.6.1 root shim inventory must classify Phase29 root files as compatibility adapters separate from domain-owned ml_shadow implementations: phase29_shadow_dataset.py"
+
+immediate_deletion_repo="${workdir}/immediate-deletion-claim"
+create_valid_repo "${immediate_deletion_repo}"
+printf '%s\n' "Legacy root shims may be deleted immediately." \
+  >>"${immediate_deletion_repo}/${contract_path}"
+assert_fails_with \
+  "${immediate_deletion_repo}" \
+  "Forbidden Phase 52.6.1 root shim inventory claim: Legacy root shims may be deleted immediately."
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/${contract_path}"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.6.1 root shim inventory: workstation-local absolute path detected"
+
+echo "Phase 52.6.1 root shim inventory verifier negative and valid fixtures passed."

--- a/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md"
+package_root="${repo_root}/control-plane/aegisops_control_plane"
+
+required_headings=(
+  "# ADR-0014: Phase 52.6.1 Root Shim Inventory and Deprecation Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Phase 52.5 Root File Baseline"
+  "## 4. Classification Rules"
+  "## 5. Root File Inventory"
+  "## 6. Phase29 Boundary"
+  "## 7. Deprecation Decision Rules"
+  "## 8. Forbidden Claims"
+  "## 9. Validation"
+  "## 10. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-02"
+  "- **Related Issues**: #1105, #1106"
+  "- **Depends On**: #1094"
+  "This contract is documentation and verification only. It does not delete shims, change imports, rename the public package, change the outer \`control-plane/\` directory, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  "Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, compatibility shims, alias rows, inventory rows, and operator-facing text remain subordinate context."
+  "The root shim inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, action-execution, Wazuh, Shuffle, ticket, CLI, HTTP, or deployment behavior."
+  "The Phase 52.5 closeout baseline for root-level Python files under \`control-plane/aegisops_control_plane/\` is \`63\`."
+  "The baseline counts only direct \`.py\` files in \`control-plane/aegisops_control_plane/\`; package-owned files below subdirectories are tracked by ADR-0012 and stay outside this root shim baseline."
+  "The Phase29 root files are legacy compatibility adapters only. They are not production owners."
+  "The domain-owned implementations are the directly linked \`ml_shadow\` modules listed in the inventory. Any later removal plan must test both the legacy \`phase29_*\` import path and the domain-owned \`ml_shadow\` import path before deleting a root adapter."
+  "Physical root shim deletion is allowed only when a later issue records the exact root file, replacement owner import path, caller evidence, deprecation window, focused legacy-import regression, rollback path, and authority-boundary impact."
+  "Alias preservation is allowed only when the alias remains a narrow reference to the moved owner and does not make compatibility state, summary text, or module identity authoritative workflow truth."
+  "Retained blockers stay physically present until the referenced compatibility policy is superseded by a later accepted ADR or issue-specific contract."
+  "If a prerequisite signal is missing, malformed, ambiguous, or only partially trusted, the deletion path fails closed and the root file stays available."
+  "Run \`bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh\`."
+  "Run \`bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1106 --config <supervisor-config-path>\`."
+)
+
+allowed_classifications=(
+  "retained owner"
+  "simple shim"
+  "compatibility adapter"
+  "alias candidate"
+  "retained compatibility blocker"
+)
+
+forbidden_claims=(
+  "This contract changes runtime behavior."
+  "This contract allows Phase29 root files as production owners."
+  "Legacy root shims may be deleted immediately."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.6.1 root shim inventory contract: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${package_root}" ]]; then
+  echo "Missing control-plane package root: ${package_root}" >&2
+  exit 1
+fi
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+doc_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${doc_path}"
+)"
+doc_raw_markdown="$(cat "${doc_path}")"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.6.1 root shim inventory heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.6.1 root shim inventory statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+  local markdown="$2"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 8\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${markdown}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}" "${doc_raw_markdown}"; then
+    echo "Forbidden Phase 52.6.1 root shim inventory claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.6.1 root shim inventory: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+allowed_pattern="$(printf '%s\n' "${allowed_classifications[@]}" | paste -sd '|' -)"
+
+export PHASE52_6_1_DOC_PATH="${doc_path}"
+export PHASE52_6_1_PACKAGE_ROOT="${package_root}"
+export PHASE52_6_1_ALLOWED_PATTERN="${allowed_pattern}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import sys
+
+doc_path = pathlib.Path(os.environ["PHASE52_6_1_DOC_PATH"])
+package_root = pathlib.Path(os.environ["PHASE52_6_1_PACKAGE_ROOT"])
+allowed = frozenset(os.environ["PHASE52_6_1_ALLOWED_PATTERN"].split("|"))
+
+doc_text = doc_path.read_text(encoding="utf-8")
+row_pattern = re.compile(
+    r"^\| `(?P<module>[^`]+\.py)` \| `(?P<family>[^`]+)` \| (?P<classification>[^|]+) \| (?P<decision>[^|][^|]*) \|$",
+    re.MULTILINE,
+)
+
+rows: dict[str, tuple[str, str]] = {}
+duplicates: set[str] = set()
+invalid_classifications: list[str] = []
+empty_decisions: list[str] = []
+for match in row_pattern.finditer(doc_text):
+    module = match.group("module")
+    classification = match.group("classification").strip()
+    decision = match.group("decision").strip()
+    if module in rows:
+        duplicates.add(module)
+    rows[module] = (classification, decision)
+    if classification not in allowed:
+        invalid_classifications.append(f"{module}: {classification}")
+    if not decision:
+        empty_decisions.append(module)
+
+actual_modules = sorted(
+    path.name
+    for path in package_root.glob("*.py")
+    if path.is_file()
+)
+
+if duplicates:
+    print(
+        "Phase 52.6.1 root shim inventory has duplicate root file rows: "
+        + ", ".join(sorted(duplicates)),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+missing = [module for module in actual_modules if module not in rows]
+extra = sorted(set(rows) - set(actual_modules))
+if missing:
+    print(
+        "Phase 52.6.1 root shim inventory is missing root file rows: "
+        + ", ".join(missing),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if extra:
+    print(
+        "Phase 52.6.1 root shim inventory lists root files not present under control-plane/aegisops_control_plane: "
+        + ", ".join(extra),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if len(actual_modules) != 63:
+    print(
+        f"Phase 52.6.1 root shim inventory expected Phase 52.5 root baseline of 63 files, found {len(actual_modules)}.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if invalid_classifications:
+    print(
+        "Phase 52.6.1 root shim inventory uses unsupported classifications: "
+        + "; ".join(invalid_classifications),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if empty_decisions:
+    print(
+        "Phase 52.6.1 root shim inventory has empty deprecation decision rows: "
+        + ", ".join(empty_decisions),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+required_classifications = {
+    "retained owner",
+    "simple shim",
+    "compatibility adapter",
+    "alias candidate",
+    "retained compatibility blocker",
+}
+missing_classifications = sorted(required_classifications - {row[0] for row in rows.values()})
+if missing_classifications:
+    print(
+        "Phase 52.6.1 root shim inventory does not use required classifications: "
+        + ", ".join(missing_classifications),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+phase29_modules = sorted(module for module in actual_modules if module.startswith("phase29_"))
+bad_phase29 = [
+    module
+    for module in phase29_modules
+    if rows[module][0] != "compatibility adapter"
+    or "domain-owned `ml_shadow` implementation" not in rows[module][1]
+]
+if bad_phase29:
+    print(
+        "Phase 52.6.1 root shim inventory must classify Phase29 root files as compatibility adapters separate from domain-owned ml_shadow implementations: "
+        + ", ".join(bad_phase29),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if rows.get("service.py", ("", ""))[0] != "retained compatibility blocker":
+    print(
+        "Phase 52.6.1 root shim inventory must classify service.py as a retained compatibility blocker.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(
+    "Phase 52.6.1 root shim inventory classifies "
+    f"{len(actual_modules)} root Python files, records the Phase 52.5 baseline, "
+    "separates Phase29 adapters from ml_shadow owners, and documents deprecation rules."
+)
+PY

--- a/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -39,6 +39,7 @@ required_phrases=(
   "If a prerequisite signal is missing, malformed, ambiguous, or only partially trusted, the deletion path fails closed and the root file stays available."
   "Run \`bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh\`."
   "Run \`bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh\`."
+  "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
   "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1106 --config <supervisor-config-path>\`."
 )
 

--- a/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -55,7 +55,6 @@ forbidden_claims=(
   "This contract changes runtime behavior."
   "This contract allows Phase29 root files as production owners."
   "Legacy root shims may be deleted immediately."
-  "inventory rows, and operator-facing text remain subordinate context."
 )
 
 if [[ ! -f "${doc_path}" ]]; then

--- a/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -27,7 +27,7 @@ required_phrases=(
   "- **Depends On**: #1094"
   "This contract is documentation and verification only. It does not delete shims, change imports, rename the public package, change the outer \`control-plane/\` directory, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior."
   "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
-  "Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, compatibility shims, alias rows, inventory rows, and operator-facing text remain subordinate context."
+  "Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, compatibility shims, alias rows, and operator-facing text remain subordinate context."
   "The root shim inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, action-execution, Wazuh, Shuffle, ticket, CLI, HTTP, or deployment behavior."
   "The Phase 52.5 closeout baseline for root-level Python files under \`control-plane/aegisops_control_plane/\` is \`63\`."
   "The baseline counts only direct \`.py\` files in \`control-plane/aegisops_control_plane/\`; package-owned files below subdirectories are tracked by ADR-0012 and stay outside this root shim baseline."
@@ -55,6 +55,7 @@ forbidden_claims=(
   "This contract changes runtime behavior."
   "This contract allows Phase29 root files as production owners."
   "Legacy root shims may be deleted immediately."
+  "inventory rows, and operator-facing text remain subordinate context."
 )
 
 if [[ ! -f "${doc_path}" ]]; then


### PR DESCRIPTION
## Summary
- Add ADR-0014 root-level shim inventory for control-plane/aegisops_control_plane
- Record the Phase 52.5 root file baseline of 63 files and classify every root .py file
- Add focused verifier and negative fixture coverage for unclassified files, forbidden runtime-change claims, Phase29 owner drift, immediate deletion claims, and publishable path hygiene

## Verification
- bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
- bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1106 --config <supervisor-config-path>

Closes #1106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Architecture Decision Record describing a root-level shim inventory and deprecation contract, classification roles, deprecation decision rules, forbidden claims, Phase29 special handling, concrete validation steps, and non-goals.

* **Tests**
  * Added a verifier and test harness that validate the ADR and inventory consistency: required headings/phrases, forbidden-claim and path-hygiene checks, exact root-file count/classifications, Phase29 ownership rules, and multiple pass/fail fixture assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->