### PR TITLE
Phase 52.6.2 canonical domain import rewiring

### DIFF
--- a/control-plane/main.py
+++ b/control-plane/main.py
@@ -7,8 +7,8 @@ import json
 import sys
 from typing import Sequence, TextIO
 
-from aegisops_control_plane import cli, http_surface
-from aegisops_control_plane.entrypoint_support import (
+from aegisops_control_plane.api import cli, http_surface
+from aegisops_control_plane.api.entrypoint_support import (
     MAX_WAZUH_INGEST_BODY_BYTES,
     read_json_file as _read_json_file,
     require_loopback_operator_request as _require_loopback_operator_request,

--- a/control-plane/tests/_cli_inspection_support.py
+++ b/control-plane/tests/_cli_inspection_support.py
@@ -24,7 +24,7 @@ if str(TESTS_ROOT) not in sys.path:
 import main
 from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
-from aegisops_control_plane.execution_coordinator import _approved_payload_binding_hash
+from aegisops_control_plane.actions.execution_coordinator import _approved_payload_binding_hash
 from aegisops_control_plane.models import (
     AITraceRecord,
     ActionExecutionRecord,

--- a/control-plane/tests/_service_persistence_support.py
+++ b/control-plane/tests/_service_persistence_support.py
@@ -16,7 +16,7 @@ CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
-from aegisops_control_plane.assistant_context import (
+from aegisops_control_plane.assistant.assistant_context import (
     _reviewed_context_identifier_citations,
 )
 from aegisops_control_plane.config import RuntimeConfig
@@ -40,7 +40,7 @@ from aegisops_control_plane.models import (
     RecommendationRecord,
 )
 from aegisops_control_plane.adapters.wazuh import WazuhAlertAdapter
-from aegisops_control_plane.execution_coordinator import _approved_payload_binding_hash
+from aegisops_control_plane.actions.execution_coordinator import _approved_payload_binding_hash
 from aegisops_control_plane.service import (
     AegisOpsControlPlaneService,
     AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES,

--- a/control-plane/tests/test_action_receipt_validation.py
+++ b/control-plane/tests/test_action_receipt_validation.py
@@ -10,7 +10,7 @@ CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
-from aegisops_control_plane.action_receipt_validation import (
+from aegisops_control_plane.actions.action_receipt_validation import (
     MissingReceiptValueError,
     require_receipt_string_value,
     require_receipt_https_url_value,

--- a/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
+++ b/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
@@ -16,7 +16,7 @@ for candidate in (CONTROL_PLANE_ROOT, TESTS_ROOT):
 
 
 from _cli_inspection_support import ControlPlaneCliInspectionTestBase
-from aegisops_control_plane.assistant_provider import AssistantProviderAdapter
+from aegisops_control_plane.assistant.assistant_provider import AssistantProviderAdapter
 from aegisops_control_plane.models import (
     AITraceRecord,
     ActionExecutionRecord,

--- a/control-plane/tests/test_execution_coordinator_boundary.py
+++ b/control-plane/tests/test_execution_coordinator_boundary.py
@@ -12,14 +12,14 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
 from aegisops_control_plane.config import RuntimeConfig
-from aegisops_control_plane.action_lifecycle_write_coordinator import (
+from aegisops_control_plane.actions.action_lifecycle_write_coordinator import (
     ActionLifecycleWriteCoordinator,
 )
-from aegisops_control_plane.action_reconciliation_orchestration import (
+from aegisops_control_plane.actions.action_reconciliation_orchestration import (
     ActionOrchestrationBoundary,
     ReconciliationOrchestrationBoundary,
 )
-from aegisops_control_plane.execution_coordinator import ExecutionCoordinator
+from aegisops_control_plane.actions.execution_coordinator import ExecutionCoordinator
 from aegisops_control_plane.service import AegisOpsControlPlaneService
 from postgres_test_support import make_store
 

--- a/control-plane/tests/test_phase21_runtime_auth_validation.py
+++ b/control-plane/tests/test_phase21_runtime_auth_validation.py
@@ -16,7 +16,7 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 
 import main
 from aegisops_control_plane.config import RuntimeConfig
-from aegisops_control_plane.http_protected_surface import (
+from aegisops_control_plane.api.http_protected_surface import (
     OPERATOR_ANALYST_PATHS,
     OPERATOR_APPROVER_PATHS,
     PROTECTED_READ_ROLES_BY_PATH,
@@ -24,8 +24,8 @@ from aegisops_control_plane.http_protected_surface import (
     protected_read_roles,
     protected_write_roles,
 )
-from aegisops_control_plane.http_runtime_surface import RUNTIME_READ_PATHS
-from aegisops_control_plane.operations import (
+from aegisops_control_plane.api.http_runtime_surface import RUNTIME_READ_PATHS
+from aegisops_control_plane.runtime.operations import (
     RestoreReadinessService,
     RuntimeBoundaryService,
 )

--- a/control-plane/tests/test_phase24_live_assistant_adversarial_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_adversarial_validation.py
@@ -15,7 +15,7 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
 from _service_persistence_support import ServicePersistenceTestBase
-from aegisops_control_plane.assistant_provider import (
+from aegisops_control_plane.assistant.assistant_provider import (
     AssistantProviderAdapter,
     AssistantProviderResult,
 )
@@ -274,7 +274,7 @@ class Phase24LiveAssistantAdversarialValidationTests(ServicePersistenceTestBase)
         )
 
         with mock.patch(
-            "aegisops_control_plane.live_assistant_workflow.phase24_live_assistant_citations_from_context",
+            "aegisops_control_plane.assistant.live_assistant_workflow.phase24_live_assistant_citations_from_context",
             return_value=(),
         ):
             snapshot = service.run_live_assistant_workflow(

--- a/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_feedback_loop_validation.py
@@ -15,11 +15,11 @@ from _service_persistence_support import (
     RecommendationRecord,
     ServicePersistenceTestBase,
 )
-from aegisops_control_plane.assistant_provider import (
+from aegisops_control_plane.assistant.assistant_provider import (
     AssistantProviderAdapter,
     AssistantProviderResult,
 )
-from aegisops_control_plane.live_assistant_workflow import (
+from aegisops_control_plane.assistant.live_assistant_workflow import (
     phase24_live_assistant_citations_from_context,
 )
 

--- a/control-plane/tests/test_phase24_live_assistant_provider_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_provider_validation.py
@@ -13,7 +13,7 @@ CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
-from aegisops_control_plane.assistant_provider import (  # type: ignore[attr-defined]
+from aegisops_control_plane.assistant.assistant_provider import (  # type: ignore[attr-defined]
     AssistantProviderAdapter,
     AssistantProviderAttemptFailure,
     AssistantProviderFailure,

--- a/control-plane/tests/test_phase24_live_assistant_surface_validation.py
+++ b/control-plane/tests/test_phase24_live_assistant_surface_validation.py
@@ -18,7 +18,7 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 import main  # type: ignore[import-not-found]
 
 from _service_persistence_support import ServicePersistenceTestBase
-from aegisops_control_plane.assistant_provider import AssistantProviderResult
+from aegisops_control_plane.assistant.assistant_provider import AssistantProviderResult
 
 
 class Phase24LiveAssistantSurfaceValidationTests(ServicePersistenceTestBase):
@@ -397,7 +397,7 @@ class Phase24LiveAssistantSurfaceValidationTests(ServicePersistenceTestBase):
 
         stdout = io.StringIO()
         with mock.patch(
-            "aegisops_control_plane.live_assistant_workflow.phase24_live_assistant_citations_from_context",
+            "aegisops_control_plane.assistant.live_assistant_workflow.phase24_live_assistant_citations_from_context",
             return_value=(),
         ):
             main.main(

--- a/control-plane/tests/test_phase27_day2_runtime_contract.py
+++ b/control-plane/tests/test_phase27_day2_runtime_contract.py
@@ -16,7 +16,7 @@ if str(TESTS_ROOT) not in sys.path:
 
 from support.service_persistence import ServicePersistenceTestBase
 from aegisops_control_plane.config import RuntimeConfig
-from aegisops_control_plane.http_protected_surface import authenticate_protected_write
+from aegisops_control_plane.api.http_protected_surface import authenticate_protected_write
 from aegisops_control_plane.service import (
     AegisOpsControlPlaneService,
     ActionExecutionRecord,

--- a/control-plane/tests/test_phase28_external_evidence_boundary_refactor.py
+++ b/control-plane/tests/test_phase28_external_evidence_boundary_refactor.py
@@ -13,9 +13,9 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 
 
 from aegisops_control_plane.config import RuntimeConfig
-from aegisops_control_plane import external_evidence_boundary
-from aegisops_control_plane import external_evidence_endpoint
-from aegisops_control_plane import external_evidence_facade
+from aegisops_control_plane.evidence import external_evidence_boundary
+from aegisops_control_plane.evidence import external_evidence_endpoint
+from aegisops_control_plane.evidence import external_evidence_facade
 from aegisops_control_plane.service import AegisOpsControlPlaneService
 from postgres_test_support import make_store
 

--- a/control-plane/tests/test_phase49_5_pilot_reporting_export.py
+++ b/control-plane/tests/test_phase49_5_pilot_reporting_export.py
@@ -14,7 +14,7 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 
 from aegisops_control_plane.config import RuntimeConfig
 from aegisops_control_plane.models import CaseRecord, EvidenceRecord
-from aegisops_control_plane.pilot_reporting_export import (
+from aegisops_control_plane.reporting.pilot_reporting_export import (
     export_pilot_executive_summary,
 )
 from aegisops_control_plane.service import AegisOpsControlPlaneService

--- a/control-plane/tests/test_runtime_skeleton.py
+++ b/control-plane/tests/test_runtime_skeleton.py
@@ -177,7 +177,7 @@ class RuntimeSkeletonTests(unittest.TestCase):
             )
 
     def test_cli_module_owns_parser_and_command_dispatch(self) -> None:
-        from aegisops_control_plane import cli
+        from aegisops_control_plane.api import cli
 
         parser = cli.build_parser()
         parsed = parser.parse_args(["runtime"])
@@ -191,7 +191,7 @@ class RuntimeSkeletonTests(unittest.TestCase):
         self.assertEqual(payload["persistence_mode"], "postgresql")
 
     def test_http_surface_module_owns_request_handler_construction(self) -> None:
-        from aegisops_control_plane import http_surface
+        from aegisops_control_plane.api import http_surface
 
         service = AegisOpsControlPlaneService(
             RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops")
@@ -206,7 +206,7 @@ class RuntimeSkeletonTests(unittest.TestCase):
         self.assertTrue(issubclass(handler_class, BaseHTTPRequestHandler))
 
     def test_http_surface_dispatch_uses_declared_route_tables(self) -> None:
-        from aegisops_control_plane import http_surface
+        from aegisops_control_plane.api import http_surface
 
         self.assertIn("/inspect-records", http_surface.HTTP_GET_ROUTES)
         self.assertIn(
@@ -235,7 +235,7 @@ class RuntimeSkeletonTests(unittest.TestCase):
     def test_readyz_uses_current_readiness_diagnostics_status(self) -> None:
         from http.server import ThreadingHTTPServer
 
-        from aegisops_control_plane import http_surface
+        from aegisops_control_plane.api import http_surface
 
         readiness_snapshot = mock.Mock()
         readiness_snapshot.to_dict.return_value = {
@@ -282,7 +282,7 @@ class RuntimeSkeletonTests(unittest.TestCase):
         service.inspect_readiness_diagnostics.assert_called_once_with()
 
     def test_readyz_runtime_status_fails_closed_for_unknown_status(self) -> None:
-        from aegisops_control_plane.readiness_contracts import (
+        from aegisops_control_plane.runtime.readiness_contracts import (
             resolve_readyz_runtime_status,
         )
 

--- a/control-plane/tests/test_service_persistence_assistant_advisory.py
+++ b/control-plane/tests/test_service_persistence_assistant_advisory.py
@@ -33,7 +33,7 @@ from _service_persistence_support import (
     timedelta,
     timezone,
 )
-from aegisops_control_plane.assistant_advisory import AssistantAdvisoryCoordinator
+from aegisops_control_plane.assistant.assistant_advisory import AssistantAdvisoryCoordinator
 
 
 class AssistantAdvisoryPersistenceTests(ServicePersistenceTestBase):

--- a/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
+++ b/control-plane/tests/test_service_persistence_ingest_case_lifecycle.py
@@ -12,9 +12,9 @@ if str(TESTS_ROOT) not in sys.path:
 import _service_persistence_support as support
 from _service_persistence_support import ServicePersistenceTestBase
 import aegisops_control_plane.service as service_module
-from aegisops_control_plane.case_workflow import CaseWorkflowService
-from aegisops_control_plane.detection_lifecycle import DetectionIntakeService
-from aegisops_control_plane.evidence_linkage import EvidenceLinkageService
+from aegisops_control_plane.ingestion.case_workflow import CaseWorkflowService
+from aegisops_control_plane.ingestion.detection_lifecycle import DetectionIntakeService
+from aegisops_control_plane.ingestion.evidence_linkage import EvidenceLinkageService
 from aegisops_control_plane.models import AlertRecord, AnalyticSignalRecord, CaseRecord
 
 REVIEWED_PROXY_SECRET = "reviewed-proxy-secret"  # noqa: S105 - test fixture secret

--- a/scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh
+++ b/scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-6-2-canonical-domain-imports.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_fixture() {
+  local target="$1"
+
+  mkdir -p \
+    "${target}/control-plane/aegisops_control_plane/actions" \
+    "${target}/control-plane/aegisops_control_plane/api" \
+    "${target}/control-plane/aegisops_control_plane/evidence" \
+    "${target}/control-plane/aegisops_control_plane/ml_shadow" \
+    "${target}/control-plane/tests" \
+    "${target}/docs/adr" \
+    "${target}/scripts"
+
+  cat >"${target}/control-plane/aegisops_control_plane/action_policy.py" <<'EOF'
+from .actions.action_policy import evaluate_action_policy_record
+EOF
+
+  cat >"${target}/control-plane/aegisops_control_plane/actions/action_policy.py" <<'EOF'
+def evaluate_action_policy_record(record):
+    return record
+EOF
+
+  cat >"${target}/control-plane/aegisops_control_plane/api/cli.py" <<'EOF'
+def build_parser():
+    return object()
+EOF
+
+  cat >"${target}/control-plane/main.py" <<'EOF'
+from aegisops_control_plane.api import cli
+
+def build():
+    return cli.build_parser()
+EOF
+
+  cat >"${target}/control-plane/tests/test_canonical_imports.py" <<'EOF'
+from aegisops_control_plane.actions.action_policy import evaluate_action_policy_record
+
+def test_evaluate_action_policy_record():
+    assert evaluate_action_policy_record({"id": "record-1"}) == {"id": "record-1"}
+EOF
+
+  cat >"${target}/control-plane/tests/test_phase29_shadow_scoring_validation.py" <<'EOF'
+import aegisops_control_plane.phase29_shadow_scoring as legacy_shadow_scoring
+
+def test_legacy_shadow_scoring_import_path_preserves_adapter_surface():
+    assert legacy_shadow_scoring is not None
+EOF
+
+  cat >"${target}/docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md" <<'EOF'
+Legacy compatibility checks retain `aegisops_control_plane.action_policy`.
+EOF
+}
+
+assert_passes() {
+  local target="$1"
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+  if ! grep -F "${expected}" "${fail_stderr}" >/dev/null; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+passing_repo="${workdir}/passing"
+create_fixture "${passing_repo}"
+assert_passes "${passing_repo}"
+if ! grep -F "approved legacy compatibility usage is limited to" "${pass_stdout}" >/dev/null; then
+  echo "Expected passing output to report approved legacy usage." >&2
+  cat "${pass_stdout}" >&2
+  exit 1
+fi
+
+production_root_import_repo="${workdir}/production-root-import"
+create_fixture "${production_root_import_repo}"
+cat >"${production_root_import_repo}/control-plane/main.py" <<'EOF'
+from aegisops_control_plane import cli
+
+def build():
+    return cli.build_parser()
+EOF
+assert_fails_with \
+  "${production_root_import_repo}" \
+  "control-plane/main.py:1 imports aegisops_control_plane.cli; use aegisops_control_plane.api.cli"
+
+test_root_import_repo="${workdir}/test-root-import"
+create_fixture "${test_root_import_repo}"
+cat >"${test_root_import_repo}/control-plane/tests/test_canonical_imports.py" <<'EOF'
+from aegisops_control_plane.action_policy import evaluate_action_policy_record
+
+def test_evaluate_action_policy_record():
+    assert evaluate_action_policy_record({"id": "record-1"}) == {"id": "record-1"}
+EOF
+assert_fails_with \
+  "${test_root_import_repo}" \
+  "control-plane/tests/test_canonical_imports.py:1 imports aegisops_control_plane.action_policy; use aegisops_control_plane.actions.action_policy"
+
+doc_root_import_repo="${workdir}/doc-root-import"
+create_fixture "${doc_root_import_repo}"
+cat >"${doc_root_import_repo}/docs/operator-guide.md" <<'EOF'
+Operators should import `aegisops_control_plane.action_policy` directly.
+EOF
+assert_fails_with \
+  "${doc_root_import_repo}" \
+  "docs/operator-guide.md:1 mentions a root compatibility import path"
+
+echo "verify-phase-52-6-2-canonical-domain-imports tests passed"

--- a/scripts/verify-phase-52-6-2-canonical-domain-imports.sh
+++ b/scripts/verify-phase-52-6-2-canonical-domain-imports.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+control_plane_root="${repo_root}/control-plane"
+
+if [[ ! -d "${control_plane_root}/aegisops_control_plane" ]]; then
+  echo "Missing control-plane package root: control-plane/aegisops_control_plane" >&2
+  exit 1
+fi
+
+export PHASE52_6_2_REPO_ROOT="${repo_root}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+import re
+import sys
+
+repo_root = Path(os.environ["PHASE52_6_2_REPO_ROOT"]).resolve()
+package_root = repo_root / "control-plane" / "aegisops_control_plane"
+
+legacy_owner_modules = {
+    "aegisops_control_plane.ai_trace_lifecycle": "aegisops_control_plane.assistant.ai_trace_lifecycle",
+    "aegisops_control_plane.assistant_advisory": "aegisops_control_plane.assistant.assistant_advisory",
+    "aegisops_control_plane.assistant_context": "aegisops_control_plane.assistant.assistant_context",
+    "aegisops_control_plane.assistant_provider": "aegisops_control_plane.assistant.assistant_provider",
+    "aegisops_control_plane.live_assistant_workflow": "aegisops_control_plane.assistant.live_assistant_workflow",
+    "aegisops_control_plane.audit_export": "aegisops_control_plane.reporting.audit_export",
+    "aegisops_control_plane.pilot_reporting_export": "aegisops_control_plane.reporting.pilot_reporting_export",
+    "aegisops_control_plane.action_review_chain": "aegisops_control_plane.actions.review.action_review_chain",
+    "aegisops_control_plane.action_review_coordination": "aegisops_control_plane.actions.review.action_review_coordination",
+    "aegisops_control_plane.action_review_index": "aegisops_control_plane.actions.review.action_review_index",
+    "aegisops_control_plane.action_review_inspection": "aegisops_control_plane.actions.review.action_review_inspection",
+    "aegisops_control_plane.action_review_path_health": "aegisops_control_plane.actions.review.action_review_path_health",
+    "aegisops_control_plane.action_review_projection": "aegisops_control_plane.actions.review.action_review_projection",
+    "aegisops_control_plane.action_review_timeline": "aegisops_control_plane.actions.review.action_review_timeline",
+    "aegisops_control_plane.action_review_visibility": "aegisops_control_plane.actions.review.action_review_visibility",
+    "aegisops_control_plane.action_review_write_surface": "aegisops_control_plane.actions.review.action_review_write_surface",
+    "aegisops_control_plane.action_lifecycle_write_coordinator": "aegisops_control_plane.actions.action_lifecycle_write_coordinator",
+    "aegisops_control_plane.action_policy": "aegisops_control_plane.actions.action_policy",
+    "aegisops_control_plane.action_receipt_validation": "aegisops_control_plane.actions.action_receipt_validation",
+    "aegisops_control_plane.action_reconciliation_orchestration": "aegisops_control_plane.actions.action_reconciliation_orchestration",
+    "aegisops_control_plane.execution_coordinator": "aegisops_control_plane.actions.execution_coordinator",
+    "aegisops_control_plane.execution_coordinator_action_requests": "aegisops_control_plane.actions.execution_coordinator_action_requests",
+    "aegisops_control_plane.execution_coordinator_delegation": "aegisops_control_plane.actions.execution_coordinator_delegation",
+    "aegisops_control_plane.execution_coordinator_reconciliation": "aegisops_control_plane.actions.execution_coordinator_reconciliation",
+    "aegisops_control_plane.runtime_boundary": "aegisops_control_plane.runtime.runtime_boundary",
+    "aegisops_control_plane.readiness_contracts": "aegisops_control_plane.runtime.readiness_contracts",
+    "aegisops_control_plane.readiness_operability": "aegisops_control_plane.runtime.readiness_operability",
+    "aegisops_control_plane.restore_readiness": "aegisops_control_plane.runtime.restore_readiness",
+    "aegisops_control_plane.restore_readiness_projection": "aegisops_control_plane.runtime.restore_readiness_projection",
+    "aegisops_control_plane.restore_readiness_backup_restore": "aegisops_control_plane.runtime.restore_readiness_backup_restore",
+    "aegisops_control_plane.runtime_restore_readiness_diagnostics": "aegisops_control_plane.runtime.runtime_restore_readiness_diagnostics",
+    "aegisops_control_plane.service_snapshots": "aegisops_control_plane.runtime.service_snapshots",
+    "aegisops_control_plane.operations": "aegisops_control_plane.runtime.operations",
+    "aegisops_control_plane.cli": "aegisops_control_plane.api.cli",
+    "aegisops_control_plane.entrypoint_support": "aegisops_control_plane.api.entrypoint_support",
+    "aegisops_control_plane.http_surface": "aegisops_control_plane.api.http_surface",
+    "aegisops_control_plane.http_protected_surface": "aegisops_control_plane.api.http_protected_surface",
+    "aegisops_control_plane.http_runtime_surface": "aegisops_control_plane.api.http_runtime_surface",
+    "aegisops_control_plane.detection_lifecycle": "aegisops_control_plane.ingestion.detection_lifecycle",
+    "aegisops_control_plane.detection_lifecycle_helpers": "aegisops_control_plane.ingestion.detection_lifecycle_helpers",
+    "aegisops_control_plane.detection_native_context": "aegisops_control_plane.ingestion.detection_native_context",
+    "aegisops_control_plane.case_workflow": "aegisops_control_plane.ingestion.case_workflow",
+    "aegisops_control_plane.evidence_linkage": "aegisops_control_plane.ingestion.evidence_linkage",
+    "aegisops_control_plane.external_evidence_boundary": "aegisops_control_plane.evidence.external_evidence_boundary",
+    "aegisops_control_plane.external_evidence_facade": "aegisops_control_plane.evidence.external_evidence_facade",
+    "aegisops_control_plane.external_evidence_misp": "aegisops_control_plane.evidence.external_evidence_misp",
+    "aegisops_control_plane.external_evidence_osquery": "aegisops_control_plane.evidence.external_evidence_osquery",
+    "aegisops_control_plane.external_evidence_endpoint": "aegisops_control_plane.evidence.external_evidence_endpoint",
+    "aegisops_control_plane.phase29_shadow_dataset": "aegisops_control_plane.ml_shadow.dataset",
+    "aegisops_control_plane.phase29_shadow_scoring": "aegisops_control_plane.ml_shadow.scoring",
+    "aegisops_control_plane.phase29_evidently_drift_visibility": "aegisops_control_plane.ml_shadow.drift_visibility",
+    "aegisops_control_plane.phase29_mlflow_shadow_model_registry": "aegisops_control_plane.ml_shadow.mlflow_registry",
+}
+
+root_shim_names = {module.rsplit(".", 1)[1] for module in legacy_owner_modules}
+root_shim_paths = {
+    "control-plane/aegisops_control_plane/" + module.rsplit(".", 1)[1] + ".py"
+    for module in legacy_owner_modules
+}
+
+approved_legacy_python_files = {
+    "control-plane/tests/test_phase29_shadow_scoring_validation.py",
+    "control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py",
+    "control-plane/tests/test_service_snapshot_extraction.py",
+    "scripts/verify-phase-52-5-2-import-compatibility.sh",
+    "scripts/verify-phase-52-5-9-service-facade-freeze.sh",
+    "scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh",
+    "scripts/test-verify-phase-52-5-9-service-facade-freeze.sh",
+    "scripts/verify-phase-52-5-closeout-evaluation.sh",
+    "scripts/verify-phase-52-6-2-canonical-domain-imports.sh",
+    "scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh",
+}
+
+approved_legacy_text_files = {
+    "docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md",
+    "docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md",
+    "docs/control-plane-service-internal-boundaries.md",
+    "docs/phase-52-5-closeout-evaluation.md",
+} | approved_legacy_python_files
+
+
+def relative(path: Path) -> str:
+    return path.relative_to(repo_root).as_posix()
+
+
+def is_root_shim_file(path: Path) -> bool:
+    return relative(path) in root_shim_paths
+
+
+def python_candidates() -> list[Path]:
+    roots = [repo_root / "control-plane", repo_root / "scripts"]
+    paths: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        for pattern in ("*.py", "*.sh"):
+            paths.extend(root.rglob(pattern))
+    return sorted(set(paths))
+
+
+def text_candidates() -> list[Path]:
+    paths: list[Path] = []
+    for root_name, patterns in {
+        "docs": ("*.md",),
+        "scripts": ("*.sh",),
+        ".github": ("*.yml", "*.yaml", "*.md"),
+    }.items():
+        root = repo_root / root_name
+        if not root.exists():
+            continue
+        for pattern in patterns:
+            paths.extend(root.rglob(pattern))
+    for extra in ("README.md", "package.json"):
+        path = repo_root / extra
+        if path.exists():
+            paths.append(path)
+    return sorted(set(paths))
+
+
+def import_from_candidates(module: str | None, node: ast.ImportFrom) -> list[str]:
+    if module is None:
+        return []
+    candidates = [module]
+    if module == "aegisops_control_plane":
+        candidates.extend(f"{module}.{alias.name}" for alias in node.names)
+    return candidates
+
+
+python_violations: list[str] = []
+approved_python_hits: set[str] = set()
+for path in python_candidates():
+    rel = relative(path)
+    if rel in approved_legacy_python_files or is_root_shim_file(path):
+        approved_python_hits.add(rel)
+        continue
+    if path.suffix != ".py":
+        continue
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+    except SyntaxError as exc:
+        print(f"Could not parse {rel}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in legacy_owner_modules:
+                    owner = legacy_owner_modules[alias.name]
+                    python_violations.append(
+                        f"{rel}:{node.lineno} imports {alias.name}; use {owner}"
+                    )
+        elif isinstance(node, ast.ImportFrom) and node.level == 0:
+            for candidate in import_from_candidates(node.module, node):
+                if candidate in legacy_owner_modules:
+                    owner = legacy_owner_modules[candidate]
+                    python_violations.append(
+                        f"{rel}:{node.lineno} imports {candidate}; use {owner}"
+                    )
+
+legacy_text_pattern = re.compile(
+    r"\baegisops_control_plane\.(?:"
+    + "|".join(re.escape(name.rsplit(".", 1)[1]) for name in sorted(legacy_owner_modules))
+    + r")\b"
+)
+text_violations: list[str] = []
+approved_text_hits: set[str] = set()
+for path in text_candidates():
+    rel = relative(path)
+    text = path.read_text(encoding="utf-8")
+    if not legacy_text_pattern.search(text):
+        continue
+    if rel in approved_legacy_text_files:
+        approved_text_hits.add(rel)
+        continue
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if legacy_text_pattern.search(line):
+            text_violations.append(
+                f"{rel}:{line_number} mentions a root compatibility import path"
+            )
+
+violations = python_violations + text_violations
+if violations:
+    print(
+        "Phase 52.6.2 canonical domain import verifier found non-approved "
+        "root compatibility shim usage:",
+        file=sys.stderr,
+    )
+    for violation in violations:
+        print(f"- {violation}", file=sys.stderr)
+    sys.exit(1)
+
+approved_hits = sorted(approved_python_hits | approved_text_hits)
+print(
+    "Phase 52.6.2 canonical domain import verifier passed: internal callers use "
+    "canonical domain imports; approved legacy compatibility usage is limited to "
+    + ", ".join(approved_hits)
+)
+PY


### PR DESCRIPTION
## Summary

- rewires `control-plane/main.py` and non-compatibility control-plane tests/helpers from root compatibility shims to canonical domain package imports
- adds `scripts/verify-phase-52-6-2-canonical-domain-imports.sh` to reject non-approved internal root shim imports and root-shim mentions in non-approved docs/scripts
- keeps public legacy compatibility imports and dedicated compatibility tests intact

Part of #1105
Closes #1107
Depends on #1106

## Approved legacy import allowlist

- root compatibility shim files under `control-plane/aegisops_control_plane/*.py`
- compatibility tests: `test_phase29_shadow_scoring_validation.py`, `test_service_persistence_action_reconciliation_review_surfaces.py`, `test_service_snapshot_extraction.py`
- compatibility policy/evidence artifacts: ADR-0013, ADR-0014, Phase 52.5 closeout, service boundary docs, existing compatibility/import verifier scripts

## Verification

- `bash scripts/verify-phase-52-6-2-canonical-domain-imports.sh`
- `bash scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh`
- `bash scripts/verify-phase-52-5-2-import-compatibility.sh`
- `bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`
- `bash scripts/test-verify-phase-52-5-9-service-facade-freeze.sh`
- `python3 -m unittest tests.test_action_receipt_validation tests.test_cross_boundary_negative_e2e_validation tests.test_execution_coordinator_boundary tests.test_phase21_runtime_auth_validation tests.test_phase24_live_assistant_adversarial_validation tests.test_phase24_live_assistant_feedback_loop_validation tests.test_phase24_live_assistant_provider_validation tests.test_phase24_live_assistant_surface_validation tests.test_phase27_day2_runtime_contract tests.test_phase28_external_evidence_boundary_refactor tests.test_phase49_5_pilot_reporting_export tests.test_runtime_skeleton tests.test_service_persistence_assistant_advisory tests.test_service_persistence_ingest_case_lifecycle` from `control-plane/` -> 225 tests OK
- `node <codex-supervisor-root>/dist/index.js issue-lint 1107 --config <supervisor-config-path>` -> `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Refactored internal module import paths across test and main components to establish a standardized package structure
* Introduced automated verification tooling to enforce canonical import path conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->