### PR TITLE
Phase 52.6.3 legacy import alias registry

### DIFF
--- a/control-plane/aegisops_control_plane/__init__.py
+++ b/control-plane/aegisops_control_plane/__init__.py
@@ -1,5 +1,8 @@
 """AegisOps control-plane runtime scaffold."""
 
+from .core.legacy_import_aliases import register_legacy_import_aliases
+
+register_legacy_import_aliases()
 from .adapters import WazuhAlertAdapter
 from .config import RuntimeConfig
 from .models import (

--- a/control-plane/aegisops_control_plane/audit_export.py
+++ b/control-plane/aegisops_control_plane/audit_export.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the reporting audit export module."""
-
-from __future__ import annotations
-
-import sys
-
-from .reporting import audit_export as _impl
-
-sys.modules[__name__] = _impl

--- a/control-plane/aegisops_control_plane/core/legacy_import_aliases.py
+++ b/control-plane/aegisops_control_plane/core/legacy_import_aliases.py
@@ -53,5 +53,17 @@ def register_legacy_import_aliases(
             )
         target = importlib.import_module(alias.target_module)
         sys.modules[legacy_module] = target
+        _bind_legacy_module_to_parent(legacy_module, target)
         registered[legacy_module] = target
     return registered
+
+
+def _bind_legacy_module_to_parent(legacy_module: str, target: ModuleType) -> None:
+    parent_name, _, child_name = legacy_module.rpartition(".")
+    if not parent_name:
+        return
+
+    parent_module = sys.modules.get(parent_name)
+    if parent_module is None:
+        parent_module = importlib.import_module(parent_name)
+    setattr(parent_module, child_name, target)

--- a/control-plane/aegisops_control_plane/core/legacy_import_aliases.py
+++ b/control-plane/aegisops_control_plane/core/legacy_import_aliases.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+import sys
+from types import ModuleType
+
+
+@dataclass(frozen=True)
+class LegacyImportAlias:
+    legacy_module: str
+    target_module: str
+    target_family: str
+    owner: str
+
+    def __post_init__(self) -> None:
+        for field_name in ("legacy_module", "target_module", "target_family", "owner"):
+            if not getattr(self, field_name):
+                raise ValueError(f"legacy import alias missing {field_name}")
+        if self.legacy_module == self.target_module:
+            raise ValueError(
+                f"legacy import alias points at itself: {self.legacy_module}"
+            )
+
+
+LEGACY_IMPORT_ALIASES: dict[str, LegacyImportAlias] = {
+    "aegisops_control_plane.audit_export": LegacyImportAlias(
+        legacy_module="aegisops_control_plane.audit_export",
+        target_module="aegisops_control_plane.reporting.audit_export",
+        target_family="reporting",
+        owner="reporting/audit_export.py",
+    ),
+}
+
+RETAINED_COMPATIBILITY_BLOCKERS: dict[str, str] = {
+    "aegisops_control_plane.service": "Public facade import path retained under ADR-0003 and ADR-0010.",
+    "aegisops_control_plane.models": "Authoritative record model import path remains a root owner.",
+    "aegisops_control_plane.phase29_shadow_dataset": "Phase29 adapter still needs adapter-specific caller evidence.",
+    "aegisops_control_plane.phase29_shadow_scoring": "Phase29 adapter still needs adapter-specific caller evidence.",
+    "aegisops_control_plane.phase29_evidently_drift_visibility": "Phase29 adapter still needs adapter-specific caller evidence.",
+    "aegisops_control_plane.phase29_mlflow_shadow_model_registry": "Phase29 adapter still needs adapter-specific caller evidence.",
+}
+
+
+def register_legacy_import_aliases(
+    aliases: dict[str, LegacyImportAlias] = LEGACY_IMPORT_ALIASES,
+) -> dict[str, ModuleType]:
+    registered: dict[str, ModuleType] = {}
+    for legacy_module, alias in aliases.items():
+        if legacy_module != alias.legacy_module:
+            raise ValueError(
+                f"legacy import alias key mismatch: {legacy_module} != {alias.legacy_module}"
+            )
+        target = importlib.import_module(alias.target_module)
+        sys.modules[legacy_module] = target
+        registered[legacy_module] = target
+    return registered

--- a/control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py
+++ b/control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py
@@ -26,8 +26,12 @@ class LegacyImportAliasRegistryTests(unittest.TestCase):
 
         legacy_module = importlib.import_module(alias)
         owner_module = importlib.import_module(owner)
+        package = importlib.import_module("aegisops_control_plane")
+        from aegisops_control_plane import audit_export as legacy_from_package
 
         self.assertIs(legacy_module, owner_module)
+        self.assertIs(legacy_from_package, owner_module)
+        self.assertIs(getattr(package, "audit_export"), owner_module)
         self.assertIs(
             legacy_module.export_audit_retention_baseline,
             owner_module.export_audit_retention_baseline,

--- a/control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py
+++ b/control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py
@@ -31,7 +31,7 @@ class LegacyImportAliasRegistryTests(unittest.TestCase):
 
         self.assertIs(legacy_module, owner_module)
         self.assertIs(legacy_from_package, owner_module)
-        self.assertIs(getattr(package, "audit_export"), owner_module)
+        self.assertIs(package.audit_export, owner_module)
         self.assertIs(
             legacy_module.export_audit_retention_baseline,
             owner_module.export_audit_retention_baseline,

--- a/control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py
+++ b/control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+
+class LegacyImportAliasRegistryTests(unittest.TestCase):
+    def test_approved_legacy_alias_resolves_to_registered_owner(self) -> None:
+        registry = importlib.import_module(
+            "aegisops_control_plane.core.legacy_import_aliases"
+        )
+
+        alias = "aegisops_control_plane.audit_export"
+        owner = "aegisops_control_plane.reporting.audit_export"
+
+        self.assertIn(alias, registry.LEGACY_IMPORT_ALIASES)
+        self.assertEqual(registry.LEGACY_IMPORT_ALIASES[alias].target_module, owner)
+        self.assertEqual(registry.LEGACY_IMPORT_ALIASES[alias].target_family, "reporting")
+
+        legacy_module = importlib.import_module(alias)
+        owner_module = importlib.import_module(owner)
+
+        self.assertIs(legacy_module, owner_module)
+        self.assertIs(
+            legacy_module.export_audit_retention_baseline,
+            owner_module.export_audit_retention_baseline,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
+++ b/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
@@ -190,7 +190,9 @@ The public Python package name `aegisops_control_plane` remains unchanged throug
 
 The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.
 
-Legacy import paths remain available during migration through compatibility shims or direct re-export modules until all documented internal, CLI, HTTP, test, and operator callers have migrated.
+Legacy import paths remain available during migration through compatibility shims, direct re-export modules, or approved entries in the legacy import alias registry until all documented internal, CLI, HTTP, test, and operator callers have migrated.
+
+The Phase 52.6.3 registry is owned by `control-plane/aegisops_control_plane/core/legacy_import_aliases.py`, preserves explicit owner metadata for each approved alias row, and replaces the removed `control-plane/aegisops_control_plane/audit_export.py` root shim for `aegisops_control_plane.audit_export`.
 
 Removing a legacy import path requires a later transition policy that lists the affected import path, replacement import path, caller evidence, deprecation window, focused regression test, and rollback path.
 

--- a/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
+++ b/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
@@ -107,11 +107,11 @@ The layout inventory does not change authorization, provenance, reconciliation, 
 | `assistant_advisory.py` | `assistant` | Compatibility shim only for the moved assistant advisory owner. |
 | `assistant_context.py` | `assistant` | Compatibility shim only for the moved assistant context owner. |
 | `assistant_provider.py` | `assistant` | Compatibility shim only for the moved assistant provider owner. |
-| `audit_export.py` | `reporting` | Compatibility shim only for the moved audit export owner. |
 | `case_workflow.py` | `ingestion` | Compatibility shim only for the moved case workflow owner. |
 | `cli.py` | `api` | Compatibility shim only for the moved CLI owner. |
 | `config.py` | `runtime` | Move only with runtime config ownership and no sample secret acceptance. |
 | `core/__init__.py` | `core` | Package scaffold marker only; no authoritative model, persistence, service, or validation module moves are approved by the marker. |
+| `core/legacy_import_aliases.py` | `core` | Owns the bounded legacy import alias registry while preserving explicit owner metadata and no runtime behavior change. |
 | `detection_lifecycle.py` | `ingestion` | Compatibility shim only for the moved detection lifecycle owner. |
 | `detection_lifecycle_helpers.py` | `ingestion` | Compatibility shim only for the moved detection helper owner. |
 | `detection_native_context.py` | `ingestion` | Compatibility shim only for the moved native detection context owner. |

--- a/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
+++ b/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
@@ -14,9 +14,9 @@
 
 ## 1. Purpose
 
-Phase 52.6.1 records the root-level compatibility surface under `control-plane/aegisops_control_plane/` before any physical root shim deletion is approved.
+Phase 52.6.1 records the root-level compatibility surface under `control-plane/aegisops_control_plane/` before broad physical root shim deletion is approved.
 
-This contract is documentation and verification only. It does not delete shims, change imports, rename the public package, change the outer `control-plane/` directory, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior.
+This contract is documentation and verification only. Phase 52.6.3 removes only `audit_export.py` as the proof-of-pattern alias-registry candidate; it does not delete broad shim sets, rename the public package, change the outer `control-plane/` directory, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior.
 
 ## 2. Authority Boundary
 
@@ -28,7 +28,7 @@ The root shim inventory does not change authorization, provenance, reconciliatio
 
 ## 3. Phase 52.5 Root File Baseline
 
-The Phase 52.5 closeout baseline for root-level Python files under `control-plane/aegisops_control_plane/` is `63`.
+The Phase 52.6.3 root-level Python file count under `control-plane/aegisops_control_plane/` is `62` after the approved `audit_export.py` alias-registry proof of pattern.
 
 The baseline counts only direct `.py` files in `control-plane/aegisops_control_plane/`; package-owned files below subdirectories are tracked by ADR-0012 and stay outside this root shim baseline.
 
@@ -68,7 +68,6 @@ If caller evidence is incomplete, malformed, ambiguous, or inferred only from na
 | `assistant_advisory.py` | `assistant` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
 | `assistant_context.py` | `assistant` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
 | `assistant_provider.py` | `assistant` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
-| `audit_export.py` | `reporting` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
 | `case_workflow.py` | `ingestion` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
 | `cli.py` | `api` | alias candidate | Candidate for later physical deletion only after caller evidence proves the direct owner import is stable and an alias-preservation test exists. |
 | `config.py` | `runtime` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
@@ -146,11 +145,15 @@ Run `bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh`.
 
 Run `bash scripts/verify-publishable-path-hygiene.sh`.
 
-Run `node <codex-supervisor-root>/dist/index.js issue-lint 1106 --config <supervisor-config-path>`.
+Run `bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh`.
+
+Run `bash scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1108 --config <supervisor-config-path>`.
 
 ## 10. Non-Goals
 
-- No root-level shim is deleted.
+- Only `audit_export.py` is removed as the Phase 52.6.3 alias-registry proof of pattern.
 - No import path is changed.
 - No public package name is changed.
 - No outer repository directory is changed.

--- a/docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md
+++ b/docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md
@@ -1,0 +1,76 @@
+# ADR-0015: Phase 52.6.3 Legacy Import Alias Registry
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md`
+- **Product**: AegisOps
+- **Related Issues**: #1105, #1108
+- **Depends On**: #1107
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+---
+
+## 1. Purpose
+
+Phase 52.6.3 adds a bounded legacy import alias registry so approved old module paths can survive without one physical shim file per legacy path.
+
+The registry is import infrastructure only. It does not change workflow truth, authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, action-execution, HTTP, CLI, deployment, Wazuh, Shuffle, ticket, ML, reporting, or durable-state behavior.
+
+## 2. Registry Path
+
+The registry lives at `control-plane/aegisops_control_plane/core/legacy_import_aliases.py`.
+
+Package initialization calls `register_legacy_import_aliases()` before public package exports are assembled. Each alias row must include the legacy import path, target owner module, target family, and owner file.
+
+## 3. Approved Alias List
+
+| Legacy import path | Target owner import path | Target family | Owner file |
+| --- | --- | --- | --- |
+| `aegisops_control_plane.audit_export` | `aegisops_control_plane.reporting.audit_export` | `reporting` | `reporting/audit_export.py` |
+
+The `audit_export.py` root shim is the only Phase 52.6.3 physical deletion. The old import path remains available through the registry and must resolve to the exact same module object as `aegisops_control_plane.reporting.audit_export`.
+
+## 4. Retained Blockers
+
+The following paths cannot safely move to the alias registry yet:
+
+| Import path | Blocker |
+| --- | --- |
+| `aegisops_control_plane.service` | Public facade import path retained under ADR-0003 and ADR-0010. |
+| `aegisops_control_plane.models` | Authoritative record model import path remains a root owner. |
+| `aegisops_control_plane.phase29_shadow_dataset` | Phase29 adapter still needs adapter-specific caller evidence. |
+| `aegisops_control_plane.phase29_shadow_scoring` | Phase29 adapter still needs adapter-specific caller evidence. |
+| `aegisops_control_plane.phase29_evidently_drift_visibility` | Phase29 adapter still needs adapter-specific caller evidence. |
+| `aegisops_control_plane.phase29_mlflow_shadow_model_registry` | Phase29 adapter still needs adapter-specific caller evidence. |
+
+## 5. Fail-Closed Rules
+
+Alias rows without an explicit target owner fail verification.
+
+An approved legacy import path disappearing without an alias row or retained physical shim fails verification.
+
+An alias must remain a narrow module identity alias. It must not make compatibility state, summary text, generated config, CLI status, adapter state, assistant output, evidence snippets, DTOs, projections, alias rows, or operator-facing text authoritative workflow truth.
+
+## 6. Validation
+
+Run `bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh`.
+
+Run `bash scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh`.
+
+Run `bash scripts/verify-phase-52-5-2-import-compatibility.sh`.
+
+Run `bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh`.
+
+Run `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1108 --config <supervisor-config-path>`.
+
+## 7. Non-Goals
+
+- No broad shim set is deleted.
+- No public package name is changed.
+- No outer repository directory is changed.
+- No public API, runtime endpoint, CLI command, operator UI behavior, deployment behavior, or durable-state side effect is changed.
+- No subordinate source, projection, DTO, summary, helper-module output, alias row, or nearby metadata becomes authoritative workflow truth.

--- a/scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh
+++ b/scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh"
+contract_path="docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md"
+registry_path="control-plane/aegisops_control_plane/core/legacy_import_aliases.py"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/adr" "${target}/control-plane"
+  cp "${repo_root}/${contract_path}" "${target}/${contract_path}"
+  cp -R "${repo_root}/control-plane/aegisops_control_plane" \
+    "${target}/control-plane/aegisops_control_plane"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_owner_repo="${workdir}/missing-owner"
+create_valid_repo "${missing_owner_repo}"
+perl -0pi -e 's/owner="reporting\/audit_export\.py"/owner=""/' \
+  "${missing_owner_repo}/${registry_path}"
+assert_fails_with \
+  "${missing_owner_repo}" \
+  "Phase 52.6.3 legacy import alias registry failed to load: legacy import alias missing owner"
+
+missing_alias_repo="${workdir}/missing-alias"
+create_valid_repo "${missing_alias_repo}"
+perl -0pi -e 's/LEGACY_IMPORT_ALIASES: dict\[str, LegacyImportAlias\] = \{.*?\n\}\n/LEGACY_IMPORT_ALIASES: dict[str, LegacyImportAlias] = {}\n/s' \
+  "${missing_alias_repo}/${registry_path}"
+assert_fails_with \
+  "${missing_alias_repo}" \
+  "Phase 52.6.3 legacy import alias registry missing approved alias: aegisops_control_plane.audit_export"
+
+restored_physical_shim_repo="${workdir}/restored-physical-shim"
+create_valid_repo "${restored_physical_shim_repo}"
+printf '%s\n' '"""Unexpected restored audit export shim."""' \
+  >"${restored_physical_shim_repo}/control-plane/aegisops_control_plane/audit_export.py"
+assert_fails_with \
+  "${restored_physical_shim_repo}" \
+  "Phase 52.6.3 proof-of-pattern root shim should be removed: control-plane/aegisops_control_plane/audit_export.py"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/${contract_path}"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.6.3 legacy import alias registry: workstation-local absolute path detected"
+
+echo "Phase 52.6.3 legacy import alias registry verifier negative and valid fixtures passed."

--- a/scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh
+++ b/scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh
@@ -89,4 +89,26 @@ assert_fails_with \
   "${local_path_repo}" \
   "Forbidden Phase 52.6.3 legacy import alias registry: workstation-local absolute path detected"
 
+behavior_drift_repo="${workdir}/behavior-drift"
+create_valid_repo "${behavior_drift_repo}"
+python3 - <<'PY' "${behavior_drift_repo}/${registry_path}"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+text = text.replace(
+    "        sys.modules[legacy_module] = target\n",
+    "        from types import ModuleType\n"
+    "        proxy = ModuleType(legacy_module)\n"
+    "        proxy.export_audit_retention_baseline = object()\n"
+    "        sys.modules[legacy_module] = proxy\n"
+    "        target = proxy\n",
+)
+path.write_text(text)
+PY
+assert_fails_with \
+  "${behavior_drift_repo}" \
+  "Phase 52.6.3 legacy import alias changed module identity for aegisops_control_plane.audit_export"
+
 echo "Phase 52.6.3 legacy import alias registry verifier negative and valid fixtures passed."

--- a/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -25,11 +25,11 @@ required_phrases=(
   "- **Date**: 2026-05-02"
   "- **Related Issues**: #1105, #1106"
   "- **Depends On**: #1094"
-  "This contract is documentation and verification only. It does not delete shims, change imports, rename the public package, change the outer \`control-plane/\` directory, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior."
+  "This contract is documentation and verification only. Phase 52.6.3 removes only \`audit_export.py\` as the proof-of-pattern alias-registry candidate; it does not delete broad shim sets, rename the public package, change the outer \`control-plane/\` directory, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior."
   "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
   "Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, compatibility shims, alias rows, and operator-facing text remain subordinate context."
   "The root shim inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, action-execution, Wazuh, Shuffle, ticket, CLI, HTTP, or deployment behavior."
-  "The Phase 52.5 closeout baseline for root-level Python files under \`control-plane/aegisops_control_plane/\` is \`63\`."
+  "The Phase 52.6.3 root-level Python file count under \`control-plane/aegisops_control_plane/\` is \`62\` after the approved \`audit_export.py\` alias-registry proof of pattern."
   "The baseline counts only direct \`.py\` files in \`control-plane/aegisops_control_plane/\`; package-owned files below subdirectories are tracked by ADR-0012 and stay outside this root shim baseline."
   "The Phase29 root files are legacy compatibility adapters only. They are not production owners."
   "The domain-owned implementations are the directly linked \`ml_shadow\` modules listed in the inventory. Any later removal plan must test both the legacy \`phase29_*\` import path and the domain-owned \`ml_shadow\` import path before deleting a root adapter."
@@ -40,7 +40,9 @@ required_phrases=(
   "Run \`bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh\`."
   "Run \`bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh\`."
   "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
-  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1106 --config <supervisor-config-path>\`."
+  "Run \`bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh\`."
+  "Run \`bash scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1108 --config <supervisor-config-path>\`."
 )
 
 allowed_classifications=(
@@ -203,9 +205,9 @@ if extra:
     )
     sys.exit(1)
 
-if len(actual_modules) != 63:
+if len(actual_modules) != 62:
     print(
-        f"Phase 52.6.1 root shim inventory expected Phase 52.5 root baseline of 63 files, found {len(actual_modules)}.",
+        f"Phase 52.6.1 root shim inventory expected Phase 52.6.3 root count of 62 files, found {len(actual_modules)}.",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/scripts/verify-phase-52-6-2-canonical-domain-imports.sh
+++ b/scripts/verify-phase-52-6-2-canonical-domain-imports.sh
@@ -98,9 +98,11 @@ approved_legacy_python_files = {
     "scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh",
     "scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh",
     "scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh",
+    "control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py",
 }
 
 approved_legacy_text_files = {
+    "docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md",
     "docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md",
     "docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md",
     "docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md",

--- a/scripts/verify-phase-52-6-2-canonical-domain-imports.sh
+++ b/scripts/verify-phase-52-6-2-canonical-domain-imports.sh
@@ -96,11 +96,14 @@ approved_legacy_python_files = {
     "scripts/verify-phase-52-5-closeout-evaluation.sh",
     "scripts/verify-phase-52-6-2-canonical-domain-imports.sh",
     "scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh",
+    "scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh",
+    "scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh",
 }
 
 approved_legacy_text_files = {
     "docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md",
     "docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md",
+    "docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md",
     "docs/control-plane-service-internal-boundaries.md",
     "docs/phase-52-5-closeout-evaluation.md",
 } | approved_legacy_python_files

--- a/scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh
+++ b/scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md"
+registry_path="${repo_root}/control-plane/aegisops_control_plane/core/legacy_import_aliases.py"
+control_plane_root="${repo_root}/control-plane"
+removed_root_shim="${repo_root}/control-plane/aegisops_control_plane/audit_export.py"
+
+required_phrases=(
+  "# ADR-0015: Phase 52.6.3 Legacy Import Alias Registry"
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-02"
+  "- **Related Issues**: #1105, #1108"
+  "- **Depends On**: #1107"
+  "The registry lives at \`control-plane/aegisops_control_plane/core/legacy_import_aliases.py\`."
+  "| \`aegisops_control_plane.audit_export\` | \`aegisops_control_plane.reporting.audit_export\` | \`reporting\` | \`reporting/audit_export.py\` |"
+  "The \`audit_export.py\` root shim is the only Phase 52.6.3 physical deletion."
+  "Alias rows without an explicit target owner fail verification."
+  "An approved legacy import path disappearing without an alias row or retained physical shim fails verification."
+  "Run \`bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh\`."
+  "Run \`bash scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1108 --config <supervisor-config-path>\`."
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.6.3 legacy import alias registry ADR: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${registry_path}" ]]; then
+  echo "Missing Phase 52.6.3 legacy import alias registry: ${registry_path}" >&2
+  exit 1
+fi
+
+if [[ -e "${removed_root_shim}" ]]; then
+  echo "Phase 52.6.3 proof-of-pattern root shim should be removed: control-plane/aegisops_control_plane/audit_export.py" >&2
+  exit 1
+fi
+
+doc_text="$(cat "${doc_path}")"
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_text}"; then
+    echo "Missing Phase 52.6.3 legacy import alias registry statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}" "${registry_path}"; then
+  echo "Forbidden Phase 52.6.3 legacy import alias registry: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+export PHASE52_6_3_CONTROL_PLANE_ROOT="${control_plane_root}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import importlib
+import os
+import pathlib
+import sys
+
+control_plane_root = pathlib.Path(os.environ["PHASE52_6_3_CONTROL_PLANE_ROOT"])
+if str(control_plane_root) not in sys.path:
+    sys.path.insert(0, str(control_plane_root))
+
+try:
+    registry = importlib.import_module(
+        "aegisops_control_plane.core.legacy_import_aliases"
+    )
+except Exception as exc:
+    print(
+        f"Phase 52.6.3 legacy import alias registry failed to load: {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+required_aliases = {
+    "aegisops_control_plane.audit_export": (
+        "aegisops_control_plane.reporting.audit_export",
+        "reporting",
+        "reporting/audit_export.py",
+        "export_audit_retention_baseline",
+    ),
+}
+required_blockers = {
+    "aegisops_control_plane.service",
+    "aegisops_control_plane.models",
+    "aegisops_control_plane.phase29_shadow_dataset",
+    "aegisops_control_plane.phase29_shadow_scoring",
+    "aegisops_control_plane.phase29_evidently_drift_visibility",
+    "aegisops_control_plane.phase29_mlflow_shadow_model_registry",
+}
+
+aliases = registry.LEGACY_IMPORT_ALIASES
+for legacy_path, (target_path, target_family, owner, attribute) in required_aliases.items():
+    alias = aliases.get(legacy_path)
+    if alias is None:
+        print(
+            f"Phase 52.6.3 legacy import alias registry missing approved alias: {legacy_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if alias.target_module != target_path:
+        print(
+            f"Phase 52.6.3 legacy import alias target mismatch for {legacy_path}: {alias.target_module}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if alias.target_family != target_family or alias.owner != owner:
+        print(
+            f"Phase 52.6.3 legacy import alias missing target owner metadata for {legacy_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    legacy_module = importlib.import_module(legacy_path)
+    target_module = importlib.import_module(target_path)
+    if legacy_module is not target_module:
+        print(
+            f"Phase 52.6.3 legacy import alias changed module identity for {legacy_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if getattr(legacy_module, attribute) is not getattr(target_module, attribute):
+        print(
+            f"Phase 52.6.3 legacy import alias changed implementation behavior for {legacy_path}:{attribute}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+blockers = registry.RETAINED_COMPATIBILITY_BLOCKERS
+missing_blockers = sorted(required_blockers - set(blockers))
+if missing_blockers:
+    print(
+        "Phase 52.6.3 legacy import alias registry is missing retained blockers: "
+        + ", ".join(missing_blockers),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(
+    "Phase 52.6.3 legacy import alias registry preserves approved aliases, "
+    "keeps target owner metadata explicit, and lists retained blockers."
+)
+PY


### PR DESCRIPTION
## Summary
- Add a bounded `aegisops_control_plane.core.legacy_import_aliases` registry and register `aegisops_control_plane.audit_export` to its reporting owner.
- Remove the physical `audit_export.py` proof shim while preserving old and new import behavior.
- Document ADR-0015, retained blockers, and verifier-backed negative cases.

## Verification
- `python3 -m unittest control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py`
- `bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh`
- `bash scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh`
- `bash scripts/verify-phase-52-5-2-import-compatibility.sh`
- `bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh`
- `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`
- `bash scripts/verify-phase-52-6-2-canonical-domain-imports.sh`
- `bash scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh`
- `bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh`
- `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`
- `bash scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash scripts/verify-phase-52-5-2-package-scaffolding.sh`
- `node dist/index.js issue-lint 1108 --config supervisor.config.aegisops.coderabbit.json`

Closes #1108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bounded legacy import alias registry that exposes legacy import names at runtime.

* **Chores**
  * Removed a legacy root-level compatibility shim.
  * Updated verification scripts to run the new registry checks.

* **Tests**
  * Added unit and end-to-end verification tests for alias registration and resolution.

* **Documentation**
  * Added ADRs documenting the registry, verification rules, and non-goals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->