### PR TITLE
Phase 52.6.5: Retire Phase29 root filenames

### DIFF
--- a/control-plane/aegisops_control_plane/core/legacy_import_aliases.py
+++ b/control-plane/aegisops_control_plane/core/legacy_import_aliases.py
@@ -164,6 +164,30 @@ LEGACY_IMPORT_ALIASES: dict[str, LegacyImportAlias] = {
         "runtime",
         "runtime/operations.py",
     ),
+    "aegisops_control_plane.phase29_evidently_drift_visibility": _alias(
+        "aegisops_control_plane.phase29_evidently_drift_visibility",
+        "aegisops_control_plane.ml_shadow.drift_visibility",
+        "ml_shadow",
+        "ml_shadow/drift_visibility.py",
+    ),
+    "aegisops_control_plane.phase29_mlflow_shadow_model_registry": _alias(
+        "aegisops_control_plane.phase29_mlflow_shadow_model_registry",
+        "aegisops_control_plane.ml_shadow.mlflow_registry",
+        "ml_shadow",
+        "ml_shadow/mlflow_registry.py",
+    ),
+    "aegisops_control_plane.phase29_shadow_dataset": _alias(
+        "aegisops_control_plane.phase29_shadow_dataset",
+        "aegisops_control_plane.ml_shadow.dataset",
+        "ml_shadow",
+        "ml_shadow/dataset.py",
+    ),
+    "aegisops_control_plane.phase29_shadow_scoring": _alias(
+        "aegisops_control_plane.phase29_shadow_scoring",
+        "aegisops_control_plane.ml_shadow.legacy_scoring_adapter",
+        "ml_shadow",
+        "ml_shadow/legacy_scoring_adapter.py",
+    ),
     "aegisops_control_plane.service_snapshots": _alias(
         "aegisops_control_plane.service_snapshots",
         "aegisops_control_plane.runtime.service_snapshots",
@@ -175,10 +199,6 @@ LEGACY_IMPORT_ALIASES: dict[str, LegacyImportAlias] = {
 RETAINED_COMPATIBILITY_BLOCKERS: dict[str, str] = {
     "aegisops_control_plane.service": "Public facade import path retained under ADR-0003 and ADR-0010.",
     "aegisops_control_plane.models": "Authoritative record model import path remains a root owner.",
-    "aegisops_control_plane.phase29_shadow_dataset": "Phase29 adapter still needs adapter-specific caller evidence.",
-    "aegisops_control_plane.phase29_shadow_scoring": "Phase29 adapter still needs adapter-specific caller evidence.",
-    "aegisops_control_plane.phase29_evidently_drift_visibility": "Phase29 adapter still needs adapter-specific caller evidence.",
-    "aegisops_control_plane.phase29_mlflow_shadow_model_registry": "Phase29 adapter still needs adapter-specific caller evidence.",
 }
 
 

--- a/control-plane/aegisops_control_plane/ml_shadow/legacy_scoring_adapter.py
+++ b/control-plane/aegisops_control_plane/ml_shadow/legacy_scoring_adapter.py
@@ -1,4 +1,4 @@
-"""Compatibility shim for the legacy Phase 29 shadow scoring import path."""
+"""Compatibility adapter for the legacy Phase 29 shadow scoring import path."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from dataclasses import replace
 from datetime import datetime
 from typing import Mapping
 
-from .ml_shadow import scoring as _impl
+from . import scoring as _impl
 
 
 Phase29ShadowScoringError = _impl.Phase29ShadowScoringError

--- a/control-plane/aegisops_control_plane/phase29_evidently_drift_visibility.py
+++ b/control-plane/aegisops_control_plane/phase29_evidently_drift_visibility.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the Phase 29 drift visibility module."""
-
-from __future__ import annotations
-
-import sys
-
-from .ml_shadow import drift_visibility as _impl
-
-sys.modules[__name__] = _impl

--- a/control-plane/aegisops_control_plane/phase29_mlflow_shadow_model_registry.py
+++ b/control-plane/aegisops_control_plane/phase29_mlflow_shadow_model_registry.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the Phase 29 MLflow shadow registry module."""
-
-from __future__ import annotations
-
-import sys
-
-from .ml_shadow import mlflow_registry as _impl
-
-sys.modules[__name__] = _impl

--- a/control-plane/aegisops_control_plane/phase29_shadow_dataset.py
+++ b/control-plane/aegisops_control_plane/phase29_shadow_dataset.py
@@ -1,9 +1,0 @@
-"""Compatibility shim for the Phase 29 shadow dataset module."""
-
-from __future__ import annotations
-
-import sys
-
-from .ml_shadow import dataset as _impl
-
-sys.modules[__name__] = _impl

--- a/control-plane/tests/test_phase52_6_4_root_shim_alias_removal.py
+++ b/control-plane/tests/test_phase52_6_4_root_shim_alias_removal.py
@@ -57,16 +57,12 @@ class Phase5264RootShimAliasRemovalTests(unittest.TestCase):
                     importlib.import_module(target_module),
                 )
 
-    def test_phase29_and_public_root_owners_stay_physical_blockers(self) -> None:
+    def test_public_root_owners_stay_physical_blockers(self) -> None:
         retained = {
             "models.py",
             "service.py",
             "config.py",
             "record_validation.py",
-            "phase29_shadow_dataset.py",
-            "phase29_shadow_scoring.py",
-            "phase29_evidently_drift_visibility.py",
-            "phase29_mlflow_shadow_model_registry.py",
             "assistant_context.py",
             "action_lifecycle_write_coordinator.py",
             "action_policy.py",

--- a/control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py
+++ b/control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = CONTROL_PLANE_ROOT / "aegisops_control_plane"
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+
+PHASE29_LEGACY_IMPORTS = {
+    "aegisops_control_plane.phase29_shadow_dataset": (
+        "aegisops_control_plane.ml_shadow.dataset",
+        "Phase29ShadowDatasetSnapshot",
+    ),
+    "aegisops_control_plane.phase29_evidently_drift_visibility": (
+        "aegisops_control_plane.ml_shadow.drift_visibility",
+        "Phase29EvidentlyDriftVisibilityReport",
+    ),
+    "aegisops_control_plane.phase29_mlflow_shadow_model_registry": (
+        "aegisops_control_plane.ml_shadow.mlflow_registry",
+        "Phase29MlflowShadowModelTrackingResult",
+    ),
+}
+
+
+class Phase5265Phase29RootFilenameRetirementTests(unittest.TestCase):
+    def test_phase29_root_files_are_retired_to_registered_aliases(self) -> None:
+        registry = importlib.import_module(
+            "aegisops_control_plane.core.legacy_import_aliases"
+        )
+
+        expected_aliases = {
+            **{
+                legacy_module: target_module
+                for legacy_module, (target_module, _attribute) in PHASE29_LEGACY_IMPORTS.items()
+            },
+            "aegisops_control_plane.phase29_shadow_scoring": (
+                "aegisops_control_plane.ml_shadow.legacy_scoring_adapter"
+            ),
+        }
+
+        for legacy_module, target_module in expected_aliases.items():
+            with self.subTest(legacy_module=legacy_module):
+                legacy_file = PACKAGE_ROOT / f"{legacy_module.rsplit('.', 1)[-1]}.py"
+                self.assertFalse(legacy_file.exists(), legacy_file)
+                self.assertIn(legacy_module, registry.LEGACY_IMPORT_ALIASES)
+                self.assertEqual(
+                    registry.LEGACY_IMPORT_ALIASES[legacy_module].target_module,
+                    target_module,
+                )
+                self.assertEqual(
+                    registry.LEGACY_IMPORT_ALIASES[legacy_module].target_family,
+                    "ml_shadow",
+                )
+                self.assertNotIn(legacy_module, registry.RETAINED_COMPATIBILITY_BLOCKERS)
+
+    def test_phase29_legacy_imports_preserve_required_compatibility_surface(self) -> None:
+        for legacy_module, (target_module, attribute) in PHASE29_LEGACY_IMPORTS.items():
+            with self.subTest(legacy_module=legacy_module):
+                legacy = importlib.import_module(legacy_module)
+                target = importlib.import_module(target_module)
+                self.assertIs(legacy, target)
+                self.assertIs(getattr(legacy, attribute), getattr(target, attribute))
+
+        legacy_scoring = importlib.import_module(
+            "aegisops_control_plane.phase29_shadow_scoring"
+        )
+        canonical_scoring = importlib.import_module("aegisops_control_plane.ml_shadow.scoring")
+
+        self.assertIsNot(legacy_scoring, canonical_scoring)
+        self.assertIs(
+            legacy_scoring.Phase29ShadowScoringError,
+            canonical_scoring.Phase29ShadowScoringError,
+        )
+        self.assertTrue(
+            hasattr(
+                legacy_scoring.Phase29ShadowScoreResult,
+                "feature_frequencies_at_inference_time",
+            )
+        )
+        self.assertTrue(
+            hasattr(
+                legacy_scoring.Phase29OfflineShadowScoringSnapshot,
+                "scored_examples",
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
+++ b/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
@@ -5,10 +5,10 @@
 - **Owners**: AegisOps maintainers
 - **Related Baseline**: `docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md`
 - **Product**: AegisOps
-- **Related Issues**: #1105, #1106
+- **Related Issues**: #1105, #1106, #1110
 - **Depends On**: #1094
 - **Supersedes**: N/A
-- **Superseded By**: N/A
+- **Superseded By**: Phase 52.6.5 retires the Phase29 root filenames listed by this baseline.
 
 ---
 
@@ -28,7 +28,7 @@ The root shim inventory does not change authorization, provenance, reconciliatio
 
 ## 3. Phase 52.5 Root File Baseline
 
-The Phase 52.6.4 root-level Python file count under `control-plane/aegisops_control_plane/` is `41` after removing simple physical root shims covered by the legacy import alias registry and focused compatibility tests.
+The Phase 52.6.5 root-level Python file count under `control-plane/aegisops_control_plane/` is `37` after removing simple physical root shims and the Phase29 root filenames covered by the legacy import alias registry and focused compatibility tests.
 
 The baseline counts only direct `.py` files in `control-plane/aegisops_control_plane/`; package-owned files below subdirectories are tracked by ADR-0012 and stay outside this root shim baseline.
 
@@ -73,10 +73,6 @@ If caller evidence is incomplete, malformed, ambiguous, or inferred only from na
 | `models.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
 | `operator_inspection.py` | `reporting` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
 | `persistence_lifecycle.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
-| `phase29_evidently_drift_visibility.py` | `ml_shadow` | compatibility adapter | Retain as a Phase29 legacy adapter; `ml_shadow/drift_visibility.py` is the domain-owned `ml_shadow` implementation. |
-| `phase29_mlflow_shadow_model_registry.py` | `ml_shadow` | compatibility adapter | Retain as a Phase29 legacy adapter; `ml_shadow/mlflow_registry.py` is the domain-owned `ml_shadow` implementation. |
-| `phase29_shadow_dataset.py` | `ml_shadow` | compatibility adapter | Retain as a Phase29 legacy adapter; `ml_shadow/dataset.py` is the domain-owned `ml_shadow` implementation. |
-| `phase29_shadow_scoring.py` | `ml_shadow` | compatibility adapter | Retain as a Phase29 legacy adapter; `ml_shadow/scoring.py` is the domain-owned `ml_shadow` implementation. |
 | `pilot_reporting_export.py` | `reporting` | alias candidate | Retain physically because Phase 49.5 reporting export docs and tests still name this root file directly. |
 | `publishable_paths.py` | `core` | retained owner | Retain physically until a later owner-move issue proves identical behavior and caller compatibility. |
 | `readiness_contracts.py` | `runtime` | alias candidate | Retain physically because Phase 47 responsibility-decomposition tests and docs still name this root file directly. |
@@ -98,13 +94,21 @@ Phase 52.6.4 removed these 21 simple physical root shims after adding explicit l
 
 `action_receipt_validation.py`, `action_review_chain.py`, `action_review_coordination.py`, `action_review_index.py`, `action_review_inspection.py`, `action_review_path_health.py`, `action_review_timeline.py`, `action_review_visibility.py`, `assistant_provider.py`, `detection_lifecycle_helpers.py`, `detection_native_context.py`, `entrypoint_support.py`, `execution_coordinator.py`, `execution_coordinator_delegation.py`, `execution_coordinator_reconciliation.py`, `external_evidence_endpoint.py`, `external_evidence_facade.py`, `external_evidence_misp.py`, `external_evidence_osquery.py`, `operations.py`, and `service_snapshots.py`.
 
-Retained blockers remain physical root files: real root owners (`config.py`, `models.py`, `record_validation.py`, and related core owners), the public `service.py` facade, Phase29 compatibility adapters, and root shim files that current regression tests still inspect directly.
+Retained blockers remain physical root files: real root owners (`config.py`, `models.py`, `record_validation.py`, and related core owners), the public `service.py` facade, and root shim files that current regression tests still inspect directly.
+
+## 5.2 Phase 52.6.5 Removed Phase29 Root Filename List
+
+Phase 52.6.5 removed these four Phase29-named root files after adding explicit legacy import alias rows and the focused `control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py` regression:
+
+`phase29_shadow_dataset.py`, `phase29_shadow_scoring.py`, `phase29_evidently_drift_visibility.py`, and `phase29_mlflow_shadow_model_registry.py`.
+
+The production-owned implementations remain under `ml_shadow/dataset.py`, `ml_shadow/scoring.py`, `ml_shadow/drift_visibility.py`, and `ml_shadow/mlflow_registry.py`. The legacy scoring wrapper behavior that differs from canonical scoring now lives in `ml_shadow/legacy_scoring_adapter.py`.
 
 ## 6. Phase29 Boundary
 
-The Phase29 root files are legacy compatibility adapters only. They are not production owners.
+The retired Phase29 root filenames were legacy compatibility adapters only. They were not production owners.
 
-The domain-owned implementations are the directly linked `ml_shadow` modules listed in the inventory. Any later removal plan must test both the legacy `phase29_*` import path and the domain-owned `ml_shadow` import path before deleting a root adapter.
+The domain-owned implementations are the directly linked `ml_shadow` modules listed in the retired filename list. Legacy `phase29_*` import paths remain available only through the alias registry and focused compatibility tests.
 
 ## 7. Deprecation Decision Rules
 
@@ -136,11 +140,15 @@ Run `bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh`.
 
 Run `bash scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh`.
 
-Run `node <codex-supervisor-root>/dist/index.js issue-lint 1108 --config <supervisor-config-path>`.
+Run `bash scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh`.
+
+Run `bash scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1110 --config <supervisor-config-path>`.
 
 ## 10. Non-Goals
 
-- Only `audit_export.py` is removed as the Phase 52.6.3 alias-registry proof of pattern.
+- No additional root file beyond the Phase 52.6.4 and Phase 52.6.5 deletion sets is removed by this update.
 - No import path is changed.
 - No public package name is changed.
 - No outer repository directory is changed.

--- a/docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md
+++ b/docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md
@@ -5,7 +5,7 @@
 - **Owners**: AegisOps maintainers
 - **Related Baseline**: `docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md`
 - **Product**: AegisOps
-- **Related Issues**: #1105, #1108
+- **Related Issues**: #1105, #1108, #1110
 - **Depends On**: #1107
 - **Supersedes**: N/A
 - **Superseded By**: N/A
@@ -29,8 +29,14 @@ Package initialization calls `register_legacy_import_aliases()` before public pa
 | Legacy import path | Target owner import path | Target family | Owner file |
 | --- | --- | --- | --- |
 | `aegisops_control_plane.audit_export` | `aegisops_control_plane.reporting.audit_export` | `reporting` | `reporting/audit_export.py` |
+| `aegisops_control_plane.phase29_shadow_dataset` | `aegisops_control_plane.ml_shadow.dataset` | `ml_shadow` | `ml_shadow/dataset.py` |
+| `aegisops_control_plane.phase29_shadow_scoring` | `aegisops_control_plane.ml_shadow.legacy_scoring_adapter` | `ml_shadow` | `ml_shadow/legacy_scoring_adapter.py` |
+| `aegisops_control_plane.phase29_evidently_drift_visibility` | `aegisops_control_plane.ml_shadow.drift_visibility` | `ml_shadow` | `ml_shadow/drift_visibility.py` |
+| `aegisops_control_plane.phase29_mlflow_shadow_model_registry` | `aegisops_control_plane.ml_shadow.mlflow_registry` | `ml_shadow` | `ml_shadow/mlflow_registry.py` |
 
 The `audit_export.py` root shim is the only Phase 52.6.3 physical deletion. The old import path remains available through the registry and must resolve to the exact same module object as `aegisops_control_plane.reporting.audit_export`.
+
+Phase 52.6.5 retires the four Phase29 physical root filenames. Dataset, drift visibility, and MLflow registry legacy paths resolve to the exact `ml_shadow` owner modules. The legacy scoring path resolves to `ml_shadow/legacy_scoring_adapter.py` because that import path deliberately preserves the old `scored_examples`, `feature_frequencies_at_inference_time`, and `shadow_output_type` wrapper behavior while canonical scoring remains owned by `ml_shadow/scoring.py`.
 
 ## 4. Retained Blockers
 
@@ -40,10 +46,6 @@ The following paths cannot safely move to the alias registry yet:
 | --- | --- |
 | `aegisops_control_plane.service` | Public facade import path retained under ADR-0003 and ADR-0010. |
 | `aegisops_control_plane.models` | Authoritative record model import path remains a root owner. |
-| `aegisops_control_plane.phase29_shadow_dataset` | Phase29 adapter still needs adapter-specific caller evidence. |
-| `aegisops_control_plane.phase29_shadow_scoring` | Phase29 adapter still needs adapter-specific caller evidence. |
-| `aegisops_control_plane.phase29_evidently_drift_visibility` | Phase29 adapter still needs adapter-specific caller evidence. |
-| `aegisops_control_plane.phase29_mlflow_shadow_model_registry` | Phase29 adapter still needs adapter-specific caller evidence. |
 
 ## 5. Fail-Closed Rules
 

--- a/scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -69,13 +69,13 @@ assert_fails_with \
   "${behavior_change_repo}" \
   "Forbidden Phase 52.6.1 root shim inventory claim: This contract changes runtime behavior."
 
-phase29_owner_repo="${workdir}/phase29-production-owner"
-create_valid_repo "${phase29_owner_repo}"
-perl -0pi -e 's/\| `phase29_shadow_dataset\.py` \| `ml_shadow` \| compatibility adapter \| Retain as a Phase29 legacy adapter; `ml_shadow\/dataset\.py` is the domain-owned `ml_shadow` implementation\. \|/\| `phase29_shadow_dataset.py` \| `ml_shadow` \| retained owner \| Retain as a Phase29 production owner. \|/' \
-  "${phase29_owner_repo}/${contract_path}"
+phase29_restored_repo="${workdir}/phase29-restored-root-file"
+create_valid_repo "${phase29_restored_repo}"
+printf '%s\n' "\"\"\"Fixture Phase29 root file intentionally restored.\"\"\"" \
+  >"${phase29_restored_repo}/control-plane/aegisops_control_plane/phase29_shadow_dataset.py"
 assert_fails_with \
-  "${phase29_owner_repo}" \
-  "Phase 52.6.1 root shim inventory must classify Phase29 root files as compatibility adapters separate from domain-owned ml_shadow implementations: phase29_shadow_dataset.py"
+  "${phase29_restored_repo}" \
+  "Phase 52.6.1 root shim inventory is missing root file rows: phase29_shadow_dataset.py"
 
 immediate_deletion_repo="${workdir}/immediate-deletion-claim"
 create_valid_repo "${immediate_deletion_repo}"
@@ -100,6 +100,14 @@ perl -0pi -e 's/\nRun `bash scripts\/verify-publishable-path-hygiene\.sh`\.\n//'
 assert_fails_with \
   "${missing_publishable_hygiene_repo}" \
   "Missing Phase 52.6.1 root shim inventory statement: Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
+
+missing_phase5265_verifier_repo="${workdir}/missing-phase5265-verifier"
+create_valid_repo "${missing_phase5265_verifier_repo}"
+perl -0pi -e 's/\nRun `bash scripts\/verify-phase-52-6-5-retire-phase29-root-filenames\.sh`\.\n//' \
+  "${missing_phase5265_verifier_repo}/${contract_path}"
+assert_fails_with \
+  "${missing_phase5265_verifier_repo}" \
+  "Missing Phase 52.6.1 root shim inventory statement: Run \`bash scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh\`."
 
 subordinate_inventory_rows_repo="${workdir}/subordinate-inventory-rows"
 create_valid_repo "${subordinate_inventory_rows_repo}"

--- a/scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh
+++ b/scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh
@@ -81,6 +81,14 @@ assert_fails_with \
   "${wrong_scoring_owner_repo}" \
   "Phase 52.6.5 Phase29 alias target mismatch for aegisops_control_plane.phase29_shadow_scoring"
 
+wrong_attribute_owner_repo="${workdir}/wrong-attribute-owner"
+create_valid_repo "${wrong_attribute_owner_repo}"
+perl -0pi -e 's/class Phase29ShadowScoreResult\(_impl\.Phase29ShadowScoreResult\):\n    \@property\n    def feature_frequencies_at_inference_time\(self\) -> Mapping\[str, object\]:\n        return \{}\n\n\nclass Phase29OfflineShadowScoringSnapshot\(_impl\.Phase29OfflineShadowScoringSnapshot\):/class Phase29ShadowScoreResult(_impl.Phase29ShadowScoreResult):\n    pass\n\n\nclass Phase29OfflineShadowScoringSnapshot(_impl.Phase29OfflineShadowScoringSnapshot):\n    \@property\n    def feature_frequencies_at_inference_time(self) -> Mapping[str, object]:\n        return {}/' \
+  "${wrong_attribute_owner_repo}/control-plane/aegisops_control_plane/ml_shadow/legacy_scoring_adapter.py"
+assert_fails_with \
+  "${wrong_attribute_owner_repo}" \
+  "Phase 52.6.5 legacy scoring wrapper is missing feature_frequencies_at_inference_time"
+
 retained_blocker_repo="${workdir}/retained-blocker"
 create_valid_repo "${retained_blocker_repo}"
 perl -0pi -e 's/RETAINED_COMPATIBILITY_BLOCKERS: dict\[str, str\] = \{/RETAINED_COMPATIBILITY_BLOCKERS: dict[str, str] = {\n    "aegisops_control_plane.phase29_shadow_dataset": "stale blocker.",/' \

--- a/scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh
+++ b/scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/control-plane" "${target}/scripts"
+  cp -R "${repo_root}/control-plane/aegisops_control_plane" \
+    "${target}/control-plane/aegisops_control_plane"
+  mkdir -p "${target}/control-plane/tests"
+  cp "${repo_root}/control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py" \
+    "${target}/control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+restored_root_file_repo="${workdir}/restored-root-file"
+create_valid_repo "${restored_root_file_repo}"
+printf '%s\n' '"""Unexpected restored Phase29 root file."""' \
+  >"${restored_root_file_repo}/control-plane/aegisops_control_plane/phase29_shadow_dataset.py"
+assert_fails_with \
+  "${restored_root_file_repo}" \
+  "Phase 52.6.5 Phase29 root filename must be retired: control-plane/aegisops_control_plane/phase29_shadow_dataset.py"
+
+missing_alias_repo="${workdir}/missing-alias"
+create_valid_repo "${missing_alias_repo}"
+perl -0pi -e 's/    "aegisops_control_plane\.phase29_shadow_dataset": _alias\(.*?    \),\n//s' \
+  "${missing_alias_repo}/control-plane/aegisops_control_plane/core/legacy_import_aliases.py"
+assert_fails_with \
+  "${missing_alias_repo}" \
+  "Phase 52.6.5 missing Phase29 legacy alias: aegisops_control_plane.phase29_shadow_dataset"
+
+wrong_scoring_owner_repo="${workdir}/wrong-scoring-owner"
+create_valid_repo "${wrong_scoring_owner_repo}"
+perl -0pi -e 's/aegisops_control_plane\.ml_shadow\.legacy_scoring_adapter/aegisops_control_plane.ml_shadow.scoring/' \
+  "${wrong_scoring_owner_repo}/control-plane/aegisops_control_plane/core/legacy_import_aliases.py"
+assert_fails_with \
+  "${wrong_scoring_owner_repo}" \
+  "Phase 52.6.5 Phase29 alias target mismatch for aegisops_control_plane.phase29_shadow_scoring"
+
+retained_blocker_repo="${workdir}/retained-blocker"
+create_valid_repo "${retained_blocker_repo}"
+perl -0pi -e 's/RETAINED_COMPATIBILITY_BLOCKERS: dict\[str, str\] = \{/RETAINED_COMPATIBILITY_BLOCKERS: dict[str, str] = {\n    "aegisops_control_plane.phase29_shadow_dataset": "stale blocker.",/' \
+  "${retained_blocker_repo}/control-plane/aegisops_control_plane/core/legacy_import_aliases.py"
+assert_fails_with \
+  "${retained_blocker_repo}" \
+  "Phase 52.6.5 Phase29 path still listed as a retained blocker: aegisops_control_plane.phase29_shadow_dataset"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.6.5 Phase29 retirement artifact: workstation-local absolute path detected"
+
+echo "Phase 52.6.5 Phase29 root filename retirement verifier negative and valid fixtures passed."

--- a/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
+++ b/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
@@ -23,16 +23,16 @@ required_headings=(
 required_phrases=(
   "- **Status**: Accepted"
   "- **Date**: 2026-05-02"
-  "- **Related Issues**: #1105, #1106"
+  "- **Related Issues**: #1105, #1106, #1110"
   "- **Depends On**: #1094"
   "This contract is documentation and verification only. Phase 52.6.3 removes only \`audit_export.py\` as the proof-of-pattern alias-registry candidate; it does not delete broad shim sets, rename the public package, change the outer \`control-plane/\` directory, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior."
   "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
   "Wazuh, Shuffle, tickets, assistant output, generated config, CLI status, demo data, adapters, DTOs, projections, summaries, compatibility shims, alias rows, and operator-facing text remain subordinate context."
   "The root shim inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, action-execution, Wazuh, Shuffle, ticket, CLI, HTTP, or deployment behavior."
-  "The Phase 52.6.4 root-level Python file count under \`control-plane/aegisops_control_plane/\` is \`41\` after removing simple physical root shims covered by the legacy import alias registry and focused compatibility tests."
+  "The Phase 52.6.5 root-level Python file count under \`control-plane/aegisops_control_plane/\` is \`37\` after removing simple physical root shims and the Phase29 root filenames covered by the legacy import alias registry and focused compatibility tests."
   "The baseline counts only direct \`.py\` files in \`control-plane/aegisops_control_plane/\`; package-owned files below subdirectories are tracked by ADR-0012 and stay outside this root shim baseline."
-  "The Phase29 root files are legacy compatibility adapters only. They are not production owners."
-  "The domain-owned implementations are the directly linked \`ml_shadow\` modules listed in the inventory. Any later removal plan must test both the legacy \`phase29_*\` import path and the domain-owned \`ml_shadow\` import path before deleting a root adapter."
+  "The retired Phase29 root filenames were legacy compatibility adapters only. They were not production owners."
+  "The domain-owned implementations are the directly linked \`ml_shadow\` modules listed in the retired filename list. Legacy \`phase29_*\` import paths remain available only through the alias registry and focused compatibility tests."
   "Physical root shim deletion is allowed only when a later issue records the exact root file, replacement owner import path, caller evidence, deprecation window, focused legacy-import regression, rollback path, and authority-boundary impact."
   "Alias preservation is allowed only when the alias remains a narrow reference to the moved owner and does not make compatibility state, summary text, or module identity authoritative workflow truth."
   "Retained blockers stay physically present until the referenced compatibility policy is superseded by a later accepted ADR or issue-specific contract."
@@ -42,7 +42,9 @@ required_phrases=(
   "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
   "Run \`bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh\`."
   "Run \`bash scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh\`."
-  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1108 --config <supervisor-config-path>\`."
+  "Run \`bash scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh\`."
+  "Run \`bash scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1110 --config <supervisor-config-path>\`."
 )
 
 allowed_classifications=(
@@ -205,9 +207,9 @@ if extra:
     )
     sys.exit(1)
 
-if len(actual_modules) != 41:
+if len(actual_modules) != 37:
     print(
-        f"Phase 52.6.1 root shim inventory expected Phase 52.6.4 root count of 41 files, found {len(actual_modules)}.",
+        f"Phase 52.6.1 root shim inventory expected Phase 52.6.5 root count of 37 files, found {len(actual_modules)}.",
         file=sys.stderr,
     )
     sys.exit(1)
@@ -228,7 +230,6 @@ if empty_decisions:
 
 required_classifications = {
     "retained owner",
-    "compatibility adapter",
     "retained compatibility blocker",
 }
 missing_classifications = sorted(required_classifications - {row[0] for row in rows.values()})
@@ -241,16 +242,10 @@ if missing_classifications:
     sys.exit(1)
 
 phase29_modules = sorted(module for module in actual_modules if module.startswith("phase29_"))
-bad_phase29 = [
-    module
-    for module in phase29_modules
-    if rows[module][0] != "compatibility adapter"
-    or "domain-owned `ml_shadow` implementation" not in rows[module][1]
-]
-if bad_phase29:
+if phase29_modules:
     print(
-        "Phase 52.6.1 root shim inventory must classify Phase29 root files as compatibility adapters separate from domain-owned ml_shadow implementations: "
-        + ", ".join(bad_phase29),
+        "Phase 52.6.1 root shim inventory must not retain Phase29 root filenames after Phase 52.6.5: "
+        + ", ".join(phase29_modules),
         file=sys.stderr,
     )
     sys.exit(1)
@@ -265,6 +260,6 @@ if rows.get("service.py", ("", ""))[0] != "retained compatibility blocker":
 print(
     "Phase 52.6.1 root shim inventory classifies "
     f"{len(actual_modules)} root Python files, records the Phase 52.5 baseline, "
-    "separates Phase29 adapters from ml_shadow owners, and documents deprecation rules."
+    "keeps Phase29 root filenames retired, and documents deprecation rules."
 )
 PY

--- a/scripts/verify-phase-52-6-2-canonical-domain-imports.sh
+++ b/scripts/verify-phase-52-6-2-canonical-domain-imports.sh
@@ -98,7 +98,10 @@ approved_legacy_python_files = {
     "scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh",
     "scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh",
     "scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh",
+    "scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh",
+    "scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh",
     "control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py",
+    "control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py",
 }
 
 approved_legacy_text_files = {

--- a/scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh
+++ b/scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh
@@ -7,16 +7,27 @@ doc_path="${repo_root}/docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.m
 registry_path="${repo_root}/control-plane/aegisops_control_plane/core/legacy_import_aliases.py"
 control_plane_root="${repo_root}/control-plane"
 removed_root_shim="${repo_root}/control-plane/aegisops_control_plane/audit_export.py"
+removed_phase29_root_shims=(
+  "${repo_root}/control-plane/aegisops_control_plane/phase29_shadow_dataset.py"
+  "${repo_root}/control-plane/aegisops_control_plane/phase29_shadow_scoring.py"
+  "${repo_root}/control-plane/aegisops_control_plane/phase29_evidently_drift_visibility.py"
+  "${repo_root}/control-plane/aegisops_control_plane/phase29_mlflow_shadow_model_registry.py"
+)
 
 required_phrases=(
   "# ADR-0015: Phase 52.6.3 Legacy Import Alias Registry"
   "- **Status**: Accepted"
   "- **Date**: 2026-05-02"
-  "- **Related Issues**: #1105, #1108"
+  "- **Related Issues**: #1105, #1108, #1110"
   "- **Depends On**: #1107"
   "The registry lives at \`control-plane/aegisops_control_plane/core/legacy_import_aliases.py\`."
   "| \`aegisops_control_plane.audit_export\` | \`aegisops_control_plane.reporting.audit_export\` | \`reporting\` | \`reporting/audit_export.py\` |"
+  "| \`aegisops_control_plane.phase29_shadow_dataset\` | \`aegisops_control_plane.ml_shadow.dataset\` | \`ml_shadow\` | \`ml_shadow/dataset.py\` |"
+  "| \`aegisops_control_plane.phase29_shadow_scoring\` | \`aegisops_control_plane.ml_shadow.legacy_scoring_adapter\` | \`ml_shadow\` | \`ml_shadow/legacy_scoring_adapter.py\` |"
+  "| \`aegisops_control_plane.phase29_evidently_drift_visibility\` | \`aegisops_control_plane.ml_shadow.drift_visibility\` | \`ml_shadow\` | \`ml_shadow/drift_visibility.py\` |"
+  "| \`aegisops_control_plane.phase29_mlflow_shadow_model_registry\` | \`aegisops_control_plane.ml_shadow.mlflow_registry\` | \`ml_shadow\` | \`ml_shadow/mlflow_registry.py\` |"
   "The \`audit_export.py\` root shim is the only Phase 52.6.3 physical deletion."
+  "Phase 52.6.5 retires the four Phase29 physical root filenames."
   "Alias rows without an explicit target owner fail verification."
   "An approved legacy import path disappearing without an alias row or retained physical shim fails verification."
   "Run \`bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh\`."
@@ -38,6 +49,14 @@ if [[ -e "${removed_root_shim}" ]]; then
   echo "Phase 52.6.3 proof-of-pattern root shim should be removed: control-plane/aegisops_control_plane/audit_export.py" >&2
   exit 1
 fi
+
+for removed_phase29_root_shim in "${removed_phase29_root_shims[@]}"; do
+  if [[ -e "${removed_phase29_root_shim}" ]]; then
+    rel_removed="${removed_phase29_root_shim#"${repo_root}/"}"
+    echo "Phase 52.6.5 Phase29 root filename should be retired: ${rel_removed}" >&2
+    exit 1
+  fi
+done
 
 doc_text="$(cat "${doc_path}")"
 for phrase in "${required_phrases[@]}"; do
@@ -90,14 +109,34 @@ required_aliases = {
         "reporting/audit_export.py",
         "export_audit_retention_baseline",
     ),
+    "aegisops_control_plane.phase29_shadow_dataset": (
+        "aegisops_control_plane.ml_shadow.dataset",
+        "ml_shadow",
+        "ml_shadow/dataset.py",
+        "Phase29ShadowDatasetSnapshot",
+    ),
+    "aegisops_control_plane.phase29_shadow_scoring": (
+        "aegisops_control_plane.ml_shadow.legacy_scoring_adapter",
+        "ml_shadow",
+        "ml_shadow/legacy_scoring_adapter.py",
+        "Phase29ShadowScoreResult",
+    ),
+    "aegisops_control_plane.phase29_evidently_drift_visibility": (
+        "aegisops_control_plane.ml_shadow.drift_visibility",
+        "ml_shadow",
+        "ml_shadow/drift_visibility.py",
+        "Phase29EvidentlyDriftVisibilityReport",
+    ),
+    "aegisops_control_plane.phase29_mlflow_shadow_model_registry": (
+        "aegisops_control_plane.ml_shadow.mlflow_registry",
+        "ml_shadow",
+        "ml_shadow/mlflow_registry.py",
+        "Phase29MlflowShadowModelTrackingResult",
+    ),
 }
 required_blockers = {
     "aegisops_control_plane.service",
     "aegisops_control_plane.models",
-    "aegisops_control_plane.phase29_shadow_dataset",
-    "aegisops_control_plane.phase29_shadow_scoring",
-    "aegisops_control_plane.phase29_evidently_drift_visibility",
-    "aegisops_control_plane.phase29_mlflow_shadow_model_registry",
 }
 
 aliases = registry.LEGACY_IMPORT_ALIASES

--- a/scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh
+++ b/scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+control_plane_root="${repo_root}/control-plane"
+package_root="${control_plane_root}/aegisops_control_plane"
+registry_path="${package_root}/core/legacy_import_aliases.py"
+compatibility_test="${repo_root}/control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py"
+legacy_scoring_adapter="${package_root}/ml_shadow/legacy_scoring_adapter.py"
+
+retired_root_files=(
+  "phase29_shadow_dataset.py"
+  "phase29_shadow_scoring.py"
+  "phase29_evidently_drift_visibility.py"
+  "phase29_mlflow_shadow_model_registry.py"
+)
+
+if [[ ! -d "${package_root}" ]]; then
+  echo "Missing control-plane package root: control-plane/aegisops_control_plane" >&2
+  exit 1
+fi
+
+if [[ ! -f "${registry_path}" ]]; then
+  echo "Missing legacy import alias registry: control-plane/aegisops_control_plane/core/legacy_import_aliases.py" >&2
+  exit 1
+fi
+
+if [[ ! -f "${compatibility_test}" ]]; then
+  echo "Missing Phase 52.6.5 compatibility regression: control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py" >&2
+  exit 1
+fi
+
+if [[ ! -f "${legacy_scoring_adapter}" ]]; then
+  echo "Missing legacy scoring adapter owner: control-plane/aegisops_control_plane/ml_shadow/legacy_scoring_adapter.py" >&2
+  exit 1
+fi
+
+for retired_root_file in "${retired_root_files[@]}"; do
+  if [[ -e "${package_root}/${retired_root_file}" ]]; then
+    echo "Phase 52.6.5 Phase29 root filename must be retired: control-plane/aegisops_control_plane/${retired_root_file}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" \
+  "${registry_path}" "${compatibility_test}" "${legacy_scoring_adapter}"; then
+  echo "Forbidden Phase 52.6.5 Phase29 retirement artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+export PHASE52_6_5_CONTROL_PLANE_ROOT="${control_plane_root}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+import sys
+
+control_plane_root = Path(os.environ["PHASE52_6_5_CONTROL_PLANE_ROOT"])
+if str(control_plane_root) not in sys.path:
+    sys.path.insert(0, str(control_plane_root))
+
+registry = importlib.import_module("aegisops_control_plane.core.legacy_import_aliases")
+
+expected_aliases = {
+    "aegisops_control_plane.phase29_shadow_dataset": (
+        "aegisops_control_plane.ml_shadow.dataset",
+        "ml_shadow",
+        "ml_shadow/dataset.py",
+        "Phase29ShadowDatasetSnapshot",
+        True,
+    ),
+    "aegisops_control_plane.phase29_evidently_drift_visibility": (
+        "aegisops_control_plane.ml_shadow.drift_visibility",
+        "ml_shadow",
+        "ml_shadow/drift_visibility.py",
+        "Phase29EvidentlyDriftVisibilityReport",
+        True,
+    ),
+    "aegisops_control_plane.phase29_mlflow_shadow_model_registry": (
+        "aegisops_control_plane.ml_shadow.mlflow_registry",
+        "ml_shadow",
+        "ml_shadow/mlflow_registry.py",
+        "Phase29MlflowShadowModelTrackingResult",
+        True,
+    ),
+    "aegisops_control_plane.phase29_shadow_scoring": (
+        "aegisops_control_plane.ml_shadow.legacy_scoring_adapter",
+        "ml_shadow",
+        "ml_shadow/legacy_scoring_adapter.py",
+        "Phase29ShadowScoreResult",
+        False,
+    ),
+}
+
+for legacy_path, (
+    target_path,
+    target_family,
+    owner,
+    attribute,
+    require_same_module,
+) in expected_aliases.items():
+    alias = registry.LEGACY_IMPORT_ALIASES.get(legacy_path)
+    if alias is None:
+        print(
+            f"Phase 52.6.5 missing Phase29 legacy alias: {legacy_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if alias.target_module != target_path:
+        print(
+            f"Phase 52.6.5 Phase29 alias target mismatch for {legacy_path}: {alias.target_module}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if alias.target_family != target_family or alias.owner != owner:
+        print(
+            f"Phase 52.6.5 Phase29 alias owner metadata mismatch for {legacy_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if legacy_path in registry.RETAINED_COMPATIBILITY_BLOCKERS:
+        print(
+            f"Phase 52.6.5 Phase29 path still listed as a retained blocker: {legacy_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    legacy_module = importlib.import_module(legacy_path)
+    target_module = importlib.import_module(target_path)
+    if require_same_module and legacy_module is not target_module:
+        print(
+            f"Phase 52.6.5 Phase29 alias changed module identity for {legacy_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if getattr(legacy_module, attribute) is not getattr(target_module, attribute):
+        print(
+            f"Phase 52.6.5 Phase29 alias changed compatibility attribute for {legacy_path}:{attribute}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+legacy_scoring = importlib.import_module("aegisops_control_plane.phase29_shadow_scoring")
+canonical_scoring = importlib.import_module("aegisops_control_plane.ml_shadow.scoring")
+if legacy_scoring is canonical_scoring:
+    print(
+        "Phase 52.6.5 legacy scoring path must preserve wrapper behavior outside canonical scoring.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if legacy_scoring.Phase29ShadowScoringError is not canonical_scoring.Phase29ShadowScoringError:
+    print(
+        "Phase 52.6.5 legacy scoring path lost canonical error compatibility.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+for compatibility_attribute in (
+    "feature_frequencies_at_inference_time",
+    "scored_examples",
+):
+    owners = (
+        legacy_scoring.Phase29ShadowScoreResult,
+        legacy_scoring.Phase29OfflineShadowScoringSnapshot,
+    )
+    if not any(hasattr(owner, compatibility_attribute) for owner in owners):
+        print(
+            "Phase 52.6.5 legacy scoring wrapper is missing "
+            + compatibility_attribute,
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+print(
+    "Phase 52.6.5 Phase29 root filenames are retired, ml_shadow remains the owner, "
+    "and legacy import compatibility is explicitly registered."
+)
+PY

--- a/scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh
+++ b/scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh
@@ -164,15 +164,12 @@ if legacy_scoring.Phase29ShadowScoringError is not canonical_scoring.Phase29Shad
         file=sys.stderr,
     )
     sys.exit(1)
-for compatibility_attribute in (
-    "feature_frequencies_at_inference_time",
-    "scored_examples",
-):
-    owners = (
-        legacy_scoring.Phase29ShadowScoreResult,
-        legacy_scoring.Phase29OfflineShadowScoringSnapshot,
-    )
-    if not any(hasattr(owner, compatibility_attribute) for owner in owners):
+expected_compatibility_owners = {
+    "feature_frequencies_at_inference_time": legacy_scoring.Phase29ShadowScoreResult,
+    "scored_examples": legacy_scoring.Phase29OfflineShadowScoringSnapshot,
+}
+for compatibility_attribute, owner in expected_compatibility_owners.items():
+    if not hasattr(owner, compatibility_attribute):
         print(
             "Phase 52.6.5 legacy scoring wrapper is missing "
             + compatibility_attribute,


### PR DESCRIPTION
## Summary
- Retire the four root `phase29_*` filenames and keep legacy imports available through the legacy import alias registry.
- Move the scoring-specific legacy wrapper to `aegisops_control_plane.ml_shadow.legacy_scoring_adapter` so canonical `ml_shadow.scoring` remains the production owner.
- Add Phase 52.6.5 verifier coverage plus ADR/verifier updates for the 37-file root baseline and retained compatibility list.

Part of #1105.
Depends on #1109.
Addresses #1110.

## Verification
- `bash scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh`
- `bash scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh`
- `python3 -m unittest control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py control-plane/tests/test_phase52_6_4_root_shim_alias_removal.py control-plane/tests/test_phase29_shadow_scoring_validation.py`
- `bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh && bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh && bash scripts/verify-phase-52-6-2-canonical-domain-imports.sh`
- `python3 -m unittest control-plane/tests/test_phase29_shadow_dataset_generation_validation.py control-plane/tests/test_phase29_shadow_scoring_validation.py control-plane/tests/test_phase29_evidently_drift_visibility_validation.py control-plane/tests/test_phase29_mlflow_shadow_model_registry_validation.py control-plane/tests/test_phase29_no_authority_ml_and_optional_network_validation.py`
- `bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh`
- `bash scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh`
- `bash scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh`
- `bash scripts/verify-phase-52-5-2-import-compatibility.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1110 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`
- `python3 -m unittest control-plane/tests/test_phase29_ml_shadow_mode_boundary_docs.py control-plane/tests/test_cross_boundary_negative_e2e_validation.py`
- `bash scripts/verify-phase-52-5-closeout-evaluation.sh`
- `bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Retired legacy root files and served them via the legacy import alias registry to preserve backward compatibility.

* **Tests**
  * Added and updated verification suites to assert legacy aliases, identity/compatibility behavior, and wrapper preservation.

* **Documentation**
  * Updated architecture ADRs to reflect retirement and alias registry details.

* **Chores**
  * Added and revised verification scripts and test fixtures for the retirement/registry workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->