### PR TITLE
Phase 52.6.6 root package guardrails

### DIFF
--- a/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
+++ b/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
@@ -104,6 +104,20 @@ Phase 52.6.5 removed these four Phase29-named root files after adding explicit l
 
 The production-owned implementations remain under `ml_shadow/dataset.py`, `ml_shadow/scoring.py`, `ml_shadow/drift_visibility.py`, and `ml_shadow/mlflow_registry.py`. The legacy scoring wrapper behavior that differs from canonical scoring now lives in `ml_shadow/legacy_scoring_adapter.py`.
 
+## 5.3 Phase 52.6.6 Retained Root Owner Policy
+
+After Phase 52.6.6, the only retained root owner files are `__init__.py`, `config.py`, `models.py`, `operator_inspection.py`, `persistence_lifecycle.py`, `publishable_paths.py`, `record_validation.py`, `reviewed_slice_policy.py`, `service_composition.py`, and `structured_events.py`.
+
+`service.py` is not a retained owner; it is the single retained compatibility blocker and the public `service.py` facade stays a retained compatibility blocker under ADR-0003 and ADR-0010 until a later facade transition issue supersedes that policy.
+
+No other direct root Python file may be promoted to retained owner status without a later accepted ADR or issue-specific contract that names the root file, authoritative owner, caller evidence, focused regression coverage, rollback path, and authority-boundary impact.
+
+The root package guardrail baseline is exactly `37` direct `.py` files under `control-plane/aegisops_control_plane/`.
+
+No direct root Python filename may begin with `phaseNN` or `phaseNN_` after Phase 52.6.6.
+
+A new flat root module fails verification unless the root file inventory classifies it and the root-count baseline is intentionally updated by policy.
+
 ## 6. Phase29 Boundary
 
 The retired Phase29 root filenames were legacy compatibility adapters only. They were not production owners.
@@ -119,6 +133,8 @@ Alias preservation is allowed only when the alias remains a narrow reference to 
 Retained blockers stay physically present until the referenced compatibility policy is superseded by a later accepted ADR or issue-specific contract.
 
 If a prerequisite signal is missing, malformed, ambiguous, or only partially trusted, the deletion path fails closed and the root file stays available.
+
+The future public package rename, outer `control-plane/` directory rename, retained-root owner relocation, and `service.py` facade relocation remain blocked until a later accepted ADR names caller evidence, replacement paths, deprecation window, focused regression coverage, rollback path, and authority-boundary impact.
 
 ## 8. Forbidden Claims
 
@@ -144,7 +160,17 @@ Run `bash scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh`.
 
 Run `bash scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh`.
 
+Run `bash scripts/verify-phase-52-6-6-root-package-guardrails.sh`.
+
+Run `bash scripts/test-verify-phase-52-6-6-root-package-guardrails.sh`.
+
+Run `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`.
+
+Run `bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`.
+
 Run `node <codex-supervisor-root>/dist/index.js issue-lint 1110 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1111 --config <supervisor-config-path>`.
 
 ## 10. Non-Goals
 

--- a/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
+++ b/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md
@@ -168,8 +168,6 @@ Run `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`.
 
 Run `bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`.
 
-Run `node <codex-supervisor-root>/dist/index.js issue-lint 1110 --config <supervisor-config-path>`.
-
 Run `node <codex-supervisor-root>/dist/index.js issue-lint 1111 --config <supervisor-config-path>`.
 
 ## 10. Non-Goals

--- a/scripts/test-verify-phase-52-6-6-root-package-guardrails.sh
+++ b/scripts/test-verify-phase-52-6-6-root-package-guardrails.sh
@@ -72,6 +72,14 @@ assert_fails_with \
   "${phase_numbered_root_repo}" \
   "Phase 52.6.6 root package guardrail rejects phase-numbered root filenames: phase52_new_owner.py"
 
+phase_numbered_prefix_repo="${workdir}/phase-numbered-prefix-root"
+create_valid_repo "${phase_numbered_prefix_repo}"
+printf '%s\n' '"""Fixture phase-numbered prefix root file."""' \
+  >"${phase_numbered_prefix_repo}/control-plane/aegisops_control_plane/phase52foo.py"
+assert_fails_with \
+  "${phase_numbered_prefix_repo}" \
+  "Phase 52.6.6 root package guardrail rejects phase-numbered root filenames: phase52foo.py"
+
 missing_retained_owner_policy_repo="${workdir}/missing-retained-owner-policy"
 create_valid_repo "${missing_retained_owner_policy_repo}"
 perl -0pi -e 's/\n## 5\.3 Phase 52\.6\.6 Retained Root Owner Policy.*?(?=\n## 6\. Phase29 Boundary)//s' \

--- a/scripts/test-verify-phase-52-6-6-root-package-guardrails.sh
+++ b/scripts/test-verify-phase-52-6-6-root-package-guardrails.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-6-6-root-package-guardrails.sh"
+contract_path="docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/adr" "${target}/control-plane"
+  cp "${repo_root}/${contract_path}" "${target}/${contract_path}"
+  cp -R "${repo_root}/control-plane/aegisops_control_plane" \
+    "${target}/control-plane/aegisops_control_plane"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+root_count_growth_repo="${workdir}/root-count-growth"
+create_valid_repo "${root_count_growth_repo}"
+printf '%s\n' '"""Fixture root file that must not pass without policy."""' \
+  >"${root_count_growth_repo}/control-plane/aegisops_control_plane/new_flat_owner.py"
+assert_fails_with \
+  "${root_count_growth_repo}" \
+  "Phase 52.6.6 root package guardrail expected 37 direct root Python files, found 38."
+
+phase_numbered_root_repo="${workdir}/phase-numbered-root"
+create_valid_repo "${phase_numbered_root_repo}"
+printf '%s\n' '"""Fixture phase-numbered root file."""' \
+  >"${phase_numbered_root_repo}/control-plane/aegisops_control_plane/phase52_new_owner.py"
+assert_fails_with \
+  "${phase_numbered_root_repo}" \
+  "Phase 52.6.6 root package guardrail rejects phase-numbered root filenames: phase52_new_owner.py"
+
+missing_retained_owner_policy_repo="${workdir}/missing-retained-owner-policy"
+create_valid_repo "${missing_retained_owner_policy_repo}"
+perl -0pi -e 's/\n## 5\.3 Phase 52\.6\.6 Retained Root Owner Policy.*?(?=\n## 6\. Phase29 Boundary)//s' \
+  "${missing_retained_owner_policy_repo}/${contract_path}"
+assert_fails_with \
+  "${missing_retained_owner_policy_repo}" \
+  "Missing Phase 52.6.6 retained root owner policy statement: After Phase 52.6.6, the only retained root owner files are"
+
+extra_retained_owner_repo="${workdir}/extra-retained-owner"
+create_valid_repo "${extra_retained_owner_repo}"
+perl -0pi -e 's/\| `action_policy\.py` \| `actions` \| simple shim \|/\| `action_policy.py` \| `actions` \| retained owner \|/' \
+  "${extra_retained_owner_repo}/${contract_path}"
+assert_fails_with \
+  "${extra_retained_owner_repo}" \
+  "Phase 52.6.6 retained root owner set mismatch: unexpected retained owner rows: action_policy.py"
+
+service_policy_removed_repo="${workdir}/service-policy-removed"
+create_valid_repo "${service_policy_removed_repo}"
+perl -0pi -e 's/\n`service\.py` is not a retained owner; it is the single retained compatibility blocker and the public `service\.py` facade stays a retained compatibility blocker under ADR-0003 and ADR-0010 until a later facade transition issue supersedes that policy\.\n/\n/' \
+  "${service_policy_removed_repo}/${contract_path}"
+assert_fails_with \
+  "${service_policy_removed_repo}" \
+  'Missing Phase 52.6.6 retained root owner policy statement: `service.py` is not a retained owner'
+
+future_blockers_removed_repo="${workdir}/future-blockers-removed"
+create_valid_repo "${future_blockers_removed_repo}"
+perl -0pi -e 's/\n## 7\. Deprecation Decision Rules/\n## 7. Deprecation Decision Rules/' \
+  "${future_blockers_removed_repo}/${contract_path}"
+perl -0pi -e 's/\nThe future public package rename, outer `control-plane\/` directory rename, retained-root owner relocation, and `service\.py` facade relocation remain blocked until a later accepted ADR names caller evidence, replacement paths, deprecation window, focused regression coverage, rollback path, and authority-boundary impact\.//' \
+  "${future_blockers_removed_repo}/${contract_path}"
+assert_fails_with \
+  "${future_blockers_removed_repo}" \
+  'Missing Phase 52.6.6 future blocker statement: The future public package rename, outer `control-plane/` directory rename'
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/${contract_path}"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.6.6 root package guardrail artifact: workstation-local absolute path detected"
+
+echo "Phase 52.6.6 root package guardrail verifier negative and valid fixtures passed."

--- a/scripts/test-verify-phase-52-6-6-root-package-guardrails.sh
+++ b/scripts/test-verify-phase-52-6-6-root-package-guardrails.sh
@@ -88,6 +88,14 @@ assert_fails_with \
   "${missing_retained_owner_policy_repo}" \
   "Missing Phase 52.6.6 retained root owner policy statement: After Phase 52.6.6, the only retained root owner files are"
 
+truncated_retained_owner_policy_repo="${workdir}/truncated-retained-owner-policy"
+create_valid_repo "${truncated_retained_owner_policy_repo}"
+perl -0pi -e 's/No other direct root Python file may be promoted to retained owner status without a later accepted ADR or issue-specific contract that names the root file, authoritative owner, caller evidence, focused regression coverage, rollback path, and authority-boundary impact\./No other direct root Python file may be promoted to retained owner status without a later accepted ADR or issue-specific contract/' \
+  "${truncated_retained_owner_policy_repo}/${contract_path}"
+assert_fails_with \
+  "${truncated_retained_owner_policy_repo}" \
+  "Missing Phase 52.6.6 retained root owner policy statement: No other direct root Python file may be promoted to retained owner status without a later accepted ADR or issue-specific contract that names the root file, authoritative owner, caller evidence, focused regression coverage, rollback path, and authority-boundary impact."
+
 extra_retained_owner_repo="${workdir}/extra-retained-owner"
 create_valid_repo "${extra_retained_owner_repo}"
 perl -0pi -e 's/\| `action_policy\.py` \| `actions` \| simple shim \|/\| `action_policy.py` \| `actions` \| retained owner \|/' \
@@ -95,6 +103,14 @@ perl -0pi -e 's/\| `action_policy\.py` \| `actions` \| simple shim \|/\| `action
 assert_fails_with \
   "${extra_retained_owner_repo}" \
   "Phase 52.6.6 retained root owner set mismatch: unexpected retained owner rows: action_policy.py"
+
+invalid_classification_repo="${workdir}/invalid-classification"
+create_valid_repo "${invalid_classification_repo}"
+perl -0pi -e 's/\| `action_policy\.py` \| `actions` \| simple shim \|/\| `action_policy.py` \| `actions` \| simple shim typo \|/' \
+  "${invalid_classification_repo}/${contract_path}"
+assert_fails_with \
+  "${invalid_classification_repo}" \
+  "Phase 52.6.6 root package guardrail found invalid root inventory classifications: action_policy.py: simple shim typo"
 
 service_policy_removed_repo="${workdir}/service-policy-removed"
 create_valid_repo "${service_policy_removed_repo}"

--- a/scripts/verify-phase-52-6-6-root-package-guardrails.sh
+++ b/scripts/verify-phase-52-6-6-root-package-guardrails.sh
@@ -10,7 +10,7 @@ required_phrases=(
   'After Phase 52.6.6, the only retained root owner files are'
   '`__init__.py`, `config.py`, `models.py`, `operator_inspection.py`, `persistence_lifecycle.py`, `publishable_paths.py`, `record_validation.py`, `reviewed_slice_policy.py`, `service_composition.py`, and `structured_events.py`.'
   '`service.py` is not a retained owner; it is the single retained compatibility blocker'
-  'No other direct root Python file may be promoted to retained owner status without a later accepted ADR or issue-specific contract'
+  'No other direct root Python file may be promoted to retained owner status without a later accepted ADR or issue-specific contract that names the root file, authoritative owner, caller evidence, focused regression coverage, rollback path, and authority-boundary impact.'
   'The root package guardrail baseline is exactly `37` direct `.py` files under `control-plane/aegisops_control_plane/`.'
   'No direct root Python filename may begin with `phaseNN` or `phaseNN_` after Phase 52.6.6.'
   'A new flat root module fails verification unless the root file inventory classifies it and the root-count baseline is intentionally updated by policy.'
@@ -81,6 +81,13 @@ expected_retained_owners = {
     "service_composition.py",
     "structured_events.py",
 }
+allowed_classifications = {
+    "retained owner",
+    "simple shim",
+    "compatibility adapter",
+    "alias candidate",
+    "retained compatibility blocker",
+}
 phase_numbered_pattern = re.compile(r"^phase\d+")
 row_pattern = re.compile(
     r"^\| `(?P<module>[^`]+\.py)` \| `(?P<family>[^`]+)` \| "
@@ -109,16 +116,29 @@ if len(actual_root_files) != expected_root_count:
 doc_text = doc_path.read_text(encoding="utf-8")
 rows: dict[str, str] = {}
 duplicates: set[str] = set()
+invalid_classifications: list[str] = []
 for match in row_pattern.finditer(doc_text):
     module = match.group("module")
     if module in rows:
         duplicates.add(module)
-    rows[module] = match.group("classification").strip()
+    classification = match.group("classification").strip()
+    if classification not in allowed_classifications:
+        invalid_classifications.append(f"{module}: {classification}")
+    rows[module] = classification
 
 if duplicates:
     print(
         "Phase 52.6.6 root package guardrail found duplicate root inventory rows: "
         + ", ".join(sorted(duplicates)),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if invalid_classifications:
+    print(
+        "Phase 52.6.6 root package guardrail found invalid root inventory "
+        "classifications: "
+        + ", ".join(sorted(invalid_classifications)),
         file=sys.stderr,
     )
     sys.exit(1)

--- a/scripts/verify-phase-52-6-6-root-package-guardrails.sh
+++ b/scripts/verify-phase-52-6-6-root-package-guardrails.sh
@@ -81,7 +81,7 @@ expected_retained_owners = {
     "service_composition.py",
     "structured_events.py",
 }
-phase_numbered_pattern = re.compile(r"^phase\d+(?:_|\.py$)")
+phase_numbered_pattern = re.compile(r"^phase\d+")
 row_pattern = re.compile(
     r"^\| `(?P<module>[^`]+\.py)` \| `(?P<family>[^`]+)` \| "
     r"(?P<classification>[^|]+) \| (?P<decision>[^|][^|]*) \|$",

--- a/scripts/verify-phase-52-6-6-root-package-guardrails.sh
+++ b/scripts/verify-phase-52-6-6-root-package-guardrails.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md"
+package_root="${repo_root}/control-plane/aegisops_control_plane"
+
+required_phrases=(
+  'After Phase 52.6.6, the only retained root owner files are'
+  '`__init__.py`, `config.py`, `models.py`, `operator_inspection.py`, `persistence_lifecycle.py`, `publishable_paths.py`, `record_validation.py`, `reviewed_slice_policy.py`, `service_composition.py`, and `structured_events.py`.'
+  '`service.py` is not a retained owner; it is the single retained compatibility blocker'
+  'No other direct root Python file may be promoted to retained owner status without a later accepted ADR or issue-specific contract'
+  'The root package guardrail baseline is exactly `37` direct `.py` files under `control-plane/aegisops_control_plane/`.'
+  'No direct root Python filename may begin with `phaseNN` or `phaseNN_` after Phase 52.6.6.'
+  'A new flat root module fails verification unless the root file inventory classifies it and the root-count baseline is intentionally updated by policy.'
+  'The future public package rename, outer `control-plane/` directory rename, retained-root owner relocation, and `service.py` facade relocation remain blocked until a later accepted ADR names caller evidence, replacement paths, deprecation window, focused regression coverage, rollback path, and authority-boundary impact.'
+  'Run `bash scripts/verify-phase-52-6-6-root-package-guardrails.sh`.'
+  'Run `bash scripts/test-verify-phase-52-6-6-root-package-guardrails.sh`.'
+  'Run `bash scripts/verify-phase-52-5-2-layout-guardrail.sh`.'
+  'Run `bash scripts/verify-phase-52-5-9-service-facade-freeze.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1111 --config <supervisor-config-path>`.'
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.6 root shim inventory contract: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${package_root}" ]]; then
+  echo "Missing control-plane package root: control-plane/aegisops_control_plane" >&2
+  exit 1
+fi
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    if [[ "${phrase}" == "The future public package rename,"* ]]; then
+      echo "Missing Phase 52.6.6 future blocker statement: ${phrase}" >&2
+      exit 1
+    fi
+    echo "Missing Phase 52.6.6 retained root owner policy statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.6.6 root package guardrail artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+export PHASE52_6_6_DOC_PATH="${doc_path}"
+export PHASE52_6_6_PACKAGE_ROOT="${package_root}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import sys
+
+doc_path = Path(os.environ["PHASE52_6_6_DOC_PATH"])
+package_root = Path(os.environ["PHASE52_6_6_PACKAGE_ROOT"])
+
+expected_root_count = 37
+expected_retained_owners = {
+    "__init__.py",
+    "config.py",
+    "models.py",
+    "operator_inspection.py",
+    "persistence_lifecycle.py",
+    "publishable_paths.py",
+    "record_validation.py",
+    "reviewed_slice_policy.py",
+    "service_composition.py",
+    "structured_events.py",
+}
+phase_numbered_pattern = re.compile(r"^phase\d+(?:_|\.py$)")
+row_pattern = re.compile(
+    r"^\| `(?P<module>[^`]+\.py)` \| `(?P<family>[^`]+)` \| "
+    r"(?P<classification>[^|]+) \| (?P<decision>[^|][^|]*) \|$",
+    re.MULTILINE,
+)
+
+actual_root_files = sorted(path.name for path in package_root.glob("*.py") if path.is_file())
+phase_numbered = [name for name in actual_root_files if phase_numbered_pattern.match(name)]
+if phase_numbered:
+    print(
+        "Phase 52.6.6 root package guardrail rejects phase-numbered root filenames: "
+        + ", ".join(phase_numbered),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if len(actual_root_files) != expected_root_count:
+    print(
+        "Phase 52.6.6 root package guardrail expected "
+        f"{expected_root_count} direct root Python files, found {len(actual_root_files)}.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+doc_text = doc_path.read_text(encoding="utf-8")
+rows: dict[str, str] = {}
+duplicates: set[str] = set()
+for match in row_pattern.finditer(doc_text):
+    module = match.group("module")
+    if module in rows:
+        duplicates.add(module)
+    rows[module] = match.group("classification").strip()
+
+if duplicates:
+    print(
+        "Phase 52.6.6 root package guardrail found duplicate root inventory rows: "
+        + ", ".join(sorted(duplicates)),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+missing_rows = [name for name in actual_root_files if name not in rows]
+extra_rows = sorted(set(rows) - set(actual_root_files))
+if missing_rows:
+    print(
+        "Phase 52.6.6 root package guardrail found unclassified flat root modules: "
+        + ", ".join(missing_rows),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if extra_rows:
+    print(
+        "Phase 52.6.6 root package guardrail inventory lists absent root files: "
+        + ", ".join(extra_rows),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+actual_retained_owners = {
+    module for module, classification in rows.items() if classification == "retained owner"
+}
+missing_retained_owners = sorted(expected_retained_owners - actual_retained_owners)
+unexpected_retained_owners = sorted(actual_retained_owners - expected_retained_owners)
+if missing_retained_owners or unexpected_retained_owners:
+    parts: list[str] = []
+    if missing_retained_owners:
+        parts.append("missing retained owner rows: " + ", ".join(missing_retained_owners))
+    if unexpected_retained_owners:
+        parts.append("unexpected retained owner rows: " + ", ".join(unexpected_retained_owners))
+    print(
+        "Phase 52.6.6 retained root owner set mismatch: " + "; ".join(parts),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if rows.get("service.py") != "retained compatibility blocker":
+    print(
+        "Phase 52.6.6 root package guardrail requires service.py to remain "
+        "a retained compatibility blocker, not a retained owner.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(
+    "Phase 52.6.6 root package guardrails retain 37 root Python files, "
+    "pin the retained-owner set, reject phase-numbered root filenames, "
+    "and keep service.py under retained compatibility-blocker policy."
+)
+PY


### PR DESCRIPTION
## Summary
- Document the Phase 52.6.6 retained root owner policy in ADR-0014.
- Add a root package guardrail verifier for the 37-file baseline, exact retained-owner set, phase-numbered root filenames, unclassified flat root modules, service.py blocker posture, and future rename/removal blockers.
- Add negative fixture coverage for root-count growth, phaseNN root filenames, retained-owner drift, service.py policy removal, future blocker removal, and publishable path hygiene.

## Verification
- bash scripts/verify-phase-52-6-6-root-package-guardrails.sh
- bash scripts/test-verify-phase-52-6-6-root-package-guardrails.sh
- bash scripts/verify-phase-52-5-2-layout-guardrail.sh
- bash scripts/verify-phase-52-5-9-service-facade-freeze.sh
- bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
- bash scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh
- bash scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh
- bash scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1111 --config <supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 52.6.6 "Retained Root Owner Policy" specifying the retained root-owner set, reaffirming a single retained compatibility blocker, introducing root-package guardrails, forbidding phase-prefixed root filenames, and tightening deprecation decision rules for package/dir/facade renames.

* **Tests**
  * Added guardrail verifier scripts and a test harness to validate root-package layout, naming rules, ownership classifications, ADR content, and related deprecation-blocker checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->