### PR TITLE
Phase 52.7.1 namespace layout inventory contract

### DIFF
--- a/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
+++ b/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md
@@ -145,6 +145,7 @@ The layout inventory does not change authorization, provenance, reconciliation, 
 | `ml_shadow/__init__.py` | `ml_shadow` | Package marker for reviewed ML shadow-mode modules. |
 | `ml_shadow/dataset.py` | `ml_shadow` | Owns shadow dataset lineage while preserving reviewed dataset checks. |
 | `ml_shadow/drift_visibility.py` | `ml_shadow` | Owns ML shadow drift visibility while preserving subordinate ML posture. |
+| `ml_shadow/legacy_scoring_adapter.py` | `ml_shadow` | Owns legacy scoring import compatibility while canonical scoring remains under `ml_shadow/scoring.py`. |
 | `ml_shadow/mlflow_registry.py` | `ml_shadow` | Owns shadow registry behavior while preserving no model-as-authority regression. |
 | `ml_shadow/scoring.py` | `ml_shadow` | Owns shadow scoring behavior while preserving subordinate recommendation checks. |
 | `models.py` | `core` | Move only with authoritative model import compatibility and schema regression tests. |

--- a/docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md
+++ b/docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md
@@ -1,0 +1,107 @@
+# ADR-0016: Phase 52.7.1 Namespace and Layout Inventory Contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-52-6-closeout-evaluation.md`, `docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md`, `docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md`
+- **Product**: AegisOps
+- **Related Issues**: #1120, #1121
+- **Depends On**: #1112
+- **Supersedes**: N/A
+- **Superseded By**: N/A
+
+---
+
+## 1. Purpose
+
+Phase 52.7.1 records the namespace and layout inventory that must exist before any public package rename, outer directory rename, retained-root owner relocation, facade relocation, docs move, script move, CI move, or supervisor-facing command change.
+
+This contract is documentation and verification only. It does not move files, rewrite imports, delete shims, change packaging, alter CI behavior, change supervisor policy, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior.
+
+## 2. Authority Boundary
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+Namespace bridges, filesystem layout, compatibility aliases, generated config, docs, verifier output, CI status, supervisor-facing issue text, UI cache, browser state, downstream receipts, Wazuh, Shuffle, tickets, assistant output, optional evidence, and demo data remain subordinate evidence or implementation context.
+
+The namespace and layout inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, action-execution, HTTP, CLI, deployment, Wazuh, Shuffle, ticket, CI, or durable-state behavior.
+
+## 3. Inventory Scope
+
+The inventory covers repo-owned references that a later namespace-normalization or root-owner-reduction issue would otherwise be tempted to infer from path shape, comments, issue text, or nearby metadata.
+
+Every row below is a migration prerequisite, not migration approval. If caller evidence is missing, malformed, ambiguous, or only partially trusted, the current reference remains the supported reference and the proposed reference remains blocked.
+
+## 4. Namespace And Layout Inventory
+
+| Reference class | Current repo-owned reference | Proposed or next reference | Contract |
+| --- | --- | --- | --- |
+| `current filesystem path` | `control-plane/aegisops_control_plane/` | `control-plane/aegisops/control_plane/` | Current filesystem path remains authoritative for live package files until a later accepted ADR proves caller evidence, compatibility coverage, rollback path, and authority-boundary impact. |
+| `current import package` | `aegisops_control_plane` | `aegisops.control_plane` | Current import package remains supported; proposed canonical namespace is documentation-only and not importable in this slice. |
+| `proposed canonical namespace` | `aegisops_control_plane` | `aegisops.control_plane` | Later migration must preserve legacy imports or document explicit retained blockers before introducing the canonical namespace. |
+| `packaging entrypoint` | `python3 control-plane/main.py` | `python3 control-plane/main.py` | Runtime entrypoint stays unchanged because this slice does not change packaging or CLI behavior. |
+| `docs path` | `docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md` | `docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md` | This ADR is the contract source for this slice and must remain publishable with repo-relative paths. |
+| `script path` | `scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh` | `scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh` | The verifier remains repo-relative and non-mutating. |
+| `negative fixture test path` | `scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh` | `scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh` | The focused negative fixture test must prove missing current package rows, missing proposed namespace rows, and file movement rejection. |
+| `CI path` | `.github/workflows/ci.yml` | `.github/workflows/ci.yml` | Existing CI path is inventory only; this slice does not change workflow behavior. |
+| `supervisor-facing path` | `node <codex-supervisor-root>/dist/index.js issue-lint 1121 --config <supervisor-config-path>` | `node <codex-supervisor-root>/dist/index.js issue-lint 1121 --config <supervisor-config-path>` | Supervisor-facing guidance must use placeholders, not workstation-local absolute paths. |
+
+## 5. Compatibility And Blockers
+
+The public Python package name `aegisops_control_plane` remains unchanged in Phase 52.7.1.
+
+The proposed canonical namespace `aegisops.control_plane` is a future target only. It is not implemented, imported, packaged, or advertised as available by this slice.
+
+The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.
+
+`service.py` remains a retained compatibility blocker under ADR-0003, ADR-0010, ADR-0014, and the Phase 52.6 closeout evaluation.
+
+Retained root owners remain physical files until a later owner-move issue proves identical behavior, caller compatibility, rollback path, and authority-boundary impact.
+
+Legacy import aliases remain compatibility mechanisms only. They do not make compatibility state, summary text, generated config, CLI status, adapter state, assistant output, evidence snippets, DTOs, projections, alias rows, namespace rows, or operator-facing text authoritative workflow truth.
+
+## 6. Movement Guard
+
+Phase 52.7.1 rejects file movement. The current `control-plane/aegisops_control_plane/` package, `control-plane/main.py`, `.github/workflows/ci.yml`, this ADR, and the focused verifier scripts must remain at the inventory paths above.
+
+The current package file manifest remains governed by ADR-0012 and the retained-root owner policy remains governed by ADR-0014. This ADR adds the namespace/layout row contract above those existing inventories; it does not replace them.
+
+Any later move must name the exact current path, replacement path, caller evidence, deprecation window, focused regression coverage, rollback path, and authority-boundary impact before it can proceed.
+
+## 7. Forbidden Claims
+
+The verifier rejects this contract if it asserts any of these claims outside this section:
+
+- This contract changes runtime behavior.
+- The `aegisops.control_plane` namespace is importable now.
+- The `aegisops_control_plane` package may be removed immediately.
+- This contract implements Wazuh product profiles.
+- This contract implements Shuffle product profiles.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh`.
+
+Run `bash scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`.
+
+Run `bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1120 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1121 --config <supervisor-config-path>`.
+
+## 9. Non-Goals
+
+- No file is moved.
+- No import is rewritten.
+- No shim is deleted.
+- No public package name is changed.
+- No proposed canonical namespace is implemented.
+- No packaging entrypoint is changed.
+- No CI workflow behavior is changed.
+- No supervisor policy is changed.
+- No runtime behavior, HTTP behavior, CLI behavior, deployment behavior, Wazuh behavior, Shuffle behavior, ticket behavior, assistant behavior, evidence behavior, reporting behavior, backup behavior, restore behavior, readiness behavior, action-execution behavior, authorization behavior, provenance behavior, or durable-state side effect is changed.

--- a/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh
+++ b/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh"
+contract_path="docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/adr" "${target}/control-plane" "${target}/scripts" "${target}/.github/workflows"
+  cp "${repo_root}/${contract_path}" "${target}/${contract_path}"
+  cp "${repo_root}/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md" \
+    "${target}/docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md"
+  cp "${repo_root}/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md" \
+    "${target}/docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md"
+  cp "${repo_root}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh" \
+    "${target}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh"
+  cp "${repo_root}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh" \
+    "${target}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh"
+  cp "${repo_root}/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh" \
+    "${target}/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh"
+  cp "${repo_root}/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh" \
+    "${target}/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh"
+  cp "${repo_root}/.github/workflows/ci.yml" "${target}/.github/workflows/ci.yml"
+  cp "${repo_root}/control-plane/main.py" "${target}/control-plane/main.py"
+  cp -R "${repo_root}/control-plane/aegisops_control_plane" \
+    "${target}/control-plane/aegisops_control_plane"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_current_package_repo="${workdir}/missing-current-package-row"
+create_valid_repo "${missing_current_package_repo}"
+perl -0pi -e 's/^\| `current import package` \|.*\n//m' \
+  "${missing_current_package_repo}/${contract_path}"
+assert_fails_with \
+  "${missing_current_package_repo}" \
+  "Missing Phase 52.7.1 namespace inventory row: current import package"
+
+missing_proposed_namespace_repo="${workdir}/missing-proposed-namespace-row"
+create_valid_repo "${missing_proposed_namespace_repo}"
+perl -0pi -e 's/^\| `proposed canonical namespace` \|.*\n//m' \
+  "${missing_proposed_namespace_repo}/${contract_path}"
+assert_fails_with \
+  "${missing_proposed_namespace_repo}" \
+  "Missing Phase 52.7.1 namespace inventory row: proposed canonical namespace"
+
+wrong_proposed_namespace_repo="${workdir}/wrong-proposed-namespace"
+create_valid_repo "${wrong_proposed_namespace_repo}"
+perl -0pi -e 's/aegisops\.control_plane/aegisops.controlplane/g' \
+  "${wrong_proposed_namespace_repo}/${contract_path}"
+assert_fails_with \
+  "${wrong_proposed_namespace_repo}" \
+  'Missing Phase 52.7.1 namespace/layout statement: The proposed canonical namespace `aegisops.control_plane` is a future target only.'
+
+package_moved_repo="${workdir}/package-moved"
+create_valid_repo "${package_moved_repo}"
+mkdir -p "${package_moved_repo}/control-plane/aegisops"
+mv "${package_moved_repo}/control-plane/aegisops_control_plane" \
+  "${package_moved_repo}/control-plane/aegisops/control_plane"
+assert_fails_with \
+  "${package_moved_repo}" \
+  "Phase 52.7.1 file movement rejected: missing current package path control-plane/aegisops_control_plane/"
+
+entrypoint_moved_repo="${workdir}/entrypoint-moved"
+create_valid_repo "${entrypoint_moved_repo}"
+mv "${entrypoint_moved_repo}/control-plane/main.py" \
+  "${entrypoint_moved_repo}/control-plane/aegisops-main.py"
+assert_fails_with \
+  "${entrypoint_moved_repo}" \
+  "Phase 52.7.1 file movement rejected: missing current path control-plane/main.py"
+
+behavior_change_repo="${workdir}/behavior-change-claim"
+create_valid_repo "${behavior_change_repo}"
+printf '%s\n' "This contract changes runtime behavior." \
+  >>"${behavior_change_repo}/${contract_path}"
+assert_fails_with \
+  "${behavior_change_repo}" \
+  "Forbidden Phase 52.7.1 namespace/layout claim: This contract changes runtime behavior."
+
+importable_namespace_repo="${workdir}/importable-namespace-claim"
+create_valid_repo "${importable_namespace_repo}"
+printf '%s\n' 'The `aegisops.control_plane` namespace is importable now.' \
+  >>"${importable_namespace_repo}/${contract_path}"
+assert_fails_with \
+  "${importable_namespace_repo}" \
+  'Forbidden Phase 52.7.1 namespace/layout claim: The `aegisops.control_plane` namespace is importable now.'
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/${contract_path}"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.7.1 namespace/layout inventory: workstation-local absolute path detected"
+
+echo "Phase 52.7.1 namespace/layout inventory verifier negative and valid fixtures passed."

--- a/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh
+++ b/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh
@@ -85,11 +85,11 @@ assert_fails_with \
 
 wrong_proposed_namespace_repo="${workdir}/wrong-proposed-namespace"
 create_valid_repo "${wrong_proposed_namespace_repo}"
-perl -0pi -e 's/aegisops\.control_plane/aegisops.controlplane/g' \
+perl -0pi -e 's{^\| \x60proposed canonical namespace\x60 \| \x60aegisops_control_plane\x60 \| \x60\Kaegisops\.control_plane(?=\x60 \|)}{aegisops.controlplane}m' \
   "${wrong_proposed_namespace_repo}/${contract_path}"
 assert_fails_with \
   "${wrong_proposed_namespace_repo}" \
-  'Missing Phase 52.7.1 namespace/layout statement: The proposed canonical namespace `aegisops.control_plane` is a future target only.'
+  "Phase 52.7.1 namespace inventory proposed reference mismatch for proposed canonical namespace: expected aegisops.control_plane, got aegisops.controlplane"
 
 package_moved_repo="${workdir}/package-moved"
 create_valid_repo "${package_moved_repo}"
@@ -99,6 +99,13 @@ mv "${package_moved_repo}/control-plane/aegisops_control_plane" \
 assert_fails_with \
   "${package_moved_repo}" \
   "Phase 52.7.1 file movement rejected: missing current package path control-plane/aegisops_control_plane/"
+
+proposed_package_added_repo="${workdir}/proposed-package-added"
+create_valid_repo "${proposed_package_added_repo}"
+mkdir -p "${proposed_package_added_repo}/control-plane/aegisops/control_plane"
+assert_fails_with \
+  "${proposed_package_added_repo}" \
+  "Phase 52.7.1 namespace/layout inventory rejected: proposed package path already exists at control-plane/aegisops/control_plane/"
 
 entrypoint_moved_repo="${workdir}/entrypoint-moved"
 create_valid_repo "${entrypoint_moved_repo}"
@@ -123,6 +130,20 @@ printf '%s\n' 'The `aegisops.control_plane` namespace is importable now.' \
 assert_fails_with \
   "${importable_namespace_repo}" \
   'Forbidden Phase 52.7.1 namespace/layout claim: The `aegisops.control_plane` namespace is importable now.'
+
+non_executable_prerequisite_repo="${workdir}/non-executable-prerequisite"
+create_valid_repo "${non_executable_prerequisite_repo}"
+chmod -x \
+  "${non_executable_prerequisite_repo}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh" \
+  "${non_executable_prerequisite_repo}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh"
+assert_passes "${non_executable_prerequisite_repo}"
+
+missing_prerequisite_repo="${workdir}/missing-prerequisite"
+create_valid_repo "${missing_prerequisite_repo}"
+rm "${missing_prerequisite_repo}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh"
+assert_fails_with \
+  "${missing_prerequisite_repo}" \
+  "Missing prerequisite verifier: verify-phase-52-5-1-control-plane-layout-inventory-contract.sh"
 
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"

--- a/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
+++ b/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
@@ -30,7 +30,7 @@ required_phrases=(
   "The layout inventory does not change authorization, provenance, reconciliation, snapshot, backup, restore, export, readiness, assistant, evidence, or action-execution behavior."
   'The public Python package name `aegisops_control_plane` remains unchanged throughout Phase 52.5.1 and later child issues unless a later accepted ADR explicitly approves a rename.'
   'The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.'
-  "Legacy import paths remain available during migration through compatibility shims or direct re-export modules until all documented internal, CLI, HTTP, test, and operator callers have migrated."
+  "Legacy import paths remain available during migration through compatibility shims, direct re-export modules, or approved entries in the legacy import alias registry until all documented internal, CLI, HTTP, test, and operator callers have migrated."
   "Removing a legacy import path requires a later transition policy that lists the affected import path, replacement import path, caller evidence, deprecation window, focused regression test, and rollback path."
   "If caller evidence is incomplete, malformed, or ambiguous, the old import path stays available."
   "Phase 52.5.1 does not itself approve any additional production module moves, import rewrites beyond the documented compatibility shims, package renames, directory renames, Wazuh profile work, Shuffle profile work, runtime behavior changes, deployment behavior changes, or authority-boundary changes."
@@ -159,7 +159,7 @@ row_pattern = re.compile(
     re.MULTILINE,
 )
 
-rows: dict[str, str] = {}
+rows: dict[str, tuple[str, str]] = {}
 duplicates: set[str] = set()
 invalid_families: list[str] = []
 empty_contracts: list[str] = []
@@ -169,7 +169,7 @@ for match in row_pattern.finditer(doc_text):
     contract = match.group("contract").strip()
     if module in rows:
         duplicates.add(module)
-    rows[module] = family
+    rows[module] = (family, contract)
     if family not in allowed:
         invalid_families.append(f"{module}: {family}")
     if not contract:
@@ -190,7 +190,11 @@ if duplicates:
     sys.exit(1)
 
 missing = [module for module in actual_modules if module not in rows]
-extra = sorted(set(rows) - set(actual_modules))
+extra = sorted(
+    module
+    for module, (_, contract) in rows.items()
+    if module not in actual_modules and "Compatibility shim only" not in contract
+)
 if missing:
     print(
         "Phase 52.5.1 layout inventory is missing module rows: "
@@ -220,7 +224,7 @@ if empty_contracts:
     )
     sys.exit(1)
 
-missing_families = sorted(allowed - set(rows.values()))
+missing_families = sorted(allowed - {family for family, _ in rows.values()})
 if missing_families:
     print(
         "Phase 52.5.1 layout inventory does not use required target families: "

--- a/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh
+++ b/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 doc_path="${repo_root}/docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md"
 package_root="${repo_root}/control-plane/aegisops_control_plane"
+proposed_package_root="${repo_root}/control-plane/aegisops/control_plane"
 
 required_headings=(
   "# ADR-0016: Phase 52.7.1 Namespace and Layout Inventory Contract"
@@ -88,6 +89,11 @@ if [[ ! -d "${package_root}" ]]; then
   exit 1
 fi
 
+if [[ -d "${proposed_package_root}" ]]; then
+  echo "Phase 52.7.1 namespace/layout inventory rejected: proposed package path already exists at control-plane/aegisops/control_plane/" >&2
+  exit 1
+fi
+
 for required_path in \
   "${repo_root}/control-plane/main.py" \
   "${repo_root}/.github/workflows/ci.yml" \
@@ -95,7 +101,8 @@ for required_path in \
   "${repo_root}/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh"
 do
   if [[ ! -f "${required_path}" ]]; then
-    echo "Phase 52.7.1 file movement rejected: missing current path ${required_path#${repo_root}/}" >&2
+    required_path_display="${required_path#"${repo_root}/"}"
+    echo "Phase 52.7.1 file movement rejected: missing current path ${required_path_display}" >&2
     exit 1
   fi
 done
@@ -232,10 +239,13 @@ print(
 )
 PY
 
-if [[ -x "${repo_root}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh" ]]; then
-  bash "${repo_root}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh" "${repo_root}" >/dev/null
-fi
-
-if [[ -x "${repo_root}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh" ]]; then
-  bash "${repo_root}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh" "${repo_root}" >/dev/null
-fi
+for prerequisite in \
+  "${repo_root}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh" \
+  "${repo_root}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh"
+do
+  if [[ ! -f "${prerequisite}" ]]; then
+    echo "Missing prerequisite verifier: $(basename "${prerequisite}")" >&2
+    exit 1
+  fi
+  bash "${prerequisite}" "${repo_root}" >/dev/null
+done

--- a/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh
+++ b/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md"
+package_root="${repo_root}/control-plane/aegisops_control_plane"
+
+required_headings=(
+  "# ADR-0016: Phase 52.7.1 Namespace and Layout Inventory Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Inventory Scope"
+  "## 4. Namespace And Layout Inventory"
+  "## 5. Compatibility And Blockers"
+  "## 6. Movement Guard"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted"
+  "- **Date**: 2026-05-02"
+  "- **Related Issues**: #1120, #1121"
+  "- **Depends On**: #1112"
+  "This contract is documentation and verification only. It does not move files, rewrite imports, delete shims, change packaging, alter CI behavior, change supervisor policy, start Wazuh profile work, start Shuffle profile work, or alter runtime behavior."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+  "Namespace bridges, filesystem layout, compatibility aliases, generated config, docs, verifier output, CI status, supervisor-facing issue text, UI cache, browser state, downstream receipts, Wazuh, Shuffle, tickets, assistant output, optional evidence, and demo data remain subordinate evidence or implementation context."
+  "Every row below is a migration prerequisite, not migration approval. If caller evidence is missing, malformed, ambiguous, or only partially trusted, the current reference remains the supported reference and the proposed reference remains blocked."
+  'The public Python package name `aegisops_control_plane` remains unchanged in Phase 52.7.1.'
+  'The proposed canonical namespace `aegisops.control_plane` is a future target only. It is not implemented, imported, packaged, or advertised as available by this slice.'
+  'The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.'
+  '`service.py` remains a retained compatibility blocker under ADR-0003, ADR-0010, ADR-0014, and the Phase 52.6 closeout evaluation.'
+  'Phase 52.7.1 rejects file movement. The current `control-plane/aegisops_control_plane/` package, `control-plane/main.py`, `.github/workflows/ci.yml`, this ADR, and the focused verifier scripts must remain at the inventory paths above.'
+  "The current package file manifest remains governed by ADR-0012 and the retained-root owner policy remains governed by ADR-0014. This ADR adds the namespace/layout row contract above those existing inventories; it does not replace them."
+  'Run `bash scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh`.'
+  'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
+  'Run `bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh`.'
+  'Run `bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1120 --config <supervisor-config-path>`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1121 --config <supervisor-config-path>`.'
+)
+
+required_rows=(
+  'current filesystem path|control-plane/aegisops_control_plane/|control-plane/aegisops/control_plane/'
+  'current import package|aegisops_control_plane|aegisops.control_plane'
+  'proposed canonical namespace|aegisops_control_plane|aegisops.control_plane'
+  'packaging entrypoint|python3 control-plane/main.py|python3 control-plane/main.py'
+  'docs path|docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md|docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md'
+  'script path|scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh|scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh'
+  'negative fixture test path|scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh|scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh'
+  'CI path|.github/workflows/ci.yml|.github/workflows/ci.yml'
+  'supervisor-facing path|node <codex-supervisor-root>/dist/index.js issue-lint 1121 --config <supervisor-config-path>|node <codex-supervisor-root>/dist/index.js issue-lint 1121 --config <supervisor-config-path>'
+)
+
+forbidden_claims=(
+  "This contract changes runtime behavior."
+  "The \`aegisops.control_plane\` namespace is importable now."
+  "The \`aegisops_control_plane\` package may be removed immediately."
+  "This contract implements Wazuh product profiles."
+  "This contract implements Shuffle product profiles."
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.7.1 namespace/layout inventory contract: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${package_root}" ]]; then
+  echo "Phase 52.7.1 file movement rejected: missing current package path control-plane/aegisops_control_plane/" >&2
+  exit 1
+fi
+
+for required_path in \
+  "${repo_root}/control-plane/main.py" \
+  "${repo_root}/.github/workflows/ci.yml" \
+  "${repo_root}/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh" \
+  "${repo_root}/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh"
+do
+  if [[ ! -f "${required_path}" ]]; then
+    echo "Phase 52.7.1 file movement rejected: missing current path ${required_path#${repo_root}/}" >&2
+    exit 1
+  fi
+done
+
+doc_rendered_markdown="$(rendered_markdown_without_code_blocks "${doc_path}")"
+doc_raw_markdown="$(cat "${doc_path}")"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.7.1 namespace/layout heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 52.7.1 namespace/layout statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+  local markdown="$2"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${markdown}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}" "${doc_raw_markdown}"; then
+    echo "Forbidden Phase 52.7.1 namespace/layout claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}"; then
+  echo "Forbidden Phase 52.7.1 namespace/layout inventory: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+export PHASE52_7_1_DOC_PATH="${doc_path}"
+export PHASE52_7_1_REQUIRED_ROWS="$(printf '%s\n' "${required_rows[@]}")"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import sys
+
+doc_path = pathlib.Path(os.environ["PHASE52_7_1_DOC_PATH"])
+required_rows = [line.split("|", 2) for line in os.environ["PHASE52_7_1_REQUIRED_ROWS"].splitlines()]
+doc_text = doc_path.read_text(encoding="utf-8")
+
+row_pattern = re.compile(
+    r"^\| `(?P<class>[^`]+)` \| `(?P<current>[^`]+)` \| `(?P<proposed>[^`]+)` \| (?P<contract>[^|][^|]*) \|$",
+    re.MULTILINE,
+)
+
+rows: dict[str, tuple[str, str, str]] = {}
+duplicates: set[str] = set()
+empty_contracts: list[str] = []
+for match in row_pattern.finditer(doc_text):
+    row_class = match.group("class")
+    if row_class in rows:
+        duplicates.add(row_class)
+    rows[row_class] = (
+        match.group("current"),
+        match.group("proposed"),
+        match.group("contract").strip(),
+    )
+    if not match.group("contract").strip():
+        empty_contracts.append(row_class)
+
+if duplicates:
+    print(
+        "Phase 52.7.1 namespace/layout inventory has duplicate rows: "
+        + ", ".join(sorted(duplicates)),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+for row_class, current, proposed in required_rows:
+    if row_class not in rows:
+        print(f"Missing Phase 52.7.1 namespace inventory row: {row_class}", file=sys.stderr)
+        sys.exit(1)
+    actual_current, actual_proposed, _ = rows[row_class]
+    if actual_current != current:
+        print(
+            f"Phase 52.7.1 namespace inventory current reference mismatch for {row_class}: "
+            f"expected {current}, got {actual_current}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if actual_proposed != proposed:
+        print(
+            f"Phase 52.7.1 namespace inventory proposed reference mismatch for {row_class}: "
+            f"expected {proposed}, got {actual_proposed}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+if empty_contracts:
+    print(
+        "Phase 52.7.1 namespace/layout inventory has empty contract rows: "
+        + ", ".join(empty_contracts),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if "aegisops_control_plane" not in doc_text:
+    print("Missing current aegisops_control_plane references in Phase 52.7.1 namespace inventory.", file=sys.stderr)
+    sys.exit(1)
+if "aegisops.control_plane" not in doc_text:
+    print("Missing proposed canonical namespace references in Phase 52.7.1 namespace inventory.", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    "Phase 52.7.1 namespace/layout inventory records current package, proposed namespace, "
+    "entrypoint, docs, script, CI, and supervisor-facing references."
+)
+PY
+
+if [[ -x "${repo_root}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh" ]]; then
+  bash "${repo_root}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh" "${repo_root}" >/dev/null
+fi
+
+if [[ -x "${repo_root}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh" ]]; then
+  bash "${repo_root}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh" "${repo_root}" >/dev/null
+fi


### PR DESCRIPTION
## Summary
- add ADR-0016 for the Phase 52.7.1 namespace/layout inventory contract
- add focused verifier and negative fixture test for current package references, proposed namespace references, path hygiene, and file movement rejection
- repair Phase 52.5.1 layout inventory drift for the legacy scoring adapter and alias-registry-era compatibility rows

## Verification
- bash scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh
- bash scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh
- bash scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
- bash scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh
- bash scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh
- bash scripts/verify-publishable-path-hygiene.sh
- bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh
- bash scripts/test-verify-phase-51-6-authority-boundary-negative-test-policy.sh
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1120 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1121 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 52.7.1 Namespace and Layout Inventory Contract ADR.
  * Extended module inventory to include a legacy scoring adapter entry.

* **Tests**
  * Added comprehensive verification tests for the Phase 52.7.1 namespace/layout inventory contract.
  * Improved Phase 52.5.1 contract validation to more accurately parse and validate inventory rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->