### PR TITLE
Phase 52.7.2 canonical namespace bridge

### DIFF
--- a/control-plane/aegisops/__init__.py
+++ b/control-plane/aegisops/__init__.py
@@ -1,0 +1,2 @@
+"""Canonical AegisOps namespace package."""
+

--- a/control-plane/aegisops/control_plane/__init__.py
+++ b/control-plane/aegisops/control_plane/__init__.py
@@ -1,0 +1,71 @@
+"""Canonical namespace bridge for the AegisOps control plane.
+
+The implementation package remains :mod:`aegisops_control_plane`.  This bridge
+lets callers validate the future canonical namespace without relocating modules
+or breaking legacy imports.
+"""
+
+from __future__ import annotations
+
+from importlib.abc import Loader, MetaPathFinder
+from importlib.machinery import ModuleSpec
+import importlib
+import importlib.util
+import sys
+from types import ModuleType
+
+import aegisops_control_plane as _legacy_control_plane
+
+_CANONICAL_PREFIX = __name__ + "."
+_LEGACY_PREFIX = "aegisops_control_plane."
+
+
+class _CanonicalControlPlaneAliasLoader(Loader):
+    def __init__(self, canonical_name: str, legacy_name: str) -> None:
+        self._canonical_name = canonical_name
+        self._legacy_name = legacy_name
+
+    def create_module(self, spec: ModuleSpec) -> ModuleType:
+        module = importlib.import_module(self._legacy_name)
+        sys.modules[self._canonical_name] = module
+        return module
+
+    def exec_module(self, module: ModuleType) -> None:
+        sys.modules[self._canonical_name] = module
+
+
+class _CanonicalControlPlaneAliasFinder(MetaPathFinder):
+    def find_spec(
+        self,
+        fullname: str,
+        path: object | None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
+        if not fullname.startswith(_CANONICAL_PREFIX):
+            return None
+
+        legacy_name = _LEGACY_PREFIX + fullname.removeprefix(_CANONICAL_PREFIX)
+        legacy_spec = importlib.util.find_spec(legacy_name)
+        if legacy_spec is None:
+            return None
+
+        return ModuleSpec(
+            fullname,
+            _CanonicalControlPlaneAliasLoader(fullname, legacy_name),
+            is_package=legacy_spec.submodule_search_locations is not None,
+        )
+
+
+def _install_canonical_alias_finder() -> None:
+    for finder in sys.meta_path:
+        if isinstance(finder, _CanonicalControlPlaneAliasFinder):
+            return
+    sys.meta_path.insert(0, _CanonicalControlPlaneAliasFinder())
+
+
+_install_canonical_alias_finder()
+
+for _name in _legacy_control_plane.__all__:
+    globals()[_name] = getattr(_legacy_control_plane, _name)
+
+__all__ = list(_legacy_control_plane.__all__)

--- a/control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py
+++ b/control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib
+import pathlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+
+class Phase5272CanonicalNamespaceBridgeTests(unittest.TestCase):
+    def test_missing_bridge_registration_keeps_canonical_namespace_unavailable(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            package_root = pathlib.Path(temp_dir) / "aegisops_control_plane"
+            package_root.mkdir()
+            (package_root / "__init__.py").write_text("", encoding="utf-8")
+
+            script = textwrap.dedent(
+                """
+                import importlib
+
+                importlib.import_module("aegisops_control_plane")
+
+                try:
+                    importlib.import_module("aegisops.control_plane")
+                except ModuleNotFoundError as exc:
+                    if exc.name == "aegisops":
+                        raise SystemExit(0)
+                    raise
+                raise SystemExit("canonical namespace unexpectedly imported")
+                """
+            )
+
+            subprocess.run(
+                [sys.executable, "-c", script],
+                check=True,
+                env={"PYTHONPATH": temp_dir},
+            )
+
+    def test_canonical_root_exports_legacy_public_surface(self) -> None:
+        legacy = importlib.import_module("aegisops_control_plane")
+        canonical = importlib.import_module("aegisops.control_plane")
+
+        self.assertEqual(canonical.__all__, legacy.__all__)
+        for attribute in (
+            "AegisOpsControlPlaneService",
+            "AlertRecord",
+            "RuntimeConfig",
+            "build_runtime_service",
+        ):
+            with self.subTest(attribute=attribute):
+                self.assertIs(getattr(canonical, attribute), getattr(legacy, attribute))
+
+    def test_canonical_submodules_share_legacy_module_identity(self) -> None:
+        module_pairs = {
+            "aegisops.control_plane.service": "aegisops_control_plane.service",
+            "aegisops.control_plane.models": "aegisops_control_plane.models",
+            "aegisops.control_plane.actions.review.action_review_chain": (
+                "aegisops_control_plane.actions.review.action_review_chain"
+            ),
+            "aegisops.control_plane.audit_export": (
+                "aegisops_control_plane.reporting.audit_export"
+            ),
+        }
+
+        for canonical_name, legacy_name in module_pairs.items():
+            with self.subTest(canonical_name=canonical_name):
+                canonical = importlib.import_module(canonical_name)
+                legacy = importlib.import_module(legacy_name)
+                self.assertIs(canonical, legacy)
+
+    def test_legacy_imports_remain_available_after_canonical_bridge(self) -> None:
+        importlib.import_module("aegisops.control_plane")
+
+        legacy_service = importlib.import_module("aegisops_control_plane.service")
+        legacy_package = importlib.import_module("aegisops_control_plane")
+
+        self.assertIs(
+            legacy_service.AegisOpsControlPlaneService,
+            legacy_package.AegisOpsControlPlaneService,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md
+++ b/docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md
@@ -1,0 +1,60 @@
+# ADR-0017: Phase 52.7.2 Canonical Namespace Bridge
+
+## Status
+
+Accepted for Phase 52.7.2 implementation.
+
+## Context
+
+Phase 52.7.1 kept `aegisops.control_plane` as a proposed namespace only. Phase
+52.7.2 introduces the smallest compatibility bridge needed to validate that
+namespace before repo-owned callers are rewired.
+
+The implementation package remains `aegisops_control_plane`. Legacy imports
+must continue to work, and implementation modules are not physically relocated
+in this slice.
+
+## Decision
+
+Add `control-plane/aegisops/control_plane/` as a bridge package.
+
+The bridge imports the existing `aegisops_control_plane` package, re-exports its
+approved root public surface, and installs a bounded import alias finder that
+maps `aegisops.control_plane.*` submodule imports to the corresponding
+`aegisops_control_plane.*` module.
+
+The bridge is compatibility infrastructure only. AegisOps control-plane records
+remain authoritative for runtime workflow truth. Namespace bridges, aliases,
+docs, tests, verifiers, and generated output remain subordinate implementation
+context.
+
+## Compatibility Contract
+
+The following behavior is required:
+
+- `import aegisops_control_plane` continues to pass.
+- `import aegisops.control_plane` passes through the bridge.
+- `aegisops.control_plane.service` resolves to the same module object as
+  `aegisops_control_plane.service`.
+- `aegisops.control_plane.models` resolves to the same module object as
+  `aegisops_control_plane.models`.
+- Registry-backed legacy paths such as `aegisops.control_plane.audit_export`
+  resolve to the same owner module as the corresponding
+  `aegisops_control_plane` legacy import.
+
+## Non-Goals
+
+- Do not move implementation files out of `control-plane/aegisops_control_plane/`.
+- Do not delete or deprecate `aegisops_control_plane` imports.
+- Do not rewrite broad repo callers in this slice.
+- Do not change runtime authority, persistence, HTTP API, CLI behavior, or
+  product semantics.
+
+## Verification
+
+Run:
+
+- `python3 -m unittest control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py`
+- `bash scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh`
+- `bash scripts/test-verify-phase-52-7-2-canonical-namespace-bridge.sh`
+

--- a/scripts/test-verify-phase-52-7-2-canonical-namespace-bridge.sh
+++ b/scripts/test-verify-phase-52-7-2-canonical-namespace-bridge.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/control-plane" "${target}/docs/adr" "${target}/scripts"
+  cp -R "${repo_root}/control-plane/aegisops_control_plane" \
+    "${target}/control-plane/aegisops_control_plane"
+  cp -R "${repo_root}/control-plane/aegisops" \
+    "${target}/control-plane/aegisops"
+  mkdir -p "${target}/control-plane/tests"
+  cp "${repo_root}/control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py" \
+    "${target}/control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py"
+  cp "${repo_root}/docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md" \
+    "${target}/docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_bridge_repo="${workdir}/missing-bridge"
+create_valid_repo "${missing_bridge_repo}"
+rm -rf "${missing_bridge_repo}/control-plane/aegisops"
+assert_fails_with \
+  "${missing_bridge_repo}" \
+  "Missing Phase 52.7.2 canonical namespace bridge path: control-plane/aegisops/__init__.py"
+
+broken_identity_repo="${workdir}/broken-identity"
+create_valid_repo "${broken_identity_repo}"
+cat >"${broken_identity_repo}/control-plane/aegisops/control_plane/__init__.py" <<'PY'
+class AegisOpsControlPlaneService:
+    pass
+
+class AlertRecord:
+    pass
+
+class RuntimeConfig:
+    pass
+
+def build_runtime_service():
+    return None
+PY
+assert_fails_with \
+  "${broken_identity_repo}" \
+  "Phase 52.7.2 canonical namespace bridge changed public attribute identity: AegisOpsControlPlaneService"
+
+legacy_deleted_repo="${workdir}/legacy-deleted"
+create_valid_repo "${legacy_deleted_repo}"
+rm -rf "${legacy_deleted_repo}/control-plane/aegisops_control_plane"
+assert_fails_with \
+  "${legacy_deleted_repo}" \
+  "Missing Phase 52.7.2 canonical namespace bridge path: control-plane/aegisops_control_plane/__init__.py"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 52.7.2 canonical namespace bridge: workstation-local absolute path detected"
+
+echo "Phase 52.7.2 canonical namespace bridge verifier negative and valid fixtures passed."

--- a/scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh
+++ b/scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+control_plane_root="${repo_root}/control-plane"
+bridge_root="${control_plane_root}/aegisops"
+bridge_package="${bridge_root}/control_plane"
+doc_path="${repo_root}/docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md"
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 52.7.2 canonical namespace bridge ADR: docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md" >&2
+  exit 1
+fi
+
+for required_path in \
+  "${bridge_root}/__init__.py" \
+  "${bridge_package}/__init__.py" \
+  "${control_plane_root}/aegisops_control_plane/__init__.py"; do
+  if [[ ! -f "${required_path}" ]]; then
+    echo "Missing Phase 52.7.2 canonical namespace bridge path: ${required_path#${repo_root}/}" >&2
+    exit 1
+  fi
+done
+
+if grep -R -E '(/Users/[^[:space:]]+|/home/[^[:space:]]+|[A-Za-z]:\\Users\\)' \
+  "${doc_path}" \
+  "${bridge_root}" \
+  "${repo_root}/control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py" >/dev/null; then
+  echo "Forbidden Phase 52.7.2 canonical namespace bridge: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+export PHASE52_7_2_CONTROL_PLANE_ROOT="${control_plane_root}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import importlib
+import os
+import pathlib
+import sys
+
+control_plane_root = pathlib.Path(os.environ["PHASE52_7_2_CONTROL_PLANE_ROOT"])
+if str(control_plane_root) not in sys.path:
+    sys.path.insert(0, str(control_plane_root))
+
+try:
+    legacy = importlib.import_module("aegisops_control_plane")
+    canonical = importlib.import_module("aegisops.control_plane")
+except Exception as exc:
+    print(f"Phase 52.7.2 canonical namespace bridge failed to load: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+for attribute in (
+    "AegisOpsControlPlaneService",
+    "AlertRecord",
+    "RuntimeConfig",
+    "build_runtime_service",
+):
+    if getattr(canonical, attribute, None) is not getattr(legacy, attribute, None):
+        print(
+            f"Phase 52.7.2 canonical namespace bridge changed public attribute identity: {attribute}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+module_pairs = {
+    "aegisops.control_plane.service": "aegisops_control_plane.service",
+    "aegisops.control_plane.models": "aegisops_control_plane.models",
+    "aegisops.control_plane.actions.review.action_review_chain": (
+        "aegisops_control_plane.actions.review.action_review_chain"
+    ),
+    "aegisops.control_plane.audit_export": "aegisops_control_plane.reporting.audit_export",
+}
+
+for canonical_name, legacy_name in module_pairs.items():
+    canonical_module = importlib.import_module(canonical_name)
+    legacy_module = importlib.import_module(legacy_name)
+    if canonical_module is not legacy_module:
+        print(
+            f"Phase 52.7.2 canonical namespace bridge changed module identity: {canonical_name}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+importlib.import_module("aegisops_control_plane")
+importlib.import_module("aegisops_control_plane.service")
+
+print("Phase 52.7.2 canonical namespace bridge verifier passed.")
+PY

--- a/scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh
+++ b/scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh
@@ -23,7 +23,12 @@ for required_path in \
   fi
 done
 
-if grep -R -E '(/Users/[^[:space:]]+|/home/[^[:space:]]+|[A-Za-z]:\\Users\\)' \
+mac_home_segment="Users"
+linux_home_segment="home"
+windows_home_segment="Users"
+workstation_path_pattern="(/${mac_home_segment}/[^[:space:]]+|/${linux_home_segment}/[^[:space:]]+|[A-Za-z]:\\\\${windows_home_segment}\\\\)"
+
+if grep -R -E "${workstation_path_pattern}" \
   "${doc_path}" \
   "${bridge_root}" \
   "${repo_root}/control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py" >/dev/null; then


### PR DESCRIPTION
## Summary
- add the `aegisops.control_plane` bridge package without moving `aegisops_control_plane` implementation files
- preserve legacy public surface and submodule identity through a canonical import alias finder
- document ADR-0017 and add focused bridge verifier plus negative fixtures

## Verification
- `python3 -m unittest control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py`
- `bash scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh`
- `bash scripts/test-verify-phase-52-7-2-canonical-namespace-bridge.sh`
- `bash scripts/verify-phase-52-5-2-import-compatibility.sh`
- `bash scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh`
- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node dist/index.js issue-lint 1122 --config supervisor.config.aegisops.coderabbit.json`

Closes #1122


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canonical namespace bridge for the control plane, enabling imports under the canonical package while maintaining backward compatibility with legacy imports.

* **Tests**
  * Added comprehensive test suite validating namespace bridge functionality, module identity consistency, and legacy import availability.

* **Documentation**
  * Added architectural decision record documenting the canonical namespace bridge design and verification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->