### PR TITLE
Phase 52.7.6 namespace path packaging guardrails

### DIFF
--- a/docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md
+++ b/docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md
@@ -1,0 +1,67 @@
+# ADR-0018: Phase 52.7.6 Namespace, Path, And Packaging Guardrails
+
+## Status
+
+Accepted for Phase 52.7.6 validation.
+
+## Context
+
+Phase 52.7.4 moved implementation ownership to `control-plane/aegisops/control_plane/`.
+Phase 52.7.5 reduced the canonical package root to the explicit retained root
+files and preserved legacy import compatibility through the alias registry and
+the `control-plane/aegisops_control_plane/__init__.py` compatibility shim.
+
+This contract pins that accepted state so stale path guidance, duplicate legacy
+namespace guidance, unclassified root files, and publishable workstation-local
+paths do not return.
+
+## Authority Boundary
+
+AegisOps control-plane records remain authoritative for alert, case, evidence,
+approval, action request, execution receipt, reconciliation, audit, limitation,
+release, gate, and closeout truth. Namespace bridges, filesystem layout,
+compatibility aliases, generated config, docs, verifier output, CI status,
+supervisor-facing issue text, UI cache, browser state, downstream receipts,
+Wazuh, Shuffle, tickets, assistant output, optional evidence, and demo data
+remain subordinate evidence or implementation context.
+
+## Pinned State
+
+| Class | Required state |
+| --- | --- |
+| Canonical implementation package | `control-plane/aegisops/control_plane/` |
+| Legacy compatibility package | `control-plane/aegisops_control_plane/__init__.py` only |
+| Canonical import namespace | `aegisops.control_plane` |
+| Legacy compatibility namespace | `aegisops_control_plane` remains importable only as a compatibility surface |
+| Packaging entrypoint | `python3 control-plane/main.py` |
+| Supervisor command guidance | `node <codex-supervisor-root>/dist/index.js issue-lint 1126 --config <supervisor-config-path>` |
+| Publishable path guidance | Repo-relative paths, documented env vars, and explicit placeholders only |
+
+## Guardrail Rules
+
+- New guidance that points implementation ownership at `control-plane/aegisops_control_plane/` is rejected unless the file is an approved compatibility note, compatibility verifier, or negative fixture.
+- New repo-owned Python imports must use `aegisops.control_plane` unless the file is an approved compatibility shim or compatibility regression test.
+- The legacy compatibility package must not contain implementation files beyond `__init__.py`.
+- New direct canonical root Python files fail verification unless the retained-root file set is intentionally updated by policy.
+- Workstation-local absolute paths in publishable tracked content fail verification.
+- Packaging and supervisor command examples must use repo-relative paths or placeholders, not host-specific absolute paths.
+
+## Verification
+
+Run:
+
+- `bash scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh`
+- `bash scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh`
+- `bash scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh`
+- `bash scripts/verify-phase-52-7-5-root-shim-reduction.sh`
+- `bash scripts/verify-phase-52-6-6-root-package-guardrails.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `bash scripts/verify-phase-52-5-2-import-compatibility.sh`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1126 --config <supervisor-config-path>`
+
+## Non-Goals
+
+- Do not change runtime behavior, HTTP API behavior, CLI behavior, persistence
+  semantics, authorization semantics, operator UI behavior, Wazuh profile
+  behavior, Shuffle profile behavior, or product readiness claims.
+- Do not remove legacy import compatibility.

--- a/scripts/test-verify-ci-phase-contract-runner.sh
+++ b/scripts/test-verify-ci-phase-contract-runner.sh
@@ -41,9 +41,12 @@ required_manifest_commands=(
   "bash scripts/test-verify-ci-phase-28-workflow-coverage.sh"
 )
 
+verifier_commands="$("${runner_path}" --print all-verifiers)"
+shell_test_commands="$("${runner_path}" --print all-shell-tests)"
+
 for command in "${required_manifest_commands[@]}"; do
-  if ! "${runner_path}" --print all-verifiers | grep -Fqx -- "${command}" >/dev/null && \
-     ! "${runner_path}" --print all-shell-tests | grep -Fqx -- "${command}" >/dev/null; then
+  if ! grep -Fqx -- "${command}" <<<"${verifier_commands}" && \
+     ! grep -Fqx -- "${command}" <<<"${shell_test_commands}"; then
     echo "Missing required phase-contract command from shared runner output: ${command}" >&2
     exit 1
   fi

--- a/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh
+++ b/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh
@@ -33,8 +33,19 @@ create_valid_repo() {
     "${target}/scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh"
   cp "${repo_root}/.github/workflows/ci.yml" "${target}/.github/workflows/ci.yml"
   cp "${repo_root}/control-plane/main.py" "${target}/control-plane/main.py"
+  cp -R "${repo_root}/control-plane/aegisops" \
+    "${target}/control-plane/aegisops"
   cp -R "${repo_root}/control-plane/aegisops_control_plane" \
     "${target}/control-plane/aegisops_control_plane"
+  cp "${repo_root}/scripts/verify-phase-52-7-4-physical-layout-migration.sh" \
+    "${target}/scripts/verify-phase-52-7-4-physical-layout-migration.sh"
+  cp "${repo_root}/scripts/verify-phase-52-7-5-root-shim-reduction.sh" \
+    "${target}/scripts/verify-phase-52-7-5-root-shim-reduction.sh"
+  mkdir -p "${target}/control-plane/tests"
+  cp "${repo_root}/control-plane/tests/test_phase52_7_4_physical_layout_migration.py" \
+    "${target}/control-plane/tests/test_phase52_7_4_physical_layout_migration.py"
+  cp "${repo_root}/control-plane/tests/test_phase52_7_5_root_shim_reduction.py" \
+    "${target}/control-plane/tests/test_phase52_7_5_root_shim_reduction.py"
 }
 
 assert_passes() {
@@ -91,21 +102,19 @@ assert_fails_with \
   "${wrong_proposed_namespace_repo}" \
   "Phase 52.7.1 namespace inventory proposed reference mismatch for proposed canonical namespace: expected aegisops.control_plane, got aegisops.controlplane"
 
-package_moved_repo="${workdir}/package-moved"
-create_valid_repo "${package_moved_repo}"
-mkdir -p "${package_moved_repo}/control-plane/aegisops"
-mv "${package_moved_repo}/control-plane/aegisops_control_plane" \
-  "${package_moved_repo}/control-plane/aegisops/control_plane"
+missing_legacy_package_repo="${workdir}/missing-legacy-package"
+create_valid_repo "${missing_legacy_package_repo}"
+rm -rf "${missing_legacy_package_repo}/control-plane/aegisops_control_plane"
 assert_fails_with \
-  "${package_moved_repo}" \
-  "Phase 52.7.1 file movement rejected: missing current package path control-plane/aegisops_control_plane/"
+  "${missing_legacy_package_repo}" \
+  "Phase 52.7.1 compatibility path rejected: missing legacy package marker control-plane/aegisops_control_plane/__init__.py"
 
-proposed_package_added_repo="${workdir}/proposed-package-added"
-create_valid_repo "${proposed_package_added_repo}"
-mkdir -p "${proposed_package_added_repo}/control-plane/aegisops/control_plane"
+missing_canonical_package_repo="${workdir}/missing-canonical-package"
+create_valid_repo "${missing_canonical_package_repo}"
+rm -rf "${missing_canonical_package_repo}/control-plane/aegisops/control_plane"
 assert_fails_with \
-  "${proposed_package_added_repo}" \
-  "Phase 52.7.1 namespace/layout inventory rejected: proposed package path already exists at control-plane/aegisops/control_plane/"
+  "${missing_canonical_package_repo}" \
+  "Phase 52.7.1 follow-on namespace guard rejected: missing canonical package marker control-plane/aegisops/control_plane/__init__.py"
 
 entrypoint_moved_repo="${workdir}/entrypoint-moved"
 create_valid_repo "${entrypoint_moved_repo}"
@@ -140,10 +149,10 @@ assert_passes "${non_executable_prerequisite_repo}"
 
 missing_prerequisite_repo="${workdir}/missing-prerequisite"
 create_valid_repo "${missing_prerequisite_repo}"
-rm "${missing_prerequisite_repo}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh"
+rm "${missing_prerequisite_repo}/scripts/verify-phase-52-7-4-physical-layout-migration.sh"
 assert_fails_with \
   "${missing_prerequisite_repo}" \
-  "Missing prerequisite verifier: verify-phase-52-5-1-control-plane-layout-inventory-contract.sh"
+  "Missing prerequisite verifier: verify-phase-52-7-4-physical-layout-migration.sh"
 
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"

--- a/scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
+++ b/scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
@@ -92,6 +92,15 @@ assert_fails_with \
   "${legacy_impl_file_repo}" \
   "Phase 52.7.6 guardrail rejected legacy implementation files: __init__.py, service.py"
 
+nested_legacy_impl_file_repo="${workdir}/nested-legacy-implementation-file"
+create_repo_copy "${nested_legacy_impl_file_repo}"
+mkdir -p "${nested_legacy_impl_file_repo}/control-plane/aegisops_control_plane/core"
+printf '%s\n' '"""Stale nested legacy implementation file."""' \
+  >"${nested_legacy_impl_file_repo}/control-plane/aegisops_control_plane/core/legacy_import_aliases.py"
+assert_fails_with \
+  "${nested_legacy_impl_file_repo}" \
+  "Phase 52.7.6 guardrail rejected legacy implementation files: __init__.py, core/legacy_import_aliases.py"
+
 canonical_root_growth_repo="${workdir}/canonical-root-growth"
 create_repo_copy "${canonical_root_growth_repo}"
 printf '%s\n' '"""Unclassified canonical root file."""' \

--- a/scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
+++ b/scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_repo_copy() {
+  local target="$1"
+
+  mkdir -p "${target}/control-plane" "${target}/docs/adr" "${target}/scripts" "${target}/.github/workflows"
+  cp -R "${repo_root}/control-plane/aegisops" "${target}/control-plane/aegisops"
+  cp -R "${repo_root}/control-plane/aegisops_control_plane" "${target}/control-plane/aegisops_control_plane"
+  cp "${repo_root}/control-plane/main.py" "${target}/control-plane/main.py"
+  cp -R "${repo_root}/control-plane/tests" "${target}/control-plane/tests"
+  cp "${repo_root}/docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md" \
+    "${target}/docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md"
+  cp -R "${repo_root}/docs/adr" "${target}/docs"
+  cp "${repo_root}/docs/phase-52-5-closeout-evaluation.md" "${target}/docs/phase-52-5-closeout-evaluation.md"
+  cp "${repo_root}/docs/phase-52-6-closeout-evaluation.md" "${target}/docs/phase-52-6-closeout-evaluation.md"
+  cp "${repo_root}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-5-2-import-compatibility.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-5-2-layout-guardrail.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-5-2-package-scaffolding.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-6-2-canonical-domain-imports.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-6-6-root-package-guardrails.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-7-4-physical-layout-migration.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-7-5-root-shim-reduction.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh" "${target}/scripts/"
+  cp "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${target}/scripts/"
+  cp "${repo_root}"/scripts/test-verify-phase-52-{5,6,7}-*.sh "${target}/scripts/" 2>/dev/null || true
+  cp "${repo_root}/.github/workflows/ci.yml" "${target}/.github/workflows/ci.yml"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+  git -C "${target}" add .
+  git -C "${target}" commit -q -m "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+create_repo_copy "${valid_repo}"
+assert_passes "${valid_repo}"
+
+legacy_impl_file_repo="${workdir}/legacy-implementation-file"
+create_repo_copy "${legacy_impl_file_repo}"
+printf '%s\n' '"""Stale legacy implementation file."""' \
+  >"${legacy_impl_file_repo}/control-plane/aegisops_control_plane/service.py"
+assert_fails_with \
+  "${legacy_impl_file_repo}" \
+  "Phase 52.7.6 guardrail rejected legacy implementation files: __init__.py, service.py"
+
+canonical_root_growth_repo="${workdir}/canonical-root-growth"
+create_repo_copy "${canonical_root_growth_repo}"
+printf '%s\n' '"""Unclassified canonical root file."""' \
+  >"${canonical_root_growth_repo}/control-plane/aegisops/control_plane/new_root_owner.py"
+assert_fails_with \
+  "${canonical_root_growth_repo}" \
+  "Phase 52.7.6 guardrail expected canonical root files"
+
+legacy_guidance_repo="${workdir}/legacy-guidance"
+create_repo_copy "${legacy_guidance_repo}"
+printf '%s\n' 'New implementation files belong under `control-plane/aegisops_control_plane/`.' \
+  >"${legacy_guidance_repo}/docs/new-guidance.md"
+git -C "${legacy_guidance_repo}" add docs/new-guidance.md
+git -C "${legacy_guidance_repo}" commit -q -m "add stale guidance"
+assert_fails_with \
+  "${legacy_guidance_repo}" \
+  "docs/new-guidance.md:1 points implementation guidance at control-plane/aegisops_control_plane/"
+
+legacy_import_repo="${workdir}/legacy-import"
+create_repo_copy "${legacy_import_repo}"
+printf '%s\n' 'from aegisops_control_plane.service import build_runtime_service' \
+  >"${legacy_import_repo}/control-plane/tests/test_new_runtime_import.py"
+assert_fails_with \
+  "${legacy_import_repo}" \
+  "control-plane/tests/test_new_runtime_import.py:1 imports aegisops_control_plane.service; use aegisops.control_plane.service"
+
+workstation_path_repo="${workdir}/workstation-path"
+create_repo_copy "${workstation_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${workstation_path_repo}/docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md"
+assert_fails_with \
+  "${workstation_path_repo}" \
+  "Forbidden Phase 52.7.6 guardrail artifact: workstation-local absolute path detected"
+
+echo "Phase 52.7.6 namespace/path packaging guardrail verifier negative and valid fixtures passed."

--- a/scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
+++ b/scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
@@ -42,7 +42,13 @@ create_repo_copy() {
   cp "${repo_root}/scripts/verify-phase-52-7-5-root-shim-reduction.sh" "${target}/scripts/"
   cp "${repo_root}/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh" "${target}/scripts/"
   cp "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${target}/scripts/"
-  cp "${repo_root}"/scripts/test-verify-phase-52-{5,6,7}-*.sh "${target}/scripts/" 2>/dev/null || true
+  local phase_test_scripts=()
+  shopt -s nullglob
+  phase_test_scripts=("${repo_root}"/scripts/test-verify-phase-52-{5,6,7}-*.sh)
+  shopt -u nullglob
+  if ((${#phase_test_scripts[@]})); then
+    cp "${phase_test_scripts[@]}" "${target}/scripts/"
+  fi
   cp "${repo_root}/.github/workflows/ci.yml" "${target}/.github/workflows/ci.yml"
   git -C "${target}" init -q
   git -C "${target}" config user.name "Codex Test"

--- a/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh
+++ b/scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh
@@ -84,13 +84,13 @@ if [[ ! -f "${doc_path}" ]]; then
   exit 1
 fi
 
-if [[ ! -d "${package_root}" ]]; then
-  echo "Phase 52.7.1 file movement rejected: missing current package path control-plane/aegisops_control_plane/" >&2
+if [[ ! -f "${package_root}/__init__.py" ]]; then
+  echo "Phase 52.7.1 compatibility path rejected: missing legacy package marker control-plane/aegisops_control_plane/__init__.py" >&2
   exit 1
 fi
 
-if [[ -d "${proposed_package_root}" ]]; then
-  echo "Phase 52.7.1 namespace/layout inventory rejected: proposed package path already exists at control-plane/aegisops/control_plane/" >&2
+if [[ ! -f "${proposed_package_root}/__init__.py" ]]; then
+  echo "Phase 52.7.1 follow-on namespace guard rejected: missing canonical package marker control-plane/aegisops/control_plane/__init__.py" >&2
   exit 1
 fi
 
@@ -240,8 +240,8 @@ print(
 PY
 
 for prerequisite in \
-  "${repo_root}/scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh" \
-  "${repo_root}/scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh"
+  "${repo_root}/scripts/verify-phase-52-7-4-physical-layout-migration.sh" \
+  "${repo_root}/scripts/verify-phase-52-7-5-root-shim-reduction.sh"
 do
   if [[ ! -f "${prerequisite}" ]]; then
     echo "Missing prerequisite verifier: $(basename "${prerequisite}")" >&2

--- a/scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh
+++ b/scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh
@@ -37,8 +37,12 @@ approved_legacy_python_files = {
     "control-plane/tests/test_phase52_6_3_legacy_import_alias_registry.py",
     "control-plane/tests/test_phase52_6_4_root_shim_alias_removal.py",
     "control-plane/tests/test_phase52_6_5_phase29_root_filename_retirement.py",
+    "control-plane/tests/test_phase29_shadow_scoring_validation.py",
+    "control-plane/tests/test_service_persistence_action_reconciliation_review_surfaces.py",
+    "control-plane/tests/test_service_snapshot_extraction.py",
     "control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py",
     "control-plane/tests/test_phase52_7_4_physical_layout_migration.py",
+    "control-plane/tests/test_phase52_7_5_root_shim_reduction.py",
 }
 
 approved_legacy_text_files = {
@@ -59,6 +63,7 @@ approved_legacy_text_files = {
     "docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md",
     "docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md",
     "docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md",
+    "docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md",
     "docs/control-plane-service-internal-boundaries.md",
     "docs/maintainability-decomposition-thresholds.md",
     "docs/maintainability-hotspot-baseline.txt",
@@ -95,6 +100,8 @@ approved_legacy_text_files = {
     "scripts/test-verify-phase-52-7-2-canonical-namespace-bridge.sh",
     "scripts/test-verify-phase-52-7-3-repo-owned-canonical-namespace.sh",
     "scripts/test-verify-phase-52-7-4-physical-layout-migration.sh",
+    "scripts/test-verify-phase-52-7-5-root-shim-reduction.sh",
+    "scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh",
     "scripts/test-verify-phase-9-control-plane-runtime-boundary-validation.sh",
     "scripts/verify-control-plane-runtime-skeleton.sh",
     "scripts/verify-maintainability-hotspots.sh",
@@ -122,6 +129,8 @@ approved_legacy_text_files = {
     "scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh",
     "scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh",
     "scripts/verify-phase-52-7-4-physical-layout-migration.sh",
+    "scripts/verify-phase-52-7-5-root-shim-reduction.sh",
+    "scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh",
 } | approved_legacy_python_files
 
 legacy_import_pattern = re.compile(r"\baegisops_control_plane(?:\.|\b)")

--- a/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
+++ b/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+control_plane_root="${repo_root}/control-plane"
+canonical_root="${control_plane_root}/aegisops/control_plane"
+legacy_root="${control_plane_root}/aegisops_control_plane"
+doc_path="${repo_root}/docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md"
+
+for required_path in \
+  "${doc_path}" \
+  "${canonical_root}/__init__.py" \
+  "${canonical_root}/service.py" \
+  "${canonical_root}/models.py" \
+  "${canonical_root}/core/legacy_import_aliases.py" \
+  "${legacy_root}/__init__.py" \
+  "${control_plane_root}/main.py"; do
+  if [[ ! -f "${required_path}" ]]; then
+    echo "Missing Phase 52.7.6 namespace/path packaging guardrail path: ${required_path#"${repo_root}/"}" >&2
+    exit 1
+  fi
+done
+
+required_phrases=(
+  "# ADR-0018: Phase 52.7.6 Namespace, Path, And Packaging Guardrails"
+  "Phase 52.7.4 moved implementation ownership to \`control-plane/aegisops/control_plane/\`."
+  "Legacy compatibility package | \`control-plane/aegisops_control_plane/__init__.py\` only"
+  "Canonical import namespace | \`aegisops.control_plane\`"
+  "Packaging entrypoint | \`python3 control-plane/main.py\`"
+  "Supervisor command guidance | \`node <codex-supervisor-root>/dist/index.js issue-lint 1126 --config <supervisor-config-path>\`"
+  "New guidance that points implementation ownership at \`control-plane/aegisops_control_plane/\` is rejected unless the file is an approved compatibility note, compatibility verifier, or negative fixture."
+  "\`bash scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh\`"
+  "\`bash scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh\`"
+)
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 52.7.6 guardrail statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" \
+  "${doc_path}" \
+  "${repo_root}/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh" \
+  "${repo_root}/scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh"; then
+  echo "Forbidden Phase 52.7.6 guardrail artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+export PHASE52_7_6_REPO_ROOT="${repo_root}"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import sys
+
+repo_root = Path(os.environ["PHASE52_7_6_REPO_ROOT"]).resolve()
+control_plane_root = repo_root / "control-plane"
+canonical_root = control_plane_root / "aegisops" / "control_plane"
+legacy_root = control_plane_root / "aegisops_control_plane"
+
+retained_root_files = {
+    "__init__.py",
+    "cli.py",
+    "config.py",
+    "models.py",
+    "operator_inspection.py",
+    "persistence_lifecycle.py",
+    "publishable_paths.py",
+    "record_validation.py",
+    "reviewed_slice_policy.py",
+    "service.py",
+    "service_composition.py",
+    "structured_events.py",
+}
+
+legacy_root_files = sorted(path.name for path in legacy_root.glob("*.py"))
+if legacy_root_files != ["__init__.py"]:
+    print(
+        "Phase 52.7.6 guardrail rejected legacy implementation files: "
+        + ", ".join(legacy_root_files),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+actual_root_files = sorted(path.name for path in canonical_root.glob("*.py"))
+if actual_root_files != sorted(retained_root_files):
+    print(
+        "Phase 52.7.6 guardrail expected canonical root files "
+        + ", ".join(sorted(retained_root_files))
+        + "; found "
+        + ", ".join(actual_root_files),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+approved_legacy_path_text_files = {
+    "docs/adr/0003-phase-49-service-decomposition-boundaries.md",
+    "docs/adr/0004-phase-50-maintainability-hotspot-map-and-migration-order.md",
+    "docs/adr/0005-phase-50-8-residual-service-hotspot-migration-contract.md",
+    "docs/adr/0006-phase-50-9-residual-facade-convergence-and-projection-guard.md",
+    "docs/adr/0007-phase-50-10-facade-floor-and-external-evidence-guard.md",
+    "docs/adr/0008-phase-50-11-service-residual-extraction-contract.md",
+    "docs/adr/0009-phase-50-12-service-facade-pressure-contract.md",
+    "docs/adr/0010-phase-50-13-public-facade-api-inventory-and-compatibility-policy.md",
+    "docs/adr/0012-phase-52-5-1-control-plane-layout-inventory-and-migration-contract.md",
+    "docs/adr/0013-phase-52-5-2-package-scaffolding-and-compatibility-shim-policy.md",
+    "docs/adr/0014-phase-52-6-1-root-shim-inventory-and-deprecation-contract.md",
+    "docs/adr/0015-phase-52-6-3-legacy-import-alias-registry.md",
+    "docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md",
+    "docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md",
+    "docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md",
+    "docs/phase-52-5-closeout-evaluation.md",
+    "docs/phase-52-6-closeout-evaluation.md",
+    "docs/control-plane-service-internal-boundaries.md",
+    "docs/maintainability-decomposition-thresholds.md",
+    "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-boundary.md",
+    "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-validation.md",
+    "docs/phase-47-control-plane-responsibility-decomposition-boundary.md",
+    "docs/phase-47-control-plane-responsibility-decomposition-validation.md",
+    "docs/phase-49-5-pilot-reporting-executive-summary-export-validation.md",
+    "docs/phase-50-10-5-facade-method-rewiring.md",
+    "docs/phase-50-maintainability-closeout.md",
+    "scripts/test-verify-control-plane-runtime-skeleton.sh",
+    "scripts/test-verify-maintainability-hotspots.sh",
+    "scripts/test-verify-phase-9-control-plane-runtime-boundary-validation.sh",
+    "scripts/test-verify-phase-50-8-residual-service-hotspot-contract.sh",
+    "scripts/test-verify-phase-50-9-residual-facade-convergence-contract.sh",
+    "scripts/test-verify-phase-50-10-facade-floor-external-evidence-contract.sh",
+    "scripts/test-verify-phase-50-11-service-residual-extraction-contract.sh",
+    "scripts/test-verify-phase-50-12-service-facade-pressure-contract.sh",
+    "scripts/test-verify-phase-50-13-public-facade-inventory-contract.sh",
+    "scripts/test-verify-phase-50-maintainability-adr.sh",
+    "scripts/verify-control-plane-runtime-skeleton.sh",
+    "scripts/verify-maintainability-hotspots.sh",
+    "scripts/verify-phase-50-8-residual-service-hotspot-contract.sh",
+    "scripts/verify-phase-50-9-residual-facade-convergence-contract.sh",
+    "scripts/verify-phase-50-10-facade-floor-external-evidence-contract.sh",
+    "scripts/verify-phase-50-11-service-residual-extraction-contract.sh",
+    "scripts/verify-phase-50-12-service-facade-pressure-contract.sh",
+    "scripts/verify-phase-50-13-public-facade-inventory-contract.sh",
+    "scripts/verify-phase-50-maintainability-adr.sh",
+    "scripts/verify-phase-52-5-1-control-plane-layout-inventory-contract.sh",
+    "scripts/verify-phase-52-5-2-import-compatibility.sh",
+    "scripts/verify-phase-52-5-2-layout-guardrail.sh",
+    "scripts/verify-phase-52-5-2-package-scaffolding.sh",
+    "scripts/verify-phase-52-6-1-root-shim-inventory-contract.sh",
+    "scripts/verify-phase-52-6-2-canonical-domain-imports.sh",
+    "scripts/verify-phase-52-6-3-legacy-import-alias-registry.sh",
+    "scripts/verify-phase-52-6-5-retire-phase29-root-filenames.sh",
+    "scripts/verify-phase-52-6-6-root-package-guardrails.sh",
+    "scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh",
+    "scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh",
+    "scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh",
+    "scripts/verify-phase-52-7-4-physical-layout-migration.sh",
+    "scripts/verify-phase-52-7-5-root-shim-reduction.sh",
+    "scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh",
+    "scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh",
+    "scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh",
+    "scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh",
+    "scripts/test-verify-phase-52-6-2-canonical-domain-imports.sh",
+    "scripts/test-verify-phase-52-6-3-legacy-import-alias-registry.sh",
+    "scripts/test-verify-phase-52-6-5-retire-phase29-root-filenames.sh",
+    "scripts/test-verify-phase-52-6-6-root-package-guardrails.sh",
+    "scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh",
+    "scripts/test-verify-phase-52-7-2-canonical-namespace-bridge.sh",
+    "scripts/test-verify-phase-52-7-3-repo-owned-canonical-namespace.sh",
+    "scripts/test-verify-phase-52-7-4-physical-layout-migration.sh",
+    "scripts/test-verify-phase-52-7-5-root-shim-reduction.sh",
+    "scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh",
+}
+
+def rel(path: Path) -> str:
+    return path.relative_to(repo_root).as_posix()
+
+
+violations: list[str] = []
+legacy_path_pattern = re.compile(r"control-plane/aegisops_control_plane/?")
+for root_name, patterns in {
+    "docs": ("*.md", "*.txt", "*.rst"),
+    "scripts": ("*.sh",),
+    ".github": ("*.yml", "*.yaml", "*.md"),
+}.items():
+    root = repo_root / root_name
+    if not root.exists():
+        continue
+    for pattern in patterns:
+        for path in root.rglob(pattern):
+            relative = rel(path)
+            if relative in approved_legacy_path_text_files:
+                continue
+            text = path.read_text(encoding="utf-8")
+            for line_number, line in enumerate(text.splitlines(), start=1):
+                if legacy_path_pattern.search(line):
+                    violations.append(
+                        f"{relative}:{line_number} points implementation guidance at control-plane/aegisops_control_plane/"
+                    )
+
+for extra in ("README.md", "package.json", "package-lock.json"):
+    path = repo_root / extra
+    if path.exists():
+        text = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if legacy_path_pattern.search(line):
+                violations.append(
+                    f"{extra}:{line_number} points implementation guidance at control-plane/aegisops_control_plane/"
+                )
+
+if violations:
+    print("Phase 52.7.6 namespace/path packaging guardrail found violations:", file=sys.stderr)
+    for violation in violations:
+        print(f"- {violation}", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    "Phase 52.7.6 namespace/path packaging guardrails passed: canonical implementation path, "
+    "legacy shim boundary, retained root set, compatibility imports, and publishable guidance are pinned."
+)
+PY
+
+for prerequisite in \
+  "${repo_root}/scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh" \
+  "${repo_root}/scripts/verify-phase-52-7-5-root-shim-reduction.sh" \
+  "${repo_root}/scripts/verify-phase-52-6-6-root-package-guardrails.sh" \
+  "${repo_root}/scripts/verify-publishable-path-hygiene.sh" \
+  "${repo_root}/scripts/verify-phase-52-5-2-import-compatibility.sh"; do
+  if [[ ! -f "${prerequisite}" ]]; then
+    echo "Missing Phase 52.7.6 prerequisite verifier: ${prerequisite#"${repo_root}/"}" >&2
+    exit 1
+  fi
+  bash "${prerequisite}" "${repo_root}" >/dev/null
+done

--- a/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
+++ b/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
@@ -85,7 +85,9 @@ retained_root_files = {
     "structured_events.py",
 }
 
-legacy_root_files = sorted(path.name for path in legacy_root.glob("*.py"))
+legacy_root_files = sorted(
+    path.relative_to(legacy_root).as_posix() for path in legacy_root.rglob("*.py")
+)
 if legacy_root_files != ["__init__.py"]:
     print(
         "Phase 52.7.6 guardrail rejected legacy implementation files: "


### PR DESCRIPTION
## Summary
- Add ADR-0018 to pin the accepted Phase 52.7 namespace/path/package state.
- Add a Phase 52.7.6 verifier and negative fixture suite for stale legacy implementation paths, unclassified canonical root files, legacy implementation files, and workstation-local publishable paths.
- Repair stale Phase 52.7.1 and 52.7.3 guardrails so they align with the current canonical implementation package and retained compatibility surfaces.

## Verification
- `bash scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh && bash scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh && bash scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh && bash scripts/test-verify-phase-52-7-3-repo-owned-canonical-namespace.sh && bash scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh && bash scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh`
- `bash scripts/verify-phase-52-6-6-root-package-guardrails.sh && bash scripts/test-verify-phase-52-6-6-root-package-guardrails.sh && bash scripts/verify-phase-52-7-5-root-shim-reduction.sh && bash scripts/test-verify-phase-52-7-5-root-shim-reduction.sh`
- `bash scripts/verify-publishable-path-hygiene.sh && bash scripts/test-verify-publishable-path-hygiene.sh`
- `bash scripts/verify-phase-52-5-2-import-compatibility.sh && python3 -m unittest control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py control-plane/tests/test_phase52_7_4_physical_layout_migration.py control-plane/tests/test_phase52_7_5_root_shim_reduction.py`
- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh && bash scripts/test-verify-phase-51-6-authority-boundary-negative-test-policy.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1126 --config <supervisor-config-path>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR defining Phase 52.7.6 guardrails for canonical vs legacy namespaces, packaging, publishable-path rules, and explicit guidance phrases.

* **Tests**
  * Added a Phase 52.7.6 test harness and expanded fixtures for positive and negative namespace/packaging scenarios.
  * Strengthened verifier suites to require specific guardrail artifacts, reject missing package markers, enforce exact ADR guidance, ban workstation-local absolute paths, update prerequisite checks, and extend approved legacy allowlists.

* **Chores**
  * Optimized CI verifier command capture to avoid repeated invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->