### PR TITLE
Phase 52.7 closeout evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.10 closeout evaluation](docs/phase-52-closeout-evaluation.md) records the Phase 52 child issue outcomes, focused verifier results, issue-lint summary, accepted limitations, and Phase 53/54 materialization recommendation.
 - [Phase 52.5 closeout evaluation](docs/phase-52-5-closeout-evaluation.md) records the Phase 52.5 package-layout hardening outcomes, moved modules, compatibility shims, verifier results, accepted limitations, and bounded Phase 53 readiness recommendation.
 - [Phase 52.6 closeout evaluation](docs/phase-52-6-closeout-evaluation.md) records the Phase 52.6 compatibility-shim deprecation outcomes, root package count reduction, retained owners and blockers, verifier results, and bounded Phase 53 readiness recommendation.
+- [Phase 52.7 closeout evaluation](docs/phase-52-7-closeout-evaluation.md) records the Phase 52.7 namespace normalization outcomes, root owner reduction, compatibility behavior, namespace/path guardrails, verifier results, and bounded Phase 53 readiness recommendation.
 
 ## Product positioning
 
@@ -76,6 +77,8 @@ The Phase 52.10 closeout evaluation is defined by the [Phase 52.10 closeout eval
 The Phase 52.5 package-layout hardening closeout is defined by the [Phase 52.5 closeout evaluation](docs/phase-52-5-closeout-evaluation.md).
 
 The Phase 52.6 compatibility-shim deprecation closeout is defined by the [Phase 52.6 closeout evaluation](docs/phase-52-6-closeout-evaluation.md).
+
+The Phase 52.7 namespace normalization closeout is defined by the [Phase 52.7 closeout evaluation](docs/phase-52-7-closeout-evaluation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-52-7-closeout-evaluation.md
+++ b/docs/phase-52-7-closeout-evaluation.md
@@ -1,0 +1,141 @@
+# Phase 52.7 Closeout Evaluation
+
+**Status**: Accepted as control-plane namespace normalization and root owner reduction; Phase 53 Wazuh product profile work can start after #1127 lands.
+
+**Related Issues**: #1120, #1121, #1122, #1123, #1124, #1125, #1126, #1127
+
+**Authority Boundary**: This closeout is release and planning evidence only. AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth. Namespace bridges, filesystem layout, compatibility aliases, root owner inventories, verifier output, issue-lint output, and this document do not change runtime workflow truth.
+
+Phase 52.7 is accepted as the namespace normalization and root owner reduction phase that moved implementation ownership to `control-plane/aegisops/control_plane/`, retained `aegisops_control_plane` as a compatibility namespace, reduced the canonical root file set, and pinned namespace/path guardrails while preserving runtime authority, public compatibility behavior, and product semantics.
+
+This closeout does not claim that Phase 53 Wazuh product profile work was completed, Shuffle product profile work was completed, AegisOps is GA, RC, Beta, or self-service commercially ready, or that runtime product behavior changed during Phase 52.7.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1120 | Epic: Phase 52.7 Control-Plane Namespace Normalization and Root Owner Reduction | Open until #1127 lands; accepted when this closeout, verifiers, and issue-lint pass. |
+| #1121 | Phase 52.7.1 namespace and layout inventory contract | Closed. ADR-0016 records the current namespace/layout inventory, future canonical namespace target, movement guard, compatibility blockers, and supervisor command placeholders. PR #1128. |
+| #1122 | Phase 52.7.2 canonical namespace bridge | Closed. ADR-0017 and the bridge package make `aegisops.control_plane` importable while preserving `aegisops_control_plane` compatibility. PR #1129. |
+| #1123 | Phase 52.7.3 repo-owned canonical namespace rewiring | Closed. Repo-owned imports and guidance use `aegisops.control_plane` except approved compatibility surfaces and negative fixtures. PR #1130. |
+| #1124 | Phase 52.7.4 physical layout migration | Closed. Implementation ownership moved to `control-plane/aegisops/control_plane/`; `control-plane/aegisops_control_plane/__init__.py` remains the only legacy compatibility package file. PR #1131. |
+| #1125 | Phase 52.7.5 root shim reduction | Closed. Twenty-five simple canonical root shim files were removed after canonical and legacy alias coverage plus focused regressions preserved import identity. PR #1132. |
+| #1126 | Phase 52.7.6 namespace/path packaging guardrails | Closed. ADR-0018 pins canonical implementation path, legacy shim boundary, retained root set, package entrypoint, supervisor placeholders, and publishable path hygiene. PR #1133. |
+| #1127 | Phase 52.7.7 Phase 52.7 closeout evaluation | Open until this closeout lands; accepted when this document, focused verifier, all Phase 52.7 verifiers, issue-lint, and path hygiene pass. |
+
+## Root File Count Before And After
+
+| Baseline | Direct root `.py` files |
+| --- | ---: |
+| Phase 52.6 accepted baseline before Phase 52.7 physical layout migration, under `control-plane/aegisops_control_plane/` | 37 |
+| Phase 52.7.5 accepted canonical root baseline after namespace normalization, under `control-plane/aegisops/control_plane/` | 12 |
+| Phase 52.7.4 accepted legacy compatibility package baseline after migration, under `control-plane/aegisops_control_plane/` | 1 |
+
+The after count is intentionally bounded to direct root `.py` files. Package-owned implementation files below canonical subdirectories remain governed by the retained-owner policy and the namespace/path packaging guardrails.
+
+## Namespace And Path Before And After
+
+| Surface | Before Phase 52.7 | After Phase 52.7 |
+| --- | --- | --- |
+| Implementation package path | `control-plane/aegisops_control_plane/` | `control-plane/aegisops/control_plane/` |
+| Compatibility package path | `control-plane/aegisops_control_plane/` contained implementation files | `control-plane/aegisops_control_plane/__init__.py` only |
+| Canonical import namespace | Proposed by ADR-0016, not yet the repo-owned implementation target | `aegisops.control_plane` |
+| Legacy import namespace | `aegisops_control_plane` public package and implementation namespace | `aegisops_control_plane` retained as compatibility namespace only |
+| Packaging entrypoint | `python3 control-plane/main.py` | `python3 control-plane/main.py` |
+| Supervisor command guidance | Issue-specific placeholders such as `node <codex-supervisor-root>/dist/index.js issue-lint 1121 --config <supervisor-config-path>` | Issue-specific placeholders such as `node <codex-supervisor-root>/dist/index.js issue-lint 1127 --config <supervisor-config-path>` |
+
+## Retained Compatibility Behavior
+
+Legacy compatibility behavior is preserved, not removed. `import aegisops_control_plane` continues to work through the compatibility package, legacy submodule imports remain available through explicit alias registry rows, and canonical imports resolve through `aegisops.control_plane`.
+
+The retained compatibility namespace is subordinate implementation context only. Compatibility aliases, bridge modules, package paths, import identity, generated config, CLI status, Wazuh state, Shuffle state, tickets, assistant output, optional evidence, demo data, verifier output, issue-lint output, and operator-facing text do not become AegisOps workflow truth.
+
+Retained root owners are exactly `__init__.py`, `cli.py`, `config.py`, `models.py`, `operator_inspection.py`, `persistence_lifecycle.py`, `publishable_paths.py`, `record_validation.py`, `reviewed_slice_policy.py`, `service.py`, `service_composition.py`, and `structured_events.py`.
+
+`service.py` remains a retained compatibility blocker under ADR-0003, ADR-0010, ADR-0014, ADR-0018, and the Phase 52.7 guardrail baseline. Phase 52.7 does not complete all future facade decomposition.
+
+## Changed Files
+
+Phase 52.7 materially changed or added these enforcement surfaces:
+
+- `docs/adr/0016-phase-52-7-1-namespace-and-layout-inventory-contract.md`
+- `docs/adr/0017-phase-52-7-2-canonical-namespace-bridge.md`
+- `docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md`
+- `control-plane/aegisops/control_plane/`
+- `control-plane/aegisops_control_plane/__init__.py`
+- `control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py`
+- `control-plane/tests/test_phase52_7_4_physical_layout_migration.py`
+- `control-plane/tests/test_phase52_7_5_root_shim_reduction.py`
+- `scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh`
+- `scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh`
+- `scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh`
+- `scripts/verify-phase-52-7-4-physical-layout-migration.sh`
+- `scripts/verify-phase-52-7-5-root-shim-reduction.sh`
+- `scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh`
+- `scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh`
+- `scripts/test-verify-phase-52-7-2-canonical-namespace-bridge.sh`
+- `scripts/test-verify-phase-52-7-3-repo-owned-canonical-namespace.sh`
+- `scripts/test-verify-phase-52-7-4-physical-layout-migration.sh`
+- `scripts/test-verify-phase-52-7-5-root-shim-reduction.sh`
+- `scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh`
+- `docs/phase-52-7-closeout-evaluation.md`
+- `scripts/verify-phase-52-7-closeout-evaluation.sh`
+- `scripts/test-verify-phase-52-7-closeout-evaluation.sh`
+
+## Verifier Evidence
+
+Focused Phase 52.7 verifiers passed:
+
+- `bash scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh`: namespace and layout inventory records current references, proposed canonical namespace, compatibility blockers, movement guard, and supervisor placeholders.
+- `bash scripts/test-verify-phase-52-7-1-namespace-layout-inventory-contract.sh`: inventory negative and valid fixtures passed.
+- `bash scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh`: canonical namespace bridge preserves root public exports and module identity for approved bridge paths.
+- `bash scripts/test-verify-phase-52-7-2-canonical-namespace-bridge.sh`: bridge negative and valid fixtures passed.
+- `bash scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh`: repo-owned references use `aegisops.control_plane` except approved compatibility surfaces.
+- `bash scripts/test-verify-phase-52-7-3-repo-owned-canonical-namespace.sh`: namespace rewiring negative and valid fixtures passed.
+- `bash scripts/verify-phase-52-7-4-physical-layout-migration.sh`: implementation files live under `control-plane/aegisops/control_plane/` and legacy imports preserve module identity.
+- `bash scripts/test-verify-phase-52-7-4-physical-layout-migration.sh`: physical layout negative and valid fixtures passed.
+- `bash scripts/verify-phase-52-7-5-root-shim-reduction.sh`: 25 simple canonical root shims were removed, 12 retained canonical root files remain, and canonical plus legacy alias identity is preserved.
+- `bash scripts/test-verify-phase-52-7-5-root-shim-reduction.sh`: root shim reduction negative and valid fixtures passed.
+- `bash scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh`: canonical implementation path, legacy shim boundary, retained root set, compatibility imports, and publishable guidance are pinned.
+- `bash scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh`: namespace/path packaging guardrail negative and valid fixtures passed.
+- `bash scripts/verify-publishable-path-hygiene.sh`: publishable tracked content does not contain workstation-local absolute paths.
+- `bash scripts/verify-phase-52-7-closeout-evaluation.sh`: this closeout records child outcomes, compatibility behavior before/after, root file-count before/after, namespace/path before/after, changed files, verifier evidence, issue-lint summary, retained limitations, and bounded Phase 53 recommendation.
+- `bash scripts/test-verify-phase-52-7-closeout-evaluation.sh`: closeout negative fixtures reject missing retained legacy compatibility, Phase 53 completion overclaims, missing root file-count before/after, missing namespace/path before/after, and workstation-local absolute paths.
+
+Focused import/package test evidence:
+
+- `python3 -m unittest control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py`: canonical namespace bridge compatibility passed.
+- `python3 -m unittest control-plane/tests/test_phase52_7_4_physical_layout_migration.py`: physical layout migration compatibility passed.
+- `python3 -m unittest control-plane/tests/test_phase52_7_5_root_shim_reduction.py`: canonical root shim reduction compatibility passed.
+
+Broad control-plane test evidence:
+
+- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`: broad control-plane tests passed after the namespace/path and root-owner changes.
+
+Issue-lint evidence for #1120 through #1127:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1120 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1121 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1122 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1123 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1124 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1125 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1126 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1127 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+
+## Accepted Limitations And Retained Blockers
+
+- The public compatibility namespace `aegisops_control_plane` remains supported; removing it requires a later accepted ADR, caller evidence, operator migration plan, focused regression tests, rollback path, and authority-boundary impact.
+- The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.
+- `service.py` remains a retained compatibility blocker under ADR-0003, ADR-0010, ADR-0014, and ADR-0018; Phase 52.7 does not complete all future facade decomposition.
+- Retained canonical root owners remain physical files until a later owner-move issue proves identical behavior, caller compatibility, rollback path, and authority-boundary impact.
+- Legacy import aliases are compatibility mechanisms only. They do not make compatibility state, namespace rows, path rows, summary text, module identity, Wazuh state, Shuffle state, tickets, assistant output, generated config, CLI status, verifier output, issue-lint output, or operator-facing text authoritative workflow truth.
+- Phase 52.7 does not implement Wazuh product profiles, Shuffle product profiles, public compatibility namespace removal, outer directory rename, product behavior changes, deployment behavior changes, authorization changes, provenance changes, snapshot semantics changes, backup/restore changes, export changes, readiness changes, assistant behavior changes, evidence behavior changes, action-execution behavior changes, HTTP behavior changes, CLI behavior changes, or durable-state changes.
+
+## Phase 53 Recommendation
+
+Phase 53 can start after #1127 lands and all Phase 52.7 verifiers remain green. No additional namespace cleanup or root-owner reduction is required before starting the bounded Wazuh product profile implementation.
+
+The recommendation is bounded to Wazuh product profile materialization. Phase 53 should consume the canonical `aegisops.control_plane` implementation namespace, keep `aegisops_control_plane` compatibility intact, keep retained root owners and retained blockers intact, and avoid outer directory rename, Shuffle profile work, or additional compatibility deletion unless a later accepted ADR explicitly changes that boundary.
+
+Do not treat this recommendation as a claim that the Wazuh product profile is complete, Shuffle product profile work is complete, or Phase 52.7 changed runtime product behavior.

--- a/scripts/test-verify-phase-52-7-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-52-7-closeout-evaluation.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-52-7-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-52-7-closeout-evaluation.md" "${target}/docs/phase-52-7-closeout-evaluation.md"
+  cp "${repo_root}/README.md" "${target}/README.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+cp "${repo_root}/README.md" "${missing_doc_repo}/README.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 52.7 closeout evaluation: docs/phase-52-7-closeout-evaluation.md"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+copy_valid_repo "${missing_readme_link_repo}"
+perl -0pi -e 's/\[Phase 52\.7 closeout evaluation\]\(docs\/phase-52-7-closeout-evaluation\.md\)/Phase 52.7 closeout evaluation/g' \
+  "${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "Missing README Phase 52.7 closeout link: [Phase 52.7 closeout evaluation](docs/phase-52-7-closeout-evaluation.md)"
+
+missing_compatibility_repo="${workdir}/missing-retained-compatibility"
+copy_valid_repo "${missing_compatibility_repo}"
+perl -0pi -e 's/Legacy compatibility behavior is preserved, not removed\.//' \
+  "${missing_compatibility_repo}/docs/phase-52-7-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_compatibility_repo}" \
+  "Missing required Phase 52.7 closeout term in docs/phase-52-7-closeout-evaluation.md: Legacy compatibility behavior is preserved, not removed."
+
+phase53_overclaim_repo="${workdir}/phase53-overclaim"
+copy_valid_repo "${phase53_overclaim_repo}"
+printf '%s\n' "Phase 53 Wazuh product profile work is completed" >>"${phase53_overclaim_repo}/docs/phase-52-7-closeout-evaluation.md"
+assert_fails_with \
+  "${phase53_overclaim_repo}" \
+  "Forbidden Phase 52.7 closeout evaluation claim: Phase 53 Wazuh product profile work is completed"
+
+missing_root_counts_repo="${workdir}/missing-root-counts"
+copy_valid_repo "${missing_root_counts_repo}"
+perl -0pi -e 's/\| Phase 52\.6 accepted baseline before Phase 52\.7 physical layout migration, under `control-plane\/aegisops_control_plane\/` \| 37 \|\n//' \
+  "${missing_root_counts_repo}/docs/phase-52-7-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_root_counts_repo}" \
+  'Missing required Phase 52.7 closeout term in docs/phase-52-7-closeout-evaluation.md: | Phase 52.6 accepted baseline before Phase 52.7 physical layout migration, under `control-plane/aegisops_control_plane/` | 37 |'
+
+missing_namespace_paths_repo="${workdir}/missing-namespace-paths"
+copy_valid_repo "${missing_namespace_paths_repo}"
+perl -0pi -e 's/\| Implementation package path \| `control-plane\/aegisops_control_plane\/` \| `control-plane\/aegisops\/control_plane\/` \|\n//' \
+  "${missing_namespace_paths_repo}/docs/phase-52-7-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_namespace_paths_repo}" \
+  'Missing required Phase 52.7 closeout term in docs/phase-52-7-closeout-evaluation.md: | Implementation package path | `control-plane/aegisops_control_plane/` | `control-plane/aegisops/control_plane/` |'
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+mac_home_prefix="/""Users/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${mac_home_prefix}" >>"${absolute_path_repo}/docs/phase-52-7-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 52.7 closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 52.7 closeout evaluation verifier tests passed."

--- a/scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh
+++ b/scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh
@@ -76,6 +76,7 @@ approved_legacy_text_files = {
     "docs/phase-50-maintainability-closeout.md",
     "docs/phase-52-5-closeout-evaluation.md",
     "docs/phase-52-6-closeout-evaluation.md",
+    "docs/phase-52-7-closeout-evaluation.md",
     "scripts/test-verify-control-plane-runtime-skeleton.sh",
     "scripts/test-verify-customer-like-rehearsal-environment.sh",
     "scripts/test-verify-maintainability-hotspots.sh",
@@ -102,6 +103,7 @@ approved_legacy_text_files = {
     "scripts/test-verify-phase-52-7-4-physical-layout-migration.sh",
     "scripts/test-verify-phase-52-7-5-root-shim-reduction.sh",
     "scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh",
+    "scripts/test-verify-phase-52-7-closeout-evaluation.sh",
     "scripts/test-verify-phase-9-control-plane-runtime-boundary-validation.sh",
     "scripts/verify-control-plane-runtime-skeleton.sh",
     "scripts/verify-maintainability-hotspots.sh",
@@ -131,6 +133,7 @@ approved_legacy_text_files = {
     "scripts/verify-phase-52-7-4-physical-layout-migration.sh",
     "scripts/verify-phase-52-7-5-root-shim-reduction.sh",
     "scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh",
+    "scripts/verify-phase-52-7-closeout-evaluation.sh",
 } | approved_legacy_python_files
 
 legacy_import_pattern = re.compile(r"\baegisops_control_plane(?:\.|\b)")

--- a/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
+++ b/scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh
@@ -125,6 +125,7 @@ approved_legacy_path_text_files = {
     "docs/adr/0018-phase-52-7-6-namespace-path-packaging-guardrails.md",
     "docs/phase-52-5-closeout-evaluation.md",
     "docs/phase-52-6-closeout-evaluation.md",
+    "docs/phase-52-7-closeout-evaluation.md",
     "docs/control-plane-service-internal-boundaries.md",
     "docs/maintainability-decomposition-thresholds.md",
     "docs/phase-45-daily-soc-queue-and-operator-ux-hardening-boundary.md",
@@ -168,6 +169,7 @@ approved_legacy_path_text_files = {
     "scripts/verify-phase-52-7-4-physical-layout-migration.sh",
     "scripts/verify-phase-52-7-5-root-shim-reduction.sh",
     "scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh",
+    "scripts/verify-phase-52-7-closeout-evaluation.sh",
     "scripts/test-verify-phase-52-5-1-control-plane-layout-inventory-contract.sh",
     "scripts/test-verify-phase-52-5-2-package-scaffolding-and-shim-policy.sh",
     "scripts/test-verify-phase-52-6-1-root-shim-inventory-contract.sh",
@@ -181,6 +183,7 @@ approved_legacy_path_text_files = {
     "scripts/test-verify-phase-52-7-4-physical-layout-migration.sh",
     "scripts/test-verify-phase-52-7-5-root-shim-reduction.sh",
     "scripts/test-verify-phase-52-7-6-namespace-path-packaging-guardrails.sh",
+    "scripts/test-verify-phase-52-7-closeout-evaluation.sh",
 }
 
 def rel(path: Path) -> str:

--- a/scripts/verify-phase-52-7-closeout-evaluation.sh
+++ b/scripts/verify-phase-52-7-closeout-evaluation.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-52-7-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${file}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 52.7 closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+require_phrase "${readme_path}" "[Phase 52.7 closeout evaluation](docs/phase-52-7-closeout-evaluation.md)" "README Phase 52.7 closeout link"
+
+required_phrases=()
+while IFS= read -r phrase; do
+  required_phrases+=("${phrase}")
+done <<'EOF'
+# Phase 52.7 Closeout Evaluation
+**Status**: Accepted as control-plane namespace normalization and root owner reduction; Phase 53 Wazuh product profile work can start after #1127 lands.
+**Related Issues**: #1120, #1121, #1122, #1123, #1124, #1125, #1126, #1127
+Namespace bridges, filesystem layout, compatibility aliases, root owner inventories, verifier output, issue-lint output, and this document do not change runtime workflow truth.
+This closeout does not claim that Phase 53 Wazuh product profile work was completed, Shuffle product profile work was completed, AegisOps is GA, RC, Beta, or self-service commercially ready, or that runtime product behavior changed during Phase 52.7.
+| #1120 | Epic: Phase 52.7 Control-Plane Namespace Normalization and Root Owner Reduction | Open until #1127 lands; accepted when this closeout, verifiers, and issue-lint pass. |
+| #1121 | Phase 52.7.1 namespace and layout inventory contract | Closed.
+| #1122 | Phase 52.7.2 canonical namespace bridge | Closed.
+| #1123 | Phase 52.7.3 repo-owned canonical namespace rewiring | Closed.
+| #1124 | Phase 52.7.4 physical layout migration | Closed.
+| #1125 | Phase 52.7.5 root shim reduction | Closed.
+| #1126 | Phase 52.7.6 namespace/path packaging guardrails | Closed.
+| #1127 | Phase 52.7.7 Phase 52.7 closeout evaluation | Open until this closeout lands; accepted when this document, focused verifier, all Phase 52.7 verifiers, issue-lint, and path hygiene pass. |
+| Phase 52.6 accepted baseline before Phase 52.7 physical layout migration, under `control-plane/aegisops_control_plane/` | 37 |
+| Phase 52.7.5 accepted canonical root baseline after namespace normalization, under `control-plane/aegisops/control_plane/` | 12 |
+| Phase 52.7.4 accepted legacy compatibility package baseline after migration, under `control-plane/aegisops_control_plane/` | 1 |
+| Implementation package path | `control-plane/aegisops_control_plane/` | `control-plane/aegisops/control_plane/` |
+| Compatibility package path | `control-plane/aegisops_control_plane/` contained implementation files | `control-plane/aegisops_control_plane/__init__.py` only |
+| Canonical import namespace | Proposed by ADR-0016, not yet the repo-owned implementation target | `aegisops.control_plane` |
+| Legacy import namespace | `aegisops_control_plane` public package and implementation namespace | `aegisops_control_plane` retained as compatibility namespace only |
+Legacy compatibility behavior is preserved, not removed.
+`import aegisops_control_plane` continues to work through the compatibility package
+Retained root owners are exactly `__init__.py`, `cli.py`, `config.py`, `models.py`, `operator_inspection.py`, `persistence_lifecycle.py`, `publishable_paths.py`, `record_validation.py`, `reviewed_slice_policy.py`, `service.py`, `service_composition.py`, and `structured_events.py`.
+`service.py` remains a retained compatibility blocker under ADR-0003, ADR-0010, ADR-0014, ADR-0018, and the Phase 52.7 guardrail baseline.
+`docs/phase-52-7-closeout-evaluation.md`
+`scripts/verify-phase-52-7-closeout-evaluation.sh`
+`scripts/test-verify-phase-52-7-closeout-evaluation.sh`
+`bash scripts/verify-phase-52-7-1-namespace-layout-inventory-contract.sh`: namespace and layout inventory records current references, proposed canonical namespace, compatibility blockers, movement guard, and supervisor placeholders.
+`bash scripts/verify-phase-52-7-2-canonical-namespace-bridge.sh`: canonical namespace bridge preserves root public exports and module identity for approved bridge paths.
+`bash scripts/verify-phase-52-7-3-repo-owned-canonical-namespace.sh`: repo-owned references use `aegisops.control_plane` except approved compatibility surfaces.
+`bash scripts/verify-phase-52-7-4-physical-layout-migration.sh`: implementation files live under `control-plane/aegisops/control_plane/` and legacy imports preserve module identity.
+`bash scripts/verify-phase-52-7-5-root-shim-reduction.sh`: 25 simple canonical root shims were removed, 12 retained canonical root files remain, and canonical plus legacy alias identity is preserved.
+`bash scripts/verify-phase-52-7-6-namespace-path-packaging-guardrails.sh`: canonical implementation path, legacy shim boundary, retained root set, compatibility imports, and publishable guidance are pinned.
+`bash scripts/verify-publishable-path-hygiene.sh`: publishable tracked content does not contain workstation-local absolute paths.
+`bash scripts/verify-phase-52-7-closeout-evaluation.sh`: this closeout records child outcomes, compatibility behavior before/after, root file-count before/after, namespace/path before/after, changed files, verifier evidence, issue-lint summary, retained limitations, and bounded Phase 53 recommendation.
+`bash scripts/test-verify-phase-52-7-closeout-evaluation.sh`: closeout negative fixtures reject missing retained legacy compatibility, Phase 53 completion overclaims, missing root file-count before/after, missing namespace/path before/after, and workstation-local absolute paths.
+`python3 -m unittest control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py`: canonical namespace bridge compatibility passed.
+`python3 -m unittest control-plane/tests/test_phase52_7_4_physical_layout_migration.py`: physical layout migration compatibility passed.
+`python3 -m unittest control-plane/tests/test_phase52_7_5_root_shim_reduction.py`: canonical root shim reduction compatibility passed.
+`python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`: broad control-plane tests passed after the namespace/path and root-owner changes.
+node <codex-supervisor-root>/dist/index.js issue-lint 1120 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1121 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1122 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1123 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1124 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1125 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1126 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1127 --config <supervisor-config-path>
+execution_ready=yes
+missing_required=none
+missing_recommended=none
+metadata_errors=none
+high_risk_blocking_ambiguity=none
+The public compatibility namespace `aegisops_control_plane` remains supported; removing it requires a later accepted ADR, caller evidence, operator migration plan, focused regression tests, rollback path, and authority-boundary impact.
+The outer `control-plane/` directory remains unchanged because it is the reviewed repository home for live control-plane application code, service bootstrapping, adapters, tests, and service-local documentation.
+Phase 52.7 does not implement Wazuh product profiles, Shuffle product profiles, public compatibility namespace removal, outer directory rename, product behavior changes, deployment behavior changes, authorization changes, provenance changes, snapshot semantics changes, backup/restore changes, export changes, readiness changes, assistant behavior changes, evidence behavior changes, action-execution behavior changes, HTTP behavior changes, CLI behavior changes, or durable-state changes.
+Phase 53 can start after #1127 lands and all Phase 52.7 verifiers remain green.
+The recommendation is bounded to Wazuh product profile materialization.
+Do not treat this recommendation as a claim that the Wazuh product profile is complete, Shuffle product profile work is complete, or Phase 52.7 changed runtime product behavior.
+EOF
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 52.7 closeout term in ${doc_path}"
+done
+
+mac_home_prefix="$(printf '/%s/' 'Users')"
+unix_home_prefix="$(printf '/%s/' 'home')"
+windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
+absolute_path_pattern="(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}" "${readme_path}"; then
+  echo "Forbidden Phase 52.7 closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+for forbidden in \
+  "Phase 52.7 proves GA readiness" \
+  "Phase 52.7 proves RC readiness" \
+  "Phase 52.7 proves Beta readiness" \
+  "Phase 52.7 proves self-service commercial readiness" \
+  "Phase 53 Wazuh product profile work is completed" \
+  "The Wazuh product profile is complete" \
+  "The Shuffle product profile work is complete" \
+  "Phase 52.7 proves runtime product behavior changed" \
+  "aegisops_control_plane may be removed immediately" \
+  "Compatibility aliases may be removed immediately" \
+  "service.py can grow beyond the accepted facade ceiling" \
+  "Wazuh state is AegisOps workflow truth" \
+  "Shuffle state is AegisOps workflow truth"; do
+  if grep -Fq -- "${forbidden}" "${absolute_doc_path}"; then
+    echo "Forbidden Phase 52.7 closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 52.7 closeout evaluation records child outcomes, compatibility behavior before/after, root file-count before/after, namespace/path before/after, changed files, verifier evidence, issue-lint summary, retained limitations, and bounded Phase 53 recommendation."


### PR DESCRIPTION
## Summary
- add the Phase 52.7 closeout evaluation and README link
- add closeout verifier coverage plus negative fixtures for retained compatibility, Phase 53 overclaim, root-count, namespace/path, and path-hygiene regressions
- allow the new closeout artifacts in existing namespace/path guardrails as approved compatibility documentation

## Verification
- bash scripts/test-verify-phase-52-7-closeout-evaluation.sh
- bash scripts/verify-phase-52-7-closeout-evaluation.sh
- all Phase 52.7 verifier and shell fixture scripts
- python3 -m unittest control-plane/tests/test_phase52_7_2_canonical_namespace_bridge.py control-plane/tests/test_phase52_7_4_physical_layout_migration.py control-plane/tests/test_phase52_7_5_root_shim_reduction.py
- python3 -m unittest discover -s control-plane/tests -p 'test_*.py'\n- issue-lint #1120-#1127 with AegisOps supervisor config\n\nCloses #1127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 52.7 closeout evaluation documentation detailing namespace normalization, root owner reduction, and compatibility preservation
  * Updated README with references to Phase 52.7 closeout outcomes and verification results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->