### PR TITLE
Phase 53.1: Add Wazuh profile contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.5 closeout evaluation](docs/phase-52-5-closeout-evaluation.md) records the Phase 52.5 package-layout hardening outcomes, moved modules, compatibility shims, verifier results, accepted limitations, and bounded Phase 53 readiness recommendation.
 - [Phase 52.6 closeout evaluation](docs/phase-52-6-closeout-evaluation.md) records the Phase 52.6 compatibility-shim deprecation outcomes, root package count reduction, retained owners and blockers, verifier results, and bounded Phase 53 readiness recommendation.
 - [Phase 52.7 closeout evaluation](docs/phase-52-7-closeout-evaluation.md) records the Phase 52.7 namespace normalization outcomes, root owner reduction, compatibility behavior, namespace/path guardrails, verifier results, and bounded Phase 53 readiness recommendation.
+- [Phase 53.1 Wazuh profile contract](docs/deployment/wazuh-smb-single-node-profile-contract.md) defines the `smb-single-node` Wazuh manager, indexer, dashboard, resource, port, volume, certificate, and pinned-version expectations.
 
 ## Product positioning
 
@@ -79,6 +80,8 @@ The Phase 52.5 package-layout hardening closeout is defined by the [Phase 52.5 c
 The Phase 52.6 compatibility-shim deprecation closeout is defined by the [Phase 52.6 closeout evaluation](docs/phase-52-6-closeout-evaluation.md).
 
 The Phase 52.7 namespace normalization closeout is defined by the [Phase 52.7 closeout evaluation](docs/phase-52-7-closeout-evaluation.md).
+
+The Phase 53.1 Wazuh profile contract is defined by the [Phase 53.1 Wazuh profile contract](docs/deployment/wazuh-smb-single-node-profile-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml
+++ b/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml
@@ -1,0 +1,74 @@
+profile_id: smb-single-node
+product_profile: wazuh
+profile_contract_version: 2026-05-03
+status: accepted-contract
+related_issues:
+  - 1135
+  - 1136
+authority_boundary: Wazuh provides subordinate detection substrate signals only; Wazuh manager, indexer, dashboard, generated config, alerts, status, rule state, certificate state, and version state cannot close, approve, execute, reconcile, release, gate, or mutate authoritative AegisOps records.
+components:
+  manager:
+    required: true
+    version: 4.12.0
+    image: wazuh/wazuh-manager:4.12.0
+    ports:
+      - 1514/tcp internal agent event intake
+      - 1514/udp internal agent event intake
+      - 1515/tcp internal agent enrollment
+      - 55000/tcp internal manager API
+    volumes:
+      - wazuh-manager-data
+      - wazuh-manager-rules
+      - wazuh-manager-logs
+    certificates:
+      - wazuh-manager-api-tls
+      - wazuh-ingest-shared-secret-ref
+    resource_expectation: 2 vCPU, 6 GB RAM, 120 GB durable substrate storage
+    boundary: Manager status and alert state remain subordinate signal context until admitted and linked by AegisOps.
+  indexer:
+    required: true
+    version: 4.12.0
+    image: wazuh/wazuh-indexer:4.12.0
+    ports:
+      - 9200/tcp internal indexer API
+      - 9300/tcp internal cluster transport
+    volumes:
+      - wazuh-indexer-data
+      - wazuh-indexer-backup
+    certificates:
+      - wazuh-indexer-tls
+      - wazuh-indexer-admin-client-cert
+    resource_expectation: 2 vCPU, 12 GB RAM, 250 GB durable substrate storage plus backup capacity
+    boundary: Indexer contents and search status are detection substrate evidence only, not AegisOps source or workflow truth.
+  dashboard:
+    required: true
+    version: 4.12.0
+    image: wazuh/wazuh-dashboard:4.12.0
+    ports:
+      - 5601/tcp internal dashboard UI through reviewed proxy only
+    volumes:
+      - wazuh-dashboard-config
+    certificates:
+      - wazuh-dashboard-tls
+      - wazuh-dashboard-indexer-client-cert
+    resource_expectation: 1 vCPU, 2 GB RAM, bounded config/log storage
+    boundary: Dashboard state is operator-facing substrate context only and cannot become AegisOps workflow truth.
+version_matrix:
+  - component: manager
+    version: 4.12.0
+    pin_type: exact
+    incompatible_versions: Wazuh 3.x, unreviewed Wazuh 5.x, latest, rc, beta
+  - component: indexer
+    version: 4.12.0
+    pin_type: exact
+    incompatible_versions: Wazuh 3.x, unreviewed Wazuh 5.x, latest, rc, beta
+  - component: dashboard
+    version: 4.12.0
+    pin_type: exact
+    incompatible_versions: Wazuh 3.x, unreviewed Wazuh 5.x, latest, rc, beta
+profile_expectations:
+  resource_floor: Recommended first-user host remains 8 vCPU, 32 GB RAM, and 500 GB durable disk with Wazuh growth accounted for separately from PostgreSQL.
+  ingress: Wazuh manager, indexer, and dashboard ports are internal or substrate-owned; AegisOps receives Wazuh signals only through the reviewed proxy intake route.
+  volumes: Wazuh manager, indexer, dashboard, logs, rules, certificates, and backups are separate from AegisOps PostgreSQL state and AegisOps evidence custody.
+  certificates: Certificate and secret references are trusted custody references only; placeholder, sample, fake, TODO, unsigned, or inline secret values are invalid.
+  source_health: Source-health projection is deferred to a later Phase 53 child issue and cannot use Wazuh dashboard or manager state as authoritative workflow truth.

--- a/docs/deployment/wazuh-smb-single-node-profile-contract.md
+++ b/docs/deployment/wazuh-smb-single-node-profile-contract.md
@@ -1,0 +1,97 @@
+# Phase 53.1 Wazuh SMB Single-Node Profile Contract
+
+- **Status**: Accepted contract
+- **Date**: 2026-05-03
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-52-2-smb-single-node-profile-model.md`, `docs/deployment/combined-dependency-matrix.md`, `docs/deployment/env-secrets-certs-contract.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1135, #1136
+
+This contract defines the repo-owned Wazuh `smb-single-node` product-profile contract and version matrix. It does not implement certificate generation, Wazuh intake binding, sample detection fixtures, source-health projection, upgrade automation, fleet-scale Wazuh management, Shuffle product profiles, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+## 1. Purpose
+
+The Wazuh profile gives Phase 53 one product-owned contract for manager, indexer, dashboard, resource needs, ports, volumes, certificates, and pinned versions.
+
+The required structured artifact is `docs/deployment/profiles/smb-single-node/wazuh/profile.yaml`.
+
+## 2. Authority Boundary
+
+Wazuh is a subordinate detection substrate. Wazuh manager state, Wazuh indexer state, Wazuh dashboard state, generated Wazuh config, Wazuh alerts, Wazuh rule state, Wazuh certificate state, Wazuh version state, source-health projection, verifier output, issue-lint output, operator-facing status text, and setup evidence are not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. The Wazuh profile must preserve the rule that Wazuh status, alert, rule, manager, decoder, dashboard, indexer, generated-config, ticket, AI, browser, UI cache, optional evidence, and downstream receipt state cannot close, reconcile, approve, execute, release, gate, or otherwise mutate AegisOps records without explicit AegisOps admission and linkage.
+
+## 3. Component Contract
+
+| Component | Required | Version pin | Image pin | Resource expectation | Ports | Volumes | Certificate expectations | Authority boundary |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| manager | Yes | `4.12.0` | `wazuh/wazuh-manager:4.12.0` | 2 vCPU, 6 GB RAM, 120 GB durable substrate storage. | `1514/tcp` internal agent event intake; `1514/udp` internal agent event intake; `1515/tcp` internal agent enrollment; `55000/tcp` internal manager API. | `wazuh-manager-data`; `wazuh-manager-rules`; `wazuh-manager-logs`. | `wazuh-manager-api-tls`; `wazuh-ingest-shared-secret-ref`. | Manager status and alert state remain subordinate signal context until admitted and linked by AegisOps. |
+| indexer | Yes | `4.12.0` | `wazuh/wazuh-indexer:4.12.0` | 2 vCPU, 12 GB RAM, 250 GB durable substrate storage plus backup capacity. | `9200/tcp` internal indexer API; `9300/tcp` internal cluster transport. | `wazuh-indexer-data`; `wazuh-indexer-backup`. | `wazuh-indexer-tls`; `wazuh-indexer-admin-client-cert`. | Indexer contents and search status are detection substrate evidence only, not AegisOps source or workflow truth. |
+| dashboard | Yes | `4.12.0` | `wazuh/wazuh-dashboard:4.12.0` | 1 vCPU, 2 GB RAM, bounded config/log storage. | `5601/tcp` internal dashboard UI through reviewed proxy only. | `wazuh-dashboard-config`. | `wazuh-dashboard-tls`; `wazuh-dashboard-indexer-client-cert`. | Dashboard state is operator-facing substrate context only and cannot become AegisOps workflow truth. |
+
+## 4. Version Matrix
+
+| Component | Accepted version | Pin type | Known incompatible versions | Upgrade note |
+| --- | --- | --- | --- | --- |
+| manager | `4.12.0` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; `latest`; RC; beta. | Upgrade evidence is deferred to a later Phase 53 child issue. |
+| indexer | `4.12.0` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; `latest`; RC; beta. | Upgrade evidence is deferred to a later Phase 53 child issue. |
+| dashboard | `4.12.0` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; `latest`; RC; beta. | Upgrade evidence is deferred to a later Phase 53 child issue. |
+
+## 5. Profile Expectations
+
+The Wazuh profile must preserve these expectations:
+
+- Resource floor: the recommended first-user host remains 8 vCPU, 32 GB RAM, and 500 GB durable disk, with Wazuh growth accounted for separately from PostgreSQL.
+- Ports: Wazuh manager, indexer, and dashboard ports are internal or substrate-owned; AegisOps receives Wazuh signals only through the reviewed proxy intake route.
+- Volumes: Wazuh manager, indexer, dashboard, logs, rules, certificates, and backups are separate from AegisOps PostgreSQL state and AegisOps evidence custody.
+- Certificates: certificate and secret references are trusted custody references only; placeholder, sample, fake, TODO, unsigned, or inline secret values are invalid.
+- Source health: source-health projection is deferred and cannot use Wazuh dashboard or manager state as authoritative workflow truth.
+
+## 6. Validation Rules
+
+Wazuh profile validation must fail closed when:
+
+- `docs/deployment/profiles/smb-single-node/wazuh/profile.yaml` is missing;
+- the contract document is missing;
+- manager, indexer, or dashboard coverage is missing;
+- manager, indexer, or dashboard version pins are missing, floating, RC, beta, `latest`, or otherwise not exact;
+- resource expectations, ports, volumes, certificate expectations, known incompatible versions, or authority-boundary text are missing;
+- Wazuh status, version state, dashboard state, manager state, indexer state, generated config, verifier output, or source-health projection is described as AegisOps workflow truth, production truth, release truth, gate truth, closeout truth, approval truth, execution truth, or reconciliation truth;
+- placeholder secrets, sample credentials, fake values, TODO values, unsigned tokens, inline secrets, raw forwarded headers, or inferred tenant/source linkage are treated as valid setup state; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<supervisor-config-path>`, `<codex-supervisor-root>`, `<runtime-env-file>`, and `<wazuh-profile-path>`.
+
+## 7. Forbidden Claims
+
+- Wazuh status is AegisOps workflow truth.
+- Wazuh alert status is AegisOps case truth.
+- Wazuh manager state is AegisOps source truth.
+- Wazuh dashboard state is AegisOps approval truth.
+- Wazuh indexer state is AegisOps evidence truth.
+- Wazuh version state is AegisOps release truth.
+- Source-health projection is AegisOps closeout truth.
+- Placeholder secrets are valid credentials.
+- Raw forwarded headers are trusted identity.
+- Phase 53.1 implements Wazuh intake binding.
+- Phase 53.1 implements Wazuh certificate generation.
+- Phase 53.1 implements Wazuh source-health projection.
+- Phase 53.1 implements Wazuh upgrade automation.
+- Phase 53.1 implements Shuffle product profiles.
+- Phase 53.1 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-53-1-wazuh-profile-contract.sh`.
+
+Run `bash scripts/test-verify-phase-53-1-wazuh-profile-contract.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1136 --config <supervisor-config-path>`.
+
+The verifier must fail when the Wazuh profile or contract is missing, when manager, indexer, or dashboard rows are missing, when Wazuh versions are unpinned or floating, when resource, port, volume, certificate, incompatible-version, or authority-boundary expectations are missing, when Wazuh substrate state is promoted into AegisOps authority, or when publishable guidance uses workstation-local absolute paths.
+
+## 9. Non-Goals
+
+- No certificate generation, Wazuh intake binding, sample detection fixture, source-health projection, upgrade automation, fleet-scale Wazuh management, Shuffle profile work, release-candidate behavior, general-availability behavior, or runtime behavior is implemented here.
+- No Wazuh manager state, Wazuh indexer state, Wazuh dashboard state, Wazuh alert, Wazuh version, Wazuh certificate, generated Wazuh config, source-health projection, verifier output, issue-lint output, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-53-1-wazuh-profile-contract.sh
+++ b/scripts/test-verify-phase-53-1-wazuh-profile-contract.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-53-1-wazuh-profile-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/profiles/smb-single-node/wazuh"
+  printf '%s\n' "# AegisOps" "See [Phase 53.1 Wazuh profile contract](docs/deployment/wazuh-smb-single-node-profile-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/wazuh-smb-single-node-profile-contract.md" \
+    "${target}/docs/deployment/wazuh-smb-single-node-profile-contract.md"
+  cp "${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml" \
+    "${target}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/wazuh-smb-single-node-profile-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/wazuh-smb-single-node-profile-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 53.1 Wazuh profile contract"
+
+missing_profile_repo="${workdir}/missing-profile"
+create_valid_repo "${missing_profile_repo}"
+rm "${missing_profile_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${missing_profile_repo}" \
+  "Missing Phase 53.1 Wazuh profile artifact"
+
+missing_manager_repo="${workdir}/missing-manager"
+create_valid_repo "${missing_manager_repo}"
+remove_text_from_contract "${missing_manager_repo}" \
+  "| manager | Yes | \`4.12.0\` | \`wazuh/wazuh-manager:4.12.0\` | 2 vCPU, 6 GB RAM, 120 GB durable substrate storage. | \`1514/tcp\` internal agent event intake; \`1514/udp\` internal agent event intake; \`1515/tcp\` internal agent enrollment; \`55000/tcp\` internal manager API. | \`wazuh-manager-data\`; \`wazuh-manager-rules\`; \`wazuh-manager-logs\`. | \`wazuh-manager-api-tls\`; \`wazuh-ingest-shared-secret-ref\`. | Manager status and alert state remain subordinate signal context until admitted and linked by AegisOps. |"
+assert_fails_with \
+  "${missing_manager_repo}" \
+  "Missing complete Phase 53.1 Wazuh component row: manager"
+
+missing_indexer_profile_repo="${workdir}/missing-indexer-profile"
+create_valid_repo "${missing_indexer_profile_repo}"
+perl -0pi -e 's/\n  indexer:\n    required: true.*?(?=\n  dashboard:)/\n/s' \
+  "${missing_indexer_profile_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${missing_indexer_profile_repo}" \
+  "Missing complete Phase 53.1 Wazuh profile artifact component: indexer"
+
+missing_dashboard_version_repo="${workdir}/missing-dashboard-version"
+create_valid_repo "${missing_dashboard_version_repo}"
+remove_text_from_contract "${missing_dashboard_version_repo}" \
+  "| dashboard | \`4.12.0\` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; \`latest\`; RC; beta. | Upgrade evidence is deferred to a later Phase 53 child issue. |"
+assert_fails_with \
+  "${missing_dashboard_version_repo}" \
+  "Missing complete Phase 53.1 Wazuh version matrix row: dashboard"
+
+unpinned_version_repo="${workdir}/unpinned-version"
+create_valid_repo "${unpinned_version_repo}"
+perl -0pi -e 's/version: 4\.12\.0/version: latest/' \
+  "${unpinned_version_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${unpinned_version_repo}" \
+  "Forbidden Phase 53.1 Wazuh profile artifact: unpinned version or image reference detected"
+
+missing_resources_repo="${workdir}/missing-resources"
+create_valid_repo "${missing_resources_repo}"
+perl -0pi -e 's/    resource_expectation: 2 vCPU, 6 GB RAM, 120 GB durable substrate storage\n//' \
+  "${missing_resources_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${missing_resources_repo}" \
+  "Missing complete Phase 53.1 Wazuh profile artifact component: manager"
+
+missing_certificates_repo="${workdir}/missing-certificates"
+create_valid_repo "${missing_certificates_repo}"
+perl -0pi -e 's/    certificates:\n      - wazuh-dashboard-tls\n      - wazuh-dashboard-indexer-client-cert\n//' \
+  "${missing_certificates_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${missing_certificates_repo}" \
+  "Missing complete Phase 53.1 Wazuh profile artifact component: dashboard"
+
+workflow_truth_repo="${workdir}/workflow-truth"
+create_valid_repo "${workflow_truth_repo}"
+printf '%s\n' "Wazuh status is AegisOps workflow truth." \
+  >>"${workflow_truth_repo}/docs/deployment/wazuh-smb-single-node-profile-contract.md"
+assert_fails_with \
+  "${workflow_truth_repo}" \
+  "Forbidden Phase 53.1 Wazuh profile contract claim: Wazuh status is AegisOps workflow truth"
+
+placeholder_secret_repo="${workdir}/placeholder-secret"
+create_valid_repo "${placeholder_secret_repo}"
+printf '%s\n' "Placeholder secrets are valid credentials." \
+  >>"${placeholder_secret_repo}/docs/deployment/wazuh-smb-single-node-profile-contract.md"
+assert_fails_with \
+  "${placeholder_secret_repo}" \
+  "Forbidden Phase 53.1 Wazuh profile contract claim: Placeholder secrets are valid credentials"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/wazuh-smb-single-node-profile-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 53.1 Wazuh profile contract: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 53.1 Wazuh profile contract."
+
+echo "Phase 53.1 Wazuh profile contract verifier tests passed."

--- a/scripts/test-verify-phase-53-1-wazuh-profile-contract.sh
+++ b/scripts/test-verify-phase-53-1-wazuh-profile-contract.sh
@@ -124,6 +124,46 @@ assert_fails_with \
   "${missing_certificates_repo}" \
   "Missing complete Phase 53.1 Wazuh profile artifact component: dashboard"
 
+wrong_dashboard_image_repo="${workdir}/wrong-dashboard-image"
+create_valid_repo "${wrong_dashboard_image_repo}"
+perl -0pi -e 's/image: wazuh\/wazuh-dashboard:4\.12\.0/image: wazuh\/wazuh-manager:4.12.0/' \
+  "${wrong_dashboard_image_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${wrong_dashboard_image_repo}" \
+  "Missing complete Phase 53.1 Wazuh profile artifact component: dashboard"
+
+empty_ports_repo="${workdir}/empty-ports"
+create_valid_repo "${empty_ports_repo}"
+perl -0pi -e 's/    ports:\n      - 1514\/tcp internal agent event intake\n      - 1514\/udp internal agent event intake\n      - 1515\/tcp internal agent enrollment\n      - 55000\/tcp internal manager API\n/    ports:\n/' \
+  "${empty_ports_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${empty_ports_repo}" \
+  "Missing complete Phase 53.1 Wazuh profile artifact component: manager"
+
+empty_volumes_repo="${workdir}/empty-volumes"
+create_valid_repo "${empty_volumes_repo}"
+perl -0pi -e 's/    volumes:\n      - wazuh-indexer-data\n      - wazuh-indexer-backup\n/    volumes:\n/' \
+  "${empty_volumes_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${empty_volumes_repo}" \
+  "Missing complete Phase 53.1 Wazuh profile artifact component: indexer"
+
+blank_boundary_repo="${workdir}/blank-boundary"
+create_valid_repo "${blank_boundary_repo}"
+perl -0pi -e 's/    boundary: Dashboard state is operator-facing substrate context only and cannot become AegisOps workflow truth\./    boundary: /' \
+  "${blank_boundary_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${blank_boundary_repo}" \
+  "Missing complete Phase 53.1 Wazuh profile artifact component: dashboard"
+
+missing_matrix_incompatibility_repo="${workdir}/missing-matrix-incompatibility"
+create_valid_repo "${missing_matrix_incompatibility_repo}"
+perl -0pi -e 's/incompatible_versions: Wazuh 3\.x, unreviewed Wazuh 5\.x, latest, rc, beta/incompatible_versions: latest, rc, beta/g' \
+  "${missing_matrix_incompatibility_repo}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+assert_fails_with \
+  "${missing_matrix_incompatibility_repo}" \
+  "Missing complete Phase 53.1 Wazuh profile artifact version matrix row: manager"
+
 workflow_truth_repo="${workdir}/workflow-truth"
 create_valid_repo "${workflow_truth_repo}"
 printf '%s\n' "Wazuh status is AegisOps workflow truth." \

--- a/scripts/test-verify-phase-53-1-wazuh-profile-contract.sh
+++ b/scripts/test-verify-phase-53-1-wazuh-profile-contract.sh
@@ -84,6 +84,22 @@ assert_fails_with \
   "${missing_manager_repo}" \
   "Missing complete Phase 53.1 Wazuh component row: manager"
 
+missing_indexer_contract_repo="${workdir}/missing-indexer-contract"
+create_valid_repo "${missing_indexer_contract_repo}"
+remove_text_from_contract "${missing_indexer_contract_repo}" \
+  "| indexer | Yes | \`4.12.0\` | \`wazuh/wazuh-indexer:4.12.0\` | 2 vCPU, 12 GB RAM, 250 GB durable substrate storage plus backup capacity. | \`9200/tcp\` internal indexer API; \`9300/tcp\` internal cluster transport. | \`wazuh-indexer-data\`; \`wazuh-indexer-backup\`. | \`wazuh-indexer-tls\`; \`wazuh-indexer-admin-client-cert\`. | Indexer contents and search status are detection substrate evidence only, not AegisOps source or workflow truth. |"
+assert_fails_with \
+  "${missing_indexer_contract_repo}" \
+  "Missing complete Phase 53.1 Wazuh component row: indexer"
+
+missing_dashboard_contract_repo="${workdir}/missing-dashboard-contract"
+create_valid_repo "${missing_dashboard_contract_repo}"
+remove_text_from_contract "${missing_dashboard_contract_repo}" \
+  "| dashboard | Yes | \`4.12.0\` | \`wazuh/wazuh-dashboard:4.12.0\` | 1 vCPU, 2 GB RAM, bounded config/log storage. | \`5601/tcp\` internal dashboard UI through reviewed proxy only. | \`wazuh-dashboard-config\`. | \`wazuh-dashboard-tls\`; \`wazuh-dashboard-indexer-client-cert\`. | Dashboard state is operator-facing substrate context only and cannot become AegisOps workflow truth. |"
+assert_fails_with \
+  "${missing_dashboard_contract_repo}" \
+  "Missing complete Phase 53.1 Wazuh component row: dashboard"
+
 missing_indexer_profile_repo="${workdir}/missing-indexer-profile"
 create_valid_repo "${missing_indexer_profile_repo}"
 perl -0pi -e 's/\n  indexer:\n    required: true.*?(?=\n  dashboard:)/\n/s' \
@@ -178,7 +194,7 @@ printf '%s\n' "Placeholder secrets are valid credentials." \
   >>"${placeholder_secret_repo}/docs/deployment/wazuh-smb-single-node-profile-contract.md"
 assert_fails_with \
   "${placeholder_secret_repo}" \
-  "Forbidden Phase 53.1 Wazuh profile contract claim: Placeholder secrets are valid credentials"
+  "Forbidden Phase 53.1 Wazuh profile contract claim: placeholder secrets accepted as valid credentials"
 
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"

--- a/scripts/verify-phase-53-1-wazuh-profile-contract.sh
+++ b/scripts/verify-phase-53-1-wazuh-profile-contract.sh
@@ -133,29 +133,71 @@ for component in "${components[@]}"; do
     exit 1
   fi
 
-  if ! awk -v component="${component}" '
+  expected_image="wazuh/wazuh-${component}:4.12.0"
+  if ! awk -v component="${component}" -v expected_image="${expected_image}" '
+    function trim(value) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      return value
+    }
+    function list_has_items() {
+      if (active_list == "ports" && list_items > 0) {
+        ports = 1
+      } else if (active_list == "volumes" && list_items > 0) {
+        volumes = 1
+      } else if (active_list == "certificates" && list_items > 0) {
+        certificates = 1
+      }
+      active_list = ""
+      list_items = 0
+    }
+    function value_after_key(line, key) {
+      sub("^    " key ":[[:space:]]*", "", line)
+      return trim(line)
+    }
     $0 == "  " component ":" {
       in_component = 1
       required = version = image = ports = volumes = certificates = resources = boundary = 0
+      active_list = ""
+      list_items = 0
       next
     }
-    /^version_matrix:/ && in_component { in_component = 0 }
-    /^  [a-z][a-z0-9_-]*:[[:space:]]*$/ && in_component { in_component = 0 }
-    in_component && /required: true/ { required = 1 }
-    in_component && /version: 4\.12\.0/ { version = 1 }
-    in_component && /image: wazuh\/wazuh-[a-z]+:4\.12\.0/ { image = 1 }
-    in_component && /ports:/ { ports = 1 }
-    in_component && /volumes:/ { volumes = 1 }
-    in_component && /certificates:/ { certificates = 1 }
-    in_component && /resource_expectation:/ { resources = 1 }
-    in_component && /boundary:/ { boundary = 1 }
-    END { exit(required && version && image && ports && volumes && certificates && resources && boundary ? 0 : 1) }
+    in_component && (/^version_matrix:/ || /^  [a-z][a-z0-9_-]*:[[:space:]]*$/) {
+      list_has_items()
+      in_component = 0
+      next
+    }
+    in_component && /^    [a-z_]+:/ { list_has_items() }
+    in_component && $0 == "    required: true" { required = 1 }
+    in_component && $0 == "    version: 4.12.0" { version = 1 }
+    in_component && $0 == "    image: " expected_image { image = 1 }
+    in_component && $0 == "    ports:" {
+      active_list = "ports"
+      list_items = 0
+      next
+    }
+    in_component && $0 == "    volumes:" {
+      active_list = "volumes"
+      list_items = 0
+      next
+    }
+    in_component && $0 == "    certificates:" {
+      active_list = "certificates"
+      list_items = 0
+      next
+    }
+    in_component && active_list != "" && /^      - [^[:space:]]/ { list_items++ }
+    in_component && /^    resource_expectation:/ && value_after_key($0, "resource_expectation") != "" { resources = 1 }
+    in_component && /^    boundary:/ && value_after_key($0, "boundary") != "" { boundary = 1 }
+    END {
+      list_has_items()
+      exit(required && version && image && ports && volumes && certificates && resources && boundary ? 0 : 1)
+    }
   ' "${profile_path}"; then
     echo "Missing complete Phase 53.1 Wazuh profile artifact component: ${component}" >&2
     exit 1
   fi
 
-  if ! awk -v component="${component}" '
+  if ! awk -v component="${component}" -v expected_incompatible="Wazuh 3.x, unreviewed Wazuh 5.x, latest, rc, beta" '
     /version_matrix:/ { in_matrix = 1; next }
     /^profile_expectations:/ { in_matrix = 0 }
     in_matrix && $0 == "  - component: " component {
@@ -164,9 +206,9 @@ for component in "${components[@]}"; do
       next
     }
     in_matrix && /^  - component:/ && in_component { in_component = 0 }
-    in_component && /version: 4\.12\.0/ { version = 1 }
-    in_component && /pin_type: exact/ { pin = 1 }
-    in_component && /latest, rc, beta/ { incompatible = 1 }
+    in_component && $0 == "    version: 4.12.0" { version = 1 }
+    in_component && $0 == "    pin_type: exact" { pin = 1 }
+    in_component && $0 == "    incompatible_versions: " expected_incompatible { incompatible = 1 }
     END { exit(version && pin && incompatible ? 0 : 1) }
   ' "${profile_path}"; then
     echo "Missing complete Phase 53.1 Wazuh profile artifact version matrix row: ${component}" >&2

--- a/scripts/verify-phase-53-1-wazuh-profile-contract.sh
+++ b/scripts/verify-phase-53-1-wazuh-profile-contract.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+contract_path="${repo_root}/docs/deployment/wazuh-smb-single-node-profile-contract.md"
+profile_path="${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 53.1 Wazuh SMB Single-Node Profile Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Component Contract"
+  "## 4. Version Matrix"
+  "## 5. Profile Expectations"
+  "## 6. Validation Rules"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted contract"
+  "- **Date**: 2026-05-03"
+  "- **Related Issues**: #1135, #1136"
+  "This contract defines the repo-owned Wazuh \`smb-single-node\` product-profile contract and version matrix."
+  "The required structured artifact is \`docs/deployment/profiles/smb-single-node/wazuh/profile.yaml\`."
+  "Wazuh is a subordinate detection substrate."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth."
+  "This contract cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`."
+  "| Component | Required | Version pin | Image pin | Resource expectation | Ports | Volumes | Certificate expectations | Authority boundary |"
+  "| Component | Accepted version | Pin type | Known incompatible versions | Upgrade note |"
+  "Run \`bash scripts/verify-phase-53-1-wazuh-profile-contract.sh\`."
+  "Run \`bash scripts/test-verify-phase-53-1-wazuh-profile-contract.sh\`."
+  "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1136 --config <supervisor-config-path>\`."
+)
+
+components=(manager indexer dashboard)
+required_profile_terms=(
+  "profile_id: smb-single-node"
+  "product_profile: wazuh"
+  "profile_contract_version: 2026-05-03"
+  "authority_boundary: Wazuh provides subordinate detection substrate signals only;"
+  "resource_floor:"
+  "ingress:"
+  "volumes:"
+  "certificates:"
+  "source_health:"
+)
+
+forbidden_claims=(
+  "Wazuh status is AegisOps workflow truth"
+  "Wazuh alert status is AegisOps case truth"
+  "Wazuh manager state is AegisOps source truth"
+  "Wazuh dashboard state is AegisOps approval truth"
+  "Wazuh indexer state is AegisOps evidence truth"
+  "Wazuh version state is AegisOps release truth"
+  "Source-health projection is AegisOps closeout truth"
+  "Placeholder secrets are valid credentials"
+  "Raw forwarded headers are trusted identity"
+  "Phase 53.1 implements Wazuh intake binding"
+  "Phase 53.1 implements Wazuh certificate generation"
+  "Phase 53.1 implements Wazuh source-health projection"
+  "Phase 53.1 implements Wazuh upgrade automation"
+  "Phase 53.1 implements Shuffle product profiles"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${contract_path}" ]]; then
+  echo "Missing Phase 53.1 Wazuh profile contract: ${contract_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${profile_path}" ]]; then
+  echo "Missing Phase 53.1 Wazuh profile artifact: ${profile_path}" >&2
+  exit 1
+fi
+
+contract_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${contract_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.1 Wazuh profile contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.1 Wazuh profile contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for term in "${required_profile_terms[@]}"; do
+  if ! grep -Fq -- "${term}" "${profile_path}"; then
+    echo "Missing Phase 53.1 Wazuh profile artifact term: ${term}" >&2
+    exit 1
+  fi
+done
+
+if grep -Eq '(^|[^[:alnum:]_.-])(latest|stable|current|main|master|HEAD|rc|beta)([^[:alnum:]_.-]|$)' <(grep -E '^[[:space:]]*(version|image):' "${profile_path}"); then
+  echo "Forbidden Phase 53.1 Wazuh profile artifact: unpinned version or image reference detected" >&2
+  exit 1
+fi
+
+for component in "${components[@]}"; do
+  if ! grep -Eq "^\| ${component} \| Yes \| \`4\.12\.0\` \| \`wazuh/wazuh-${component}:4\.12\.0\` \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${contract_rendered_markdown}"; then
+    echo "Missing complete Phase 53.1 Wazuh component row: ${component}" >&2
+    exit 1
+  fi
+
+  if ! grep -Eq "^\| ${component} \| \`4\.12\.0\` \| exact \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${contract_rendered_markdown}"; then
+    echo "Missing complete Phase 53.1 Wazuh version matrix row: ${component}" >&2
+    exit 1
+  fi
+
+  if ! awk -v component="${component}" '
+    $0 == "  " component ":" {
+      in_component = 1
+      required = version = image = ports = volumes = certificates = resources = boundary = 0
+      next
+    }
+    /^version_matrix:/ && in_component { in_component = 0 }
+    /^  [a-z][a-z0-9_-]*:[[:space:]]*$/ && in_component { in_component = 0 }
+    in_component && /required: true/ { required = 1 }
+    in_component && /version: 4\.12\.0/ { version = 1 }
+    in_component && /image: wazuh\/wazuh-[a-z]+:4\.12\.0/ { image = 1 }
+    in_component && /ports:/ { ports = 1 }
+    in_component && /volumes:/ { volumes = 1 }
+    in_component && /certificates:/ { certificates = 1 }
+    in_component && /resource_expectation:/ { resources = 1 }
+    in_component && /boundary:/ { boundary = 1 }
+    END { exit(required && version && image && ports && volumes && certificates && resources && boundary ? 0 : 1) }
+  ' "${profile_path}"; then
+    echo "Missing complete Phase 53.1 Wazuh profile artifact component: ${component}" >&2
+    exit 1
+  fi
+
+  if ! awk -v component="${component}" '
+    /version_matrix:/ { in_matrix = 1; next }
+    /^profile_expectations:/ { in_matrix = 0 }
+    in_matrix && $0 == "  - component: " component {
+      in_component = 1
+      version = pin = incompatible = 0
+      next
+    }
+    in_matrix && /^  - component:/ && in_component { in_component = 0 }
+    in_component && /version: 4\.12\.0/ { version = 1 }
+    in_component && /pin_type: exact/ { pin = 1 }
+    in_component && /latest, rc, beta/ { incompatible = 1 }
+    END { exit(version && pin && incompatible ? 0 : 1) }
+  ' "${profile_path}"; then
+    echo "Missing complete Phase 53.1 Wazuh profile artifact version matrix row: ${component}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+contains_placeholder_secret_valid_claim() {
+  awk '
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    {
+      line = tolower($0)
+      negative_context = line ~ /(must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|subordinate|deferred)/
+      if (!in_forbidden_claims && !negative_context && line ~ /(^|[^[:alnum:]_])placeholder secrets?[[:space:]]+(are|is|count as|counts as|may be|can be|remain|stays)[[:space:]]+([^.]*[^[:alnum:]_])?(valid|trusted|accepted|production)([^[:alnum:]_]|$)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${contract_rendered_markdown}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 53.1 Wazuh profile contract claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if contains_placeholder_secret_valid_claim; then
+  echo "Forbidden Phase 53.1 Wazuh profile contract claim: placeholder secrets accepted as valid credentials" >&2
+  exit 1
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${contract_path}" "${profile_path}"; then
+  echo "Forbidden Phase 53.1 Wazuh profile contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 53.1 Wazuh profile contract link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/wazuh-smb-single-node-profile-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 53.1 Wazuh profile contract." >&2
+  exit 1
+fi
+
+echo "Phase 53.1 Wazuh profile contract is present and preserves component coverage, exact version pins, resource/port/volume/certificate expectations, and authority boundaries."

--- a/scripts/verify-phase-53-1-wazuh-profile-contract.sh
+++ b/scripts/verify-phase-53-1-wazuh-profile-contract.sh
@@ -58,7 +58,6 @@ forbidden_claims=(
   "Wazuh indexer state is AegisOps evidence truth"
   "Wazuh version state is AegisOps release truth"
   "Source-health projection is AegisOps closeout truth"
-  "Placeholder secrets are valid credentials"
   "Raw forwarded headers are trusted identity"
   "Phase 53.1 implements Wazuh intake binding"
   "Phase 53.1 implements Wazuh certificate generation"


### PR DESCRIPTION
## Summary
- Adds the repo-owned `docs/deployment/profiles/smb-single-node/wazuh/profile.yaml` Wazuh profile contract artifact.
- Documents the Phase 53.1 Wazuh manager, indexer, dashboard, resource, port, volume, certificate, authority-boundary, and exact version matrix expectations.
- Adds focused verifier and negative-fixture tests for missing rows, unpinned versions, missing expectations, authority overclaims, and publishable path hygiene.

## Verification
- `bash scripts/verify-phase-53-1-wazuh-profile-contract.sh`
- `bash scripts/test-verify-phase-53-1-wazuh-profile-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash -n scripts/verify-phase-53-1-wazuh-profile-contract.sh scripts/test-verify-phase-53-1-wazuh-profile-contract.sh`
- `bash scripts/verify-repository-skeleton.sh`
- `bash scripts/run-ci-phase-contract.sh all-verifiers`
- docs-and-skeleton remaining command tail from CI after `run-ci-phase-contract`
- `node dist/index.js issue-lint 1136 --config supervisor.config.aegisops.coderabbit.json`
- `node dist/index.js issue-lint 1135 --config supervisor.config.aegisops.coderabbit.json`

## Limitations
- Certificate generation, Wazuh intake binding, source-health projection, sample detection fixtures, upgrade evidence, and runtime authority-boundary tests remain later Phase 53 child issue scope.

Closes #1136
Part of #1135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 53.1 Wazuh smb-single-node product-profile contract and profile artifact documenting required manager/indexer/dashboard attributes, exact version pins, images, resource/port/volume/certificate expectations, authority boundary, validation rules, forbidden claims, and non-goals; README updated to link the contract.

* **Tests**
  * Added a comprehensive verification suite covering positive and numerous negative scenarios to enforce contract/profile consistency and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->