### PR TITLE
Phase 53.2 Wazuh certificate credential contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.6 closeout evaluation](docs/phase-52-6-closeout-evaluation.md) records the Phase 52.6 compatibility-shim deprecation outcomes, root package count reduction, retained owners and blockers, verifier results, and bounded Phase 53 readiness recommendation.
 - [Phase 52.7 closeout evaluation](docs/phase-52-7-closeout-evaluation.md) records the Phase 52.7 namespace normalization outcomes, root owner reduction, compatibility behavior, namespace/path guardrails, verifier results, and bounded Phase 53 readiness recommendation.
 - [Phase 53.1 Wazuh profile contract](docs/deployment/wazuh-smb-single-node-profile-contract.md) defines the `smb-single-node` Wazuh manager, indexer, dashboard, resource, port, volume, certificate, and pinned-version expectations.
+- [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 
 ## Product positioning
 
@@ -82,6 +83,8 @@ The Phase 52.6 compatibility-shim deprecation closeout is defined by the [Phase 
 The Phase 52.7 namespace normalization closeout is defined by the [Phase 52.7 closeout evaluation](docs/phase-52-7-closeout-evaluation.md).
 
 The Phase 53.1 Wazuh profile contract is defined by the [Phase 53.1 Wazuh profile contract](docs/deployment/wazuh-smb-single-node-profile-contract.md).
+
+The Phase 53.2 Wazuh certificate and credential contract is defined by the [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml
+++ b/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml
@@ -1,0 +1,62 @@
+profile_id: smb-single-node
+product_profile: wazuh
+profile_contract_version: 2026-05-03
+certificate_credential_contract_version: 2026-05-03
+status: accepted-contract
+related_issues:
+  - 1135
+  - 1136
+  - 1137
+authority_boundary: Wazuh certificate and credential state remains subordinate setup context only; it cannot close, approve, execute, reconcile, release, gate, or mutate authoritative AegisOps records.
+tls_ready_profile: true
+certificate_generation_wrapper:
+  posture: demo-or-local-rehearsal-only
+  demo_mode_required: true
+  custody_requirement: generated demo certificate material must be ignored or untracked and labeled demo-only
+  production_truth: false
+certificate_paths:
+  - wazuh-manager-api-tls-chain-ref
+  - wazuh-manager-api-tls-private-key-ref
+  - wazuh-indexer-tls-chain-ref
+  - wazuh-indexer-tls-private-key-ref
+  - wazuh-indexer-admin-client-cert-ref
+  - wazuh-dashboard-tls-chain-ref
+  - wazuh-dashboard-tls-private-key-ref
+  - wazuh-dashboard-indexer-client-cert-ref
+credential_custody:
+  wazuh_api_credentials: AEGISOPS_WAZUH_API_CREDENTIALS_FILE or AEGISOPS_WAZUH_API_CREDENTIALS_OPENBAO_PATH
+  wazuh_indexer_admin_credentials: AEGISOPS_WAZUH_INDEXER_ADMIN_CREDENTIALS_FILE or AEGISOPS_WAZUH_INDEXER_ADMIN_CREDENTIALS_OPENBAO_PATH
+  wazuh_dashboard_credentials: AEGISOPS_WAZUH_DASHBOARD_CREDENTIALS_FILE or AEGISOPS_WAZUH_DASHBOARD_CREDENTIALS_OPENBAO_PATH
+  wazuh_ingest_shared_secret: AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE or AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH
+default_credential_policy:
+  posture: reject
+  examples_blocked:
+    - admin:admin
+    - wazuh:wazuh
+    - wazuh:wazuh123
+    - wazuh:SecretPassword
+placeholder_credential_policy:
+  posture: reject
+  examples_blocked:
+    - changeme
+    - change-me
+    - password
+    - Password123
+    - secret
+    - sample
+    - example
+    - fake
+    - dummy
+    - todo
+committed_secret_policy:
+  posture: reject-resolved-values
+  allowed_tracked_values: reference names, documented env vars, file bindings, OpenBao bindings, and placeholder-safe angle-bracket references only
+rotation_guidance:
+  posture: rotate-custody-references-only
+  required_scope:
+    - Wazuh API credentials
+    - Wazuh indexer admin credentials
+    - Wazuh dashboard credentials
+    - Wazuh ingest shared secret
+  evidence: reviewer, rotation window, rollback owner, reload or restart evidence, and AegisOps handoff record when applicable
+  raw_secret_values_allowed: false

--- a/docs/deployment/wazuh-certificate-credential-contract.md
+++ b/docs/deployment/wazuh-certificate-credential-contract.md
@@ -1,0 +1,113 @@
+# Phase 53.2 Wazuh Certificate And Credential Handling Contract
+
+- **Status**: Accepted contract
+- **Date**: 2026-05-03
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/deployment/wazuh-smb-single-node-profile-contract.md`, `docs/deployment/env-secrets-certs-contract.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1135, #1136, #1137
+
+This contract defines Wazuh certificate generation-wrapper posture, credential custody expectations, default-credential rejection, rotation guidance, and fail-closed secret validation for the `smb-single-node` Wazuh product profile.
+
+It does not implement live certificate generation, secret backend integration, production credential provisioning, Wazuh intake binding, source-health projection, upgrade automation, fleet-scale Wazuh management, Shuffle profile work, release-candidate behavior, general-availability behavior, or runtime behavior.
+
+The required structured artifact is `docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml`.
+
+## 1. Purpose
+
+Phase 53.2 makes the Wazuh product-profile certificate and credential posture enforceable before later setup or source-health work can rely on it.
+
+The contract covers Wazuh manager API TLS, indexer TLS, indexer admin client certificate, dashboard TLS, dashboard indexer client certificate, Wazuh ingest shared secret custody, Wazuh API credential custody, Wazuh indexer admin credential custody, and Wazuh dashboard credential custody.
+
+## 2. Authority Boundary
+
+Wazuh is a subordinate detection substrate. Wazuh certificate state, Wazuh credential state, Wazuh manager state, Wazuh indexer state, Wazuh dashboard state, generated Wazuh config, Wazuh alerts, Wazuh rule state, verifier output, issue-lint output, operator-facing status text, and setup evidence are not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. The Wazuh certificate and credential contract must preserve the rule that placeholders, sample credentials, fake secrets, TODO values, generated demo certificates, Wazuh status, Wazuh certificate state, Wazuh credential state, ticket state, AI output, browser state, UI cache, optional evidence, and downstream receipt state cannot become AegisOps production truth or mutate AegisOps records.
+
+## 3. Certificate Handling Contract
+
+The Wazuh certificate generation wrapper may generate demo or local rehearsal material only when demo mode is explicit.
+
+Generated demo certificate material must be written to ignored or untracked certificate custody paths, must be labeled demo-only, and must not satisfy production TLS custody.
+
+TLS-ready Wazuh profile validation must require certificate path references for:
+
+- `wazuh-manager-api-tls-chain-ref`
+- `wazuh-manager-api-tls-private-key-ref`
+- `wazuh-indexer-tls-chain-ref`
+- `wazuh-indexer-tls-private-key-ref`
+- `wazuh-indexer-admin-client-cert-ref`
+- `wazuh-dashboard-tls-chain-ref`
+- `wazuh-dashboard-tls-private-key-ref`
+- `wazuh-dashboard-indexer-client-cert-ref`
+
+Certificate path references must be documented env vars, reviewed file bindings, reviewed OpenBao bindings, or explicit placeholders such as `<wazuh-cert-chain-ref>`, `<wazuh-private-key-ref>`, and `<wazuh-client-cert-ref>`. Certificate path existence, generated demo certificate presence, self-signed local material, or Wazuh dashboard status is not production truth.
+
+## 4. Credential Handling Contract
+
+Wazuh credentials must be supplied through reviewed file bindings or reviewed OpenBao bindings. Inline secrets, committed values, copied comments, generated examples, default credentials, sample credentials, placeholder values, fake values, TODO values, unsigned tokens, guessed scope, raw forwarded headers, or inferred tenant/source linkage are invalid.
+
+Default Wazuh credentials must fail validation. The blocked default credential class includes `admin:admin`, `wazuh:wazuh`, `wazuh:wazuh123`, `wazuh:SecretPassword`, and any documented upstream default reused as trusted setup state.
+
+Placeholder credentials must fail validation. The blocked placeholder class includes `changeme`, `change-me`, `password`, `Password123`, `secret`, `sample`, `example`, `fake`, `dummy`, `todo`, and `set-trusted-secret-ref` when treated as a resolved value instead of a required placeholder guard.
+
+Committed live secret-looking values must fail validation. Tracked Wazuh profile artifacts may contain secret reference names, env var names, file-binding names, OpenBao binding names, and placeholder-safe `<...>` references only; they must not contain resolved passwords, bearer tokens, API keys, private keys, certificate private-key material, or customer-specific credential values.
+
+## 5. Rotation Guidance
+
+Rotation must replace Wazuh API, indexer admin, dashboard, and ingest shared-secret custody references without committing the old or new secret value.
+
+Rotation evidence must identify the rotated custody reference, reviewer, rotation window, rollback owner, reload or restart evidence, and AegisOps handoff record when applicable. The evidence may cite references and hashes approved for disclosure, but must not include raw secret values or private-key material.
+
+Rotation must not treat Wazuh dashboard state, Wazuh manager state, Wazuh indexer state, generated config, verifier output, or issue-lint output as AegisOps production truth, release truth, gate truth, workflow truth, reconciliation truth, approval truth, execution truth, or closeout truth.
+
+## 6. Validation Rules
+
+Wazuh certificate and credential validation must fail closed when:
+
+- `docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml` is missing;
+- the contract document is missing;
+- certificate generation-wrapper posture is missing;
+- TLS-ready certificate path references are missing;
+- Wazuh API, indexer admin, dashboard, or ingest shared-secret custody references are missing;
+- default Wazuh credentials are accepted;
+- placeholder, sample, fake, TODO, unsigned, inline, or committed secret-looking values are accepted;
+- private-key material appears in tracked Wazuh profile contract artifacts;
+- rotation guidance is missing;
+- Wazuh certificate or credential state is described as AegisOps workflow truth, production truth, release truth, gate truth, closeout truth, approval truth, execution truth, or reconciliation truth; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<supervisor-config-path>`, `<codex-supervisor-root>`, `<wazuh-cert-chain-ref>`, and `<wazuh-secret-ref>`.
+
+## 7. Forbidden Claims
+
+- Wazuh credential state is AegisOps production truth.
+- Wazuh certificate state is AegisOps gate truth.
+- Generated Wazuh certificates are production truth.
+- Default Wazuh credentials are valid credentials.
+- Placeholder Wazuh secrets are valid credentials.
+- Committed Wazuh secret-looking values are acceptable.
+- Raw forwarded headers are trusted identity.
+- Phase 53.2 implements live certificate generation.
+- Phase 53.2 implements secret backend integration.
+- Phase 53.2 implements Wazuh source-health projection.
+- Phase 53.2 implements Wazuh intake binding.
+- Phase 53.2 implements Shuffle product profiles.
+- Phase 53.2 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh`.
+
+Run `bash scripts/test-verify-phase-53-2-wazuh-cert-credential-contract.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1137 --config <supervisor-config-path>`.
+
+The verifier must fail when the Wazuh certificate and credential contract or structured artifact is missing, when TLS-ready certificate path references are missing, when default credentials are present, when placeholder credentials are present, when committed secret-looking values or private-key material appear, when rotation guidance is missing, when Wazuh substrate state is promoted into AegisOps authority, or when publishable guidance uses workstation-local absolute paths.
+
+## 9. Non-Goals
+
+- No live certificate generation, secret backend integration, production credential provisioning, Wazuh intake binding, source-health projection, upgrade automation, fleet-scale Wazuh management, Shuffle profile work, release-candidate behavior, general-availability behavior, or runtime behavior is implemented here.
+- No live secret, customer-specific value, private key, certificate material, bearer token, API key, password, env file, generated config, generated certificate, generated secret, Wazuh manager state, Wazuh indexer state, Wazuh dashboard state, Wazuh alert, Wazuh credential state, Wazuh certificate state, verifier output, issue-lint output, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-53-2-wazuh-cert-credential-contract.sh
+++ b/scripts/test-verify-phase-53-2-wazuh-cert-credential-contract.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/profiles/smb-single-node/wazuh"
+  printf '%s\n' "# AegisOps" "See [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/wazuh-certificate-credential-contract.md" \
+    "${target}/docs/deployment/wazuh-certificate-credential-contract.md"
+  cp "${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml" \
+    "${target}/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/wazuh-certificate-credential-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/wazuh-certificate-credential-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 53.2 Wazuh certificate and credential contract"
+
+missing_artifact_repo="${workdir}/missing-artifact"
+create_valid_repo "${missing_artifact_repo}"
+rm "${missing_artifact_repo}/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml"
+assert_fails_with \
+  "${missing_artifact_repo}" \
+  "Missing Phase 53.2 Wazuh certificate and credential artifact"
+
+missing_wrapper_repo="${workdir}/missing-wrapper"
+create_valid_repo "${missing_wrapper_repo}"
+remove_text_from_contract "${missing_wrapper_repo}" \
+  "The Wazuh certificate generation wrapper may generate demo or local rehearsal material only when demo mode is explicit."
+assert_fails_with \
+  "${missing_wrapper_repo}" \
+  "Missing Phase 53.2 Wazuh certificate and credential contract statement"
+
+missing_cert_paths_repo="${workdir}/missing-cert-paths"
+create_valid_repo "${missing_cert_paths_repo}"
+perl -0pi -e 's/\ncertificate_paths:\n(?:  - .+\n)+/\n/' \
+  "${missing_cert_paths_repo}/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml"
+assert_fails_with \
+  "${missing_cert_paths_repo}" \
+  "Missing Phase 53.2 Wazuh certificate path expectation"
+
+default_credentials_repo="${workdir}/default-credentials"
+create_valid_repo "${default_credentials_repo}"
+printf '%s\n' "default_credentials: admin:admin" \
+  >>"${default_credentials_repo}/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml"
+assert_fails_with \
+  "${default_credentials_repo}" \
+  "Forbidden Phase 53.2 Wazuh credential value: default Wazuh credential detected"
+
+placeholder_secret_repo="${workdir}/placeholder-secret"
+create_valid_repo "${placeholder_secret_repo}"
+printf '%s\n' "placeholder_secret: changeme" \
+  >>"${placeholder_secret_repo}/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml"
+assert_fails_with \
+  "${placeholder_secret_repo}" \
+  "Forbidden Phase 53.2 Wazuh credential value: placeholder secret detected"
+
+secret_looking_value_repo="${workdir}/secret-looking-value"
+create_valid_repo "${secret_looking_value_repo}"
+printf '%s\n' "wazuh_api_password: CorrectHorseBatteryStaple42" \
+  >>"${secret_looking_value_repo}/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml"
+assert_fails_with \
+  "${secret_looking_value_repo}" \
+  "Forbidden Phase 53.2 Wazuh credential value: committed secret-looking value detected"
+
+private_key_repo="${workdir}/private-key"
+create_valid_repo "${private_key_repo}"
+printf '%s\n' "-----BEGIN PRIVATE KEY-----" \
+  >>"${private_key_repo}/docs/deployment/wazuh-certificate-credential-contract.md"
+assert_fails_with \
+  "${private_key_repo}" \
+  "Forbidden Phase 53.2 Wazuh credential value: committed private key material detected"
+
+missing_rotation_repo="${workdir}/missing-rotation"
+create_valid_repo "${missing_rotation_repo}"
+remove_text_from_contract "${missing_rotation_repo}" \
+  "Rotation must replace Wazuh API, indexer admin, dashboard, and ingest shared-secret custody references without committing the old or new secret value."
+assert_fails_with \
+  "${missing_rotation_repo}" \
+  "Missing Phase 53.2 Wazuh certificate and credential contract statement"
+
+authority_truth_repo="${workdir}/authority-truth"
+create_valid_repo "${authority_truth_repo}"
+printf '%s\n' "Wazuh credential state is AegisOps production truth." \
+  >>"${authority_truth_repo}/docs/deployment/wazuh-certificate-credential-contract.md"
+assert_fails_with \
+  "${authority_truth_repo}" \
+  "Forbidden Phase 53.2 Wazuh certificate and credential claim: Wazuh credential state is AegisOps production truth"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/wazuh-certificate-credential-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 53.2 Wazuh certificate and credential contract: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 53.2 Wazuh certificate and credential contract."
+
+echo "Phase 53.2 Wazuh certificate and credential contract verifier tests passed."

--- a/scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh
+++ b/scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+contract_path="${repo_root}/docs/deployment/wazuh-certificate-credential-contract.md"
+artifact_path="${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 53.2 Wazuh Certificate And Credential Handling Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Certificate Handling Contract"
+  "## 4. Credential Handling Contract"
+  "## 5. Rotation Guidance"
+  "## 6. Validation Rules"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted contract"
+  "- **Date**: 2026-05-03"
+  "- **Related Issues**: #1135, #1136, #1137"
+  "This contract defines Wazuh certificate generation-wrapper posture, credential custody expectations, default-credential rejection, rotation guidance, and fail-closed secret validation for the \`smb-single-node\` Wazuh product profile."
+  "The required structured artifact is \`docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml\`."
+  "Wazuh is a subordinate detection substrate."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth."
+  "This contract cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`."
+  "The Wazuh certificate generation wrapper may generate demo or local rehearsal material only when demo mode is explicit."
+  "TLS-ready Wazuh profile validation must require certificate path references for:"
+  "Wazuh credentials must be supplied through reviewed file bindings or reviewed OpenBao bindings."
+  "Default Wazuh credentials must fail validation."
+  "Placeholder credentials must fail validation."
+  "Committed live secret-looking values must fail validation."
+  "Rotation must replace Wazuh API, indexer admin, dashboard, and ingest shared-secret custody references without committing the old or new secret value."
+  "Run \`bash scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh\`."
+  "Run \`bash scripts/test-verify-phase-53-2-wazuh-cert-credential-contract.sh\`."
+  "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1137 --config <supervisor-config-path>\`."
+)
+
+required_artifact_terms=(
+  "profile_id: smb-single-node"
+  "product_profile: wazuh"
+  "certificate_credential_contract_version: 2026-05-03"
+  "tls_ready_profile: true"
+  "certificate_generation_wrapper:"
+  "demo_mode_required: true"
+  "production_truth: false"
+  "credential_custody:"
+  "wazuh_api_credentials: AEGISOPS_WAZUH_API_CREDENTIALS_FILE or AEGISOPS_WAZUH_API_CREDENTIALS_OPENBAO_PATH"
+  "wazuh_indexer_admin_credentials: AEGISOPS_WAZUH_INDEXER_ADMIN_CREDENTIALS_FILE or AEGISOPS_WAZUH_INDEXER_ADMIN_CREDENTIALS_OPENBAO_PATH"
+  "wazuh_dashboard_credentials: AEGISOPS_WAZUH_DASHBOARD_CREDENTIALS_FILE or AEGISOPS_WAZUH_DASHBOARD_CREDENTIALS_OPENBAO_PATH"
+  "wazuh_ingest_shared_secret: AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE or AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH"
+  "default_credential_policy:"
+  "placeholder_credential_policy:"
+  "committed_secret_policy:"
+  "rotation_guidance:"
+  "raw_secret_values_allowed: false"
+)
+
+required_certificate_paths=(
+  "wazuh-manager-api-tls-chain-ref"
+  "wazuh-manager-api-tls-private-key-ref"
+  "wazuh-indexer-tls-chain-ref"
+  "wazuh-indexer-tls-private-key-ref"
+  "wazuh-indexer-admin-client-cert-ref"
+  "wazuh-dashboard-tls-chain-ref"
+  "wazuh-dashboard-tls-private-key-ref"
+  "wazuh-dashboard-indexer-client-cert-ref"
+)
+
+forbidden_claims=(
+  "Wazuh credential state is AegisOps production truth"
+  "Wazuh certificate state is AegisOps gate truth"
+  "Generated Wazuh certificates are production truth"
+  "Default Wazuh credentials are valid credentials"
+  "Placeholder Wazuh secrets are valid credentials"
+  "Committed Wazuh secret-looking values are acceptable"
+  "Raw forwarded headers are trusted identity"
+  "Phase 53.2 implements live certificate generation"
+  "Phase 53.2 implements secret backend integration"
+  "Phase 53.2 implements Wazuh source-health projection"
+  "Phase 53.2 implements Wazuh intake binding"
+  "Phase 53.2 implements Shuffle product profiles"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${contract_path}" ]]; then
+  echo "Missing Phase 53.2 Wazuh certificate and credential contract: ${contract_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${artifact_path}" ]]; then
+  echo "Missing Phase 53.2 Wazuh certificate and credential artifact: ${artifact_path}" >&2
+  exit 1
+fi
+
+contract_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${contract_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.2 Wazuh certificate and credential contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.2 Wazuh certificate and credential contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for term in "${required_artifact_terms[@]}"; do
+  if ! grep -Fq -- "${term}" "${artifact_path}"; then
+    echo "Missing Phase 53.2 Wazuh certificate and credential artifact term: ${term}" >&2
+    exit 1
+  fi
+done
+
+for certificate_path in "${required_certificate_paths[@]}"; do
+  if ! grep -Fq -- "- ${certificate_path}" "${artifact_path}"; then
+    echo "Missing Phase 53.2 Wazuh certificate path expectation: ${certificate_path}" >&2
+    exit 1
+  fi
+done
+
+if ! awk '
+  /^certificate_paths:/ { in_paths = 1; count = 0; next }
+  /^[a-z_]+:/ && in_paths { in_paths = 0 }
+  in_paths && /^  - [^[:space:]]/ { count++ }
+  END { exit(count >= 8 ? 0 : 1) }
+' "${artifact_path}"; then
+  echo "Missing Phase 53.2 Wazuh certificate path expectation: TLS-ready profile requires certificate path references" >&2
+  exit 1
+fi
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 53.2 Wazuh certificate and credential claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if grep -Eiq '(^|[^[:alnum:]_-])(admin:admin|wazuh:wazuh|wazuh:wazuh123|wazuh:SecretPassword)([^[:alnum:]_-]|$)' "${contract_path}" "${artifact_path}"; then
+  if grep -Eiq '^[[:space:]]*(default_credentials|wazuh_api_password|wazuh_password|password|credential|secret)[[:space:]]*:[[:space:]]*(admin:admin|wazuh:wazuh|wazuh:wazuh123|wazuh:SecretPassword)' "${artifact_path}"; then
+    echo "Forbidden Phase 53.2 Wazuh credential value: default Wazuh credential detected" >&2
+    exit 1
+  fi
+fi
+
+if grep -Eiq '^[[:space:]]*([a-z0-9_-]*_)?(password|secret|credential|token|api_key|placeholder_secret)[[:space:]]*:[[:space:]]*(changeme|change-me|password|Password123|secret|sample|example|fake|dummy|todo)([[:space:]]*$|[^[:alnum:]_-])' "${artifact_path}"; then
+  echo "Forbidden Phase 53.2 Wazuh credential value: placeholder secret detected" >&2
+  exit 1
+fi
+
+if grep -Eq -- '-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----' "${contract_path}" "${artifact_path}"; then
+  echo "Forbidden Phase 53.2 Wazuh credential value: committed private key material detected" >&2
+  exit 1
+fi
+
+if awk '
+  BEGIN { found = 0 }
+  /^[[:space:]]*([a-z0-9_-]*_)?(password|secret|token|api_key|private_key)[[:space:]]*:/ {
+    value = $0
+    sub(/^[^:]+:[[:space:]]*/, "", value)
+    if (length(value) >= 12 && value !~ /^(AEGISOPS_|<|\$\{)/) {
+      found = 1
+    }
+  }
+  END { exit(found ? 0 : 1) }
+' "${artifact_path}"; then
+  echo "Forbidden Phase 53.2 Wazuh credential value: committed secret-looking value detected" >&2
+  exit 1
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${contract_path}" "${artifact_path}"; then
+  echo "Forbidden Phase 53.2 Wazuh certificate and credential contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 53.2 Wazuh certificate and credential contract link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/wazuh-certificate-credential-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 53.2 Wazuh certificate and credential contract." >&2
+  exit 1
+fi
+
+echo "Phase 53.2 Wazuh certificate and credential contract is present and rejects default credentials, placeholders, missing TLS certificate paths, committed secret-looking values, private keys, and authority-boundary overclaims."


### PR DESCRIPTION
## Summary
- Adds the Phase 53.2 Wazuh certificate and credential handling contract.
- Adds a structured Wazuh certificate/credential contract artifact for TLS paths, credential custody, default/placeholder rejection, committed-secret rejection, and rotation guidance.
- Adds focused verifier and negative fixture suite for the contract, plus README links.

## Verification
- `bash scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh`
- `bash scripts/test-verify-phase-53-2-wazuh-cert-credential-contract.sh`
- `bash scripts/test-verify-phase-53-1-wazuh-profile-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node dist/index.js issue-lint 1137 --config supervisor.config.aegisops.json`

Closes #1137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 53.2 Wazuh certificate and credential contract specifications and enforcement guidelines for secure credential handling.

* **New Features**
  * Added smb-single-node deployment profile configuration with built-in certificate and credential management support for Wazuh infrastructure.

* **Tests**
  * Added verification and validation scripts for Phase 53.2 contract compliance and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->