### PR TITLE
Phase 53.3 Wazuh intake binding contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Canonical cross-phase boundary reference:
 - [Phase 52.7 closeout evaluation](docs/phase-52-7-closeout-evaluation.md) records the Phase 52.7 namespace normalization outcomes, root owner reduction, compatibility behavior, namespace/path guardrails, verifier results, and bounded Phase 53 readiness recommendation.
 - [Phase 53.1 Wazuh profile contract](docs/deployment/wazuh-smb-single-node-profile-contract.md) defines the `smb-single-node` Wazuh manager, indexer, dashboard, resource, port, volume, certificate, and pinned-version expectations.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
+- [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 
 ## Product positioning
 
@@ -85,6 +86,8 @@ The Phase 52.7 namespace normalization closeout is defined by the [Phase 52.7 cl
 The Phase 53.1 Wazuh profile contract is defined by the [Phase 53.1 Wazuh profile contract](docs/deployment/wazuh-smb-single-node-profile-contract.md).
 
 The Phase 53.2 Wazuh certificate and credential contract is defined by the [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md).
+
+The Phase 53.3 Wazuh intake binding contract is defined by the [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml
+++ b/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml
@@ -1,0 +1,48 @@
+profile_id: smb-single-node
+product_profile: wazuh
+profile_contract_version: 2026-05-03
+intake_binding_contract_version: 2026-05-03
+status: accepted-contract
+related_issues:
+  - 1135
+  - 1136
+  - 1137
+  - 1138
+authority_boundary: Wazuh-origin input remains subordinate candidate analytic-signal context until AegisOps admits it and links it to an AegisOps-owned record; Wazuh manager, indexer, dashboard, alert, rule, timestamp, webhook acknowledgement, generated config, and forwarded headers cannot close, approve, execute, reconcile, release, gate, or mutate authoritative AegisOps records.
+intake_url: /intake/wazuh
+proxy_route: aegisops-proxy:/intake/wazuh -> aegisops-control-plane:/intake/wazuh
+manager_delivery: reviewed-proxy-only
+shared_secret_custody: AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE or AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH
+raw_secret_values_allowed: false
+forwarded_headers_trusted: false
+source_linkage_inference_allowed: false
+admission_posture: candidate-analytic-signal-until-aegisops-admission-and-linkage
+pre_admission_authority: false
+provenance_fields:
+  - source_family
+  - source_system
+  - source_component
+  - source_id
+  - event_id
+  - event_timestamp
+  - wazuh_manager_id
+  - wazuh_rule_id
+  - wazuh_rule_level
+  - ingest_channel
+  - admission_channel
+  - secret_custody_reference
+  - proxy_route
+  - reviewed_by
+negative_admission_tests:
+  - missing_intake_url
+  - missing_secret_custody_reference
+  - missing_wazuh_provenance_fields
+  - raw_forwarded_headers_trusted
+  - inferred_source_linkage
+  - pre_admission_case_truth
+  - webhook_acknowledgement_as_reconciliation_truth
+admission_result:
+  admitted_record_owner: aegisops-control-plane
+  subordinate_payload_preservation: required
+  alert_case_evidence_authority: aegisops-record-chain-only
+  direct_wazuh_to_shuffle_shortcut_allowed: false

--- a/docs/deployment/wazuh-manager-intake-binding-contract.md
+++ b/docs/deployment/wazuh-manager-intake-binding-contract.md
@@ -1,0 +1,121 @@
+# Phase 53.3 Wazuh Manager Intake Binding Contract
+
+- **Status**: Accepted contract
+- **Date**: 2026-05-03
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/deployment/wazuh-smb-single-node-profile-contract.md`, `docs/deployment/wazuh-certificate-credential-contract.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1135, #1136, #1137, #1138
+
+This contract defines the Wazuh manager-to-AegisOps intake URL binding, shared-secret custody reference, reviewed proxy binding, required provenance fields, and analytic-signal admission posture for the `smb-single-node` Wazuh product profile.
+
+It does not implement source-health projection, Wazuh upgrade automation, fleet-scale Wazuh management, Shuffle product profiles, release-candidate behavior, general-availability behavior, or runtime behavior beyond the reviewed intake-binding contract surface.
+
+The required structured artifact is `docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml`.
+
+## 1. Purpose
+
+Phase 53.3 makes the Wazuh manager-to-AegisOps intake binding enforceable before later Wazuh profile setup, source-health, or live clean-host work can rely on Wazuh-origin events.
+
+The contract covers the reviewed intake URL, proxy route, manager delivery posture, shared-secret custody reference, required provenance fields, and the rule that Wazuh-origin input remains a candidate analytic signal until AegisOps admission and linkage.
+
+## 2. Authority Boundary
+
+Wazuh is a subordinate detection substrate. Wazuh manager state, Wazuh dashboard state, Wazuh indexer state, Wazuh alert state, Wazuh rule state, Wazuh timestamp state, webhook acknowledgement, generated Wazuh config, verifier output, issue-lint output, operator-facing status text, and setup evidence are not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, source, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. The Wazuh intake binding must preserve the rule that Wazuh alert, manager, decoder, rule, status, timestamp, webhook acknowledgement, raw forwarded header, placeholder secret, inferred source linkage, ticket, AI, browser, UI cache, optional evidence, and downstream receipt state cannot become AegisOps truth or mutate AegisOps records without explicit AegisOps admission and linkage.
+
+## 3. Intake Binding Contract
+
+The reviewed AegisOps intake URL is `/intake/wazuh`.
+
+The reviewed proxy route binding is `aegisops-proxy:/intake/wazuh -> aegisops-control-plane:/intake/wazuh`.
+
+The Wazuh manager must send alerts to AegisOps through the reviewed proxy route only.
+
+The shared-secret custody reference must be `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE` or `AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH`.
+
+Raw shared-secret values, placeholder secrets, sample secrets, fake values, TODO values, unsigned tokens, raw forwarded headers, or inferred source linkage must fail validation.
+
+The reviewed binding is a contract for the `smb-single-node` Wazuh product profile. It does not authorize direct Wazuh-to-Shuffle shortcuts, direct Wazuh Active Response as an authority path, Wazuh dashboard status as workflow truth, or Wazuh alert status as case truth.
+
+## 4. Required Provenance Fields
+
+Wazuh-origin events must carry explicit provenance before AegisOps admission can treat them as candidate analytic signals:
+
+- `source_family`
+- `source_system`
+- `source_component`
+- `source_id`
+- `event_id`
+- `event_timestamp`
+- `wazuh_manager_id`
+- `wazuh_rule_id`
+- `wazuh_rule_level`
+- `ingest_channel`
+- `admission_channel`
+- `secret_custody_reference`
+- `proxy_route`
+- `reviewed_by`
+
+The required provenance must be explicit. It must not be inferred from hostnames, URL paths, nearby comments, dashboard names, manager names, forwarded headers, tenant hints, or issue text.
+
+## 5. Analytic-Signal Admission
+
+Wazuh-origin input remains a candidate analytic signal until AegisOps admits it and links it to an AegisOps record.
+
+A Wazuh alert, manager status, dashboard status, rule state, timestamp, or webhook acknowledgement must not be treated as case, alert, reconciliation, release, gate, closeout, or source truth before AegisOps admission and linkage.
+
+Admission must fail closed when the intake URL, shared-secret custody reference, reviewed proxy binding, or required provenance fields are missing, malformed, placeholder-backed, unsigned, inferred, forwarded-header-derived, or otherwise untrusted.
+
+Admission may produce or link an AegisOps analytic signal only after the reviewed AegisOps boundary validates the binding and preserves the Wazuh payload as subordinate evidence. Later alert, case, evidence, approval, action, execution, and reconciliation records must still come from AegisOps-owned records.
+
+## 6. Validation Rules
+
+Wazuh intake binding validation must fail closed when:
+
+- `docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml` is missing;
+- the contract document is missing;
+- the reviewed intake URL is missing or placeholder-backed;
+- the reviewed proxy route binding is missing;
+- the manager delivery posture is not reviewed-proxy-only;
+- the shared-secret custody reference is missing or replaced by a raw secret, placeholder, sample, fake value, TODO value, unsigned token, inline secret, or committed secret-looking value;
+- required provenance fields are missing;
+- raw forwarded headers or inferred source linkage are treated as trusted input;
+- Wazuh-origin input is promoted into AegisOps authority before admission and linkage;
+- Wazuh manager, dashboard, indexer, alert, rule, timestamp, webhook, generated-config, verifier, or issue-lint state is described as AegisOps workflow, production, release, gate, closeout, source, approval, execution, or reconciliation truth; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<supervisor-config-path>`, `<codex-supervisor-root>`, `<wazuh-intake-url>`, and `<wazuh-secret-ref>`.
+
+## 7. Forbidden Claims
+
+- Wazuh-origin input is AegisOps case truth before admission.
+- Wazuh alert status is AegisOps case truth.
+- Wazuh manager state is AegisOps source truth.
+- Wazuh dashboard state is AegisOps workflow truth.
+- Webhook acknowledgement is AegisOps reconciliation truth.
+- Wazuh timestamp is AegisOps release truth.
+- Placeholder Wazuh intake secrets are valid credentials.
+- Raw forwarded headers are trusted identity.
+- Inferred Wazuh source linkage is valid admission.
+- Phase 53.3 implements Wazuh source-health projection.
+- Phase 53.3 implements Wazuh upgrade automation.
+- Phase 53.3 implements Shuffle product profiles.
+- Phase 53.3 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh`.
+
+Run `bash scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1138 --config <supervisor-config-path>`.
+
+The verifier must fail when the Wazuh intake binding contract or structured artifact is missing, when the intake URL is missing, when the shared-secret custody reference is missing, when required Wazuh provenance fields are missing, when raw secrets or committed secret-looking values appear, when forwarded headers or inferred linkage are trusted, when Wazuh-origin input is promoted into AegisOps authority before admission and linkage, or when publishable guidance uses workstation-local absolute paths.
+
+## 9. Non-Goals
+
+- No source-health projection, upgrade automation, fleet-scale Wazuh management, Shuffle profile work, release-candidate behavior, general-availability behavior, direct Wazuh-to-Shuffle shortcut, Wazuh Active Response authority path, or broad SIEM detector catalog is implemented here.
+- No live secret, customer-specific value, private key, bearer token, API key, password, env file, generated config, generated secret, Wazuh manager state, Wazuh indexer state, Wazuh dashboard state, Wazuh alert, Wazuh rule state, Wazuh timestamp, webhook acknowledgement, verifier output, issue-lint output, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh
+++ b/scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh
@@ -84,6 +84,14 @@ assert_fails_with \
   "${missing_intake_url_repo}" \
   "Missing Phase 53.3 Wazuh intake binding artifact term: intake_url: /intake/wazuh"
 
+commented_intake_url_repo="${workdir}/commented-intake-url"
+create_valid_repo "${commented_intake_url_repo}"
+perl -0pi -e 's/^intake_url: /# intake_url: /m' \
+  "${commented_intake_url_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${commented_intake_url_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding artifact term: intake_url: /intake/wazuh"
+
 missing_proxy_route_repo="${workdir}/missing-proxy-route"
 create_valid_repo "${missing_proxy_route_repo}"
 perl -0pi -e 's/^proxy_route: .+\n//m' \
@@ -124,6 +132,14 @@ assert_fails_with \
   "${missing_provenance_repo}" \
   "Missing Phase 53.3 Wazuh provenance field: wazuh_rule_id"
 
+commented_provenance_repo="${workdir}/commented-provenance"
+create_valid_repo "${commented_provenance_repo}"
+perl -0pi -e 's/^  - reviewed_by/  # - reviewed_by/m' \
+  "${commented_provenance_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${commented_provenance_repo}" \
+  "Missing Phase 53.3 Wazuh provenance field: reviewed_by"
+
 missing_source_linkage_guard_repo="${workdir}/missing-source-linkage-guard"
 create_valid_repo "${missing_source_linkage_guard_repo}"
 perl -0pi -e 's/^source_linkage_inference_allowed: false\n//m' \
@@ -147,6 +163,14 @@ remove_text_from_contract "${missing_admission_statement_repo}" \
 assert_fails_with \
   "${missing_admission_statement_repo}" \
   "Missing Phase 53.3 Wazuh intake binding contract statement"
+
+missing_forbidden_claim_repo="${workdir}/missing-forbidden-claim"
+create_valid_repo "${missing_forbidden_claim_repo}"
+remove_text_from_contract "${missing_forbidden_claim_repo}" \
+  "Phase 53.3 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness."
+assert_fails_with \
+  "${missing_forbidden_claim_repo}" \
+  "Missing Phase 53.3 Wazuh forbidden claim: Phase 53.3 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness"
 
 pre_admission_truth_repo="${workdir}/pre-admission-truth"
 create_valid_repo "${pre_admission_truth_repo}"

--- a/scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh
+++ b/scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh
@@ -124,6 +124,22 @@ assert_fails_with \
   "${missing_provenance_repo}" \
   "Missing Phase 53.3 Wazuh provenance field: wazuh_rule_id"
 
+missing_source_linkage_guard_repo="${workdir}/missing-source-linkage-guard"
+create_valid_repo "${missing_source_linkage_guard_repo}"
+perl -0pi -e 's/^source_linkage_inference_allowed: false\n//m' \
+  "${missing_source_linkage_guard_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${missing_source_linkage_guard_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding artifact term: source_linkage_inference_allowed: false"
+
+missing_direct_shuffle_guard_repo="${workdir}/missing-direct-shuffle-guard"
+create_valid_repo "${missing_direct_shuffle_guard_repo}"
+perl -0pi -e 's/^  direct_wazuh_to_shuffle_shortcut_allowed: false\n//m' \
+  "${missing_direct_shuffle_guard_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${missing_direct_shuffle_guard_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding artifact term: direct_wazuh_to_shuffle_shortcut_allowed: false"
+
 missing_admission_statement_repo="${workdir}/missing-admission-statement"
 create_valid_repo "${missing_admission_statement_repo}"
 remove_text_from_contract "${missing_admission_statement_repo}" \

--- a/scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh
+++ b/scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh
@@ -106,7 +106,7 @@ perl -0pi -e 's/^shared_secret_custody: .+$/shared_secret_custody: /m' \
   "${missing_secret_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
 assert_fails_with \
   "${missing_secret_repo}" \
-  "Missing Phase 53.3 Wazuh intake binding artifact term: shared_secret_custody"
+  "Forbidden Phase 53.3 Wazuh intake binding artifact: missing secret custody reference"
 
 placeholder_secret_repo="${workdir}/placeholder-secret"
 create_valid_repo "${placeholder_secret_repo}"
@@ -114,7 +114,7 @@ perl -0pi -e 's/^shared_secret_custody: .+$/shared_secret_custody: changeme/m' \
   "${placeholder_secret_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
 assert_fails_with \
   "${placeholder_secret_repo}" \
-  "Missing Phase 53.3 Wazuh intake binding artifact term: shared_secret_custody"
+  "Forbidden Phase 53.3 Wazuh intake binding artifact: missing secret custody reference"
 
 secret_looking_value_repo="${workdir}/secret-looking-value"
 create_valid_repo "${secret_looking_value_repo}"

--- a/scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh
+++ b/scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/profiles/smb-single-node/wazuh"
+  printf '%s\n' "# AegisOps" "See [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/wazuh-manager-intake-binding-contract.md" \
+    "${target}/docs/deployment/wazuh-manager-intake-binding-contract.md"
+  cp "${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml" \
+    "${target}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/wazuh-manager-intake-binding-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/wazuh-manager-intake-binding-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding contract"
+
+missing_artifact_repo="${workdir}/missing-artifact"
+create_valid_repo "${missing_artifact_repo}"
+rm "${missing_artifact_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${missing_artifact_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding artifact"
+
+missing_intake_url_repo="${workdir}/missing-intake-url"
+create_valid_repo "${missing_intake_url_repo}"
+perl -0pi -e 's/^intake_url: .+$/intake_url: /m' \
+  "${missing_intake_url_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${missing_intake_url_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding artifact term: intake_url: /intake/wazuh"
+
+missing_proxy_route_repo="${workdir}/missing-proxy-route"
+create_valid_repo "${missing_proxy_route_repo}"
+perl -0pi -e 's/^proxy_route: .+\n//m' \
+  "${missing_proxy_route_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${missing_proxy_route_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding artifact term: proxy_route"
+
+missing_secret_repo="${workdir}/missing-secret"
+create_valid_repo "${missing_secret_repo}"
+perl -0pi -e 's/^shared_secret_custody: .+$/shared_secret_custody: /m' \
+  "${missing_secret_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${missing_secret_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding artifact term: shared_secret_custody"
+
+placeholder_secret_repo="${workdir}/placeholder-secret"
+create_valid_repo "${placeholder_secret_repo}"
+perl -0pi -e 's/^shared_secret_custody: .+$/shared_secret_custody: changeme/m' \
+  "${placeholder_secret_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${placeholder_secret_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding artifact term: shared_secret_custody"
+
+secret_looking_value_repo="${workdir}/secret-looking-value"
+create_valid_repo "${secret_looking_value_repo}"
+printf '%s\n' "wazuh_intake_secret: CorrectHorseBatteryStaple42" \
+  >>"${secret_looking_value_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${secret_looking_value_repo}" \
+  "Forbidden Phase 53.3 Wazuh intake binding artifact: committed secret-looking value detected"
+
+missing_provenance_repo="${workdir}/missing-provenance"
+create_valid_repo "${missing_provenance_repo}"
+perl -0pi -e 's/^  - wazuh_rule_id\n//m' \
+  "${missing_provenance_repo}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+assert_fails_with \
+  "${missing_provenance_repo}" \
+  "Missing Phase 53.3 Wazuh provenance field: wazuh_rule_id"
+
+missing_admission_statement_repo="${workdir}/missing-admission-statement"
+create_valid_repo "${missing_admission_statement_repo}"
+remove_text_from_contract "${missing_admission_statement_repo}" \
+  "Wazuh-origin input remains a candidate analytic signal until AegisOps admits it and links it to an AegisOps record."
+assert_fails_with \
+  "${missing_admission_statement_repo}" \
+  "Missing Phase 53.3 Wazuh intake binding contract statement"
+
+pre_admission_truth_repo="${workdir}/pre-admission-truth"
+create_valid_repo "${pre_admission_truth_repo}"
+printf '%s\n' "Wazuh-origin input is AegisOps case truth before admission." \
+  >>"${pre_admission_truth_repo}/docs/deployment/wazuh-manager-intake-binding-contract.md"
+assert_fails_with \
+  "${pre_admission_truth_repo}" \
+  "Forbidden Phase 53.3 Wazuh intake binding claim: Wazuh-origin input is AegisOps case truth before admission"
+
+forwarded_header_repo="${workdir}/forwarded-header"
+create_valid_repo "${forwarded_header_repo}"
+printf '%s\n' "Raw forwarded headers are trusted identity." \
+  >>"${forwarded_header_repo}/docs/deployment/wazuh-manager-intake-binding-contract.md"
+assert_fails_with \
+  "${forwarded_header_repo}" \
+  "Forbidden Phase 53.3 Wazuh intake binding claim: Raw forwarded headers are trusted identity"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/wazuh-manager-intake-binding-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 53.3 Wazuh intake binding contract: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 53.3 Wazuh intake binding contract."
+
+echo "Phase 53.3 Wazuh intake binding contract verifier tests passed."

--- a/scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh
+++ b/scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh
@@ -154,6 +154,11 @@ has_uncommented_substring() {
   ' "${file_path}"
 }
 
+if grep -Eiq '^[[:space:]]*shared_secret_custody:[[:space:]]*($|<|todo|tbd|none|null|changeme|change-me|password|secret|sample|example|fake|dummy)' "${artifact_path}"; then
+  echo "Forbidden Phase 53.3 Wazuh intake binding artifact: missing secret custody reference" >&2
+  exit 1
+fi
+
 for term in "${required_artifact_terms[@]}"; do
   if ! has_uncommented_substring "${term}" "${artifact_path}"; then
     echo "Missing Phase 53.3 Wazuh intake binding artifact term: ${term}" >&2
@@ -184,11 +189,6 @@ fi
 
 if grep -Eiq '^[[:space:]]*intake_url:[[:space:]]*($|<|todo|tbd|none|null)' "${artifact_path}"; then
   echo "Forbidden Phase 53.3 Wazuh intake binding artifact: missing intake URL" >&2
-  exit 1
-fi
-
-if grep -Eiq '^[[:space:]]*shared_secret_custody:[[:space:]]*($|<|todo|tbd|none|null|changeme|change-me|password|secret|sample|example|fake|dummy)' "${artifact_path}"; then
-  echo "Forbidden Phase 53.3 Wazuh intake binding artifact: missing secret custody reference" >&2
   exit 1
 fi
 

--- a/scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh
+++ b/scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh
@@ -53,8 +53,10 @@ required_artifact_terms=(
   "shared_secret_custody: AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE or AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH"
   "raw_secret_values_allowed: false"
   "forwarded_headers_trusted: false"
+  "source_linkage_inference_allowed: false"
   "admission_posture: candidate-analytic-signal-until-aegisops-admission-and-linkage"
   "pre_admission_authority: false"
+  "direct_wazuh_to_shuffle_shortcut_allowed: false"
   "provenance_fields:"
   "negative_admission_tests:"
 )

--- a/scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh
+++ b/scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+contract_path="${repo_root}/docs/deployment/wazuh-manager-intake-binding-contract.md"
+artifact_path="${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 53.3 Wazuh Manager Intake Binding Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Intake Binding Contract"
+  "## 4. Required Provenance Fields"
+  "## 5. Analytic-Signal Admission"
+  "## 6. Validation Rules"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted contract"
+  "- **Date**: 2026-05-03"
+  "- **Related Issues**: #1135, #1136, #1137, #1138"
+  "This contract defines the Wazuh manager-to-AegisOps intake URL binding, shared-secret custody reference, reviewed proxy binding, required provenance fields, and analytic-signal admission posture for the \`smb-single-node\` Wazuh product profile."
+  "The required structured artifact is \`docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml\`."
+  "Wazuh is a subordinate detection substrate."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth."
+  "This contract cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`."
+  "The reviewed AegisOps intake URL is \`/intake/wazuh\`."
+  "The reviewed proxy route binding is \`aegisops-proxy:/intake/wazuh -> aegisops-control-plane:/intake/wazuh\`."
+  "The Wazuh manager must send alerts to AegisOps through the reviewed proxy route only."
+  "The shared-secret custody reference must be \`AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE\` or \`AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH\`."
+  "Raw shared-secret values, placeholder secrets, sample secrets, fake values, TODO values, unsigned tokens, raw forwarded headers, or inferred source linkage must fail validation."
+  "Wazuh-origin input remains a candidate analytic signal until AegisOps admits it and links it to an AegisOps record."
+  "A Wazuh alert, manager status, dashboard status, rule state, timestamp, or webhook acknowledgement must not be treated as case, alert, reconciliation, release, gate, closeout, or source truth before AegisOps admission and linkage."
+  "Run \`bash scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh\`."
+  "Run \`bash scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh\`."
+  "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1138 --config <supervisor-config-path>\`."
+)
+
+required_artifact_terms=(
+  "profile_id: smb-single-node"
+  "product_profile: wazuh"
+  "intake_binding_contract_version: 2026-05-03"
+  "status: accepted-contract"
+  "intake_url: /intake/wazuh"
+  "proxy_route: aegisops-proxy:/intake/wazuh -> aegisops-control-plane:/intake/wazuh"
+  "manager_delivery: reviewed-proxy-only"
+  "shared_secret_custody: AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE or AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH"
+  "raw_secret_values_allowed: false"
+  "forwarded_headers_trusted: false"
+  "admission_posture: candidate-analytic-signal-until-aegisops-admission-and-linkage"
+  "pre_admission_authority: false"
+  "provenance_fields:"
+  "negative_admission_tests:"
+)
+
+required_provenance_fields=(
+  "source_family"
+  "source_system"
+  "source_component"
+  "source_id"
+  "event_id"
+  "event_timestamp"
+  "wazuh_manager_id"
+  "wazuh_rule_id"
+  "wazuh_rule_level"
+  "ingest_channel"
+  "admission_channel"
+  "secret_custody_reference"
+  "proxy_route"
+  "reviewed_by"
+)
+
+forbidden_claims=(
+  "Wazuh-origin input is AegisOps case truth before admission"
+  "Wazuh alert status is AegisOps case truth"
+  "Wazuh manager state is AegisOps source truth"
+  "Wazuh dashboard state is AegisOps workflow truth"
+  "Webhook acknowledgement is AegisOps reconciliation truth"
+  "Wazuh timestamp is AegisOps release truth"
+  "Placeholder Wazuh intake secrets are valid credentials"
+  "Raw forwarded headers are trusted identity"
+  "Inferred Wazuh source linkage is valid admission"
+  "Phase 53.3 implements Wazuh source-health projection"
+  "Phase 53.3 implements Wazuh upgrade automation"
+  "Phase 53.3 implements Shuffle product profiles"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(\`\`\`|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${contract_path}" ]]; then
+  echo "Missing Phase 53.3 Wazuh intake binding contract: ${contract_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${artifact_path}" ]]; then
+  echo "Missing Phase 53.3 Wazuh intake binding artifact: ${artifact_path}" >&2
+  exit 1
+fi
+
+contract_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${contract_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.3 Wazuh intake binding contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.3 Wazuh intake binding contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for term in "${required_artifact_terms[@]}"; do
+  if ! grep -Fq -- "${term}" "${artifact_path}"; then
+    echo "Missing Phase 53.3 Wazuh intake binding artifact term: ${term}" >&2
+    exit 1
+  fi
+done
+
+for field in "${required_provenance_fields[@]}"; do
+  if ! grep -Fq -- "- ${field}" "${artifact_path}"; then
+    echo "Missing Phase 53.3 Wazuh provenance field: ${field}" >&2
+    exit 1
+  fi
+done
+
+if ! awk '
+  /^provenance_fields:/ { in_fields = 1; count = 0; next }
+  /^[a-z_]+:/ && in_fields { in_fields = 0 }
+  in_fields && /^  - [^[:space:]]/ { count++ }
+  END { exit(count >= 14 ? 0 : 1) }
+' "${artifact_path}"; then
+  echo "Missing Phase 53.3 Wazuh provenance field coverage: expected at least 14 required fields" >&2
+  exit 1
+fi
+
+if grep -Eiq '^[[:space:]]*intake_url:[[:space:]]*($|<|todo|tbd|none|null)' "${artifact_path}"; then
+  echo "Forbidden Phase 53.3 Wazuh intake binding artifact: missing intake URL" >&2
+  exit 1
+fi
+
+if grep -Eiq '^[[:space:]]*shared_secret_custody:[[:space:]]*($|<|todo|tbd|none|null|changeme|change-me|password|secret|sample|example|fake|dummy)' "${artifact_path}"; then
+  echo "Forbidden Phase 53.3 Wazuh intake binding artifact: missing secret custody reference" >&2
+  exit 1
+fi
+
+if awk '
+  BEGIN { found = 0 }
+  /^[[:space:]]*([a-z0-9_-]*_)?(password|secret|token|api_key)[[:space:]]*:/ {
+    value = $0
+    sub(/^[^:]+:[[:space:]]*/, "", value)
+    if (length(value) >= 12 && value !~ /^(AEGISOPS_|<|\$\{)/) {
+      found = 1
+    }
+  }
+  END { exit(found ? 0 : 1) }
+' "${artifact_path}"; then
+  echo "Forbidden Phase 53.3 Wazuh intake binding artifact: committed secret-looking value detected" >&2
+  exit 1
+fi
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 53.3 Wazuh intake binding claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${contract_path}" "${artifact_path}"; then
+  echo "Forbidden Phase 53.3 Wazuh intake binding contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 53.3 Wazuh intake binding contract link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | tr -d '\140'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/wazuh-manager-intake-binding-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 53.3 Wazuh intake binding contract." >&2
+  exit 1
+fi
+
+echo "Phase 53.3 Wazuh intake binding contract is present and rejects missing intake URL, missing secret custody, missing provenance, pre-admission authority, committed secrets, trusted forwarded headers, inferred source linkage, and workstation-local paths."

--- a/scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh
+++ b/scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh
@@ -91,6 +91,7 @@ forbidden_claims=(
   "Phase 53.3 implements Wazuh source-health projection"
   "Phase 53.3 implements Wazuh upgrade automation"
   "Phase 53.3 implements Shuffle product profiles"
+  "Phase 53.3 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness"
 )
 
 rendered_markdown_without_code_blocks() {
@@ -136,15 +137,36 @@ for phrase in "${required_phrases[@]}"; do
   fi
 done
 
+has_uncommented_substring() {
+  local needle="$1"
+  local file_path="$2"
+
+  awk -v needle="${needle}" '
+    /^[[:space:]]*#/ { next }
+    {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      if (index(line, needle)) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"
+}
+
 for term in "${required_artifact_terms[@]}"; do
-  if ! grep -Fq -- "${term}" "${artifact_path}"; then
+  if ! has_uncommented_substring "${term}" "${artifact_path}"; then
     echo "Missing Phase 53.3 Wazuh intake binding artifact term: ${term}" >&2
     exit 1
   fi
 done
 
 for field in "${required_provenance_fields[@]}"; do
-  if ! grep -Fq -- "- ${field}" "${artifact_path}"; then
+  if ! awk -v field="${field}" '
+    /^[[:space:]]*#/ { next }
+    $0 ~ ("^[[:space:]]*-[[:space:]]+" field "([[:space:]]*(#.*)?)?$") { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${artifact_path}"; then
     echo "Missing Phase 53.3 Wazuh provenance field: ${field}" >&2
     exit 1
   fi
@@ -197,7 +219,24 @@ contains_forbidden_outside_forbidden_section() {
   ' "${contract_path}"
 }
 
+contains_forbidden_claim_in_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
 for claim in "${forbidden_claims[@]}"; do
+  if ! contains_forbidden_claim_in_section "${claim}"; then
+    echo "Missing Phase 53.3 Wazuh forbidden claim: ${claim}" >&2
+    exit 1
+  fi
+
   if contains_forbidden_outside_forbidden_section "${claim}"; then
     echo "Forbidden Phase 53.3 Wazuh intake binding claim: ${claim}" >&2
     exit 1


### PR DESCRIPTION
## Summary
- Add the Phase 53.3 Wazuh manager-to-AegisOps intake binding contract.
- Add structured `intake-binding.yaml` with reviewed proxy route, secret custody reference, provenance fields, and fail-closed admission posture.
- Add focused verifier and negative fixture tests, plus README links.

## Verification
- `bash scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh`
- `bash scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash scripts/verify-phase-53-1-wazuh-profile-contract.sh`
- `bash scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh`
- `bash -n scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh`
- `git diff --check`
- `node dist/index.js issue-lint 1138 --config supervisor.config.aegisops.json` from `<codex-supervisor-root>`

Closes #1138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 53.3 Wazuh Manager Intake Binding Contract and updated README to reference it.

* **Configuration**
  * Added an SMB single-node Wazuh intake binding profile with intake URL, proxy routing, shared-secret custody, required provenance fields, admission posture, and negative admission cases.

* **Tests**
  * Added contract verification and test-harness scripts to validate the contract, artifact, negative failure cases, and README linkage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->