### PR TITLE
Phase 53.4: Add sample Wazuh detection fixture

### DIFF
--- a/control-plane/aegisops/control_plane/adapters/wazuh.py
+++ b/control-plane/aegisops/control_plane/adapters/wazuh.py
@@ -86,6 +86,7 @@ class WazuhAlertAdapter:
         "data.privilege.role",
     )
     required_wazuh_detection_provenance_fields: tuple[str, ...] = (
+        "product_profile",
         "source_system",
         "source_component",
         "source_id",
@@ -352,9 +353,11 @@ class WazuhAlertAdapter:
         if correlation_id is not None:
             provenance["correlation_id"] = correlation_id
         if source_family == "wazuh_detection":
-            product_profile = _optional_string(data.get("product_profile"))
-            if product_profile is not None:
-                profile["source"]["product_profile"] = product_profile
+            product_profile = _require_non_empty_string(
+                data.get("product_profile"),
+                "data.product_profile",
+            )
+            profile["source"]["product_profile"] = product_profile
             detection = self._build_wazuh_detection_profile(data)
             if detection is not None:
                 profile["detection"] = detection

--- a/control-plane/aegisops/control_plane/adapters/wazuh.py
+++ b/control-plane/aegisops/control_plane/adapters/wazuh.py
@@ -66,10 +66,39 @@ class WazuhAlertAdapter:
         "data.organization.name",
         "data.repository.id",
         "data.repository.full_name",
+        "data.product_profile",
+        "data.source_system",
+        "data.source_component",
+        "data.source_id",
+        "data.event_id",
+        "data.event_timestamp",
+        "data.wazuh_manager_id",
+        "data.wazuh_rule_id",
+        "data.wazuh_rule_level",
+        "data.ingest_channel",
+        "data.admission_channel",
+        "data.secret_custody_reference",
+        "data.proxy_route",
+        "data.reviewed_by",
         "data.privilege.change_type",
         "data.privilege.scope",
         "data.privilege.permission",
         "data.privilege.role",
+    )
+    required_wazuh_detection_provenance_fields: tuple[str, ...] = (
+        "source_system",
+        "source_component",
+        "source_id",
+        "event_id",
+        "event_timestamp",
+        "wazuh_manager_id",
+        "wazuh_rule_id",
+        "wazuh_rule_level",
+        "ingest_channel",
+        "admission_channel",
+        "secret_custody_reference",
+        "proxy_route",
+        "reviewed_by",
     )
 
     def build_native_detection_record(
@@ -247,11 +276,14 @@ class WazuhAlertAdapter:
 
         source_family = _optional_string(data.get("source_family"))
         if source_family not in {
+            "wazuh_detection",
             "github_audit",
             "microsoft_365_audit",
             "entra_id",
         }:
             return None
+        if source_family == "wazuh_detection":
+            self._require_wazuh_detection_provenance(data)
 
         actor = self._build_identity_entity(_optional_mapping(data.get("actor")))
         target = self._build_identity_entity(_optional_mapping(data.get("target")))
@@ -319,6 +351,34 @@ class WazuhAlertAdapter:
         correlation_id = _optional_string(data.get("correlation_id"))
         if correlation_id is not None:
             provenance["correlation_id"] = correlation_id
+        if source_family == "wazuh_detection":
+            product_profile = _optional_string(data.get("product_profile"))
+            if product_profile is not None:
+                profile["source"]["product_profile"] = product_profile
+            detection = self._build_wazuh_detection_profile(data)
+            if detection is not None:
+                profile["detection"] = detection
+            network = self._build_wazuh_network_profile(data)
+            if network is not None:
+                profile["network"] = network
+            for field_name in (
+                "source_system",
+                "source_component",
+                "source_id",
+                "event_id",
+                "event_timestamp",
+                "wazuh_manager_id",
+                "wazuh_rule_id",
+                "wazuh_rule_level",
+                "ingest_channel",
+                "admission_channel",
+                "secret_custody_reference",
+                "proxy_route",
+                "reviewed_by",
+            ):
+                value = _optional_string(data.get(field_name))
+                if value is not None:
+                    provenance[field_name] = value
         if actor is not None or target is not None:
             identity_profile: dict[str, object] = {}
             if actor is not None:
@@ -344,6 +404,65 @@ class WazuhAlertAdapter:
             profile["authentication"] = authentication
         if privilege is not None:
             profile["privilege"] = privilege
+        return profile
+
+    def _require_wazuh_detection_provenance(
+        self,
+        data: Mapping[str, object],
+    ) -> None:
+        for field_name in self.required_wazuh_detection_provenance_fields:
+            _require_non_empty_string(data.get(field_name), f"data.{field_name}")
+        source_system = _require_non_empty_string(
+            data.get("source_system"),
+            "data.source_system",
+        )
+        if source_system != self.substrate_key:
+            raise ValueError("data.source_system must be wazuh")
+        secret_custody_reference = _require_non_empty_string(
+            data.get("secret_custody_reference"),
+            "data.secret_custody_reference",
+        )
+        if secret_custody_reference not in {
+            "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE",
+            "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_OPENBAO_PATH",
+        }:
+            raise ValueError(
+                "data.secret_custody_reference must name a reviewed Wazuh "
+                "shared-secret custody binding"
+            )
+
+    @staticmethod
+    def _build_wazuh_detection_profile(
+        data: Mapping[str, object],
+    ) -> dict[str, object] | None:
+        profile: dict[str, object] = {}
+        for field_name in (
+            "event_id",
+            "event_timestamp",
+            "source_component",
+            "source_id",
+            "wazuh_manager_id",
+            "wazuh_rule_id",
+            "wazuh_rule_level",
+            "event_summary",
+        ):
+            value = _optional_string(data.get(field_name))
+            if value is not None:
+                profile[field_name] = value
+        if not profile:
+            return None
+        return profile
+
+    @staticmethod
+    def _build_wazuh_network_profile(
+        data: Mapping[str, object],
+    ) -> dict[str, object] | None:
+        profile: dict[str, object] = {}
+        source_ip = _optional_string(data.get("srcip"))
+        if source_ip is not None:
+            profile["source_ip"] = source_ip
+        if not profile:
+            return None
         return profile
 
     @staticmethod

--- a/control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-alert.json
+++ b/control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-alert.json
@@ -1,0 +1,61 @@
+{
+  "id": "1731595600.1112223",
+  "timestamp": "2026-05-03T09:15:00+00:00",
+  "rule": {
+    "id": "5710",
+    "level": 10,
+    "description": "Wazuh sample SSH authentication failure",
+    "groups": [
+      "sshd",
+      "authentication_failures"
+    ],
+    "mitre": {
+      "id": [
+        "T1110"
+      ],
+      "tactic": [
+        "Credential Access"
+      ],
+      "technique": [
+        "Brute Force"
+      ]
+    }
+  },
+  "agent": {
+    "id": "053",
+    "name": "smb-single-node-linux-01",
+    "ip": "10.53.0.10"
+  },
+  "manager": {
+    "name": "wazuh-manager-smb-1"
+  },
+  "decoder": {
+    "name": "sshd"
+  },
+  "location": "/var/log/auth.log",
+  "data": {
+    "source_family": "wazuh_detection",
+    "source_system": "wazuh",
+    "source_component": "wazuh-manager",
+    "source_id": "wazuh-manager-smb-1",
+    "event_id": "wazuh-alert-1731595600.1112223",
+    "event_timestamp": "2026-05-03T09:15:00+00:00",
+    "wazuh_manager_id": "wazuh-manager-smb-1",
+    "wazuh_rule_id": "5710",
+    "wazuh_rule_level": "10",
+    "ingest_channel": "reviewed_proxy",
+    "admission_channel": "live_wazuh_webhook",
+    "secret_custody_reference": "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE",
+    "proxy_route": "aegisops-proxy:/intake/wazuh -> aegisops-control-plane:/intake/wazuh",
+    "reviewed_by": "phase-53.4-fixture-review",
+    "product_profile": "smb-single-node",
+    "event_summary": "SSH authentication failure",
+    "srcip": "198.51.100.24",
+    "srcuser": "invalid-user",
+    "actor": {
+      "type": "user",
+      "id": "invalid-user",
+      "name": "invalid-user"
+    }
+  }
+}

--- a/control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-analytic-signal.json
+++ b/control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-analytic-signal.json
@@ -1,0 +1,49 @@
+{
+  "source": {
+    "source_system": "wazuh",
+    "source_family": "wazuh_detection",
+    "accountable_source_identity": "agent:053",
+    "delivery_path": "/var/log/auth.log",
+    "product_profile": "smb-single-node"
+  },
+  "provenance": {
+    "rule_id": "5710",
+    "rule_level": 10,
+    "rule_description": "Wazuh sample SSH authentication failure",
+    "decoder_name": "sshd",
+    "location": "/var/log/auth.log",
+    "source_system": "wazuh",
+    "source_component": "wazuh-manager",
+    "source_id": "wazuh-manager-smb-1",
+    "event_id": "wazuh-alert-1731595600.1112223",
+    "event_timestamp": "2026-05-03T09:15:00+00:00",
+    "wazuh_manager_id": "wazuh-manager-smb-1",
+    "wazuh_rule_id": "5710",
+    "wazuh_rule_level": "10",
+    "ingest_channel": "reviewed_proxy",
+    "admission_channel": "live_wazuh_webhook",
+    "secret_custody_reference": "AEGISOPS_CONTROL_PLANE_WAZUH_INGEST_SHARED_SECRET_FILE",
+    "proxy_route": "aegisops-proxy:/intake/wazuh -> aegisops-control-plane:/intake/wazuh",
+    "reviewed_by": "phase-53.4-fixture-review"
+  },
+  "detection": {
+    "event_id": "wazuh-alert-1731595600.1112223",
+    "event_timestamp": "2026-05-03T09:15:00+00:00",
+    "source_component": "wazuh-manager",
+    "source_id": "wazuh-manager-smb-1",
+    "wazuh_manager_id": "wazuh-manager-smb-1",
+    "wazuh_rule_id": "5710",
+    "wazuh_rule_level": "10",
+    "event_summary": "SSH authentication failure"
+  },
+  "network": {
+    "source_ip": "198.51.100.24"
+  },
+  "identity": {
+    "actor": {
+      "identity_type": "user",
+      "identity_id": "invalid-user",
+      "display_name": "invalid-user"
+    }
+  }
+}

--- a/control-plane/tests/test_wazuh_adapter.py
+++ b/control-plane/tests/test_wazuh_adapter.py
@@ -421,6 +421,38 @@ class WazuhAlertAdapterTests(unittest.TestCase):
             expected_profile,
         )
 
+    def test_adapter_maps_phase53_sample_detection_fixture_to_expected_signal_shape(
+        self,
+    ) -> None:
+        adapter = WazuhAlertAdapter()
+
+        record = adapter.build_native_detection_record(
+            _load_fixture("phase53-smb-single-node-ssh-auth-failure-alert.json")
+        )
+        expected_mapping = _load_fixture(
+            "phase53-smb-single-node-ssh-auth-failure-analytic-signal.json"
+        )
+
+        self.assertEqual(record.native_record_id, "1731595600.1112223")
+        self.assertEqual(record.metadata["reviewed_source_profile"], expected_mapping)
+        self.assertEqual(
+            adapter.build_analytic_signal_admission(record).reviewed_context,
+            expected_mapping,
+        )
+
+    def test_adapter_rejects_phase53_detection_fixture_missing_required_provenance(
+        self,
+    ) -> None:
+        adapter = WazuhAlertAdapter()
+        alert = _load_fixture("phase53-smb-single-node-ssh-auth-failure-alert.json")
+        alert["data"].pop("secret_custody_reference")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "data.secret_custody_reference must be a non-empty string",
+        ):
+            adapter.build_native_detection_record(alert)
+
     def test_adapter_uses_login_fields_when_reviewed_identity_names_are_absent(
         self,
     ) -> None:

--- a/control-plane/tests/test_wazuh_adapter.py
+++ b/control-plane/tests/test_wazuh_adapter.py
@@ -453,6 +453,19 @@ class WazuhAlertAdapterTests(unittest.TestCase):
         ):
             adapter.build_native_detection_record(alert)
 
+    def test_adapter_rejects_phase53_detection_fixture_missing_product_profile(
+        self,
+    ) -> None:
+        adapter = WazuhAlertAdapter()
+        alert = _load_fixture("phase53-smb-single-node-ssh-auth-failure-alert.json")
+        alert["data"].pop("product_profile")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "data.product_profile must be a non-empty string",
+        ):
+            adapter.build_native_detection_record(alert)
+
     def test_adapter_uses_login_fields_when_reviewed_identity_names_are_absent(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- Adds one Phase 53 `smb-single-node` Wazuh SSH auth-failure alert fixture.
- Adds an adjacent expected reviewed analytic-signal mapping fixture.
- Tightens the Wazuh adapter so `wazuh_detection` provenance fails closed when required Phase 53 fields or reviewed secret custody binding are missing.

## Verification
- `python3 -m unittest control-plane.tests.test_wazuh_adapter`
- `python3 -m unittest control-plane.tests.test_service_persistence_assistant_advisory.AssistantAdvisoryPersistenceTests.test_service_admits_wazuh_fixture_through_substrate_adapter_boundary`
- `bash scripts/verify-wazuh-rule-lifecycle-runbook.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1139 --config <supervisor-config-path>`

Closes #1139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced alert correlation to include additional provenance and contextual fields for better grouping and analysis.

* **Bug Fixes**
  * Stricter validation of detection provenance and required fields to prevent processing of incomplete alerts.
  * Improved provenance capture and custody/reference handling for more accurate source tracking.

* **Tests**
  * Added new detection fixtures and tests covering mapping, expected analytic output, and validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->