### PR TITLE
Phase 53.5 Wazuh agent enrollment helper contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Canonical cross-phase boundary reference:
 - [Phase 53.1 Wazuh profile contract](docs/deployment/wazuh-smb-single-node-profile-contract.md) defines the `smb-single-node` Wazuh manager, indexer, dashboard, resource, port, volume, certificate, and pinned-version expectations.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
+- [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
 
 ## Product positioning
 
@@ -88,6 +89,8 @@ The Phase 53.1 Wazuh profile contract is defined by the [Phase 53.1 Wazuh profil
 The Phase 53.2 Wazuh certificate and credential contract is defined by the [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md).
 
 The Phase 53.3 Wazuh intake binding contract is defined by the [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md).
+
+The Phase 53.5 Wazuh agent enrollment helper contract is defined by the [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml
+++ b/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml
@@ -1,0 +1,52 @@
+profile_id: smb-single-node
+product_profile: wazuh
+profile_contract_version: 2026-05-03
+agent_enrollment_helper_contract_version: 2026-05-03
+status: accepted-contract
+related_issues:
+  - 1135
+  - 1136
+  - 1140
+authority_boundary: Wazuh agent enrollment state remains subordinate setup context only; it cannot close, approve, execute, reconcile, release, gate, admit a source, or mutate authoritative AegisOps records.
+endpoint_scope: one-reviewed-endpoint
+fleet_management_scope: out-of-scope
+manager_host_placeholder: <wazuh-manager-host>
+agent_name_placeholder: <first-endpoint-agent-name>
+enrollment_secret_custody: AEGISOPS_WAZUH_AGENT_ENROLLMENT_SECRET_FILE or AEGISOPS_WAZUH_AGENT_ENROLLMENT_SECRET_OPENBAO_PATH
+raw_secret_values_allowed: false
+committed_customer_values_allowed: false
+workstation_local_paths_allowed: false
+wazuh_active_response_authority_allowed: false
+aegisops_authority_mutation_allowed: false
+prerequisites:
+  - reviewed-smb-single-node-wazuh-profile
+  - reviewed-manager-enrollment-port
+  - reviewed-agent-enrollment-secret-custody
+  - one-endpoint-operator-approval
+  - rollback-owner-identified
+enrollment_steps:
+  - confirm-reviewed-manager-address
+  - confirm-secret-custody-reference
+  - install-agent-on-one-reviewed-endpoint
+  - enroll-agent-to-reviewed-manager
+  - verify-agent-appears-as-subordinate-signal-source
+rollback_steps:
+  - disable-or-uninstall-agent-on-first-endpoint
+  - remove-agent-registration-from-wazuh-manager
+  - revoke-or-rotate-enrollment-secret-if-used
+  - record-aegisops-owned-follow-up-if-signal-custody-changed
+safety_warnings:
+  - do-not-commit-secrets
+  - do-not-use-placeholder-credentials-as-valid
+  - do-not-enroll-fleet
+  - do-not-use-wazuh-status-as-aegisops-truth
+  - do-not-enable-active-response-authority
+  - do-not-use-workstation-local-absolute-paths
+negative_validation_tests:
+  - missing-safety-warning
+  - fleet-management-overclaim
+  - committed-enrollment-secret
+  - placeholder-credential-trusted
+  - workstation-local-absolute-path
+  - wazuh-agent-state-as-aegisops-source-truth
+  - active-response-authority-path

--- a/docs/deployment/wazuh-agent-enrollment-helper-contract.md
+++ b/docs/deployment/wazuh-agent-enrollment-helper-contract.md
@@ -1,0 +1,127 @@
+# Phase 53.5 Wazuh First Agent Enrollment Helper Contract
+
+- **Status**: Accepted contract
+- **Date**: 2026-05-03
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/deployment/wazuh-smb-single-node-profile-contract.md`, `docs/deployment/wazuh-certificate-credential-contract.md`, `docs/deployment/wazuh-manager-intake-binding-contract.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1135, #1136, #1140
+
+This contract defines the bounded first Wazuh agent enrollment helper posture for one endpoint only.
+
+It does not implement fleet-scale Wazuh agent management, Wazuh upgrade automation, Shuffle product profiles, release-candidate behavior, general-availability behavior, or runtime behavior beyond the reviewed enrollment-helper contract surface.
+
+The required structured artifact is `docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml`.
+
+## 1. Purpose
+
+Phase 53.5 makes the first endpoint enrollment helper reviewable before later clean-host or source-health work can assume that a Wazuh endpoint agent can be enrolled safely.
+
+The enrollment helper covers one reviewed endpoint only. It records prerequisites, one-endpoint enrollment steps, rollback and removal notes, safety warnings, and the rule that Wazuh enrollment state remains subordinate substrate context.
+
+## 2. Authority Boundary
+
+Wazuh is a subordinate detection substrate. Wazuh agent state, Wazuh manager enrollment state, Wazuh dashboard state, generated Wazuh config, setup commands, verifier output, issue-lint output, operator-facing status text, and setup evidence are not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, source, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. The Wazuh agent enrollment helper must preserve the rule that Wazuh agent state, manager state, dashboard state, placeholder secrets, sample credentials, fake values, TODO values, setup text, ticket state, AI output, browser state, UI cache, optional evidence, and downstream receipt state cannot become AegisOps truth or mutate AegisOps records without explicit AegisOps admission and linkage.
+
+## 3. Enrollment Helper Contract
+
+The helper is a contract for the `smb-single-node` Wazuh product profile and a single reviewed endpoint.
+
+Fleet-scale Wazuh agent management remains out of scope.
+
+Enrollment must use a reviewed Wazuh manager address placeholder such as `<wazuh-manager-host>` and a reviewed agent enrollment token or password custody reference.
+
+The helper must not require committed secrets, inline credentials, customer-specific values, or workstation-local absolute paths.
+
+The helper must not enable Wazuh Active Response as an AegisOps authority path, route directly from Wazuh to Shuffle, or treat Wazuh agent presence as source admission.
+
+## 4. Prerequisites
+
+The first endpoint enrollment helper requires:
+
+- the accepted `smb-single-node` Wazuh profile contract;
+- the reviewed Wazuh manager enrollment port and address placeholder;
+- the reviewed enrollment secret custody reference;
+- explicit operator approval for one endpoint;
+- an identified rollback owner before enrollment starts; and
+- a reviewed AegisOps intake binding if post-enrollment signal testing is performed.
+
+Missing prerequisites block the helper. The helper must not infer endpoint, tenant, source, or customer linkage from hostnames, path shape, comments, dashboard labels, nearby metadata, or issue text.
+
+## 5. First Endpoint Enrollment Steps
+
+The bounded enrollment flow is:
+
+1. Confirm the reviewed manager address placeholder and enrollment port for `<wazuh-manager-host>`.
+2. Confirm the enrollment credential custody reference without exposing the credential value.
+3. Install the Wazuh agent on one reviewed endpoint.
+4. Enroll the agent to the reviewed Wazuh manager by using the custody-backed enrollment value.
+5. Verify the endpoint appears only as a subordinate Wazuh signal source.
+
+Post-enrollment signal review still depends on AegisOps admission and linkage. Wazuh agent status, manager status, dashboard presence, or setup output is not AegisOps source truth.
+
+## 6. Rollback And Removal
+
+Rollback must remove or disable the enrolled endpoint agent, revoke or rotate the enrollment credential when used, and preserve AegisOps-owned records as the workflow truth.
+
+Removal must also delete or disable the agent registration from the Wazuh manager when appropriate and record an AegisOps-owned follow-up only when reviewed signal custody or source admission assumptions changed.
+
+Rollback evidence is setup context only. It cannot close, reconcile, release, gate, or mutate AegisOps records without the AegisOps-owned record chain.
+
+## 7. Safety Warnings
+
+Safety warnings are mandatory:
+
+- Do not commit Wazuh enrollment secrets, tokens, passwords, API keys, private keys, customer-specific values, generated secret files, or copied credentials.
+- Do not treat placeholder credentials, sample secrets, fake values, TODO values, unsigned tokens, or default Wazuh credentials as valid.
+- Do not enroll a fleet, bulk endpoint set, endpoint group, tenant-wide source, or unmanaged endpoint collection under this helper.
+- Do not use Wazuh agent state, manager enrollment state, dashboard state, setup output, or optional endpoint evidence as AegisOps workflow truth.
+- Do not enable Wazuh Active Response as an AegisOps authority path.
+- Do not use workstation-local absolute paths in publishable guidance.
+
+## 8. Validation Rules
+
+Wazuh agent enrollment helper validation must fail closed when:
+
+- `docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml` is missing;
+- the contract document is missing;
+- prerequisites, enrollment steps, rollback steps, or safety warnings are missing;
+- the helper is not limited to one reviewed endpoint;
+- enrollment secret custody is missing or replaced by a raw secret, placeholder, sample, fake value, TODO value, unsigned token, inline secret, or committed secret-looking value;
+- committed customer-specific values or workstation-local absolute paths appear;
+- the helper claims fleet-scale Wazuh agent management, Wazuh upgrade automation, Shuffle product profile work, release-candidate behavior, general-availability behavior, or commercial readiness;
+- Wazuh agent state, manager state, dashboard state, generated config, setup output, verifier, or issue-lint state is described as AegisOps workflow, production, release, gate, closeout, source, approval, execution, evidence, or reconciliation truth; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<supervisor-config-path>`, `<codex-supervisor-root>`, `<wazuh-manager-host>`, and `<first-endpoint-agent-name>`.
+
+## 9. Forbidden Claims
+
+- Wazuh agent state is AegisOps source truth.
+- Wazuh agent enrollment is AegisOps workflow truth.
+- Wazuh manager agent status is AegisOps evidence truth.
+- Wazuh Active Response is an AegisOps authority path.
+- Placeholder Wazuh enrollment secrets are valid credentials.
+- Committed Wazuh enrollment secrets are acceptable.
+- Phase 53.5 implements fleet-scale Wazuh agent management.
+- Phase 53.5 implements Wazuh upgrade automation.
+- Phase 53.5 implements Shuffle product profiles.
+- Phase 53.5 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness.
+
+## 10. Validation
+
+Run `bash scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh`.
+
+Run `bash scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1140 --config <supervisor-config-path>`.
+
+The verifier must fail when the Wazuh enrollment helper contract or structured artifact is missing, when prerequisites, enrollment steps, rollback steps, or safety warnings are missing, when the helper permits fleet management, when raw secrets or committed secret-looking values appear, when Wazuh enrollment state is promoted into AegisOps authority, or when publishable guidance uses workstation-local absolute paths.
+
+## 11. Non-Goals
+
+- No fleet-scale Wazuh agent management, Wazuh upgrade automation, Shuffle profile work, release-candidate behavior, general-availability behavior, Wazuh Active Response authority path, direct Wazuh-to-Shuffle shortcut, broad SIEM detector catalog, source-health projection, or runtime behavior is implemented here.
+- No live secret, customer-specific value, private key, bearer token, API key, password, env file, generated config, generated secret, Wazuh agent state, Wazuh manager state, Wazuh dashboard state, Wazuh alert, Wazuh rule state, Wazuh timestamp, setup output, verifier output, issue-lint output, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
+++ b/scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
@@ -148,6 +148,22 @@ assert_fails_with \
   "${missing_forbidden_claim_repo}" \
   "Missing Phase 53.5 Wazuh forbidden claim: Phase 53.5 implements fleet-scale Wazuh agent management"
 
+contract_fleet_overclaim_repo="${workdir}/contract-fleet-overclaim"
+create_valid_repo "${contract_fleet_overclaim_repo}"
+printf '%s\n' "This helper supports fleet-wide agent enrollment." \
+  >>"${contract_fleet_overclaim_repo}/docs/deployment/wazuh-agent-enrollment-helper-contract.md"
+assert_fails_with \
+  "${contract_fleet_overclaim_repo}" \
+  "Forbidden Phase 53.5 Wazuh enrollment helper claim: fleet management overclaim detected"
+
+artifact_fleet_overclaim_repo="${workdir}/artifact-fleet-overclaim"
+create_valid_repo "${artifact_fleet_overclaim_repo}"
+printf '%s\n' "supported_mode: bulk-agent-enrollment" \
+  >>"${artifact_fleet_overclaim_repo}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+assert_fails_with \
+  "${artifact_fleet_overclaim_repo}" \
+  "Forbidden Phase 53.5 Wazuh enrollment helper claim: fleet management overclaim detected"
+
 agent_truth_repo="${workdir}/agent-truth"
 create_valid_repo "${agent_truth_repo}"
 printf '%s\n' "Wazuh agent enrollment is AegisOps workflow truth." \

--- a/scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
+++ b/scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/profiles/smb-single-node/wazuh"
+  printf '%s\n' "# AegisOps" "See [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/wazuh-agent-enrollment-helper-contract.md" \
+    "${target}/docs/deployment/wazuh-agent-enrollment-helper-contract.md"
+  cp "${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml" \
+    "${target}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/wazuh-agent-enrollment-helper-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/wazuh-agent-enrollment-helper-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 53.5 Wazuh agent enrollment helper contract"
+
+missing_artifact_repo="${workdir}/missing-artifact"
+create_valid_repo "${missing_artifact_repo}"
+rm "${missing_artifact_repo}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+assert_fails_with \
+  "${missing_artifact_repo}" \
+  "Missing Phase 53.5 Wazuh agent enrollment helper artifact"
+
+missing_prerequisite_repo="${workdir}/missing-prerequisite"
+create_valid_repo "${missing_prerequisite_repo}"
+perl -0pi -e 's/^  - reviewed-agent-enrollment-secret-custody\n//m' \
+  "${missing_prerequisite_repo}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+assert_fails_with \
+  "${missing_prerequisite_repo}" \
+  "Missing Phase 53.5 Wazuh enrollment prerequisite: reviewed-agent-enrollment-secret-custody"
+
+missing_step_repo="${workdir}/missing-step"
+create_valid_repo "${missing_step_repo}"
+perl -0pi -e 's/^  - enroll-agent-to-reviewed-manager\n//m' \
+  "${missing_step_repo}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+assert_fails_with \
+  "${missing_step_repo}" \
+  "Missing Phase 53.5 Wazuh enrollment step: enroll-agent-to-reviewed-manager"
+
+missing_rollback_repo="${workdir}/missing-rollback"
+create_valid_repo "${missing_rollback_repo}"
+perl -0pi -e 's/^  - revoke-or-rotate-enrollment-secret-if-used\n//m' \
+  "${missing_rollback_repo}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+assert_fails_with \
+  "${missing_rollback_repo}" \
+  "Missing Phase 53.5 Wazuh enrollment rollback step: revoke-or-rotate-enrollment-secret-if-used"
+
+missing_warning_repo="${workdir}/missing-warning"
+create_valid_repo "${missing_warning_repo}"
+perl -0pi -e 's/^  - do-not-enroll-fleet\n//m' \
+  "${missing_warning_repo}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+assert_fails_with \
+  "${missing_warning_repo}" \
+  "Missing Phase 53.5 Wazuh enrollment safety warning: do-not-enroll-fleet"
+
+missing_secret_custody_repo="${workdir}/missing-secret-custody"
+create_valid_repo "${missing_secret_custody_repo}"
+perl -0pi -e 's/^enrollment_secret_custody: .+$/enrollment_secret_custody: /m' \
+  "${missing_secret_custody_repo}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+assert_fails_with \
+  "${missing_secret_custody_repo}" \
+  "Missing Phase 53.5 Wazuh agent enrollment helper artifact term: enrollment_secret_custody"
+
+secret_looking_value_repo="${workdir}/secret-looking-value"
+create_valid_repo "${secret_looking_value_repo}"
+printf '%s\n' "agent_enrollment_secret: CorrectHorseBatteryStaple42" \
+  >>"${secret_looking_value_repo}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+assert_fails_with \
+  "${secret_looking_value_repo}" \
+  "Forbidden Phase 53.5 Wazuh enrollment artifact: committed secret-looking value detected"
+
+missing_safety_statement_repo="${workdir}/missing-safety-statement"
+create_valid_repo "${missing_safety_statement_repo}"
+remove_text_from_contract "${missing_safety_statement_repo}" \
+  "The helper must not require committed secrets, inline credentials, customer-specific values, or workstation-local absolute paths."
+assert_fails_with \
+  "${missing_safety_statement_repo}" \
+  "Missing Phase 53.5 Wazuh agent enrollment helper contract statement"
+
+missing_fleet_statement_repo="${workdir}/missing-fleet-statement"
+create_valid_repo "${missing_fleet_statement_repo}"
+remove_text_from_contract "${missing_fleet_statement_repo}" \
+  "Fleet-scale Wazuh agent management remains out of scope."
+assert_fails_with \
+  "${missing_fleet_statement_repo}" \
+  "Missing Phase 53.5 Wazuh agent enrollment helper contract statement"
+
+missing_forbidden_claim_repo="${workdir}/missing-forbidden-claim"
+create_valid_repo "${missing_forbidden_claim_repo}"
+remove_text_from_contract "${missing_forbidden_claim_repo}" \
+  "Phase 53.5 implements fleet-scale Wazuh agent management."
+assert_fails_with \
+  "${missing_forbidden_claim_repo}" \
+  "Missing Phase 53.5 Wazuh forbidden claim: Phase 53.5 implements fleet-scale Wazuh agent management"
+
+agent_truth_repo="${workdir}/agent-truth"
+create_valid_repo "${agent_truth_repo}"
+printf '%s\n' "Wazuh agent enrollment is AegisOps workflow truth." \
+  >>"${agent_truth_repo}/docs/deployment/wazuh-agent-enrollment-helper-contract.md"
+assert_fails_with \
+  "${agent_truth_repo}" \
+  "Forbidden Phase 53.5 Wazuh enrollment helper claim: Wazuh agent enrollment is AegisOps workflow truth"
+
+active_response_repo="${workdir}/active-response"
+create_valid_repo "${active_response_repo}"
+printf '%s\n' "Wazuh Active Response is an AegisOps authority path." \
+  >>"${active_response_repo}/docs/deployment/wazuh-agent-enrollment-helper-contract.md"
+assert_fails_with \
+  "${active_response_repo}" \
+  "Forbidden Phase 53.5 Wazuh enrollment helper claim: Wazuh Active Response is an AegisOps authority path"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/wazuh-agent-enrollment-helper-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 53.5 Wazuh enrollment helper contract: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 53.5 Wazuh agent enrollment helper contract."
+
+echo "Phase 53.5 Wazuh agent enrollment helper contract verifier tests passed."

--- a/scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
+++ b/scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
@@ -114,7 +114,7 @@ perl -0pi -e 's/^enrollment_secret_custody: .+$/enrollment_secret_custody: /m' \
   "${missing_secret_custody_repo}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
 assert_fails_with \
   "${missing_secret_custody_repo}" \
-  "Missing Phase 53.5 Wazuh agent enrollment helper artifact term: enrollment_secret_custody"
+  "Missing Phase 53.5 Wazuh agent enrollment helper artifact term: enrollment_secret_custody: AEGISOPS_WAZUH_AGENT_ENROLLMENT_SECRET_FILE or AEGISOPS_WAZUH_AGENT_ENROLLMENT_SECRET_OPENBAO_PATH"
 
 secret_looking_value_repo="${workdir}/secret-looking-value"
 create_valid_repo "${secret_looking_value_repo}"

--- a/scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
+++ b/scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
@@ -180,6 +180,39 @@ contains_forbidden_claim_in_section() {
   ' "${contract_path}"
 }
 
+contains_unbounded_fleet_claim() {
+  awk '
+    function has_fleet_term(value) {
+      return value ~ /(fleet[-[:space:]]*(scale|wide|management|manager|enrollment|onboarding)|bulk[-[:space:]]*(agent|endpoint|enrollment)|mass[-[:space:]]*(agent|endpoint|enrollment))/
+    }
+
+    function is_allowed_fleet_line(value) {
+      return value ~ /(fleet-scale wazuh agent management remains out of scope|fleet_management_scope:[[:space:]]*out-of-scope|do-not-enroll-fleet|fleet-management-overclaim|no fleet-scale wazuh agent management|does not implement fleet-scale|do not enroll a fleet|claims fleet-scale wazuh agent management|must fail when)/
+    }
+
+    FNR == 1 {
+      in_forbidden_claims = 0
+    }
+
+    {
+      if ($0 ~ /^## 9\. Forbidden Claims$/) {
+        in_forbidden_claims = 1
+      } else if ($0 ~ /^## / && in_forbidden_claims) {
+        in_forbidden_claims = 0
+      }
+
+      line = tolower($0)
+      if (!in_forbidden_claims && has_fleet_term(line) && !is_allowed_fleet_line(line)) {
+        found = 1
+      }
+    }
+
+    END {
+      exit(found ? 0 : 1)
+    }
+  ' "$@"
+}
+
 if [[ ! -f "${contract_path}" ]]; then
   echo "Missing Phase 53.5 Wazuh agent enrollment helper contract: ${contract_path}" >&2
   exit 1
@@ -263,11 +296,9 @@ for claim in "${forbidden_claims[@]}"; do
   fi
 done
 
-if grep -Eiq 'fleet[-[:space:]]*(scale|wide|management|manager|enrollment|onboarding)|bulk[-[:space:]]*(agent|endpoint|enrollment)|mass[-[:space:]]*(agent|endpoint|enrollment)' "${contract_path}" "${artifact_path}"; then
-  if ! grep -Eiq 'fleet-scale Wazuh agent management remains out of scope|Fleet-scale Wazuh agent management remains out of scope|fleet_management_scope: out-of-scope|do-not-enroll-fleet|No fleet-scale Wazuh agent management' "${contract_path}" "${artifact_path}"; then
-    echo "Forbidden Phase 53.5 Wazuh enrollment helper claim: fleet management overclaim detected" >&2
-    exit 1
-  fi
+if contains_unbounded_fleet_claim "${contract_path}" "${artifact_path}"; then
+  echo "Forbidden Phase 53.5 Wazuh enrollment helper claim: fleet management overclaim detected" >&2
+  exit 1
 fi
 
 path_token_boundary="(^|[[:space:]'\"\`(<{=])"

--- a/scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
+++ b/scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+contract_path="${repo_root}/docs/deployment/wazuh-agent-enrollment-helper-contract.md"
+artifact_path="${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 53.5 Wazuh First Agent Enrollment Helper Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Enrollment Helper Contract"
+  "## 4. Prerequisites"
+  "## 5. First Endpoint Enrollment Steps"
+  "## 6. Rollback And Removal"
+  "## 7. Safety Warnings"
+  "## 8. Validation Rules"
+  "## 9. Forbidden Claims"
+  "## 10. Validation"
+  "## 11. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted contract"
+  "- **Date**: 2026-05-03"
+  "- **Related Issues**: #1135, #1136, #1140"
+  "This contract defines the bounded first Wazuh agent enrollment helper posture for one endpoint only."
+  "The required structured artifact is \`docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml\`."
+  "Wazuh is a subordinate detection substrate."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth."
+  "This contract cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`."
+  "The enrollment helper covers one reviewed endpoint only."
+  "Fleet-scale Wazuh agent management remains out of scope."
+  "Enrollment must use a reviewed Wazuh manager address placeholder such as \`<wazuh-manager-host>\` and a reviewed agent enrollment token or password custody reference."
+  "The helper must not require committed secrets, inline credentials, customer-specific values, or workstation-local absolute paths."
+  "Rollback must remove or disable the enrolled endpoint agent, revoke or rotate the enrollment credential when used, and preserve AegisOps-owned records as the workflow truth."
+  "Run \`bash scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh\`."
+  "Run \`bash scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh\`."
+  "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1140 --config <supervisor-config-path>\`."
+)
+
+required_artifact_terms=(
+  "profile_id: smb-single-node"
+  "product_profile: wazuh"
+  "agent_enrollment_helper_contract_version: 2026-05-03"
+  "status: accepted-contract"
+  "endpoint_scope: one-reviewed-endpoint"
+  "fleet_management_scope: out-of-scope"
+  "manager_host_placeholder: <wazuh-manager-host>"
+  "agent_name_placeholder: <first-endpoint-agent-name>"
+  "enrollment_secret_custody: AEGISOPS_WAZUH_AGENT_ENROLLMENT_SECRET_FILE or AEGISOPS_WAZUH_AGENT_ENROLLMENT_SECRET_OPENBAO_PATH"
+  "raw_secret_values_allowed: false"
+  "committed_customer_values_allowed: false"
+  "workstation_local_paths_allowed: false"
+  "wazuh_active_response_authority_allowed: false"
+  "aegisops_authority_mutation_allowed: false"
+  "prerequisites:"
+  "enrollment_steps:"
+  "rollback_steps:"
+  "safety_warnings:"
+  "negative_validation_tests:"
+)
+
+required_prerequisites=(
+  "reviewed-smb-single-node-wazuh-profile"
+  "reviewed-manager-enrollment-port"
+  "reviewed-agent-enrollment-secret-custody"
+  "one-endpoint-operator-approval"
+  "rollback-owner-identified"
+)
+
+required_steps=(
+  "confirm-reviewed-manager-address"
+  "confirm-secret-custody-reference"
+  "install-agent-on-one-reviewed-endpoint"
+  "enroll-agent-to-reviewed-manager"
+  "verify-agent-appears-as-subordinate-signal-source"
+)
+
+required_rollback_steps=(
+  "disable-or-uninstall-agent-on-first-endpoint"
+  "remove-agent-registration-from-wazuh-manager"
+  "revoke-or-rotate-enrollment-secret-if-used"
+  "record-aegisops-owned-follow-up-if-signal-custody-changed"
+)
+
+required_safety_warnings=(
+  "do-not-commit-secrets"
+  "do-not-use-placeholder-credentials-as-valid"
+  "do-not-enroll-fleet"
+  "do-not-use-wazuh-status-as-aegisops-truth"
+  "do-not-enable-active-response-authority"
+  "do-not-use-workstation-local-absolute-paths"
+)
+
+forbidden_claims=(
+  "Wazuh agent state is AegisOps source truth"
+  "Wazuh agent enrollment is AegisOps workflow truth"
+  "Wazuh manager agent status is AegisOps evidence truth"
+  "Wazuh Active Response is an AegisOps authority path"
+  "Placeholder Wazuh enrollment secrets are valid credentials"
+  "Committed Wazuh enrollment secrets are acceptable"
+  "Phase 53.5 implements fleet-scale Wazuh agent management"
+  "Phase 53.5 implements Wazuh upgrade automation"
+  "Phase 53.5 implements Shuffle product profiles"
+  "Phase 53.5 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+has_uncommented_substring() {
+  local needle="$1"
+  local file_path="$2"
+
+  awk -v needle="${needle}" '
+    /^[[:space:]]*#/ { next }
+    {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      if (index(line, needle)) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"
+}
+
+require_list_item() {
+  local file_path="$1"
+  local item="$2"
+  local label="$3"
+
+  if ! awk -v item="${item}" '
+    /^[[:space:]]*#/ { next }
+    $0 ~ ("^[[:space:]]*-[[:space:]]+" item "([[:space:]]*(#.*)?)?$") { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"; then
+    echo "Missing Phase 53.5 Wazuh enrollment ${label}: ${item}" >&2
+    exit 1
+  fi
+}
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 9\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+contains_forbidden_claim_in_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 9\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+if [[ ! -f "${contract_path}" ]]; then
+  echo "Missing Phase 53.5 Wazuh agent enrollment helper contract: ${contract_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${artifact_path}" ]]; then
+  echo "Missing Phase 53.5 Wazuh agent enrollment helper artifact: ${artifact_path}" >&2
+  exit 1
+fi
+
+contract_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${contract_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.5 Wazuh agent enrollment helper contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.5 Wazuh agent enrollment helper contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for term in "${required_artifact_terms[@]}"; do
+  if ! has_uncommented_substring "${term}" "${artifact_path}"; then
+    echo "Missing Phase 53.5 Wazuh agent enrollment helper artifact term: ${term}" >&2
+    exit 1
+  fi
+done
+
+for item in "${required_prerequisites[@]}"; do
+  require_list_item "${artifact_path}" "${item}" "prerequisite"
+done
+
+for item in "${required_steps[@]}"; do
+  require_list_item "${artifact_path}" "${item}" "step"
+done
+
+for item in "${required_rollback_steps[@]}"; do
+  require_list_item "${artifact_path}" "${item}" "rollback step"
+done
+
+for item in "${required_safety_warnings[@]}"; do
+  require_list_item "${artifact_path}" "${item}" "safety warning"
+done
+
+if grep -Eiq '^[[:space:]]*enrollment_secret_custody:[[:space:]]*($|<|todo|tbd|none|null|changeme|change-me|password|secret|sample|example|fake|dummy)' "${artifact_path}"; then
+  echo "Forbidden Phase 53.5 Wazuh enrollment artifact: missing enrollment secret custody reference" >&2
+  exit 1
+fi
+
+if awk '
+  BEGIN { found = 0 }
+  /^[[:space:]]*([a-z0-9_-]*_)?(password|secret|token|api_key|enrollment_key)[[:space:]]*:/ {
+    value = $0
+    sub(/^[^:]+:[[:space:]]*/, "", value)
+    if (length(value) >= 12 && value !~ /^(AEGISOPS_|<|\$\{)/) {
+      found = 1
+    }
+  }
+  END { exit(found ? 0 : 1) }
+' "${artifact_path}"; then
+  echo "Forbidden Phase 53.5 Wazuh enrollment artifact: committed secret-looking value detected" >&2
+  exit 1
+fi
+
+for claim in "${forbidden_claims[@]}"; do
+  if ! contains_forbidden_claim_in_section "${claim}"; then
+    echo "Missing Phase 53.5 Wazuh forbidden claim: ${claim}" >&2
+    exit 1
+  fi
+
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 53.5 Wazuh enrollment helper claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if grep -Eiq 'fleet[-[:space:]]*(scale|wide|management|manager|enrollment|onboarding)|bulk[-[:space:]]*(agent|endpoint|enrollment)|mass[-[:space:]]*(agent|endpoint|enrollment)' "${contract_path}" "${artifact_path}"; then
+  if ! grep -Eiq 'fleet-scale Wazuh agent management remains out of scope|Fleet-scale Wazuh agent management remains out of scope|fleet_management_scope: out-of-scope|do-not-enroll-fleet|No fleet-scale Wazuh agent management' "${contract_path}" "${artifact_path}"; then
+    echo "Forbidden Phase 53.5 Wazuh enrollment helper claim: fleet management overclaim detected" >&2
+    exit 1
+  fi
+fi
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${contract_path}" "${artifact_path}"; then
+  echo "Forbidden Phase 53.5 Wazuh enrollment helper contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 53.5 Wazuh enrollment helper contract link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | tr -d '\140'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/wazuh-agent-enrollment-helper-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 53.5 Wazuh agent enrollment helper contract." >&2
+  exit 1
+fi
+
+echo "Phase 53.5 Wazuh agent enrollment helper contract is present and rejects missing safety warnings, fleet-management overclaims, committed secrets, authority-boundary overclaims, and workstation-local paths."


### PR DESCRIPTION
## Summary
- Add the Phase 53.5 first Wazuh agent enrollment helper contract for one reviewed endpoint only.
- Add the structured Wazuh profile artifact and focused verifier/self-test for prerequisites, enrollment steps, rollback, safety warnings, secret hygiene, fleet-management overclaims, authority boundaries, and publishable path hygiene.
- Link the contract from README.

## Verification
- `bash scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh`
- `bash scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash scripts/test-verify-publishable-path-hygiene.sh`
- `bash scripts/verify-phase-53-1-wazuh-profile-contract.sh`
- `bash scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh`
- `bash scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1140 --config <supervisor-config-path>`

Closes #1140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 53.5 Wazuh agent enrollment contract, linked from the README; documents single-endpoint enrollment flow, prerequisites, rollback, safety warnings, forbidden claims, and strict validation rules.
  * Added a scoped single-node Wazuh enrollment profile with constrained scope, required custody references, ordered steps, rollback and negative-validation guidance.

* **Tests**
  * Added a verifier and test harness to assert contract/profile presence, enforce safety/compliance rules, and exercise negative validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->