### PR TITLE
Phase 53.6 Wazuh source-health projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Canonical cross-phase boundary reference:
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
+- [Phase 53.6 Wazuh source-health projection contract](docs/deployment/wazuh-source-health-projection-contract.md) defines manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched source-health projection states for the Wazuh profile.
 
 ## Product positioning
 
@@ -91,6 +92,8 @@ The Phase 53.2 Wazuh certificate and credential contract is defined by the [Phas
 The Phase 53.3 Wazuh intake binding contract is defined by the [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md).
 
 The Phase 53.5 Wazuh agent enrollment helper contract is defined by the [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md).
+
+The Phase 53.6 Wazuh source-health projection contract is defined by the [Phase 53.6 Wazuh source-health projection contract](docs/deployment/wazuh-source-health-projection-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml
+++ b/docs/deployment/profiles/smb-single-node/wazuh/profile.yaml
@@ -71,4 +71,4 @@ profile_expectations:
   ingress: Wazuh manager, indexer, and dashboard ports are internal or substrate-owned; AegisOps receives Wazuh signals only through the reviewed proxy intake route.
   volumes: Wazuh manager, indexer, dashboard, logs, rules, certificates, and backups are separate from AegisOps PostgreSQL state and AegisOps evidence custody.
   certificates: Certificate and secret references are trusted custody references only; placeholder, sample, fake, TODO, unsigned, or inline secret values are invalid.
-  source_health: Source-health projection is deferred to a later Phase 53 child issue and cannot use Wazuh dashboard or manager state as authoritative workflow truth.
+  source_health: Source-health projection is defined by docs/deployment/wazuh-source-health-projection-contract.md and cannot use Wazuh dashboard or manager state as authoritative workflow truth.

--- a/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml
+++ b/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml
@@ -1,0 +1,108 @@
+profile_id: smb-single-node
+product_profile: wazuh
+source_health_projection_contract_version: 2026-05-03
+status: accepted-contract
+related_issues:
+  - 1135
+  - 1138
+  - 1141
+projection_owner: aegisops-control-plane
+substrate_owner: wazuh
+authority_boundary: Wazuh source-health projection is subordinate detection-substrate context only; manager, dashboard, indexer, intake, freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched states cannot close, approve, execute, reconcile, release, gate, or mutate authoritative AegisOps records.
+authority_mutation_allowed: false
+raw_secret_values_allowed: false
+placeholder_credentials_valid: false
+workflow_truth_source: aegisops-record-chain-only
+components:
+  - manager
+  - dashboard
+  - indexer
+  - intake
+  - signal_freshness
+  - parser
+  - volume
+  - credential
+states:
+  - available
+  - degraded
+  - stale_source
+  - parser_failure
+  - volume_anomaly
+  - credential_degraded
+  - unavailable
+  - mismatched
+projection_rules:
+  - all-required-components-available
+  - stale-last-accepted-signal
+  - parser-failure-visible
+  - volume-anomaly-visible
+  - credential-degraded-redacted
+  - manager-dashboard-indexer-unavailable-visible
+  - component-mismatch-visible
+  - no-authority-mutation
+component_state_coverage:
+  manager:
+    allowed_states:
+      - available
+      - degraded
+      - unavailable
+      - mismatched
+    authority_note: Manager state remains subordinate signal-source context only.
+  dashboard:
+    allowed_states:
+      - available
+      - degraded
+      - unavailable
+      - mismatched
+    authority_note: Dashboard state remains operator-facing substrate context only.
+  indexer:
+    allowed_states:
+      - available
+      - degraded
+      - unavailable
+      - mismatched
+    authority_note: Indexer state remains substrate evidence context only.
+  intake:
+    allowed_states:
+      - available
+      - credential_degraded
+      - unavailable
+      - mismatched
+    authority_note: Intake acknowledgement is transport evidence until AegisOps admission and linkage.
+  signal_freshness:
+    allowed_states:
+      - available
+      - stale_source
+      - unavailable
+    authoritative_input: last accepted Wazuh signal recorded by AegisOps
+  parser:
+    allowed_states:
+      - available
+      - degraded
+      - parser_failure
+    authority_note: Parser failure blocks false healthy projection but does not rewrite record truth.
+  volume:
+    allowed_states:
+      - available
+      - degraded
+      - volume_anomaly
+    authority_note: Volume anomaly is operator context, not incident or case truth.
+  credential:
+    allowed_states:
+      - available
+      - credential_degraded
+      - unavailable
+      - mismatched
+    redaction_required: true
+    secret_material_allowed: false
+negative_validation_tests:
+  - missing-degraded-state
+  - missing-unavailable-state
+  - missing-stale-source-state
+  - missing-parser-failure-state
+  - missing-volume-anomaly-state
+  - missing-credential-degraded-state
+  - missing-mismatched-state
+  - health-status-as-workflow-truth
+  - credential-degraded-secret-leak
+  - placeholder-credential-valid

--- a/docs/deployment/wazuh-source-health-projection-contract.md
+++ b/docs/deployment/wazuh-source-health-projection-contract.md
@@ -1,0 +1,106 @@
+# Phase 53.6 Wazuh Source-Health Projection Contract
+
+- **Status**: Accepted contract
+- **Date**: 2026-05-03
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/deployment/wazuh-smb-single-node-profile-contract.md`, `docs/deployment/wazuh-manager-intake-binding-contract.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1135, #1138, #1141
+
+This contract defines the Wazuh source-health projection for the `smb-single-node` product profile. It turns Wazuh substrate availability, signal freshness, parser, volume, and credential posture into subordinate AegisOps health context only. It does not implement Wazuh Active Response authority, case closure, workflow mutation, Shuffle product profiles, release-candidate behavior, general-availability behavior, or commercial readiness.
+
+The required structured artifact is `docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml`.
+
+## 1. Purpose
+
+The source-health projection gives operators one reviewed view of whether the Wazuh manager, dashboard, indexer, intake, signal freshness, parser, event volume, and credential posture look usable for subordinate signal intake.
+
+The projection is advisory context for source reliability and triage confidence. It is not the authoritative lifecycle source for AegisOps alerts, cases, evidence, approvals, actions, executions, reconciliations, release gates, or closeout decisions.
+
+## 2. Authority Boundary
+
+Wazuh is a subordinate detection substrate. Wazuh manager state, dashboard state, indexer state, intake status, signal freshness, parser failures, volume anomalies, credential-degraded posture, unavailable posture, mismatched posture, source-health projection, verifier output, issue-lint output, operator-facing status text, and setup evidence are not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. The Wazuh source-health projection must preserve the rule that substrate status, dashboard text, manager reports, indexer search results, parser diagnostics, volume counters, credential status, tickets, AI, browser, UI cache, optional evidence, and downstream receipt state cannot close, reconcile, approve, execute, release, gate, or otherwise mutate AegisOps records without explicit AegisOps admission and linkage.
+
+## 3. Projection Inputs
+
+| Component | Input surface | Required projection coverage | Authority boundary |
+| --- | --- | --- | --- |
+| manager | Wazuh manager service/API reachability and reviewed profile identity. | `available`, `degraded`, `unavailable`, `mismatched`. | Manager health remains subordinate signal-source context. |
+| dashboard | Wazuh dashboard reachability through the reviewed proxy path. | `available`, `degraded`, `unavailable`, `mismatched`. | Dashboard status is operator-facing substrate context only. |
+| indexer | Wazuh indexer availability and reviewed profile identity. | `available`, `degraded`, `unavailable`, `mismatched`. | Indexer contents and search status are not AegisOps evidence truth. |
+| intake | Reviewed AegisOps Wazuh intake route and secret custody reference. | `available`, `credential_degraded`, `unavailable`, `mismatched`. | Intake acknowledgements remain pre-admission transport evidence until AegisOps links a record. |
+| signal_freshness | Last accepted Wazuh analytic signal timestamp recorded by AegisOps. | `available`, `stale_source`, `unavailable`. | Freshness informs source reliability only and cannot close or reopen records. |
+| parser | Reviewed parser and mapping result for accepted Wazuh payloads. | `available`, `degraded`, `parser_failure`. | Parser failures block reliable projection but do not rewrite case truth. |
+| volume | Reviewed signal volume expectation for the `smb-single-node` Wazuh profile. | `available`, `degraded`, `volume_anomaly`. | Volume anomaly is an operator signal, not an AegisOps lifecycle transition. |
+| credential | Secret custody, rotation compatibility, and redacted credential posture. | `available`, `credential_degraded`, `unavailable`, `mismatched`. | Credential posture must never expose secret material or validate placeholders. |
+
+## 4. Projection States
+
+| State | Meaning | Required handling |
+| --- | --- | --- |
+| available | Required Wazuh component signal is present, reviewed, and aligned with the accepted profile. | Surface as healthy subordinate context only. |
+| degraded | Required Wazuh component signal is present but incomplete, lagging, or operationally weak. | Surface as degraded context and preserve AegisOps authority. |
+| stale_source | The last accepted Wazuh signal is older than the reviewed freshness expectation. | Surface as stale source context without changing alert or case lifecycle truth. |
+| parser_failure | Accepted Wazuh payloads cannot be parsed or mapped to the reviewed contract. | Surface parser failure, block false healthy projection, and keep durable records unchanged unless AegisOps admission already happened. |
+| volume_anomaly | Reviewed Wazuh signal volume is unexpectedly silent, spiking, or outside bounded expectations. | Surface volume anomaly context without treating Wazuh volume as incident truth. |
+| credential_degraded | Credential custody, rotation state, or proxy-secret posture is missing, stale, mismatched, placeholder-like, or otherwise not trusted. | Surface redacted credential degradation and do not expose secret material. |
+| unavailable | Required Wazuh component or required AegisOps intake observation is absent. | Surface unavailable context and fail closed on source-health completeness. |
+| mismatched | Component identity, profile version, route, custody reference, or source linkage does not match the accepted profile. | Surface mismatch context and do not infer authoritative linkage from naming or path shape. |
+
+## 5. Projection Rules
+
+- All required components must be represented before the aggregate projection can be `available`.
+- `stale_source` must be derived from the last accepted Wazuh signal recorded by AegisOps, not from dashboard freshness text alone.
+- `parser_failure` must stay visible and must prevent a false healthy aggregate projection.
+- `volume_anomaly` must stay visible and must not become incident, case, or evidence truth by itself.
+- `credential_degraded` must use redacted state only and must reject placeholder, sample, fake, TODO, unsigned, inline, or committed credential material.
+- Unavailable manager, dashboard, indexer, intake, or credential posture must stay visible as subordinate health context.
+- Mismatched profile, route, component identity, custody reference, or source linkage must fail closed instead of inferring success.
+- No source-health state may close, approve, execute, reconcile, release, gate, or mutate authoritative AegisOps records.
+
+## 6. Validation Rules
+
+Wazuh source-health projection validation must fail closed when:
+
+- `docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml` is missing;
+- the contract document is missing;
+- manager, dashboard, indexer, intake, signal freshness, parser, volume, or credential coverage is missing;
+- `available`, `degraded`, `stale_source`, `parser_failure`, `volume_anomaly`, `credential_degraded`, `unavailable`, or `mismatched` coverage is missing;
+- stale source, parser failure, volume anomaly, credential degradation, unavailable, or mismatched handling is missing;
+- a credential-degraded state exposes secret material, accepts placeholder credentials, or validates committed credentials;
+- Wazuh source-health state is described as AegisOps workflow truth, case truth, evidence truth, approval truth, execution truth, reconciliation truth, release truth, gate truth, or closeout truth; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<supervisor-config-path>`, `<codex-supervisor-root>`, `<runtime-env-file>`, and `<wazuh-profile-path>`.
+
+## 7. Forbidden Claims
+
+- Wazuh health status is AegisOps workflow truth.
+- Wazuh source health closes AegisOps cases.
+- Wazuh manager health is AegisOps source truth.
+- Wazuh dashboard health is AegisOps workflow truth.
+- Wazuh indexer health is AegisOps evidence truth.
+- Credential-degraded state may expose secret material.
+- Placeholder Wazuh health credentials are valid credentials.
+- Source-health projection is AegisOps closeout truth.
+- Phase 53.6 implements Wazuh Active Response authority.
+- Phase 53.6 implements Shuffle product profiles.
+- Phase 53.6 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh`.
+
+Run `bash scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1141 --config <supervisor-config-path>`.
+
+The verifier must fail when the source-health projection contract or artifact is missing, when component or state coverage is missing, when degraded/unavailable/parser/volume/credential/mismatched handling is missing, when Wazuh health is promoted into AegisOps authority, when credential-degraded state leaks secret material, or when publishable guidance uses workstation-local absolute paths.
+
+## 9. Non-Goals
+
+- No Wazuh Active Response authority, Shuffle profile work, direct Wazuh-to-Shuffle shortcut, fleet-scale Wazuh management, broad SIEM detector catalog, release-candidate behavior, general-availability behavior, commercial readiness, or Wazuh replacement readiness is implemented here.
+- No Wazuh manager state, dashboard state, indexer state, intake state, signal freshness, parser state, volume state, credential state, source-health projection, verifier output, issue-lint output, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/docs/deployment/wazuh-source-health-projection-contract.md
+++ b/docs/deployment/wazuh-source-health-projection-contract.md
@@ -52,14 +52,16 @@ This contract cites the Phase 51.6 authority-boundary negative-test policy in `d
 
 ## 5. Projection Rules
 
-- All required components must be represented before the aggregate projection can be `available`.
-- `stale_source` must be derived from the last accepted Wazuh signal recorded by AegisOps, not from dashboard freshness text alone.
-- `parser_failure` must stay visible and must prevent a false healthy aggregate projection.
-- `volume_anomaly` must stay visible and must not become incident, case, or evidence truth by itself.
-- `credential_degraded` must use redacted state only and must reject placeholder, sample, fake, TODO, unsigned, inline, or committed credential material.
-- Unavailable manager, dashboard, indexer, intake, or credential posture must stay visible as subordinate health context.
-- Mismatched profile, route, component identity, custody reference, or source linkage must fail closed instead of inferring success.
-- No source-health state may close, approve, execute, reconcile, release, gate, or mutate authoritative AegisOps records.
+| Rule | Required behavior | Authority boundary |
+| --- | --- | --- |
+| all-required-components-available | All required components must be represented before the aggregate projection can be `available`. | Aggregate health remains subordinate context only. |
+| stale-last-accepted-signal | `stale_source` must be derived from the last accepted Wazuh signal recorded by AegisOps, not from dashboard freshness text alone. | Dashboard freshness text cannot become AegisOps lifecycle truth. |
+| parser-failure-visible | `parser_failure` must stay visible and must prevent a false healthy aggregate projection. | Parser diagnostics cannot rewrite case truth. |
+| volume-anomaly-visible | `volume_anomaly` must stay visible and must not become incident, case, or evidence truth by itself. | Volume counters are source-health context only. |
+| credential-degraded-redacted | `credential_degraded` must use redacted state only and must reject placeholder, sample, fake, TODO, unsigned, inline, or committed credential material. | Credential posture must not expose secret material or validate placeholders. |
+| manager-dashboard-indexer-unavailable-visible | Unavailable manager, dashboard, indexer, intake, or credential posture must stay visible as subordinate health context. | Component availability cannot close, approve, execute, reconcile, release, gate, or mutate AegisOps records. |
+| component-mismatch-visible | Mismatched profile, route, component identity, custody reference, or source linkage must fail closed instead of inferring success. | Linkage must come from explicit AegisOps admission and binding. |
+| no-authority-mutation | No source-health state may close, approve, execute, reconcile, release, gate, or mutate authoritative AegisOps records. | AegisOps control-plane records remain authoritative. |
 
 ## 6. Validation Rules
 

--- a/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
@@ -164,12 +164,28 @@ assert_fails_with \
   "${secret_looking_value_repo}" \
   "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected"
 
+quoted_secret_looking_value_repo="${workdir}/quoted-secret-looking-value"
+create_valid_repo "${quoted_secret_looking_value_repo}"
+printf '%s\n' 'health_token: "CorrectHorseBatteryStaple42"' \
+  >>"${quoted_secret_looking_value_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${quoted_secret_looking_value_repo}" \
+  "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected"
+
 contract_secret_looking_value_repo="${workdir}/contract-secret-looking-value"
 create_valid_repo "${contract_secret_looking_value_repo}"
 printf '%s\n' "health_secret: CorrectHorseBatteryStaple42" \
   >>"${contract_secret_looking_value_repo}/docs/deployment/wazuh-source-health-projection-contract.md"
 assert_fails_with \
   "${contract_secret_looking_value_repo}" \
+  "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected"
+
+quoted_contract_secret_looking_value_repo="${workdir}/quoted-contract-secret-looking-value"
+create_valid_repo "${quoted_contract_secret_looking_value_repo}"
+printf '%s\n' "health_password: 'CorrectHorseBatteryStaple42'" \
+  >>"${quoted_contract_secret_looking_value_repo}/docs/deployment/wazuh-source-health-projection-contract.md"
+assert_fails_with \
+  "${quoted_contract_secret_looking_value_repo}" \
   "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected"
 
 authority_truth_repo="${workdir}/authority-truth"

--- a/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
@@ -100,6 +100,14 @@ assert_fails_with \
   "${missing_unavailable_repo}" \
   "Missing Phase 53.6 Wazuh source-health state: unavailable"
 
+missing_stale_source_repo="${workdir}/missing-stale-source"
+create_valid_repo "${missing_stale_source_repo}"
+perl -0pi -e 's/^  - stale_source\n//m' \
+  "${missing_stale_source_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_stale_source_repo}" \
+  "Missing Phase 53.6 Wazuh source-health state: stale_source"
+
 missing_parser_failure_repo="${workdir}/missing-parser-failure"
 create_valid_repo "${missing_parser_failure_repo}"
 perl -0pi -e 's/^  - parser_failure\n//m' \
@@ -146,6 +154,14 @@ printf '%s\n' "health_secret: CorrectHorseBatteryStaple42" \
   >>"${secret_looking_value_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
 assert_fails_with \
   "${secret_looking_value_repo}" \
+  "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected"
+
+contract_secret_looking_value_repo="${workdir}/contract-secret-looking-value"
+create_valid_repo "${contract_secret_looking_value_repo}"
+printf '%s\n' "health_secret: CorrectHorseBatteryStaple42" \
+  >>"${contract_secret_looking_value_repo}/docs/deployment/wazuh-source-health-projection-contract.md"
+assert_fails_with \
+  "${contract_secret_looking_value_repo}" \
   "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected"
 
 authority_truth_repo="${workdir}/authority-truth"

--- a/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
@@ -172,6 +172,14 @@ assert_fails_with \
   "${quoted_secret_looking_value_repo}" \
   "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected"
 
+bypass_word_secret_looking_value_repo="${workdir}/bypass-word-secret-looking-value"
+create_valid_repo "${bypass_word_secret_looking_value_repo}"
+printf '%s\n' "health_secret: CorrectHorseBatteryStaple42 # custody reference" \
+  >>"${bypass_word_secret_looking_value_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${bypass_word_secret_looking_value_repo}" \
+  "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected"
+
 contract_secret_looking_value_repo="${workdir}/contract-secret-looking-value"
 create_valid_repo "${contract_secret_looking_value_repo}"
 printf '%s\n' "health_secret: CorrectHorseBatteryStaple42" \

--- a/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-53-6-wazuh-source-health-projection.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/profiles/smb-single-node/wazuh"
+  printf '%s\n' "# AegisOps" "See [Phase 53.6 Wazuh source-health projection contract](docs/deployment/wazuh-source-health-projection-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/wazuh-source-health-projection-contract.md" \
+    "${target}/docs/deployment/wazuh-source-health-projection-contract.md"
+  cp "${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml" \
+    "${target}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/wazuh-source-health-projection-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/wazuh-source-health-projection-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 53.6 Wazuh source-health projection contract"
+
+missing_artifact_repo="${workdir}/missing-artifact"
+create_valid_repo "${missing_artifact_repo}"
+rm "${missing_artifact_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_artifact_repo}" \
+  "Missing Phase 53.6 Wazuh source-health projection artifact"
+
+missing_component_repo="${workdir}/missing-component"
+create_valid_repo "${missing_component_repo}"
+perl -0pi -e 's/^  - parser\n//m' \
+  "${missing_component_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_component_repo}" \
+  "Missing Phase 53.6 Wazuh source-health component: parser"
+
+missing_degraded_repo="${workdir}/missing-degraded"
+create_valid_repo "${missing_degraded_repo}"
+perl -0pi -e 's/^  - degraded\n//m' \
+  "${missing_degraded_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_degraded_repo}" \
+  "Missing Phase 53.6 Wazuh source-health state: degraded"
+
+missing_unavailable_repo="${workdir}/missing-unavailable"
+create_valid_repo "${missing_unavailable_repo}"
+perl -0pi -e 's/^  - unavailable\n//m' \
+  "${missing_unavailable_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_unavailable_repo}" \
+  "Missing Phase 53.6 Wazuh source-health state: unavailable"
+
+missing_parser_failure_repo="${workdir}/missing-parser-failure"
+create_valid_repo "${missing_parser_failure_repo}"
+perl -0pi -e 's/^  - parser_failure\n//m' \
+  "${missing_parser_failure_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_parser_failure_repo}" \
+  "Missing Phase 53.6 Wazuh source-health state: parser_failure"
+
+missing_volume_anomaly_repo="${workdir}/missing-volume-anomaly"
+create_valid_repo "${missing_volume_anomaly_repo}"
+perl -0pi -e 's/^  - volume_anomaly\n//m' \
+  "${missing_volume_anomaly_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_volume_anomaly_repo}" \
+  "Missing Phase 53.6 Wazuh source-health state: volume_anomaly"
+
+missing_credential_degraded_repo="${workdir}/missing-credential-degraded"
+create_valid_repo "${missing_credential_degraded_repo}"
+perl -0pi -e 's/^  - credential_degraded\n//m' \
+  "${missing_credential_degraded_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_credential_degraded_repo}" \
+  "Missing Phase 53.6 Wazuh source-health state: credential_degraded"
+
+missing_mismatched_repo="${workdir}/missing-mismatched"
+create_valid_repo "${missing_mismatched_repo}"
+perl -0pi -e 's/^  - mismatched\n//m' \
+  "${missing_mismatched_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_mismatched_repo}" \
+  "Missing Phase 53.6 Wazuh source-health state: mismatched"
+
+missing_rule_repo="${workdir}/missing-rule"
+create_valid_repo "${missing_rule_repo}"
+perl -0pi -e 's/^  - credential-degraded-redacted\n//m' \
+  "${missing_rule_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${missing_rule_repo}" \
+  "Missing Phase 53.6 Wazuh source-health rule: credential-degraded-redacted"
+
+secret_looking_value_repo="${workdir}/secret-looking-value"
+create_valid_repo "${secret_looking_value_repo}"
+printf '%s\n' "health_secret: CorrectHorseBatteryStaple42" \
+  >>"${secret_looking_value_repo}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+assert_fails_with \
+  "${secret_looking_value_repo}" \
+  "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected"
+
+authority_truth_repo="${workdir}/authority-truth"
+create_valid_repo "${authority_truth_repo}"
+printf '%s\n' "Wazuh health status is AegisOps workflow truth." \
+  >>"${authority_truth_repo}/docs/deployment/wazuh-source-health-projection-contract.md"
+assert_fails_with \
+  "${authority_truth_repo}" \
+  "Forbidden Phase 53.6 Wazuh source-health projection claim: Wazuh health status is AegisOps workflow truth"
+
+credential_leak_repo="${workdir}/credential-leak"
+create_valid_repo "${credential_leak_repo}"
+printf '%s\n' "Credential-degraded state may expose secret material." \
+  >>"${credential_leak_repo}/docs/deployment/wazuh-source-health-projection-contract.md"
+assert_fails_with \
+  "${credential_leak_repo}" \
+  "Forbidden Phase 53.6 Wazuh source-health projection claim: Credential-degraded state may expose secret material"
+
+missing_forbidden_claim_repo="${workdir}/missing-forbidden-claim"
+create_valid_repo "${missing_forbidden_claim_repo}"
+remove_text_from_contract "${missing_forbidden_claim_repo}" \
+  "Wazuh source health closes AegisOps cases."
+assert_fails_with \
+  "${missing_forbidden_claim_repo}" \
+  "Missing Phase 53.6 Wazuh source-health forbidden claim: Wazuh source health closes AegisOps cases"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/wazuh-source-health-projection-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 53.6 Wazuh source-health projection artifact: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 53.6 Wazuh source-health projection contract."
+
+echo "Phase 53.6 Wazuh source-health projection verifier tests passed."

--- a/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
@@ -148,6 +148,14 @@ assert_fails_with \
   "${missing_rule_repo}" \
   "Missing Phase 53.6 Wazuh source-health rule: credential-degraded-redacted"
 
+missing_contract_rule_repo="${workdir}/missing-contract-rule"
+create_valid_repo "${missing_contract_rule_repo}"
+perl -0pi -e 's/^\| no-authority-mutation \|.*\n//m' \
+  "${missing_contract_rule_repo}/docs/deployment/wazuh-source-health-projection-contract.md"
+assert_fails_with \
+  "${missing_contract_rule_repo}" \
+  "Missing Phase 53.6 Wazuh source-health projection contract rule row: no-authority-mutation"
+
 secret_looking_value_repo="${workdir}/secret-looking-value"
 create_valid_repo "${secret_looking_value_repo}"
 printf '%s\n' "health_secret: CorrectHorseBatteryStaple42" \

--- a/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
@@ -186,7 +186,7 @@ contains_secret_looking_value() {
     /^[[:space:]]*#/ { next }
     {
       line = tolower($0)
-      if (line ~ /(secret|token|password|credential|api_key|apikey)[[:space:]]*:[[:space:]]*[[:alnum:]_\/+=.-]{16,}/ &&
+      if (line ~ /(secret|token|password|credential|api_key|apikey)[[:space:]]*:[[:space:]]*["'\''"]?[[:alnum:]_\/+=.-]{16,}["'\''"]?/ &&
           line !~ /(custody|reference|allowed:[[:space:]]*false|valid:[[:space:]]*false|redacted|placeholder|<[^>]+>)/) {
         found = 1
       }

--- a/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+contract_path="${repo_root}/docs/deployment/wazuh-source-health-projection-contract.md"
+artifact_path="${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 53.6 Wazuh Source-Health Projection Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Projection Inputs"
+  "## 4. Projection States"
+  "## 5. Projection Rules"
+  "## 6. Validation Rules"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted contract"
+  "- **Date**: 2026-05-03"
+  "- **Related Issues**: #1135, #1138, #1141"
+  "This contract defines the Wazuh source-health projection for the \`smb-single-node\` product profile."
+  "The required structured artifact is \`docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml\`."
+  "Wazuh is a subordinate detection substrate."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth."
+  "This contract cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`."
+  "Run \`bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh\`."
+  "Run \`bash scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh\`."
+  "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1141 --config <supervisor-config-path>\`."
+)
+
+required_artifact_terms=(
+  "profile_id: smb-single-node"
+  "product_profile: wazuh"
+  "source_health_projection_contract_version: 2026-05-03"
+  "status: accepted-contract"
+  "projection_owner: aegisops-control-plane"
+  "substrate_owner: wazuh"
+  "authority_mutation_allowed: false"
+  "raw_secret_values_allowed: false"
+  "placeholder_credentials_valid: false"
+  "workflow_truth_source: aegisops-record-chain-only"
+  "components:"
+  "states:"
+  "projection_rules:"
+  "negative_validation_tests:"
+)
+
+required_components=(
+  manager
+  dashboard
+  indexer
+  intake
+  signal_freshness
+  parser
+  volume
+  credential
+)
+
+required_states=(
+  available
+  degraded
+  stale_source
+  parser_failure
+  volume_anomaly
+  credential_degraded
+  unavailable
+  mismatched
+)
+
+required_rules=(
+  all-required-components-available
+  stale-last-accepted-signal
+  parser-failure-visible
+  volume-anomaly-visible
+  credential-degraded-redacted
+  manager-dashboard-indexer-unavailable-visible
+  component-mismatch-visible
+  no-authority-mutation
+)
+
+forbidden_claims=(
+  "Wazuh health status is AegisOps workflow truth"
+  "Wazuh source health closes AegisOps cases"
+  "Wazuh manager health is AegisOps source truth"
+  "Wazuh dashboard health is AegisOps workflow truth"
+  "Wazuh indexer health is AegisOps evidence truth"
+  "Credential-degraded state may expose secret material"
+  "Placeholder Wazuh health credentials are valid credentials"
+  "Source-health projection is AegisOps closeout truth"
+  "Phase 53.6 implements Wazuh Active Response authority"
+  "Phase 53.6 implements Shuffle product profiles"
+  "Phase 53.6 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+has_uncommented_substring() {
+  local needle="$1"
+  local file_path="$2"
+
+  awk -v needle="${needle}" '
+    /^[[:space:]]*#/ { next }
+    {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      if (index(line, needle)) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"
+}
+
+require_top_level_list_item() {
+  local file_path="$1"
+  local section="$2"
+  local item="$3"
+  local label="$4"
+
+  if ! awk -v section="${section}" -v item="${item}" '
+    $0 == section ":" {
+      in_section = 1
+      next
+    }
+    in_section && /^[^[:space:]][^:]*:/ {
+      in_section = 0
+    }
+    in_section && $0 ~ ("^  - " item "([[:space:]]*(#.*)?)?$") {
+      found = 1
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"; then
+    echo "Missing Phase 53.6 Wazuh source-health ${label}: ${item}" >&2
+    exit 1
+  fi
+}
+
+contains_forbidden_claim_in_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+contains_secret_looking_value() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    {
+      line = tolower($0)
+      if (line ~ /(secret|token|password|credential|api_key|apikey)[[:space:]]*:[[:space:]]*[[:alnum:]_\/+=.-]{16,}/ &&
+          line !~ /(custody|reference|allowed:[[:space:]]*false|valid:[[:space:]]*false|redacted|placeholder|<[^>]+>)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${artifact_path}"
+}
+
+if [[ ! -f "${contract_path}" ]]; then
+  echo "Missing Phase 53.6 Wazuh source-health projection contract: ${contract_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${artifact_path}" ]]; then
+  echo "Missing Phase 53.6 Wazuh source-health projection artifact: ${artifact_path}" >&2
+  exit 1
+fi
+
+contract_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${contract_path}"
+)"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.6 Wazuh source-health projection contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.6 Wazuh source-health projection contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for term in "${required_artifact_terms[@]}"; do
+  if ! has_uncommented_substring "${term}" "${artifact_path}"; then
+    echo "Missing Phase 53.6 Wazuh source-health projection artifact term: ${term}" >&2
+    exit 1
+  fi
+done
+
+for component in "${required_components[@]}"; do
+  require_top_level_list_item "${artifact_path}" "components" "${component}" "component"
+  if ! grep -Fq -- "| ${component} |" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.6 Wazuh source-health projection contract component row: ${component}" >&2
+    exit 1
+  fi
+done
+
+for state in "${required_states[@]}"; do
+  require_top_level_list_item "${artifact_path}" "states" "${state}" "state"
+  if ! grep -Fq -- "| ${state} |" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.6 Wazuh source-health projection contract state row: ${state}" >&2
+    exit 1
+  fi
+done
+
+for rule in "${required_rules[@]}"; do
+  require_top_level_list_item "${artifact_path}" "projection_rules" "${rule}" "rule"
+done
+
+for claim in "${forbidden_claims[@]}"; do
+  if ! contains_forbidden_claim_in_section "${claim}"; then
+    echo "Missing Phase 53.6 Wazuh source-health forbidden claim: ${claim}" >&2
+    exit 1
+  fi
+
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 53.6 Wazuh source-health projection claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+if contains_secret_looking_value; then
+  echo "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected" >&2
+  exit 1
+fi
+
+mac_user_home_pattern="/""Users/"
+posix_user_home_pattern="/""home/[^[:space:]/]+"
+windows_user_home_pattern='C:\\''Users\\'
+if grep -REq "${mac_user_home_pattern}|${posix_user_home_pattern}|${windows_user_home_pattern}" "${contract_path}" "${artifact_path}"; then
+  echo "Forbidden Phase 53.6 Wazuh source-health projection artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 53.6 Wazuh source-health projection link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}"
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/wazuh-source-health-projection-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 53.6 Wazuh source-health projection contract." >&2
+  exit 1
+fi
+
+echo "Phase 53.6 Wazuh source-health projection contract is present and rejects missing states, authority promotion, secret leakage, and workstation-local paths."

--- a/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
@@ -187,7 +187,7 @@ contains_secret_looking_value() {
     {
       line = tolower($0)
       if (line ~ /(secret|token|password|credential|api_key|apikey)[[:space:]]*:[[:space:]]*["'\''"]?[[:alnum:]_\/+=.-]{16,}["'\''"]?/ &&
-          line !~ /(custody|reference|allowed:[[:space:]]*false|valid:[[:space:]]*false|redacted|placeholder|<[^>]+>)/) {
+          line !~ /(allowed:[[:space:]]*false|valid:[[:space:]]*false|redacted|placeholder|<[^>]+>)/) {
         found = 1
       }
     }

--- a/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
@@ -248,6 +248,10 @@ done
 
 for rule in "${required_rules[@]}"; do
   require_top_level_list_item "${artifact_path}" "projection_rules" "${rule}" "rule"
+  if ! grep -Fq -- "| ${rule} |" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.6 Wazuh source-health projection contract rule row: ${rule}" >&2
+    exit 1
+  fi
 done
 
 for claim in "${forbidden_claims[@]}"; do

--- a/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
@@ -180,6 +180,8 @@ contains_forbidden_outside_forbidden_section() {
 }
 
 contains_secret_looking_value() {
+  local file_path="$1"
+
   awk '
     /^[[:space:]]*#/ { next }
     {
@@ -190,7 +192,7 @@ contains_secret_looking_value() {
       }
     }
     END { exit(found ? 0 : 1) }
-  ' "${artifact_path}"
+  ' "${file_path}"
 }
 
 if [[ ! -f "${contract_path}" ]]; then
@@ -260,10 +262,12 @@ for claim in "${forbidden_claims[@]}"; do
   fi
 done
 
-if contains_secret_looking_value; then
-  echo "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected" >&2
-  exit 1
-fi
+for secret_scan_path in "${contract_path}" "${artifact_path}"; do
+  if contains_secret_looking_value "${secret_scan_path}"; then
+    echo "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected" >&2
+    exit 1
+  fi
+done
 
 mac_user_home_pattern="/""Users/"
 posix_user_home_pattern="/""home/[^[:space:]/]+"

--- a/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
+++ b/scripts/verify-phase-53-6-wazuh-source-health-projection.sh
@@ -268,7 +268,7 @@ done
 
 for secret_scan_path in "${contract_path}" "${artifact_path}"; do
   if contains_secret_looking_value "${secret_scan_path}"; then
-    echo "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected" >&2
+    echo "Forbidden Phase 53.6 Wazuh source-health artifact: committed secret-looking value detected in ${secret_scan_path}" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
## Summary
- add the Phase 53.6 Wazuh source-health projection contract and structured profile artifact
- enforce manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, degraded, stale, unavailable, parser failure, volume anomaly, credential degraded, and mismatched coverage
- add verifier and negative verifier fixtures for missing states, authority promotion, secret leakage, local path hygiene, and README linkage

## Verification
- bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh
- bash scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh
- bash scripts/verify-phase-53-1-wazuh-profile-contract.sh
- bash scripts/test-verify-phase-53-1-wazuh-profile-contract.sh
- bash scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh
- bash scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh
- bash scripts/verify-publishable-path-hygiene.sh
- git diff --check
- node <codex-supervisor-root>/dist/index.js issue-lint 1141 --config <supervisor-config-path>

Closes #1141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 53.6 Wazuh source‑health projection contract and profile guidance, clarifying required components/states, projection rules, redacted credential handling, forbidden claims, strict authority boundaries, and README link to the contract.

* **Tests**
  * Added a strict verification suite and test runner that validate contract/artifact presence, required state coverage and rules, forbidden-claim enforcement, secret/path hygiene, and expected failure cases.

* **Chores**
  * Declared the accepted contract in the deployment profile and added verification tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->