### PR TITLE
Phase 53.7 Wazuh upgrade rollback evidence contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Canonical cross-phase boundary reference:
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
 - [Phase 53.6 Wazuh source-health projection contract](docs/deployment/wazuh-source-health-projection-contract.md) defines manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched source-health projection states for the Wazuh profile.
+- [Phase 53.7 Wazuh upgrade rollback evidence contract](docs/deployment/wazuh-upgrade-rollback-evidence-contract.md) defines version before/after, rollback owner, rollback trigger, evidence references, known limitations, and profile-change handoff expectations without implementing a Wazuh upgrader.
 
 ## Product positioning
 
@@ -94,6 +95,8 @@ The Phase 53.3 Wazuh intake binding contract is defined by the [Phase 53.3 Wazuh
 The Phase 53.5 Wazuh agent enrollment helper contract is defined by the [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md).
 
 The Phase 53.6 Wazuh source-health projection contract is defined by the [Phase 53.6 Wazuh source-health projection contract](docs/deployment/wazuh-source-health-projection-contract.md).
+
+The Phase 53.7 Wazuh upgrade rollback evidence contract is defined by the [Phase 53.7 Wazuh upgrade rollback evidence contract](docs/deployment/wazuh-upgrade-rollback-evidence-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml
+++ b/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml
@@ -68,8 +68,10 @@ negative_validation_tests:
   - missing-version-before
   - missing-version-after
   - missing-rollback-trigger
+  - placeholder-rollback-trigger
   - missing-evidence-references
   - missing-known-limitations
   - missing-profile-change-handoff
+  - missing-component-rollback-target
   - full-upgrader-claim
   - version-state-as-release-truth

--- a/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml
+++ b/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml
@@ -1,0 +1,75 @@
+profile_id: smb-single-node
+product_profile: wazuh
+upgrade_rollback_evidence_contract_version: 2026-05-03
+status: accepted-contract
+related_issues:
+  - 1135
+  - 1136
+  - 1142
+evidence_owner: aegisops-release-evidence
+substrate_owner: wazuh
+authority_boundary: Wazuh upgrade and rollback evidence is subordinate release-evidence context only; Wazuh version, upgrade, rollback, manager, indexer, dashboard, source-health, and generated-config state cannot close, approve, execute, reconcile, release, gate, or mutate authoritative AegisOps records.
+authority_mutation_allowed: false
+full_upgrader_implemented: false
+upgrade_automation_allowed: false
+fleet_scale_management_allowed: false
+workflow_truth_source: aegisops-record-chain-only
+version_before: 4.12.0
+version_after: <reviewed-target-wazuh-version>
+rollback_owner: aegisops-release-owner
+rollback_trigger: reviewed validation failure, source-health mismatch, restore rehearsal failure, or release-gate rejection before profile-change acceptance
+components:
+  - manager
+  - indexer
+  - dashboard
+required_evidence_fields:
+  - version_before
+  - version_after
+  - rollback_owner
+  - rollback_trigger
+  - evidence_references
+  - known_limitations
+  - profile_change_handoff
+evidence_references:
+  - aegisops-release-gate-record
+  - wazuh-profile-diff-record
+  - source-health-projection-review
+  - backup-restore-rehearsal-record
+  - validation-rerun-result
+known_limitations:
+  - release-evidence-only
+  - no-full-wazuh-upgrader
+  - no-wazuh-upgrade-automation
+  - no-fleet-scale-wazuh-management
+  - no-beta-rc-ga-commercial-readiness-claim
+profile_change_handoff:
+  target: phase-53-closeout-release-evidence
+  recipient: aegisops-maintainers
+  review_state: pending-real-version-change
+  next_action: replace <reviewed-target-wazuh-version> with a reviewed target version before any future Wazuh profile version change is accepted
+component_evidence:
+  manager:
+    version_before: 4.12.0
+    version_after: <reviewed-target-wazuh-version>
+    rollback_target: last-reviewed-manager-profile-version
+    authority_note: Manager version remains subordinate substrate context only.
+  indexer:
+    version_before: 4.12.0
+    version_after: <reviewed-target-wazuh-version>
+    rollback_target: last-reviewed-indexer-profile-version
+    authority_note: Indexer version and contents are not AegisOps evidence truth.
+  dashboard:
+    version_before: 4.12.0
+    version_after: <reviewed-target-wazuh-version>
+    rollback_target: last-reviewed-dashboard-profile-version
+    authority_note: Dashboard version and UI state remain operator context only.
+negative_validation_tests:
+  - missing-rollback-owner
+  - missing-version-before
+  - missing-version-after
+  - missing-rollback-trigger
+  - missing-evidence-references
+  - missing-known-limitations
+  - missing-profile-change-handoff
+  - full-upgrader-claim
+  - version-state-as-release-truth

--- a/docs/deployment/wazuh-smb-single-node-profile-contract.md
+++ b/docs/deployment/wazuh-smb-single-node-profile-contract.md
@@ -34,9 +34,9 @@ This contract cites the Phase 51.6 authority-boundary negative-test policy in `d
 
 | Component | Accepted version | Pin type | Known incompatible versions | Upgrade note |
 | --- | --- | --- | --- | --- |
-| manager | `4.12.0` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; `latest`; RC; beta. | Upgrade evidence is deferred to a later Phase 53 child issue. |
-| indexer | `4.12.0` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; `latest`; RC; beta. | Upgrade evidence is deferred to a later Phase 53 child issue. |
-| dashboard | `4.12.0` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; `latest`; RC; beta. | Upgrade evidence is deferred to a later Phase 53 child issue. |
+| manager | `4.12.0` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; `latest`; RC; beta. | Upgrade evidence expectations are defined by `docs/deployment/wazuh-upgrade-rollback-evidence-contract.md`. |
+| indexer | `4.12.0` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; `latest`; RC; beta. | Upgrade evidence expectations are defined by `docs/deployment/wazuh-upgrade-rollback-evidence-contract.md`. |
+| dashboard | `4.12.0` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; `latest`; RC; beta. | Upgrade evidence expectations are defined by `docs/deployment/wazuh-upgrade-rollback-evidence-contract.md`. |
 
 ## 5. Profile Expectations
 

--- a/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md
+++ b/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md
@@ -1,0 +1,92 @@
+# Phase 53.7 Wazuh Upgrade And Rollback Evidence Contract
+
+- **Status**: Accepted contract
+- **Date**: 2026-05-03
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/deployment/wazuh-smb-single-node-profile-contract.md`, `docs/deployment/wazuh-source-health-projection-contract.md`, `docs/deployment/release-handoff-evidence-package.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1135, #1136, #1142
+
+This contract defines release evidence expectations for Wazuh profile version changes in the `smb-single-node` product profile. It records the required before and after version evidence, rollback owner, rollback trigger, evidence references, known limitations, and profile-change handoff without implementing a live Wazuh upgrader.
+
+The required structured artifact is `docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml`.
+
+## 1. Purpose
+
+The Wazuh upgrade and rollback evidence contract gives maintainers a reviewed release-evidence template for future Wazuh profile version changes.
+
+The contract is intentionally evidence custody only. It does not execute upgrades, generate Wazuh configuration, mutate Wazuh manager, indexer, dashboard, agent, or certificate state, or change AegisOps workflow authority.
+
+## 2. Authority Boundary
+
+Wazuh is a subordinate detection substrate. Wazuh version state, upgrade evidence, rollback evidence, manager state, indexer state, dashboard state, agent state, generated config, source-health projection, verifier output, issue-lint output, operator-facing status text, release notes, and setup evidence are not alert, case, evidence, approval, execution, reconciliation, workflow, gate, release, production, or closeout truth.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`. A Wazuh profile version change must preserve the rule that Wazuh status, Wazuh version, manager reports, indexer contents, dashboard text, source-health projection, tickets, AI, browser, UI cache, optional evidence, and downstream receipt state cannot close, reconcile, approve, execute, release, gate, or otherwise mutate AegisOps records without explicit AegisOps admission and linkage.
+
+## 3. Required Evidence Fields
+
+| Field | Required content | Fail-closed rule |
+| --- | --- | --- |
+| `version_before` | The accepted Wazuh profile version before the reviewed change. | Missing, floating, `latest`, beta, RC, or inferred versions fail. |
+| `version_after` | The reviewed target Wazuh profile version or explicit placeholder `<reviewed-target-wazuh-version>` before a real change is selected. | Missing or unreviewed target versions fail. |
+| `rollback_owner` | Named accountable owner or owner group for rollback decisions. | Missing, placeholder-like, or inferred owner fails. |
+| `rollback_trigger` | The reviewed condition that triggers rollback review. | Missing trigger or broad operator discretion without evidence fails. |
+| `evidence_references` | AegisOps release-gate, source-health, profile diff, backup or restore, and validation evidence references. | Missing references or Wazuh-only references fail. |
+| `known_limitations` | Accepted limitations for the version change, including deferred automation and fleet-scale exclusions. | Missing limitations or commercial-readiness claims fail. |
+| `profile_change_handoff` | Handoff target, expected recipient, review state, and next profile-change action. | Missing handoff or inferred ownership fails. |
+
+## 4. Component Coverage
+
+| Component | Version evidence | Rollback evidence | Authority boundary |
+| --- | --- | --- | --- |
+| manager | Before and after Wazuh manager version or reviewed target placeholder. | Rollback returns to the last reviewed manager profile version and evidence set. | Manager version is substrate context only. |
+| indexer | Before and after Wazuh indexer version or reviewed target placeholder. | Rollback returns to the last reviewed indexer profile version and evidence set. | Indexer version and contents are not AegisOps evidence truth. |
+| dashboard | Before and after Wazuh dashboard version or reviewed target placeholder. | Rollback returns to the last reviewed dashboard profile version and evidence set. | Dashboard version and UI state are operator context only. |
+
+## 5. Validation Rules
+
+Wazuh upgrade and rollback evidence validation must fail closed when:
+
+- `docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml` is missing;
+- the contract document is missing;
+- manager, indexer, or dashboard component coverage is missing;
+- `version_before` or `version_after` evidence is missing;
+- rollback owner or rollback trigger evidence is missing;
+- evidence references are missing or only cite Wazuh-owned state;
+- known limitations are missing;
+- profile-change handoff expectations are missing;
+- the artifact claims to implement a full automatic Wazuh upgrader;
+- Wazuh version state, upgrade evidence, rollback evidence, source-health projection, dashboard state, manager state, or indexer state is described as AegisOps workflow truth, case truth, evidence truth, approval truth, execution truth, reconciliation truth, release truth, gate truth, or closeout truth; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<supervisor-config-path>`, `<codex-supervisor-root>`, `<runtime-env-file>`, and `<wazuh-profile-path>`.
+
+## 6. Forbidden Claims
+
+- Wazuh version state is AegisOps release truth.
+- Wazuh upgrade evidence is AegisOps workflow truth.
+- Wazuh rollback evidence closes AegisOps cases.
+- Wazuh manager version is AegisOps source truth.
+- Wazuh dashboard upgrade status is AegisOps approval truth.
+- Wazuh indexer upgrade status is AegisOps evidence truth.
+- Phase 53.7 implements a full Wazuh upgrader.
+- Phase 53.7 implements Wazuh upgrade automation.
+- Phase 53.7 implements fleet-scale Wazuh management.
+- Phase 53.7 implements Shuffle product profiles.
+- Phase 53.7 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness.
+
+## 7. Validation
+
+Run `bash scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh`.
+
+Run `bash scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1142 --config <supervisor-config-path>`.
+
+The verifier must fail when the upgrade and rollback evidence contract or artifact is missing, when version before or after evidence is missing, when rollback owner or trigger evidence is missing, when evidence references or known limitations are missing, when profile-change handoff expectations are missing, when Wazuh version or rollback state is promoted into AegisOps authority, when full upgrader behavior is claimed, or when publishable guidance uses workstation-local absolute paths.
+
+## 8. Non-Goals
+
+- No live Wazuh upgrader, Wazuh upgrade automation, Wazuh configuration generation, Wazuh certificate generation, fleet-scale Wazuh management, Shuffle product profile work, direct Wazuh-to-Shuffle shortcut, release-candidate behavior, general-availability behavior, commercial readiness, or Wazuh replacement readiness is implemented here.
+- No Wazuh manager state, indexer state, dashboard state, agent state, version state, generated Wazuh config, source-health projection, upgrade evidence, rollback evidence, verifier output, issue-lint output, ticket, AI output, browser state, UI cache, downstream receipt, log text, or operator-facing summary becomes authoritative AegisOps truth.

--- a/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md
+++ b/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md
@@ -50,9 +50,10 @@ Wazuh upgrade and rollback evidence validation must fail closed when:
 
 - `docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml` is missing;
 - the contract document is missing;
-- manager, indexer, or dashboard component coverage is missing;
+- manager, indexer, or dashboard component coverage is missing or lacks component-level `version_before`, `version_after`, or `rollback_target` evidence;
 - `version_before` or `version_after` evidence is missing;
 - rollback owner or rollback trigger evidence is missing;
+- rollback trigger evidence is placeholder-like or leaves rollback to broad operator discretion without a reviewed condition;
 - evidence references are missing or only cite Wazuh-owned state;
 - known limitations are missing;
 - profile-change handoff expectations are missing;
@@ -84,7 +85,7 @@ Run `bash scripts/verify-publishable-path-hygiene.sh`.
 
 Run `node <codex-supervisor-root>/dist/index.js issue-lint 1142 --config <supervisor-config-path>`.
 
-The verifier must fail when the upgrade and rollback evidence contract or artifact is missing, when version before or after evidence is missing, when rollback owner or trigger evidence is missing, when evidence references or known limitations are missing, when profile-change handoff expectations are missing, when Wazuh version or rollback state is promoted into AegisOps authority, when full upgrader behavior is claimed, or when publishable guidance uses workstation-local absolute paths.
+The verifier must fail when the upgrade and rollback evidence contract or artifact is missing, when version before or after evidence is missing, when rollback owner or trigger evidence is missing or placeholder-like, when component-level rollback targets are missing, when evidence references or known limitations are missing, when profile-change handoff expectations are missing, when Wazuh version or rollback state is promoted into AegisOps authority, when full upgrader behavior is claimed, or when publishable guidance uses workstation-local absolute paths.
 
 ## 8. Non-Goals
 

--- a/scripts/test-verify-phase-53-1-wazuh-profile-contract.sh
+++ b/scripts/test-verify-phase-53-1-wazuh-profile-contract.sh
@@ -111,7 +111,7 @@ assert_fails_with \
 missing_dashboard_version_repo="${workdir}/missing-dashboard-version"
 create_valid_repo "${missing_dashboard_version_repo}"
 remove_text_from_contract "${missing_dashboard_version_repo}" \
-  "| dashboard | \`4.12.0\` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; \`latest\`; RC; beta. | Upgrade evidence is deferred to a later Phase 53 child issue. |"
+  "| dashboard | \`4.12.0\` | exact | Wazuh 3.x; unreviewed Wazuh 5.x; \`latest\`; RC; beta. | Upgrade evidence expectations are defined by \`docs/deployment/wazuh-upgrade-rollback-evidence-contract.md\`. |"
 assert_fails_with \
   "${missing_dashboard_version_repo}" \
   "Missing complete Phase 53.1 Wazuh version matrix row: dashboard"

--- a/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -62,6 +62,16 @@ valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
 
+reviewed_future_values_repo="${workdir}/reviewed-future-values"
+create_valid_repo "${reviewed_future_values_repo}"
+perl -0pi -e 's/^version_before:.*$/version_before: 4.12.1/m;
+  s/^version_after:.*$/version_after: 4.13.0/m;
+  s/^rollback_owner:.*$/rollback_owner: secops-release-review-board/m;
+  s/^    version_before:.*$/    version_before: 4.12.1/mg;
+  s/^    version_after:.*$/    version_after: 4.13.0/mg' \
+  "${reviewed_future_values_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_passes "${reviewed_future_values_repo}"
+
 missing_contract_repo="${workdir}/missing-contract"
 create_valid_repo "${missing_contract_repo}"
 rm "${missing_contract_repo}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
@@ -82,7 +92,15 @@ perl -0pi -e 's/^rollback_owner:.*\n//m' \
   "${missing_owner_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
 assert_fails_with \
   "${missing_owner_repo}" \
-  "Missing Phase 53.7 Wazuh upgrade rollback top-level rollback owner: rollback_owner: aegisops-release-owner"
+  "Missing Phase 53.7 Wazuh upgrade rollback top-level rollback owner: rollback_owner"
+
+placeholder_owner_repo="${workdir}/placeholder-owner"
+create_valid_repo "${placeholder_owner_repo}"
+perl -0pi -e 's/^rollback_owner:.*$/rollback_owner: TBD/m' \
+  "${placeholder_owner_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${placeholder_owner_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback placeholder rollback owner: rollback_owner: TBD"
 
 missing_version_before_repo="${workdir}/missing-version-before"
 create_valid_repo "${missing_version_before_repo}"
@@ -90,7 +108,15 @@ perl -0pi -e 's/^version_before:.*\n//m' \
   "${missing_version_before_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
 assert_fails_with \
   "${missing_version_before_repo}" \
-  "Missing Phase 53.7 Wazuh upgrade rollback top-level version before: version_before: 4.12.0"
+  "Missing Phase 53.7 Wazuh upgrade rollback top-level version before: version_before"
+
+floating_version_before_repo="${workdir}/floating-version-before"
+create_valid_repo "${floating_version_before_repo}"
+perl -0pi -e 's/^version_before:.*$/version_before: latest/m' \
+  "${floating_version_before_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${floating_version_before_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback unreviewed version before: version_before: latest"
 
 missing_version_after_repo="${workdir}/missing-version-after"
 create_valid_repo "${missing_version_after_repo}"
@@ -98,7 +124,15 @@ perl -0pi -e 's/^version_after:.*\n//m' \
   "${missing_version_after_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
 assert_fails_with \
   "${missing_version_after_repo}" \
-  "Missing Phase 53.7 Wazuh upgrade rollback top-level version after: version_after: <reviewed-target-wazuh-version>"
+  "Missing Phase 53.7 Wazuh upgrade rollback top-level version after: version_after"
+
+rc_version_after_repo="${workdir}/rc-version-after"
+create_valid_repo "${rc_version_after_repo}"
+perl -0pi -e 's/^version_after:.*$/version_after: 4.13.0-rc1/m' \
+  "${rc_version_after_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${rc_version_after_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback unreviewed version after: version_after: 4.13.0-rc1"
 
 missing_trigger_repo="${workdir}/missing-trigger"
 create_valid_repo "${missing_trigger_repo}"

--- a/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -118,6 +118,14 @@ assert_fails_with \
   "${floating_version_before_repo}" \
   "Forbidden Phase 53.7 Wazuh upgrade rollback unreviewed version before: version_before: latest"
 
+duplicate_version_before_repo="${workdir}/duplicate-version-before"
+create_valid_repo "${duplicate_version_before_repo}"
+perl -0pi -e 's/^version_before:.*$/version_before: TBD\nversion_before: 4.12.0/m' \
+  "${duplicate_version_before_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${duplicate_version_before_repo}" \
+  "Duplicate Phase 53.7 Wazuh upgrade rollback top-level version before: version_before"
+
 missing_version_after_repo="${workdir}/missing-version-after"
 create_valid_repo "${missing_version_after_repo}"
 perl -0pi -e 's/^version_after:.*\n//m' \
@@ -149,6 +157,14 @@ perl -0pi -e 's/^rollback_trigger:.*$/rollback_trigger: operator decides later/m
 assert_fails_with \
   "${placeholder_trigger_repo}" \
   "Forbidden Phase 53.7 Wazuh upgrade rollback placeholder rollback trigger: rollback_trigger: operator decides later"
+
+duplicate_rollback_owner_repo="${workdir}/duplicate-rollback-owner"
+create_valid_repo "${duplicate_rollback_owner_repo}"
+perl -0pi -e 's/^rollback_owner:.*$/rollback_owner: TBD\nrollback_owner: aegisops-release-owner/m' \
+  "${duplicate_rollback_owner_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${duplicate_rollback_owner_repo}" \
+  "Duplicate Phase 53.7 Wazuh upgrade rollback top-level rollback owner: rollback_owner"
 
 missing_evidence_reference_repo="${workdir}/missing-evidence-reference"
 create_valid_repo "${missing_evidence_reference_repo}"
@@ -214,6 +230,14 @@ assert_fails_with \
   "${missing_component_rollback_target_repo}" \
   "Missing Phase 53.7 Wazuh upgrade rollback component evidence indexer field: rollback_target"
 
+duplicate_component_rollback_target_repo="${workdir}/duplicate-component-rollback-target"
+create_valid_repo "${duplicate_component_rollback_target_repo}"
+perl -0pi -e 's/^    rollback_target: last-reviewed-indexer-profile-version$/    rollback_target: TBD\n    rollback_target: last-reviewed-indexer-profile-version/m' \
+  "${duplicate_component_rollback_target_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${duplicate_component_rollback_target_repo}" \
+  "Duplicate Phase 53.7 Wazuh upgrade rollback component evidence indexer field: rollback_target"
+
 full_upgrader_claim_repo="${workdir}/full-upgrader-claim"
 create_valid_repo "${full_upgrader_claim_repo}"
 perl -0pi -e 's/full_upgrader_implemented: false/full_upgrader_implemented: true/' \
@@ -261,6 +285,24 @@ perl -0pi -e 's/upgrade_automation_allowed: false/upgrade_automation_allowed: fa
 assert_fails_with \
   "${duplicate_upgrade_automation_claim_repo}" \
   "Forbidden Phase 53.7 Wazuh upgrade rollback duplicate top-level boolean scalar: upgrade_automation_allowed"
+
+missing_contract_component_row_repo="${workdir}/missing-contract-component-row"
+create_valid_repo "${missing_contract_component_row_repo}"
+perl -0pi -e 's/^\| manager \|.*\n//m' \
+  "${missing_contract_component_row_repo}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
+printf '%s\n' '| Example | manager | stray component mention only |' \
+  >>"${missing_contract_component_row_repo}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
+assert_fails_with \
+  "${missing_contract_component_row_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback contract component row: manager"
+
+missing_contract_field_row_repo="${workdir}/missing-contract-field-row"
+create_valid_repo "${missing_contract_field_row_repo}"
+perl -0pi -e 's/^\| `version_before` \|.*\n//m' \
+  "${missing_contract_field_row_repo}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
+assert_fails_with \
+  "${missing_contract_field_row_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback contract field row: version_before"
 
 authority_truth_repo="${workdir}/authority-truth"
 create_valid_repo "${authority_truth_repo}"

--- a/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -108,6 +108,14 @@ assert_fails_with \
   "${missing_trigger_repo}" \
   "Missing Phase 53.7 Wazuh upgrade rollback top-level rollback trigger: rollback_trigger"
 
+placeholder_trigger_repo="${workdir}/placeholder-trigger"
+create_valid_repo "${placeholder_trigger_repo}"
+perl -0pi -e 's/^rollback_trigger:.*$/rollback_trigger: operator decides later/m' \
+  "${placeholder_trigger_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${placeholder_trigger_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback placeholder rollback trigger: rollback_trigger: operator decides later"
+
 missing_evidence_reference_repo="${workdir}/missing-evidence-reference"
 create_valid_repo "${missing_evidence_reference_repo}"
 perl -0pi -e 's/^  - aegisops-release-gate-record\n//m' \
@@ -131,6 +139,14 @@ perl -0pi -e 's/^profile_change_handoff:\n(?:  .*\n)+component_evidence:/compone
 assert_fails_with \
   "${missing_handoff_repo}" \
   "Missing Phase 53.7 Wazuh upgrade rollback artifact term: profile_change_handoff:"
+
+missing_component_rollback_target_repo="${workdir}/missing-component-rollback-target"
+create_valid_repo "${missing_component_rollback_target_repo}"
+perl -0pi -e 's/^    rollback_target: last-reviewed-indexer-profile-version\n//m' \
+  "${missing_component_rollback_target_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_component_rollback_target_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback component evidence indexer field: rollback_target"
 
 full_upgrader_claim_repo="${workdir}/full-upgrader-claim"
 create_valid_repo "${full_upgrader_claim_repo}"

--- a/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -190,6 +190,22 @@ assert_fails_with \
   "${missing_handoff_repo}" \
   "Missing Phase 53.7 Wazuh upgrade rollback artifact term: profile_change_handoff:"
 
+missing_handoff_target_repo="${workdir}/missing-handoff-target"
+create_valid_repo "${missing_handoff_target_repo}"
+perl -0pi -e 's/^  target:.*\n//m' \
+  "${missing_handoff_target_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_handoff_target_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback profile change handoff field: target"
+
+empty_handoff_recipient_repo="${workdir}/empty-handoff-recipient"
+create_valid_repo "${empty_handoff_recipient_repo}"
+perl -0pi -e 's/^  recipient:.*$/  recipient:/m' \
+  "${empty_handoff_recipient_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${empty_handoff_recipient_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback profile change handoff field: recipient"
+
 missing_component_rollback_target_repo="${workdir}/missing-component-rollback-target"
 create_valid_repo "${missing_component_rollback_target_repo}"
 perl -0pi -e 's/^    rollback_target: last-reviewed-indexer-profile-version\n//m' \
@@ -206,6 +222,22 @@ assert_fails_with \
   "${full_upgrader_claim_repo}" \
   "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: full upgrader implementation claim detected"
 
+quoted_full_upgrader_claim_repo="${workdir}/quoted-full-upgrader-claim"
+create_valid_repo "${quoted_full_upgrader_claim_repo}"
+perl -0pi -e 's/full_upgrader_implemented: false/full_upgrader_implemented: "True"/' \
+  "${quoted_full_upgrader_claim_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${quoted_full_upgrader_claim_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: full upgrader implementation claim detected"
+
+duplicate_full_upgrader_claim_repo="${workdir}/duplicate-full-upgrader-claim"
+create_valid_repo "${duplicate_full_upgrader_claim_repo}"
+perl -0pi -e 's/full_upgrader_implemented: false/full_upgrader_implemented: false\nfull_upgrader_implemented: True/' \
+  "${duplicate_full_upgrader_claim_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${duplicate_full_upgrader_claim_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback duplicate top-level boolean scalar: full_upgrader_implemented"
+
 upgrade_automation_claim_repo="${workdir}/upgrade-automation-claim"
 create_valid_repo "${upgrade_automation_claim_repo}"
 perl -0pi -e 's/upgrade_automation_allowed: false/upgrade_automation_allowed: true/' \
@@ -213,6 +245,22 @@ perl -0pi -e 's/upgrade_automation_allowed: false/upgrade_automation_allowed: tr
 assert_fails_with \
   "${upgrade_automation_claim_repo}" \
   "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: upgrade automation claim detected"
+
+numeric_upgrade_automation_claim_repo="${workdir}/numeric-upgrade-automation-claim"
+create_valid_repo "${numeric_upgrade_automation_claim_repo}"
+perl -0pi -e 's/upgrade_automation_allowed: false/upgrade_automation_allowed: 1/' \
+  "${numeric_upgrade_automation_claim_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${numeric_upgrade_automation_claim_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: upgrade automation claim detected"
+
+duplicate_upgrade_automation_claim_repo="${workdir}/duplicate-upgrade-automation-claim"
+create_valid_repo "${duplicate_upgrade_automation_claim_repo}"
+perl -0pi -e 's/upgrade_automation_allowed: false/upgrade_automation_allowed: false\nupgrade_automation_allowed: "true"/' \
+  "${duplicate_upgrade_automation_claim_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${duplicate_upgrade_automation_claim_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback duplicate top-level boolean scalar: upgrade_automation_allowed"
 
 authority_truth_repo="${workdir}/authority-truth"
 create_valid_repo "${authority_truth_repo}"

--- a/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -166,6 +166,22 @@ assert_fails_with \
   "${missing_known_limitation_repo}" \
   "Missing Phase 53.7 Wazuh upgrade rollback known limitation: no-full-wazuh-upgrader"
 
+prefixed_authority_key_repo="${workdir}/prefixed-authority-key"
+create_valid_repo "${prefixed_authority_key_repo}"
+perl -0pi -e 's/^authority_mutation_allowed: false$/disable_authority_mutation_allowed: false/m' \
+  "${prefixed_authority_key_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${prefixed_authority_key_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback artifact term: authority_mutation_allowed: false"
+
+prefixed_components_section_repo="${workdir}/prefixed-components-section"
+create_valid_repo "${prefixed_components_section_repo}"
+perl -0pi -e 's/^components:$/my_components:/m' \
+  "${prefixed_components_section_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${prefixed_components_section_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback artifact term: components:"
+
 missing_handoff_repo="${workdir}/missing-handoff"
 create_valid_repo "${missing_handoff_repo}"
 perl -0pi -e 's/^profile_change_handoff:\n(?:  .*\n)+component_evidence:/component_evidence:/m' \

--- a/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/profiles/smb-single-node/wazuh"
+  printf '%s\n' "# AegisOps" "See [Phase 53.7 Wazuh upgrade rollback evidence contract](docs/deployment/wazuh-upgrade-rollback-evidence-contract.md)." >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md" \
+    "${target}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
+  cp "${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml" \
+    "${target}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback evidence contract"
+
+missing_artifact_repo="${workdir}/missing-artifact"
+create_valid_repo "${missing_artifact_repo}"
+rm "${missing_artifact_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_artifact_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback evidence artifact"
+
+missing_owner_repo="${workdir}/missing-owner"
+create_valid_repo "${missing_owner_repo}"
+perl -0pi -e 's/^rollback_owner:.*\n//m' \
+  "${missing_owner_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_owner_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback top-level rollback owner: rollback_owner: aegisops-release-owner"
+
+missing_version_before_repo="${workdir}/missing-version-before"
+create_valid_repo "${missing_version_before_repo}"
+perl -0pi -e 's/^version_before:.*\n//m' \
+  "${missing_version_before_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_version_before_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback top-level version before: version_before: 4.12.0"
+
+missing_version_after_repo="${workdir}/missing-version-after"
+create_valid_repo "${missing_version_after_repo}"
+perl -0pi -e 's/^version_after:.*\n//m' \
+  "${missing_version_after_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_version_after_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback top-level version after: version_after: <reviewed-target-wazuh-version>"
+
+missing_trigger_repo="${workdir}/missing-trigger"
+create_valid_repo "${missing_trigger_repo}"
+perl -0pi -e 's/^rollback_trigger:.*\n//m' \
+  "${missing_trigger_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_trigger_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback top-level rollback trigger: rollback_trigger"
+
+missing_evidence_reference_repo="${workdir}/missing-evidence-reference"
+create_valid_repo "${missing_evidence_reference_repo}"
+perl -0pi -e 's/^  - aegisops-release-gate-record\n//m' \
+  "${missing_evidence_reference_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_evidence_reference_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback evidence reference: aegisops-release-gate-record"
+
+missing_known_limitation_repo="${workdir}/missing-known-limitation"
+create_valid_repo "${missing_known_limitation_repo}"
+perl -0pi -e 's/^  - no-full-wazuh-upgrader\n//m' \
+  "${missing_known_limitation_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_known_limitation_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback known limitation: no-full-wazuh-upgrader"
+
+missing_handoff_repo="${workdir}/missing-handoff"
+create_valid_repo "${missing_handoff_repo}"
+perl -0pi -e 's/^profile_change_handoff:\n(?:  .*\n)+component_evidence:/component_evidence:/m' \
+  "${missing_handoff_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${missing_handoff_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback artifact term: profile_change_handoff:"
+
+full_upgrader_claim_repo="${workdir}/full-upgrader-claim"
+create_valid_repo "${full_upgrader_claim_repo}"
+perl -0pi -e 's/full_upgrader_implemented: false/full_upgrader_implemented: true/' \
+  "${full_upgrader_claim_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${full_upgrader_claim_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: full upgrader implementation claim detected"
+
+upgrade_automation_claim_repo="${workdir}/upgrade-automation-claim"
+create_valid_repo "${upgrade_automation_claim_repo}"
+perl -0pi -e 's/upgrade_automation_allowed: false/upgrade_automation_allowed: true/' \
+  "${upgrade_automation_claim_repo}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+assert_fails_with \
+  "${upgrade_automation_claim_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: upgrade automation claim detected"
+
+authority_truth_repo="${workdir}/authority-truth"
+create_valid_repo "${authority_truth_repo}"
+printf '%s\n' "Wazuh version state is AegisOps release truth." \
+  >>"${authority_truth_repo}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
+assert_fails_with \
+  "${authority_truth_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback claim: Wazuh version state is AegisOps release truth"
+
+missing_forbidden_claim_repo="${workdir}/missing-forbidden-claim"
+create_valid_repo "${missing_forbidden_claim_repo}"
+remove_text_from_contract "${missing_forbidden_claim_repo}" \
+  "Phase 53.7 implements a full Wazuh upgrader."
+assert_fails_with \
+  "${missing_forbidden_claim_repo}" \
+  "Missing Phase 53.7 Wazuh upgrade rollback forbidden claim: Phase 53.7 implements a full Wazuh upgrader"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 53.7 Wazuh upgrade rollback evidence contract."
+
+echo "Phase 53.7 Wazuh upgrade rollback evidence verifier tests passed."

--- a/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -149,6 +149,48 @@ has_uncommented_exact_line() {
   ' "${file_path}"
 }
 
+require_top_level_false_scalar() {
+  local file_path="$1"
+  local key="$2"
+  local label="$3"
+
+  if ! awk -v key="${key}" -v label="${label}" '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    /^[[:space:]]*#/ { next }
+    $0 ~ ("^" key ":") {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      sub(("^" key ":"), "", line)
+      value = trim(line)
+      gsub(/^["'\'']|["'\'']$/, "", value)
+      value = tolower(trim(value))
+      count += 1
+      if (value != "false") {
+        invalid = value
+      }
+    }
+    END {
+      if (count == 1 && invalid == "") {
+        exit 0
+      }
+      if (count == 0) {
+        printf "Missing Phase 53.7 Wazuh upgrade rollback top-level boolean scalar: %s\n", key > "/dev/stderr"
+      } else if (count > 1) {
+        printf "Forbidden Phase 53.7 Wazuh upgrade rollback duplicate top-level boolean scalar: %s\n", key > "/dev/stderr"
+      } else {
+        printf "Forbidden Phase 53.7 Wazuh upgrade rollback %s\n", label > "/dev/stderr"
+      }
+      exit 1
+    }
+  ' "${file_path}"; then
+    exit 1
+  fi
+}
+
 require_top_level_list_item() {
   local file_path="$1"
   local section="$2"
@@ -169,6 +211,34 @@ require_top_level_list_item() {
     END { exit(found ? 0 : 1) }
   ' "${file_path}"; then
     echo "Missing Phase 53.7 Wazuh upgrade rollback ${label}: ${item}" >&2
+    exit 1
+  fi
+}
+
+require_nested_mapping_field() {
+  local file_path="$1"
+  local section="$2"
+  local field="$3"
+  local label="$4"
+
+  if ! awk -v section="${section}" -v field="${field}" '
+    $0 == section ":" {
+      in_section = 1
+      next
+    }
+    in_section && /^[^[:space:]][^:]*:/ {
+      in_section = 0
+    }
+    in_section {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      if (line ~ ("^  " field ":[[:space:]]+.+")) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback ${label}: ${field}" >&2
     exit 1
   fi
 }
@@ -363,15 +433,15 @@ contract_rendered_markdown="$(
   rendered_markdown_without_code_blocks "${contract_path}"
 )"
 
-if has_uncommented_exact_line "full_upgrader_implemented: true" "${artifact_path}"; then
-  echo "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: full upgrader implementation claim detected" >&2
-  exit 1
-fi
+require_top_level_false_scalar \
+  "${artifact_path}" \
+  "full_upgrader_implemented" \
+  "artifact: full upgrader implementation claim detected"
 
-if has_uncommented_exact_line "upgrade_automation_allowed: true" "${artifact_path}"; then
-  echo "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: upgrade automation claim detected" >&2
-  exit 1
-fi
+require_top_level_false_scalar \
+  "${artifact_path}" \
+  "upgrade_automation_allowed" \
+  "artifact: upgrade automation claim detected"
 
 for heading in "${required_headings[@]}"; do
   if ! grep -Fxq -- "${heading}" <<<"${contract_rendered_markdown}"; then
@@ -398,6 +468,14 @@ require_top_level_version_scalar "${artifact_path}" "version_before" "version be
 require_top_level_version_scalar "${artifact_path}" "version_after" "version after" "true"
 require_top_level_nonplaceholder_scalar "${artifact_path}" "rollback_owner" "rollback owner"
 require_top_level_nonplaceholder_scalar "${artifact_path}" "rollback_trigger" "rollback trigger"
+
+for handoff_field in target recipient review_state next_action; do
+  require_nested_mapping_field \
+    "${artifact_path}" \
+    "profile_change_handoff" \
+    "${handoff_field}" \
+    "profile change handoff field"
+done
 
 for component in "${required_components[@]}"; do
   require_top_level_list_item "${artifact_path}" "components" "${component}" "component"

--- a/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -131,16 +131,17 @@ rendered_markdown_without_code_blocks() {
   ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
 }
 
-has_uncommented_substring() {
-  local needle="$1"
+has_uncommented_exact_line() {
+  local expected="$1"
   local file_path="$2"
 
-  awk -v needle="${needle}" '
+  awk -v expected="${expected}" '
     /^[[:space:]]*#/ { next }
     {
       line = $0
       sub(/[[:space:]]+#.*/, "", line)
-      if (index(line, needle)) {
+      sub(/[[:space:]]+$/, "", line)
+      if (line == expected) {
         found = 1
       }
     }
@@ -362,12 +363,12 @@ contract_rendered_markdown="$(
   rendered_markdown_without_code_blocks "${contract_path}"
 )"
 
-if has_uncommented_substring "full_upgrader_implemented: true" "${artifact_path}"; then
+if has_uncommented_exact_line "full_upgrader_implemented: true" "${artifact_path}"; then
   echo "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: full upgrader implementation claim detected" >&2
   exit 1
 fi
 
-if has_uncommented_substring "upgrade_automation_allowed: true" "${artifact_path}"; then
+if has_uncommented_exact_line "upgrade_automation_allowed: true" "${artifact_path}"; then
   echo "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: upgrade automation claim detected" >&2
   exit 1
 fi
@@ -387,7 +388,7 @@ for phrase in "${required_phrases[@]}"; do
 done
 
 for term in "${required_artifact_terms[@]}"; do
-  if ! has_uncommented_substring "${term}" "${artifact_path}"; then
+  if ! has_uncommented_exact_line "${term}" "${artifact_path}"; then
     echo "Missing Phase 53.7 Wazuh upgrade rollback artifact term: ${term}" >&2
     exit 1
   fi
@@ -404,7 +405,7 @@ for component in "${required_components[@]}"; do
     echo "Missing Phase 53.7 Wazuh upgrade rollback contract component row: ${component}" >&2
     exit 1
   fi
-  if ! has_uncommented_substring "  ${component}:" "${artifact_path}"; then
+  if ! has_uncommented_exact_line "  ${component}:" "${artifact_path}"; then
     echo "Missing Phase 53.7 Wazuh upgrade rollback component evidence: ${component}" >&2
     exit 1
   fi

--- a/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -149,6 +149,30 @@ has_uncommented_exact_line() {
   ' "${file_path}"
 }
 
+has_markdown_table_first_column() {
+  local expected="$1"
+
+  awk -v expected="${expected}" '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    /^[[:space:]]*\|/ {
+      column_count = split($0, columns, "|")
+      if (column_count < 3) {
+        next
+      }
+      first_column = trim(columns[2])
+      gsub(/^`|`$/, "", first_column)
+      if (first_column == expected) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${contract_rendered_markdown}"
+}
+
 require_top_level_false_scalar() {
   local file_path="$1"
   local key="$2"
@@ -256,6 +280,7 @@ require_top_level_version_scalar() {
       return value
     }
     $0 ~ ("^" key ":") {
+      match_count += 1
       line = $0
       sub(/[[:space:]]+#.*/, "", line)
       sub(("^" key ":"), "", line)
@@ -283,6 +308,10 @@ require_top_level_version_scalar() {
       invalid = value
     }
     END {
+      if (match_count > 1) {
+        printf "Duplicate Phase 53.7 Wazuh upgrade rollback top-level %s: %s\n", label, key > "/dev/stderr"
+        exit 1
+      }
       if (found) {
         exit 0
       }
@@ -310,6 +339,7 @@ require_top_level_nonplaceholder_scalar() {
       return value
     }
     $0 ~ ("^" key ":") {
+      match_count += 1
       line = $0
       sub(/[[:space:]]+#.*/, "", line)
       sub(("^" key ":"), "", line)
@@ -329,6 +359,10 @@ require_top_level_nonplaceholder_scalar() {
       found = 1
     }
     END {
+      if (match_count > 1) {
+        printf "Duplicate Phase 53.7 Wazuh upgrade rollback top-level %s: %s\n", label, key > "/dev/stderr"
+        exit 1
+      }
       if (found) {
         exit 0
       }
@@ -369,12 +403,22 @@ require_component_evidence_field() {
       line = $0
       sub(/[[:space:]]+#.*/, "", line)
       if (line ~ ("^    " field ": .+")) {
+        field_count += 1
         found = 1
       }
     }
-    END { exit(found ? 0 : 1) }
+    END {
+      if (field_count > 1) {
+        printf "Duplicate Phase 53.7 Wazuh upgrade rollback component evidence %s field: %s\n", component, field > "/dev/stderr"
+        exit 1
+      }
+      if (found) {
+        exit 0
+      }
+      printf "Missing Phase 53.7 Wazuh upgrade rollback component evidence %s field: %s\n", component, field > "/dev/stderr"
+      exit 1
+    }
   ' "${file_path}"; then
-    echo "Missing Phase 53.7 Wazuh upgrade rollback component evidence ${component} field: ${field}" >&2
     exit 1
   fi
 }
@@ -479,7 +523,7 @@ done
 
 for component in "${required_components[@]}"; do
   require_top_level_list_item "${artifact_path}" "components" "${component}" "component"
-  if ! grep -Fq -- "| ${component} |" <<<"${contract_rendered_markdown}"; then
+  if ! has_markdown_table_first_column "${component}"; then
     echo "Missing Phase 53.7 Wazuh upgrade rollback contract component row: ${component}" >&2
     exit 1
   fi
@@ -494,7 +538,7 @@ done
 
 for field in "${required_evidence_fields[@]}"; do
   require_top_level_list_item "${artifact_path}" "required_evidence_fields" "${field}" "required evidence field"
-  if ! grep -Fq -- "\`${field}\`" <<<"${contract_rendered_markdown}"; then
+  if ! has_markdown_table_first_column "${field}"; then
     echo "Missing Phase 53.7 Wazuh upgrade rollback contract field row: ${field}" >&2
     exit 1
   fi

--- a/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -172,19 +172,57 @@ require_top_level_list_item() {
   fi
 }
 
-require_top_level_scalar() {
+require_top_level_version_scalar() {
   local file_path="$1"
   local key="$2"
-  local expected_value="$3"
-  local label="$4"
+  local label="$3"
+  local allow_review_placeholder="${4:-false}"
 
-  if ! awk -v key="${key}" -v expected_value="${expected_value}" '
-    $0 == key ": " expected_value {
-      found = 1
+  if ! awk -v key="${key}" -v label="${label}" -v allow_review_placeholder="${allow_review_placeholder}" '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
     }
-    END { exit(found ? 0 : 1) }
+    $0 ~ ("^" key ":") {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      sub(("^" key ":"), "", line)
+      value = trim(line)
+      gsub(/^["'\'']|["'\'']$/, "", value)
+      value = trim(value)
+      if (value == "") {
+        missing = 1
+        next
+      }
+      if (allow_review_placeholder == "true" && value == "<reviewed-target-wazuh-version>") {
+        found = 1
+        next
+      }
+      lower_value = tolower(value)
+      if (lower_value ~ /^(latest|current|active|floating|inferred|tbd|to be determined|placeholder)$/ ||
+          lower_value ~ /(beta|rc|snapshot|nightly|preview)/) {
+        invalid = value
+        next
+      }
+      if (value ~ /^[0-9]+([.][0-9]+){1,3}$/) {
+        found = 1
+        next
+      }
+      invalid = value
+    }
+    END {
+      if (found) {
+        exit 0
+      }
+      if (invalid != "") {
+        printf "Forbidden Phase 53.7 Wazuh upgrade rollback unreviewed %s: %s: %s\n", label, key, invalid > "/dev/stderr"
+      } else {
+        printf "Missing Phase 53.7 Wazuh upgrade rollback top-level %s: %s\n", label, key > "/dev/stderr"
+      }
+      exit 1
+    }
   ' "${file_path}"; then
-    echo "Missing Phase 53.7 Wazuh upgrade rollback top-level ${label}: ${key}: ${expected_value}" >&2
     exit 1
   fi
 }
@@ -355,9 +393,9 @@ for term in "${required_artifact_terms[@]}"; do
   fi
 done
 
-require_top_level_scalar "${artifact_path}" "version_before" "4.12.0" "version before"
-require_top_level_scalar "${artifact_path}" "version_after" "<reviewed-target-wazuh-version>" "version after"
-require_top_level_scalar "${artifact_path}" "rollback_owner" "aegisops-release-owner" "rollback owner"
+require_top_level_version_scalar "${artifact_path}" "version_before" "version before"
+require_top_level_version_scalar "${artifact_path}" "version_after" "version after" "true"
+require_top_level_nonplaceholder_scalar "${artifact_path}" "rollback_owner" "rollback owner"
 require_top_level_nonplaceholder_scalar "${artifact_path}" "rollback_trigger" "rollback trigger"
 
 for component in "${required_components[@]}"; do

--- a/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -93,9 +93,11 @@ required_negative_tests=(
   missing-version-before
   missing-version-after
   missing-rollback-trigger
+  placeholder-rollback-trigger
   missing-evidence-references
   missing-known-limitations
   missing-profile-change-handoff
+  missing-component-rollback-target
   full-upgrader-claim
   version-state-as-release-truth
 )
@@ -187,18 +189,83 @@ require_top_level_scalar() {
   fi
 }
 
-require_top_level_nonempty_scalar() {
+require_top_level_nonplaceholder_scalar() {
   local file_path="$1"
   local key="$2"
   local label="$3"
 
-  if ! awk -v key="${key}" '
-    $0 ~ ("^" key ": .+") {
+  if ! awk -v key="${key}" -v label="${label}" '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    $0 ~ ("^" key ":") {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      sub(("^" key ":"), "", line)
+      value = trim(line)
+      gsub(/^["'\'']|["'\'']$/, "", value)
+      value = trim(value)
+      if (value == "") {
+        missing = 1
+        next
+      }
+      lower_value = tolower(value)
+      if (lower_value ~ /^(tbd|to be determined|to be decided|operator.*later|operator.*decides|operator.*discretion|decide later|discretionary|placeholder)$/ ||
+          lower_value ~ /^tbd([[:space:][:punct:]]|$)/) {
+        placeholder = value
+        next
+      }
       found = 1
+    }
+    END {
+      if (found) {
+        exit 0
+      }
+      if (placeholder != "") {
+        printf "Forbidden Phase 53.7 Wazuh upgrade rollback placeholder %s: %s: %s\n", label, key, placeholder > "/dev/stderr"
+      } else {
+        printf "Missing Phase 53.7 Wazuh upgrade rollback top-level %s: %s\n", label, key > "/dev/stderr"
+      }
+      exit 1
+    }
+  ' "${file_path}"; then
+    exit 1
+  fi
+}
+
+require_component_evidence_field() {
+  local file_path="$1"
+  local component="$2"
+  local field="$3"
+
+  if ! awk -v component="${component}" -v field="${field}" '
+    $0 == "component_evidence:" {
+      in_component_evidence = 1
+      next
+    }
+    in_component_evidence && /^[^[:space:]][^:]*:/ {
+      in_component_evidence = 0
+      in_target_component = 0
+    }
+    in_component_evidence && $0 ~ ("^  " component ":[[:space:]]*(#.*)?$") {
+      in_target_component = 1
+      next
+    }
+    in_component_evidence && in_target_component && /^  [^[:space:]][^:]*:/ {
+      in_target_component = 0
+    }
+    in_component_evidence && in_target_component {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      if (line ~ ("^    " field ": .+")) {
+        found = 1
+      }
     }
     END { exit(found ? 0 : 1) }
   ' "${file_path}"; then
-    echo "Missing Phase 53.7 Wazuh upgrade rollback top-level ${label}: ${key}" >&2
+    echo "Missing Phase 53.7 Wazuh upgrade rollback component evidence ${component} field: ${field}" >&2
     exit 1
   fi
 }
@@ -291,7 +358,7 @@ done
 require_top_level_scalar "${artifact_path}" "version_before" "4.12.0" "version before"
 require_top_level_scalar "${artifact_path}" "version_after" "<reviewed-target-wazuh-version>" "version after"
 require_top_level_scalar "${artifact_path}" "rollback_owner" "aegisops-release-owner" "rollback owner"
-require_top_level_nonempty_scalar "${artifact_path}" "rollback_trigger" "rollback trigger"
+require_top_level_nonplaceholder_scalar "${artifact_path}" "rollback_trigger" "rollback trigger"
 
 for component in "${required_components[@]}"; do
   require_top_level_list_item "${artifact_path}" "components" "${component}" "component"
@@ -303,6 +370,9 @@ for component in "${required_components[@]}"; do
     echo "Missing Phase 53.7 Wazuh upgrade rollback component evidence: ${component}" >&2
     exit 1
   fi
+  require_component_evidence_field "${artifact_path}" "${component}" "version_before"
+  require_component_evidence_field "${artifact_path}" "${component}" "version_after"
+  require_component_evidence_field "${artifact_path}" "${component}" "rollback_target"
 done
 
 for field in "${required_evidence_fields[@]}"; do
@@ -366,4 +436,4 @@ if ! grep -Eq '\[[^]]+\]\(docs/deployment/wazuh-upgrade-rollback-evidence-contra
   exit 1
 fi
 
-echo "Phase 53.7 Wazuh upgrade rollback evidence contract is present and rejects missing owner, versions, evidence, limitations, full-upgrader claims, authority promotion, and workstation-local paths."
+echo "Phase 53.7 Wazuh upgrade rollback evidence contract is present and rejects missing owner, versions, rollback posture, component rollback targets, evidence, limitations, full-upgrader claims, authority promotion, and workstation-local paths."

--- a/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
+++ b/scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+contract_path="${repo_root}/docs/deployment/wazuh-upgrade-rollback-evidence-contract.md"
+artifact_path="${repo_root}/docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 53.7 Wazuh Upgrade And Rollback Evidence Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Required Evidence Fields"
+  "## 4. Component Coverage"
+  "## 5. Validation Rules"
+  "## 6. Forbidden Claims"
+  "## 7. Validation"
+  "## 8. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted contract"
+  "- **Date**: 2026-05-03"
+  "- **Related Issues**: #1135, #1136, #1142"
+  "This contract defines release evidence expectations for Wazuh profile version changes in the \`smb-single-node\` product profile."
+  "The required structured artifact is \`docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml\`."
+  "without implementing a live Wazuh upgrader"
+  "Wazuh is a subordinate detection substrate."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth."
+  "This contract cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`."
+  "Run \`bash scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh\`."
+  "Run \`bash scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh\`."
+  "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1142 --config <supervisor-config-path>\`."
+)
+
+required_artifact_terms=(
+  "profile_id: smb-single-node"
+  "product_profile: wazuh"
+  "upgrade_rollback_evidence_contract_version: 2026-05-03"
+  "status: accepted-contract"
+  "evidence_owner: aegisops-release-evidence"
+  "substrate_owner: wazuh"
+  "authority_mutation_allowed: false"
+  "full_upgrader_implemented: false"
+  "upgrade_automation_allowed: false"
+  "fleet_scale_management_allowed: false"
+  "workflow_truth_source: aegisops-record-chain-only"
+  "components:"
+  "required_evidence_fields:"
+  "evidence_references:"
+  "known_limitations:"
+  "profile_change_handoff:"
+  "component_evidence:"
+  "negative_validation_tests:"
+)
+
+required_components=(
+  manager
+  indexer
+  dashboard
+)
+
+required_evidence_fields=(
+  version_before
+  version_after
+  rollback_owner
+  rollback_trigger
+  evidence_references
+  known_limitations
+  profile_change_handoff
+)
+
+required_evidence_references=(
+  aegisops-release-gate-record
+  wazuh-profile-diff-record
+  source-health-projection-review
+  backup-restore-rehearsal-record
+  validation-rerun-result
+)
+
+required_known_limitations=(
+  release-evidence-only
+  no-full-wazuh-upgrader
+  no-wazuh-upgrade-automation
+  no-fleet-scale-wazuh-management
+  no-beta-rc-ga-commercial-readiness-claim
+)
+
+required_negative_tests=(
+  missing-rollback-owner
+  missing-version-before
+  missing-version-after
+  missing-rollback-trigger
+  missing-evidence-references
+  missing-known-limitations
+  missing-profile-change-handoff
+  full-upgrader-claim
+  version-state-as-release-truth
+)
+
+forbidden_claims=(
+  "Wazuh version state is AegisOps release truth"
+  "Wazuh upgrade evidence is AegisOps workflow truth"
+  "Wazuh rollback evidence closes AegisOps cases"
+  "Wazuh manager version is AegisOps source truth"
+  "Wazuh dashboard upgrade status is AegisOps approval truth"
+  "Wazuh indexer upgrade status is AegisOps evidence truth"
+  "Phase 53.7 implements a full Wazuh upgrader"
+  "Phase 53.7 implements Wazuh upgrade automation"
+  "Phase 53.7 implements fleet-scale Wazuh management"
+  "Phase 53.7 implements Shuffle product profiles"
+  "Phase 53.7 claims Beta, RC, GA, commercial readiness, or Wazuh replacement readiness"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+has_uncommented_substring() {
+  local needle="$1"
+  local file_path="$2"
+
+  awk -v needle="${needle}" '
+    /^[[:space:]]*#/ { next }
+    {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      if (index(line, needle)) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"
+}
+
+require_top_level_list_item() {
+  local file_path="$1"
+  local section="$2"
+  local item="$3"
+  local label="$4"
+
+  if ! awk -v section="${section}" -v item="${item}" '
+    $0 == section ":" {
+      in_section = 1
+      next
+    }
+    in_section && /^[^[:space:]][^:]*:/ {
+      in_section = 0
+    }
+    in_section && $0 ~ ("^  - " item "([[:space:]]*(#.*)?)?$") {
+      found = 1
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback ${label}: ${item}" >&2
+    exit 1
+  fi
+}
+
+require_top_level_scalar() {
+  local file_path="$1"
+  local key="$2"
+  local expected_value="$3"
+  local label="$4"
+
+  if ! awk -v key="${key}" -v expected_value="${expected_value}" '
+    $0 == key ": " expected_value {
+      found = 1
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback top-level ${label}: ${key}: ${expected_value}" >&2
+    exit 1
+  fi
+}
+
+require_top_level_nonempty_scalar() {
+  local file_path="$1"
+  local key="$2"
+  local label="$3"
+
+  if ! awk -v key="${key}" '
+    $0 ~ ("^" key ": .+") {
+      found = 1
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback top-level ${label}: ${key}" >&2
+    exit 1
+  fi
+}
+
+contains_forbidden_claim_in_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 6\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 6\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+contains_secret_looking_value() {
+  local file_path="$1"
+
+  awk '
+    /^[[:space:]]*#/ { next }
+    {
+      line = tolower($0)
+      if (line ~ /(secret|token|password|credential|api_key|apikey)[[:space:]]*:[[:space:]]*["'\''"]?[[:alnum:]_\/+=.-]{16,}["'\''"]?/ &&
+          line !~ /(allowed:[[:space:]]*false|valid:[[:space:]]*false|redacted|placeholder|<[^>]+>)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"
+}
+
+if [[ ! -f "${contract_path}" ]]; then
+  echo "Missing Phase 53.7 Wazuh upgrade rollback evidence contract: ${contract_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${artifact_path}" ]]; then
+  echo "Missing Phase 53.7 Wazuh upgrade rollback evidence artifact: ${artifact_path}" >&2
+  exit 1
+fi
+
+contract_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${contract_path}"
+)"
+
+if has_uncommented_substring "full_upgrader_implemented: true" "${artifact_path}"; then
+  echo "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: full upgrader implementation claim detected" >&2
+  exit 1
+fi
+
+if has_uncommented_substring "upgrade_automation_allowed: true" "${artifact_path}"; then
+  echo "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: upgrade automation claim detected" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for term in "${required_artifact_terms[@]}"; do
+  if ! has_uncommented_substring "${term}" "${artifact_path}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback artifact term: ${term}" >&2
+    exit 1
+  fi
+done
+
+require_top_level_scalar "${artifact_path}" "version_before" "4.12.0" "version before"
+require_top_level_scalar "${artifact_path}" "version_after" "<reviewed-target-wazuh-version>" "version after"
+require_top_level_scalar "${artifact_path}" "rollback_owner" "aegisops-release-owner" "rollback owner"
+require_top_level_nonempty_scalar "${artifact_path}" "rollback_trigger" "rollback trigger"
+
+for component in "${required_components[@]}"; do
+  require_top_level_list_item "${artifact_path}" "components" "${component}" "component"
+  if ! grep -Fq -- "| ${component} |" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback contract component row: ${component}" >&2
+    exit 1
+  fi
+  if ! has_uncommented_substring "  ${component}:" "${artifact_path}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback component evidence: ${component}" >&2
+    exit 1
+  fi
+done
+
+for field in "${required_evidence_fields[@]}"; do
+  require_top_level_list_item "${artifact_path}" "required_evidence_fields" "${field}" "required evidence field"
+  if ! grep -Fq -- "\`${field}\`" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback contract field row: ${field}" >&2
+    exit 1
+  fi
+done
+
+for reference in "${required_evidence_references[@]}"; do
+  require_top_level_list_item "${artifact_path}" "evidence_references" "${reference}" "evidence reference"
+done
+
+for limitation in "${required_known_limitations[@]}"; do
+  require_top_level_list_item "${artifact_path}" "known_limitations" "${limitation}" "known limitation"
+done
+
+for negative_test in "${required_negative_tests[@]}"; do
+  require_top_level_list_item "${artifact_path}" "negative_validation_tests" "${negative_test}" "negative test"
+done
+
+for claim in "${forbidden_claims[@]}"; do
+  if ! contains_forbidden_claim_in_section "${claim}"; then
+    echo "Missing Phase 53.7 Wazuh upgrade rollback forbidden claim: ${claim}" >&2
+    exit 1
+  fi
+
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 53.7 Wazuh upgrade rollback claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+for secret_scan_path in "${contract_path}" "${artifact_path}"; do
+  if contains_secret_looking_value "${secret_scan_path}"; then
+    echo "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: committed secret-looking value detected in ${secret_scan_path}" >&2
+    exit 1
+  fi
+done
+
+mac_user_home_pattern="/""Users/"
+posix_user_home_pattern="/""home/[^[:space:]/]+"
+windows_user_home_pattern='C:\\''Users\\'
+if grep -REq "${mac_user_home_pattern}|${posix_user_home_pattern}|${windows_user_home_pattern}" "${contract_path}" "${artifact_path}"; then
+  echo "Forbidden Phase 53.7 Wazuh upgrade rollback artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 53.7 Wazuh upgrade rollback link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}"
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/wazuh-upgrade-rollback-evidence-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 53.7 Wazuh upgrade rollback evidence contract." >&2
+  exit 1
+fi
+
+echo "Phase 53.7 Wazuh upgrade rollback evidence contract is present and rejects missing owner, versions, evidence, limitations, full-upgrader claims, authority promotion, and workstation-local paths."


### PR DESCRIPTION
## Summary
- Adds the Phase 53.7 Wazuh upgrade and rollback evidence contract and structured profile artifact.
- Adds a focused verifier plus negative verifier fixtures for missing owner, versions, rollback posture, evidence references, known limitations, handoff, full-upgrader claims, authority promotion, and workstation-local paths.
- Links the new contract from README and the Phase 53.1 Wazuh profile version matrix.

## Verification
- `bash scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh`
- `bash scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh`
- `bash scripts/verify-phase-53-1-wazuh-profile-contract.sh`
- `bash scripts/test-verify-phase-53-1-wazuh-profile-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1142 --config <supervisor-config-path>`

Closes #1142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 53.7 Wazuh upgrade/rollback evidence contract and a structured evidence artifact for the smb-single-node profile; README and deployment guidance updated to link and reference the contract and clarify upgrade-evidence expectations.
* **Tests**
  * Added a verifier and comprehensive test harness to validate contract/artifact presence, required fields, component-level evidence, forbidden-claim rules, and many failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->