### PR TITLE
Phase 53.8 Wazuh authority-boundary negative tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Canonical cross-phase boundary reference:
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
 - [Phase 53.6 Wazuh source-health projection contract](docs/deployment/wazuh-source-health-projection-contract.md) defines manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched source-health projection states for the Wazuh profile.
 - [Phase 53.7 Wazuh upgrade rollback evidence contract](docs/deployment/wazuh-upgrade-rollback-evidence-contract.md) defines version before/after, rollback owner, rollback trigger, evidence references, known limitations, and profile-change handoff expectations without implementing a Wazuh upgrader.
+- [Phase 53.8 Wazuh authority-boundary negative tests](docs/deployment/wazuh-authority-boundary-negative-tests.md) define focused fail-closed checks for raw Wazuh status case closure and Wazuh-triggered Shuffle runs without AegisOps delegation.
 
 ## Product positioning
 
@@ -97,6 +98,8 @@ The Phase 53.5 Wazuh agent enrollment helper contract is defined by the [Phase 5
 The Phase 53.6 Wazuh source-health projection contract is defined by the [Phase 53.6 Wazuh source-health projection contract](docs/deployment/wazuh-source-health-projection-contract.md).
 
 The Phase 53.7 Wazuh upgrade rollback evidence contract is defined by the [Phase 53.7 Wazuh upgrade rollback evidence contract](docs/deployment/wazuh-upgrade-rollback-evidence-contract.md).
+
+The Phase 53.8 Wazuh authority-boundary negative tests are defined by the [Phase 53.8 Wazuh authority-boundary negative tests](docs/deployment/wazuh-authority-boundary-negative-tests.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
+++ b/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
@@ -191,6 +191,12 @@ class ActionExecutionReconciliationCoordinator:
                     "execution run identity mismatch between authoritative action execution "
                     "and observed downstream execution"
                 )
+            elif require_binding_identifiers and authoritative_execution is None:
+                ingest_disposition = "mismatch"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "observed shuffle execution lacks an authoritative AegisOps delegation record"
+                )
             elif (
                 authoritative_execution is not None
                 and authoritative_execution.execution_surface_type == "automation_substrate"

--- a/control-plane/aegisops/control_plane/ingestion/case_workflow.py
+++ b/control-plane/aegisops/control_plane/ingestion/case_workflow.py
@@ -470,6 +470,13 @@ class CaseWorkflowService:
         rationale = service._require_non_empty_string(rationale, "rationale")
         recorded_at = service._require_aware_datetime(recorded_at, "recorded_at")
         lifecycle_state = service._case_lifecycle_for_disposition(disposition)
+        if lifecycle_state == "closed" and _rationale_uses_wazuh_status_as_authority(
+            rationale
+        ):
+            raise ValueError(
+                "Wazuh status is subordinate detection context and cannot close "
+                "an AegisOps case without an authoritative AegisOps disposition basis"
+            )
         with service._store.transaction():
             case = service._require_reviewed_operator_case(case_id)
             alert = None
@@ -508,3 +515,18 @@ class CaseWorkflowService:
                     transitioned_at=recorded_at,
                 )
         return updated_case
+
+
+def _rationale_uses_wazuh_status_as_authority(rationale: str) -> bool:
+    normalized = " ".join(rationale.lower().split())
+    if "wazuh" not in normalized:
+        return False
+    subordinate_status_terms = (
+        "alert status",
+        "dashboard",
+        "manager status",
+        "active response",
+        "workflow truth",
+        "case truth",
+    )
+    return any(term in normalized for term in subordinate_status_terms)

--- a/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
+++ b/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
@@ -365,6 +365,109 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
                 )
                 self.assertNotEqual(current_case.lifecycle_state, "closed")
 
+    def test_raw_wazuh_status_cannot_close_aegisops_case(self) -> None:
+        store, service, promoted_case, reviewed_at = self._build_wazuh_case()
+        baseline_case = store.get(CaseRecord, promoted_case.case_id)
+        baseline_alert = store.get(AlertRecord, promoted_case.alert_id)
+        baseline_reconciliation_count = len(store.list(ReconciliationRecord))
+        self.assertIsNotNone(baseline_case)
+        self.assertIsNotNone(baseline_alert)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Wazuh status is subordinate detection context",
+        ):
+            service.record_case_disposition(
+                case_id=promoted_case.case_id,
+                disposition="closed_resolved",
+                rationale=(
+                    "Wazuh alert status is closed in the dashboard, so close the "
+                    "AegisOps case."
+                ),
+                recorded_at=reviewed_at + timedelta(minutes=30),
+            )
+
+        current_case = store.get(CaseRecord, promoted_case.case_id)
+        current_alert = store.get(AlertRecord, promoted_case.alert_id)
+        self.assertIsNotNone(current_case)
+        self.assertIsNotNone(current_alert)
+        self.assertEqual(current_case.lifecycle_state, baseline_case.lifecycle_state)
+        self.assertEqual(current_alert.lifecycle_state, baseline_alert.lifecycle_state)
+        self.assertEqual(
+            len(store.list(ReconciliationRecord)),
+            baseline_reconciliation_count,
+        )
+
+    def test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched(
+        self,
+    ) -> None:
+        store, service, promoted_case, reviewed_at = self._build_wazuh_case()
+        baseline_case = store.get(CaseRecord, promoted_case.case_id)
+        baseline_execution_count = len(store.list(ActionExecutionRecord))
+        self.assertIsNotNone(baseline_case)
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-wazuh-shortcut-001",
+                approval_decision_id="approval-wazuh-shortcut-001",
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                idempotency_key="idempotency-wazuh-shortcut-001",
+                target_scope={"asset_id": "workstation-001"},
+                payload_hash="payload-hash-wazuh-shortcut-001",
+                requested_at=reviewed_at + timedelta(minutes=5),
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload={
+                    "action_type": "notify_identity_owner",
+                    "recipient_identity": "repo-owner-001",
+                    "message_intent": "Notify owner about reviewed Wazuh signal.",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "shuffle",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id="action-request-wazuh-shortcut-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": "wazuh-direct-shuffle-run-001",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": "idempotency-wazuh-shortcut-001",
+                    "approval_decision_id": "approval-wazuh-shortcut-001",
+                    "delegation_id": "wazuh-origin-shortcut-001",
+                    "payload_hash": "payload-hash-wazuh-shortcut-001",
+                    "observed_at": reviewed_at + timedelta(minutes=10),
+                    "status": "success",
+                    "source_system": "wazuh",
+                },
+            ),
+            compared_at=reviewed_at + timedelta(minutes=10),
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+
+        current_case = store.get(CaseRecord, promoted_case.case_id)
+        self.assertIsNotNone(current_case)
+        self.assertEqual(reconciliation.ingest_disposition, "mismatch")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertEqual(
+            reconciliation.mismatch_summary,
+            "observed shuffle execution lacks an authoritative AegisOps delegation record",
+        )
+        self.assertEqual(current_case.lifecycle_state, baseline_case.lifecycle_state)
+        self.assertEqual(
+            len(store.list(ActionExecutionRecord)),
+            baseline_execution_count,
+        )
+
     def test_endpoint_evidence_missing_provenance_is_not_promoted(self) -> None:
         phase28_helper = phase28_tests.Phase28EndpointEvidencePackValidationTests()
         store, service, promoted_case, anchor_evidence_id, reviewed_at = (
@@ -564,6 +667,14 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
             record_type.__name__: len(store.list(record_type))
             for record_type in _AUTHORITATIVE_RECORD_TYPES
         }
+
+    @staticmethod
+    def _build_wazuh_case():
+        cli_helper = cli_support.ControlPlaneCliInspectionTestBase()
+        store, service, promoted_case, _evidence_id, reviewed_at = (
+            cli_helper._build_phase19_in_scope_case()
+        )
+        return store, service, promoted_case, reviewed_at
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -1111,8 +1111,7 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
         self.assertEqual(reconciliation.lifecycle_state, "mismatched")
         self.assertEqual(
             reconciliation.mismatch_summary,
-            "coordination receipt mismatch between authoritative action execution "
-            "and observed downstream execution",
+            "observed shuffle execution lacks an authoritative AegisOps delegation record",
         )
     def test_service_rejects_blank_create_tracking_ticket_receipt_identifiers(
         self,

--- a/docs/deployment/wazuh-authority-boundary-negative-tests.md
+++ b/docs/deployment/wazuh-authority-boundary-negative-tests.md
@@ -1,0 +1,53 @@
+# Phase 53.8 Wazuh Authority-Boundary Negative Tests
+
+- **Status**: Accepted negative-test slice
+- **Date**: 2026-05-03
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-51-6-authority-boundary-negative-test-policy.md`, `docs/deployment/wazuh-manager-intake-binding-contract.md`, `docs/deployment/wazuh-source-health-projection-contract.md`
+- **Related Issues**: #1135, #1138, #1141, #1143
+
+This slice makes the Wazuh authority-boundary negative tests directly runnable for the Phase 53 Wazuh product profile MVP.
+
+It does not implement Shuffle product profiles, Wazuh Active Response authority, Wazuh dashboard authority, fleet-scale Wazuh management, broad SIEM detector catalog, release-candidate behavior, general-availability behavior, or commercial readiness.
+
+## 1. Purpose
+
+Phase 53.8 proves that Wazuh remains subordinate detection substrate context when raw Wazuh status or Wazuh-origin automation evidence is presented as AegisOps workflow truth.
+
+The focused enforcement tests live in `control-plane/tests/test_cross_boundary_negative_e2e_validation.py`.
+
+## 2. Authority Boundary
+
+Wazuh detections are analytic signals until admitted and linked by AegisOps.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+
+This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.
+
+Wazuh status, Wazuh alert status, Wazuh dashboard state, Wazuh manager state, Wazuh Active Response state, Wazuh-triggered Shuffle runs, Shuffle workflow state, verifier output, issue-lint output, tickets, assistant output, browser state, UI cache, optional evidence, and downstream receipts cannot close, approve, execute, reconcile, release, gate, or otherwise mutate authoritative AegisOps records without explicit AegisOps admission, approval, delegation, execution, and reconciliation records.
+
+## 3. Required Negative Tests
+
+| Negative test | Enforcement boundary | Expected result |
+| --- | --- | --- |
+| Raw Wazuh alert status closes an AegisOps case. | `record_case_disposition` | Reject the closure and leave case and alert lifecycle state unchanged. |
+| Wazuh-triggered Shuffle execution appears without AegisOps delegation. | `reconcile_action_execution` | Record a mismatched reconciliation and do not create or infer an action execution record. |
+| Wazuh Active Response is presented as AegisOps authority. | Phase 53.5 and Phase 53.8 verifier references | Keep Active Response outside authority paths. |
+| Wazuh dashboard state is presented as workflow truth. | Phase 53.6 and Phase 53.8 verifier references | Keep dashboard state subordinate source-health context only. |
+
+## 4. Validation
+
+Run `bash scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh`.
+
+Run `python3 -m unittest control-plane.tests.test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_raw_wazuh_status_cannot_close_aegisops_case control-plane.tests.test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched`.
+
+Run Wazuh source-health tests with `bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1143 --config <supervisor-config-path>`.
+
+## 5. Non-Goals
+
+- No Wazuh Active Response authority path is implemented.
+- No direct Wazuh-to-Shuffle shortcut is approved.
+- No Wazuh alert status, dashboard state, manager state, source-health projection, verifier output, or issue-lint output becomes AegisOps workflow truth.
+- No Phase 54 Shuffle product profile work is implemented.

--- a/docs/deployment/wazuh-authority-boundary-negative-tests.md
+++ b/docs/deployment/wazuh-authority-boundary-negative-tests.md
@@ -39,7 +39,7 @@ Wazuh status, Wazuh alert status, Wazuh dashboard state, Wazuh manager state, Wa
 
 Run `bash scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh`.
 
-Run `python3 -m unittest control-plane.tests.test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_raw_wazuh_status_cannot_close_aegisops_case control-plane.tests.test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched`.
+From the repository root, run `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_raw_wazuh_status_cannot_close_aegisops_case test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched`.
 
 Run Wazuh source-health tests with `bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh`.
 

--- a/docs/deployment/wazuh-authority-boundary-negative-tests.md
+++ b/docs/deployment/wazuh-authority-boundary-negative-tests.md
@@ -1,7 +1,7 @@
 # Phase 53.8 Wazuh Authority-Boundary Negative Tests
 
 - **Status**: Accepted negative-test slice
-- **Date**: 2026-05-03
+- **Date**: 2026-05-02
 - **Owners**: AegisOps maintainers
 - **Related Baseline**: `docs/phase-51-6-authority-boundary-negative-test-policy.md`, `docs/deployment/wazuh-manager-intake-binding-contract.md`, `docs/deployment/wazuh-source-health-projection-contract.md`
 - **Related Issues**: #1135, #1138, #1141, #1143

--- a/scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh
+++ b/scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/wazuh-authority-boundary-negative-tests.md"
+test_path="${repo_root}/control-plane/tests/test_cross_boundary_negative_e2e_validation.py"
+readme_path="${repo_root}/README.md"
+
+required_doc_phrases=(
+  "# Phase 53.8 Wazuh Authority-Boundary Negative Tests"
+  "- **Status**: Accepted negative-test slice"
+  "- **Related Issues**: #1135, #1138, #1141, #1143"
+  "This slice makes the Wazuh authority-boundary negative tests directly runnable for the Phase 53 Wazuh product profile MVP."
+  "Wazuh detections are analytic signals until admitted and linked by AegisOps."
+  "This slice cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`."
+  "Raw Wazuh alert status closes an AegisOps case."
+  "Wazuh-triggered Shuffle execution appears without AegisOps delegation."
+  "Wazuh Active Response is presented as AegisOps authority."
+  "Wazuh dashboard state is presented as workflow truth."
+  "Run \`bash scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh\`."
+  "Run Wazuh source-health tests with \`bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1143 --config <supervisor-config-path>\`."
+)
+
+required_test_phrases=(
+  "def test_raw_wazuh_status_cannot_close_aegisops_case"
+  "Wazuh status is subordinate detection context"
+  "def test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched"
+  "observed shuffle execution lacks an authoritative AegisOps delegation record"
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 53.8 Wazuh authority-boundary negative-test doc: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${test_path}" ]]; then
+  echo "Missing Phase 53.8 Wazuh authority-boundary negative-test module: ${test_path}" >&2
+  exit 1
+fi
+
+for phrase in "${required_doc_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 53.8 Wazuh authority-boundary statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_test_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${test_path}"; then
+    echo "Missing Phase 53.8 Wazuh authority-boundary test reference: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+if grep -Eq '(^|[[:space:]`"'"'"'(<{=])(file://)?(/Users/|/home/|[A-Za-z]:[\\/]+Users[\\/])' "${doc_path}"; then
+  echo "Forbidden Phase 53.8 Wazuh authority-boundary doc: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 53.8 Wazuh authority-boundary link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    !in_fenced_block { print }
+  ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/wazuh-authority-boundary-negative-tests\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 53.8 Wazuh authority-boundary negative tests." >&2
+  exit 1
+fi
+
+python3 -m unittest \
+  control-plane.tests.test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_raw_wazuh_status_cannot_close_aegisops_case \
+  control-plane.tests.test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched
+
+echo "Phase 53.8 Wazuh authority-boundary negative tests reject raw Wazuh case closure and direct Wazuh-to-Shuffle shortcut reconciliation."

--- a/scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh
+++ b/scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh
@@ -84,8 +84,9 @@ if ! grep -Eq '\[[^]]+\]\(docs/deployment/wazuh-authority-boundary-negative-test
   exit 1
 fi
 
-python3 -m unittest \
-  control-plane.tests.test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_raw_wazuh_status_cannot_close_aegisops_case \
-  control-plane.tests.test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched
+PYTHONPATH="${repo_root}/control-plane:${repo_root}/control-plane/tests" \
+  python3 -m unittest \
+  test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_raw_wazuh_status_cannot_close_aegisops_case \
+  test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched
 
 echo "Phase 53.8 Wazuh authority-boundary negative tests reject raw Wazuh case closure and direct Wazuh-to-Shuffle shortcut reconciliation."

--- a/scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh
+++ b/scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh
@@ -54,7 +54,12 @@ for phrase in "${required_test_phrases[@]}"; do
   fi
 done
 
-if grep -Eq '(^|[[:space:]`"'"'"'(<{=])(file://)?(/Users/|/home/|[A-Za-z]:[\\/]+Users[\\/])' "${doc_path}"; then
+mac_user_home="$(printf '/%s/' 'Users')"
+unix_user_home="$(printf '/%s/' 'home')"
+windows_user_home="$(printf '[A-Za-z]:[\\\\/]%s[\\\\/]' 'Users')"
+path_boundary="(^|[[:space:]\`\"'(<{=])"
+
+if grep -Eq "(${path_boundary})(file://)?(${mac_user_home}|${unix_user_home}|${windows_user_home})" "${doc_path}"; then
   echo "Forbidden Phase 53.8 Wazuh authority-boundary doc: workstation-local absolute path detected" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- add Phase 53.8 Wazuh authority-boundary negative tests and verifier reference
- reject Wazuh-status case closure rationales at the case disposition boundary
- mismatch Shuffle observations that lack an authoritative AegisOps delegation record

## Verification
- bash scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh
- python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_reconciliation control-plane.tests.test_cross_boundary_negative_e2e_validation
- bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1143 --config <supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 53.8 reference to README and a comprehensive deployment guide for Wazuh Authority‑Boundary Negative Tests.

* **New Features**
  * Rejects case closures based on subordinate Wazuh status context.
  * Marks reconciliations as "mismatched" when shuffle executions occur without authoritative delegation.

* **Tests**
  * Added cross‑boundary negative E2E tests for Wazuh‑driven closure restrictions and delegation‑mismatch scenarios; updated an expected mismatch message.

* **Chores**
  * Added verification script to validate Phase 53.8 docs, links, and test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->