### PR TITLE
Phase 53.9 closeout evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Canonical cross-phase boundary reference:
 - [Phase 53.6 Wazuh source-health projection contract](docs/deployment/wazuh-source-health-projection-contract.md) defines manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched source-health projection states for the Wazuh profile.
 - [Phase 53.7 Wazuh upgrade rollback evidence contract](docs/deployment/wazuh-upgrade-rollback-evidence-contract.md) defines version before/after, rollback owner, rollback trigger, evidence references, known limitations, and profile-change handoff expectations without implementing a Wazuh upgrader.
 - [Phase 53.8 Wazuh authority-boundary negative tests](docs/deployment/wazuh-authority-boundary-negative-tests.md) define focused fail-closed checks for raw Wazuh status case closure and Wazuh-triggered Shuffle runs without AegisOps delegation.
+- [Phase 53.9 closeout evaluation](docs/phase-53-closeout-evaluation.md) records the Wazuh profile MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 54/55/61 handoff.
 
 ## Product positioning
 
@@ -100,6 +101,8 @@ The Phase 53.6 Wazuh source-health projection contract is defined by the [Phase 
 The Phase 53.7 Wazuh upgrade rollback evidence contract is defined by the [Phase 53.7 Wazuh upgrade rollback evidence contract](docs/deployment/wazuh-upgrade-rollback-evidence-contract.md).
 
 The Phase 53.8 Wazuh authority-boundary negative tests are defined by the [Phase 53.8 Wazuh authority-boundary negative tests](docs/deployment/wazuh-authority-boundary-negative-tests.md).
+
+The Phase 53.9 closeout evaluation is defined by the [Phase 53.9 closeout evaluation](docs/phase-53-closeout-evaluation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-53-closeout-evaluation.md
+++ b/docs/phase-53-closeout-evaluation.md
@@ -1,0 +1,133 @@
+# Phase 53 Closeout Evaluation
+
+- **Status**: Accepted as Wazuh product profile MVP evidence and handoff baseline; Phase 54, Phase 55, and Phase 61 can consume the bounded Wazuh profile MVP with explicit retained blockers.
+- **Date**: 2026-05-03
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1135, #1136, #1137, #1138, #1139, #1140, #1141, #1142, #1143, #1144
+
+## Verdict
+
+Phase 53 is accepted as the Wazuh product profile MVP evidence baseline for the `smb-single-node` profile. The accepted MVP consists of repo-owned Wazuh profile contracts, exact Wazuh 4.12.0 component pins, certificate and credential custody expectations, intake binding, reviewed sample signal fixtures, one-endpoint enrollment helper posture, source-health projection, upgrade and rollback evidence expectations, and focused authority-boundary negative tests.
+
+Wazuh remains a subordinate detection substrate. Wazuh detections are analytic signals until admitted and linked by AegisOps. AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+
+This closeout does not claim Phase 54 Shuffle profile work is complete, Phase 55 guided first-user journey work is complete, Phase 61 SIEM breadth is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a replacement for every SIEM/SOAR capability.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1135 | Epic: Phase 53 Wazuh Product Profile MVP | Open until #1144 lands; accepted when this closeout, focused verifier, Phase 53 verifiers, focused Wazuh tests, path hygiene, and issue-lint pass. |
+| #1136 | Phase 53.1 Wazuh SMB single-node profile contract | Closed. `docs/deployment/wazuh-smb-single-node-profile-contract.md` and `docs/deployment/profiles/smb-single-node/wazuh/profile.yaml` define manager, indexer, dashboard, resources, ports, volumes, certificates, authority boundaries, and exact `4.12.0` image pins. |
+| #1137 | Phase 53.2 Wazuh certificate and credential handling | Closed. `docs/deployment/wazuh-certificate-credential-contract.md` and `docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml` define certificate wrapper posture, credential custody, default credential rejection, placeholder rejection, and rotation guidance. |
+| #1138 | Phase 53.3 Wazuh manager intake binding | Closed. `docs/deployment/wazuh-manager-intake-binding-contract.md` and `docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml` define `/intake/wazuh`, reviewed proxy binding, shared-secret custody reference, provenance fields, and candidate analytic-signal admission posture. |
+| #1139 | Phase 53.4 Wazuh sample signal fixture | Closed. `control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-alert.json`, `control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-analytic-signal.json`, and `control-plane/tests/test_wazuh_adapter.py` preserve the reviewed SMB single-node SSH authentication failure fixture and parser mapping evidence. |
+| #1140 | Phase 53.5 Wazuh first agent enrollment helper | Closed. `docs/deployment/wazuh-agent-enrollment-helper-contract.md` and `docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml` define one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion. |
+| #1141 | Phase 53.6 Wazuh source-health projection | Closed. `docs/deployment/wazuh-source-health-projection-contract.md` and `docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml` define manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched projection states. |
+| #1142 | Phase 53.7 Wazuh upgrade and rollback evidence | Closed. `docs/deployment/wazuh-upgrade-rollback-evidence-contract.md` and `docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml` define version before/after evidence, rollback owner, rollback trigger, evidence references, known limitations, and profile-change handoff without implementing a live upgrader. |
+| #1143 | Phase 53.8 Wazuh authority-boundary negative tests | Closed. `docs/deployment/wazuh-authority-boundary-negative-tests.md` and `control-plane/tests/test_cross_boundary_negative_e2e_validation.py` prove raw Wazuh status cannot close AegisOps cases and Wazuh-triggered Shuffle runs without AegisOps delegation remain mismatched. |
+| #1144 | Phase 53.9 Phase 53 closeout evaluation | Open until this closeout lands; accepted when this document and focused negative verifier pass. |
+
+## Wazuh Profile Behavior Before And After
+
+| Surface | Before Phase 53 | After Phase 53 |
+| --- | --- | --- |
+| Wazuh product profile | Deferred placeholder from Phase 52 first-user stack contracts. | Repo-owned `smb-single-node` Wazuh profile contract with manager, indexer, dashboard, exact `4.12.0` pins, resource, port, volume, and certificate expectations. |
+| Certificate and credential posture | Generic env, secret, and certificate contract from Phase 52.5. | Wazuh-specific certificate wrapper posture, trusted custody references, default credential rejection, placeholder rejection, and rotation guidance. |
+| Intake binding | Reviewed Wazuh-facing analytic-signal expectation. | `/intake/wazuh` and `aegisops-proxy:/intake/wazuh -> aegisops-control-plane:/intake/wazuh` with required provenance and shared-secret custody reference. |
+| Sample signal evidence | Existing Wazuh fixture families for earlier source work. | Reviewed SMB single-node SSH authentication failure Wazuh alert and analytic-signal fixtures tied to Phase 53.4 parser mapping evidence. |
+| Enrollment | Deferred fleet and agent posture. | One-endpoint enrollment helper contract only, with rollback notes and no fleet-scale Wazuh management claim. |
+| Source health | Deferred source-health projection. | Subordinate source-health projection states for Wazuh manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched posture. |
+| Upgrade and rollback | No Wazuh profile-change evidence template for the MVP. | Evidence template for future Wazuh profile version changes, without live upgrader or upgrade automation. |
+| Authority boundary | Wazuh subordinate posture inherited from Phase 51.6 and Phase 52 contracts. | Focused negative tests prove raw Wazuh status cannot close cases and Wazuh-triggered Shuffle runs without AegisOps delegation remain mismatched. |
+
+## Changed Files
+
+Phase 53 materially added or tightened these repo-owned surfaces:
+
+- `docs/deployment/wazuh-smb-single-node-profile-contract.md`
+- `docs/deployment/wazuh-certificate-credential-contract.md`
+- `docs/deployment/wazuh-manager-intake-binding-contract.md`
+- `docs/deployment/wazuh-agent-enrollment-helper-contract.md`
+- `docs/deployment/wazuh-source-health-projection-contract.md`
+- `docs/deployment/wazuh-upgrade-rollback-evidence-contract.md`
+- `docs/deployment/wazuh-authority-boundary-negative-tests.md`
+- `docs/deployment/profiles/smb-single-node/wazuh/profile.yaml`
+- `docs/deployment/profiles/smb-single-node/wazuh/certificate-credential-contract.yaml`
+- `docs/deployment/profiles/smb-single-node/wazuh/intake-binding.yaml`
+- `docs/deployment/profiles/smb-single-node/wazuh/agent-enrollment-helper.yaml`
+- `docs/deployment/profiles/smb-single-node/wazuh/source-health-projection.yaml`
+- `docs/deployment/profiles/smb-single-node/wazuh/upgrade-rollback-evidence.yaml`
+- `control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-alert.json`
+- `control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-analytic-signal.json`
+- `control-plane/tests/test_wazuh_adapter.py`
+- `control-plane/tests/test_cross_boundary_negative_e2e_validation.py`
+- `docs/phase-53-closeout-evaluation.md`
+- `scripts/verify-phase-53-9-closeout-evaluation.sh`
+- `scripts/test-verify-phase-53-9-closeout-evaluation.sh`
+
+## Verifier Evidence
+
+Focused Phase 53 verifiers passed or must pass before this closeout is accepted:
+
+- `bash scripts/verify-phase-53-1-wazuh-profile-contract.sh`
+- `bash scripts/test-verify-phase-53-1-wazuh-profile-contract.sh`
+- `bash scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh`
+- `bash scripts/test-verify-phase-53-2-wazuh-cert-credential-contract.sh`
+- `bash scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh`
+- `bash scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh`
+- `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_wazuh_adapter.WazuhAlertAdapterTests`
+- `bash scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh`
+- `bash scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh`
+- `bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh`
+- `bash scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh`
+- `bash scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh`
+- `bash scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh`
+- `bash scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `bash scripts/verify-phase-53-9-closeout-evaluation.sh`
+- `bash scripts/test-verify-phase-53-9-closeout-evaluation.sh`
+
+Focused negative-test evidence:
+
+- `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_raw_wazuh_status_cannot_close_aegisops_case test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched`
+
+Broad control-plane test evidence:
+
+- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+
+Issue-lint evidence for #1135 through #1144:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1135 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1136 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1137 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1138 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1139 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1140 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1141 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1142 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1143 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1144 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+
+## Accepted Limitations
+
+- Phase 53 does not implement Phase 54 Shuffle product profiles.
+- Phase 53 does not implement Phase 55 guided first-user UI journey work.
+- Phase 53 does not complete Phase 61 SIEM breadth, broad detector catalog coverage, or every source-family expectation.
+- Phase 53 does not implement Wazuh Active Response as an authority path.
+- Phase 53 does not approve a direct Wazuh-to-Shuffle shortcut.
+- Phase 53 does not let Wazuh alert status close AegisOps cases.
+- Phase 53 does not make Wazuh dashboard state, Wazuh manager state, Wazuh agent state, Wazuh indexer state, generated Wazuh config, Wazuh alerts, Wazuh source-health projection, upgrade evidence, rollback evidence, verifier output, issue-lint output, tickets, assistant output, browser state, UI cache, optional evidence, or downstream receipts authoritative AegisOps truth.
+- Phase 53 does not implement fleet-scale Wazuh agent management, a full live Wazuh upgrader, secret backend integration, customer-specific credential provisioning, Beta readiness, RC readiness, GA readiness, commercial replacement readiness, or Wazuh replacement readiness.
+
+## Phase 54, Phase 55, And Phase 61 Handoff
+
+Phase 54 can consume the Wazuh profile MVP as the reviewed Wazuh-side substrate and intake context for Shuffle profile work. Phase 54 must still implement its own Shuffle profile contract, callback custody, delegated-execution boundary, workflow catalog custody, and negative tests. Phase 54 must not infer direct Wazuh-to-Shuffle authority from Phase 53.
+
+Phase 55 can consume the Wazuh profile MVP as one setup and source-health evidence surface for the guided first-user journey. Phase 55 must still implement the guided journey, user-facing validation flow, runtime custody choices, error handling, and first-user ergonomics. Phase 55 must not treat Wazuh source-health or setup text as AegisOps workflow truth.
+
+Phase 61 can consume the Wazuh profile MVP as the first reviewed SIEM substrate profile and evidence pattern. Phase 61 must still implement SIEM breadth, source-family prioritization, detector coverage expansion, and any additional source profile contracts explicitly. Phase 53 does not complete Phase 61 SIEM breadth.
+
+## Closeout Boundary
+
+This closeout is evidence recording only. It does not choose a new runtime configuration, custody mechanism, Wazuh deployment mode, Shuffle profile shape, SIEM breadth target, first-user UI journey, production support posture, Beta gate, RC gate, GA gate, or commercial readiness claim.

--- a/docs/phase-53-closeout-evaluation.md
+++ b/docs/phase-53-closeout-evaluation.md
@@ -11,6 +11,8 @@ Phase 53 is accepted as the Wazuh product profile MVP evidence baseline for the 
 
 Wazuh remains a subordinate detection substrate. Wazuh detections are analytic signals until admitted and linked by AegisOps. AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
 
+Canonical implementation namespace remains `aegisops.control_plane`; `aegisops_control_plane` is retained for compatibility only.
+
 This closeout does not claim Phase 54 Shuffle profile work is complete, Phase 55 guided first-user journey work is complete, Phase 61 SIEM breadth is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a replacement for every SIEM/SOAR capability.
 
 ## Child Issue Outcomes
@@ -94,7 +96,7 @@ Focused negative-test evidence:
 
 Broad control-plane test evidence:
 
-- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+- `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
 
 Issue-lint evidence for #1135 through #1144:
 

--- a/docs/phase-53-closeout-evaluation.md
+++ b/docs/phase-53-closeout-evaluation.md
@@ -1,7 +1,7 @@
 # Phase 53 Closeout Evaluation
 
 - **Status**: Accepted as Wazuh product profile MVP evidence and handoff baseline; Phase 54, Phase 55, and Phase 61 can consume the bounded Wazuh profile MVP with explicit retained blockers.
-- **Date**: 2026-05-03
+- **Date**: 2026-05-02
 - **Owner**: AegisOps maintainers
 - **Related Issues**: #1135, #1136, #1137, #1138, #1139, #1140, #1141, #1142, #1143, #1144
 

--- a/scripts/test-verify-phase-53-9-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-53-9-closeout-evaluation.sh
@@ -77,6 +77,14 @@ assert_fails_with \
   "${missing_subordinate_posture_repo}" \
   "Missing required Phase 53 closeout term in docs/phase-53-closeout-evaluation.md: Wazuh remains a subordinate detection substrate."
 
+missing_namespace_repo="${workdir}/missing-namespace"
+copy_valid_repo "${missing_namespace_repo}"
+perl -0pi -e 's/Canonical implementation namespace remains `aegisops\.control_plane`; `aegisops_control_plane` is retained for compatibility only\.\n\n//' \
+  "${missing_namespace_repo}/docs/phase-53-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_namespace_repo}" \
+  'Missing required Phase 53 closeout term in docs/phase-53-closeout-evaluation.md: Canonical implementation namespace remains `aegisops.control_plane`; `aegisops_control_plane` is retained for compatibility only.'
+
 missing_source_health_repo="${workdir}/missing-source-health"
 copy_valid_repo "${missing_source_health_repo}"
 perl -0pi -e 's/\| Source health \| Deferred source-health projection\. \| Subordinate source-health projection states for Wazuh manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched posture\. \|\n//' \
@@ -92,6 +100,14 @@ perl -0pi -e 's/\| Sample signal evidence \| Existing Wazuh fixture families for
 assert_fails_with \
   "${missing_sample_signal_repo}" \
   'Missing required Phase 53 closeout term in docs/phase-53-closeout-evaluation.md: | Sample signal evidence | Existing Wazuh fixture families for earlier source work. | Reviewed SMB single-node SSH authentication failure Wazuh alert and analytic-signal fixtures tied to Phase 53.4 parser mapping evidence. |'
+
+missing_broad_unittest_repo="${workdir}/missing-broad-unittest"
+copy_valid_repo "${missing_broad_unittest_repo}"
+perl -0pi -e 's/^- `PYTHONPATH="\$\{PWD\}\/control-plane:\$\{PWD\}\/control-plane\/tests" python3 -m unittest discover -s control-plane\/tests -p '\''test_\*\.py'\''`\n//m' \
+  "${missing_broad_unittest_repo}/docs/phase-53-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_broad_unittest_repo}" \
+  'Missing required Phase 53 closeout term in docs/phase-53-closeout-evaluation.md: `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest discover -s control-plane/tests -p '\''test_*.py'\''`'
 
 missing_child_issue_lint_repo="${workdir}/missing-child-issue-lint"
 copy_valid_repo "${missing_child_issue_lint_repo}"

--- a/scripts/test-verify-phase-53-9-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-53-9-closeout-evaluation.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-53-9-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-53-closeout-evaluation.md" "${target}/docs/phase-53-closeout-evaluation.md"
+  cp "${repo_root}/README.md" "${target}/README.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+cp "${repo_root}/README.md" "${missing_doc_repo}/README.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 53 closeout evaluation: docs/phase-53-closeout-evaluation.md"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+copy_valid_repo "${missing_readme_link_repo}"
+perl -0pi -e 's/\[Phase 53\.9 closeout evaluation\]\(docs\/phase-53-closeout-evaluation\.md\)/Phase 53.9 closeout evaluation/g' \
+  "${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "Missing README Phase 53.9 closeout link: [Phase 53.9 closeout evaluation](docs/phase-53-closeout-evaluation.md)"
+
+missing_subordinate_posture_repo="${workdir}/missing-subordinate-posture"
+copy_valid_repo "${missing_subordinate_posture_repo}"
+perl -0pi -e 's/Wazuh remains a subordinate detection substrate\.//' \
+  "${missing_subordinate_posture_repo}/docs/phase-53-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_subordinate_posture_repo}" \
+  "Missing required Phase 53 closeout term in docs/phase-53-closeout-evaluation.md: Wazuh remains a subordinate detection substrate."
+
+missing_source_health_repo="${workdir}/missing-source-health"
+copy_valid_repo "${missing_source_health_repo}"
+perl -0pi -e 's/\| Source health \| Deferred source-health projection\. \| Subordinate source-health projection states for Wazuh manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched posture\. \|\n//' \
+  "${missing_source_health_repo}/docs/phase-53-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_source_health_repo}" \
+  'Missing required Phase 53 closeout term in docs/phase-53-closeout-evaluation.md: | Source health | Deferred source-health projection. | Subordinate source-health projection states for Wazuh manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched posture. |'
+
+missing_sample_signal_repo="${workdir}/missing-sample-signal"
+copy_valid_repo "${missing_sample_signal_repo}"
+perl -0pi -e 's/\| Sample signal evidence \| Existing Wazuh fixture families for earlier source work\. \| Reviewed SMB single-node SSH authentication failure Wazuh alert and analytic-signal fixtures tied to Phase 53\.4 parser mapping evidence\. \|\n//' \
+  "${missing_sample_signal_repo}/docs/phase-53-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_sample_signal_repo}" \
+  'Missing required Phase 53 closeout term in docs/phase-53-closeout-evaluation.md: | Sample signal evidence | Existing Wazuh fixture families for earlier source work. | Reviewed SMB single-node SSH authentication failure Wazuh alert and analytic-signal fixtures tied to Phase 53.4 parser mapping evidence. |'
+
+phase61_overclaim_repo="${workdir}/phase61-overclaim"
+copy_valid_repo "${phase61_overclaim_repo}"
+printf '%s\n' "Phase 61 SIEM breadth is complete" >>"${phase61_overclaim_repo}/docs/phase-53-closeout-evaluation.md"
+assert_fails_with \
+  "${phase61_overclaim_repo}" \
+  "Forbidden Phase 53 closeout evaluation claim: Phase 61 SIEM breadth is complete"
+
+commercial_overclaim_repo="${workdir}/commercial-overclaim"
+copy_valid_repo "${commercial_overclaim_repo}"
+printf '%s\n' "Phase 53 proves commercial replacement readiness" >>"${commercial_overclaim_repo}/docs/phase-53-closeout-evaluation.md"
+assert_fails_with \
+  "${commercial_overclaim_repo}" \
+  "Forbidden Phase 53 closeout evaluation claim: Phase 53 proves commercial replacement readiness"
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+mac_home_prefix="/""Users/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${mac_home_prefix}" >>"${absolute_path_repo}/docs/phase-53-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 53 closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 53 closeout evaluation verifier tests passed."

--- a/scripts/test-verify-phase-53-9-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-53-9-closeout-evaluation.sh
@@ -93,6 +93,14 @@ assert_fails_with \
   "${missing_sample_signal_repo}" \
   'Missing required Phase 53 closeout term in docs/phase-53-closeout-evaluation.md: | Sample signal evidence | Existing Wazuh fixture families for earlier source work. | Reviewed SMB single-node SSH authentication failure Wazuh alert and analytic-signal fixtures tied to Phase 53.4 parser mapping evidence. |'
 
+missing_child_issue_lint_repo="${workdir}/missing-child-issue-lint"
+copy_valid_repo "${missing_child_issue_lint_repo}"
+perl -0pi -e 's/^- `node <codex-supervisor-root>\/dist\/index\.js issue-lint 1139 --config <supervisor-config-path>`: .*?\n//m' \
+  "${missing_child_issue_lint_repo}/docs/phase-53-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_child_issue_lint_repo}" \
+  "Missing required Phase 53 closeout term in docs/phase-53-closeout-evaluation.md: node <codex-supervisor-root>/dist/index.js issue-lint 1139 --config <supervisor-config-path>"
+
 phase61_overclaim_repo="${workdir}/phase61-overclaim"
 copy_valid_repo "${phase61_overclaim_repo}"
 printf '%s\n' "Phase 61 SIEM breadth is complete" >>"${phase61_overclaim_repo}/docs/phase-53-closeout-evaluation.md"

--- a/scripts/verify-phase-53-9-closeout-evaluation.sh
+++ b/scripts/verify-phase-53-9-closeout-evaluation.sh
@@ -43,6 +43,7 @@ Phase 53 is accepted as the Wazuh product profile MVP evidence baseline for the 
 Wazuh remains a subordinate detection substrate.
 Wazuh detections are analytic signals until admitted and linked by AegisOps.
 AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+Canonical implementation namespace remains `aegisops.control_plane`; `aegisops_control_plane` is retained for compatibility only.
 This closeout does not claim Phase 54 Shuffle profile work is complete, Phase 55 guided first-user journey work is complete, Phase 61 SIEM breadth is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a replacement for every SIEM/SOAR capability.
 | #1135 | Epic: Phase 53 Wazuh Product Profile MVP | Open until #1144 lands; accepted when this closeout, focused verifier, Phase 53 verifiers, focused Wazuh tests, path hygiene, and issue-lint pass. |
 | #1136 | Phase 53.1 Wazuh SMB single-node profile contract | Closed.
@@ -93,6 +94,7 @@ This closeout does not claim Phase 54 Shuffle profile work is complete, Phase 55
 `bash scripts/verify-publishable-path-hygiene.sh`
 `bash scripts/verify-phase-53-9-closeout-evaluation.sh`
 `bash scripts/test-verify-phase-53-9-closeout-evaluation.sh`
+`PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
 node <codex-supervisor-root>/dist/index.js issue-lint 1135 --config <supervisor-config-path>
 node <codex-supervisor-root>/dist/index.js issue-lint 1136 --config <supervisor-config-path>
 node <codex-supervisor-root>/dist/index.js issue-lint 1137 --config <supervisor-config-path>

--- a/scripts/verify-phase-53-9-closeout-evaluation.sh
+++ b/scripts/verify-phase-53-9-closeout-evaluation.sh
@@ -94,6 +94,14 @@ This closeout does not claim Phase 54 Shuffle profile work is complete, Phase 55
 `bash scripts/verify-phase-53-9-closeout-evaluation.sh`
 `bash scripts/test-verify-phase-53-9-closeout-evaluation.sh`
 node <codex-supervisor-root>/dist/index.js issue-lint 1135 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1136 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1137 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1138 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1139 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1140 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1141 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1142 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1143 --config <supervisor-config-path>
 node <codex-supervisor-root>/dist/index.js issue-lint 1144 --config <supervisor-config-path>
 execution_ready=yes
 missing_required=none

--- a/scripts/verify-phase-53-9-closeout-evaluation.sh
+++ b/scripts/verify-phase-53-9-closeout-evaluation.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-53-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${file}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 53 closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -s "${readme_path}" ]]; then
+  echo "Missing README for Phase 53 closeout link check: README.md" >&2
+  exit 1
+fi
+
+require_phrase "${readme_path}" "[Phase 53.9 closeout evaluation](docs/phase-53-closeout-evaluation.md)" "README Phase 53.9 closeout link"
+
+required_phrases=()
+while IFS= read -r phrase; do
+  required_phrases+=("${phrase}")
+done <<'EOF'
+# Phase 53 Closeout Evaluation
+**Status**: Accepted as Wazuh product profile MVP evidence and handoff baseline; Phase 54, Phase 55, and Phase 61 can consume the bounded Wazuh profile MVP with explicit retained blockers.
+**Related Issues**: #1135, #1136, #1137, #1138, #1139, #1140, #1141, #1142, #1143, #1144
+Phase 53 is accepted as the Wazuh product profile MVP evidence baseline for the `smb-single-node` profile.
+Wazuh remains a subordinate detection substrate.
+Wazuh detections are analytic signals until admitted and linked by AegisOps.
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, source admission, release, gate, and closeout truth.
+This closeout does not claim Phase 54 Shuffle profile work is complete, Phase 55 guided first-user journey work is complete, Phase 61 SIEM breadth is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a replacement for every SIEM/SOAR capability.
+| #1135 | Epic: Phase 53 Wazuh Product Profile MVP | Open until #1144 lands; accepted when this closeout, focused verifier, Phase 53 verifiers, focused Wazuh tests, path hygiene, and issue-lint pass. |
+| #1136 | Phase 53.1 Wazuh SMB single-node profile contract | Closed.
+| #1137 | Phase 53.2 Wazuh certificate and credential handling | Closed.
+| #1138 | Phase 53.3 Wazuh manager intake binding | Closed.
+| #1139 | Phase 53.4 Wazuh sample signal fixture | Closed.
+| #1140 | Phase 53.5 Wazuh first agent enrollment helper | Closed.
+| #1141 | Phase 53.6 Wazuh source-health projection | Closed.
+| #1142 | Phase 53.7 Wazuh upgrade and rollback evidence | Closed.
+| #1143 | Phase 53.8 Wazuh authority-boundary negative tests | Closed.
+| #1144 | Phase 53.9 Phase 53 closeout evaluation | Open until this closeout lands; accepted when this document and focused negative verifier pass. |
+| Wazuh product profile | Deferred placeholder from Phase 52 first-user stack contracts. | Repo-owned `smb-single-node` Wazuh profile contract with manager, indexer, dashboard, exact `4.12.0` pins, resource, port, volume, and certificate expectations. |
+| Certificate and credential posture | Generic env, secret, and certificate contract from Phase 52.5. | Wazuh-specific certificate wrapper posture, trusted custody references, default credential rejection, placeholder rejection, and rotation guidance. |
+| Intake binding | Reviewed Wazuh-facing analytic-signal expectation. | `/intake/wazuh` and `aegisops-proxy:/intake/wazuh -> aegisops-control-plane:/intake/wazuh` with required provenance and shared-secret custody reference. |
+| Sample signal evidence | Existing Wazuh fixture families for earlier source work. | Reviewed SMB single-node SSH authentication failure Wazuh alert and analytic-signal fixtures tied to Phase 53.4 parser mapping evidence. |
+| Enrollment | Deferred fleet and agent posture. | One-endpoint enrollment helper contract only, with rollback notes and no fleet-scale Wazuh management claim. |
+| Source health | Deferred source-health projection. | Subordinate source-health projection states for Wazuh manager, dashboard, indexer, intake, signal freshness, parser, volume, credential, unavailable, stale, degraded, and mismatched posture. |
+| Upgrade and rollback | No Wazuh profile-change evidence template for the MVP. | Evidence template for future Wazuh profile version changes, without live upgrader or upgrade automation. |
+| Authority boundary | Wazuh subordinate posture inherited from Phase 51.6 and Phase 52 contracts. | Focused negative tests prove raw Wazuh status cannot close cases and Wazuh-triggered Shuffle runs without AegisOps delegation remain mismatched. |
+`docs/deployment/wazuh-smb-single-node-profile-contract.md`
+`docs/deployment/wazuh-certificate-credential-contract.md`
+`docs/deployment/wazuh-manager-intake-binding-contract.md`
+`docs/deployment/wazuh-agent-enrollment-helper-contract.md`
+`docs/deployment/wazuh-source-health-projection-contract.md`
+`docs/deployment/wazuh-upgrade-rollback-evidence-contract.md`
+`docs/deployment/wazuh-authority-boundary-negative-tests.md`
+`control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-alert.json`
+`control-plane/tests/fixtures/wazuh/phase53-smb-single-node-ssh-auth-failure-analytic-signal.json`
+`control-plane/tests/test_wazuh_adapter.py`
+`control-plane/tests/test_cross_boundary_negative_e2e_validation.py`
+`docs/phase-53-closeout-evaluation.md`
+`scripts/verify-phase-53-9-closeout-evaluation.sh`
+`scripts/test-verify-phase-53-9-closeout-evaluation.sh`
+`bash scripts/verify-phase-53-1-wazuh-profile-contract.sh`
+`bash scripts/test-verify-phase-53-1-wazuh-profile-contract.sh`
+`bash scripts/verify-phase-53-2-wazuh-cert-credential-contract.sh`
+`bash scripts/test-verify-phase-53-2-wazuh-cert-credential-contract.sh`
+`bash scripts/verify-phase-53-3-wazuh-intake-binding-contract.sh`
+`bash scripts/test-verify-phase-53-3-wazuh-intake-binding-contract.sh`
+`PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_wazuh_adapter.WazuhAlertAdapterTests`
+`bash scripts/verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh`
+`bash scripts/test-verify-phase-53-5-wazuh-agent-enrollment-helper-contract.sh`
+`bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh`
+`bash scripts/test-verify-phase-53-6-wazuh-source-health-projection.sh`
+`bash scripts/verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh`
+`bash scripts/test-verify-phase-53-7-wazuh-upgrade-rollback-evidence.sh`
+`bash scripts/verify-phase-53-8-wazuh-authority-boundary-negative-tests.sh`
+`bash scripts/verify-publishable-path-hygiene.sh`
+`bash scripts/verify-phase-53-9-closeout-evaluation.sh`
+`bash scripts/test-verify-phase-53-9-closeout-evaluation.sh`
+node <codex-supervisor-root>/dist/index.js issue-lint 1135 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1144 --config <supervisor-config-path>
+execution_ready=yes
+missing_required=none
+missing_recommended=none
+metadata_errors=none
+high_risk_blocking_ambiguity=none
+Phase 53 does not implement Phase 54 Shuffle product profiles.
+Phase 53 does not implement Phase 55 guided first-user UI journey work.
+Phase 53 does not complete Phase 61 SIEM breadth, broad detector catalog coverage, or every source-family expectation.
+Phase 53 does not implement Wazuh Active Response as an authority path.
+Phase 53 does not approve a direct Wazuh-to-Shuffle shortcut.
+Phase 53 does not let Wazuh alert status close AegisOps cases.
+Phase 53 does not implement fleet-scale Wazuh agent management, a full live Wazuh upgrader, secret backend integration, customer-specific credential provisioning, Beta readiness, RC readiness, GA readiness, commercial replacement readiness, or Wazuh replacement readiness.
+Phase 54 can consume the Wazuh profile MVP as the reviewed Wazuh-side substrate and intake context for Shuffle profile work.
+Phase 54 must still implement its own Shuffle profile contract, callback custody, delegated-execution boundary, workflow catalog custody, and negative tests.
+Phase 55 can consume the Wazuh profile MVP as one setup and source-health evidence surface for the guided first-user journey.
+Phase 55 must still implement the guided journey, user-facing validation flow, runtime custody choices, error handling, and first-user ergonomics.
+Phase 61 can consume the Wazuh profile MVP as the first reviewed SIEM substrate profile and evidence pattern.
+Phase 61 must still implement SIEM breadth, source-family prioritization, detector coverage expansion, and any additional source profile contracts explicitly.
+Phase 53 does not complete Phase 61 SIEM breadth.
+This closeout is evidence recording only.
+EOF
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 53 closeout term in ${doc_path}"
+done
+
+mac_home_prefix="$(printf '/%s/' 'Users')"
+unix_home_prefix="$(printf '/%s/' 'home')"
+windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
+absolute_path_pattern="(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}" "${readme_path}"; then
+  echo "Forbidden Phase 53 closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+for forbidden in \
+  "Phase 54 Shuffle profile work is complete" \
+  "Phase 55 guided first-user journey work is complete" \
+  "Phase 61 SIEM breadth is complete" \
+  "Phase 53 proves Beta readiness" \
+  "Phase 53 proves RC readiness" \
+  "Phase 53 proves GA readiness" \
+  "Phase 53 proves self-service commercial readiness" \
+  "Phase 53 proves commercial replacement readiness" \
+  "AegisOps replaces every SIEM/SOAR capability" \
+  "Wazuh Active Response is an authority path" \
+  "Direct Wazuh-to-Shuffle shortcuts are approved" \
+  "Wazuh alert status closes AegisOps cases" \
+  "Wazuh dashboard state is AegisOps workflow truth" \
+  "Wazuh source-health projection is AegisOps closeout truth" \
+  "Wazuh version state is AegisOps release truth"; do
+  if grep -F -- "${forbidden}" "${absolute_doc_path}" | grep -Fvq -- "does not claim"; then
+    echo "Forbidden Phase 53 closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 53 closeout evaluation records Wazuh profile MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 54/55/61 handoff."


### PR DESCRIPTION
## Summary
- Adds the Phase 53 closeout evaluation for the Wazuh product profile MVP.
- Adds a focused closeout verifier and negative verifier self-test.
- Links the Phase 53.9 closeout from README.

## Verification
- bash scripts/verify-phase-53-9-closeout-evaluation.sh
- bash scripts/test-verify-phase-53-9-closeout-evaluation.sh
- Phase 53 verifier set for 53.1, 53.2, 53.3, 53.5, 53.6, 53.7, 53.8
- bash scripts/verify-publishable-path-hygiene.sh
- PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_wazuh_adapter.WazuhAlertAdapterTests test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_raw_wazuh_status_cannot_close_aegisops_case test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_wazuh_triggered_shuffle_run_without_aegisops_delegation_is_mismatched
- node <codex-supervisor-root>/dist/index.js issue-lint 1135..1144 --config <supervisor-config-path>
- PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest discover -s control-plane/tests -p 'test_*.py'\n\nCloses #1144\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 53.9 closeout evaluation documenting acceptance status, verdict scope, related issue outcomes, limitations, and handoff expectations; updated README cross-reference to include the new evaluation.
* **Tests**
  * Added verification and test-harness tooling to validate the closeout document and README for required and forbidden content, including positive/negative scenario checks and content-sanity scans to prevent accidental local-path or inappropriate-claim text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->