### PR TITLE
Phase 54.6: Add AegisOps-to-Shuffle delegation binding

### DIFF
--- a/control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py
+++ b/control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py
@@ -21,6 +21,12 @@ from ..models import (
 )
 
 
+_REVIEWED_SHUFFLE_WORKFLOW_VERSIONS = {
+    "create_tracking_ticket": "create_tracking_ticket-v1-reviewed-2026-05-03",
+    "notify_identity_owner": "notify_identity_owner-v1-reviewed-2026-05-03",
+}
+
+
 class ApprovedActionDelegationCoordinator:
     def __init__(self, service: ExecutionCoordinatorServiceDependencies) -> None:
         self._service = service
@@ -144,7 +150,10 @@ class ApprovedActionDelegationCoordinator:
                         )
                     return existing
             if execution_surface_id == "shuffle":
-                self._require_reviewed_shuffle_payload(normalized_payload)
+                self._require_reviewed_shuffle_payload(
+                    action_request=action_request,
+                    approved_payload=normalized_payload,
+                )
 
             delegation_id = self._service._next_identifier("delegation")
             predispatch_execution = self._service.persist_record(
@@ -267,6 +276,8 @@ class ApprovedActionDelegationCoordinator:
 
     def _require_reviewed_shuffle_payload(
         self,
+        *,
+        action_request: ActionRequestRecord,
         approved_payload: Mapping[str, object],
     ) -> None:
         action_type = approved_payload.get("action_type")
@@ -281,8 +292,7 @@ class ApprovedActionDelegationCoordinator:
                     raise ValueError(
                         "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
                     )
-            return
-        if action_type == "create_tracking_ticket":
+        elif action_type == "create_tracking_ticket":
             for field_name in (
                 "case_id",
                 "coordination_reference_id",
@@ -304,10 +314,68 @@ class ApprovedActionDelegationCoordinator:
                 raise ValueError(
                     "approved action is outside the reviewed Phase 26 Shuffle delegation scope"
                 )
-            return
-        raise ValueError(
-            "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+        else:
+            raise ValueError(
+                "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+            )
+
+        self._require_shuffle_delegation_binding(
+            action_request=action_request,
+            approved_payload=approved_payload,
         )
+
+    def _require_shuffle_delegation_binding(
+        self,
+        *,
+        action_request: ActionRequestRecord,
+        approved_payload: Mapping[str, object],
+    ) -> Mapping[str, object] | None:
+        binding = approved_payload.get("shuffle_delegation_binding")
+        if binding is None:
+            return None
+        if not isinstance(binding, Mapping):
+            raise ValueError("shuffle delegation binding is malformed")
+
+        action_type = self._service._require_non_empty_string(
+            approved_payload.get("action_type"),
+            "approved_payload.action_type",
+        )
+        workflow_id = self._service._require_non_empty_string(
+            binding.get("workflow_id"),
+            "shuffle_delegation_binding.workflow_id",
+        )
+        workflow_version_id = self._service._require_non_empty_string(
+            binding.get("workflow_version_id"),
+            "shuffle_delegation_binding.workflow_version_id",
+        )
+        self._service._require_non_empty_string(
+            binding.get("correlation_id"),
+            "shuffle_delegation_binding.correlation_id",
+        )
+        self._service._require_non_empty_string(
+            binding.get("expected_execution_receipt_id"),
+            "shuffle_delegation_binding.expected_execution_receipt_id",
+        )
+        requested_scope = binding.get("requested_scope")
+        if not isinstance(requested_scope, Mapping):
+            raise ValueError("shuffle delegation binding requested_scope is malformed")
+
+        if workflow_id != action_type:
+            raise ValueError(
+                "shuffle delegation binding does not match approved action request scope"
+            )
+        if (
+            _REVIEWED_SHUFFLE_WORKFLOW_VERSIONS.get(workflow_id)
+            != workflow_version_id
+        ):
+            raise ValueError(
+                "shuffle delegation binding uses an unknown reviewed workflow template version"
+            )
+        if requested_scope != action_request.target_scope:
+            raise ValueError(
+                "shuffle delegation binding does not match approved action request scope"
+            )
+        return binding
 
     def _require_exact_adapter_receipt_binding(
         self,
@@ -333,6 +401,48 @@ class ApprovedActionDelegationCoordinator:
             raise ValueError(
                 "shuffle receipt does not match approved delegation binding"
             )
+        if execution_surface_id == "shuffle":
+            delegation_binding = self._require_shuffle_delegation_binding(
+                action_request=action_request,
+                approved_payload=action_request.requested_payload,
+            )
+            if delegation_binding is not None:
+                if any(
+                    (
+                        getattr(receipt, "action_request_id", None)
+                        != action_request.action_request_id,
+                        self._require_receipt_string_attribute(
+                            receipt,
+                            "workflow_id",
+                        )
+                        != delegation_binding["workflow_id"],
+                        self._require_receipt_string_attribute(
+                            receipt,
+                            "workflow_version_id",
+                        )
+                        != delegation_binding["workflow_version_id"],
+                        self._require_receipt_string_attribute(
+                            receipt,
+                            "correlation_id",
+                        )
+                        != delegation_binding["correlation_id"],
+                        self._require_receipt_string_attribute(
+                            receipt,
+                            "expected_execution_receipt_id",
+                        )
+                        != delegation_binding["expected_execution_receipt_id"],
+                        self._require_receipt_string_attribute(
+                            receipt,
+                            "external_receipt_id",
+                        )
+                        != delegation_binding["expected_execution_receipt_id"],
+                        getattr(receipt, "requested_scope", None)
+                        != delegation_binding["requested_scope"],
+                    )
+                ):
+                    raise ValueError(
+                        "shuffle receipt does not match approved delegation binding"
+                    )
         if (
             execution_surface_id == "shuffle"
             and action_request.requested_payload.get("action_type")
@@ -397,6 +507,32 @@ class ApprovedActionDelegationCoordinator:
                     "payload_hash",
                 ),
             }
+            delegation_binding = execution.approved_payload.get(
+                "shuffle_delegation_binding"
+            )
+            if isinstance(delegation_binding, Mapping):
+                provenance["downstream_binding"].update(
+                    {
+                        "action_request_id": execution.action_request_id,
+                        "workflow_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "workflow_id",
+                        ),
+                        "workflow_version_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "workflow_version_id",
+                        ),
+                        "correlation_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "correlation_id",
+                        ),
+                        "expected_execution_receipt_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "expected_execution_receipt_id",
+                        ),
+                        "requested_scope": dict(delegation_binding["requested_scope"]),
+                    }
+                )
             if execution.approved_payload.get("action_type") == "create_tracking_ticket":
                 provenance["downstream_binding"].update(
                     {

--- a/control-plane/aegisops/control_plane/adapters/shuffle.py
+++ b/control-plane/aegisops/control_plane/adapters/shuffle.py
@@ -10,11 +10,17 @@ class ShuffleDelegationReceipt:
     execution_surface_type: str
     execution_surface_id: str
     execution_run_id: str
+    action_request_id: str
     approval_decision_id: str
     delegation_id: str
     payload_hash: str
     adapter: str
     base_url: str
+    workflow_id: str | None = None
+    workflow_version_id: str | None = None
+    correlation_id: str | None = None
+    expected_execution_receipt_id: str | None = None
+    requested_scope: Mapping[str, object] | None = None
     coordination_reference_id: str | None = None
     coordination_target_type: str | None = None
     external_receipt_id: str | None = None
@@ -41,21 +47,44 @@ class ShuffleActionAdapter:
         approved_payload: Mapping[str, object],
         delegated_at: datetime,
     ) -> ShuffleDelegationReceipt:
-        del action_request_id
         del idempotency_key
         del delegated_at
         action_type = approved_payload.get("action_type")
+        delegation_binding = approved_payload.get("shuffle_delegation_binding")
+        if isinstance(delegation_binding, Mapping):
+            external_receipt_id = str(
+                delegation_binding["expected_execution_receipt_id"]
+            )
+            workflow_id = str(delegation_binding["workflow_id"])
+            workflow_version_id = str(delegation_binding["workflow_version_id"])
+            correlation_id = str(delegation_binding["correlation_id"])
+            requested_scope = delegation_binding["requested_scope"]
+            if not isinstance(requested_scope, Mapping):
+                requested_scope = None
+        else:
+            external_receipt_id = None
+            workflow_id = None
+            workflow_version_id = None
+            correlation_id = None
+            requested_scope = None
         if action_type == "notify_identity_owner":
             self._require_reviewed_phase20_notify_payload(approved_payload)
             return ShuffleDelegationReceipt(
                 execution_surface_type=self.execution_surface_type,
                 execution_surface_id=self.execution_surface_id,
                 execution_run_id=f"shuffle-run-{delegation_id}",
+                action_request_id=action_request_id,
                 approval_decision_id=approval_decision_id,
                 delegation_id=delegation_id,
                 payload_hash=payload_hash,
                 adapter="shuffle",
                 base_url=self.base_url,
+                workflow_id=workflow_id,
+                workflow_version_id=workflow_version_id,
+                correlation_id=correlation_id,
+                expected_execution_receipt_id=external_receipt_id,
+                requested_scope=requested_scope,
+                external_receipt_id=external_receipt_id,
             )
         if action_type == "create_tracking_ticket":
             self._require_reviewed_phase26_create_tracking_ticket_payload(
@@ -67,16 +96,23 @@ class ShuffleActionAdapter:
                 execution_surface_type=self.execution_surface_type,
                 execution_surface_id=self.execution_surface_id,
                 execution_run_id=f"shuffle-run-{delegation_id}",
+                action_request_id=action_request_id,
                 approval_decision_id=approval_decision_id,
                 delegation_id=delegation_id,
                 payload_hash=payload_hash,
                 adapter="shuffle",
                 base_url=self.base_url,
+                workflow_id=workflow_id,
+                workflow_version_id=workflow_version_id,
+                correlation_id=correlation_id,
+                expected_execution_receipt_id=external_receipt_id,
+                requested_scope=requested_scope,
                 coordination_reference_id=str(
                     approved_payload["coordination_reference_id"]
                 ),
                 coordination_target_type=coordination_target_type,
-                external_receipt_id=f"shuffle-receipt-{delegation_id}",
+                external_receipt_id=external_receipt_id
+                or f"shuffle-receipt-{delegation_id}",
                 coordination_target_id=coordination_target_id,
                 ticket_reference_url=(
                     "https://tickets.example.test/#ticket/"

--- a/control-plane/aegisops/control_plane/adapters/shuffle.py
+++ b/control-plane/aegisops/control_plane/adapters/shuffle.py
@@ -60,7 +60,9 @@ class ShuffleActionAdapter:
             correlation_id = str(delegation_binding["correlation_id"])
             requested_scope = delegation_binding["requested_scope"]
             if not isinstance(requested_scope, Mapping):
-                requested_scope = None
+                raise ValueError(
+                    "shuffle delegation binding requested_scope is malformed"
+                )
         else:
             external_receipt_id = None
             workflow_id = None

--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -10,6 +10,7 @@ if str(TESTS_ROOT) not in sys.path:
     sys.path.insert(0, str(TESTS_ROOT))
 
 import _service_persistence_support as support
+from aegisops.control_plane.adapters.shuffle import ShuffleActionAdapter
 from _service_persistence_support import (
     ServicePersistenceTestBase,
 )
@@ -375,6 +376,40 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
             )
 
         self.assertEqual(store.list(support.ActionExecutionRecord), ())
+
+    def test_shuffle_adapter_fail_closes_malformed_binding_requested_scope(
+        self,
+    ) -> None:
+        adapter = ShuffleActionAdapter(base_url="https://shuffle.example.test")
+        approved_payload = support._phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-malformed-scope-001",
+            alert_id="alert-tracking-malformed-scope-001",
+            finding_id="finding-tracking-malformed-scope-001",
+            coordination_reference_id="coord-ref-malformed-scope-001",
+        )
+        approved_payload["shuffle_delegation_binding"] = {
+            "workflow_id": "create_tracking_ticket",
+            "workflow_version_id": "create_tracking_ticket-v1-reviewed-2026-05-03",
+            "correlation_id": "shuffle-correlation-malformed-scope-001",
+            "expected_execution_receipt_id": "shuffle-receipt-malformed-scope-001",
+            "requested_scope": "case-tracking-malformed-scope-001",
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "shuffle delegation binding requested_scope is malformed",
+        ):
+            adapter.dispatch_approved_action(
+                delegation_id="delegation-malformed-scope-001",
+                action_request_id="action-request-malformed-scope-001",
+                approval_decision_id="approval-malformed-scope-001",
+                payload_hash="payload-hash-malformed-scope-001",
+                idempotency_key="idempotency-malformed-scope-001",
+                approved_payload=approved_payload,
+                delegated_at=support.datetime(
+                    2026, 5, 3, 4, 5, tzinfo=support.timezone.utc
+                ),
+            )
 
     def test_service_reuses_create_tracking_ticket_receipt_on_duplicate_delegation(
         self,

--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -15,6 +15,74 @@ from _service_persistence_support import (
 )
 
 class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenceTestBase):
+    def _build_phase54_create_tracking_ticket_context(
+        self,
+        *,
+        suffix: str,
+        binding: dict[str, object],
+    ) -> tuple[object, object, dict[str, object], support.datetime]:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = support.datetime(2026, 5, 3, 4, 0, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 5, 3, 4, 5, tzinfo=support.timezone.utc)
+        approved_target_scope = {
+            "case_id": f"case-tracking-{suffix}",
+            "alert_id": f"alert-tracking-{suffix}",
+            "finding_id": f"finding-tracking-{suffix}",
+            "coordination_reference_id": f"coord-ref-{suffix}",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = support._phase26_create_tracking_ticket_payload(
+            case_id=f"case-tracking-{suffix}",
+            alert_id=f"alert-tracking-{suffix}",
+            finding_id=f"finding-tracking-{suffix}",
+            coordination_reference_id=f"coord-ref-{suffix}",
+        )
+        approved_payload["shuffle_delegation_binding"] = binding
+        payload_hash = support._approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            support.ApprovalDecisionRecord(
+                approval_decision_id=f"approval-create-ticket-{suffix}",
+                action_request_id=f"action-request-create-ticket-{suffix}",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            support.ActionRequestRecord(
+                action_request_id=f"action-request-create-ticket-{suffix}",
+                approval_decision_id=f"approval-create-ticket-{suffix}",
+                case_id=f"case-tracking-{suffix}",
+                alert_id=f"alert-tracking-{suffix}",
+                finding_id=f"finding-tracking-{suffix}",
+                idempotency_key=f"idempotency-create-ticket-{suffix}",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        return store, service, approved_payload, delegated_at
+
     def test_service_delegates_approved_create_tracking_ticket_through_shuffle(
         self,
     ) -> None:
@@ -38,6 +106,13 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
             finding_id="finding-tracking-001",
             coordination_reference_id="coord-ref-create-001",
         )
+        approved_payload["shuffle_delegation_binding"] = {
+            "workflow_id": "create_tracking_ticket",
+            "workflow_version_id": "create_tracking_ticket-v1-reviewed-2026-05-03",
+            "correlation_id": "shuffle-correlation-create-ticket-001",
+            "expected_execution_receipt_id": "shuffle-receipt-create-ticket-001",
+            "requested_scope": approved_target_scope,
+        }
         payload_hash = support._approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
@@ -101,10 +176,29 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
             execution.provenance["downstream_binding"]["coordination_target_type"],
             "zammad",
         )
-        self.assertTrue(
-            execution.provenance["downstream_binding"][
-                "external_receipt_id"
-            ].startswith("shuffle-receipt-delegation-")
+        self.assertEqual(
+            execution.provenance["downstream_binding"]["workflow_id"],
+            "create_tracking_ticket",
+        )
+        self.assertEqual(
+            execution.provenance["downstream_binding"]["workflow_version_id"],
+            "create_tracking_ticket-v1-reviewed-2026-05-03",
+        )
+        self.assertEqual(
+            execution.provenance["downstream_binding"]["correlation_id"],
+            "shuffle-correlation-create-ticket-001",
+        )
+        self.assertEqual(
+            execution.provenance["downstream_binding"]["external_receipt_id"],
+            "shuffle-receipt-create-ticket-001",
+        )
+        self.assertEqual(
+            execution.provenance["downstream_binding"]["expected_execution_receipt_id"],
+            "shuffle-receipt-create-ticket-001",
+        )
+        self.assertEqual(
+            execution.provenance["downstream_binding"]["requested_scope"],
+            approved_target_scope,
         )
         self.assertTrue(
             execution.provenance["downstream_binding"][
@@ -116,6 +210,171 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
                 "ticket_reference_url"
             ].startswith("https://tickets.example.test/#ticket/zammad-ticket-delegation-")
         )
+
+    def test_service_fail_closes_unknown_shuffle_template_version_before_dispatch(
+        self,
+    ) -> None:
+        store, _ = support.make_store()
+        service = support.AegisOpsControlPlaneService(
+            support.RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        requested_at = support.datetime(2026, 5, 3, 4, 0, tzinfo=support.timezone.utc)
+        delegated_at = support.datetime(2026, 5, 3, 4, 5, tzinfo=support.timezone.utc)
+        approved_target_scope = {
+            "case_id": "case-tracking-template-version-001",
+            "alert_id": "alert-tracking-template-version-001",
+            "finding_id": "finding-tracking-template-version-001",
+            "coordination_reference_id": "coord-ref-template-version-001",
+            "coordination_target_type": "zammad",
+        }
+        approved_payload = support._phase26_create_tracking_ticket_payload(
+            case_id="case-tracking-template-version-001",
+            alert_id="alert-tracking-template-version-001",
+            finding_id="finding-tracking-template-version-001",
+            coordination_reference_id="coord-ref-template-version-001",
+        )
+        approved_payload["shuffle_delegation_binding"] = {
+            "workflow_id": "create_tracking_ticket",
+            "workflow_version_id": "create_tracking_ticket-v2-unreviewed-2026-05-03",
+            "correlation_id": "shuffle-correlation-template-version-001",
+            "expected_execution_receipt_id": (
+                "shuffle-receipt-template-version-001"
+            ),
+            "requested_scope": approved_target_scope,
+        }
+        payload_hash = support._approved_binding_hash(
+            target_scope=approved_target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        service.persist_record(
+            support.ApprovalDecisionRecord(
+                approval_decision_id="approval-create-ticket-template-version-001",
+                action_request_id="action-request-create-ticket-template-version-001",
+                approver_identities=("approver-001",),
+                target_snapshot=approved_target_scope,
+                payload_hash=payload_hash,
+                decided_at=requested_at,
+                lifecycle_state="approved",
+            )
+        )
+        service.persist_record(
+            support.ActionRequestRecord(
+                action_request_id="action-request-create-ticket-template-version-001",
+                approval_decision_id="approval-create-ticket-template-version-001",
+                case_id="case-tracking-template-version-001",
+                alert_id="alert-tracking-template-version-001",
+                finding_id="finding-tracking-template-version-001",
+                idempotency_key="idempotency-create-ticket-template-version-001",
+                target_scope=approved_target_scope,
+                payload_hash=payload_hash,
+                requested_at=requested_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "approval",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "shuffle delegation binding uses an unknown reviewed workflow template version",
+        ):
+            service.delegate_approved_action_to_shuffle(
+                action_request_id="action-request-create-ticket-template-version-001",
+                approved_payload=approved_payload,
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+            )
+
+        self.assertEqual(store.list(support.ActionExecutionRecord), ())
+
+    def test_service_fail_closes_missing_shuffle_correlation_before_dispatch(
+        self,
+    ) -> None:
+        store, service, approved_payload, delegated_at = (
+            self._build_phase54_create_tracking_ticket_context(
+                suffix="missing-correlation-001",
+                binding={
+                    "workflow_id": "create_tracking_ticket",
+                    "workflow_version_id": (
+                        "create_tracking_ticket-v1-reviewed-2026-05-03"
+                    ),
+                    "correlation_id": "",
+                    "expected_execution_receipt_id": (
+                        "shuffle-receipt-missing-correlation-001"
+                    ),
+                    "requested_scope": {
+                        "case_id": "case-tracking-missing-correlation-001",
+                        "alert_id": "alert-tracking-missing-correlation-001",
+                        "finding_id": "finding-tracking-missing-correlation-001",
+                        "coordination_reference_id": (
+                            "coord-ref-missing-correlation-001"
+                        ),
+                        "coordination_target_type": "zammad",
+                    },
+                },
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "shuffle_delegation_binding.correlation_id",
+        ):
+            service.delegate_approved_action_to_shuffle(
+                action_request_id="action-request-create-ticket-missing-correlation-001",
+                approved_payload=approved_payload,
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+            )
+
+        self.assertEqual(store.list(support.ActionExecutionRecord), ())
+
+    def test_service_fail_closes_shuffle_requested_scope_mismatch_before_dispatch(
+        self,
+    ) -> None:
+        store, service, approved_payload, delegated_at = (
+            self._build_phase54_create_tracking_ticket_context(
+                suffix="scope-mismatch-001",
+                binding={
+                    "workflow_id": "create_tracking_ticket",
+                    "workflow_version_id": (
+                        "create_tracking_ticket-v1-reviewed-2026-05-03"
+                    ),
+                    "correlation_id": "shuffle-correlation-scope-mismatch-001",
+                    "expected_execution_receipt_id": (
+                        "shuffle-receipt-scope-mismatch-001"
+                    ),
+                    "requested_scope": {
+                        "case_id": "case-tracking-scope-mismatch-001",
+                        "alert_id": "alert-tracking-scope-mismatch-001",
+                        "finding_id": "finding-tracking-scope-mismatch-001",
+                        "coordination_reference_id": "coord-ref-drifted-001",
+                        "coordination_target_type": "zammad",
+                    },
+                },
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "shuffle delegation binding does not match approved action request scope",
+        ):
+            service.delegate_approved_action_to_shuffle(
+                action_request_id="action-request-create-ticket-scope-mismatch-001",
+                approved_payload=approved_payload,
+                delegated_at=delegated_at,
+                delegation_issuer="control-plane-service",
+            )
+
+        self.assertEqual(store.list(support.ActionExecutionRecord), ())
 
     def test_service_reuses_create_tracking_ticket_receipt_on_duplicate_delegation(
         self,


### PR DESCRIPTION
## Summary
- Add Phase 54 Shuffle delegation binding validation for workflow id/version, correlation id, expected execution receipt id, and requested scope.
- Carry binding-aware Shuffle receipt fields into downstream provenance while preserving legacy delegation compatibility.
- Add focused positive and fail-closed create-tracking-ticket delegation tests.

## Verification
- PYTHONPATH=control-plane:control-plane/tests python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket
- PYTHONPATH=control-plane:control-plane/tests python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_delegation
- PYTHONPATH=control-plane:control-plane/tests python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket control-plane.tests.test_service_persistence_action_reconciliation_delegation
- node <codex-supervisor-root>/dist/index.js issue-lint 1160 --config <supervisor-config-path>

Closes #1160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation of reviewed delegation payloads with clearer error messages and early failure for unreviewed workflow versions.
  * Strengthened receipt-binding checks to ensure delegation fields (workflow/version, correlation id, expected/external receipt, requested scope) match bindings.
  * Improved provenance recording to include delegation binding details.

* **Tests**
  * Expanded and refactored tests for delegation validation, binding scenarios, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->