### PR TITLE
Phase 54.7: Normalize Shuffle execution receipts

### DIFF
--- a/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
+++ b/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
@@ -330,16 +330,14 @@ class ActionExecutionReconciliationCoordinator:
                         ),
                         transitioned_at=latest_execution["observed_at"],
                     )
-            if (
-                authoritative_execution is not None
-                and authoritative_execution.approved_payload.get("action_type")
-                == "create_tracking_ticket"
-            ):
-                downstream_binding = authoritative_execution.provenance.get(
+            downstream_binding: Mapping[str, object] | None = None
+            if authoritative_execution is not None:
+                raw_downstream_binding = authoritative_execution.provenance.get(
                     "downstream_binding",
                     {},
                 )
-                if isinstance(downstream_binding, Mapping):
+                if isinstance(raw_downstream_binding, Mapping):
+                    downstream_binding = raw_downstream_binding
                     if isinstance(downstream_binding.get("workflow_id"), str):
                         subject_linkage["workflow_ids"] = (
                             downstream_binding["workflow_id"],
@@ -359,26 +357,33 @@ class ActionExecutionReconciliationCoordinator:
                         subject_linkage["expected_execution_receipt_ids"] = (
                             downstream_binding["expected_execution_receipt_id"],
                         )
-                    if isinstance(downstream_binding.get("coordination_reference_id"), str):
-                        subject_linkage["coordination_reference_ids"] = (
-                            downstream_binding["coordination_reference_id"],
-                        )
-                    if isinstance(downstream_binding.get("coordination_target_type"), str):
-                        subject_linkage["coordination_target_types"] = (
-                            downstream_binding["coordination_target_type"],
-                        )
-                    if isinstance(downstream_binding.get("external_receipt_id"), str):
-                        subject_linkage["external_receipt_ids"] = (
-                            downstream_binding["external_receipt_id"],
-                        )
-                    if isinstance(downstream_binding.get("coordination_target_id"), str):
-                        subject_linkage["coordination_target_ids"] = (
-                            downstream_binding["coordination_target_id"],
-                        )
-                    if isinstance(downstream_binding.get("ticket_reference_url"), str):
-                        subject_linkage["ticket_reference_urls"] = (
-                            downstream_binding["ticket_reference_url"],
-                        )
+
+            if (
+                authoritative_execution is not None
+                and authoritative_execution.approved_payload.get("action_type")
+                == "create_tracking_ticket"
+                and downstream_binding is not None
+            ):
+                if isinstance(downstream_binding.get("coordination_reference_id"), str):
+                    subject_linkage["coordination_reference_ids"] = (
+                        downstream_binding["coordination_reference_id"],
+                    )
+                if isinstance(downstream_binding.get("coordination_target_type"), str):
+                    subject_linkage["coordination_target_types"] = (
+                        downstream_binding["coordination_target_type"],
+                    )
+                if isinstance(downstream_binding.get("external_receipt_id"), str):
+                    subject_linkage["external_receipt_ids"] = (
+                        downstream_binding["external_receipt_id"],
+                    )
+                if isinstance(downstream_binding.get("coordination_target_id"), str):
+                    subject_linkage["coordination_target_ids"] = (
+                        downstream_binding["coordination_target_id"],
+                    )
+                if isinstance(downstream_binding.get("ticket_reference_url"), str):
+                    subject_linkage["ticket_reference_urls"] = (
+                        downstream_binding["ticket_reference_url"],
+                    )
 
             reconciliation = self._service.persist_record(
                 ReconciliationRecord(

--- a/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
+++ b/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
@@ -139,6 +139,13 @@ class ActionExecutionReconciliationCoordinator:
             observed_approval_decision_id = latest_execution.get("approval_decision_id")
             observed_delegation_id = latest_execution.get("delegation_id")
             observed_payload_hash = latest_execution.get("payload_hash")
+            observed_action_request_id = latest_execution.get("action_request_id")
+            observed_workflow_id = latest_execution.get("workflow_id")
+            observed_workflow_version_id = latest_execution.get("workflow_version_id")
+            observed_correlation_id = latest_execution.get("correlation_id")
+            observed_expected_execution_receipt_id = latest_execution.get(
+                "expected_execution_receipt_id"
+            )
             observed_coordination_reference_id = latest_execution.get(
                 "coordination_reference_id"
             )
@@ -212,6 +219,28 @@ class ActionExecutionReconciliationCoordinator:
                 lifecycle_state = "mismatched"
                 mismatch_summary = (
                     "approved binding mismatch between authoritative action execution "
+                    "and observed downstream execution"
+                )
+            elif (
+                authoritative_execution is not None
+                and authoritative_execution.execution_surface_type
+                == "automation_substrate"
+                and authoritative_execution.execution_surface_id == "shuffle"
+                and self._shuffle_receipt_binding_mismatched(
+                    authoritative_execution=authoritative_execution,
+                    observed_action_request_id=observed_action_request_id,
+                    observed_workflow_id=observed_workflow_id,
+                    observed_workflow_version_id=observed_workflow_version_id,
+                    observed_correlation_id=observed_correlation_id,
+                    observed_expected_execution_receipt_id=(
+                        observed_expected_execution_receipt_id
+                    ),
+                )
+            ):
+                ingest_disposition = "mismatch"
+                lifecycle_state = "mismatched"
+                mismatch_summary = (
+                    "execution receipt binding mismatch between authoritative action execution "
                     "and observed downstream execution"
                 )
             elif (
@@ -311,6 +340,25 @@ class ActionExecutionReconciliationCoordinator:
                     {},
                 )
                 if isinstance(downstream_binding, Mapping):
+                    if isinstance(downstream_binding.get("workflow_id"), str):
+                        subject_linkage["workflow_ids"] = (
+                            downstream_binding["workflow_id"],
+                        )
+                    if isinstance(downstream_binding.get("workflow_version_id"), str):
+                        subject_linkage["workflow_version_ids"] = (
+                            downstream_binding["workflow_version_id"],
+                        )
+                    if isinstance(downstream_binding.get("correlation_id"), str):
+                        subject_linkage["correlation_ids"] = (
+                            downstream_binding["correlation_id"],
+                        )
+                    if isinstance(
+                        downstream_binding.get("expected_execution_receipt_id"),
+                        str,
+                    ):
+                        subject_linkage["expected_execution_receipt_ids"] = (
+                            downstream_binding["expected_execution_receipt_id"],
+                        )
                     if isinstance(downstream_binding.get("coordination_reference_id"), str):
                         subject_linkage["coordination_reference_ids"] = (
                             downstream_binding["coordination_reference_id"],
@@ -460,6 +508,39 @@ class ActionExecutionReconciliationCoordinator:
                     return execution
         return matches[0] if matches else None
 
+    @staticmethod
+    def _shuffle_receipt_binding_mismatched(
+        *,
+        authoritative_execution: ActionExecutionRecord,
+        observed_action_request_id: object,
+        observed_workflow_id: object,
+        observed_workflow_version_id: object,
+        observed_correlation_id: object,
+        observed_expected_execution_receipt_id: object,
+    ) -> bool:
+        downstream_binding = authoritative_execution.provenance.get(
+            "downstream_binding",
+            {},
+        )
+        if not isinstance(downstream_binding, Mapping):
+            return False
+
+        expected_fields = (
+            ("action_request_id", observed_action_request_id),
+            ("workflow_id", observed_workflow_id),
+            ("workflow_version_id", observed_workflow_version_id),
+            ("correlation_id", observed_correlation_id),
+            (
+                "expected_execution_receipt_id",
+                observed_expected_execution_receipt_id,
+            ),
+        )
+        return any(
+            isinstance(downstream_binding.get(field_name), str)
+            and observed_value != downstream_binding[field_name]
+            for field_name, observed_value in expected_fields
+        )
+
     def _normalize_observed_executions(
         self,
         observed_executions: tuple[Mapping[str, object], ...],
@@ -477,6 +558,13 @@ class ActionExecutionReconciliationCoordinator:
             approval_decision_id = execution.get("approval_decision_id")
             delegation_id = execution.get("delegation_id")
             payload_hash = execution.get("payload_hash")
+            action_request_id = execution.get("action_request_id")
+            workflow_id = execution.get("workflow_id")
+            workflow_version_id = execution.get("workflow_version_id")
+            correlation_id = execution.get("correlation_id")
+            expected_execution_receipt_id = execution.get(
+                "expected_execution_receipt_id"
+            )
             coordination_reference_id = execution.get("coordination_reference_id")
             coordination_target_type = execution.get("coordination_target_type")
             external_receipt_id = execution.get("external_receipt_id")
@@ -542,6 +630,11 @@ class ActionExecutionReconciliationCoordinator:
                     "approval_decision_id": approval_decision_id,
                     "delegation_id": delegation_id,
                     "payload_hash": payload_hash,
+                    "action_request_id": action_request_id,
+                    "workflow_id": workflow_id,
+                    "workflow_version_id": workflow_version_id,
+                    "correlation_id": correlation_id,
+                    "expected_execution_receipt_id": expected_execution_receipt_id,
                     "coordination_reference_id": coordination_reference_id,
                     "coordination_target_type": coordination_target_type,
                     "external_receipt_id": external_receipt_id,

--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -1171,7 +1171,7 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
     def test_service_fail_closes_when_shuffle_reconciliation_correlation_drifts(
         self,
     ) -> None:
-        store, service, approved_payload, delegated_at = (
+        _, service, approved_payload, delegated_at = (
             self._build_phase54_create_tracking_ticket_context(
                 suffix="correlation-drift-001",
                 binding={

--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -1168,6 +1168,119 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
             (downstream_binding["external_receipt_id"],),
         )
 
+    def test_service_fail_closes_when_shuffle_reconciliation_correlation_drifts(
+        self,
+    ) -> None:
+        store, service, approved_payload, delegated_at = (
+            self._build_phase54_create_tracking_ticket_context(
+                suffix="correlation-drift-001",
+                binding={
+                    "workflow_id": "create_tracking_ticket",
+                    "workflow_version_id": (
+                        "create_tracking_ticket-v1-reviewed-2026-05-03"
+                    ),
+                    "correlation_id": "shuffle-correlation-reconcile-001",
+                    "expected_execution_receipt_id": (
+                        "shuffle-receipt-correlation-drift-001"
+                    ),
+                    "requested_scope": {
+                        "case_id": "case-tracking-correlation-drift-001",
+                        "alert_id": "alert-tracking-correlation-drift-001",
+                        "finding_id": "finding-tracking-correlation-drift-001",
+                        "coordination_reference_id": (
+                            "coord-ref-correlation-drift-001"
+                        ),
+                        "coordination_target_type": "zammad",
+                    },
+                },
+            )
+        )
+        compared_at = support.datetime(
+            2026, 5, 3, 4, 10, tzinfo=support.timezone.utc
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-create-ticket-correlation-drift-001",
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-create-ticket-correlation-drift-001",),
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id="action-request-create-ticket-correlation-drift-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": (
+                        "idempotency-create-ticket-correlation-drift-001"
+                    ),
+                    "action_request_id": execution.action_request_id,
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": "shuffle-correlation-drifted-001",
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=support.datetime(
+                2026,
+                5,
+                3,
+                4,
+                30,
+                tzinfo=support.timezone.utc,
+            ),
+        )
+
+        stored_execution = service.get_record(
+            support.ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertEqual(reconciliation.ingest_disposition, "mismatch")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertEqual(
+            reconciliation.mismatch_summary,
+            "execution receipt binding mismatch between authoritative action execution "
+            "and observed downstream execution",
+        )
+        self.assertEqual(stored_execution.lifecycle_state, "queued")
+        self.assertEqual(
+            reconciliation.subject_linkage["workflow_version_ids"],
+            ("create_tracking_ticket-v1-reviewed-2026-05-03",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["correlation_ids"],
+            ("shuffle-correlation-reconcile-001",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["expected_execution_receipt_ids"],
+            ("shuffle-receipt-correlation-drift-001",),
+        )
+
     def test_service_marks_duplicate_create_tracking_ticket_receipts_degraded(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation_reconciliation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_reconciliation.py
@@ -282,6 +282,13 @@ class ActionExecutionReconciliationPersistenceTests(ServicePersistenceTestBase):
             alert_id="alert-001",
             finding_id="finding-001",
         )
+        approved_payload["shuffle_delegation_binding"] = {
+            "workflow_id": "notify_identity_owner",
+            "workflow_version_id": "notify_identity_owner-v1-reviewed-2026-05-03",
+            "correlation_id": "shuffle-correlation-notify-reconcile-001",
+            "expected_execution_receipt_id": "shuffle-receipt-notify-reconcile-001",
+            "requested_scope": approved_target_scope,
+        }
         payload_hash = _approved_binding_hash(
             target_scope=approved_target_scope,
             approved_payload=approved_payload,
@@ -312,6 +319,7 @@ class ActionExecutionReconciliationPersistenceTests(ServicePersistenceTestBase):
                 requested_at=requested_at,
                 expires_at=None,
                 lifecycle_state="approved",
+                requested_payload=approved_payload,
                 policy_evaluation={
                     "approval_requirement": "human_required",
                     "routing_target": "shuffle",
@@ -328,6 +336,7 @@ class ActionExecutionReconciliationPersistenceTests(ServicePersistenceTestBase):
             delegation_issuer="control-plane-service",
             evidence_ids=("evidence-001",),
         )
+        downstream_binding = execution.provenance["downstream_binding"]
 
         reconciliation = service.reconcile_action_execution(
             action_request_id="action-request-routine-reconcile-001",
@@ -342,6 +351,13 @@ class ActionExecutionReconciliationPersistenceTests(ServicePersistenceTestBase):
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "observed_at": compared_at,
                     "status": "success",
                 },
@@ -368,6 +384,22 @@ class ActionExecutionReconciliationPersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(
             reconciliation.subject_linkage["delegation_ids"],
             (execution.delegation_id,),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["workflow_ids"],
+            ("notify_identity_owner",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["workflow_version_ids"],
+            ("notify_identity_owner-v1-reviewed-2026-05-03",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["correlation_ids"],
+            ("shuffle-correlation-notify-reconcile-001",),
+        )
+        self.assertEqual(
+            reconciliation.subject_linkage["expected_execution_receipt_ids"],
+            ("shuffle-receipt-notify-reconcile-001",),
         )
         self.assertEqual(
             reconciliation.correlation_key,


### PR DESCRIPTION
## Summary
- Normalize observed Shuffle receipt binding fields during action reconciliation.
- Fail closed when a Shuffle callback correlation, workflow version, request, or expected receipt id drifts from the authoritative AegisOps downstream binding.
- Preserve authoritative workflow version, correlation id, and expected receipt id in reconciliation subject linkage.

## Verification
- python3 -m unittest control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
- python3 -m unittest control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py control-plane/tests/test_service_persistence_action_reconciliation_reconciliation.py control-plane/tests/test_action_receipt_validation.py
- python3 -m unittest discover -s control-plane/tests -p 'test_service_persistence_action_reconciliation*.py'
- python3 -m compileall -q control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
- node dist/index.js issue-lint 1161 --config supervisor.config.aegisops.coderabbit.json

Closes #1161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation to detect receipt-binding mismatches using additional downstream identifiers (workflow IDs, workflow version IDs, correlation IDs, expected execution receipt IDs) and to record them for accurate mismatch reporting.

* **Tests**
  * Added and expanded tests covering reconciliation drift scenarios and verifying subject linkage enrichment with the new binding identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->