### PR TITLE
Phase 54.9: Add Shuffle authority-boundary negative tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Canonical cross-phase boundary reference:
 - [Phase 54.4 create_tracking_ticket template import contract](docs/deployment/shuffle-create-tracking-ticket-template-import-contract.md) defines the reviewed ticket-coordination template import contract, including request, approval, correlation, receipt, ticket pointer, ticket system identity, custody, reviewed-version, and ticket non-authority boundaries.
 - [Phase 54.5 Read/Notify template contracts](docs/deployment/shuffle-read-notify-template-contracts.md) define enrichment-only lookup, operator notification, and manual escalation request template contracts, including protected-target mutation refusal, workflow-state non-authority, and AegisOps approval-bypass refusal.
 - [Phase 54.8 manual fallback contract](docs/deployment/shuffle-manual-fallback-contract.md) defines fallback owner, operator note, affected template/action, expected evidence, and blocked/unavailable reason requirements for unavailable Shuffle, rejected execution, missing receipt, stale receipt, and mismatched receipt paths.
+- [Phase 54.9 Shuffle authority-boundary negative tests](docs/deployment/shuffle-authority-boundary-negative-tests.md) define focused fail-closed checks for direct ad-hoc Shuffle launch, Shuffle-success shortcut reconciliation, and ticket/callback/canvas/log case-truth shortcuts.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
@@ -109,6 +110,8 @@ The Phase 53.7 Wazuh upgrade rollback evidence contract is defined by the [Phase
 The Phase 53.8 Wazuh authority-boundary negative tests are defined by the [Phase 53.8 Wazuh authority-boundary negative tests](docs/deployment/wazuh-authority-boundary-negative-tests.md).
 
 The Phase 53.9 closeout evaluation is defined by the [Phase 53.9 closeout evaluation](docs/phase-53-closeout-evaluation.md).
+
+The Phase 54.9 Shuffle authority-boundary negative tests are defined by the [Phase 54.9 Shuffle authority-boundary negative tests](docs/deployment/shuffle-authority-boundary-negative-tests.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
+++ b/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
@@ -473,6 +473,9 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
     ) -> None:
         store, service, promoted_case, reviewed_at = self._build_wazuh_case()
         baseline_case = store.get(CaseRecord, promoted_case.case_id)
+        baseline_request_ids = {
+            record.action_request_id for record in store.list(ActionRequestRecord)
+        }
         baseline_execution_ids = {
             record.action_execution_id for record in store.list(ActionExecutionRecord)
         }
@@ -501,6 +504,10 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
         self.assertIsNotNone(current_case)
         self.assertEqual(current_case.lifecycle_state, baseline_case.lifecycle_state)
         self.assertEqual(
+            {record.action_request_id for record in store.list(ActionRequestRecord)},
+            baseline_request_ids,
+        )
+        self.assertEqual(
             {
                 record.action_execution_id
                 for record in store.list(ActionExecutionRecord)
@@ -519,6 +526,19 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
         baseline_case = store.get(CaseRecord, promoted_case.case_id)
         baseline_execution_count = len(store.list(ActionExecutionRecord))
         self.assertIsNotNone(baseline_case)
+        service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-shuffle-shortcut-001",
+                action_request_id="action-request-shuffle-shortcut-001",
+                approver_identities=("approver-001",),
+                target_snapshot={"asset_id": "workstation-001"},
+                payload_hash="payload-hash-shuffle-shortcut-001",
+                decided_at=reviewed_at + timedelta(minutes=6),
+                lifecycle_state="approved",
+                decision_rationale="Approved action request before Shuffle status import.",
+                approved_expires_at=None,
+            )
+        )
         service.persist_record(
             ActionRequestRecord(
                 action_request_id="action-request-shuffle-shortcut-001",

--- a/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
+++ b/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
@@ -468,6 +468,203 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
             baseline_execution_count,
         )
 
+    def test_direct_ad_hoc_shuffle_launch_without_aegisops_approval_fails_closed(
+        self,
+    ) -> None:
+        store, service, promoted_case, reviewed_at = self._build_wazuh_case()
+        baseline_case = store.get(CaseRecord, promoted_case.case_id)
+        baseline_execution_ids = {
+            record.action_execution_id for record in store.list(ActionExecutionRecord)
+        }
+        baseline_reconciliation_ids = {
+            record.reconciliation_id for record in store.list(ReconciliationRecord)
+        }
+        self.assertIsNotNone(baseline_case)
+
+        with self.assertRaisesRegex(
+            LookupError,
+            "Missing action request 'shuffle-ad-hoc-launch-001'",
+        ):
+            service.delegate_approved_action_to_shuffle(
+                action_request_id="shuffle-ad-hoc-launch-001",
+                approved_payload={
+                    "action_type": "notify_identity_owner",
+                    "recipient_identity": "repo-owner-001",
+                    "message_intent": "Direct ad-hoc Shuffle launch.",
+                    "escalation_reason": "Bypass AegisOps approval.",
+                },
+                delegated_at=reviewed_at + timedelta(minutes=10),
+                delegation_issuer="shuffle-ui",
+            )
+
+        current_case = store.get(CaseRecord, promoted_case.case_id)
+        self.assertIsNotNone(current_case)
+        self.assertEqual(current_case.lifecycle_state, baseline_case.lifecycle_state)
+        self.assertEqual(
+            {
+                record.action_execution_id
+                for record in store.list(ActionExecutionRecord)
+            },
+            baseline_execution_ids,
+        )
+        self.assertEqual(
+            {record.reconciliation_id for record in store.list(ReconciliationRecord)},
+            baseline_reconciliation_ids,
+        )
+
+    def test_shuffle_success_without_aegisops_delegation_is_mismatched_not_truth(
+        self,
+    ) -> None:
+        store, service, promoted_case, reviewed_at = self._build_wazuh_case()
+        baseline_case = store.get(CaseRecord, promoted_case.case_id)
+        baseline_execution_count = len(store.list(ActionExecutionRecord))
+        self.assertIsNotNone(baseline_case)
+        service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-shuffle-shortcut-001",
+                approval_decision_id="approval-shuffle-shortcut-001",
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                idempotency_key="idempotency-shuffle-shortcut-001",
+                target_scope={"asset_id": "workstation-001"},
+                payload_hash="payload-hash-shuffle-shortcut-001",
+                requested_at=reviewed_at + timedelta(minutes=5),
+                expires_at=None,
+                lifecycle_state="approved",
+                requested_payload={
+                    "action_type": "notify_identity_owner",
+                    "recipient_identity": "repo-owner-001",
+                    "message_intent": "Notify owner about reviewed signal.",
+                    "escalation_reason": "Reviewed evidence requires notification.",
+                },
+                policy_evaluation={
+                    "approval_requirement": "human_required",
+                    "routing_target": "shuffle",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id="action-request-shuffle-shortcut-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": "shuffle-success-shortcut-run-001",
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": "idempotency-shuffle-shortcut-001",
+                    "approval_decision_id": "approval-shuffle-shortcut-001",
+                    "delegation_id": "shuffle-ui-shortcut-001",
+                    "payload_hash": "payload-hash-shuffle-shortcut-001",
+                    "observed_at": reviewed_at + timedelta(minutes=10),
+                    "status": "success",
+                    "callback_payload": {"case_status": "resolved"},
+                    "workflow_canvas_state": "green",
+                    "execution_log_summary": "completed successfully",
+                },
+            ),
+            compared_at=reviewed_at + timedelta(minutes=10),
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+
+        current_case = store.get(CaseRecord, promoted_case.case_id)
+        self.assertIsNotNone(current_case)
+        self.assertEqual(reconciliation.ingest_disposition, "mismatch")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertEqual(
+            reconciliation.mismatch_summary,
+            "observed shuffle execution lacks an authoritative AegisOps delegation record",
+        )
+        self.assertEqual(current_case.lifecycle_state, baseline_case.lifecycle_state)
+        self.assertEqual(
+            len(store.list(ActionExecutionRecord)),
+            baseline_execution_count,
+        )
+
+    def test_ticket_callback_canvas_and_logs_do_not_close_case_after_shuffle_success(
+        self,
+    ) -> None:
+        cli_helper = cli_support.ControlPlaneCliInspectionTestBase()
+        store, service, promoted_case, _evidence_id, reviewed_at = (
+            cli_helper._build_phase19_in_scope_case()
+        )
+        seeded = cli_helper._seed_create_tracking_ticket_request(
+            service=service,
+            promoted_case=promoted_case,
+            reviewed_at=reviewed_at,
+            suffix="shuffle-authority-boundary-001",
+            coordination_reference_id="coord-ref-shuffle-authority-boundary-001",
+        )
+        baseline_case = store.get(CaseRecord, promoted_case.case_id)
+        baseline_alert = store.get(AlertRecord, promoted_case.alert_id)
+        self.assertIsNotNone(baseline_case)
+        self.assertIsNotNone(baseline_alert)
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=seeded["action_request"].action_request_id,
+            approved_payload=seeded["approved_payload"],
+            delegated_at=reviewed_at + timedelta(minutes=15),
+            delegation_issuer="control-plane-service",
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=seeded["action_request"].action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": seeded["action_request"].idempotency_key,
+                    "approval_decision_id": seeded["approval"].approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": seeded["payload_hash"],
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": reviewed_at + timedelta(minutes=20),
+                    "status": "success",
+                    "ticket_state": "closed",
+                    "callback_payload": {"case_status": "closed_resolved"},
+                    "workflow_canvas_state": "success",
+                    "execution_log_summary": "ticket closed downstream",
+                },
+            ),
+            compared_at=reviewed_at + timedelta(minutes=20),
+            stale_after=reviewed_at + timedelta(hours=1),
+        )
+
+        current_case = store.get(CaseRecord, promoted_case.case_id)
+        current_alert = store.get(AlertRecord, promoted_case.alert_id)
+        current_execution = store.get(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertIsNotNone(current_case)
+        self.assertIsNotNone(current_alert)
+        self.assertIsNotNone(current_execution)
+        self.assertEqual(reconciliation.ingest_disposition, "matched")
+        self.assertEqual(reconciliation.lifecycle_state, "matched")
+        self.assertEqual(current_execution.lifecycle_state, "succeeded")
+        self.assertEqual(current_case.lifecycle_state, baseline_case.lifecycle_state)
+        self.assertEqual(current_alert.lifecycle_state, baseline_alert.lifecycle_state)
+        self.assertIsNone(current_case.coordination_reference_id)
+        self.assertIsNone(current_alert.coordination_reference_id)
+        self.assertNotEqual(current_case.lifecycle_state, "closed")
+
     def test_endpoint_evidence_missing_provenance_is_not_promoted(self) -> None:
         phase28_helper = phase28_tests.Phase28EndpointEvidencePackValidationTests()
         store, service, promoted_case, anchor_evidence_id, reviewed_at = (

--- a/docs/deployment/shuffle-authority-boundary-negative-tests.md
+++ b/docs/deployment/shuffle-authority-boundary-negative-tests.md
@@ -1,0 +1,51 @@
+# Phase 54.9 Shuffle Authority-Boundary Negative Tests
+
+- **Status**: Accepted negative-test slice
+- **Date**: 2026-05-03
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-51-6-authority-boundary-negative-test-policy.md`, `docs/deployment/shuffle-smb-single-node-profile-contract.md`, `docs/deployment/shuffle-reviewed-workflow-template-contract.md`, `docs/deployment/shuffle-manual-fallback-contract.md`
+- **Related Issues**: #1154, #1160, #1161, #1163
+
+This slice makes the Shuffle authority-boundary negative tests directly runnable for the Phase 54 Shuffle product profile MVP.
+
+It does not implement profile generation, template import behavior, receipt normalization, broad SOAR action catalog expansion, Controlled Write or Hard Write default enablement, release-candidate behavior, general-availability behavior, commercial readiness, or broad SOAR replacement readiness.
+
+## 1. Purpose
+
+Phase 54.9 proves that Shuffle remains subordinate routine automation substrate context when direct launch, workflow success, ticket state, callback payloads, workflow canvas state, or execution logs are presented as AegisOps workflow truth.
+
+The focused enforcement tests live in `control-plane/tests/test_cross_boundary_negative_e2e_validation.py`.
+
+## 2. Authority Boundary
+
+Shuffle executes delegated routine work only after AegisOps records the action request, approval posture, delegation, execution receipt, and reconciliation records required by policy.
+
+AegisOps control-plane records remain authoritative for approval, action request, execution receipt, reconciliation, case lifecycle, audit, limitation, release, gate, and closeout truth.
+
+This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md`.
+
+Shuffle workflow status, workflow success, workflow failure, retry state, callback payloads, workflow canvas state, execution logs, generated config, tickets, assistant output, browser state, UI cache, optional evidence, verifier output, issue-lint output, and downstream receipts cannot close, approve, execute, reconcile, release, gate, or otherwise mutate authoritative AegisOps records without explicit AegisOps approval, action request, delegation, execution receipt, and reconciliation records.
+
+## 3. Required Negative Tests
+
+| Negative test | Enforcement boundary | Expected result |
+| --- | --- | --- |
+| Direct ad-hoc Shuffle launch bypassing AegisOps approval. | `delegate_approved_action_to_shuffle` | Reject the launch before dispatch and leave case, action execution, and reconciliation records unchanged. |
+| Shuffle workflow success is presented as reconciliation truth without AegisOps delegation. | `reconcile_action_execution` | Record a mismatched reconciliation and do not create or infer an action execution record. |
+| Ticket state, callback payload, workflow canvas state, or logs are presented as AegisOps case truth. | `reconcile_action_execution` and case record inspection | Keep the matched execution receipt subordinate to the AegisOps reconciliation record and leave case and alert lifecycle state unchanged. |
+
+## 4. Validation
+
+Run `bash scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh`.
+
+From the repository root, run `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_direct_ad_hoc_shuffle_launch_without_aegisops_approval_fails_closed test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_shuffle_success_without_aegisops_delegation_is_mismatched_not_truth test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_ticket_callback_canvas_and_logs_do_not_close_case_after_shuffle_success`.
+
+Run affected Shuffle delegation and reconciliation tests with `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_service_persistence_action_reconciliation_create_tracking_ticket test_service_persistence_action_reconciliation_reconciliation`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1163 --config <supervisor-config-path>`.
+
+## 5. Non-Goals
+
+- No direct ad-hoc Shuffle launch path is approved.
+- No Shuffle workflow status, success, failure, callback payload, workflow canvas state, execution log, ticket state, verifier output, or issue-lint output becomes AegisOps workflow truth.
+- No template import, receipt normalization, profile generation, broad SOAR action catalog, Controlled Write default enablement, Hard Write default enablement, Beta, RC, GA, commercial readiness, or broad SOAR replacement readiness is implemented here.

--- a/scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh
+++ b/scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/shuffle-authority-boundary-negative-tests.md"
+test_path="${repo_root}/control-plane/tests/test_cross_boundary_negative_e2e_validation.py"
+readme_path="${repo_root}/README.md"
+
+required_doc_phrases=(
+  "# Phase 54.9 Shuffle Authority-Boundary Negative Tests"
+  "- **Status**: Accepted negative-test slice"
+  "- **Related Issues**: #1154, #1160, #1161, #1163"
+  "This slice makes the Shuffle authority-boundary negative tests directly runnable for the Phase 54 Shuffle product profile MVP."
+  "Shuffle executes delegated routine work only after AegisOps records the action request, approval posture, delegation, execution receipt, and reconciliation records required by policy."
+  "This slice cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`."
+  "Direct ad-hoc Shuffle launch bypassing AegisOps approval."
+  "Shuffle workflow success is presented as reconciliation truth without AegisOps delegation."
+  "Ticket state, callback payload, workflow canvas state, or logs are presented as AegisOps case truth."
+  "Run \`bash scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1163 --config <supervisor-config-path>\`."
+)
+
+required_test_phrases=(
+  "def test_direct_ad_hoc_shuffle_launch_without_aegisops_approval_fails_closed"
+  "Missing action request 'shuffle-ad-hoc-launch-001'"
+  "def test_shuffle_success_without_aegisops_delegation_is_mismatched_not_truth"
+  "observed shuffle execution lacks an authoritative AegisOps delegation record"
+  "def test_ticket_callback_canvas_and_logs_do_not_close_case_after_shuffle_success"
+  "\"ticket_state\": \"closed\""
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 54.9 Shuffle authority-boundary negative-test doc: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${test_path}" ]]; then
+  echo "Missing Phase 54.9 Shuffle authority-boundary negative-test module: ${test_path}" >&2
+  exit 1
+fi
+
+for phrase in "${required_doc_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 54.9 Shuffle authority-boundary statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_test_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${test_path}"; then
+    echo "Missing Phase 54.9 Shuffle authority-boundary test reference: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+mac_user_home="$(printf '/%s/' 'Users')"
+unix_user_home="$(printf '/%s/' 'home')"
+windows_user_home="$(printf '[A-Za-z]:[\\\\/]%s[\\\\/]' 'Users')"
+path_boundary="(^|[[:space:]\`\"'(<{=])"
+
+if grep -Eq "(${path_boundary})(file://)?(${mac_user_home}|${unix_user_home}|${windows_user_home})" "${doc_path}"; then
+  echo "Forbidden Phase 54.9 Shuffle authority-boundary doc: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 54.9 Shuffle authority-boundary link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    !in_fenced_block { print }
+  ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/shuffle-authority-boundary-negative-tests\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 54.9 Shuffle authority-boundary negative tests." >&2
+  exit 1
+fi
+
+PYTHONPATH="${repo_root}/control-plane:${repo_root}/control-plane/tests" \
+  python3 -m unittest \
+  test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_direct_ad_hoc_shuffle_launch_without_aegisops_approval_fails_closed \
+  test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_shuffle_success_without_aegisops_delegation_is_mismatched_not_truth \
+  test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_ticket_callback_canvas_and_logs_do_not_close_case_after_shuffle_success
+
+echo "Phase 54.9 Shuffle authority-boundary negative tests reject direct launch, Shuffle success shortcut reconciliation, and ticket/callback/canvas/log case-truth shortcuts."


### PR DESCRIPTION
## Summary
- add focused Shuffle authority-boundary negative tests for direct launch, success shortcut reconciliation, and ticket/callback/canvas/log case-truth shortcuts
- add the Phase 54.9 contract doc and README links
- add a runnable Phase 54.9 verifier

## Verification
- bash scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh
- PYTHONPATH="$PWD/control-plane:$PWD/control-plane/tests" python3 -m unittest test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_direct_ad_hoc_shuffle_launch_without_aegisops_approval_fails_closed test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_shuffle_success_without_aegisops_delegation_is_mismatched_not_truth test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_ticket_callback_canvas_and_logs_do_not_close_case_after_shuffle_success
- PYTHONPATH="$PWD/control-plane:$PWD/control-plane/tests" python3 -m unittest test_service_persistence_action_reconciliation_create_tracking_ticket test_service_persistence_action_reconciliation_reconciliation
- git diff --check
- node <codex-supervisor-root>/dist/index.js issue-lint 1163 --config <supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 54.9 Shuffle authority-boundary negative tests doc with specifications, owners, non-goals, and validation guidance.

* **Tests**
  * Added three cross-boundary negative end-to-end tests covering ad-hoc launch, delegation mismatches, and case/alert lifecycle behavior after shuffle.

* **Chores**
  * Added a verification script to assert consistency between the Phase 54.9 documentation and the corresponding tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->