### PR TITLE
Phase 54.10 closeout evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Canonical cross-phase boundary reference:
 - [Phase 54.5 Read/Notify template contracts](docs/deployment/shuffle-read-notify-template-contracts.md) define enrichment-only lookup, operator notification, and manual escalation request template contracts, including protected-target mutation refusal, workflow-state non-authority, and AegisOps approval-bypass refusal.
 - [Phase 54.8 manual fallback contract](docs/deployment/shuffle-manual-fallback-contract.md) defines fallback owner, operator note, affected template/action, expected evidence, and blocked/unavailable reason requirements for unavailable Shuffle, rejected execution, missing receipt, stale receipt, and mismatched receipt paths.
 - [Phase 54.9 Shuffle authority-boundary negative tests](docs/deployment/shuffle-authority-boundary-negative-tests.md) define focused fail-closed checks for direct ad-hoc Shuffle launch, Shuffle-success shortcut reconciliation, and ticket/callback/canvas/log case-truth shortcuts.
+- [Phase 54.10 closeout evaluation](docs/phase-54-closeout-evaluation.md) records the Shuffle profile MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 55/58/62/66 handoff.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
@@ -112,6 +113,8 @@ The Phase 53.8 Wazuh authority-boundary negative tests are defined by the [Phase
 The Phase 53.9 closeout evaluation is defined by the [Phase 53.9 closeout evaluation](docs/phase-53-closeout-evaluation.md).
 
 The Phase 54.9 Shuffle authority-boundary negative tests are defined by the [Phase 54.9 Shuffle authority-boundary negative tests](docs/deployment/shuffle-authority-boundary-negative-tests.md).
+
+The Phase 54.10 closeout evaluation is defined by the [Phase 54.10 closeout evaluation](docs/phase-54-closeout-evaluation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-54-closeout-evaluation.md
+++ b/docs/phase-54-closeout-evaluation.md
@@ -1,0 +1,144 @@
+# Phase 54 Closeout Evaluation
+
+- **Status**: Accepted as Shuffle product profile MVP evidence and handoff baseline; Phase 55, Phase 58, Phase 62, and Phase 66 can consume the bounded Shuffle profile MVP with explicit retained blockers.
+- **Date**: 2026-05-03
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1154, #1155, #1156, #1157, #1158, #1159, #1160, #1161, #1162, #1163, #1164
+
+## Verdict
+
+Phase 54 is accepted as the Shuffle product profile MVP evidence baseline for the `smb-single-node` profile. The accepted MVP consists of repo-owned Shuffle profile contracts, exact Shuffle 2.2.0 and OpenSearch 3.2.0 component pins, reviewed workflow template metadata, low-risk notification and ticket-coordination import contracts, Read/Notify-only template coverage, AegisOps-to-Shuffle delegation binding, execution receipt normalization, manual fallback posture, and focused authority-boundary negative tests.
+
+Shuffle remains a subordinate routine automation substrate. Shuffle executes delegated routine work only after AegisOps records the action request, approval posture, delegation, execution receipt, and reconciliation records required by policy.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, delegation intent, release, gate, and closeout truth.
+
+Canonical implementation namespace remains `aegisops.control_plane`; `aegisops_control_plane` is retained for compatibility only.
+
+This closeout does not claim Phase 55 guided first-user journey work is complete, Phase 58 supportability work is complete, Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a replacement for every SIEM/SOAR capability.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1154 | Epic: Phase 54 Shuffle Product Profile MVP | Open until #1164 lands; accepted when this closeout, focused verifier, Phase 54 verifiers, focused Shuffle tests, path hygiene, and issue-lint pass. |
+| #1155 | Phase 54.1 Shuffle profile contract and version matrix | Closed. `docs/deployment/shuffle-smb-single-node-profile-contract.md` and `docs/deployment/profiles/smb-single-node/shuffle/profile.yaml` define frontend, backend, orborus, worker, OpenSearch, resources, ports, volumes, credentials, authority boundaries, and exact `2.2.0` Shuffle image pins plus exact `3.2.0` OpenSearch pin. |
+| #1156 | Phase 54.2 reviewed workflow template contract | Closed. `docs/deployment/shuffle-reviewed-workflow-template-contract.md` and `docs/deployment/profiles/smb-single-node/shuffle/reviewed-workflow-template-contract.yaml` define required template metadata, input, output, correlation, action request, approval decision, execution receipt, version, owner, review-status, and callback fields. |
+| #1157 | Phase 54.3 notify_identity_owner template import contract | Closed. `docs/deployment/shuffle-notify-identity-owner-template-import-contract.md` and `docs/deployment/profiles/smb-single-node/shuffle/templates/notify_identity_owner-import-contract.yaml` define the reviewed low-risk identity-owner notification import contract and protected-state mutation refusal. |
+| #1158 | Phase 54.4 create_tracking_ticket template import contract | Closed. `docs/deployment/shuffle-create-tracking-ticket-template-import-contract.md` and `docs/deployment/profiles/smb-single-node/shuffle/templates/create_tracking_ticket-import-contract.yaml` define the reviewed ticket-coordination import contract, ticket pointer custody, ticket non-authority boundary, and reviewed version pin. |
+| #1159 | Phase 54.5 Read/Notify template contracts | Closed. `docs/deployment/shuffle-read-notify-template-contracts.md` and the `enrichment_only_lookup`, `operator_notification`, and `manual_escalation_request` structured artifacts define enrichment-only lookup, operator notification, and manual escalation request paths without protected-target mutation or AegisOps approval bypass. |
+| #1160 | Phase 54.6 AegisOps-to-Shuffle delegation binding | Closed. `control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py` and `control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py` require reviewed workflow version, correlation, expected receipt, requested scope, and approved action-request linkage before dispatch. |
+| #1161 | Phase 54.7 execution receipt normalization contract | Closed. `control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py`, `control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py`, `control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py`, and `control-plane/tests/test_service_persistence_action_reconciliation_reconciliation.py` normalize Shuffle receipt binding and reject missing, placeholder, stale, mismatched, or non-authoritative receipts. |
+| #1162 | Phase 54.8 manual fallback contract | Closed. `docs/deployment/shuffle-manual-fallback-contract.md` and `docs/deployment/profiles/smb-single-node/shuffle/manual-fallback-contract.yaml` define fallback owner, operator note, affected template/action, expected evidence, and blocked/unavailable, rejected, missing, stale, and mismatched receipt reasons. |
+| #1163 | Phase 54.9 Shuffle authority-boundary negative tests | Closed. `docs/deployment/shuffle-authority-boundary-negative-tests.md` and `control-plane/tests/test_cross_boundary_negative_e2e_validation.py` prove direct ad-hoc Shuffle launch fails closed, Shuffle success without AegisOps delegation remains mismatched, and ticket/callback/canvas/log state cannot close cases. |
+| #1164 | Phase 54.10 Phase 54 closeout evaluation | Open until this closeout lands; accepted when this document and focused negative verifier pass. |
+
+## Shuffle Profile Behavior Before And After
+
+| Surface | Before Phase 54 | After Phase 54 |
+| --- | --- | --- |
+| Shuffle product profile | Deferred placeholder from Phase 52 first-user stack contracts and Phase 53 Wazuh-side handoff. | Repo-owned `smb-single-node` Shuffle profile contract with frontend, backend, orborus, worker, OpenSearch, exact `2.2.0` Shuffle pins, exact `3.2.0` OpenSearch pin, resource, port, volume, API, callback, and credential expectations. |
+| Workflow template contract | Generic delegated-execution expectations from earlier action policy work. | Reviewed workflow template metadata requires correlation, action request, approval decision, execution receipt, version, owner, reviewed status, callback URL, and trusted callback secret reference before import. |
+| Template import coverage | No Phase 54 reviewed template import catalog. | `notify_identity_owner`, `create_tracking_ticket`, `enrichment_only_lookup`, `operator_notification`, and `manual_escalation_request` are represented by repo-owned reviewed artifacts with low-risk or Read/Notify boundaries. |
+| Delegation binding | Shuffle dispatch could rely on generic approved action request routing. | AegisOps-to-Shuffle dispatch requires explicit `shuffle_delegation_binding` fields, reviewed workflow version, correlation id, expected execution receipt id, and requested-scope match before adapter dispatch. |
+| Receipt normalization | Downstream receipt handling was not pinned to the Phase 54 profile contract. | Shuffle receipts are normalized into AegisOps execution receipt context only when the observed run, delegation id, expected receipt id, approval id, payload hash, idempotency key, and coordination binding match the authoritative action execution. |
+| Manual fallback | Unavailable or rejected Shuffle paths did not have a Phase 54 manual fallback artifact. | Manual fallback requires owner, operator note, affected template/action, expected evidence, and blocked, unavailable, rejected, missing receipt, stale receipt, or mismatched receipt reason. |
+| Authority boundary | Shuffle subordinate posture inherited from Phase 51.6, Phase 52, and Phase 53 contracts. | Focused negative tests prove direct ad-hoc Shuffle launch fails closed, Shuffle-success shortcut reconciliation remains mismatched, and ticket/callback/canvas/log state cannot close cases. |
+
+## Changed Files
+
+Phase 54 materially added or tightened these repo-owned surfaces:
+
+- `docs/deployment/shuffle-smb-single-node-profile-contract.md`
+- `docs/deployment/shuffle-reviewed-workflow-template-contract.md`
+- `docs/deployment/shuffle-notify-identity-owner-template-import-contract.md`
+- `docs/deployment/shuffle-create-tracking-ticket-template-import-contract.md`
+- `docs/deployment/shuffle-read-notify-template-contracts.md`
+- `docs/deployment/shuffle-manual-fallback-contract.md`
+- `docs/deployment/shuffle-authority-boundary-negative-tests.md`
+- `docs/deployment/profiles/smb-single-node/shuffle/profile.yaml`
+- `docs/deployment/profiles/smb-single-node/shuffle/reviewed-workflow-template-contract.yaml`
+- `docs/deployment/profiles/smb-single-node/shuffle/manual-fallback-contract.yaml`
+- `docs/deployment/profiles/smb-single-node/shuffle/templates/notify_identity_owner-import-contract.yaml`
+- `docs/deployment/profiles/smb-single-node/shuffle/templates/create_tracking_ticket-import-contract.yaml`
+- `docs/deployment/profiles/smb-single-node/shuffle/templates/enrichment_only_lookup-import-contract.yaml`
+- `docs/deployment/profiles/smb-single-node/shuffle/templates/operator_notification-import-contract.yaml`
+- `docs/deployment/profiles/smb-single-node/shuffle/templates/manual_escalation_request-import-contract.yaml`
+- `control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py`
+- `control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py`
+- `control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py`
+- `control-plane/tests/test_service_persistence_action_reconciliation_reconciliation.py`
+- `control-plane/tests/test_cross_boundary_negative_e2e_validation.py`
+- `docs/phase-54-closeout-evaluation.md`
+- `scripts/verify-phase-54-10-closeout-evaluation.sh`
+- `scripts/test-verify-phase-54-10-closeout-evaluation.sh`
+
+## Verifier Evidence
+
+Focused Phase 54 verifiers passed or must pass before this closeout is accepted:
+
+- `bash scripts/verify-phase-54-1-shuffle-profile-contract.sh`
+- `bash scripts/test-verify-phase-54-1-shuffle-profile-contract.sh`
+- `bash scripts/verify-phase-54-2-reviewed-workflow-template-contract.sh`
+- `bash scripts/test-verify-phase-54-2-reviewed-workflow-template-contract.sh`
+- `bash scripts/verify-phase-54-3-notify-identity-owner-template-import-contract.sh`
+- `bash scripts/test-verify-phase-54-3-notify-identity-owner-template-import-contract.sh`
+- `bash scripts/verify-phase-54-4-create-tracking-ticket-template-import-contract.sh`
+- `bash scripts/test-verify-phase-54-4-create-tracking-ticket-template-import-contract.sh`
+- `bash scripts/verify-phase-54-5-read-notify-template-contracts.sh`
+- `bash scripts/test-verify-phase-54-5-read-notify-template-contracts.sh`
+- `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_service_persistence_action_reconciliation_create_tracking_ticket`
+- `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_service_persistence_action_reconciliation_reconciliation`
+- `bash scripts/verify-phase-54-8-manual-fallback-contract.sh`
+- `bash scripts/test-verify-phase-54-8-manual-fallback-contract.sh`
+- `bash scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `bash scripts/verify-phase-54-10-closeout-evaluation.sh`
+- `bash scripts/test-verify-phase-54-10-closeout-evaluation.sh`
+
+Focused negative-test evidence:
+
+- `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_direct_ad_hoc_shuffle_launch_without_aegisops_approval_fails_closed test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_shuffle_success_without_aegisops_delegation_is_mismatched_not_truth test_cross_boundary_negative_e2e_validation.CrossBoundaryNegativeE2EValidationTests.test_ticket_callback_canvas_and_logs_do_not_close_case_after_shuffle_success`
+
+Broad control-plane test evidence:
+
+- `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+
+Issue-lint evidence for #1154 through #1164:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1154 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1155 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1156 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1157 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1158 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1159 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1160 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1161 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1162 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1163 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1164 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+
+## Accepted Limitations
+
+- Phase 54 does not implement Phase 55 guided first-user UI journey work.
+- Phase 54 does not implement Phase 58 supportability, production runbook completeness, support workflows, or customer support operations.
+- Phase 54 does not complete Phase 62 SOAR breadth, broad workflow catalog coverage, marketplace work, or every action-family expectation.
+- Phase 54 does not complete Phase 66 RC proof, RC readiness, GA readiness, Beta readiness, or self-service commercial readiness.
+- Phase 54 does not enable Controlled Write or Hard Write by default.
+- Phase 54 does not approve direct ad-hoc Shuffle launch, direct Wazuh-to-Shuffle shortcut execution, Shuffle workflow status case closure, Shuffle success as reconciliation truth, ticket status as case truth, or Shuffle logs as audit truth.
+- Phase 54 does not make Shuffle frontend state, backend state, orborus state, worker state, OpenSearch state, workflow success, workflow failure, retry state, callback payload, workflow canvas state, execution log, generated config, template metadata, ticket state, verifier output, issue-lint output, assistant output, browser state, UI cache, optional evidence, downstream receipt, or operator-facing summary authoritative AegisOps truth.
+- Phase 54 does not implement live customer-specific Shuffle credentials, production workflow catalog custody, live backup/restore for Shuffle volumes, runtime profile generation, template marketplace import, broad SOAR replacement readiness, or commercial replacement readiness.
+
+## Phase 55, Phase 58, Phase 62, And Phase 66 Handoff
+
+Phase 55 can consume the Shuffle profile MVP as one setup, template, delegation, receipt, and fallback evidence surface for the guided first-user journey. Phase 55 must still implement the guided journey, user-facing validation flow, runtime custody choices, setup error handling, and first-user ergonomics. Phase 55 must not treat Shuffle profile status, template status, or manual fallback text as AegisOps workflow truth.
+
+Phase 58 can consume the Shuffle profile MVP as the reviewed automation-substrate support boundary for supportability work. Phase 58 must still implement support playbooks, customer-safe diagnostics, escalation paths, backup/restore rehearsals, and operator support evidence. Phase 54 does not complete Phase 58 supportability.
+
+Phase 62 can consume the Shuffle profile MVP as the first reviewed routine-automation substrate profile and evidence pattern. Phase 62 must still implement SOAR breadth, action-family prioritization, workflow catalog custody expansion, write-capable action gating, and any additional automation profile contracts explicitly. Phase 54 does not complete Phase 62 SOAR breadth.
+
+Phase 66 can consume the Shuffle profile MVP as one prerequisite evidence packet for RC proof. Phase 66 must still prove RC gate criteria, production-readiness evidence, upgrade/rollback posture, supportability, security review, and end-to-end first-user journey behavior. Phase 54 does not complete Phase 66 RC proof.
+
+## Closeout Boundary
+
+This closeout is evidence recording only. It does not choose a new runtime configuration, custody mechanism, Shuffle deployment mode, workflow catalog expansion, SOAR breadth target, guided first-user journey, support posture, Beta gate, RC gate, GA gate, or commercial readiness claim.

--- a/scripts/test-verify-phase-54-10-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-54-10-closeout-evaluation.sh
@@ -124,6 +124,13 @@ assert_fails_with \
   "${phase62_overclaim_repo}" \
   "Forbidden Phase 54 closeout evaluation claim: Phase 62 SOAR breadth is complete"
 
+phase62_contradictory_overclaim_repo="${workdir}/phase62-contradictory-overclaim"
+copy_valid_repo "${phase62_contradictory_overclaim_repo}"
+printf '%s\n' "This closeout does not claim Phase 62 SOAR breadth is complete, but Phase 62 SOAR breadth is complete." >>"${phase62_contradictory_overclaim_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${phase62_contradictory_overclaim_repo}" \
+  "Forbidden Phase 54 closeout evaluation claim: Phase 62 SOAR breadth is complete"
+
 rc_overclaim_repo="${workdir}/rc-overclaim"
 copy_valid_repo "${rc_overclaim_repo}"
 printf '%s\n' "Phase 54 proves RC readiness" >>"${rc_overclaim_repo}/docs/phase-54-closeout-evaluation.md"

--- a/scripts/test-verify-phase-54-10-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-54-10-closeout-evaluation.sh
@@ -131,6 +131,13 @@ assert_fails_with \
   "${phase62_contradictory_overclaim_repo}" \
   "Forbidden Phase 54 closeout evaluation claim: Phase 62 SOAR breadth is complete"
 
+phase62_allowlisted_sentence_append_repo="${workdir}/phase62-allowlisted-sentence-append"
+copy_valid_repo "${phase62_allowlisted_sentence_append_repo}"
+printf '%s\n' "This closeout does not claim Phase 55 guided first-user journey work is complete, Phase 58 supportability work is complete, Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a replacement for every SIEM/SOAR capability. Phase 62 SOAR breadth is complete." >>"${phase62_allowlisted_sentence_append_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${phase62_allowlisted_sentence_append_repo}" \
+  "Forbidden Phase 54 closeout evaluation claim: Phase 55 guided first-user journey work is complete"
+
 rc_overclaim_repo="${workdir}/rc-overclaim"
 copy_valid_repo "${rc_overclaim_repo}"
 printf '%s\n' "Phase 54 proves RC readiness" >>"${rc_overclaim_repo}/docs/phase-54-closeout-evaluation.md"

--- a/scripts/test-verify-phase-54-10-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-54-10-closeout-evaluation.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-54-10-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-54-closeout-evaluation.md" "${target}/docs/phase-54-closeout-evaluation.md"
+  cp "${repo_root}/README.md" "${target}/README.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+cp "${repo_root}/README.md" "${missing_doc_repo}/README.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 54 closeout evaluation: docs/phase-54-closeout-evaluation.md"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+copy_valid_repo "${missing_readme_link_repo}"
+perl -0pi -e 's/\[Phase 54\.10 closeout evaluation\]\(docs\/phase-54-closeout-evaluation\.md\)/Phase 54.10 closeout evaluation/g' \
+  "${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "Missing README Phase 54.10 closeout link: [Phase 54.10 closeout evaluation](docs/phase-54-closeout-evaluation.md)"
+
+missing_subordinate_posture_repo="${workdir}/missing-subordinate-posture"
+copy_valid_repo "${missing_subordinate_posture_repo}"
+perl -0pi -e 's/Shuffle remains a subordinate routine automation substrate\.//' \
+  "${missing_subordinate_posture_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_subordinate_posture_repo}" \
+  "Missing required Phase 54 closeout term in docs/phase-54-closeout-evaluation.md: Shuffle remains a subordinate routine automation substrate."
+
+missing_workflow_template_repo="${workdir}/missing-workflow-template"
+copy_valid_repo "${missing_workflow_template_repo}"
+perl -0pi -e 's/\| Workflow template contract \| Generic delegated-execution expectations from earlier action policy work\. \| Reviewed workflow template metadata requires correlation, action request, approval decision, execution receipt, version, owner, reviewed status, callback URL, and trusted callback secret reference before import\. \|\n//' \
+  "${missing_workflow_template_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_workflow_template_repo}" \
+  'Missing required Phase 54 closeout term in docs/phase-54-closeout-evaluation.md: | Workflow template contract | Generic delegated-execution expectations from earlier action policy work. | Reviewed workflow template metadata requires correlation, action request, approval decision, execution receipt, version, owner, reviewed status, callback URL, and trusted callback secret reference before import. |'
+
+missing_delegation_binding_repo="${workdir}/missing-delegation-binding"
+copy_valid_repo "${missing_delegation_binding_repo}"
+perl -0pi -e 's/\| Delegation binding \| Shuffle dispatch could rely on generic approved action request routing\. \| AegisOps-to-Shuffle dispatch requires explicit `shuffle_delegation_binding` fields, reviewed workflow version, correlation id, expected execution receipt id, and requested-scope match before adapter dispatch\. \|\n//' \
+  "${missing_delegation_binding_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_delegation_binding_repo}" \
+  'Missing required Phase 54 closeout term in docs/phase-54-closeout-evaluation.md: | Delegation binding | Shuffle dispatch could rely on generic approved action request routing. | AegisOps-to-Shuffle dispatch requires explicit `shuffle_delegation_binding` fields, reviewed workflow version, correlation id, expected execution receipt id, and requested-scope match before adapter dispatch. |'
+
+missing_receipt_repo="${workdir}/missing-receipt"
+copy_valid_repo "${missing_receipt_repo}"
+perl -0pi -e 's/\| Receipt normalization \| Downstream receipt handling was not pinned to the Phase 54 profile contract\. \| Shuffle receipts are normalized into AegisOps execution receipt context only when the observed run, delegation id, expected receipt id, approval id, payload hash, idempotency key, and coordination binding match the authoritative action execution\. \|\n//' \
+  "${missing_receipt_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_receipt_repo}" \
+  'Missing required Phase 54 closeout term in docs/phase-54-closeout-evaluation.md: | Receipt normalization | Downstream receipt handling was not pinned to the Phase 54 profile contract. | Shuffle receipts are normalized into AegisOps execution receipt context only when the observed run, delegation id, expected receipt id, approval id, payload hash, idempotency key, and coordination binding match the authoritative action execution. |'
+
+missing_manual_fallback_repo="${workdir}/missing-manual-fallback"
+copy_valid_repo "${missing_manual_fallback_repo}"
+perl -0pi -e 's/\| Manual fallback \| Unavailable or rejected Shuffle paths did not have a Phase 54 manual fallback artifact\. \| Manual fallback requires owner, operator note, affected template\/action, expected evidence, and blocked, unavailable, rejected, missing receipt, stale receipt, or mismatched receipt reason\. \|\n//' \
+  "${missing_manual_fallback_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_manual_fallback_repo}" \
+  'Missing required Phase 54 closeout term in docs/phase-54-closeout-evaluation.md: | Manual fallback | Unavailable or rejected Shuffle paths did not have a Phase 54 manual fallback artifact. | Manual fallback requires owner, operator note, affected template/action, expected evidence, and blocked, unavailable, rejected, missing receipt, stale receipt, or mismatched receipt reason. |'
+
+missing_issue_lint_repo="${workdir}/missing-issue-lint"
+copy_valid_repo "${missing_issue_lint_repo}"
+perl -0pi -e 's/^- `node <codex-supervisor-root>\/dist\/index\.js issue-lint 1161 --config <supervisor-config-path>`: .*?\n//m' \
+  "${missing_issue_lint_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_issue_lint_repo}" \
+  "Missing required Phase 54 closeout term in docs/phase-54-closeout-evaluation.md: node <codex-supervisor-root>/dist/index.js issue-lint 1161 --config <supervisor-config-path>"
+
+phase62_overclaim_repo="${workdir}/phase62-overclaim"
+copy_valid_repo "${phase62_overclaim_repo}"
+printf '%s\n' "Phase 62 SOAR breadth is complete" >>"${phase62_overclaim_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${phase62_overclaim_repo}" \
+  "Forbidden Phase 54 closeout evaluation claim: Phase 62 SOAR breadth is complete"
+
+rc_overclaim_repo="${workdir}/rc-overclaim"
+copy_valid_repo "${rc_overclaim_repo}"
+printf '%s\n' "Phase 54 proves RC readiness" >>"${rc_overclaim_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${rc_overclaim_repo}" \
+  "Forbidden Phase 54 closeout evaluation claim: Phase 54 proves RC readiness"
+
+shuffle_truth_repo="${workdir}/shuffle-truth"
+copy_valid_repo "${shuffle_truth_repo}"
+printf '%s\n' "Shuffle success is AegisOps reconciliation truth" >>"${shuffle_truth_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${shuffle_truth_repo}" \
+  "Forbidden Phase 54 closeout evaluation claim: Shuffle success is AegisOps reconciliation truth"
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+mac_home_prefix="/""Users/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${mac_home_prefix}" >>"${absolute_path_repo}/docs/phase-54-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 54 closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 54 closeout evaluation verifier tests passed."

--- a/scripts/verify-phase-54-10-closeout-evaluation.sh
+++ b/scripts/verify-phase-54-10-closeout-evaluation.sh
@@ -177,7 +177,7 @@ for forbidden in \
   "Shuffle logs are AegisOps audit truth" \
   "Shuffle workflow success is AegisOps workflow truth" \
   "Shuffle callback payload is AegisOps execution receipt truth"; do
-  if grep -Fv -- "${allowed_non_claim_line}" "${absolute_doc_path}" | grep -Fq -- "${forbidden}"; then
+  if grep -Fxv -- "${allowed_non_claim_line}" "${absolute_doc_path}" | grep -Fq -- "${forbidden}"; then
     echo "Forbidden Phase 54 closeout evaluation claim: ${forbidden}" >&2
     exit 1
   fi

--- a/scripts/verify-phase-54-10-closeout-evaluation.sh
+++ b/scripts/verify-phase-54-10-closeout-evaluation.sh
@@ -154,6 +154,8 @@ if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}" "${readme_path}
   exit 1
 fi
 
+allowed_non_claim_line="This closeout does not claim Phase 55 guided first-user journey work is complete, Phase 58 supportability work is complete, Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a replacement for every SIEM/SOAR capability."
+
 for forbidden in \
   "Phase 55 guided first-user journey work is complete" \
   "Phase 58 supportability work is complete" \
@@ -175,7 +177,7 @@ for forbidden in \
   "Shuffle logs are AegisOps audit truth" \
   "Shuffle workflow success is AegisOps workflow truth" \
   "Shuffle callback payload is AegisOps execution receipt truth"; do
-  if grep -F -- "${forbidden}" "${absolute_doc_path}" | grep -Fvq -- "does not claim"; then
+  if grep -Fv -- "${allowed_non_claim_line}" "${absolute_doc_path}" | grep -Fq -- "${forbidden}"; then
     echo "Forbidden Phase 54 closeout evaluation claim: ${forbidden}" >&2
     exit 1
   fi

--- a/scripts/verify-phase-54-10-closeout-evaluation.sh
+++ b/scripts/verify-phase-54-10-closeout-evaluation.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-54-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${file}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 54 closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -s "${readme_path}" ]]; then
+  echo "Missing README for Phase 54 closeout link check: README.md" >&2
+  exit 1
+fi
+
+require_phrase "${readme_path}" "[Phase 54.10 closeout evaluation](docs/phase-54-closeout-evaluation.md)" "README Phase 54.10 closeout link"
+
+required_phrases=()
+while IFS= read -r phrase; do
+  required_phrases+=("${phrase}")
+done <<'EOF'
+# Phase 54 Closeout Evaluation
+**Status**: Accepted as Shuffle product profile MVP evidence and handoff baseline; Phase 55, Phase 58, Phase 62, and Phase 66 can consume the bounded Shuffle profile MVP with explicit retained blockers.
+**Related Issues**: #1154, #1155, #1156, #1157, #1158, #1159, #1160, #1161, #1162, #1163, #1164
+Phase 54 is accepted as the Shuffle product profile MVP evidence baseline for the `smb-single-node` profile.
+Shuffle remains a subordinate routine automation substrate.
+Shuffle executes delegated routine work only after AegisOps records the action request, approval posture, delegation, execution receipt, and reconciliation records required by policy.
+AegisOps control-plane records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, limitation, delegation intent, release, gate, and closeout truth.
+Canonical implementation namespace remains `aegisops.control_plane`; `aegisops_control_plane` is retained for compatibility only.
+This closeout does not claim Phase 55 guided first-user journey work is complete, Phase 58 supportability work is complete, Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a replacement for every SIEM/SOAR capability.
+| #1154 | Epic: Phase 54 Shuffle Product Profile MVP | Open until #1164 lands; accepted when this closeout, focused verifier, Phase 54 verifiers, focused Shuffle tests, path hygiene, and issue-lint pass. |
+| #1155 | Phase 54.1 Shuffle profile contract and version matrix | Closed.
+| #1156 | Phase 54.2 reviewed workflow template contract | Closed.
+| #1157 | Phase 54.3 notify_identity_owner template import contract | Closed.
+| #1158 | Phase 54.4 create_tracking_ticket template import contract | Closed.
+| #1159 | Phase 54.5 Read/Notify template contracts | Closed.
+| #1160 | Phase 54.6 AegisOps-to-Shuffle delegation binding | Closed.
+| #1161 | Phase 54.7 execution receipt normalization contract | Closed.
+| #1162 | Phase 54.8 manual fallback contract | Closed.
+| #1163 | Phase 54.9 Shuffle authority-boundary negative tests | Closed.
+| #1164 | Phase 54.10 Phase 54 closeout evaluation | Open until this closeout lands; accepted when this document and focused negative verifier pass. |
+| Shuffle product profile | Deferred placeholder from Phase 52 first-user stack contracts and Phase 53 Wazuh-side handoff. | Repo-owned `smb-single-node` Shuffle profile contract with frontend, backend, orborus, worker, OpenSearch, exact `2.2.0` Shuffle pins, exact `3.2.0` OpenSearch pin, resource, port, volume, API, callback, and credential expectations. |
+| Workflow template contract | Generic delegated-execution expectations from earlier action policy work. | Reviewed workflow template metadata requires correlation, action request, approval decision, execution receipt, version, owner, reviewed status, callback URL, and trusted callback secret reference before import. |
+| Template import coverage | No Phase 54 reviewed template import catalog. | `notify_identity_owner`, `create_tracking_ticket`, `enrichment_only_lookup`, `operator_notification`, and `manual_escalation_request` are represented by repo-owned reviewed artifacts with low-risk or Read/Notify boundaries. |
+| Delegation binding | Shuffle dispatch could rely on generic approved action request routing. | AegisOps-to-Shuffle dispatch requires explicit `shuffle_delegation_binding` fields, reviewed workflow version, correlation id, expected execution receipt id, and requested-scope match before adapter dispatch. |
+| Receipt normalization | Downstream receipt handling was not pinned to the Phase 54 profile contract. | Shuffle receipts are normalized into AegisOps execution receipt context only when the observed run, delegation id, expected receipt id, approval id, payload hash, idempotency key, and coordination binding match the authoritative action execution. |
+| Manual fallback | Unavailable or rejected Shuffle paths did not have a Phase 54 manual fallback artifact. | Manual fallback requires owner, operator note, affected template/action, expected evidence, and blocked, unavailable, rejected, missing receipt, stale receipt, or mismatched receipt reason. |
+| Authority boundary | Shuffle subordinate posture inherited from Phase 51.6, Phase 52, and Phase 53 contracts. | Focused negative tests prove direct ad-hoc Shuffle launch fails closed, Shuffle-success shortcut reconciliation remains mismatched, and ticket/callback/canvas/log state cannot close cases. |
+`docs/deployment/shuffle-smb-single-node-profile-contract.md`
+`docs/deployment/shuffle-reviewed-workflow-template-contract.md`
+`docs/deployment/shuffle-notify-identity-owner-template-import-contract.md`
+`docs/deployment/shuffle-create-tracking-ticket-template-import-contract.md`
+`docs/deployment/shuffle-read-notify-template-contracts.md`
+`docs/deployment/shuffle-manual-fallback-contract.md`
+`docs/deployment/shuffle-authority-boundary-negative-tests.md`
+`docs/deployment/profiles/smb-single-node/shuffle/profile.yaml`
+`docs/deployment/profiles/smb-single-node/shuffle/reviewed-workflow-template-contract.yaml`
+`docs/deployment/profiles/smb-single-node/shuffle/manual-fallback-contract.yaml`
+`docs/deployment/profiles/smb-single-node/shuffle/templates/notify_identity_owner-import-contract.yaml`
+`docs/deployment/profiles/smb-single-node/shuffle/templates/create_tracking_ticket-import-contract.yaml`
+`docs/deployment/profiles/smb-single-node/shuffle/templates/enrichment_only_lookup-import-contract.yaml`
+`docs/deployment/profiles/smb-single-node/shuffle/templates/operator_notification-import-contract.yaml`
+`docs/deployment/profiles/smb-single-node/shuffle/templates/manual_escalation_request-import-contract.yaml`
+`control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py`
+`control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py`
+`control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py`
+`control-plane/tests/test_service_persistence_action_reconciliation_reconciliation.py`
+`control-plane/tests/test_cross_boundary_negative_e2e_validation.py`
+`docs/phase-54-closeout-evaluation.md`
+`scripts/verify-phase-54-10-closeout-evaluation.sh`
+`scripts/test-verify-phase-54-10-closeout-evaluation.sh`
+`bash scripts/verify-phase-54-1-shuffle-profile-contract.sh`
+`bash scripts/test-verify-phase-54-1-shuffle-profile-contract.sh`
+`bash scripts/verify-phase-54-2-reviewed-workflow-template-contract.sh`
+`bash scripts/test-verify-phase-54-2-reviewed-workflow-template-contract.sh`
+`bash scripts/verify-phase-54-3-notify-identity-owner-template-import-contract.sh`
+`bash scripts/test-verify-phase-54-3-notify-identity-owner-template-import-contract.sh`
+`bash scripts/verify-phase-54-4-create-tracking-ticket-template-import-contract.sh`
+`bash scripts/test-verify-phase-54-4-create-tracking-ticket-template-import-contract.sh`
+`bash scripts/verify-phase-54-5-read-notify-template-contracts.sh`
+`bash scripts/test-verify-phase-54-5-read-notify-template-contracts.sh`
+`PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_service_persistence_action_reconciliation_create_tracking_ticket`
+`PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest test_service_persistence_action_reconciliation_reconciliation`
+`bash scripts/verify-phase-54-8-manual-fallback-contract.sh`
+`bash scripts/test-verify-phase-54-8-manual-fallback-contract.sh`
+`bash scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh`
+`bash scripts/verify-publishable-path-hygiene.sh`
+`bash scripts/verify-phase-54-10-closeout-evaluation.sh`
+`bash scripts/test-verify-phase-54-10-closeout-evaluation.sh`
+`PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
+node <codex-supervisor-root>/dist/index.js issue-lint 1154 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1155 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1156 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1157 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1158 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1159 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1160 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1161 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1162 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1163 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1164 --config <supervisor-config-path>
+execution_ready=yes
+missing_required=none
+missing_recommended=none
+metadata_errors=none
+high_risk_blocking_ambiguity=none
+Phase 54 does not implement Phase 55 guided first-user UI journey work.
+Phase 54 does not implement Phase 58 supportability, production runbook completeness, support workflows, or customer support operations.
+Phase 54 does not complete Phase 62 SOAR breadth, broad workflow catalog coverage, marketplace work, or every action-family expectation.
+Phase 54 does not complete Phase 66 RC proof, RC readiness, GA readiness, Beta readiness, or self-service commercial readiness.
+Phase 54 does not enable Controlled Write or Hard Write by default.
+Phase 54 does not approve direct ad-hoc Shuffle launch, direct Wazuh-to-Shuffle shortcut execution, Shuffle workflow status case closure, Shuffle success as reconciliation truth, ticket status as case truth, or Shuffle logs as audit truth.
+Phase 55 can consume the Shuffle profile MVP as one setup, template, delegation, receipt, and fallback evidence surface for the guided first-user journey.
+Phase 55 must still implement the guided journey, user-facing validation flow, runtime custody choices, setup error handling, and first-user ergonomics.
+Phase 58 can consume the Shuffle profile MVP as the reviewed automation-substrate support boundary for supportability work.
+Phase 58 must still implement support playbooks, customer-safe diagnostics, escalation paths, backup/restore rehearsals, and operator support evidence.
+Phase 62 can consume the Shuffle profile MVP as the first reviewed routine-automation substrate profile and evidence pattern.
+Phase 62 must still implement SOAR breadth, action-family prioritization, workflow catalog custody expansion, write-capable action gating, and any additional automation profile contracts explicitly.
+Phase 54 does not complete Phase 62 SOAR breadth.
+Phase 66 can consume the Shuffle profile MVP as one prerequisite evidence packet for RC proof.
+Phase 66 must still prove RC gate criteria, production-readiness evidence, upgrade/rollback posture, supportability, security review, and end-to-end first-user journey behavior.
+Phase 54 does not complete Phase 66 RC proof.
+This closeout is evidence recording only.
+EOF
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 54 closeout term in ${doc_path}"
+done
+
+mac_home_prefix="$(printf '/%s/' 'Users')"
+unix_home_prefix="$(printf '/%s/' 'home')"
+windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
+absolute_path_pattern="(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}" "${readme_path}"; then
+  echo "Forbidden Phase 54 closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+for forbidden in \
+  "Phase 55 guided first-user journey work is complete" \
+  "Phase 58 supportability work is complete" \
+  "Phase 62 SOAR breadth is complete" \
+  "Phase 66 RC proof is complete" \
+  "Phase 54 proves Beta readiness" \
+  "Phase 54 proves RC readiness" \
+  "Phase 54 proves GA readiness" \
+  "Phase 54 proves self-service commercial readiness" \
+  "Phase 54 proves commercial replacement readiness" \
+  "AegisOps replaces every SIEM/SOAR capability" \
+  "Controlled Write is enabled by default" \
+  "Hard Write is enabled by default" \
+  "Direct ad-hoc Shuffle launch is approved" \
+  "Direct Wazuh-to-Shuffle shortcuts are approved" \
+  "Shuffle workflow status closes AegisOps cases" \
+  "Shuffle success is AegisOps reconciliation truth" \
+  "Ticket status is AegisOps case truth" \
+  "Shuffle logs are AegisOps audit truth" \
+  "Shuffle workflow success is AegisOps workflow truth" \
+  "Shuffle callback payload is AegisOps execution receipt truth"; do
+  if grep -F -- "${forbidden}" "${absolute_doc_path}" | grep -Fvq -- "does not claim"; then
+    echo "Forbidden Phase 54 closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 54 closeout evaluation records Shuffle profile MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 55/58/62/66 handoff."


### PR DESCRIPTION
## Summary
- add Phase 54 closeout evaluation for the Shuffle profile MVP
- add focused Phase 54.10 closeout verifier and negative verifier tests
- link the closeout from README

## Verification
- bash scripts/verify-phase-54-10-closeout-evaluation.sh
- bash scripts/test-verify-phase-54-10-closeout-evaluation.sh
- all Phase 54 verifiers and verifier tests
- bash scripts/verify-publishable-path-hygiene.sh
- focused Shuffle authority/delegation/reconciliation unittest commands
- PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest discover -s control-plane/tests -p 'test_*.py'
- node <codex-supervisor-root>/dist/index.js issue-lint 1154..1164 --config <supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 54.10 closeout evaluation reference in README
  * Added a Phase 54 closeout evaluation document describing acceptance verdict, evidence baseline, limitations, and handoff guidance

* **Tests**
  * Added a verification tool to validate closeout documentation integrity and required phrases
  * Added a test harness exercising verification success and failure scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->