### PR TITLE
Phase 55.2 first-login checklist UI contract

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx
@@ -1,0 +1,170 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createDefaultDependencies } from "./OperatorRoutes";
+import {
+  createAuthorizedFetch,
+  renderOperatorRoute,
+} from "./OperatorRoutes.testSupport";
+
+export function registerOperatorRoutesFirstLoginChecklistTests() {
+  describe("first-login checklist route", () => {
+    it("renders the Phase 55 checklist sequence from backend-owned records", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-first-login-checklist": {
+            records: [
+              {
+                step_key: "stack_health",
+                state: "completed",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "runtime_readiness",
+                authority_record_id: "ready",
+              },
+              {
+                step_key: "seeded_queue",
+                state: "completed",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "queue",
+                authority_record_id: "demo-queue-1",
+              },
+              {
+                step_key: "sample_wazuh_alert",
+                state: "completed",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "alert",
+                authority_record_id: "alert-wazuh-1",
+              },
+              {
+                step_key: "promote_to_case",
+                state: "completed",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "case",
+                authority_record_id: "case-1",
+              },
+              {
+                step_key: "evidence",
+                state: "degraded",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "evidence",
+                authority_record_id: "evidence-1",
+              },
+              {
+                step_key: "ai_summary",
+                state: "skipped",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "assistant_advisory",
+                authority_record_id: "advisory-1",
+              },
+              {
+                step_key: "action_request",
+                state: "completed",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "action_request",
+                authority_record_id: "action-request-1",
+              },
+              {
+                step_key: "approval_decision",
+                state: "blocked",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "action_review",
+                authority_record_id: "review-1",
+              },
+              {
+                step_key: "shuffle_receipt",
+                state: "unavailable",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "execution_receipt",
+                authority_record_id: "receipt-1",
+              },
+              {
+                step_key: "reconciliation",
+                state: "completed",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "reconciliation",
+                authority_record_id: "recon-1",
+              },
+              {
+                step_key: "report_export",
+                state: "skipped",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "report_export",
+                authority_record_id: "report-1",
+              },
+            ],
+            total_records: 11,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/first-login-checklist", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "First-Login Checklist" }),
+        ).toBeInTheDocument();
+      });
+
+      const checklist = screen.getByRole("list", {
+        name: "Phase 55 first-login checklist",
+      });
+      const rows = within(checklist).getAllByRole("listitem");
+      expect(rows).toHaveLength(11);
+      expect(rows.map((row) => within(row).getByTestId("step-title").textContent)).toEqual([
+        "Stack health",
+        "Seeded queue",
+        "Sample Wazuh-origin alert",
+        "Promote to case",
+        "Evidence",
+        "AI summary",
+        "Action request",
+        "Approval or rejection",
+        "Shuffle execution receipt",
+        "Reconciliation",
+        "Report export",
+      ]);
+      expect(
+        within(rows[4]).getByText("State: degraded"),
+      ).toBeInTheDocument();
+      expect(within(rows[5]).getByText("State: skipped")).toBeInTheDocument();
+      expect(within(rows[7]).getByText("State: blocked")).toBeInTheDocument();
+      expect(
+        within(rows[8]).getByText("State: unavailable"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Checklist progress is derived from backend records only; browser state, UI cache, Wazuh state, Shuffle state, AI output, tickets, verifier output, and issue-lint output remain subordinate context.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("fails closed when checklist completion comes from browser cache", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-first-login-checklist": {
+            records: [
+              {
+                step_key: "stack_health",
+                state: "completed",
+                authority_source: "browser_cache",
+                authority_record_family: "runtime_readiness",
+                authority_record_id: "ready",
+              },
+            ],
+            total_records: 1,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/first-login-checklist", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Checklist state from browser_cache is not trusted workflow truth.",
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText("State: completed")).not.toBeInTheDocument();
+    });
+  });
+}

--- a/apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx
@@ -166,5 +166,35 @@ export function registerOperatorRoutesFirstLoginChecklistTests() {
       });
       expect(screen.queryByText("State: completed")).not.toBeInTheDocument();
     });
+
+    it("fails closed when a checklist step is bound to the wrong backend record family", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-first-login-checklist": {
+            records: [
+              {
+                step_key: "stack_health",
+                state: "completed",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "case",
+                authority_record_id: "case-1",
+              },
+            ],
+            total_records: 1,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/first-login-checklist", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Checklist step stack_health is bound to case, expected runtime_readiness.",
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText("State: completed")).not.toBeInTheDocument();
+    });
   });
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -5,6 +5,7 @@ import { registerOperatorRoutesAssistantTests } from "./OperatorRoutes.assistant
 import { registerOperatorRoutesAuthAndShellTests } from "./OperatorRoutes.authAndShell.testSuite";
 import { registerOperatorRoutesCaseworkTests } from "./OperatorRoutes.casework.testSuite";
 import { registerOperatorRoutesControlPlaneTests } from "./OperatorRoutes.controlPlane.testSuite";
+import { registerOperatorRoutesFirstLoginChecklistTests } from "./OperatorRoutes.firstLoginChecklist.testSuite";
 
 describe("OperatorRoutes", () => {
   beforeEach(() => {
@@ -16,4 +17,5 @@ describe("OperatorRoutes", () => {
   registerOperatorRoutesCaseworkTests();
   registerOperatorRoutesAssistantTests();
   registerOperatorRoutesControlPlaneTests();
+  registerOperatorRoutesFirstLoginChecklistTests();
 });

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -12,6 +12,7 @@ import GavelOutlinedIcon from "@mui/icons-material/GavelOutlined";
 import InboxOutlinedIcon from "@mui/icons-material/InboxOutlined";
 import InsightsOutlinedIcon from "@mui/icons-material/InsightsOutlined";
 import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
+import PlaylistAddCheckOutlinedIcon from "@mui/icons-material/PlaylistAddCheckOutlined";
 import RuleFolderOutlinedIcon from "@mui/icons-material/RuleFolderOutlined";
 import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
 import {
@@ -74,6 +75,8 @@ const CaseDetailPage =
   lazyOperatorConsolePage("CaseDetailPage") as unknown as typeof import("./operatorConsolePages").CaseDetailPage;
 const CaseIndexPage =
   lazyOperatorConsolePage("CaseIndexPage") as unknown as typeof import("./operatorConsolePages").CaseIndexPage;
+const FirstLoginChecklistPage =
+  lazyOperatorConsolePage("FirstLoginChecklistPage") as unknown as typeof import("./operatorConsolePages").FirstLoginChecklistPage;
 const ProvenancePage =
   lazyOperatorConsolePage("ProvenancePage") as unknown as typeof import("./operatorConsolePages").ProvenancePage;
 const ProvenanceIndexPage =
@@ -164,6 +167,11 @@ function OperatorMenu({
         leftIcon={<CheckCircleOutlineIcon />}
         primaryText="Readiness"
         to={buildOperatorShellPath(basePath, "readiness")}
+      />
+      <Menu.Item
+        leftIcon={<PlaylistAddCheckOutlinedIcon />}
+        primaryText="First Login"
+        to={buildOperatorShellPath(basePath, "first-login-checklist")}
       />
       <Menu.Item
         leftIcon={<RuleFolderOutlinedIcon />}
@@ -400,6 +408,10 @@ function OperatorShellContent({
           <Route element={<ProvenanceIndexPage />} path="provenance/:family" />
           <Route element={<ProvenancePage />} path="provenance/:family/:recordId" />
           <Route element={<ReadinessPage />} path="readiness" />
+          <Route
+            element={<FirstLoginChecklistPage />}
+            path="first-login-checklist"
+          />
           <Route element={<ReconciliationPage />} path="reconciliation" />
           <Route element={<AssistantAdvisoryPage />} path="assistant" />
           <Route

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -10,6 +10,7 @@ export {
 } from "./operatorConsolePages/drilldownIndexPages";
 export { ActionReviewPage } from "./operatorConsolePages/actionReviewPages";
 export { AssistantAdvisoryPage } from "./operatorConsolePages/assistantPages";
+export { FirstLoginChecklistPage } from "./operatorConsolePages/firstLoginChecklistPages";
 export {
   ProvenancePage,
   ReadinessPage,

--- a/apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx
@@ -1,0 +1,331 @@
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import PauseCircleOutlineIcon from "@mui/icons-material/PauseCircleOutline";
+import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
+import { Alert, Chip, Stack, Typography } from "@mui/material";
+import { useMemo } from "react";
+import { OperatorDataProviderContractError } from "../../dataProvider";
+import {
+  asString,
+  formatLabel,
+  LoadingState,
+  PageFrame,
+  QueryStateNotice,
+  SectionCard,
+  useOperatorList,
+  type UnknownRecord,
+} from "./shared";
+
+type ChecklistState =
+  | "completed"
+  | "skipped"
+  | "degraded"
+  | "blocked"
+  | "unavailable";
+
+interface ChecklistStepContract {
+  key: string;
+  title: string;
+  backendAnchor: string;
+  expectedRecordFamily: string;
+}
+
+interface ChecklistStepView extends ChecklistStepContract {
+  authorityRecordFamily: string;
+  authorityRecordId: string;
+  state: ChecklistState;
+}
+
+const TRUSTED_AUTHORITY_SOURCE = "backend_authoritative_record";
+
+const CHECKLIST_STEPS: ChecklistStepContract[] = [
+  {
+    key: "stack_health",
+    title: "Stack health",
+    backendAnchor: "Reviewed diagnostics/readiness record",
+    expectedRecordFamily: "runtime_readiness",
+  },
+  {
+    key: "seeded_queue",
+    title: "Seeded queue",
+    backendAnchor: "Demo-only queue record admitted by AegisOps",
+    expectedRecordFamily: "queue",
+  },
+  {
+    key: "sample_wazuh_alert",
+    title: "Sample Wazuh-origin alert",
+    backendAnchor: "AegisOps alert record with Wazuh provenance",
+    expectedRecordFamily: "alert",
+  },
+  {
+    key: "promote_to_case",
+    title: "Promote to case",
+    backendAnchor: "AegisOps case lifecycle record",
+    expectedRecordFamily: "case",
+  },
+  {
+    key: "evidence",
+    title: "Evidence",
+    backendAnchor: "Case-bound evidence record",
+    expectedRecordFamily: "evidence",
+  },
+  {
+    key: "ai_summary",
+    title: "AI summary",
+    backendAnchor: "Assistant advisory output anchored to the workflow record",
+    expectedRecordFamily: "assistant_advisory",
+  },
+  {
+    key: "action_request",
+    title: "Action request",
+    backendAnchor: "Reviewed action request record",
+    expectedRecordFamily: "action_request",
+  },
+  {
+    key: "approval_decision",
+    title: "Approval or rejection",
+    backendAnchor: "Action review decision record",
+    expectedRecordFamily: "action_review",
+  },
+  {
+    key: "shuffle_receipt",
+    title: "Shuffle execution receipt",
+    backendAnchor: "Execution receipt linked to the approved request",
+    expectedRecordFamily: "execution_receipt",
+  },
+  {
+    key: "reconciliation",
+    title: "Reconciliation",
+    backendAnchor: "AegisOps reconciliation record",
+    expectedRecordFamily: "reconciliation",
+  },
+  {
+    key: "report_export",
+    title: "Report export",
+    backendAnchor: "Report export artifact derived from authoritative records",
+    expectedRecordFamily: "report_export",
+  },
+];
+
+const ALLOWED_STATES = new Set<ChecklistState>([
+  "completed",
+  "skipped",
+  "degraded",
+  "blocked",
+  "unavailable",
+]);
+
+function checklistStateIcon(state: ChecklistState) {
+  switch (state) {
+    case "completed":
+      return <CheckCircleOutlineIcon fontSize="small" />;
+    case "skipped":
+      return <PauseCircleOutlineIcon fontSize="small" />;
+    case "degraded":
+      return <ReportProblemOutlinedIcon fontSize="small" />;
+    case "blocked":
+      return <ErrorOutlineIcon fontSize="small" />;
+    case "unavailable":
+      return <InfoOutlinedIcon fontSize="small" />;
+  }
+}
+
+function checklistStateColor(
+  state: ChecklistState,
+): "default" | "error" | "info" | "success" | "warning" {
+  switch (state) {
+    case "completed":
+      return "success";
+    case "skipped":
+    case "unavailable":
+      return "default";
+    case "degraded":
+      return "warning";
+    case "blocked":
+      return "error";
+  }
+}
+
+function readChecklistState(record: UnknownRecord): ChecklistState {
+  const state = asString(record.state);
+  if (!ALLOWED_STATES.has(state as ChecklistState)) {
+    throw new OperatorDataProviderContractError(
+      `Checklist state ${state ?? "missing"} is not part of the reviewed contract.`,
+    );
+  }
+
+  return state as ChecklistState;
+}
+
+function buildChecklistRows(records: UnknownRecord[]): ChecklistStepView[] {
+  const contractByKey = new Map(CHECKLIST_STEPS.map((step) => [step.key, step]));
+  const recordsByKey = new Map<string, UnknownRecord>();
+
+  for (const record of records) {
+    const stepKey = asString(record.step_key);
+    if (stepKey === null || !contractByKey.has(stepKey)) {
+      throw new OperatorDataProviderContractError(
+        "First-login checklist payload includes an unsupported step.",
+      );
+    }
+
+    if (recordsByKey.has(stepKey)) {
+      throw new OperatorDataProviderContractError(
+        `First-login checklist payload includes duplicate step ${stepKey}.`,
+      );
+    }
+
+    recordsByKey.set(stepKey, record);
+  }
+
+  return CHECKLIST_STEPS.map((step) => {
+    const record = recordsByKey.get(step.key);
+    if (!record) {
+      return {
+        ...step,
+        authorityRecordFamily: step.expectedRecordFamily,
+        authorityRecordId: "Not available",
+        state: "unavailable",
+      };
+    }
+
+    const authoritySource = asString(record.authority_source);
+    if (authoritySource !== TRUSTED_AUTHORITY_SOURCE) {
+      throw new OperatorDataProviderContractError(
+        `Checklist state from ${authoritySource ?? "missing_authority_source"} is not trusted workflow truth.`,
+      );
+    }
+
+    const authorityRecordFamily = asString(record.authority_record_family);
+    const authorityRecordId = asString(record.authority_record_id);
+    if (authorityRecordFamily === null || authorityRecordId === null) {
+      throw new OperatorDataProviderContractError(
+        `Checklist step ${step.key} is missing its backend authority record binding.`,
+      );
+    }
+
+    return {
+      ...step,
+      authorityRecordFamily,
+      authorityRecordId,
+      state: readChecklistState(record),
+    };
+  });
+}
+
+export function FirstLoginChecklistPage() {
+  const filter = useMemo(() => ({}), []);
+  const sort = useMemo(
+    () => ({
+      field: "step_key",
+      order: "ASC" as const,
+    }),
+    [],
+  );
+  const { data, error, loading, refreshing } = useOperatorList(
+    "firstLoginChecklist",
+    filter,
+    sort,
+    CHECKLIST_STEPS.length,
+  );
+
+  let checklistRows: ChecklistStepView[] | null = null;
+  let contractError: Error | null = null;
+  if (data) {
+    try {
+      checklistRows = buildChecklistRows(data as UnknownRecord[]);
+    } catch (error) {
+      contractError = error instanceof Error ? error : new Error(String(error));
+    }
+  }
+
+  return (
+    <PageFrame
+      subtitle="This first-login checklist guides the Phase 55 first-user path while keeping browser progress subordinate to backend-owned workflow records."
+      title="First-Login Checklist"
+    >
+      {loading && !data ? (
+        <LoadingState label="Loading first-login checklist" />
+      ) : null}
+      {error && !data ? (
+        <Alert severity="error" variant="outlined">
+          {error.message}
+        </Alert>
+      ) : null}
+      {contractError ? (
+        <Alert severity="error" variant="outlined">
+          {contractError.message}
+        </Alert>
+      ) : null}
+      {checklistRows ? (
+        <Stack spacing={3}>
+          <QueryStateNotice error={error} refreshing={refreshing} />
+          <Alert severity="info" variant="outlined">
+            Checklist progress is derived from backend records only; browser
+            state, UI cache, Wazuh state, Shuffle state, AI output, tickets,
+            verifier output, and issue-lint output remain subordinate context.
+          </Alert>
+          <SectionCard
+            subtitle="Skipped, degraded, blocked, and unavailable states remain distinct and never count as successful completion."
+            title="Guided workflow contract"
+          >
+            <Stack
+              aria-label="Phase 55 first-login checklist"
+              component="ol"
+              spacing={2}
+              sx={{ m: 0, pl: 0 }}
+            >
+              {checklistRows.map((step, index) => (
+                <Stack
+                  component="li"
+                  key={step.key}
+                  spacing={1}
+                  sx={{
+                    borderBottom:
+                      index === checklistRows.length - 1
+                        ? "none"
+                        : "1px solid",
+                    borderColor: "divider",
+                    display: "block",
+                    listStyle: "none",
+                    pb: index === checklistRows.length - 1 ? 0 : 2,
+                  }}
+                >
+                  <Stack
+                    alignItems={{ xs: "flex-start", sm: "center" }}
+                    direction={{ xs: "column", sm: "row" }}
+                    justifyContent="space-between"
+                    spacing={1}
+                  >
+                    <Typography data-testid="step-title" variant="subtitle1">
+                      {step.title}
+                    </Typography>
+                    <Chip
+                      color={checklistStateColor(step.state)}
+                      icon={checklistStateIcon(step.state)}
+                      label={`State: ${step.state}`}
+                      size="small"
+                      variant={
+                        checklistStateColor(step.state) === "default"
+                          ? "outlined"
+                          : "filled"
+                      }
+                    />
+                  </Stack>
+                  <Typography color="text.secondary" variant="body2">
+                    Backend anchor: {step.backendAnchor}
+                  </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Authority record: {formatLabel(step.authorityRecordFamily)}{" "}
+                    {step.authorityRecordId}
+                  </Typography>
+                </Stack>
+              ))}
+            </Stack>
+          </SectionCard>
+        </Stack>
+      ) : null}
+    </PageFrame>
+  );
+}

--- a/apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx
@@ -204,6 +204,11 @@ function buildChecklistRows(records: UnknownRecord[]): ChecklistStepView[] {
         `Checklist step ${step.key} is missing its backend authority record binding.`,
       );
     }
+    if (authorityRecordFamily !== step.expectedRecordFamily) {
+      throw new OperatorDataProviderContractError(
+        `Checklist step ${step.key} is bound to ${authorityRecordFamily}, expected ${step.expectedRecordFamily}.`,
+      );
+    }
 
     return {
       ...step,

--- a/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
+++ b/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
@@ -24,6 +24,11 @@ export const RESOURCE_BINDINGS: Record<
     listSemantics: "client",
     recordFamily: "case",
   },
+  firstLoginChecklist: {
+    idField: "step_key",
+    listPath: "/inspect-first-login-checklist",
+    listSemantics: "client",
+  },
   queue: {
     idField: "alert_id",
     listPath: "/inspect-analyst-queue",

--- a/apps/operator-ui/src/operatorDataProvider/types.ts
+++ b/apps/operator-ui/src/operatorDataProvider/types.ts
@@ -4,6 +4,7 @@ export type OperatorResourceName =
   | "queue"
   | "alerts"
   | "cases"
+  | "firstLoginChecklist"
   | "runtimeReadiness"
   | "reconciliations"
   | "advisoryOutput"


### PR DESCRIPTION
## Summary
- add a protected first-login checklist route and menu entry for the Phase 55 guided workflow
- bind the operator data provider to a backend-owned first-login checklist resource
- render completed, skipped, degraded, blocked, and unavailable checklist states without treating browser/UI cache state as workflow truth
- add focused OperatorRoutes coverage for progression and browser-cache rejection

## Verification
- npm run test --workspace @aegisops/operator-ui -- src/app/OperatorRoutes.test.tsx
- npm run typecheck --workspace @aegisops/operator-ui
- npm run test --workspace @aegisops/operator-ui
- npm run build --workspace @aegisops/operator-ui
- bash scripts/verify-publishable-path-hygiene.sh
- node dist/index.js issue-lint 1177 --config supervisor.config.aegisops.coderabbit.json

Closes #1177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a First Login Checklist page in the operator UI showing ordered checklist steps, per-step states, authoritative binding info, and a disclaimer that progress is derived from backend records only; accessible from the operator menu.
  * Shows fail-closed warnings when a step’s authority is untrusted or bound to the wrong record.

* **Tests**
  * Added end-to-end tests covering route rendering, step ordering, state text, warnings, and fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->