### PR TITLE
Phase 55.3 demo seed family bundle

### DIFF
--- a/docs/deployment/demo-seed-contract.md
+++ b/docs/deployment/demo-seed-contract.md
@@ -10,7 +10,7 @@ This contract defines demo seed records and demo/prod separation expectations fo
 
 ## 1. Purpose
 
-The demo seed contract gives later setup and `seed-demo` work one reviewed bundle shape for first-user workflow rehearsal. The bundle may create demo alerts, cases, evidence, action requests, approvals, execution receipts, and reconciliation notes, but every seeded record remains demo-only rehearsal state.
+The demo seed contract gives later setup and `seed-demo` work one reviewed bundle shape for first-user workflow rehearsal. The bundle may create demo Wazuh alerts, analytic signals, AegisOps alerts, cases, evidence, recommendations, action reviews, execution receipts, and reconciliation records, but every seeded record remains demo-only rehearsal state.
 
 Demo seed output is workflow rehearsal evidence only.
 
@@ -26,15 +26,23 @@ This contract cites the Phase 51.6 authority-boundary negative-test policy in `d
 
 | Record type | Required demo fields | Presentation rule | Production exclusion |
 | --- | --- | --- | --- |
+| Demo Wazuh alert | Stable demo Wazuh alert identifier, fixture provenance, demo source family, Wazuh alert identifier, demo labels, and reviewed timestamp placeholder. | Must render as demo-only Wazuh alert rehearsal. | Must not satisfy production Wazuh source truth, customer evidence, detector activation truth, or release gate truth. |
+| Demo analytic signal | Stable demo analytic signal identifier, linked demo Wazuh alert, signal name, signal disposition, and demo labels. | Must render as demo-only analytic signal rehearsal. | Must not satisfy production analytic truth, detector admission, customer evidence, or release gate truth. |
+| Demo AegisOps alert | Stable demo AegisOps alert identifier, linked demo analytic signal, control-plane alert identifier, alert state, demo labels, and reviewed timestamp placeholder. | Must render as demo-only AegisOps alert rehearsal. | Must not satisfy production alert admission, customer evidence, release gate, or detector activation truth. |
 | Demo alert | Stable demo alert identifier, fixture provenance, demo source family, demo labels, and reviewed timestamp placeholder. | Must render as demo-only alert rehearsal. | Must not satisfy production alert admission, customer evidence, release gate, or detector activation truth. |
 | Demo case | Stable demo case identifier, linked demo alert, analyst owner placeholder, demo labels, and rehearsal status. | Must render as demo-only case rehearsal. | Must not satisfy production case ownership, customer queue state, release gate, or closeout truth. |
 | Demo evidence | Stable demo evidence identifier, linked demo case, fixture path, demo labels, and provenance note. | Must render as demo-only evidence rehearsal. | Must not satisfy customer evidence, audit evidence, production detection proof, or release evidence truth. |
+| Demo recommendation | Stable demo recommendation identifier, linked demo case, recommended action placeholder, recommendation basis, and demo labels. | Must render as demo-only recommendation rehearsal. | Must not satisfy production recommendation truth, approval truth, execution authorization, or customer evidence. |
+| Demo action review | Stable demo action-review identifier, linked demo recommendation, review decision placeholder, review boundary, and demo labels. | Must render as demo-only action review rehearsal. | Must not satisfy real approval truth, production action authorization, release gate truth, or customer evidence. |
 | Demo action request | Stable demo action-request identifier, linked demo case, requested action placeholder, demo labels, and non-production scope. | Must render as demo-only action rehearsal. | Must not authorize production action, substrate mutation, approval gate, or execution truth. |
 | Demo approval | Explicit demo approval identifier, demo labels, linked demo action request, and reviewer placeholder. | Must render as demo-only approval rehearsal. | Must not satisfy real approval truth, release gate truth, execution authorization, or customer evidence. |
-| Demo execution receipt | Stable demo execution receipt identifier, linked demo action request, mocked executor note, and demo labels. | Must render as demo-only execution rehearsal. | Must not satisfy real execution truth, Shuffle truth, substrate mutation proof, or customer evidence. |
+| Demo execution receipt | Stable demo execution receipt identifier, linked demo action review, mocked executor note, and demo labels. | Must render as demo-only execution rehearsal. | Must not satisfy real execution truth, Shuffle truth, substrate mutation proof, or customer evidence. |
+| Demo reconciliation | Stable demo reconciliation identifier, linked demo execution receipt, reconciliation result, outcome placeholder, and demo labels. | Must render as demo-only reconciliation rehearsal. | Must not satisfy production reconciliation truth, closeout truth, customer evidence, or release gate truth. |
 | Demo reconciliation note | Stable demo reconciliation identifier, linked demo execution receipt, outcome placeholder, and demo labels. | Must render as demo-only reconciliation rehearsal. | Must not satisfy production reconciliation truth, closeout truth, customer evidence, or release gate truth. |
 
 Every seeded record must include `production_claim=false`, `authority=demo_rehearsal_only`, and an empty `truth_surfaces` list.
+
+The Phase 55.3 family bundle must include one directly linked record in each required family: demo Wazuh alert, demo analytic signal, demo AegisOps alert, demo case, demo evidence, demo recommendation, demo action review, demo execution receipt, and demo reconciliation. The link chain must be explicit through stable demo identifiers, and repeat loads must upsert the same demo family by stable ID without creating duplicate authoritative records.
 
 ## 4. Demo Labels
 
@@ -92,7 +100,7 @@ Validation must fail closed when:
 - reset selector, production guard, or failure cleanup coverage is missing;
 - fixture expectations are missing;
 - a negative fixture becomes valid;
-- a valid fixture lacks required labels, demo mode, production exclusion, or reset safety;
+- a valid fixture lacks required labels, demo mode, production exclusion, family linkage, repeatable stable identifiers, or reset safety;
 - demo records are described as production truth, gate truth, customer evidence, approval truth, execution truth, reconciliation truth, or closeout truth;
 - placeholder credentials, sample secrets, fake credentials, raw forwarded headers, or inferred scope bindings are treated as valid; or
 - publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<demo-fixture-bundle>`, `<profile-name>`, `<supervisor-config-path>`, and `<codex-supervisor-root>`.

--- a/docs/deployment/demo-seed-contract.md
+++ b/docs/deployment/demo-seed-contract.md
@@ -30,7 +30,7 @@ This contract cites the Phase 51.6 authority-boundary negative-test policy in `d
 | Demo analytic signal | Stable demo analytic signal identifier, linked demo Wazuh alert, signal name, signal disposition, and demo labels. | Must render as demo-only analytic signal rehearsal. | Must not satisfy production analytic truth, detector admission, customer evidence, or release gate truth. |
 | Demo AegisOps alert | Stable demo AegisOps alert identifier, linked demo analytic signal, control-plane alert identifier, alert state, demo labels, and reviewed timestamp placeholder. | Must render as demo-only AegisOps alert rehearsal. | Must not satisfy production alert admission, customer evidence, release gate, or detector activation truth. |
 | Demo alert | Stable demo alert identifier, fixture provenance, demo source family, demo labels, and reviewed timestamp placeholder. | Must render as demo-only alert rehearsal. | Must not satisfy production alert admission, customer evidence, release gate, or detector activation truth. |
-| Demo case | Stable demo case identifier, linked demo alert, analyst owner placeholder, demo labels, and rehearsal status. | Must render as demo-only case rehearsal. | Must not satisfy production case ownership, customer queue state, release gate, or closeout truth. |
+| Demo case | Stable demo case identifier, linked demo AegisOps alert, analyst owner placeholder, demo labels, and rehearsal status. | Must render as demo-only case rehearsal. | Must not satisfy production case ownership, customer queue state, release gate, or closeout truth. |
 | Demo evidence | Stable demo evidence identifier, linked demo case, fixture path, demo labels, and provenance note. | Must render as demo-only evidence rehearsal. | Must not satisfy customer evidence, audit evidence, production detection proof, or release evidence truth. |
 | Demo recommendation | Stable demo recommendation identifier, linked demo case, recommended action placeholder, recommendation basis, and demo labels. | Must render as demo-only recommendation rehearsal. | Must not satisfy production recommendation truth, approval truth, execution authorization, or customer evidence. |
 | Demo action review | Stable demo action-review identifier, linked demo recommendation, review decision placeholder, review boundary, and demo labels. | Must render as demo-only action review rehearsal. | Must not satisfy real approval truth, production action authorization, release gate truth, or customer evidence. |
@@ -128,7 +128,7 @@ Run `bash scripts/verify-phase-52-7-demo-seed-contract.sh`.
 
 Run `bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`.
 
-Run `node <codex-supervisor-root>/dist/index.js issue-lint 1070 --config <supervisor-config-path>`.
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1178 --config <supervisor-config-path>`.
 
 The verifier must fail when the demo seed contract is missing, when label, reset, fixture, production exclusion, or authority-boundary coverage is incomplete, when negative fixtures falsely pass, when demo records are treated as production truth, or when publishable guidance uses workstation-local absolute paths.
 

--- a/docs/deployment/fixtures/demo-seed/valid-demo-seed.json
+++ b/docs/deployment/fixtures/demo-seed/valid-demo-seed.json
@@ -2,10 +2,15 @@
   "bundle": "phase-52-7-demo-seed",
   "mode": "demo",
   "profile": "smb-single-node",
+  "repeatability": {
+    "load_strategy": "upsert-demo-records-by-stable-id",
+    "duplicate_behavior": "replace-demo-record-family-only",
+    "idempotency_key": "phase-55-3-demo-seed-family-v1"
+  },
   "records": [
     {
-      "id": "demo-alert-001",
-      "type": "demo-alert",
+      "id": "demo-wazuh-alert-001",
+      "type": "demo-wazuh-alert",
       "labels": [
         "demo-only",
         "first-user-rehearsal",
@@ -15,9 +20,43 @@
       "production_claim": false,
       "truth_surfaces": [],
       "fixture_provenance": "docs/deployment/fixtures/demo-seed/valid-demo-seed.json",
-      "demo_source_family": "demo-fixture",
+      "demo_source_family": "wazuh-demo-fixture",
+      "wazuh_alert_id": "wazuh-demo-alert-001",
       "reviewed_at": null,
-      "presentation": "demo-only alert rehearsal"
+      "presentation": "demo-only Wazuh alert rehearsal"
+    },
+    {
+      "id": "demo-analytic-signal-001",
+      "type": "demo-analytic-signal",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "linked_demo_wazuh_alert_id": "demo-wazuh-alert-001",
+      "signal_name": "demo suspicious admin login signal",
+      "signal_disposition": "rehearsal-only",
+      "presentation": "demo-only analytic signal rehearsal"
+    },
+    {
+      "id": "demo-aegisops-alert-001",
+      "type": "demo-aegisops-alert",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "linked_demo_signal_id": "demo-analytic-signal-001",
+      "control_plane_alert_id": "aegisops-demo-alert-001",
+      "alert_state": "reviewed-demo",
+      "reviewed_at": null,
+      "presentation": "demo-only AegisOps alert rehearsal"
     },
     {
       "id": "demo-case-001",
@@ -30,10 +69,89 @@
       "authority": "demo_rehearsal_only",
       "production_claim": false,
       "truth_surfaces": [],
-      "linked_demo_alert_id": "demo-alert-001",
+      "linked_demo_alert_id": "demo-aegisops-alert-001",
       "analyst_owner": null,
       "rehearsal_status": "rehearsal",
       "presentation": "demo-only case rehearsal"
+    },
+    {
+      "id": "demo-evidence-001",
+      "type": "demo-evidence",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "linked_demo_case_id": "demo-case-001",
+      "fixture_path": "docs/deployment/fixtures/demo-seed/valid-demo-seed.json",
+      "provenance_note": "demo fixture evidence only",
+      "presentation": "demo-only evidence rehearsal"
+    },
+    {
+      "id": "demo-recommendation-001",
+      "type": "demo-recommendation",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "linked_demo_case_id": "demo-case-001",
+      "recommended_action": "review demo account activity",
+      "recommendation_basis": "demo-only analytic signal and fixture evidence",
+      "presentation": "demo-only recommendation rehearsal"
+    },
+    {
+      "id": "demo-action-review-001",
+      "type": "demo-action-review",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "linked_demo_recommendation_id": "demo-recommendation-001",
+      "review_decision": "demo-approved-for-rehearsal",
+      "review_boundary": "no production authorization",
+      "presentation": "demo-only action review rehearsal"
+    },
+    {
+      "id": "demo-execution-receipt-001",
+      "type": "demo-execution-receipt",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "linked_demo_action_review_id": "demo-action-review-001",
+      "mocked_executor_note": "demo executor receipt; no substrate mutation",
+      "presentation": "demo-only execution rehearsal"
+    },
+    {
+      "id": "demo-reconciliation-001",
+      "type": "demo-reconciliation",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "linked_demo_execution_receipt_id": "demo-execution-receipt-001",
+      "reconciliation_result": "demo-matched",
+      "outcome_placeholder": "demo reconciliation only",
+      "presentation": "demo-only reconciliation rehearsal"
     }
   ],
   "reset": {

--- a/scripts/test-verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/test-verify-phase-52-7-demo-seed-contract.sh
@@ -158,6 +158,46 @@ assert_fails_with \
   "${valid_missing_family_linkage_repo}" \
   "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
 
+valid_missing_action_request_linkage_repo="${workdir}/valid-missing-action-request-linkage"
+create_valid_repo "${valid_missing_action_request_linkage_repo}"
+set_fixture_json_value \
+  "${valid_missing_action_request_linkage_repo}" \
+  "valid-demo-seed.json" \
+  "payload['records'].append({'type': 'demo-action-request', 'id': 'demo-action-request-001', 'linked_demo_case_id': 'missing-demo-case', 'requested_action': 'isolate demo host', 'non_production_scope': True, 'presentation': 'demo-only action rehearsal', 'labels': ['demo-only', 'first-user-rehearsal', 'not-production-truth'], 'production_claim': False, 'truth_surfaces': [], 'authority': 'demo_rehearsal_only'})"
+assert_fails_with \
+  "${valid_missing_action_request_linkage_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
+valid_missing_approval_linkage_repo="${workdir}/valid-missing-approval-linkage"
+create_valid_repo "${valid_missing_approval_linkage_repo}"
+set_fixture_json_value \
+  "${valid_missing_approval_linkage_repo}" \
+  "valid-demo-seed.json" \
+  "payload['records'].append({'type': 'demo-action-request', 'id': 'demo-action-request-001', 'linked_demo_case_id': 'demo-case-001', 'requested_action': 'isolate demo host', 'non_production_scope': True, 'presentation': 'demo-only action rehearsal', 'labels': ['demo-only', 'first-user-rehearsal', 'not-production-truth'], 'production_claim': False, 'truth_surfaces': [], 'authority': 'demo_rehearsal_only'}); payload['records'].append({'type': 'demo-approval', 'id': 'demo-approval-001', 'linked_demo_action_request_id': 'missing-demo-action-request', 'reviewer_placeholder': 'Demo reviewer', 'presentation': 'demo-only approval rehearsal', 'labels': ['demo-only', 'first-user-rehearsal', 'not-production-truth'], 'production_claim': False, 'truth_surfaces': [], 'authority': 'demo_rehearsal_only'})"
+assert_fails_with \
+  "${valid_missing_approval_linkage_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
+valid_missing_reconciliation_note_linkage_repo="${workdir}/valid-missing-reconciliation-note-linkage"
+create_valid_repo "${valid_missing_reconciliation_note_linkage_repo}"
+set_fixture_json_value \
+  "${valid_missing_reconciliation_note_linkage_repo}" \
+  "valid-demo-seed.json" \
+  "payload['records'].append({'type': 'demo-reconciliation-note', 'id': 'demo-reconciliation-note-001', 'linked_demo_execution_receipt_id': 'missing-demo-execution-receipt', 'outcome_placeholder': 'Demo outcome note', 'presentation': 'demo-only reconciliation rehearsal', 'labels': ['demo-only', 'first-user-rehearsal', 'not-production-truth'], 'production_claim': False, 'truth_surfaces': [], 'authority': 'demo_rehearsal_only'})"
+assert_fails_with \
+  "${valid_missing_reconciliation_note_linkage_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
+valid_duplicate_required_family_repo="${workdir}/valid-duplicate-required-family"
+create_valid_repo "${valid_duplicate_required_family_repo}"
+set_fixture_json_value \
+  "${valid_duplicate_required_family_repo}" \
+  "valid-demo-seed.json" \
+  "payload['records'].append(dict(payload['records'][3], id='demo-case-duplicate'))"
+assert_fails_with \
+  "${valid_duplicate_required_family_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
 valid_non_repeatable_seed_repo="${workdir}/valid-non-repeatable-seed"
 create_valid_repo "${valid_non_repeatable_seed_repo}"
 set_fixture_json_value \

--- a/scripts/test-verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/test-verify-phase-52-7-demo-seed-contract.sh
@@ -138,22 +138,50 @@ assert_fails_with \
   "${valid_missing_demo_alert_field_repo}" \
   "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
 
+valid_missing_required_family_repo="${workdir}/valid-missing-required-family"
+create_valid_repo "${valid_missing_required_family_repo}"
+set_fixture_json_value \
+  "${valid_missing_required_family_repo}" \
+  "valid-demo-seed.json" \
+  "payload['records'] = [record for record in payload['records'] if record.get('type') != 'demo-recommendation']"
+assert_fails_with \
+  "${valid_missing_required_family_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
+valid_missing_family_linkage_repo="${workdir}/valid-missing-family-linkage"
+create_valid_repo "${valid_missing_family_linkage_repo}"
+set_fixture_json_value \
+  "${valid_missing_family_linkage_repo}" \
+  "valid-demo-seed.json" \
+  "payload['records'][2]['linked_demo_signal_id'] = 'missing-demo-signal'"
+assert_fails_with \
+  "${valid_missing_family_linkage_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
+valid_non_repeatable_seed_repo="${workdir}/valid-non-repeatable-seed"
+create_valid_repo "${valid_non_repeatable_seed_repo}"
+set_fixture_json_value \
+  "${valid_non_repeatable_seed_repo}" \
+  "valid-demo-seed.json" \
+  "payload['repeatability']['load_strategy'] = 'append-new-demo-records'"
+assert_fails_with \
+  "${valid_non_repeatable_seed_repo}" \
+  "Invalid Phase 52.7 demo seed fixture state for valid-demo-seed.json: expected valid"
+
 negative_label_false_pass_repo="${workdir}/negative-label-false-pass"
 create_valid_repo "${negative_label_false_pass_repo}"
-set_fixture_json_value \
-  "${negative_label_false_pass_repo}" \
-  "missing-label.json" \
-  "payload['records'][0]['labels'] = ['demo-only', 'first-user-rehearsal', 'not-production-truth']"
+cp \
+  "${negative_label_false_pass_repo}/docs/deployment/fixtures/demo-seed/valid-demo-seed.json" \
+  "${negative_label_false_pass_repo}/docs/deployment/fixtures/demo-seed/missing-label.json"
 assert_fails_with \
   "${negative_label_false_pass_repo}" \
   "Invalid Phase 52.7 demo seed fixture state for missing-label.json: expected rejection"
 
 destructive_reset_false_pass_repo="${workdir}/destructive-reset-false-pass"
 create_valid_repo "${destructive_reset_false_pass_repo}"
-set_fixture_json_value \
-  "${destructive_reset_false_pass_repo}" \
-  "destructive-reset.json" \
-  "payload['reset']['deletes_production_records'] = False; payload['reset']['scope'] = 'demo-bundle-only'; payload['reset']['selector'] = {'bundle': 'phase-52-7-demo-seed', 'labels': ['demo-only', 'first-user-rehearsal', 'not-production-truth']}"
+cp \
+  "${destructive_reset_false_pass_repo}/docs/deployment/fixtures/demo-seed/valid-demo-seed.json" \
+  "${destructive_reset_false_pass_repo}/docs/deployment/fixtures/demo-seed/destructive-reset.json"
 assert_fails_with \
   "${destructive_reset_false_pass_repo}" \
   "Invalid Phase 52.7 demo seed fixture state for destructive-reset.json: expected rejection"
@@ -180,10 +208,9 @@ assert_fails_with \
 
 production_claim_false_pass_repo="${workdir}/production-claim-false-pass"
 create_valid_repo "${production_claim_false_pass_repo}"
-set_fixture_json_value \
-  "${production_claim_false_pass_repo}" \
-  "production-claim.json" \
-  "payload['records'][0]['production_claim'] = False; payload['records'][0]['truth_surfaces'] = []; payload['records'][0]['authority'] = 'demo_rehearsal_only'; payload['records'][0]['presentation'] = 'demo-only alert rehearsal'; payload['production_exclusion']['may_satisfy_production_truth'] = False; payload['production_exclusion']['blocked_truth_surfaces'] = ['production', 'gate', 'customer_evidence', 'approval', 'execution', 'reconciliation', 'closeout']"
+cp \
+  "${production_claim_false_pass_repo}/docs/deployment/fixtures/demo-seed/valid-demo-seed.json" \
+  "${production_claim_false_pass_repo}/docs/deployment/fixtures/demo-seed/production-claim.json"
 assert_fails_with \
   "${production_claim_false_pass_repo}" \
   "Invalid Phase 52.7 demo seed fixture state for production-claim.json: expected rejection"

--- a/scripts/verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/verify-phase-52-7-demo-seed-contract.sh
@@ -38,7 +38,7 @@ required_phrases=(
   "| Fixture | Expected validity | Required rejection |"
   'Run `bash scripts/verify-phase-52-7-demo-seed-contract.sh`.'
   'Run `bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`.'
-  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1070 --config <supervisor-config-path>`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1178 --config <supervisor-config-path>`.'
 )
 
 record_types=(

--- a/scripts/verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/verify-phase-52-7-demo-seed-contract.sh
@@ -183,6 +183,7 @@ if grep -REq "(${path_token_boundary}${local_path_token}|file:///?${local_path_t
 fi
 
 python3 - "${fixtures_dir}" "${fixture_expectations[@]}" <<'PY'
+from collections import Counter
 import json
 import pathlib
 import sys
@@ -301,8 +302,11 @@ required_linkages = {
     "demo-evidence": ("linked_demo_case_id", "demo-case"),
     "demo-recommendation": ("linked_demo_case_id", "demo-case"),
     "demo-action-review": ("linked_demo_recommendation_id", "demo-recommendation"),
+    "demo-action-request": ("linked_demo_case_id", "demo-case"),
+    "demo-approval": ("linked_demo_action_request_id", "demo-action-request"),
     "demo-execution-receipt": ("linked_demo_action_review_id", "demo-action-review"),
     "demo-reconciliation": ("linked_demo_execution_receipt_id", "demo-execution-receipt"),
+    "demo-reconciliation-note": ("linked_demo_execution_receipt_id", "demo-execution-receipt"),
 }
 
 
@@ -349,9 +353,13 @@ def rejection_reasons(payload):
     if len(records_by_id) != len(records):
         reasons.append("non-repeatable seed load")
 
-    present_record_types = {record.get("type") for record in records}
-    for required_record_type in sorted(required_record_types - present_record_types):
-        reasons.append(f"missing required record family {required_record_type}")
+    record_type_counts = Counter(record.get("type") for record in records)
+    for required_record_type in sorted(required_record_types):
+        required_record_type_count = record_type_counts.get(required_record_type, 0)
+        if required_record_type_count == 0:
+            reasons.append(f"missing required record family {required_record_type}")
+        elif required_record_type_count > 1:
+            reasons.append(f"multiple records in required family {required_record_type}")
 
     for record in records:
         record_type = record.get("type")

--- a/scripts/verify-phase-52-7-demo-seed-contract.sh
+++ b/scripts/verify-phase-52-7-demo-seed-contract.sh
@@ -42,12 +42,18 @@ required_phrases=(
 )
 
 record_types=(
+  "Demo Wazuh alert"
+  "Demo analytic signal"
+  "Demo AegisOps alert"
   "Demo alert"
   "Demo case"
   "Demo evidence"
+  "Demo recommendation"
+  "Demo action review"
   "Demo action request"
   "Demo approval"
   "Demo execution receipt"
+  "Demo reconciliation"
   "Demo reconciliation note"
 )
 
@@ -209,6 +215,21 @@ def has_field(record, field):
 
 
 type_requirements = {
+    "demo-wazuh-alert": {
+        "presentation": "demo-only Wazuh alert rehearsal",
+        "non_empty": ("id", "fixture_provenance", "demo_source_family", "wazuh_alert_id"),
+        "present": ("reviewed_at",),
+    },
+    "demo-analytic-signal": {
+        "presentation": "demo-only analytic signal rehearsal",
+        "non_empty": ("id", "linked_demo_wazuh_alert_id", "signal_name", "signal_disposition"),
+        "present": (),
+    },
+    "demo-aegisops-alert": {
+        "presentation": "demo-only AegisOps alert rehearsal",
+        "non_empty": ("id", "linked_demo_signal_id", "control_plane_alert_id", "alert_state"),
+        "present": ("reviewed_at",),
+    },
     "demo-alert": {
         "presentation": "demo-only alert rehearsal",
         "non_empty": ("id", "fixture_provenance", "demo_source_family"),
@@ -224,6 +245,16 @@ type_requirements = {
         "non_empty": ("id", "linked_demo_case_id", "fixture_path", "provenance_note"),
         "present": (),
     },
+    "demo-recommendation": {
+        "presentation": "demo-only recommendation rehearsal",
+        "non_empty": ("id", "linked_demo_case_id", "recommended_action", "recommendation_basis"),
+        "present": (),
+    },
+    "demo-action-review": {
+        "presentation": "demo-only action review rehearsal",
+        "non_empty": ("id", "linked_demo_recommendation_id", "review_decision", "review_boundary"),
+        "present": (),
+    },
     "demo-action-request": {
         "presentation": "demo-only action rehearsal",
         "non_empty": ("id", "linked_demo_case_id", "requested_action"),
@@ -236,7 +267,7 @@ type_requirements = {
     },
     "demo-execution-receipt": {
         "presentation": "demo-only execution rehearsal",
-        "non_empty": ("id", "linked_demo_action_request_id", "mocked_executor_note"),
+        "non_empty": ("id", "linked_demo_action_review_id", "mocked_executor_note"),
         "present": (),
     },
     "demo-reconciliation-note": {
@@ -244,6 +275,34 @@ type_requirements = {
         "non_empty": ("id", "linked_demo_execution_receipt_id", "outcome_placeholder"),
         "present": (),
     },
+    "demo-reconciliation": {
+        "presentation": "demo-only reconciliation rehearsal",
+        "non_empty": ("id", "linked_demo_execution_receipt_id", "reconciliation_result", "outcome_placeholder"),
+        "present": (),
+    },
+}
+
+required_record_types = {
+    "demo-wazuh-alert",
+    "demo-analytic-signal",
+    "demo-aegisops-alert",
+    "demo-case",
+    "demo-evidence",
+    "demo-recommendation",
+    "demo-action-review",
+    "demo-execution-receipt",
+    "demo-reconciliation",
+}
+
+required_linkages = {
+    "demo-analytic-signal": ("linked_demo_wazuh_alert_id", "demo-wazuh-alert"),
+    "demo-aegisops-alert": ("linked_demo_signal_id", "demo-analytic-signal"),
+    "demo-case": ("linked_demo_alert_id", "demo-aegisops-alert"),
+    "demo-evidence": ("linked_demo_case_id", "demo-case"),
+    "demo-recommendation": ("linked_demo_case_id", "demo-case"),
+    "demo-action-review": ("linked_demo_recommendation_id", "demo-recommendation"),
+    "demo-execution-receipt": ("linked_demo_action_review_id", "demo-action-review"),
+    "demo-reconciliation": ("linked_demo_execution_receipt_id", "demo-execution-receipt"),
 }
 
 
@@ -256,6 +315,9 @@ def rejection_reasons(payload):
 
     for record in records:
         record_type = record.get("type")
+        if not has_non_empty_string(record, "id"):
+            reasons.append("missing stable demo record identifier")
+            continue
         requirements = type_requirements.get(record_type)
         if requirements is None:
             reasons.append("missing demo record type contract")
@@ -278,6 +340,37 @@ def rejection_reasons(payload):
             reasons.append("demo record claims production truth")
         if record.get("authority") != "demo_rehearsal_only":
             reasons.append("demo record claims production truth")
+
+    records_by_id = {
+        record.get("id"): record
+        for record in records
+        if isinstance(record.get("id"), str) and record.get("id").strip()
+    }
+    if len(records_by_id) != len(records):
+        reasons.append("non-repeatable seed load")
+
+    present_record_types = {record.get("type") for record in records}
+    for required_record_type in sorted(required_record_types - present_record_types):
+        reasons.append(f"missing required record family {required_record_type}")
+
+    for record in records:
+        record_type = record.get("type")
+        linkage = required_linkages.get(record_type)
+        if linkage is None:
+            continue
+        linkage_field, expected_parent_type = linkage
+        parent_id = record.get(linkage_field)
+        parent_record = records_by_id.get(parent_id)
+        if parent_record is None or parent_record.get("type") != expected_parent_type:
+            reasons.append("missing expected record family linkage")
+
+    repeatability = payload.get("repeatability") or {}
+    if repeatability.get("load_strategy") != "upsert-demo-records-by-stable-id":
+        reasons.append("non-repeatable seed load")
+    if repeatability.get("duplicate_behavior") != "replace-demo-record-family-only":
+        reasons.append("non-repeatable seed load")
+    if not isinstance(repeatability.get("idempotency_key"), str) or not repeatability.get("idempotency_key").strip():
+        reasons.append("non-repeatable seed load")
 
     reset = payload.get("reset") or {}
     if reset.get("deletes_production_records") is not False:


### PR DESCRIPTION
## Summary
- expands the demo seed contract with Phase 55.3 record-family expectations
- adds a repeatable linked demo bundle covering Wazuh alert, analytic signal, AegisOps alert, case, evidence, recommendation, action review, execution receipt, and reconciliation
- tightens verifier and negative harness coverage for missing family, broken linkage, and non-repeatable seed loads

## Verification
- bash scripts/verify-phase-52-7-demo-seed-contract.sh
- bash scripts/test-verify-phase-52-7-demo-seed-contract.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1178 --config <supervisor-config-path>

Closes #1178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded demo seed docs to describe a full end-to-end demo workflow (alerts → signals → cases → recommendations → actions → receipts → reconciliations), new demo record types, stricter demo-only and repeatability rules, and updated verification identifier.

* **Tests**
  * Strengthened validation rules and added negative test scenarios to enforce required families, linkage, stable identifiers, and repeatable upsert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->