### PR TITLE
Phase 55.4 demo reset and mode separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Canonical cross-phase boundary reference:
 - [Phase 54.10 closeout evaluation](docs/phase-54-closeout-evaluation.md) records the Shuffle profile MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 55/58/62/66 handoff.
 - [Phase 55.1 first-user journey](docs/getting-started/first-user-journey.md) defines the workflow-first path from stack health to seeded queue, sample alert, case, evidence, AI summary, action review, receipt, reconciliation, and report export.
 - [Phase 55.1 first 30 minutes](docs/getting-started/first-30-minutes.md) defines the first-session operator path without deep architecture dumping or production-readiness claims.
+- [Phase 55.4 demo reset and mode separation contract](docs/deployment/demo-reset-mode-separation.md) defines repeatable demo reset, demo/live mode separation, live-record preservation, and backup/restore overclaim rejection.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
@@ -117,6 +118,8 @@ The Phase 53.9 closeout evaluation is defined by the [Phase 53.9 closeout evalua
 The Phase 54.9 Shuffle authority-boundary negative tests are defined by the [Phase 54.9 Shuffle authority-boundary negative tests](docs/deployment/shuffle-authority-boundary-negative-tests.md).
 
 The Phase 54.10 closeout evaluation is defined by the [Phase 54.10 closeout evaluation](docs/phase-54-closeout-evaluation.md).
+
+The Phase 55.4 demo reset and mode separation contract is defined by the [Phase 55.4 demo reset and mode separation contract](docs/deployment/demo-reset-mode-separation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/deployment/demo-reset-mode-separation.md
+++ b/docs/deployment/demo-reset-mode-separation.md
@@ -1,0 +1,115 @@
+# Phase 55.4 Demo Reset and Mode Separation
+
+- **Status**: Accepted as Phase 55.4 demo reset and mode separation contract
+- **Date**: 2026-05-03
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/deployment/demo-seed-contract.md`, `docs/getting-started/first-user-journey.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1175, #1178, #1179
+
+This contract defines repeatable demo reset behavior and demo/live mode separation for the Phase 55 guided first-user journey only.
+
+It does not implement production reset, backup, restore, support bundle behavior, supportability cleanup, report export, daily SOC workbench behavior, Beta readiness, RC readiness, GA readiness, or commercial readiness.
+
+## 1. Purpose
+
+Phase 55.4 gives first-user demos one bounded reset contract so the same demo can be repeated without deleting, relabeling, mutating, or closing live records.
+
+Demo reset targets only records that are explicitly labeled with `demo-only`, `first-user-rehearsal`, and `not-production-truth` and bound to the reviewed demo fixture bundle.
+
+Live records, production records, audit records, unlabeled records, imported customer records, and non-demo workflow truth must remain unchanged after every demo reset attempt.
+
+## 2. Demo Reset Contract
+
+| Reset boundary | Required behavior | Rejection rule |
+| --- | --- | --- |
+| Selector scope | Reset must use a structured selector for bundle `phase-52-7-demo-seed` and all three required demo labels. | Selectors based on profile name, timestamp, path shape, title, nearby metadata, inferred parent lineage, or partial labels fail. |
+| Repeatability | Reset must upsert or replace the same demo family by stable demo identifiers. | Appending duplicate authoritative records, changing stable identifiers, or widening the target set fails. |
+| Live preservation | Reset must preserve live, production, audit, imported, customer-private, unlabeled, and non-demo workflow records byte-for-byte. | Any deleted live record, changed production-truth field, audit mutation, or customer-data cleanup fails. |
+| Failure cleanup | Rejected reset attempts must leave durable live and non-demo state unchanged. | Any partial durable write, orphan record, half-reset state, or untracked cleanup result fails. |
+
+Demo reset must be repeatable by stable demo identifiers and must not append duplicate authoritative records.
+
+A failed or rejected demo reset must leave durable live and non-demo state unchanged.
+
+## 3. Mode Separation
+
+| Mode | Authority posture | Reset rule |
+| --- | --- | --- |
+| Demo | Explicit rehearsal mode for records labeled `demo-only`, `first-user-rehearsal`, and `not-production-truth` with `authority=demo_rehearsal_only`. | Demo reset may replace only the reviewed demo bundle by stable demo identifiers and must keep demo badges visible. |
+| Live | Authoritative workflow mode for AegisOps control-plane records, production truth, audit truth, and customer-bound records. | Demo reset cannot delete, mutate, relabel, close, reconcile, approve, or clean live records. |
+
+Demo mode is explicit rehearsal mode. Live mode is authoritative workflow mode.
+
+Reset output, UI state, browser state, logs, verifier output, issue-lint output, and demo labels cannot override authoritative AegisOps live records or production truth.
+
+## 4. Reset Safety Rules
+
+Demo reset validation must fail closed when:
+
+- a reset selector omits any required demo label;
+- a reset selector targets unlabeled, live, production, imported, audit, customer-private, or non-demo workflow records;
+- a reset attempts to close, reconcile, approve, relabel, or mutate production truth;
+- a reset uses UI state, browser state, logs, issue-lint output, verifier output, demo output, or fixture text as authority for live records;
+- a reset relies on naming convention, path shape, timestamp, comments, adjacent metadata, profile name alone, or inferred lineage to decide scope; or
+- a reset is presented as backup, restore, supportability cleanup, production cleanup, support bundle, or disaster-recovery behavior.
+
+Reset reported as backup/restore supportability must fail because this slice does not implement backup, restore, support bundle, or production cleanup behavior.
+
+## 5. Fixture Expectations
+
+Fixture expectations live under `docs/deployment/fixtures/demo-reset-mode-separation/`.
+
+| Fixture | Expected validity | Required rejection |
+| --- | --- | --- |
+| `valid-repeatable-demo-reset.json` | `valid` | None |
+| `delete-live-record.json` | `invalid` | demo reset deletes live records |
+| `mutate-production-truth.json` | `invalid` | demo reset mutates production truth |
+| `unlabeled-record-reset.json` | `invalid` | demo reset targets unlabeled records |
+| `backup-restore-claim.json` | `invalid` | reset reported as backup/restore supportability |
+
+Negative fixtures must fail closed when demo reset deletes live records, mutates production truth, targets unlabeled records, or is reported as backup/restore supportability.
+
+## 6. Validation Rules
+
+Validation must fail closed when:
+
+- this contract is missing;
+- reset boundary rows are missing or incomplete;
+- mode separation rows are missing or incomplete;
+- fixture expectations are missing;
+- a negative fixture becomes valid;
+- a valid fixture deletes or mutates live records;
+- a valid fixture appends duplicate demo records instead of repeating stable demo identifiers;
+- reset output is presented as backup, restore, supportability, production cleanup, production truth, gate truth, approval truth, execution truth, reconciliation truth, or closeout truth; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented env vars, or placeholders such as `<runtime-env-file>`, `<profile-name>`, `<supervisor-config-path>`, and `<codex-supervisor-root>`.
+
+## 7. Forbidden Claims
+
+- Demo reset may delete live records.
+- Demo reset may mutate production truth.
+- Unlabeled records may be reset.
+- Demo reset is backup restore supportability.
+- Demo reset is production cleanup.
+- Demo mode is live mode.
+- Live records are demo records.
+- Demo labels override production truth.
+
+## 8. Validation
+
+Run `bash scripts/verify-phase-55-4-demo-reset-mode-separation.sh`.
+
+Run `bash scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1179 --config <supervisor-config-path>`.
+
+The verifier must fail when the contract is missing, reset or mode-separation rows are incomplete, demo reset deletes live records, demo reset mutates production truth, an unlabeled record is reset, reset is reported as backup/restore supportability, README does not link this contract, or publishable guidance uses workstation-local absolute paths.
+
+## 9. Non-Goals
+
+- No production reset or destructive cleanup is implemented here.
+- No backup, restore, support bundle, supportability cleanup, or disaster-recovery behavior is implemented here.
+- No report export implementation is approved here.
+- No daily SOC workbench, SIEM breadth, SOAR breadth, Beta, RC, GA, or commercial-readiness claim is approved here.
+- No demo record, demo label, reset output, UI state, browser state, log text, verifier output, or issue-lint output becomes production truth, gate truth, approval truth, execution truth, reconciliation truth, closeout truth, or authoritative workflow truth.

--- a/docs/deployment/fixtures/demo-reset-mode-separation/backup-restore-claim.json
+++ b/docs/deployment/fixtures/demo-reset-mode-separation/backup-restore-claim.json
@@ -1,0 +1,53 @@
+{
+  "scenario": "backup-restore-claim",
+  "operation": "demo-reset",
+  "reset_contract": {
+    "bundle": "phase-52-7-demo-seed",
+    "mode": "demo",
+    "selector": {
+      "bundle": "phase-52-7-demo-seed",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ]
+    },
+    "repeatable_by_stable_id": true,
+    "deletes_live_records": false,
+    "mutates_production_truth": false,
+    "reported_as": "backup-restore-supportability"
+  },
+  "before_records": [
+    {
+      "id": "demo-case-001",
+      "mode": "demo",
+      "type": "demo-case",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "status": "demo-rehearsal"
+    }
+  ],
+  "after_records": [
+    {
+      "id": "demo-case-001",
+      "mode": "demo",
+      "type": "demo-case",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "status": "demo-rehearsal",
+      "reset_reported_as": "backup-restore-supportability"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/demo-reset-mode-separation/delete-live-record.json
+++ b/docs/deployment/fixtures/demo-reset-mode-separation/delete-live-record.json
@@ -1,0 +1,67 @@
+{
+  "scenario": "delete-live-record",
+  "operation": "demo-reset",
+  "reset_contract": {
+    "bundle": "phase-52-7-demo-seed",
+    "mode": "demo",
+    "selector": {
+      "bundle": "phase-52-7-demo-seed",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ]
+    },
+    "repeatable_by_stable_id": true,
+    "deletes_live_records": true,
+    "mutates_production_truth": false,
+    "reported_as": "demo-reset"
+  },
+  "before_records": [
+    {
+      "id": "demo-case-001",
+      "mode": "demo",
+      "type": "demo-case",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "status": "demo-rehearsal"
+    },
+    {
+      "id": "live-case-001",
+      "mode": "live",
+      "type": "case",
+      "labels": [
+        "customer-bound",
+        "production-truth"
+      ],
+      "authority": "aegisops_control_plane",
+      "production_claim": true,
+      "truth_surfaces": [
+        "production"
+      ],
+      "status": "open"
+    }
+  ],
+  "after_records": [
+    {
+      "id": "demo-case-001",
+      "mode": "demo",
+      "type": "demo-case",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "status": "demo-rehearsal"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/demo-reset-mode-separation/mutate-production-truth.json
+++ b/docs/deployment/fixtures/demo-reset-mode-separation/mutate-production-truth.json
@@ -1,0 +1,84 @@
+{
+  "scenario": "mutate-production-truth",
+  "operation": "demo-reset",
+  "reset_contract": {
+    "bundle": "phase-52-7-demo-seed",
+    "mode": "demo",
+    "selector": {
+      "bundle": "phase-52-7-demo-seed",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ]
+    },
+    "repeatable_by_stable_id": true,
+    "deletes_live_records": false,
+    "mutates_production_truth": true,
+    "reported_as": "demo-reset"
+  },
+  "before_records": [
+    {
+      "id": "demo-case-001",
+      "mode": "demo",
+      "type": "demo-case",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "status": "demo-rehearsal"
+    },
+    {
+      "id": "live-case-001",
+      "mode": "live",
+      "type": "case",
+      "labels": [
+        "customer-bound",
+        "production-truth"
+      ],
+      "authority": "aegisops_control_plane",
+      "production_claim": true,
+      "truth_surfaces": [
+        "production"
+      ],
+      "status": "open",
+      "audit_marker": "live-case-marker"
+    }
+  ],
+  "after_records": [
+    {
+      "id": "demo-case-001",
+      "mode": "demo",
+      "type": "demo-case",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "status": "demo-rehearsal"
+    },
+    {
+      "id": "live-case-001",
+      "mode": "live",
+      "type": "case",
+      "labels": [
+        "customer-bound",
+        "production-truth"
+      ],
+      "authority": "aegisops_control_plane",
+      "production_claim": true,
+      "truth_surfaces": [
+        "production"
+      ],
+      "status": "closed-by-demo-reset",
+      "audit_marker": "live-case-marker"
+    }
+  ]
+}

--- a/docs/deployment/fixtures/demo-reset-mode-separation/unlabeled-record-reset.json
+++ b/docs/deployment/fixtures/demo-reset-mode-separation/unlabeled-record-reset.json
@@ -1,0 +1,31 @@
+{
+  "scenario": "unlabeled-record-reset",
+  "operation": "demo-reset",
+  "reset_contract": {
+    "bundle": "phase-52-7-demo-seed",
+    "mode": "demo",
+    "selector": {
+      "bundle": "phase-52-7-demo-seed",
+      "labels": [
+        "demo-only"
+      ]
+    },
+    "repeatable_by_stable_id": true,
+    "deletes_live_records": false,
+    "mutates_production_truth": false,
+    "reported_as": "demo-reset"
+  },
+  "before_records": [
+    {
+      "id": "unlabeled-note-001",
+      "mode": "unknown",
+      "type": "operator-note",
+      "labels": [],
+      "authority": "operator_context",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "status": "retained"
+    }
+  ],
+  "after_records": []
+}

--- a/docs/deployment/fixtures/demo-reset-mode-separation/valid-repeatable-demo-reset.json
+++ b/docs/deployment/fixtures/demo-reset-mode-separation/valid-repeatable-demo-reset.json
@@ -1,0 +1,118 @@
+{
+  "scenario": "valid-repeatable-demo-reset",
+  "operation": "demo-reset",
+  "reset_contract": {
+    "bundle": "phase-52-7-demo-seed",
+    "mode": "demo",
+    "selector": {
+      "bundle": "phase-52-7-demo-seed",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ]
+    },
+    "repeatable_by_stable_id": true,
+    "deletes_live_records": false,
+    "mutates_production_truth": false,
+    "reported_as": "demo-reset"
+  },
+  "before_records": [
+    {
+      "id": "demo-alert-001",
+      "mode": "demo",
+      "type": "demo-alert",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "reset_generation": 1,
+      "status": "demo-open"
+    },
+    {
+      "id": "demo-case-001",
+      "mode": "demo",
+      "type": "demo-case",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "linked_demo_alert_id": "demo-alert-001",
+      "reset_generation": 1,
+      "status": "demo-rehearsal"
+    },
+    {
+      "id": "live-case-001",
+      "mode": "live",
+      "type": "case",
+      "labels": [
+        "customer-bound",
+        "production-truth"
+      ],
+      "authority": "aegisops_control_plane",
+      "production_claim": true,
+      "truth_surfaces": [
+        "production"
+      ],
+      "status": "open",
+      "audit_marker": "live-case-marker"
+    }
+  ],
+  "after_records": [
+    {
+      "id": "demo-alert-001",
+      "mode": "demo",
+      "type": "demo-alert",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "reset_generation": 2,
+      "status": "demo-open"
+    },
+    {
+      "id": "demo-case-001",
+      "mode": "demo",
+      "type": "demo-case",
+      "labels": [
+        "demo-only",
+        "first-user-rehearsal",
+        "not-production-truth"
+      ],
+      "authority": "demo_rehearsal_only",
+      "production_claim": false,
+      "truth_surfaces": [],
+      "linked_demo_alert_id": "demo-alert-001",
+      "reset_generation": 2,
+      "status": "demo-rehearsal"
+    },
+    {
+      "id": "live-case-001",
+      "mode": "live",
+      "type": "case",
+      "labels": [
+        "customer-bound",
+        "production-truth"
+      ],
+      "authority": "aegisops_control_plane",
+      "production_claim": true,
+      "truth_surfaces": [
+        "production"
+      ],
+      "status": "open",
+      "audit_marker": "live-case-marker"
+    }
+  ]
+}

--- a/scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh
+++ b/scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-55-4-demo-reset-mode-separation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/fixtures/demo-reset-mode-separation"
+  printf '%s\n' \
+    "# AegisOps" \
+    "See [Phase 55.4 demo reset and mode separation contract](docs/deployment/demo-reset-mode-separation.md)." \
+    >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/demo-reset-mode-separation.md" \
+    "${target}/docs/deployment/demo-reset-mode-separation.md"
+  cp "${repo_root}/docs/deployment/fixtures/demo-reset-mode-separation/"*.json \
+    "${target}/docs/deployment/fixtures/demo-reset-mode-separation/"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/demo-reset-mode-separation.md"
+}
+
+set_fixture_json_value() {
+  local target="$1"
+  local fixture="$2"
+  local expression="$3"
+
+  python3 - "${target}/docs/deployment/fixtures/demo-reset-mode-separation/${fixture}" "${expression}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+expression = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+exec(expression, {"payload": payload})
+path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/demo-reset-mode-separation.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 55.4 demo reset and mode separation contract"
+
+missing_reset_row_repo="${workdir}/missing-reset-row"
+create_valid_repo "${missing_reset_row_repo}"
+remove_text_from_contract "${missing_reset_row_repo}" \
+  "| Live preservation | Reset must preserve live, production, audit, imported, customer-private, unlabeled, and non-demo workflow records byte-for-byte. | Any deleted live record, changed production-truth field, audit mutation, or customer-data cleanup fails. |"
+assert_fails_with \
+  "${missing_reset_row_repo}" \
+  "Missing complete Phase 55.4 reset boundary row: Live preservation"
+
+missing_mode_row_repo="${workdir}/missing-mode-row"
+create_valid_repo "${missing_mode_row_repo}"
+remove_text_from_contract "${missing_mode_row_repo}" \
+  "| Live | Authoritative workflow mode for AegisOps control-plane records, production truth, audit truth, and customer-bound records. | Demo reset cannot delete, mutate, relabel, close, reconcile, approve, or clean live records. |"
+assert_fails_with \
+  "${missing_mode_row_repo}" \
+  "Missing complete Phase 55.4 mode separation row: Live"
+
+missing_fixture_repo="${workdir}/missing-fixture"
+create_valid_repo "${missing_fixture_repo}"
+rm "${missing_fixture_repo}/docs/deployment/fixtures/demo-reset-mode-separation/delete-live-record.json"
+assert_fails_with \
+  "${missing_fixture_repo}" \
+  "Missing Phase 55.4 demo reset fixture: delete-live-record.json"
+
+valid_deletes_live_repo="${workdir}/valid-deletes-live"
+create_valid_repo "${valid_deletes_live_repo}"
+set_fixture_json_value \
+  "${valid_deletes_live_repo}" \
+  "valid-repeatable-demo-reset.json" \
+  "payload['after_records'] = [record for record in payload['after_records'] if record['id'] != 'live-case-001']"
+assert_fails_with \
+  "${valid_deletes_live_repo}" \
+  "Invalid Phase 55.4 demo reset fixture state for valid-repeatable-demo-reset.json: expected valid"
+
+valid_mutates_live_repo="${workdir}/valid-mutates-live"
+create_valid_repo "${valid_mutates_live_repo}"
+set_fixture_json_value \
+  "${valid_mutates_live_repo}" \
+  "valid-repeatable-demo-reset.json" \
+  "payload['after_records'][2]['status'] = 'closed-by-demo-reset'"
+assert_fails_with \
+  "${valid_mutates_live_repo}" \
+  "Invalid Phase 55.4 demo reset fixture state for valid-repeatable-demo-reset.json: expected valid"
+
+valid_non_repeatable_repo="${workdir}/valid-non-repeatable"
+create_valid_repo "${valid_non_repeatable_repo}"
+set_fixture_json_value \
+  "${valid_non_repeatable_repo}" \
+  "valid-repeatable-demo-reset.json" \
+  "payload['after_records'].append(dict(payload['after_records'][0], id='demo-case-duplicate'))"
+assert_fails_with \
+  "${valid_non_repeatable_repo}" \
+  "Invalid Phase 55.4 demo reset fixture state for valid-repeatable-demo-reset.json: expected valid"
+
+delete_live_false_pass_repo="${workdir}/delete-live-false-pass"
+create_valid_repo "${delete_live_false_pass_repo}"
+cp \
+  "${delete_live_false_pass_repo}/docs/deployment/fixtures/demo-reset-mode-separation/valid-repeatable-demo-reset.json" \
+  "${delete_live_false_pass_repo}/docs/deployment/fixtures/demo-reset-mode-separation/delete-live-record.json"
+assert_fails_with \
+  "${delete_live_false_pass_repo}" \
+  "Invalid Phase 55.4 demo reset fixture state for delete-live-record.json: expected rejection"
+
+mutate_production_false_pass_repo="${workdir}/mutate-production-false-pass"
+create_valid_repo "${mutate_production_false_pass_repo}"
+cp \
+  "${mutate_production_false_pass_repo}/docs/deployment/fixtures/demo-reset-mode-separation/valid-repeatable-demo-reset.json" \
+  "${mutate_production_false_pass_repo}/docs/deployment/fixtures/demo-reset-mode-separation/mutate-production-truth.json"
+assert_fails_with \
+  "${mutate_production_false_pass_repo}" \
+  "Invalid Phase 55.4 demo reset fixture state for mutate-production-truth.json: expected rejection"
+
+unlabeled_false_pass_repo="${workdir}/unlabeled-false-pass"
+create_valid_repo "${unlabeled_false_pass_repo}"
+cp \
+  "${unlabeled_false_pass_repo}/docs/deployment/fixtures/demo-reset-mode-separation/valid-repeatable-demo-reset.json" \
+  "${unlabeled_false_pass_repo}/docs/deployment/fixtures/demo-reset-mode-separation/unlabeled-record-reset.json"
+assert_fails_with \
+  "${unlabeled_false_pass_repo}" \
+  "Invalid Phase 55.4 demo reset fixture state for unlabeled-record-reset.json: expected rejection"
+
+backup_restore_false_pass_repo="${workdir}/backup-restore-false-pass"
+create_valid_repo "${backup_restore_false_pass_repo}"
+cp \
+  "${backup_restore_false_pass_repo}/docs/deployment/fixtures/demo-reset-mode-separation/valid-repeatable-demo-reset.json" \
+  "${backup_restore_false_pass_repo}/docs/deployment/fixtures/demo-reset-mode-separation/backup-restore-claim.json"
+assert_fails_with \
+  "${backup_restore_false_pass_repo}" \
+  "Invalid Phase 55.4 demo reset fixture state for backup-restore-claim.json: expected rejection"
+
+forbidden_claim_repo="${workdir}/forbidden-claim"
+create_valid_repo "${forbidden_claim_repo}"
+printf '%s\n' "Demo reset may delete live records." \
+  >>"${forbidden_claim_repo}/docs/deployment/demo-reset-mode-separation.md"
+assert_fails_with \
+  "${forbidden_claim_repo}" \
+  "Forbidden Phase 55.4 demo reset claim: Demo reset may delete live records"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for setup.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/demo-reset-mode-separation.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 55.4 demo reset contract: workstation-local absolute path detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 55.4 demo reset and mode separation contract."
+
+echo "Phase 55.4 demo reset and mode separation negative and valid checks passed."

--- a/scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh
+++ b/scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh
@@ -133,6 +133,26 @@ assert_fails_with \
   "${valid_mutates_live_repo}" \
   "Invalid Phase 55.4 demo reset fixture state for valid-repeatable-demo-reset.json: expected valid"
 
+valid_adds_live_repo="${workdir}/valid-adds-live"
+create_valid_repo "${valid_adds_live_repo}"
+set_fixture_json_value \
+  "${valid_adds_live_repo}" \
+  "valid-repeatable-demo-reset.json" \
+  "payload['after_records'].append(dict(payload['before_records'][2], id='live-case-added'))"
+assert_fails_with \
+  "${valid_adds_live_repo}" \
+  "Invalid Phase 55.4 demo reset fixture state for valid-repeatable-demo-reset.json: expected valid"
+
+valid_adds_unlabeled_repo="${workdir}/valid-adds-unlabeled"
+create_valid_repo "${valid_adds_unlabeled_repo}"
+set_fixture_json_value \
+  "${valid_adds_unlabeled_repo}" \
+  "valid-repeatable-demo-reset.json" \
+  "payload['after_records'].append({'id': 'unlabeled-case-added', 'mode': 'demo', 'authority': 'demo_rehearsal_only', 'labels': [], 'production_claim': False, 'truth_surfaces': []})"
+assert_fails_with \
+  "${valid_adds_unlabeled_repo}" \
+  "Invalid Phase 55.4 demo reset fixture state for valid-repeatable-demo-reset.json: expected valid"
+
 valid_non_repeatable_repo="${workdir}/valid-non-repeatable"
 create_valid_repo "${valid_non_repeatable_repo}"
 set_fixture_json_value \

--- a/scripts/verify-phase-55-4-demo-reset-mode-separation.sh
+++ b/scripts/verify-phase-55-4-demo-reset-mode-separation.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/deployment/demo-reset-mode-separation.md"
+readme_path="${repo_root}/README.md"
+fixtures_dir="${repo_root}/docs/deployment/fixtures/demo-reset-mode-separation"
+
+required_headings=(
+  "# Phase 55.4 Demo Reset and Mode Separation"
+  "## 1. Purpose"
+  "## 2. Demo Reset Contract"
+  "## 3. Mode Separation"
+  "## 4. Reset Safety Rules"
+  "## 5. Fixture Expectations"
+  "## 6. Validation Rules"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted as Phase 55.4 demo reset and mode separation contract"
+  "- **Date**: 2026-05-03"
+  "- **Related Issues**: #1175, #1178, #1179"
+  "This contract defines repeatable demo reset behavior and demo/live mode separation for the Phase 55 guided first-user journey only."
+  'Demo reset targets only records that are explicitly labeled with `demo-only`, `first-user-rehearsal`, and `not-production-truth` and bound to the reviewed demo fixture bundle.'
+  "Live records, production records, audit records, unlabeled records, imported customer records, and non-demo workflow truth must remain unchanged after every demo reset attempt."
+  "Demo mode is explicit rehearsal mode. Live mode is authoritative workflow mode."
+  "Reset output, UI state, browser state, logs, verifier output, issue-lint output, and demo labels cannot override authoritative AegisOps live records or production truth."
+  "Demo reset must be repeatable by stable demo identifiers and must not append duplicate authoritative records."
+  "A failed or rejected demo reset must leave durable live and non-demo state unchanged."
+  "Reset reported as backup/restore supportability must fail because this slice does not implement backup, restore, support bundle, or production cleanup behavior."
+  'Run `bash scripts/verify-phase-55-4-demo-reset-mode-separation.sh`.'
+  'Run `bash scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh`.'
+  'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1179 --config <supervisor-config-path>`.'
+)
+
+fixture_expectations=(
+  "valid-repeatable-demo-reset.json|valid|"
+  "delete-live-record.json|invalid|demo reset deletes live records"
+  "mutate-production-truth.json|invalid|demo reset mutates production truth"
+  "unlabeled-record-reset.json|invalid|demo reset targets unlabeled records"
+  "backup-restore-claim.json|invalid|reset reported as backup/restore supportability"
+)
+
+forbidden_claims=(
+  "Demo reset may delete live records"
+  "Demo reset may mutate production truth"
+  "Unlabeled records may be reset"
+  "Demo reset is backup restore supportability"
+  "Demo reset is production cleanup"
+  "Demo mode is live mode"
+  "Live records are demo records"
+  "Demo labels override production truth"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 55.4 demo reset and mode separation contract: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_rendered_markdown="$(rendered_markdown_without_code_blocks "${doc_path}")"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 55.4 demo reset heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_rendered_markdown}"; then
+    echo "Missing Phase 55.4 demo reset statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for boundary in "Selector scope" "Repeatability" "Live preservation" "Failure cleanup"; do
+  if ! grep -Eq "^\| ${boundary} \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 55.4 reset boundary row: ${boundary}" >&2
+    exit 1
+  fi
+done
+
+for mode in "Demo" "Live"; do
+  if ! grep -Eq "^\| ${mode} \| [^|[:space:]][^|]* \| [^|[:space:]][^|]* \|$" <<<"${doc_rendered_markdown}"; then
+    echo "Missing complete Phase 55.4 mode separation row: ${mode}" >&2
+    exit 1
+  fi
+done
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${doc_path}"
+}
+
+for claim in "${forbidden_claims[@]}"; do
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 55.4 demo reset claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+path_token_boundary="(^|[[:space:]'\"\`(<{=])"
+path_token_chars="[^[:space:]'\"\` )>}|]"
+home_absolute_path="/(Users|home)/${path_token_chars}+"
+windows_user_path="[A-Za-z]:[\\\\/]Users[\\\\/]${path_token_chars}*"
+local_path_token="(${home_absolute_path}|${windows_user_path})"
+
+if grep -REq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" "${doc_path}" "${fixtures_dir}" 2>/dev/null; then
+  echo "Forbidden Phase 55.4 demo reset contract: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+python3 - "${fixtures_dir}" "${fixture_expectations[@]}" <<'PY'
+import json
+import pathlib
+import sys
+
+fixtures_dir = pathlib.Path(sys.argv[1])
+expectations = [item.split("|", 2) for item in sys.argv[2:]]
+required_labels = {"demo-only", "first-user-rehearsal", "not-production-truth"}
+
+if not fixtures_dir.is_dir():
+    print(f"Missing Phase 55.4 demo reset fixtures directory: {fixtures_dir}", file=sys.stderr)
+    sys.exit(1)
+
+
+def record_key(record):
+    return record.get("id")
+
+
+def indexed(records):
+    return {
+        record_key(record): record
+        for record in records
+        if isinstance(record, dict) and isinstance(record_key(record), str)
+    }
+
+
+def is_demo_record(record):
+    labels = set(record.get("labels") or [])
+    return (
+        record.get("mode") == "demo"
+        and record.get("authority") == "demo_rehearsal_only"
+        and required_labels.issubset(labels)
+        and record.get("production_claim") is False
+        and record.get("truth_surfaces") == []
+    )
+
+
+def is_live_record(record):
+    return record.get("mode") == "live" or record.get("authority") == "aegisops_control_plane"
+
+
+def rejection_reasons(payload):
+    reasons = []
+    reset = payload.get("reset_contract") or {}
+    selector = reset.get("selector")
+    selector_labels = set()
+    if isinstance(selector, dict) and isinstance(selector.get("labels"), list):
+        selector_labels = set(selector.get("labels") or [])
+
+    if payload.get("operation") != "demo-reset" or reset.get("mode") != "demo":
+        reasons.append("demo reset targets unlabeled records")
+    if reset.get("reported_as") in {"backup-restore", "backup_restore", "supportability", "backup-restore-supportability"}:
+        reasons.append("reset reported as backup/restore supportability")
+    if (
+        not isinstance(selector, dict)
+        or selector.get("bundle") != "phase-52-7-demo-seed"
+        or not required_labels.issubset(selector_labels)
+    ):
+        reasons.append("demo reset targets unlabeled records")
+    if reset.get("repeatable_by_stable_id") is not True:
+        reasons.append("non-repeatable demo reset")
+    if reset.get("deletes_live_records") is not False:
+        reasons.append("demo reset deletes live records")
+    if reset.get("mutates_production_truth") is not False:
+        reasons.append("demo reset mutates production truth")
+
+    before = payload.get("before_records")
+    after = payload.get("after_records")
+    if not isinstance(before, list) or not isinstance(after, list):
+        reasons.append("missing reset record snapshot")
+        return reasons
+
+    before_by_id = indexed(before)
+    after_by_id = indexed(after)
+    if len(before_by_id) != len(before) or len(after_by_id) != len(after):
+        reasons.append("non-repeatable demo reset")
+
+    demo_before_ids = {
+        record["id"]
+        for record in before
+        if isinstance(record, dict) and isinstance(record.get("id"), str) and is_demo_record(record)
+    }
+    demo_after_ids = {
+        record["id"]
+        for record in after
+        if isinstance(record, dict) and isinstance(record.get("id"), str) and is_demo_record(record)
+    }
+    if demo_before_ids != demo_after_ids:
+        reasons.append("non-repeatable demo reset")
+
+    for record in before:
+        if not isinstance(record, dict) or not isinstance(record.get("id"), str):
+            continue
+        after_record = after_by_id.get(record["id"])
+        if is_live_record(record):
+            if after_record is None:
+                reasons.append("demo reset deletes live records")
+            elif after_record != record:
+                reasons.append("demo reset mutates production truth")
+        elif not is_demo_record(record):
+            if after_record != record:
+                reasons.append("demo reset targets unlabeled records")
+
+    for record in after:
+        if not isinstance(record, dict):
+            continue
+        if is_live_record(record) and record.get("production_claim") is not True:
+            reasons.append("demo reset mutates production truth")
+        if record.get("reset_reported_as") in {"backup-restore", "backup_restore", "supportability", "backup-restore-supportability"}:
+            reasons.append("reset reported as backup/restore supportability")
+
+    return reasons
+
+
+for fixture, expected_validity, required_rejection in expectations:
+    path = fixtures_dir / fixture
+    if not path.is_file():
+        print(f"Missing Phase 55.4 demo reset fixture: {fixture}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"Invalid Phase 55.4 demo reset fixture JSON for {fixture}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    reasons = rejection_reasons(payload)
+    if expected_validity == "valid" and reasons:
+        print(
+            f"Invalid Phase 55.4 demo reset fixture state for {fixture}: expected valid, got {sorted(set(reasons))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if expected_validity == "invalid":
+        if not reasons:
+            print(f"Invalid Phase 55.4 demo reset fixture state for {fixture}: expected rejection", file=sys.stderr)
+            sys.exit(1)
+        if required_rejection not in reasons:
+            print(
+                f"Invalid Phase 55.4 demo reset fixture state for {fixture}: expected {required_rejection}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+PY
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 55.4 demo reset link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  rendered_markdown_without_code_blocks "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/demo-reset-mode-separation\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 55.4 demo reset and mode separation contract." >&2
+  exit 1
+fi
+
+echo "Phase 55.4 demo reset and mode separation contract verified."

--- a/scripts/verify-phase-55-4-demo-reset-mode-separation.sh
+++ b/scripts/verify-phase-55-4-demo-reset-mode-separation.sh
@@ -241,7 +241,13 @@ def rejection_reasons(payload):
                 reasons.append("demo reset targets unlabeled records")
 
     for record in after:
-        if not isinstance(record, dict):
+        if not isinstance(record, dict) or not isinstance(record.get("id"), str):
+            continue
+        if record["id"] not in before_by_id:
+            if is_live_record(record):
+                reasons.append("demo reset mutates production truth")
+            elif not is_demo_record(record):
+                reasons.append("demo reset targets unlabeled records")
             continue
         if is_live_record(record) and record.get("production_claim") is not True:
             reasons.append("demo reset mutates production truth")


### PR DESCRIPTION
## Summary
- Add Phase 55.4 demo reset and mode separation contract.
- Add reset fixtures for valid repeatable reset plus live deletion, production mutation, unlabeled reset, and backup/restore overclaim rejection.
- Add focused verifier and negative harness, and link the contract from README.

## Verification
- `bash scripts/verify-phase-55-4-demo-reset-mode-separation.sh`
- `bash scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh`
- `bash scripts/verify-phase-52-7-demo-seed-contract.sh`
- `bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`
- `bash scripts/verify-phase-55-1-first-user-journey-docs.sh`
- `bash scripts/test-verify-phase-55-1-first-user-journey-docs.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1179 --config <supervisor-config-path>`

Closes #1179


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 55.4 “demo reset and mode separation” contract to the product documentation and index, describing demo scope, repeatability, preservation of live records, failure cleanup, authority posture, forbidden claims, and non-goals.

* **Tests**
  * Added verification scripts and a suite of fixtures to validate demo-reset behaviors and enforce mode-separation rules across positive and negative scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->