### PR TITLE
Phase 55.5 failure-state checklist copy

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx
@@ -196,5 +196,133 @@ export function registerOperatorRoutesFirstLoginChecklistTests() {
       });
       expect(screen.queryByText("State: completed")).not.toBeInTheDocument();
     });
+
+    it("renders bounded empty-state and failure-state copy without promoting UI state to workflow truth", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-first-login-checklist": {
+            records: [
+              {
+                step_key: "stack_health",
+                state: "blocked",
+                failure_state_key: "port_conflict",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "runtime_readiness",
+                authority_record_id: "ready-blocked",
+              },
+              {
+                step_key: "seeded_queue",
+                state: "unavailable",
+                failure_state_key: "missing_seed_data",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "queue",
+                authority_record_id: "queue-empty",
+              },
+              {
+                step_key: "sample_wazuh_alert",
+                state: "blocked",
+                failure_state_key: "missing_wazuh",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "alert",
+                authority_record_id: "alert-missing-wazuh",
+              },
+              {
+                step_key: "promote_to_case",
+                state: "blocked",
+                failure_state_key: "missing_idp",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "case",
+                authority_record_id: "case-idp-blocked",
+              },
+              {
+                step_key: "evidence",
+                state: "blocked",
+                failure_state_key: "missing_secrets",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "evidence",
+                authority_record_id: "evidence-secret-blocked",
+              },
+              {
+                step_key: "approval_decision",
+                state: "blocked",
+                failure_state_key: "protected_surface_denial",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "action_review",
+                authority_record_id: "review-denied",
+              },
+              {
+                step_key: "shuffle_receipt",
+                state: "blocked",
+                failure_state_key: "missing_shuffle",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "execution_receipt",
+                authority_record_id: "receipt-missing-shuffle",
+              },
+            ],
+            total_records: 7,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/first-login-checklist", dependencies);
+
+      const expectedCopies = [
+        "A required port is already in use. Free the conflicting service or select a reviewed profile override, then rerun startup checks.",
+        "Demo seed data is empty. Run the reviewed demo seed path and refresh only after AegisOps records are admitted.",
+        "Wazuh signal intake is unavailable. Confirm the reviewed Wazuh profile and intake binding, then rerun the readiness check.",
+        "Identity provider configuration is missing. Configure the reviewed IdP issuer, client, and redirect binding before enabling protected workflows.",
+        "Required secret references are missing. Mount the reviewed secret files or OpenBao bindings and restart the affected service; placeholder values stay blocked.",
+        "Protected surface access was denied. Sign in with an authorized operator role or ask an administrator to review RBAC; denial remains correct until backend auth changes.",
+        "Shuffle delegated execution is unavailable. Confirm the reviewed Shuffle profile and template import contract, then retry after backend records report readiness.",
+      ];
+
+      for (const copy of expectedCopies) {
+        await waitFor(() => {
+          expect(screen.getByText(copy)).toBeInTheDocument();
+        });
+      }
+
+      expect(
+        screen.getAllByText(
+          "This copy is operator guidance only and cannot approve, repair, reconcile, close, release, gate, or mutate authoritative AegisOps records.",
+        ),
+      ).toHaveLength(expectedCopies.length);
+
+      const pageText = document.body.textContent ?? "";
+      expect(pageText).not.toMatch(/automatic repair/i);
+      expect(pageText).not.toMatch(/UI copy is workflow truth/i);
+      expect(pageText).not.toMatch(/Phase 58 supportability is complete/i);
+    });
+
+    it("fails closed when missing Wazuh is presented as successful completion", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-first-login-checklist": {
+            records: [
+              {
+                step_key: "sample_wazuh_alert",
+                state: "completed",
+                failure_state_key: "missing_wazuh",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "alert",
+                authority_record_id: "alert-missing-wazuh",
+              },
+            ],
+            total_records: 1,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/first-login-checklist", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Checklist step sample_wazuh_alert cannot present failure state missing_wazuh as successful completion.",
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText("State: completed")).not.toBeInTheDocument();
+    });
   });
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx
@@ -324,5 +324,36 @@ export function registerOperatorRoutesFirstLoginChecklistTests() {
       });
       expect(screen.queryByText("State: completed")).not.toBeInTheDocument();
     });
+
+    it("fails closed when the failure-state key is inherited from the copy map prototype", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-first-login-checklist": {
+            records: [
+              {
+                step_key: "stack_health",
+                state: "blocked",
+                failure_state_key: "__proto__",
+                authority_source: "backend_authoritative_record",
+                authority_record_family: "runtime_readiness",
+                authority_record_id: "ready-blocked",
+              },
+            ],
+            total_records: 1,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/first-login-checklist", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "First-login checklist failure state __proto__ is not part of the reviewed contract.",
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText("State: blocked")).not.toBeInTheDocument();
+    });
   });
 }

--- a/apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx
@@ -24,6 +24,15 @@ type ChecklistState =
   | "blocked"
   | "unavailable";
 
+type FailureStateKey =
+  | "missing_wazuh"
+  | "missing_shuffle"
+  | "missing_secrets"
+  | "port_conflict"
+  | "missing_idp"
+  | "missing_seed_data"
+  | "protected_surface_denial";
+
 interface ChecklistStepContract {
   key: string;
   title: string;
@@ -34,10 +43,13 @@ interface ChecklistStepContract {
 interface ChecklistStepView extends ChecklistStepContract {
   authorityRecordFamily: string;
   authorityRecordId: string;
+  failureStateKey: FailureStateKey | null;
   state: ChecklistState;
 }
 
 const TRUSTED_AUTHORITY_SOURCE = "backend_authoritative_record";
+const FAILURE_COPY_AUTHORITY_NOTICE =
+  "This copy is operator guidance only and cannot approve, repair, reconcile, close, release, gate, or mutate authoritative AegisOps records.";
 
 const CHECKLIST_STEPS: ChecklistStepContract[] = [
   {
@@ -116,6 +128,23 @@ const ALLOWED_STATES = new Set<ChecklistState>([
   "unavailable",
 ]);
 
+const FAILURE_STATE_COPY: Record<FailureStateKey, string> = {
+  missing_wazuh:
+    "Wazuh signal intake is unavailable. Confirm the reviewed Wazuh profile and intake binding, then rerun the readiness check.",
+  missing_shuffle:
+    "Shuffle delegated execution is unavailable. Confirm the reviewed Shuffle profile and template import contract, then retry after backend records report readiness.",
+  missing_secrets:
+    "Required secret references are missing. Mount the reviewed secret files or OpenBao bindings and restart the affected service; placeholder values stay blocked.",
+  port_conflict:
+    "A required port is already in use. Free the conflicting service or select a reviewed profile override, then rerun startup checks.",
+  missing_idp:
+    "Identity provider configuration is missing. Configure the reviewed IdP issuer, client, and redirect binding before enabling protected workflows.",
+  missing_seed_data:
+    "Demo seed data is empty. Run the reviewed demo seed path and refresh only after AegisOps records are admitted.",
+  protected_surface_denial:
+    "Protected surface access was denied. Sign in with an authorized operator role or ask an administrator to review RBAC; denial remains correct until backend auth changes.",
+};
+
 function checklistStateIcon(state: ChecklistState) {
   switch (state) {
     case "completed":
@@ -158,6 +187,20 @@ function readChecklistState(record: UnknownRecord): ChecklistState {
   return state as ChecklistState;
 }
 
+function readFailureStateKey(record: UnknownRecord): FailureStateKey | null {
+  const failureStateKey = asString(record.failure_state_key);
+  if (failureStateKey === null) {
+    return null;
+  }
+  if (!(failureStateKey in FAILURE_STATE_COPY)) {
+    throw new OperatorDataProviderContractError(
+      `First-login checklist failure state ${failureStateKey} is not part of the reviewed contract.`,
+    );
+  }
+
+  return failureStateKey as FailureStateKey;
+}
+
 function buildChecklistRows(records: UnknownRecord[]): ChecklistStepView[] {
   const contractByKey = new Map(CHECKLIST_STEPS.map((step) => [step.key, step]));
   const recordsByKey = new Map<string, UnknownRecord>();
@@ -186,6 +229,7 @@ function buildChecklistRows(records: UnknownRecord[]): ChecklistStepView[] {
         ...step,
         authorityRecordFamily: step.expectedRecordFamily,
         authorityRecordId: "Not available",
+        failureStateKey: null,
         state: "unavailable",
       };
     }
@@ -210,11 +254,20 @@ function buildChecklistRows(records: UnknownRecord[]): ChecklistStepView[] {
       );
     }
 
+    const state = readChecklistState(record);
+    const failureStateKey = readFailureStateKey(record);
+    if (failureStateKey !== null && state === "completed") {
+      throw new OperatorDataProviderContractError(
+        `Checklist step ${step.key} cannot present failure state ${failureStateKey} as successful completion.`,
+      );
+    }
+
     return {
       ...step,
       authorityRecordFamily,
       authorityRecordId,
-      state: readChecklistState(record),
+      failureStateKey,
+      state,
     };
   });
 }
@@ -325,6 +378,23 @@ export function FirstLoginChecklistPage() {
                     Authority record: {formatLabel(step.authorityRecordFamily)}{" "}
                     {step.authorityRecordId}
                   </Typography>
+                  {step.failureStateKey ? (
+                    <Alert
+                      severity={
+                        step.state === "blocked" ? "warning" : "info"
+                      }
+                      variant="outlined"
+                    >
+                      <Stack spacing={0.5}>
+                        <Typography variant="body2">
+                          {FAILURE_STATE_COPY[step.failureStateKey]}
+                        </Typography>
+                        <Typography color="text.secondary" variant="caption">
+                          {FAILURE_COPY_AUTHORITY_NOTICE}
+                        </Typography>
+                      </Stack>
+                    </Alert>
+                  ) : null}
                 </Stack>
               ))}
             </Stack>

--- a/apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx
@@ -192,7 +192,12 @@ function readFailureStateKey(record: UnknownRecord): FailureStateKey | null {
   if (failureStateKey === null) {
     return null;
   }
-  if (!(failureStateKey in FAILURE_STATE_COPY)) {
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      FAILURE_STATE_COPY,
+      failureStateKey,
+    )
+  ) {
     throw new OperatorDataProviderContractError(
       `First-login checklist failure state ${failureStateKey} is not part of the reviewed contract.`,
     );


### PR DESCRIPTION
## Summary
- Add reviewed first-login checklist failure-state copy for missing Wazuh, Shuffle, secrets, ports, IdP, seed data, and protected surface denial.
- Keep copy subordinate to backend-authoritative checklist records and fail closed when a failure marker is presented as completed.
- Add UI regression coverage for bounded copy and negative completion handling.

## Verification
- npm test -- --run src/app/OperatorRoutes.test.tsx -t "bounded empty-state"
- npm test -- --run src/app/OperatorRoutes.test.tsx -t "first-login checklist route"
- npm run typecheck
- npm test -- --run
- node <codex-supervisor-root>/dist/index.js issue-lint 1180 --config <supervisor-config-path>

Closes #1180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-login checklist now displays failure-state guidance per step, including an informational warning and an authority-only notice when a step is blocked.

* **Tests**
  * Added tests covering failure-state rendering, blocked/unavailable step behavior, absence of misleading automated/completed UI text, and fail-closed handling for unexpected keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->