### PR TITLE
Phase 55.7 closeout evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Canonical cross-phase boundary reference:
 - [Phase 55.1 first 30 minutes](docs/getting-started/first-30-minutes.md) defines the first-session operator path without deep architecture dumping or production-readiness claims.
 - [Phase 55.4 demo reset and mode separation contract](docs/deployment/demo-reset-mode-separation.md) defines repeatable demo reset, demo/live mode separation, live-record preservation, and backup/restore overclaim rejection.
 - [Phase 55.6 first-user demo report export skeleton](docs/getting-started/first-user-demo-report-export.md) defines demo-labeled report export output, direct demo journey references, secret hygiene, and commercial-reporting scope guardrails for the guided first-user journey.
+- [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md) records the guided first-user journey outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 56/57/58/60/66 handoff.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
@@ -123,6 +124,8 @@ The Phase 54.10 closeout evaluation is defined by the [Phase 54.10 closeout eval
 The Phase 55.4 demo reset and mode separation contract is defined by the [Phase 55.4 demo reset and mode separation contract](docs/deployment/demo-reset-mode-separation.md).
 
 The Phase 55.6 first-user demo report export skeleton is defined by the [Phase 55.6 first-user demo report export skeleton](docs/getting-started/first-user-demo-report-export.md).
+
+The Phase 55.7 closeout evaluation is defined by the [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-55-closeout-evaluation.md
+++ b/docs/phase-55-closeout-evaluation.md
@@ -1,0 +1,137 @@
+# Phase 55 Closeout Evaluation
+
+- **Status**: Accepted as guided first-user journey evidence and handoff baseline; Phase 56, Phase 57, Phase 58, Phase 60, and Phase 66 can consume the bounded Phase 55 first-user journey with explicit retained blockers.
+- **Date**: 2026-05-03
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1175, #1176, #1177, #1178, #1179, #1180, #1181, #1182
+
+## Verdict
+
+Phase 55 is accepted as the guided first-user journey evidence baseline for the `smb-single-node` profile. The accepted journey consists of workflow-first first-user docs, first-30-minutes guidance, backend-authoritative first-login checklist UI contract, demo seed family bundle, demo reset and mode separation contract, empty-state and failure-state copy, and first-user demo report export skeleton.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+First-user docs, checklist state, demo seed records, demo reset output, demo report export output, empty-state copy, failure-state copy, browser state, UI cache, Wazuh state, Shuffle state, AI output, tickets, verifier output, and issue-lint output remain subordinate context.
+
+Demo records and demo report exports are rehearsal evidence only. Demo labels, fixture provenance, reset output, and generated report files cannot become production truth, approval truth, execution truth, reconciliation truth, audit truth, gate truth, release truth, or closeout truth.
+
+This closeout does not claim Phase 56 daily SOC workbench is complete, Phase 57 packaging is complete, Phase 58 supportability is complete, Phase 60 audit or reporting breadth is complete, Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1175 | Epic: Phase 55 Guided First-User Journey | Open until #1182 lands; accepted when this closeout, focused verifier, Phase 55 verifiers, focused first-user/UI/demo tests, path hygiene, and issue-lint pass. |
+| #1176 | Phase 55.1 first-user journey and first-30-minutes docs | Closed. `docs/getting-started/first-user-journey.md` and `docs/getting-started/first-30-minutes.md` define the workflow-first path from stack health to report export without deep architecture dumping or production-readiness claims. |
+| #1177 | Phase 55.2 first-login checklist UI contract | Closed. `apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx` and `apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx` render checklist progress only from backend authoritative records and fail closed on browser-cache or wrong-family state. |
+| #1178 | Phase 55.3 demo seed record family bundle | Closed. `docs/deployment/demo-seed-contract.md` and `docs/deployment/fixtures/demo-seed/valid-demo-seed.json` define directly linked demo Wazuh alert, analytic signal, AegisOps alert, case, evidence, recommendation, action review, execution receipt, and reconciliation records. |
+| #1179 | Phase 55.4 demo reset and mode separation | Closed. `docs/deployment/demo-reset-mode-separation.md` and reset fixtures define repeatable demo reset by stable identifiers, demo/live mode separation, live-record preservation, and backup/restore overclaim rejection. |
+| #1180 | Phase 55.5 empty-state and failure-state copy | Closed. The first-login checklist UI displays bounded missing Wazuh, missing Shuffle, missing secrets, port conflict, missing IdP, missing seed data, and protected-surface denial copy while preserving backend authority. |
+| #1181 | Phase 55.6 first-user report export skeleton | Closed. `docs/getting-started/first-user-demo-report-export.md` and report export fixtures define demo-labeled report output, direct demo journey references, secret hygiene, and commercial-reporting guardrails. |
+| #1182 | Phase 55.7 Phase 55 closeout evaluation | Open until this document and focused closeout verifier land. |
+
+## First-User Journey Behavior Before And After
+
+| Surface | Before Phase 55 | After Phase 55 |
+| --- | --- | --- |
+| First-user docs | Phase 52 first-user stack docs described the few-command setup path but did not provide a workflow-first guided journey. | Phase 55.1 documents the first-user flow from stack health, seeded queue, sample Wazuh alert, case, evidence, AI summary, action review, receipt, reconciliation, and report export. |
+| First 30 minutes | New users had setup contracts and closeout evidence but no bounded first-session path. | Phase 55.1 first-30-minutes guidance keeps operators focused on the record chain and explicitly avoids production-readiness claims. |
+| First-login checklist | Operator UI did not have the Phase 55 checklist surface. | Phase 55.2 renders the checklist from backend authoritative records only and rejects browser cache, wrong record family, duplicate, missing, unsupported, or malformed checklist state. |
+| Demo seed bundle | Phase 52.7 described demo seed expectations without the Phase 55 linked family bundle. | Phase 55.3 adds a linked demo family spanning Wazuh alert, analytic signal, AegisOps alert, case, evidence, recommendation, action review, execution receipt, and reconciliation. |
+| Demo reset | Demo reset behavior was not bounded for repeatable first-user rehearsal. | Phase 55.4 requires demo-only selectors, stable identifiers, live-record preservation, and fail-closed rejection of production cleanup or backup/restore claims. |
+| Failure states | Checklist failure copy was not enumerated for common first-user blockers. | Phase 55.5 adds bounded copy for missing Wazuh, missing Shuffle, missing secrets, port conflict, missing IdP, missing seed data, and protected-surface denial without authorizing repair or supportability completion. |
+| Demo report export | The first-user journey lacked a bounded report export skeleton. | Phase 55.6 defines demo-labeled report export output with direct demo record references, unavailable follow-up handling, secret hygiene, and commercial-reporting guardrails. |
+| Authority boundary | Phase 51.6, Phase 52, Phase 53, and Phase 54 supplied the prior boundary. | Phase 55 preserves control-plane authority and proves first-user docs, UI state, demo records, reset output, failure copy, and report export remain subordinate. |
+
+## Changed Files
+
+Phase 55 materially added or tightened these repo-owned surfaces:
+
+- `docs/getting-started/first-user-journey.md`
+- `docs/getting-started/first-30-minutes.md`
+- `apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.test.tsx`
+- `apps/operator-ui/src/app/OperatorShell.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages.tsx`
+- `apps/operator-ui/src/operatorDataProvider/resourceBindings.ts`
+- `apps/operator-ui/src/operatorDataProvider/types.ts`
+- `docs/deployment/demo-seed-contract.md`
+- `docs/deployment/fixtures/demo-seed/valid-demo-seed.json`
+- `docs/deployment/demo-reset-mode-separation.md`
+- `docs/deployment/fixtures/demo-reset-mode-separation/valid-repeatable-demo-reset.json`
+- `docs/deployment/fixtures/demo-reset-mode-separation/delete-live-record.json`
+- `docs/deployment/fixtures/demo-reset-mode-separation/mutate-production-truth.json`
+- `docs/deployment/fixtures/demo-reset-mode-separation/unlabeled-record-reset.json`
+- `docs/deployment/fixtures/demo-reset-mode-separation/backup-restore-claim.json`
+- `docs/getting-started/first-user-demo-report-export.md`
+- `docs/getting-started/fixtures/first-user-demo-report-export/valid-demo-report-export.json`
+- `docs/getting-started/fixtures/first-user-demo-report-export/unavailable-follow-up-reference.json`
+- `scripts/verify-phase-55-1-first-user-journey-docs.sh`
+- `scripts/test-verify-phase-55-1-first-user-journey-docs.sh`
+- `scripts/verify-phase-55-4-demo-reset-mode-separation.sh`
+- `scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh`
+- `scripts/verify-phase-55-6-first-user-report-export-skeleton.sh`
+- `scripts/test-verify-phase-55-6-first-user-report-export-skeleton.sh`
+- `docs/phase-55-closeout-evaluation.md`
+- `scripts/verify-phase-55-7-closeout-evaluation.sh`
+- `scripts/test-verify-phase-55-7-closeout-evaluation.sh`
+
+## Verifier Evidence
+
+Focused Phase 55 verifiers passed or must pass before this closeout is accepted:
+
+- `bash scripts/verify-phase-55-1-first-user-journey-docs.sh`
+- `bash scripts/test-verify-phase-55-1-first-user-journey-docs.sh`
+- `npm run test --workspace @aegisops/operator-ui -- OperatorRoutes`
+- `bash scripts/verify-phase-52-7-demo-seed-contract.sh`
+- `bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`
+- `bash scripts/verify-phase-55-4-demo-reset-mode-separation.sh`
+- `bash scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh`
+- `bash scripts/verify-phase-55-6-first-user-report-export-skeleton.sh`
+- `bash scripts/test-verify-phase-55-6-first-user-report-export-skeleton.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `bash scripts/verify-phase-55-7-closeout-evaluation.sh`
+- `bash scripts/test-verify-phase-55-7-closeout-evaluation.sh`
+
+Focused UI and failure-state evidence:
+
+- `npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.firstLoginChecklist`
+
+Issue-lint evidence for #1175 through #1182:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1175 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1176 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1177 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1178 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1179 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1180 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1181 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1182 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+
+## Accepted Limitations
+
+- Phase 55 does not implement Phase 56 daily SOC workbench breadth, queue optimization, production daily operations completeness, or analyst productivity breadth.
+- Phase 55 does not implement Phase 57 packaging, installer completeness, release packaging, or customer-ready distribution.
+- Phase 55 does not implement Phase 58 supportability, break-glass support workflows, backup/restore support operations, support bundles, support diagnostics, or customer support operations.
+- Phase 55 does not implement Phase 60 audit export administration, commercial reporting breadth, executive reporting completeness, or compliance reporting completeness.
+- Phase 55 does not implement Phase 62 SOAR breadth, broad workflow catalog coverage, marketplace work, or every action-family expectation.
+- Phase 55 does not implement Phase 66 RC proof, RC readiness, GA readiness, Beta readiness, or self-service commercial readiness.
+- Phase 55 does not implement production data import, production reset, production report templates, support bundles, customer evidence packets, or audit export completeness.
+- Phase 55 does not make demo records, demo labels, fixture provenance, reset output, generated report files, checklist UI state, browser state, UI cache, failure copy, Wazuh state, Shuffle state, AI output, ticket state, verifier output, issue-lint output, or operator-facing summaries authoritative AegisOps truth.
+
+## Phase 56, Phase 57, Phase 58, Phase 60, And Phase 66 Handoff
+
+Phase 56 can consume the Phase 55 first-user journey as the bounded workflow sequence for daily SOC workbench design. Phase 56 must still implement daily queue ergonomics, triage breadth, operational filters, repeated analyst workflows, and production daily-operation behavior. Phase 55 does not complete Phase 56 daily SOC workbench.
+
+Phase 57 can consume the Phase 55 first-user journey as one package-entry acceptance fixture. Phase 57 must still implement packaging, installation, upgrade, distribution, and release-bundle behavior explicitly. Phase 55 does not complete Phase 57 packaging.
+
+Phase 58 can consume the Phase 55 failure-state copy and reset/report boundaries as supportability inputs. Phase 58 must still implement support playbooks, customer-safe diagnostics, backup/restore rehearsals, break-glass support flows, support bundles, and escalation evidence. Phase 55 does not complete Phase 58 supportability.
+
+Phase 60 can consume the Phase 55 demo report export skeleton as a demo-only export shape. Phase 60 must still implement audit export administration, commercial reporting breadth, executive reporting, compliance reporting, custody, retention, and production report templates. Phase 55 does not complete Phase 60 audit or reporting breadth.
+
+Phase 66 can consume the Phase 55 first-user journey as one prerequisite evidence packet for RC proof. Phase 66 must still prove RC gate criteria, production-readiness evidence, upgrade/rollback posture, supportability, security review, packaging, and end-to-end first-user behavior under the approved RC gate. Phase 55 does not complete Phase 66 RC proof.
+
+## Closeout Boundary
+
+This closeout is release and planning evidence only. It does not choose a new runtime configuration, create new first-user implementation work, expand daily SOC workbench scope, add supportability behavior, approve SOAR breadth, approve commercial reporting breadth, change authority custody, or claim Beta, RC, GA, or commercial replacement readiness.

--- a/scripts/test-verify-phase-55-7-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-55-7-closeout-evaluation.sh
@@ -61,13 +61,21 @@ assert_fails_with \
   "${missing_doc_repo}" \
   "Missing Phase 55 closeout evaluation: docs/phase-55-closeout-evaluation.md"
 
-missing_readme_link_repo="${workdir}/missing-readme-link"
-copy_valid_repo "${missing_readme_link_repo}"
-perl -0pi -e 's/\[Phase 55\.7 closeout evaluation\]\(docs\/phase-55-closeout-evaluation\.md\)/Phase 55.7 closeout evaluation/g' \
-  "${missing_readme_link_repo}/README.md"
+missing_readme_canonical_bullet_repo="${workdir}/missing-readme-canonical-bullet"
+copy_valid_repo "${missing_readme_canonical_bullet_repo}"
+perl -0pi -e 's/- \[Phase 55\.7 closeout evaluation\]\(docs\/phase-55-closeout-evaluation\.md\)( records the guided first-user journey outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 56\/57\/58\/60\/66 handoff\.)/- Phase 55.7 closeout evaluation$1/' \
+  "${missing_readme_canonical_bullet_repo}/README.md"
 assert_fails_with \
-  "${missing_readme_link_repo}" \
-  "Missing README Phase 55.7 closeout link: [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md)"
+  "${missing_readme_canonical_bullet_repo}" \
+  "Missing README canonical cross-phase boundary bullet: - [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md)"
+
+missing_readme_product_positioning_repo="${workdir}/missing-readme-product-positioning"
+copy_valid_repo "${missing_readme_product_positioning_repo}"
+perl -0pi -e 's/The Phase 55\.7 closeout evaluation is defined by the \[Phase 55\.7 closeout evaluation\]\(docs\/phase-55-closeout-evaluation\.md\)\./The Phase 55.7 closeout evaluation is defined by the Phase 55.7 closeout evaluation./' \
+  "${missing_readme_product_positioning_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_product_positioning_repo}" \
+  "Missing README Product positioning reference: The Phase 55.7 closeout evaluation is defined by the [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md)."
 
 missing_authority_repo="${workdir}/missing-authority"
 copy_valid_repo "${missing_authority_repo}"

--- a/scripts/test-verify-phase-55-7-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-55-7-closeout-evaluation.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-55-7-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-55-closeout-evaluation.md" "${target}/docs/phase-55-closeout-evaluation.md"
+  cp "${repo_root}/README.md" "${target}/README.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+cp "${repo_root}/README.md" "${missing_doc_repo}/README.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 55 closeout evaluation: docs/phase-55-closeout-evaluation.md"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+copy_valid_repo "${missing_readme_link_repo}"
+perl -0pi -e 's/\[Phase 55\.7 closeout evaluation\]\(docs\/phase-55-closeout-evaluation\.md\)/Phase 55.7 closeout evaluation/g' \
+  "${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "Missing README Phase 55.7 closeout link: [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md)"
+
+missing_authority_repo="${workdir}/missing-authority"
+copy_valid_repo "${missing_authority_repo}"
+perl -0pi -e 's/AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth\.//' \
+  "${missing_authority_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_authority_repo}" \
+  "Missing required Phase 55 closeout term in docs/phase-55-closeout-evaluation.md: AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+
+missing_failure_state_repo="${workdir}/missing-failure-state"
+copy_valid_repo "${missing_failure_state_repo}"
+perl -0pi -e 's/\| Failure states \| Checklist failure copy was not enumerated for common first-user blockers\. \| Phase 55\.5 adds bounded copy for missing Wazuh, missing Shuffle, missing secrets, port conflict, missing IdP, missing seed data, and protected-surface denial without authorizing repair or supportability completion\. \|\n//' \
+  "${missing_failure_state_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_failure_state_repo}" \
+  'Missing required Phase 55 closeout term in docs/phase-55-closeout-evaluation.md: | Failure states | Checklist failure copy was not enumerated for common first-user blockers. | Phase 55.5 adds bounded copy for missing Wazuh, missing Shuffle, missing secrets, port conflict, missing IdP, missing seed data, and protected-surface denial without authorizing repair or supportability completion. |'
+
+missing_phase60_handoff_repo="${workdir}/missing-phase60-handoff"
+copy_valid_repo "${missing_phase60_handoff_repo}"
+perl -0pi -e 's/Phase 60 can consume the Phase 55 demo report export skeleton as a demo-only export shape\.//' \
+  "${missing_phase60_handoff_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_phase60_handoff_repo}" \
+  "Missing required Phase 55 closeout term in docs/phase-55-closeout-evaluation.md: Phase 60 can consume the Phase 55 demo report export skeleton as a demo-only export shape."
+
+missing_issue_lint_repo="${workdir}/missing-issue-lint"
+copy_valid_repo "${missing_issue_lint_repo}"
+perl -0pi -e 's/^- `node <codex-supervisor-root>\/dist\/index\.js issue-lint 1180 --config <supervisor-config-path>`: .*?\n//m' \
+  "${missing_issue_lint_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_issue_lint_repo}" \
+  "Missing required Phase 55 closeout term in docs/phase-55-closeout-evaluation.md: node <codex-supervisor-root>/dist/index.js issue-lint 1180 --config <supervisor-config-path>"
+
+phase56_overclaim_repo="${workdir}/phase56-overclaim"
+copy_valid_repo "${phase56_overclaim_repo}"
+printf '%s\n' "Phase 56 daily SOC workbench is complete" >>"${phase56_overclaim_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${phase56_overclaim_repo}" \
+  "Forbidden Phase 55 closeout evaluation claim: Phase 56 daily SOC workbench is complete"
+
+phase58_overclaim_repo="${workdir}/phase58-overclaim"
+copy_valid_repo "${phase58_overclaim_repo}"
+printf '%s\n' "Phase 58 supportability is complete" >>"${phase58_overclaim_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${phase58_overclaim_repo}" \
+  "Forbidden Phase 55 closeout evaluation claim: Phase 58 supportability is complete"
+
+phase62_overclaim_repo="${workdir}/phase62-overclaim"
+copy_valid_repo "${phase62_overclaim_repo}"
+printf '%s\n' "Phase 62 SOAR breadth is complete" >>"${phase62_overclaim_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${phase62_overclaim_repo}" \
+  "Forbidden Phase 55 closeout evaluation claim: Phase 62 SOAR breadth is complete"
+
+commercial_overclaim_repo="${workdir}/commercial-overclaim"
+copy_valid_repo "${commercial_overclaim_repo}"
+printf '%s\n' "Phase 55 proves commercial replacement readiness" >>"${commercial_overclaim_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${commercial_overclaim_repo}" \
+  "Forbidden Phase 55 closeout evaluation claim: Phase 55 proves commercial replacement readiness"
+
+demo_truth_repo="${workdir}/demo-truth"
+copy_valid_repo "${demo_truth_repo}"
+printf '%s\n' "Demo records are production truth" >>"${demo_truth_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${demo_truth_repo}" \
+  "Forbidden Phase 55 closeout evaluation claim: Demo records are production truth"
+
+ui_truth_repo="${workdir}/ui-truth"
+copy_valid_repo "${ui_truth_repo}"
+printf '%s\n' "Checklist UI state is workflow truth" >>"${ui_truth_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${ui_truth_repo}" \
+  "Forbidden Phase 55 closeout evaluation claim: Checklist UI state is workflow truth"
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+mac_home_prefix="/""Users/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${mac_home_prefix}" >>"${absolute_path_repo}/docs/phase-55-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 55 closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 55 closeout evaluation verifier tests passed."

--- a/scripts/verify-phase-55-7-closeout-evaluation.sh
+++ b/scripts/verify-phase-55-7-closeout-evaluation.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-55-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${file}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 55 closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -s "${readme_path}" ]]; then
+  echo "Missing README for Phase 55 closeout link check: README.md" >&2
+  exit 1
+fi
+
+require_phrase "${readme_path}" "[Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md)" "README Phase 55.7 closeout link"
+
+required_phrases=()
+while IFS= read -r phrase; do
+  required_phrases+=("${phrase}")
+done <<'EOF'
+# Phase 55 Closeout Evaluation
+**Status**: Accepted as guided first-user journey evidence and handoff baseline; Phase 56, Phase 57, Phase 58, Phase 60, and Phase 66 can consume the bounded Phase 55 first-user journey with explicit retained blockers.
+**Related Issues**: #1175, #1176, #1177, #1178, #1179, #1180, #1181, #1182
+Phase 55 is accepted as the guided first-user journey evidence baseline for the `smb-single-node` profile.
+AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+First-user docs, checklist state, demo seed records, demo reset output, demo report export output, empty-state copy, failure-state copy, browser state, UI cache, Wazuh state, Shuffle state, AI output, tickets, verifier output, and issue-lint output remain subordinate context.
+Demo records and demo report exports are rehearsal evidence only.
+This closeout does not claim Phase 56 daily SOC workbench is complete, Phase 57 packaging is complete, Phase 58 supportability is complete, Phase 60 audit or reporting breadth is complete, Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability.
+| #1175 | Epic: Phase 55 Guided First-User Journey | Open until #1182 lands; accepted when this closeout, focused verifier, Phase 55 verifiers, focused first-user/UI/demo tests, path hygiene, and issue-lint pass. |
+| #1176 | Phase 55.1 first-user journey and first-30-minutes docs | Closed.
+| #1177 | Phase 55.2 first-login checklist UI contract | Closed.
+| #1178 | Phase 55.3 demo seed record family bundle | Closed.
+| #1179 | Phase 55.4 demo reset and mode separation | Closed.
+| #1180 | Phase 55.5 empty-state and failure-state copy | Closed.
+| #1181 | Phase 55.6 first-user report export skeleton | Closed.
+| #1182 | Phase 55.7 Phase 55 closeout evaluation | Open until this document and focused closeout verifier land. |
+| First-user docs | Phase 52 first-user stack docs described the few-command setup path but did not provide a workflow-first guided journey. | Phase 55.1 documents the first-user flow from stack health, seeded queue, sample Wazuh alert, case, evidence, AI summary, action review, receipt, reconciliation, and report export. |
+| First-login checklist | Operator UI did not have the Phase 55 checklist surface. | Phase 55.2 renders the checklist from backend authoritative records only and rejects browser cache, wrong record family, duplicate, missing, unsupported, or malformed checklist state. |
+| Demo seed bundle | Phase 52.7 described demo seed expectations without the Phase 55 linked family bundle. | Phase 55.3 adds a linked demo family spanning Wazuh alert, analytic signal, AegisOps alert, case, evidence, recommendation, action review, execution receipt, and reconciliation. |
+| Demo reset | Demo reset behavior was not bounded for repeatable first-user rehearsal. | Phase 55.4 requires demo-only selectors, stable identifiers, live-record preservation, and fail-closed rejection of production cleanup or backup/restore claims. |
+| Failure states | Checklist failure copy was not enumerated for common first-user blockers. | Phase 55.5 adds bounded copy for missing Wazuh, missing Shuffle, missing secrets, port conflict, missing IdP, missing seed data, and protected-surface denial without authorizing repair or supportability completion. |
+| Demo report export | The first-user journey lacked a bounded report export skeleton. | Phase 55.6 defines demo-labeled report export output with direct demo record references, unavailable follow-up handling, secret hygiene, and commercial-reporting guardrails. |
+`docs/getting-started/first-user-journey.md`
+`docs/getting-started/first-30-minutes.md`
+`apps/operator-ui/src/app/operatorConsolePages/firstLoginChecklistPages.tsx`
+`apps/operator-ui/src/app/OperatorRoutes.firstLoginChecklist.testSuite.tsx`
+`docs/deployment/demo-seed-contract.md`
+`docs/deployment/fixtures/demo-seed/valid-demo-seed.json`
+`docs/deployment/demo-reset-mode-separation.md`
+`docs/getting-started/first-user-demo-report-export.md`
+`docs/phase-55-closeout-evaluation.md`
+`scripts/verify-phase-55-7-closeout-evaluation.sh`
+`scripts/test-verify-phase-55-7-closeout-evaluation.sh`
+`bash scripts/verify-phase-55-1-first-user-journey-docs.sh`
+`bash scripts/test-verify-phase-55-1-first-user-journey-docs.sh`
+`npm run test --workspace @aegisops/operator-ui -- OperatorRoutes`
+`bash scripts/verify-phase-52-7-demo-seed-contract.sh`
+`bash scripts/test-verify-phase-52-7-demo-seed-contract.sh`
+`bash scripts/verify-phase-55-4-demo-reset-mode-separation.sh`
+`bash scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh`
+`bash scripts/verify-phase-55-6-first-user-report-export-skeleton.sh`
+`bash scripts/test-verify-phase-55-6-first-user-report-export-skeleton.sh`
+`bash scripts/verify-publishable-path-hygiene.sh`
+`bash scripts/verify-phase-55-7-closeout-evaluation.sh`
+`bash scripts/test-verify-phase-55-7-closeout-evaluation.sh`
+node <codex-supervisor-root>/dist/index.js issue-lint 1175 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1176 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1177 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1178 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1179 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1180 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1181 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1182 --config <supervisor-config-path>
+execution_ready=yes
+missing_required=none
+missing_recommended=none
+metadata_errors=none
+high_risk_blocking_ambiguity=none
+Phase 55 does not implement Phase 56 daily SOC workbench breadth, queue optimization, production daily operations completeness, or analyst productivity breadth.
+Phase 55 does not implement Phase 57 packaging, installer completeness, release packaging, or customer-ready distribution.
+Phase 55 does not implement Phase 58 supportability, break-glass support workflows, backup/restore support operations, support bundles, support diagnostics, or customer support operations.
+Phase 55 does not implement Phase 60 audit export administration, commercial reporting breadth, executive reporting completeness, or compliance reporting completeness.
+Phase 55 does not implement Phase 62 SOAR breadth, broad workflow catalog coverage, marketplace work, or every action-family expectation.
+Phase 55 does not implement Phase 66 RC proof, RC readiness, GA readiness, Beta readiness, or self-service commercial readiness.
+Phase 56 can consume the Phase 55 first-user journey as the bounded workflow sequence for daily SOC workbench design.
+Phase 55 does not complete Phase 56 daily SOC workbench.
+Phase 57 can consume the Phase 55 first-user journey as one package-entry acceptance fixture.
+Phase 55 does not complete Phase 57 packaging.
+Phase 58 can consume the Phase 55 failure-state copy and reset/report boundaries as supportability inputs.
+Phase 55 does not complete Phase 58 supportability.
+Phase 60 can consume the Phase 55 demo report export skeleton as a demo-only export shape.
+Phase 55 does not complete Phase 60 audit or reporting breadth.
+Phase 66 can consume the Phase 55 first-user journey as one prerequisite evidence packet for RC proof.
+Phase 55 does not complete Phase 66 RC proof.
+This closeout is release and planning evidence only.
+EOF
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 55 closeout term in ${doc_path}"
+done
+
+mac_home_prefix="$(printf '/%s/' 'Users')"
+unix_home_prefix="$(printf '/%s/' 'home')"
+windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
+absolute_path_pattern="(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}" "${readme_path}"; then
+  echo "Forbidden Phase 55 closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+allowed_non_claim_line="This closeout does not claim Phase 56 daily SOC workbench is complete, Phase 57 packaging is complete, Phase 58 supportability is complete, Phase 60 audit or reporting breadth is complete, Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability."
+
+for forbidden in \
+  "Phase 56 daily SOC workbench is complete" \
+  "Phase 57 packaging is complete" \
+  "Phase 58 supportability is complete" \
+  "Phase 60 audit or reporting breadth is complete" \
+  "Phase 62 SOAR breadth is complete" \
+  "Phase 66 RC proof is complete" \
+  "AegisOps is Beta" \
+  "AegisOps is RC" \
+  "AegisOps is GA" \
+  "AegisOps is self-service commercially ready" \
+  "AegisOps is a commercial replacement for every SIEM/SOAR capability" \
+  "Phase 55 proves Beta readiness" \
+  "Phase 55 proves RC readiness" \
+  "Phase 55 proves GA readiness" \
+  "Phase 55 proves commercial replacement readiness" \
+  "Demo records are production truth" \
+  "Demo report exports are production truth" \
+  "Demo reset output is production truth" \
+  "Checklist UI state is workflow truth" \
+  "Browser state is workflow truth" \
+  "Wazuh state is AegisOps workflow truth" \
+  "Shuffle state is AegisOps workflow truth"; do
+  if grep -Fxv -- "${allowed_non_claim_line}" "${absolute_doc_path}" | grep -Fq -- "${forbidden}"; then
+    echo "Forbidden Phase 55 closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 55 closeout evaluation records first-user journey outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 56/57/58/60/66 handoff."

--- a/scripts/verify-phase-55-7-closeout-evaluation.sh
+++ b/scripts/verify-phase-55-7-closeout-evaluation.sh
@@ -30,7 +30,8 @@ if [[ ! -s "${readme_path}" ]]; then
   exit 1
 fi
 
-require_phrase "${readme_path}" "[Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md)" "README Phase 55.7 closeout link"
+require_phrase "${readme_path}" "- [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md)" "README canonical cross-phase boundary bullet"
+require_phrase "${readme_path}" "The Phase 55.7 closeout evaluation is defined by the [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md)." "README Product positioning reference"
 
 required_phrases=()
 while IFS= read -r phrase; do


### PR DESCRIPTION
## Summary
- Adds the Phase 55 closeout evaluation document and README handoff links.
- Adds the focused Phase 55.7 closeout verifier and negative-test harness.
- Records child outcomes, authority-boundary posture, accepted limitations, issue-lint evidence, and Phase 56/57/58/60/66 handoff notes.

## Verification
- bash scripts/verify-phase-55-7-closeout-evaluation.sh
- bash scripts/test-verify-phase-55-7-closeout-evaluation.sh
- bash scripts/verify-publishable-path-hygiene.sh
- bash scripts/verify-phase-55-1-first-user-journey-docs.sh && bash scripts/test-verify-phase-55-1-first-user-journey-docs.sh
- bash scripts/verify-phase-52-7-demo-seed-contract.sh && bash scripts/test-verify-phase-52-7-demo-seed-contract.sh
- bash scripts/verify-phase-55-4-demo-reset-mode-separation.sh && bash scripts/test-verify-phase-55-4-demo-reset-mode-separation.sh
- bash scripts/verify-phase-55-6-first-user-report-export-skeleton.sh && bash scripts/test-verify-phase-55-6-first-user-report-export-skeleton.sh
- npm run test --workspace @aegisops/operator-ui -- OperatorRoutes
- node <codex-supervisor-root>/dist/index.js issue-lint 1175..1182 --config <supervisor-config-path>

Closes #1182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 55.7 closeout evaluation to README and a new closeout document outlining acceptance status, first-user journey baseline, scope limits, preserved authority boundaries, child-issue outcomes, and handoff guidance for downstream phases.

* **Tests**
  * Added verification and test harnesses that validate presence of required closeout content, reject forbidden readiness/production claims and workstation-local paths, and exercise failing/succeeding fixture cases to ensure doc integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->