### PR TITLE
Phase 56.1 Today view backend projection contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Canonical cross-phase boundary reference:
 - [Phase 55.4 demo reset and mode separation contract](docs/deployment/demo-reset-mode-separation.md) defines repeatable demo reset, demo/live mode separation, live-record preservation, and backup/restore overclaim rejection.
 - [Phase 55.6 first-user demo report export skeleton](docs/getting-started/first-user-demo-report-export.md) defines demo-labeled report export output, direct demo journey references, secret hygiene, and commercial-reporting scope guardrails for the guided first-user journey.
 - [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md) records the guided first-user journey outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 56/57/58/60/66 handoff.
+- [Phase 56.1 Today view backend projection contract](docs/deployment/today-view-backend-projection-contract.md) defines priority, stale work, pending approvals, degraded sources, reconciliation mismatches, evidence gaps, and advisory-only AI focus lanes for the Daily SOC Workbench backend projection.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
@@ -126,6 +127,8 @@ The Phase 55.4 demo reset and mode separation contract is defined by the [Phase 
 The Phase 55.6 first-user demo report export skeleton is defined by the [Phase 55.6 first-user demo report export skeleton](docs/getting-started/first-user-demo-report-export.md).
 
 The Phase 55.7 closeout evaluation is defined by the [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md).
+
+The Phase 56.1 Today view backend projection contract is defined by the [Phase 56.1 Today view backend projection contract](docs/deployment/today-view-backend-projection-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/control-plane/tests/test_phase56_1_today_projection_contract.py
+++ b/control-plane/tests/test_phase56_1_today_projection_contract.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CONTRACT_PATH = REPO_ROOT / "docs/deployment/today-view-backend-projection-contract.md"
+ARTIFACT_PATH = (
+    REPO_ROOT
+    / "docs/deployment/profiles/smb-single-node/today-view-projection.yaml"
+)
+
+
+class Phase561TodayProjectionContractTests(unittest.TestCase):
+    @staticmethod
+    def _read(path: pathlib.Path) -> str:
+        if not path.exists():
+            raise AssertionError(f"expected file at {path.relative_to(REPO_ROOT)}")
+        return path.read_text(encoding="utf-8")
+
+    def test_contract_names_required_lanes_states_and_authority_boundary(self) -> None:
+        text = self._read(CONTRACT_PATH)
+
+        for term in (
+            "Phase 56.1 Today View Backend Projection Contract",
+            "priority",
+            "stale_work",
+            "pending_approvals",
+            "degraded_sources",
+            "reconciliation_mismatches",
+            "evidence_gaps",
+            "ai_suggested_focus",
+            "empty",
+            "normal",
+            "degraded",
+            "stale",
+            "mismatch",
+            "evidence_gap",
+            "advisory-only",
+            "AegisOps control-plane records remain authoritative",
+            "Stale or cached Today projection output cannot satisfy authority, approval, execution, or reconciliation truth.",
+        ):
+            self.assertIn(term, text)
+
+    def test_artifact_names_required_lanes_states_and_negative_cases(self) -> None:
+        text = self._read(ARTIFACT_PATH)
+
+        for term in (
+            "today_view_projection_contract_version: 2026-05-04",
+            "projection_owner: aegisops-control-plane",
+            "workflow_truth_source: aegisops-record-chain-only",
+            "authority_mutation_allowed: false",
+            "cached_projection_authority_allowed: false",
+            "ai_focus_authority_allowed: false",
+            "lanes:",
+            "states:",
+            "negative_validation_tests:",
+            "stale-projection-as-current-truth",
+            "ai-focus-as-authority",
+            "wazuh-shuffle-ticket-closeout-shortcut",
+            "today-summary-as-approval-execution-reconciliation-truth",
+        ):
+            self.assertIn(term, text)
+
+        for lane in (
+            "priority",
+            "stale_work",
+            "pending_approvals",
+            "degraded_sources",
+            "reconciliation_mismatches",
+            "evidence_gaps",
+            "ai_suggested_focus",
+        ):
+            self.assertRegex(text, rf"(?m)^  - {lane}$")
+
+        for state in ("empty", "normal", "degraded", "stale", "mismatch", "evidence_gap"):
+            self.assertRegex(text, rf"(?m)^  - {state}$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/deployment/profiles/smb-single-node/today-view-projection.yaml
+++ b/docs/deployment/profiles/smb-single-node/today-view-projection.yaml
@@ -1,0 +1,117 @@
+profile_id: smb-single-node
+today_view_projection_contract_version: 2026-05-04
+status: accepted-contract
+related_issues:
+  - 1190
+  - 1191
+projection_owner: aegisops-control-plane
+workflow_truth_source: aegisops-record-chain-only
+authority_boundary: Today view projection is subordinate backend summary context only; priority, stale work, pending approvals, degraded sources, reconciliation mismatches, evidence gaps, AI-suggested focus, UI cache, Wazuh, Shuffle, tickets, reports, and health summaries cannot close, approve, execute, reconcile, release, gate, or mutate authoritative AegisOps records.
+authority_mutation_allowed: false
+cached_projection_authority_allowed: false
+ai_focus_authority_allowed: false
+subordinate_surfaces_authority_allowed: false
+lanes:
+  - priority
+  - stale_work
+  - pending_approvals
+  - degraded_sources
+  - reconciliation_mismatches
+  - evidence_gaps
+  - ai_suggested_focus
+states:
+  - empty
+  - normal
+  - degraded
+  - stale
+  - mismatch
+  - evidence_gap
+projection_rules:
+  - all-required-lanes-present
+  - empty-state-visible
+  - normal-state-authoritative-anchors
+  - degraded-subordinate-context-visible
+  - stale-projection-rejected-as-truth
+  - mismatch-preserved
+  - evidence-gap-preserved
+  - ai-focus-advisory-only
+  - no-authority-mutation
+lane_contracts:
+  priority:
+    allowed_states:
+      - empty
+      - normal
+      - stale
+      - mismatch
+      - evidence_gap
+    authoritative_anchor: aegisops-alert-case-approval-action-reconciliation-records
+  stale_work:
+    allowed_states:
+      - empty
+      - normal
+      - stale
+    authoritative_anchor: aegisops-lifecycle-timestamps
+    cached_projection_current_truth_allowed: false
+  pending_approvals:
+    allowed_states:
+      - empty
+      - normal
+      - stale
+    authoritative_anchor: aegisops-approval-and-action-review-records
+    approval_truth_source: aegisops-approval-record-only
+  degraded_sources:
+    allowed_states:
+      - empty
+      - normal
+      - degraded
+      - stale
+      - mismatch
+    authoritative_anchor: directly-linked-aegisops-source-admission-records
+    subordinate_context:
+      - wazuh
+      - shuffle
+      - tickets
+      - reports
+      - health_summaries
+  reconciliation_mismatches:
+    allowed_states:
+      - empty
+      - normal
+      - stale
+      - mismatch
+    authoritative_anchor: aegisops-reconciliation-records
+    shuffle_success_closeout_allowed: false
+    ticket_state_closeout_allowed: false
+  evidence_gaps:
+    allowed_states:
+      - empty
+      - normal
+      - stale
+      - evidence_gap
+    authoritative_anchor: aegisops-evidence-records
+    missing_evidence_hidden_by_summary_allowed: false
+  ai_suggested_focus:
+    allowed_states:
+      - empty
+      - normal
+      - degraded
+      - stale
+      - mismatch
+      - evidence_gap
+    authoritative_anchor: directly-linked-aegisops-records
+    advisory_only: true
+    approval_allowed: false
+    execution_allowed: false
+    reconciliation_allowed: false
+negative_validation_tests:
+  - missing-required-lane
+  - missing-empty-state
+  - missing-normal-state
+  - missing-degraded-state
+  - missing-stale-state
+  - missing-mismatch-state
+  - missing-evidence-gap-state
+  - stale-projection-as-current-truth
+  - ai-focus-as-authority
+  - wazuh-shuffle-ticket-closeout-shortcut
+  - today-summary-as-approval-execution-reconciliation-truth

--- a/docs/deployment/today-view-backend-projection-contract.md
+++ b/docs/deployment/today-view-backend-projection-contract.md
@@ -1,0 +1,115 @@
+# Phase 56.1 Today View Backend Projection Contract
+
+- **Status**: Accepted contract
+- **Date**: 2026-05-04
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1190, #1191
+- **Related Baseline**: `docs/phase-55-closeout-evaluation.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+
+This contract defines the backend projection shape that powers the Daily SOC Workbench `Today` view. The required structured artifact is `docs/deployment/profiles/smb-single-node/today-view-projection.yaml`.
+
+## 1. Purpose
+
+The Today projection gives a low-staff SMB operator one backend-owned work-focus surface for the current operating day. It may rank, group, and summarize records, but it must not create workflow truth.
+
+The projection lanes are:
+
+| Lane | Purpose | Authority posture |
+| --- | --- | --- |
+| priority | Show the highest-priority AegisOps-owned work items for review. | Derived from authoritative AegisOps alert, case, approval, action request, receipt, reconciliation, gate, limitation, and closeout records. |
+| stale_work | Show authoritative records whose reviewed freshness or lifecycle timestamps require attention. | Uses AegisOps lifecycle timestamps; stale projection text is not current truth. |
+| pending_approvals | Show approval-bound action reviews that need an approver decision. | Approval truth remains the AegisOps approval record, not the Today lane. |
+| degraded_sources | Show subordinate source-health context that may affect review confidence. | Wazuh, Shuffle, ticket, report, and health-summary state remain subordinate context. |
+| reconciliation_mismatches | Show action, receipt, and reconciliation records with mismatch or unresolved status. | Reconciliation truth remains the AegisOps reconciliation record. |
+| evidence_gaps | Show cases or action reviews missing required linked evidence, custody, or scope-binding records. | Evidence truth remains explicit AegisOps evidence records. |
+| ai_suggested_focus | Show advisory-only focus hints grounded in directly linked AegisOps records. | AI-suggested focus is advisory-only and cannot approve, execute, reconcile, close, gate, or mutate records. |
+
+## 2. Authority Boundary
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, approval, action request, receipt, reconciliation, audit, limitation, gate, release, and closeout truth.
+
+The Today projection can prioritize and summarize work, but it cannot create workflow truth. Stale or cached Today projection output cannot satisfy authority, approval, execution, or reconciliation truth.
+
+UI, browser cache, AI focus hints, Wazuh state, Shuffle state, tickets, reports, and health summaries are subordinate to backend AegisOps control-plane records. If these surfaces drift from the authoritative record chain, repair or reject the projection instead of redefining truth around the summary.
+
+This contract cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md` for AI, Wazuh, Shuffle, tickets, browser state, UI cache, downstream receipts, and derived projection shortcut rejection.
+
+## 3. Projection Inputs
+
+| Input | Required binding |
+| --- | --- |
+| AegisOps alert records | Durable alert identifier, lifecycle state, severity, source admission binding, authoritative timestamps. |
+| AegisOps case records | Durable case identifier, lifecycle state, owner or queue assignment, authoritative timestamps. |
+| AegisOps evidence records | Evidence identifier, custody posture, scope binding, linked case or action-review record. |
+| AegisOps recommendation records | Recommendation identifier, directly linked subject record, advisory lineage, freshness. |
+| AegisOps approval and action review records | Review identifier, requested action, approver state, separation and decision posture. |
+| AegisOps receipt and reconciliation records | Action request identifier, receipt identifier, reconciliation state, mismatch or unresolved marker. |
+| Subordinate Wazuh, Shuffle, ticket, report, and health context | Explicit linkage to an AegisOps record and non-authority posture. |
+
+## 4. Projection States
+
+| State | Meaning | Required behavior |
+| --- | --- | --- |
+| empty | No eligible authoritative work records exist for the operator scope. | Return an empty lane set with explicit non-authority posture. |
+| normal | Eligible records are current and directly linked to authoritative AegisOps records. | Rank and summarize without mutating truth. |
+| degraded | One or more subordinate reads, source-health contexts, tickets, reports, or health summaries are unavailable or incomplete. | Preserve authoritative records and mark subordinate context degraded. |
+| stale | One or more authoritative records require attention based on AegisOps timestamps, or a projection snapshot is stale. | Surface stale work, but reject stale projection output as current truth. |
+| mismatch | A directly linked AegisOps receipt, reconciliation, or source-linkage record disagrees with expected state. | Keep mismatch visible and do not close or reconcile from subordinate state. |
+| evidence_gap | Required evidence, custody, or scope binding is absent for a directly linked case or action review. | Surface the gap and keep authority anchored to AegisOps evidence records. |
+
+## 5. Projection Rules
+
+| Rule | Required behavior |
+| --- | --- |
+| all-required-lanes-present | The backend contract and artifact name priority, stale_work, pending_approvals, degraded_sources, reconciliation_mismatches, evidence_gaps, and ai_suggested_focus. |
+| empty-state-visible | Empty output must be explicit and must not imply healthy production readiness or completed workflow truth. |
+| normal-state-authoritative-anchors | Normal output must point to authoritative AegisOps record identifiers for every lane item. |
+| degraded-subordinate-context-visible | Missing Wazuh, Shuffle, ticket, report, or health context must be labeled subordinate and degraded. |
+| stale-projection-rejected-as-truth | Cached or stale projection output cannot satisfy current authority, approval, execution, or reconciliation truth. |
+| mismatch-preserved | Reconciliation mismatch and source-link mismatch must remain visible until the AegisOps reconciliation or linkage record is corrected. |
+| evidence-gap-preserved | Missing evidence or custody linkage must stay visible and cannot be hidden by summary status. |
+| ai-focus-advisory-only | AI-suggested focus remains advisory-only and directly linked to authoritative AegisOps records. |
+| no-authority-mutation | The Today projection cannot close, approve, execute, reconcile, gate, release, or mutate authoritative records. |
+
+## 6. Validation Rules
+
+Focused backend tests must cover empty, normal, degraded, stale, mismatch, and evidence_gap states. The tests must also reject stale projection output as current truth, AI-suggested focus as authority, Wazuh/Shuffle/ticket state as authoritative closeout, and Today summary state as approval, execution, or reconciliation truth.
+
+## 7. Forbidden Claims
+
+- Today projection is AegisOps approval truth.
+- Today projection is AegisOps execution truth.
+- Today projection is AegisOps reconciliation truth.
+- Today projection closes AegisOps cases.
+- Stale Today projection output is current AegisOps truth.
+- Cached Today view output satisfies approval truth.
+- AI-suggested focus approves actions.
+- AI-suggested focus executes actions.
+- AI-suggested focus reconciles actions.
+- Wazuh state closes Today work.
+- Shuffle state closes Today work.
+- Ticket state closes Today work.
+- Health summary state is AegisOps workflow truth.
+- Report output is AegisOps closeout truth.
+- Phase 56.1 implements the Today UI.
+- Phase 56.1 claims Beta, RC, GA, or commercial readiness.
+
+## 8. Validation
+
+Run `python3 -m unittest control-plane.tests.test_phase56_1_today_projection_contract`.
+
+Run `bash scripts/verify-phase-56-1-today-view-projection-contract.sh`.
+
+Run `bash scripts/test-verify-phase-56-1-today-view-projection-contract.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1190 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1191 --config <supervisor-config-path>`.
+
+## 9. Non-Goals
+
+Phase 56.1 does not implement Today UI, browser cache behavior, case timeline projection, task cards, handoff UI, navigation, health summary, admin/RBAC, supportability, reporting breadth, SOAR breadth, RC readiness, GA readiness, or commercial readiness.
+
+Phase 56.1 does not make UI, browser cache, AI focus hints, Wazuh state, Shuffle state, tickets, reports, health summaries, verifier output, or issue-lint output authoritative AegisOps truth.

--- a/scripts/test-verify-phase-56-1-today-view-projection-contract.sh
+++ b/scripts/test-verify-phase-56-1-today-view-projection-contract.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-56-1-today-view-projection-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/deployment/profiles/smb-single-node"
+  printf '%s\n' \
+    "# AegisOps" \
+    "See [Phase 56.1 Today view backend projection contract](docs/deployment/today-view-backend-projection-contract.md)." \
+    >"${target}/README.md"
+  cp "${repo_root}/docs/deployment/today-view-backend-projection-contract.md" \
+    "${target}/docs/deployment/today-view-backend-projection-contract.md"
+  cp "${repo_root}/docs/deployment/profiles/smb-single-node/today-view-projection.yaml" \
+    "${target}/docs/deployment/profiles/smb-single-node/today-view-projection.yaml"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/deployment/today-view-backend-projection-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/deployment/today-view-backend-projection-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 56.1 Today projection contract"
+
+missing_artifact_repo="${workdir}/missing-artifact"
+create_valid_repo "${missing_artifact_repo}"
+rm "${missing_artifact_repo}/docs/deployment/profiles/smb-single-node/today-view-projection.yaml"
+assert_fails_with \
+  "${missing_artifact_repo}" \
+  "Missing Phase 56.1 Today projection artifact"
+
+missing_lane_repo="${workdir}/missing-lane"
+create_valid_repo "${missing_lane_repo}"
+perl -0pi -e 's/^  - evidence_gaps\n//m' \
+  "${missing_lane_repo}/docs/deployment/profiles/smb-single-node/today-view-projection.yaml"
+assert_fails_with \
+  "${missing_lane_repo}" \
+  "Missing Phase 56.1 Today projection lane: evidence_gaps"
+
+missing_state_repo="${workdir}/missing-state"
+create_valid_repo "${missing_state_repo}"
+perl -0pi -e 's/^  - evidence_gap\n//m' \
+  "${missing_state_repo}/docs/deployment/profiles/smb-single-node/today-view-projection.yaml"
+assert_fails_with \
+  "${missing_state_repo}" \
+  "Missing Phase 56.1 Today projection state: evidence_gap"
+
+missing_negative_repo="${workdir}/missing-negative"
+create_valid_repo "${missing_negative_repo}"
+perl -0pi -e 's/^  - ai-focus-as-authority\n//m' \
+  "${missing_negative_repo}/docs/deployment/profiles/smb-single-node/today-view-projection.yaml"
+assert_fails_with \
+  "${missing_negative_repo}" \
+  "Missing Phase 56.1 Today projection negative validation test: ai-focus-as-authority"
+
+missing_advisory_repo="${workdir}/missing-advisory"
+create_valid_repo "${missing_advisory_repo}"
+remove_text_from_contract "${missing_advisory_repo}" "AI-suggested focus is advisory-only"
+assert_fails_with \
+  "${missing_advisory_repo}" \
+  "Missing Phase 56.1 Today projection contract statement: AI-suggested focus is advisory-only"
+
+authority_truth_repo="${workdir}/authority-truth"
+create_valid_repo "${authority_truth_repo}"
+printf '%s\n' "Today projection is AegisOps approval truth." \
+  >>"${authority_truth_repo}/docs/deployment/today-view-backend-projection-contract.md"
+assert_fails_with \
+  "${authority_truth_repo}" \
+  "Forbidden Phase 56.1 Today projection claim: Today projection is AegisOps approval truth"
+
+stale_truth_repo="${workdir}/stale-truth"
+create_valid_repo "${stale_truth_repo}"
+printf '%s\n' "Stale Today projection output is current AegisOps truth." \
+  >>"${stale_truth_repo}/docs/deployment/today-view-backend-projection-contract.md"
+assert_fails_with \
+  "${stale_truth_repo}" \
+  "Forbidden Phase 56.1 Today projection claim: Stale Today projection output is current AegisOps truth"
+
+missing_forbidden_claim_repo="${workdir}/missing-forbidden-claim"
+create_valid_repo "${missing_forbidden_claim_repo}"
+remove_text_from_contract "${missing_forbidden_claim_repo}" \
+  "AI-suggested focus approves actions."
+assert_fails_with \
+  "${missing_forbidden_claim_repo}" \
+  "Missing Phase 56.1 Today projection forbidden claim: AI-suggested focus approves actions"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf 'Use /%s/example/AegisOps for projection review.\n' "Users" \
+  >>"${local_path_repo}/docs/deployment/today-view-backend-projection-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Forbidden Phase 56.1 Today projection artifact: workstation-local absolute path detected"
+
+secret_looking_value_repo="${workdir}/secret-looking-value"
+create_valid_repo "${secret_looking_value_repo}"
+printf '%s\n' "projection_token: CorrectHorseBatteryStaple42" \
+  >>"${secret_looking_value_repo}/docs/deployment/profiles/smb-single-node/today-view-projection.yaml"
+assert_fails_with \
+  "${secret_looking_value_repo}" \
+  "Forbidden Phase 56.1 Today projection artifact: committed secret-looking value detected"
+
+missing_readme_link_repo="${workdir}/missing-readme-link"
+create_valid_repo "${missing_readme_link_repo}"
+printf '%s\n' "# AegisOps" >"${missing_readme_link_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_link_repo}" \
+  "README must link the Phase 56.1 Today view backend projection contract."
+
+echo "Phase 56.1 Today view projection verifier tests passed."

--- a/scripts/verify-phase-56-1-today-view-projection-contract.sh
+++ b/scripts/verify-phase-56-1-today-view-projection-contract.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+contract_path="${repo_root}/docs/deployment/today-view-backend-projection-contract.md"
+artifact_path="${repo_root}/docs/deployment/profiles/smb-single-node/today-view-projection.yaml"
+readme_path="${repo_root}/README.md"
+
+required_headings=(
+  "# Phase 56.1 Today View Backend Projection Contract"
+  "## 1. Purpose"
+  "## 2. Authority Boundary"
+  "## 3. Projection Inputs"
+  "## 4. Projection States"
+  "## 5. Projection Rules"
+  "## 6. Validation Rules"
+  "## 7. Forbidden Claims"
+  "## 8. Validation"
+  "## 9. Non-Goals"
+)
+
+required_phrases=(
+  "- **Status**: Accepted contract"
+  "- **Date**: 2026-05-04"
+  "- **Related Issues**: #1190, #1191"
+  "The required structured artifact is \`docs/deployment/profiles/smb-single-node/today-view-projection.yaml\`."
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, approval, action request, receipt, reconciliation, audit, limitation, gate, release, and closeout truth."
+  "Stale or cached Today projection output cannot satisfy authority, approval, execution, or reconciliation truth."
+  "AI-suggested focus is advisory-only"
+  "This contract cites the Phase 51.6 authority-boundary negative-test policy in \`docs/phase-51-6-authority-boundary-negative-test-policy.md\`"
+  "Run \`python3 -m unittest control-plane.tests.test_phase56_1_today_projection_contract\`."
+  "Run \`bash scripts/verify-phase-56-1-today-view-projection-contract.sh\`."
+  "Run \`bash scripts/test-verify-phase-56-1-today-view-projection-contract.sh\`."
+  "Run \`bash scripts/verify-publishable-path-hygiene.sh\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1190 --config <supervisor-config-path>\`."
+  "Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1191 --config <supervisor-config-path>\`."
+)
+
+required_artifact_terms=(
+  "profile_id: smb-single-node"
+  "today_view_projection_contract_version: 2026-05-04"
+  "status: accepted-contract"
+  "projection_owner: aegisops-control-plane"
+  "workflow_truth_source: aegisops-record-chain-only"
+  "authority_mutation_allowed: false"
+  "cached_projection_authority_allowed: false"
+  "ai_focus_authority_allowed: false"
+  "subordinate_surfaces_authority_allowed: false"
+  "lanes:"
+  "states:"
+  "projection_rules:"
+  "negative_validation_tests:"
+)
+
+required_lanes=(
+  priority
+  stale_work
+  pending_approvals
+  degraded_sources
+  reconciliation_mismatches
+  evidence_gaps
+  ai_suggested_focus
+)
+
+required_states=(
+  empty
+  normal
+  degraded
+  stale
+  mismatch
+  evidence_gap
+)
+
+required_rules=(
+  all-required-lanes-present
+  empty-state-visible
+  normal-state-authoritative-anchors
+  degraded-subordinate-context-visible
+  stale-projection-rejected-as-truth
+  mismatch-preserved
+  evidence-gap-preserved
+  ai-focus-advisory-only
+  no-authority-mutation
+)
+
+required_negative_tests=(
+  missing-required-lane
+  missing-empty-state
+  missing-normal-state
+  missing-degraded-state
+  missing-stale-state
+  missing-mismatch-state
+  missing-evidence-gap-state
+  stale-projection-as-current-truth
+  ai-focus-as-authority
+  wazuh-shuffle-ticket-closeout-shortcut
+  today-summary-as-approval-execution-reconciliation-truth
+)
+
+forbidden_claims=(
+  "Today projection is AegisOps approval truth"
+  "Today projection is AegisOps execution truth"
+  "Today projection is AegisOps reconciliation truth"
+  "Today projection closes AegisOps cases"
+  "Stale Today projection output is current AegisOps truth"
+  "Cached Today view output satisfies approval truth"
+  "AI-suggested focus approves actions"
+  "AI-suggested focus executes actions"
+  "AI-suggested focus reconciles actions"
+  "Wazuh state closes Today work"
+  "Shuffle state closes Today work"
+  "Ticket state closes Today work"
+  "Health summary state is AegisOps workflow truth"
+  "Report output is AegisOps closeout truth"
+  "Phase 56.1 implements the Today UI"
+  "Phase 56.1 claims Beta, RC, GA, or commercial readiness"
+)
+
+rendered_markdown_without_code_blocks() {
+  local markdown_path="$1"
+
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    in_fenced_block { next }
+    substr($0, 1, 1) == "\t" { next }
+    substr($0, 1, 4) == "    " { next }
+    { print }
+  ' "${markdown_path}" | perl -0pe 's/<!--.*?-->//gs'
+}
+
+has_uncommented_substring() {
+  local needle="$1"
+  local file_path="$2"
+
+  awk -v needle="${needle}" '
+    /^[[:space:]]*#/ { next }
+    {
+      line = $0
+      sub(/[[:space:]]+#.*/, "", line)
+      if (index(line, needle)) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"
+}
+
+require_top_level_list_item() {
+  local file_path="$1"
+  local section="$2"
+  local item="$3"
+  local label="$4"
+
+  if ! awk -v section="${section}" -v item="${item}" '
+    $0 == section ":" {
+      in_section = 1
+      next
+    }
+    in_section && /^[^[:space:]][^:]*:/ {
+      in_section = 0
+    }
+    in_section && $0 ~ ("^  - " item "([[:space:]]*(#.*)?)?$") {
+      found = 1
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"; then
+    echo "Missing Phase 56.1 Today projection ${label}: ${item}" >&2
+    exit 1
+  fi
+}
+
+contains_forbidden_claim_in_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+contains_forbidden_outside_forbidden_section() {
+  local claim="$1"
+
+  awk -v claim="${claim}" '
+    BEGIN { claim_lower = tolower(claim) }
+    /^## 7\. Forbidden Claims$/ { in_forbidden_claims = 1; next }
+    /^## / && in_forbidden_claims { in_forbidden_claims = 0 }
+    !in_forbidden_claims && index(tolower($0), claim_lower) { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${contract_path}"
+}
+
+contains_secret_looking_value() {
+  local file_path="$1"
+
+  awk '
+    /^[[:space:]]*#/ { next }
+    {
+      line = tolower($0)
+      if (line ~ /(secret|token|password|credential|api_key|apikey)[[:space:]]*:[[:space:]]*["'\''"]?[[:alnum:]_\/+=.-]{16,}["'\''"]?/ &&
+          line !~ /(allowed:[[:space:]]*false|valid:[[:space:]]*false|redacted|placeholder|<[^>]+>)/) {
+        found = 1
+      }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${file_path}"
+}
+
+if [[ ! -f "${contract_path}" ]]; then
+  echo "Missing Phase 56.1 Today projection contract: ${contract_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${artifact_path}" ]]; then
+  echo "Missing Phase 56.1 Today projection artifact: ${artifact_path}" >&2
+  exit 1
+fi
+
+contract_rendered_markdown="$(rendered_markdown_without_code_blocks "${contract_path}")"
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 56.1 Today projection contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 56.1 Today projection contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for term in "${required_artifact_terms[@]}"; do
+  if ! has_uncommented_substring "${term}" "${artifact_path}"; then
+    echo "Missing Phase 56.1 Today projection artifact term: ${term}" >&2
+    exit 1
+  fi
+done
+
+for lane in "${required_lanes[@]}"; do
+  require_top_level_list_item "${artifact_path}" "lanes" "${lane}" "lane"
+  if ! grep -Fq -- "| ${lane} |" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 56.1 Today projection contract lane row: ${lane}" >&2
+    exit 1
+  fi
+done
+
+for state in "${required_states[@]}"; do
+  require_top_level_list_item "${artifact_path}" "states" "${state}" "state"
+  if ! grep -Fq -- "| ${state} |" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 56.1 Today projection contract state row: ${state}" >&2
+    exit 1
+  fi
+done
+
+for rule in "${required_rules[@]}"; do
+  require_top_level_list_item "${artifact_path}" "projection_rules" "${rule}" "rule"
+  if ! grep -Fq -- "| ${rule} |" <<<"${contract_rendered_markdown}"; then
+    echo "Missing Phase 56.1 Today projection contract rule row: ${rule}" >&2
+    exit 1
+  fi
+done
+
+for negative_test in "${required_negative_tests[@]}"; do
+  require_top_level_list_item "${artifact_path}" "negative_validation_tests" "${negative_test}" "negative validation test"
+done
+
+for claim in "${forbidden_claims[@]}"; do
+  if ! contains_forbidden_claim_in_section "${claim}"; then
+    echo "Missing Phase 56.1 Today projection forbidden claim: ${claim}" >&2
+    exit 1
+  fi
+
+  if contains_forbidden_outside_forbidden_section "${claim}"; then
+    echo "Forbidden Phase 56.1 Today projection claim: ${claim}" >&2
+    exit 1
+  fi
+done
+
+for secret_scan_path in "${contract_path}" "${artifact_path}"; do
+  if contains_secret_looking_value "${secret_scan_path}"; then
+    echo "Forbidden Phase 56.1 Today projection artifact: committed secret-looking value detected in ${secret_scan_path}" >&2
+    exit 1
+  fi
+done
+
+mac_user_home_pattern="/""Users/"
+posix_user_home_pattern="/""home/[^[:space:]/]+"
+windows_user_home_pattern='C:\\''Users\\'
+if grep -REq "${mac_user_home_pattern}|${posix_user_home_pattern}|${windows_user_home_pattern}" "${contract_path}" "${artifact_path}"; then
+  echo "Forbidden Phase 56.1 Today projection artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 56.1 Today projection link check: ${readme_path}" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(rendered_markdown_without_code_blocks "${readme_path}")"
+
+if ! grep -Eq '\[[^]]+\]\(docs/deployment/today-view-backend-projection-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 56.1 Today view backend projection contract." >&2
+  exit 1
+fi
+
+echo "Phase 56.1 Today view backend projection contract is present and rejects missing lanes, stale projection truth, AI authority, subordinate closeout shortcuts, and workstation-local paths."


### PR DESCRIPTION
## Summary
- Adds the Phase 56.1 Today view backend projection contract and `smb-single-node` structured projection artifact.
- Names required Today lanes and empty/normal/degraded/stale/mismatch/evidence-gap states.
- Adds focused backend contract tests plus verifier/self-test coverage for stale projection truth, AI authority, subordinate closeout shortcuts, path hygiene, and README linkage.

## Verification
- `python3 -m unittest control-plane.tests.test_phase56_1_today_projection_contract`
- `bash scripts/verify-phase-56-1-today-view-projection-contract.sh`
- `bash scripts/test-verify-phase-56-1-today-view-projection-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1190 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.json`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1191 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.json`

Closes #1191


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 56.1 contract documentation defining backend projection structure for the Daily SOC Workbench Today view
  * Added SMB single-node deployment profile configuration with authority boundary constraints

* **Tests**
  * Added comprehensive contract validation tests and verification scripts for Phase 56.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->