### PR TITLE
Phase 56.2: Add Today view UI

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -6,6 +6,7 @@ import { registerOperatorRoutesAuthAndShellTests } from "./OperatorRoutes.authAn
 import { registerOperatorRoutesCaseworkTests } from "./OperatorRoutes.casework.testSuite";
 import { registerOperatorRoutesControlPlaneTests } from "./OperatorRoutes.controlPlane.testSuite";
 import { registerOperatorRoutesFirstLoginChecklistTests } from "./OperatorRoutes.firstLoginChecklist.testSuite";
+import { registerOperatorRoutesTodayTests } from "./OperatorRoutes.today.testSuite";
 
 describe("OperatorRoutes", () => {
   beforeEach(() => {
@@ -18,4 +19,5 @@ describe("OperatorRoutes", () => {
   registerOperatorRoutesAssistantTests();
   registerOperatorRoutesControlPlaneTests();
   registerOperatorRoutesFirstLoginChecklistTests();
+  registerOperatorRoutesTodayTests();
 });

--- a/apps/operator-ui/src/app/OperatorRoutes.testSupport.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.testSupport.tsx
@@ -166,6 +166,9 @@ export function TestRouteNavigator() {
       >
         Go to alert detail
       </button>
+      <button onClick={() => navigate("/operator/today")} type="button">
+        Go to Today
+      </button>
     </>
   );
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
@@ -1,9 +1,14 @@
-import { screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { createDefaultDependencies } from "./OperatorRoutes";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { createDefaultDependencies, OperatorRoutes } from "./OperatorRoutes";
 import {
   createAuthorizedFetch,
+  createReadinessResponse,
+  jsonResponse,
   renderOperatorRoute,
+  TestRouteNavigator,
 } from "./OperatorRoutes.testSupport";
 
 const normalTodayProjection = {
@@ -232,6 +237,120 @@ export function registerOperatorRoutesTodayTests() {
           "The backend projection was stale or malformed, so the browser refused to present it as current workflow guidance.",
         ),
       ).toBeInTheDocument();
+    });
+
+    it.each([
+      [
+        "missing",
+        () => {
+          const payload: Record<string, unknown> = {
+            ...normalTodayProjection,
+          };
+          delete payload.stale_cache;
+          return payload;
+        },
+      ],
+      [
+        "non-boolean",
+        () => ({
+          ...normalTodayProjection,
+          stale_cache: "false",
+        }),
+      ],
+    ])(
+      "rejects %s stale_cache contract values instead of presenting them as current authority",
+      async (_caseName, buildProjection) => {
+        const dependencies = createDefaultDependencies({
+          fetchFn: createAuthorizedFetch({
+            "/inspect-today-view": buildProjection(),
+          }),
+        });
+
+        renderOperatorRoute("/operator/today", dependencies);
+
+        await waitFor(() => {
+          expect(
+            screen.getByRole("heading", {
+              name: "Today projection unavailable",
+            }),
+          ).toBeInTheDocument();
+        });
+
+        expect(screen.queryByText("Review case-101")).toBeNull();
+        expect(
+          screen.getByText(
+            "The backend projection was stale or malformed, so the browser refused to present it as current workflow guidance.",
+          ),
+        ).toBeInTheDocument();
+      },
+    );
+
+    it("fails closed when a Today projection reread errors after cached data exists", async () => {
+      const user = userEvent.setup();
+      let todayRequests = 0;
+      const fetchFn = vi.fn<typeof fetch>().mockImplementation((input) => {
+        const url = String(input);
+
+        if (url.startsWith("/api/operator/session")) {
+          return Promise.resolve(
+            jsonResponse({
+              identity: "analyst@example.com",
+              provider: "authentik",
+              roles: ["Analyst"],
+              subject: "operator-7",
+            }),
+          );
+        }
+
+        if (url.startsWith("/inspect-today-view")) {
+          todayRequests += 1;
+
+          if (todayRequests === 1) {
+            return Promise.resolve(jsonResponse(normalTodayProjection));
+          }
+
+          return Promise.reject(
+            new Error("Today projection refresh unavailable."),
+          );
+        }
+
+        if (url.startsWith("/diagnostics/readiness")) {
+          return Promise.resolve(jsonResponse(createReadinessResponse()));
+        }
+
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      });
+      const dependencies = createDefaultDependencies({ fetchFn });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/today"]}>
+          <TestRouteNavigator />
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Today" }),
+        ).toBeInTheDocument();
+      });
+      expect(screen.getByText("Review case-101")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Go to readiness" }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Readiness" }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "Go to Today" }));
+
+      expect(
+        await screen.findByRole("heading", {
+          name: "Today projection unavailable",
+        }),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Review case-101")).not.toBeInTheDocument();
     });
   });
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
@@ -1,0 +1,237 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createDefaultDependencies } from "./OperatorRoutes";
+import {
+  createAuthorizedFetch,
+  renderOperatorRoute,
+} from "./OperatorRoutes.testSupport";
+
+const normalTodayProjection = {
+  authority_boundary:
+    "Today view projection is subordinate backend summary context only.",
+  generated_at: "2026-05-04T08:00:00Z",
+  lanes: {
+    ai_suggested_focus: [
+      {
+        advisory_only: true,
+        authoritative_record: {
+          family: "case",
+          id: "case-101",
+        },
+        id: "focus-1",
+        reason: "Directly linked stale case and evidence gap need review.",
+        state: "normal",
+        title: "Review case-101 before lunch handoff",
+      },
+    ],
+    degraded_sources: [
+      {
+        authoritative_record: {
+          family: "source",
+          id: "source-wazuh-1",
+        },
+        id: "degraded-1",
+        reason: "Wazuh source health is lagging but remains subordinate.",
+        source_family: "wazuh",
+        state: "degraded",
+        title: "Wazuh manager freshness degraded",
+      },
+    ],
+    evidence_gaps: [
+      {
+        authoritative_record: {
+          family: "case",
+          id: "case-101",
+        },
+        id: "evidence-1",
+        reason: "Required custody record is missing.",
+        state: "evidence_gap",
+        title: "Evidence custody gap on case-101",
+      },
+    ],
+    pending_approvals: [
+      {
+        authoritative_record: {
+          family: "action_review",
+          id: "review-101",
+        },
+        id: "approval-1",
+        reason: "Approver decision is required before execution.",
+        state: "normal",
+        title: "Approve containment request review-101",
+      },
+    ],
+    priority: [
+      {
+        authoritative_record: {
+          family: "case",
+          id: "case-101",
+        },
+        id: "priority-1",
+        priority_rank: 1,
+        reason: "High severity case has pending approval and evidence gap.",
+        state: "normal",
+        title: "Review case-101",
+      },
+    ],
+    reconciliation_mismatches: [
+      {
+        authoritative_record: {
+          family: "reconciliation",
+          id: "recon-101",
+        },
+        id: "mismatch-1",
+        reason: "Receipt and reconciliation state disagree.",
+        state: "mismatch",
+        title: "Reconciliation mismatch recon-101",
+      },
+    ],
+    stale_work: [
+      {
+        authoritative_record: {
+          family: "alert",
+          id: "alert-101",
+        },
+        id: "stale-1",
+        reason: "No authoritative lifecycle update in four hours.",
+        state: "stale",
+        title: "Stale alert alert-101",
+      },
+    ],
+  },
+  projection_id: "today-2026-05-04",
+  projection_state: "normal",
+  read_only: true,
+  stale_cache: false,
+  today_view_projection_contract_version: "2026-05-04",
+};
+
+export function registerOperatorRoutesTodayTests() {
+  describe("today workbench route", () => {
+    it("discovers the Today workbench through reviewed operator navigation", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-today-view": normalTodayProjection,
+        }),
+      });
+
+      renderOperatorRoute("/operator/today", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Today" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole("menuitem", { name: "Today" })).toHaveAttribute(
+        "href",
+        expect.stringContaining("/operator/today"),
+      );
+      expect(screen.getByText("Daily SOC Workbench")).toBeInTheDocument();
+    });
+
+    it("renders normal work focus, stale and degraded badges, gaps, mismatches, approvals, and advisory AI focus", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-today-view": normalTodayProjection,
+        }),
+      });
+
+      renderOperatorRoute("/operator/today", dependencies);
+
+      await waitFor(() => {
+        expect(screen.getByText("Review case-101")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Stale alert alert-101")).toBeInTheDocument();
+      expect(
+        screen.getByText("Wazuh manager freshness degraded"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Approve containment request review-101"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Reconciliation mismatch recon-101"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Evidence custody gap on case-101"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Review case-101 before lunch handoff"),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText("Stale").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Degraded").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Advisory only").length).toBeGreaterThan(0);
+      expect(screen.queryByRole("button", { name: /approve/i })).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: /close today work/i }),
+      ).toBeNull();
+      expect(screen.queryByRole("button", { name: /execute/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /reconcile/i })).toBeNull();
+    });
+
+    it("renders an explicit empty state without implying workflow completion", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-today-view": {
+            ...normalTodayProjection,
+            lanes: {
+              ai_suggested_focus: [],
+              degraded_sources: [],
+              evidence_gaps: [],
+              pending_approvals: [],
+              priority: [],
+              reconciliation_mismatches: [],
+              stale_work: [],
+            },
+            projection_id: "today-empty",
+            projection_state: "empty",
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/today", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Today" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText("No eligible AegisOps work is in the Today projection."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Empty Today output is not production readiness, approval, execution, reconciliation, or closeout truth.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("rejects stale cache or malformed backend data instead of presenting it as current authority", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-today-view": {
+            ...normalTodayProjection,
+            stale_cache: true,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/today", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Today projection unavailable" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Review case-101")).toBeNull();
+      expect(
+        screen.getByText(
+          "The backend projection was stale or malformed, so the browser refused to present it as current workflow guidance.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+}

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -14,6 +14,7 @@ import InsightsOutlinedIcon from "@mui/icons-material/InsightsOutlined";
 import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
 import PlaylistAddCheckOutlinedIcon from "@mui/icons-material/PlaylistAddCheckOutlined";
 import RuleFolderOutlinedIcon from "@mui/icons-material/RuleFolderOutlined";
+import TodayOutlinedIcon from "@mui/icons-material/TodayOutlined";
 import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
 import {
   Card,
@@ -87,6 +88,8 @@ const ReadinessPage =
   lazyOperatorConsolePage("ReadinessPage") as unknown as typeof import("./operatorConsolePages").ReadinessPage;
 const ReconciliationPage =
   lazyOperatorConsolePage("ReconciliationPage") as unknown as typeof import("./operatorConsolePages").ReconciliationPage;
+const TodayPage =
+  lazyOperatorConsolePage("TodayPage") as unknown as typeof import("./operatorConsolePages").TodayPage;
 
 function hasReviewedOperatorRole(
   operatorRoles: readonly string[],
@@ -143,6 +146,11 @@ function OperatorMenu({
   return (
     <Menu>
       <Menu.DashboardItem primaryText="Overview" />
+      <Menu.Item
+        leftIcon={<TodayOutlinedIcon />}
+        primaryText="Today"
+        to={buildOperatorShellPath(basePath, "today")}
+      />
       <Menu.Item
         leftIcon={<InboxOutlinedIcon />}
         primaryText="Queue"
@@ -393,6 +401,7 @@ function OperatorShellContent({
       <Suspense fallback={<DeferredPageFallback />}>
         <Routes>
           <Route element={<OverviewPage operatorRoles={operatorRoles} />} index />
+          <Route element={<TodayPage />} path="today" />
           <Route element={<QueuePage />} path="queue" />
           <Route element={<AlertIndexPage />} path="alerts" />
           <Route

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -1,4 +1,5 @@
 export { QueuePage } from "./operatorConsolePages/queuePages";
+export { TodayPage } from "./operatorConsolePages/todayPages";
 export {
   AlertDetailPage,
   CaseDetailPage,

--- a/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
@@ -1,0 +1,230 @@
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
+import { Alert, Chip, Grid, Stack, Typography } from "@mui/material";
+import { useMemo } from "react";
+import {
+  asRecord,
+  asRecordArray,
+  asString,
+  EmptyState,
+  ErrorState,
+  formatLabel,
+  LoadingState,
+  PageFrame,
+  SectionCard,
+  statusTone,
+  useOperatorRecord,
+} from "./shared";
+
+const TODAY_LANES = [
+  {
+    key: "priority",
+    title: "Priority",
+    subtitle: "Highest-priority AegisOps-owned records for review.",
+  },
+  {
+    key: "stale_work",
+    title: "Stale work",
+    subtitle: "Authoritative lifecycle timestamps that need attention.",
+  },
+  {
+    key: "pending_approvals",
+    title: "Pending approvals",
+    subtitle: "Approval-bound action reviews awaiting approver decision.",
+  },
+  {
+    key: "degraded_sources",
+    title: "Degraded sources",
+    subtitle: "Subordinate source-health context that affects review confidence.",
+  },
+  {
+    key: "reconciliation_mismatches",
+    title: "Reconciliation mismatches",
+    subtitle: "Directly linked reconciliation records that remain unresolved.",
+  },
+  {
+    key: "evidence_gaps",
+    title: "Evidence gaps",
+    subtitle: "Required evidence, custody, or scope-binding records are absent.",
+  },
+  {
+    key: "ai_suggested_focus",
+    title: "AI-suggested focus",
+    subtitle: "Advisory-only focus hints anchored to directly linked records.",
+  },
+] as const;
+
+function TodayProjectionUnavailable() {
+  return (
+    <PageFrame
+      subtitle="The browser refuses to promote unverified Today projection output to workflow guidance."
+      title="Today projection unavailable"
+    >
+      <Alert severity="error" variant="outlined">
+        The backend projection was stale or malformed, so the browser refused
+        to present it as current workflow guidance.
+      </Alert>
+    </PageFrame>
+  );
+}
+
+function TodayLaneItem({
+  item,
+  lane,
+}: {
+  item: Record<string, unknown>;
+  lane: string;
+}) {
+  const title = asString(item.title) ?? "Untitled Today item";
+  const reason = asString(item.reason);
+  const state = asString(item.state);
+  const anchor = asRecord(item.authoritative_record);
+  const anchorFamily = asString(anchor?.family);
+  const anchorId = asString(anchor?.id);
+  const advisoryOnly = lane === "ai_suggested_focus";
+
+  return (
+    <Stack
+      spacing={1}
+      sx={{
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 1,
+        p: 1.5,
+      }}
+    >
+      <Stack direction="row" flexWrap="wrap" gap={1}>
+        {state ? (
+          <Chip
+            color={statusTone(state)}
+            label={formatLabel(state)}
+            size="small"
+            variant={state === "normal" ? "outlined" : "filled"}
+          />
+        ) : null}
+        {advisoryOnly ? (
+          <Chip
+            color="info"
+            icon={<AutoAwesomeOutlinedIcon />}
+            label="Advisory only"
+            size="small"
+            variant="outlined"
+          />
+        ) : null}
+      </Stack>
+      <Typography variant="subtitle2">{title}</Typography>
+      {reason ? (
+        <Typography color="text.secondary" variant="body2">
+          {reason}
+        </Typography>
+      ) : null}
+      <Typography color="text.secondary" variant="caption">
+        Authoritative anchor: {anchorFamily ?? "record"}:{anchorId ?? "missing"}
+      </Typography>
+    </Stack>
+  );
+}
+
+function TodayLane({
+  items,
+  lane,
+  subtitle,
+  title,
+}: {
+  items: Record<string, unknown>[];
+  lane: string;
+  subtitle: string;
+  title: string;
+}) {
+  return (
+    <SectionCard subtitle={subtitle} title={title}>
+      {items.length > 0 ? (
+        <Stack spacing={1.5}>
+          {items.map((item) => (
+            <TodayLaneItem
+              item={item}
+              key={asString(item.id) ?? JSON.stringify(item)}
+              lane={lane}
+            />
+          ))}
+        </Stack>
+      ) : (
+        <EmptyState
+          message={`No ${title.toLowerCase()} items in the current backend projection.`}
+        />
+      )}
+    </SectionCard>
+  );
+}
+
+export function TodayPage() {
+  const meta = useMemo(() => ({}), []);
+  const { data, error, loading } = useOperatorRecord(
+    "todayView",
+    "current",
+    meta,
+  );
+  const lanes = asRecord(data?.lanes);
+  const totalItems = TODAY_LANES.reduce(
+    (total, lane) => total + asRecordArray(lanes?.[lane.key]).length,
+    0,
+  );
+
+  if (loading && !data) {
+    return (
+      <PageFrame
+        subtitle="Daily SOC Workbench loads one backend-owned work-focus projection for the current operating day."
+        title="Today"
+      >
+        <LoadingState label="Loading Today workbench" />
+      </PageFrame>
+    );
+  }
+
+  if (error && !data) {
+    return <TodayProjectionUnavailable />;
+  }
+
+  return (
+    <PageFrame
+      subtitle="Daily SOC Workbench. Today display state, ordering, badges, browser state, local cache, and AI focus hints remain operator guidance only; backend AegisOps records remain authoritative."
+      title="Today"
+    >
+      {error ? <ErrorState error={error} /> : null}
+      <Stack spacing={3}>
+        <Typography variant="subtitle1">Daily SOC Workbench</Typography>
+        <Alert severity="info" variant="outlined">
+          AI focus hints are advisory-only and cannot approve, close, execute,
+          reconcile, gate, release, or mutate work.
+        </Alert>
+
+        {totalItems === 0 ? (
+          <SectionCard
+            subtitle="The backend returned an explicit empty Today projection."
+            title="Today work focus"
+          >
+            <Stack spacing={1}>
+              <EmptyState message="No eligible AegisOps work is in the Today projection." />
+              <Typography color="text.secondary" variant="body2">
+                Empty Today output is not production readiness, approval,
+                execution, reconciliation, or closeout truth.
+              </Typography>
+            </Stack>
+          </SectionCard>
+        ) : null}
+
+        <Grid container spacing={2}>
+          {TODAY_LANES.map((lane) => (
+            <Grid key={lane.key} size={{ xs: 12, lg: 6 }}>
+              <TodayLane
+                items={asRecordArray(lanes?.[lane.key])}
+                lane={lane.key}
+                subtitle={lane.subtitle}
+                title={lane.title}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      </Stack>
+    </PageFrame>
+  );
+}

--- a/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
@@ -180,7 +180,7 @@ export function TodayPage() {
     );
   }
 
-  if (error && !data) {
+  if (error) {
     return <TodayProjectionUnavailable />;
   }
 

--- a/apps/operator-ui/src/dataProvider.ts
+++ b/apps/operator-ui/src/dataProvider.ts
@@ -3,6 +3,7 @@ import {
   getOneForActionReview,
   getOneForAdvisoryOutput,
   getOneForStandardResource,
+  getOneForTodayView,
 } from "./operatorDataProvider/detailReaders";
 import {
   OperatorDataProviderAuthorizationError,
@@ -56,6 +57,10 @@ export function createOperatorDataProvider({
 
       if (resource === "actionReview") {
         return getOneForActionReview(fetchFn, params);
+      }
+
+      if (resource === "todayView") {
+        return getOneForTodayView(fetchFn);
       }
 
       if (!isStandardResource(resource)) {

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -4,6 +4,16 @@ import { RESOURCE_BINDINGS } from "./resourceBindings";
 import { asObject, asString, buildDetailPath, fetchJson, normalizeRecord, resolveReconciliationRecord } from "./shared";
 import type { StandardOperatorResourceName } from "./types";
 
+const TODAY_VIEW_LANES = [
+  "priority",
+  "stale_work",
+  "pending_approvals",
+  "degraded_sources",
+  "reconciliation_mismatches",
+  "evidence_gaps",
+  "ai_suggested_focus",
+] as const;
+
 export async function getOneForStandardResource(
   fetchFn: typeof fetch,
   resource: StandardOperatorResourceName,
@@ -71,6 +81,101 @@ export async function getOneForAdvisoryOutput(
       id: requestedId,
       record_family: recordFamily,
       record_id: recordId,
+    },
+  };
+}
+
+function validateTodayLaneItem(
+  lane: string,
+  item: unknown,
+): Record<string, unknown> {
+  const record = asObject(
+    item,
+    `Resource todayView lane ${lane} returned a non-object item.`,
+  );
+  const id = asString(record.id);
+  const title = asString(record.title);
+  const state = asString(record.state);
+  const anchor = asObject(
+    record.authoritative_record,
+    `Resource todayView lane ${lane} item is missing authoritative_record.`,
+  );
+
+  if (id === null || title === null || state === null) {
+    throw new OperatorDataProviderContractError(
+      `Resource todayView lane ${lane} item is missing id, title, or state.`,
+    );
+  }
+
+  if (asString(anchor.family) === null || asString(anchor.id) === null) {
+    throw new OperatorDataProviderContractError(
+      `Resource todayView lane ${lane} item authoritative_record is missing family or id.`,
+    );
+  }
+
+  if (lane === "ai_suggested_focus" && record.advisory_only !== true) {
+    throw new OperatorDataProviderContractError(
+      "Resource todayView ai_suggested_focus items must be advisory_only.",
+    );
+  }
+
+  return record;
+}
+
+export async function getOneForTodayView(
+  fetchFn: typeof fetch,
+): Promise<GetOneResult> {
+  const payload = asObject(
+    await fetchJson(fetchFn, "/inspect-today-view"),
+    "Resource todayView returned a malformed detail payload.",
+  );
+  const projectionId = asString(payload.projection_id);
+  const contractVersion = asString(
+    payload.today_view_projection_contract_version,
+  );
+  const lanes = asObject(
+    payload.lanes,
+    "Resource todayView detail payload is missing lanes.",
+  );
+
+  if (projectionId === null || contractVersion === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource todayView detail payload is missing projection_id or contract version.",
+    );
+  }
+
+  if (payload.stale_cache === true) {
+    throw new OperatorDataProviderContractError(
+      "Resource todayView rejected stale projection cache as current guidance.",
+    );
+  }
+
+  if (payload.read_only !== true) {
+    throw new OperatorDataProviderContractError(
+      "Resource todayView detail payload must be read_only.",
+    );
+  }
+
+  const normalizedLanes = TODAY_VIEW_LANES.reduce<Record<string, unknown[]>>(
+    (result, lane) => {
+      const rawLane = lanes[lane];
+      if (!Array.isArray(rawLane)) {
+        throw new OperatorDataProviderContractError(
+          `Resource todayView detail payload is missing lane ${lane}.`,
+        );
+      }
+
+      result[lane] = rawLane.map((item) => validateTodayLaneItem(lane, item));
+      return result;
+    },
+    {},
+  );
+
+  return {
+    data: {
+      ...payload,
+      id: "current",
+      lanes: normalizedLanes,
     },
   };
 }

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -144,9 +144,9 @@ export async function getOneForTodayView(
     );
   }
 
-  if (payload.stale_cache === true) {
+  if (payload.stale_cache !== false) {
     throw new OperatorDataProviderContractError(
-      "Resource todayView rejected stale projection cache as current guidance.",
+      "Resource todayView requires stale_cache=false and rejects stale or malformed projection cache guidance.",
     );
   }
 

--- a/apps/operator-ui/src/operatorDataProvider/types.ts
+++ b/apps/operator-ui/src/operatorDataProvider/types.ts
@@ -7,6 +7,7 @@ export type OperatorResourceName =
   | "firstLoginChecklist"
   | "runtimeReadiness"
   | "reconciliations"
+  | "todayView"
   | "advisoryOutput"
   | "actionReview";
 
@@ -37,7 +38,7 @@ export interface StandardListReaderOptions {
 
 export type StandardOperatorResourceName = Exclude<
   OperatorResourceName,
-  "advisoryOutput" | "actionReview"
+  "advisoryOutput" | "actionReview" | "todayView"
 >;
 
 export type OperatorRecord = RaRecord;


### PR DESCRIPTION
## Summary
- Add the reviewed `/operator/today` Today workbench route and navigation entry.
- Add a `todayView` data-provider reader for `/inspect-today-view` with fail-closed validation for required lanes, authoritative anchors, read-only posture, stale cache rejection, and advisory-only AI focus.
- Add focused route tests for discovery, normal work-focus lanes, stale/degraded badges, empty state, stale/malformed projection rejection, and advisory-only AI hints.

## Verification
- `npm --prefix apps/operator-ui run test -- src/app/OperatorRoutes.test.tsx --testNamePattern "today workbench route"`
- `npm --prefix apps/operator-ui run typecheck`
- `npm --prefix apps/operator-ui run test -- src/app/OperatorRoutes.test.tsx`
- `npm --prefix apps/operator-ui run test -- src/dataProvider.test.ts`
- `npm --prefix apps/operator-ui run test`
- `npm --prefix apps/operator-ui run build`
- `node dist/index.js issue-lint 1190 --config supervisor.config.aegisops.json`
- `node dist/index.js issue-lint 1192 --config supervisor.config.aegisops.json`

## Limitations
- No browser screenshot was captured in this checkpoint; the route behavior is covered by focused React/Vitest tests.

Closes #1192
Part of #1190
Depends on #1191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Today" workbench to the operator console with a dedicated navigation entry and route.
  * Shows lane-organized work items with status chips, "Advisory only" indicators, and authoritative anchors.
  * Handles loading, explicit empty-state messaging, and a clear "Today projection unavailable" error view.

* **Tests**
  * Comprehensive tests covering discovery, rendering, empty/error scenarios, and contract validation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->