### PR TITLE
Phase 56.3 case timeline authority projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Canonical cross-phase boundary reference:
 - [Phase 55.6 first-user demo report export skeleton](docs/getting-started/first-user-demo-report-export.md) defines demo-labeled report export output, direct demo journey references, secret hygiene, and commercial-reporting scope guardrails for the guided first-user journey.
 - [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md) records the guided first-user journey outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 56/57/58/60/66 handoff.
 - [Phase 56.1 Today view backend projection contract](docs/deployment/today-view-backend-projection-contract.md) defines priority, stale work, pending approvals, degraded sources, reconciliation mismatches, evidence gaps, and advisory-only AI focus lanes for the Daily SOC Workbench backend projection.
+- [Phase 56.3 case timeline authority projection contract](docs/deployment/case-timeline-authority-projection-contract.md) defines Wazuh signal, alert, evidence, AI summary, recommendation, action request, approval, Shuffle receipt, and reconciliation timeline segments with explicit authority posture and direct backend record binding.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
@@ -129,6 +130,8 @@ The Phase 55.6 first-user demo report export skeleton is defined by the [Phase 5
 The Phase 55.7 closeout evaluation is defined by the [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md).
 
 The Phase 56.1 Today view backend projection contract is defined by the [Phase 56.1 Today view backend projection contract](docs/deployment/today-view-backend-projection-contract.md).
+
+The Phase 56.3 case timeline authority projection contract is defined by the [Phase 56.3 case timeline authority projection contract](docs/deployment/case-timeline-authority-projection-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -4,10 +4,12 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Protocol, Type, TypeVar
 
 from .models import (
+    ActionExecutionRecord,
     ActionRequestRecord,
     AlertRecord,
     AnalyticSignalRecord,
     AITraceRecord,
+    ApprovalDecisionRecord,
     CaseRecord,
     ControlPlaneRecord,
     EvidenceRecord,
@@ -822,6 +824,11 @@ class OperatorInspectionReadSurface:
             linked_evidence_records=context_snapshot.linked_evidence_records,
             linked_observation_records=observation_records,
         )
+        case_timeline_projection = self._build_case_timeline_projection(
+            case=case,
+            linked_alert_records=context_snapshot.linked_alert_records,
+            linked_evidence_records=context_snapshot.linked_evidence_records,
+        )
         return self._case_detail_snapshot_factory(
             read_only=True,
             case_id=case_id,
@@ -844,6 +851,7 @@ class OperatorInspectionReadSurface:
             linked_reconciliation_records=context_snapshot.linked_reconciliation_records,
             lifecycle_transitions=context_snapshot.lifecycle_transitions,
             cross_source_timeline=cross_source_timeline,
+            case_timeline_projection=case_timeline_projection,
             provenance_summary=provenance_summary,
             current_action_review=dict(action_reviews[0]) if action_reviews else None,
             action_reviews=action_reviews,
@@ -852,6 +860,442 @@ class OperatorInspectionReadSurface:
                 linked_alert_records=context_snapshot.linked_alert_records,
             ),
         )
+
+    def _build_case_timeline_projection(
+        self,
+        *,
+        case: CaseRecord,
+        linked_alert_records: tuple[dict[str, object], ...],
+        linked_evidence_records: tuple[dict[str, object], ...],
+    ) -> dict[str, object]:
+        alert_id = case.alert_id
+        directly_linked_alert = next(
+            (
+                record
+                for record in linked_alert_records
+                if isinstance(record.get("alert_id"), str)
+                and record.get("alert_id") == alert_id
+            ),
+            None,
+        )
+        evidence_records = tuple(
+            record
+            for record in linked_evidence_records
+            if record.get("case_id") == case.case_id or record.get("alert_id") == alert_id
+        )
+        ai_trace = self._latest_direct_case_ai_trace(
+            case=case,
+            evidence_records=evidence_records,
+        )
+        recommendation = self._latest_direct_case_recommendation(case)
+        action_request = self._latest_direct_case_action_request(case)
+        approval = (
+            self._service._store.get(
+                ApprovalDecisionRecord,
+                action_request.approval_decision_id,
+            )
+            if action_request is not None
+            and action_request.approval_decision_id is not None
+            else None
+        )
+        execution = (
+            self._latest_direct_action_execution(action_request)
+            if action_request is not None
+            else None
+        )
+        reconciliation = self._latest_direct_case_reconciliation(
+            case=case,
+            action_request=action_request,
+            execution=execution,
+        )
+        segments = (
+            self._case_timeline_segment(
+                segment="wazuh_signal",
+                authority_posture="subordinate_context",
+                record_family="reconciliation",
+                record_id=(
+                    reconciliation.reconciliation_id
+                    if reconciliation is not None
+                    and self._service._reconciliation_is_wazuh_origin(reconciliation)
+                    else None
+                ),
+                state=(
+                    "normal"
+                    if reconciliation is not None
+                    and self._service._reconciliation_is_wazuh_origin(reconciliation)
+                    else "missing"
+                ),
+                incomplete_reason=(
+                    None if reconciliation is not None else "missing_wazuh_signal_binding"
+                ),
+                truth_source="aegisops_alert_admission_record",
+            ),
+            self._case_timeline_segment(
+                segment="aegisops_alert",
+                authority_posture="authoritative_aegisops_record",
+                record_family="alert",
+                record_id=alert_id if directly_linked_alert is not None else None,
+                state="normal" if directly_linked_alert is not None else "missing",
+                incomplete_reason=(
+                    None
+                    if directly_linked_alert is not None
+                    else "missing_authoritative_alert"
+                ),
+                truth_source="aegisops_alert_record",
+            ),
+            self._case_evidence_timeline_segment(evidence_records),
+            self._case_timeline_segment(
+                segment="ai_summary",
+                authority_posture="subordinate_context",
+                record_family="ai_trace",
+                record_id=None if ai_trace is None else ai_trace.ai_trace_id,
+                state="normal" if ai_trace is not None else "missing",
+                incomplete_reason=(
+                    None if ai_trace is not None else "missing_direct_ai_trace_binding"
+                ),
+                truth_source="aegisops_case_record",
+            ),
+            self._case_timeline_segment(
+                segment="recommendation",
+                authority_posture="subordinate_context",
+                record_family="recommendation",
+                record_id=(
+                    None
+                    if recommendation is None
+                    else recommendation.recommendation_id
+                ),
+                state="normal" if recommendation is not None else "missing",
+                incomplete_reason=(
+                    None
+                    if recommendation is not None
+                    else "missing_direct_recommendation_binding"
+                ),
+                truth_source="aegisops_recommendation_record",
+            ),
+            self._case_timeline_segment(
+                segment="action_request",
+                authority_posture="authoritative_aegisops_record",
+                record_family="action_request",
+                record_id=(
+                    None if action_request is None else action_request.action_request_id
+                ),
+                state="normal" if action_request is not None else "missing",
+                incomplete_reason=(
+                    None
+                    if action_request is not None
+                    else "missing_direct_action_request_binding"
+                ),
+                truth_source="aegisops_action_request_record",
+            ),
+            self._case_timeline_segment(
+                segment="approval",
+                authority_posture="authoritative_aegisops_record",
+                record_family="approval_decision",
+                record_id=(
+                    None if approval is None else approval.approval_decision_id
+                ),
+                state="normal" if approval is not None else "missing",
+                incomplete_reason=(
+                    None if approval is not None else "missing_direct_approval_binding"
+                ),
+                truth_source="aegisops_approval_decision_record",
+            ),
+            self._case_timeline_segment(
+                segment="shuffle_receipt",
+                authority_posture="subordinate_context",
+                record_family="action_execution",
+                record_id=(
+                    None if execution is None else execution.action_execution_id
+                ),
+                state=(
+                    "normal"
+                    if execution is not None
+                    and execution.execution_surface_id == "shuffle"
+                    else "missing"
+                ),
+                incomplete_reason=(
+                    None
+                    if execution is not None
+                    else "missing_direct_shuffle_receipt_binding"
+                ),
+                truth_source="aegisops_action_execution_record",
+            ),
+            self._case_reconciliation_timeline_segment(reconciliation),
+        )
+        return {
+            "contract_version": "phase-56-3",
+            "case_id": case.case_id,
+            "authority_boundary": (
+                "Case timeline projection is derived display context only; "
+                "AegisOps records remain authoritative for alert, case, evidence, "
+                "approval, action request, receipt, reconciliation, audit, gate, "
+                "release, and closeout truth."
+            ),
+            "projection_authority_allowed": False,
+            "inferred_linkage_allowed": False,
+            "segments": segments,
+        }
+
+    @staticmethod
+    def _case_timeline_segment(
+        *,
+        segment: str,
+        authority_posture: str,
+        record_family: str,
+        record_id: str | None,
+        state: str,
+        incomplete_reason: str | None,
+        truth_source: str,
+    ) -> dict[str, object]:
+        return {
+            "segment": segment,
+            "authority_posture": authority_posture,
+            "state": state,
+            "operator_visible": True,
+            "backend_record_binding": {
+                "record_family": record_family,
+                "record_id": record_id,
+                "direct_binding_required": True,
+            },
+            "truth_source": truth_source,
+            "projection_can_complete_segment": False,
+            "incomplete_reason": incomplete_reason,
+        }
+
+    def _case_evidence_timeline_segment(
+        self,
+        evidence_records: tuple[dict[str, object], ...],
+    ) -> dict[str, object]:
+        first_record = evidence_records[0] if evidence_records else None
+        degraded_reason = next(
+            (
+                reason
+                for record in evidence_records
+                for reason in (self._case_evidence_degraded_reason(record),)
+                if reason is not None
+            ),
+            None,
+        )
+        if not evidence_records:
+            state = "missing"
+            reason = "missing_direct_evidence_binding"
+        elif degraded_reason is not None:
+            state = "degraded"
+            reason = degraded_reason
+        else:
+            state = "normal"
+            reason = None
+        return self._case_timeline_segment(
+            segment="evidence",
+            authority_posture="authoritative_aegisops_record",
+            record_family="evidence",
+            record_id=(
+                None
+                if first_record is None
+                else self._service._normalize_optional_string(
+                    first_record.get("evidence_id"),
+                    "evidence.evidence_id",
+                )
+            ),
+            state=state,
+            incomplete_reason=reason,
+            truth_source="aegisops_evidence_record",
+        )
+
+    @staticmethod
+    def _case_evidence_degraded_reason(record: Mapping[str, object]) -> str | None:
+        blocking_reason = record.get("blocking_reason")
+        if isinstance(blocking_reason, str) and blocking_reason:
+            return blocking_reason
+        provenance = record.get("provenance")
+        if not isinstance(provenance, Mapping) or not provenance:
+            return "missing_provenance"
+        required_fields = ("classification", "source_id", "timestamp", "reviewed_by")
+        if any(
+            not isinstance(provenance.get(field), str) or not provenance.get(field)
+            for field in required_fields
+        ):
+            return "missing_or_invalid_required_provenance_fields"
+        return None
+
+    def _case_reconciliation_timeline_segment(
+        self,
+        reconciliation: ReconciliationRecord | None,
+    ) -> dict[str, object]:
+        if reconciliation is None:
+            state = "missing"
+            reason = "missing_direct_reconciliation_binding"
+        elif reconciliation.lifecycle_state == "matched":
+            state = "normal"
+            reason = None
+        elif reconciliation.lifecycle_state in {"mismatched", "pending"}:
+            state = "mismatch"
+            reason = reconciliation.mismatch_summary or reconciliation.lifecycle_state
+        elif reconciliation.lifecycle_state == "stale":
+            state = "stale"
+            reason = reconciliation.mismatch_summary or "stale_reconciliation"
+        else:
+            state = "unsupported"
+            reason = reconciliation.lifecycle_state
+        return self._case_timeline_segment(
+            segment="reconciliation",
+            authority_posture="authoritative_aegisops_record",
+            record_family="reconciliation",
+            record_id=(
+                None if reconciliation is None else reconciliation.reconciliation_id
+            ),
+            state=state,
+            incomplete_reason=reason,
+            truth_source="aegisops_reconciliation_record",
+        )
+
+    def _latest_direct_case_ai_trace(
+        self,
+        *,
+        case: CaseRecord,
+        evidence_records: tuple[dict[str, object], ...],
+    ) -> AITraceRecord | None:
+        evidence_ids = {
+            evidence_id
+            for record in evidence_records
+            for evidence_id in (record.get("evidence_id"),)
+            if isinstance(evidence_id, str)
+        }
+        candidates = [
+            record
+            for record in self._service._store.list(AITraceRecord)
+            if self._ai_trace_directly_binds_case(
+                record,
+                case=case,
+                evidence_ids=evidence_ids,
+            )
+        ]
+        candidates.sort(
+            key=lambda record: (record.generated_at, record.ai_trace_id),
+            reverse=True,
+        )
+        return candidates[0] if candidates else None
+
+    @staticmethod
+    def _ai_trace_directly_binds_case(
+        record: AITraceRecord,
+        *,
+        case: CaseRecord,
+        evidence_ids: set[str],
+    ) -> bool:
+        linkage = record.subject_linkage
+        case_ids = linkage.get("case_ids")
+        alert_ids = linkage.get("alert_ids")
+        linked_evidence_ids = linkage.get("evidence_ids")
+        if isinstance(case_ids, (list, tuple)) and case.case_id in case_ids:
+            return True
+        if isinstance(alert_ids, (list, tuple)) and case.alert_id in alert_ids:
+            return True
+        if (
+            evidence_ids
+            and isinstance(linked_evidence_ids, (list, tuple))
+            and any(evidence_id in evidence_ids for evidence_id in linked_evidence_ids)
+        ):
+            return True
+        return False
+
+    def _latest_direct_case_recommendation(
+        self,
+        case: CaseRecord,
+    ) -> RecommendationRecord | None:
+        candidates = [
+            record
+            for record in self._service._store.list(RecommendationRecord)
+            if record.case_id == case.case_id or record.alert_id == case.alert_id
+        ]
+        candidates.sort(key=lambda record: record.recommendation_id, reverse=True)
+        return candidates[0] if candidates else None
+
+    def _latest_direct_case_action_request(
+        self,
+        case: CaseRecord,
+    ) -> ActionRequestRecord | None:
+        candidates = [
+            record
+            for record in self._service._store.list(ActionRequestRecord)
+            if record.case_id == case.case_id or record.alert_id == case.alert_id
+        ]
+        candidates.sort(
+            key=lambda record: (record.requested_at, record.action_request_id),
+            reverse=True,
+        )
+        return candidates[0] if candidates else None
+
+    def _latest_direct_action_execution(
+        self,
+        action_request: ActionRequestRecord,
+    ) -> ActionExecutionRecord | None:
+        candidates = [
+            record
+            for record in self._service._store.list(ActionExecutionRecord)
+            if record.action_request_id == action_request.action_request_id
+        ]
+        candidates.sort(
+            key=lambda record: (record.delegated_at, record.action_execution_id),
+            reverse=True,
+        )
+        return candidates[0] if candidates else None
+
+    def _latest_direct_case_reconciliation(
+        self,
+        *,
+        case: CaseRecord,
+        action_request: ActionRequestRecord | None,
+        execution: ActionExecutionRecord | None,
+    ) -> ReconciliationRecord | None:
+        candidates = [
+            record
+            for record in self._service._store.list(ReconciliationRecord)
+            if self._reconciliation_directly_binds_case(
+                record,
+                case=case,
+                action_request=action_request,
+                execution=execution,
+            )
+        ]
+        candidates.sort(
+            key=lambda record: (record.compared_at, record.reconciliation_id),
+            reverse=True,
+        )
+        return candidates[0] if candidates else None
+
+    @staticmethod
+    def _reconciliation_directly_binds_case(
+        record: ReconciliationRecord,
+        *,
+        case: CaseRecord,
+        action_request: ActionRequestRecord | None,
+        execution: ActionExecutionRecord | None,
+    ) -> bool:
+        if record.alert_id == case.alert_id or record.finding_id == case.finding_id:
+            return True
+        linkage = record.subject_linkage
+        case_ids = linkage.get("case_ids")
+        alert_ids = linkage.get("alert_ids")
+        action_request_ids = linkage.get("action_request_ids")
+        action_execution_ids = linkage.get("action_execution_ids")
+        if isinstance(case_ids, (list, tuple)) and case.case_id in case_ids:
+            return True
+        if isinstance(alert_ids, (list, tuple)) and case.alert_id in alert_ids:
+            return True
+        if (
+            action_request is not None
+            and isinstance(action_request_ids, (list, tuple))
+            and action_request.action_request_id in action_request_ids
+        ):
+            return True
+        if (
+            execution is not None
+            and isinstance(action_execution_ids, (list, tuple))
+            and execution.action_execution_id in action_execution_ids
+        ):
+            return True
+        return False
 
     def inspect_action_review_detail(self, action_request_id: str) -> object:
         action_request_id = self._service._require_non_empty_string(

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -909,27 +909,7 @@ class OperatorInspectionReadSurface:
             execution=execution,
         )
         segments = (
-            self._case_timeline_segment(
-                segment="wazuh_signal",
-                authority_posture="subordinate_context",
-                record_family="reconciliation",
-                record_id=(
-                    reconciliation.reconciliation_id
-                    if reconciliation is not None
-                    and self._service._reconciliation_is_wazuh_origin(reconciliation)
-                    else None
-                ),
-                state=(
-                    "normal"
-                    if reconciliation is not None
-                    and self._service._reconciliation_is_wazuh_origin(reconciliation)
-                    else "missing"
-                ),
-                incomplete_reason=(
-                    None if reconciliation is not None else "missing_wazuh_signal_binding"
-                ),
-                truth_source="aegisops_alert_admission_record",
-            ),
+            self._case_wazuh_signal_timeline_segment(reconciliation),
             self._case_timeline_segment(
                 segment="aegisops_alert",
                 authority_posture="authoritative_aegisops_record",
@@ -1000,26 +980,7 @@ class OperatorInspectionReadSurface:
                 ),
                 truth_source="aegisops_approval_decision_record",
             ),
-            self._case_timeline_segment(
-                segment="shuffle_receipt",
-                authority_posture="subordinate_context",
-                record_family="action_execution",
-                record_id=(
-                    None if execution is None else execution.action_execution_id
-                ),
-                state=(
-                    "normal"
-                    if execution is not None
-                    and execution.execution_surface_id == "shuffle"
-                    else "missing"
-                ),
-                incomplete_reason=(
-                    None
-                    if execution is not None
-                    else "missing_direct_shuffle_receipt_binding"
-                ),
-                truth_source="aegisops_action_execution_record",
-            ),
+            self._case_shuffle_receipt_timeline_segment(execution),
             self._case_reconciliation_timeline_segment(reconciliation),
         )
         return {
@@ -1061,6 +1022,58 @@ class OperatorInspectionReadSurface:
             "projection_can_complete_segment": False,
             "incomplete_reason": incomplete_reason,
         }
+
+    def _case_wazuh_signal_timeline_segment(
+        self,
+        reconciliation: ReconciliationRecord | None,
+    ) -> dict[str, object]:
+        is_wazuh_origin = (
+            reconciliation is not None
+            and self._service._reconciliation_is_wazuh_origin(reconciliation)
+        )
+        if is_wazuh_origin:
+            state = "normal"
+            reason = None
+        elif reconciliation is None:
+            state = "missing"
+            reason = "missing_wazuh_signal_binding"
+        else:
+            state = "unsupported"
+            reason = "unsupported_wazuh_binding"
+        return self._case_timeline_segment(
+            segment="wazuh_signal",
+            authority_posture="subordinate_context",
+            record_family="reconciliation",
+            record_id=(
+                None if not is_wazuh_origin else reconciliation.reconciliation_id
+            ),
+            state=state,
+            incomplete_reason=reason,
+            truth_source="aegisops_alert_admission_record",
+        )
+
+    def _case_shuffle_receipt_timeline_segment(
+        self,
+        execution: ActionExecutionRecord | None,
+    ) -> dict[str, object]:
+        if execution is None:
+            state = "missing"
+            reason = "missing_direct_shuffle_receipt_binding"
+        elif execution.execution_surface_id == "shuffle":
+            state = "normal"
+            reason = None
+        else:
+            state = "unsupported"
+            reason = f"unsupported_execution_surface:{execution.execution_surface_id}"
+        return self._case_timeline_segment(
+            segment="shuffle_receipt",
+            authority_posture="subordinate_context",
+            record_family="action_execution",
+            record_id=None if execution is None else execution.action_execution_id,
+            state=state,
+            incomplete_reason=reason,
+            truth_source="aegisops_action_execution_record",
+        )
 
     def _case_evidence_timeline_segment(
         self,

--- a/control-plane/aegisops/control_plane/runtime/service_snapshots.py
+++ b/control-plane/aegisops/control_plane/runtime/service_snapshots.py
@@ -173,6 +173,7 @@ class CaseDetailSnapshot:
     linked_reconciliation_records: tuple[dict[str, object], ...]
     lifecycle_transitions: tuple[dict[str, object], ...]
     cross_source_timeline: tuple[dict[str, object], ...]
+    case_timeline_projection: dict[str, object]
     provenance_summary: dict[str, object]
     current_action_review: dict[str, object] | None
     action_reviews: tuple[dict[str, object], ...]
@@ -200,6 +201,7 @@ class CaseDetailSnapshot:
                 "linked_reconciliation_records": self.linked_reconciliation_records,
                 "lifecycle_transitions": self.lifecycle_transitions,
                 "cross_source_timeline": self.cross_source_timeline,
+                "case_timeline_projection": self.case_timeline_projection,
                 "provenance_summary": self.provenance_summary,
                 "current_action_review": self.current_action_review,
                 "action_reviews": self.action_reviews,

--- a/control-plane/tests/test_phase56_3_case_timeline_projection.py
+++ b/control-plane/tests/test_phase56_3_case_timeline_projection.py
@@ -19,7 +19,7 @@ from _service_persistence_support import (
 
 class Phase563CaseTimelineProjectionTests(ServicePersistenceTestBase):
     def test_case_detail_projects_required_segments_with_authority_posture(self) -> None:
-        store, service, promoted_case, evidence_id, reviewed_at = (
+        _store, service, promoted_case, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()
         )
         recommendation = service.persist_record(

--- a/control-plane/tests/test_phase56_3_case_timeline_projection.py
+++ b/control-plane/tests/test_phase56_3_case_timeline_projection.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+
+from _service_persistence_support import (
+    AITraceRecord,
+    ActionExecutionRecord,
+    ActionRequestRecord,
+    ApprovalDecisionRecord,
+    EvidenceRecord,
+    ReconciliationRecord,
+    RecommendationRecord,
+    ServicePersistenceTestBase,
+    _approved_binding_hash,
+    _phase20_notify_identity_owner_payload,
+)
+
+
+class Phase563CaseTimelineProjectionTests(ServicePersistenceTestBase):
+    def test_case_detail_projects_required_segments_with_authority_posture(self) -> None:
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase563-001",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                ai_trace_id="ai-trace-phase563-001",
+                review_owner="analyst-001",
+                intended_outcome="Ask an approver to notify the identity owner.",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-phase563-001",
+                subject_linkage={
+                    "case_ids": (promoted_case.case_id,),
+                    "alert_ids": (promoted_case.alert_id,),
+                    "recommendation_ids": (recommendation.recommendation_id,),
+                    "evidence_ids": (evidence_id,),
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-56-3-test",
+                generated_at=reviewed_at,
+                material_input_refs=(evidence_id,),
+                reviewer_identity="analyst-001",
+                lifecycle_state="under_review",
+            )
+        )
+        target_scope = {"asset_id": "asset-phase563-001"}
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="identity-owner-phase563-001",
+            case_id=promoted_case.case_id,
+            alert_id=promoted_case.alert_id,
+            finding_id=promoted_case.finding_id,
+            source_record_id=recommendation.recommendation_id,
+            recommendation_id=recommendation.recommendation_id,
+            linked_evidence_ids=(evidence_id,),
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase563-001",
+                action_request_id="action-request-phase563-001",
+                approver_identities=("approver-001",),
+                target_snapshot=target_scope,
+                payload_hash=payload_hash,
+                decided_at=reviewed_at,
+                lifecycle_state="approved",
+            )
+        )
+        action_request = service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-phase563-001",
+                approval_decision_id=approval.approval_decision_id,
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                idempotency_key="idempotency-phase563-001",
+                target_scope=target_scope,
+                payload_hash=payload_hash,
+                requested_at=reviewed_at,
+                expires_at=None,
+                lifecycle_state="approved",
+                requester_identity="analyst-001",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                },
+            )
+        )
+        execution = service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-phase563-001",
+                action_request_id=action_request.action_request_id,
+                approval_decision_id=approval.approval_decision_id,
+                delegation_id="delegation-phase563-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="shuffle",
+                execution_run_id="shuffle-run-phase563-001",
+                idempotency_key="execution-idempotency-phase563-001",
+                target_scope=target_scope,
+                approved_payload=approved_payload,
+                payload_hash=payload_hash,
+                delegated_at=reviewed_at + timedelta(minutes=1),
+                expires_at=None,
+                provenance={
+                    "adapter": "shuffle",
+                    "downstream_binding": {
+                        "system": "shuffle",
+                        "execution_run_id": "shuffle-run-phase563-001",
+                    },
+                },
+                lifecycle_state="succeeded",
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase563-001",
+                subject_linkage={
+                    "case_ids": (promoted_case.case_id,),
+                    "alert_ids": (promoted_case.alert_id,),
+                    "action_request_ids": (action_request.action_request_id,),
+                    "approval_decision_ids": (approval.approval_decision_id,),
+                    "action_execution_ids": (execution.action_execution_id,),
+                    "evidence_ids": (evidence_id,),
+                },
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id=execution.execution_run_id,
+                linked_execution_run_ids=(execution.execution_run_id,),
+                correlation_key="phase563-reconciliation",
+                first_seen_at=reviewed_at,
+                last_seen_at=reviewed_at + timedelta(minutes=2),
+                ingest_disposition="matched",
+                mismatch_summary="",
+                compared_at=reviewed_at + timedelta(minutes=3),
+                lifecycle_state="matched",
+            )
+        )
+        service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase563-sibling",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id="alert-phase563-sibling",
+                case_id=None,
+                ai_trace_id="ai-trace-phase563-001",
+                review_owner="analyst-002",
+                intended_outcome="Do not infer this sibling into the case timeline.",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+
+        detail = service.inspect_case_detail(promoted_case.case_id)
+        projection = detail.case_timeline_projection
+        segments = {segment["segment"]: segment for segment in projection["segments"]}
+
+        self.assertEqual(projection["case_id"], promoted_case.case_id)
+        self.assertFalse(projection["projection_authority_allowed"])
+        self.assertEqual(
+            tuple(segments),
+            (
+                "wazuh_signal",
+                "aegisops_alert",
+                "evidence",
+                "ai_summary",
+                "recommendation",
+                "action_request",
+                "approval",
+                "shuffle_receipt",
+                "reconciliation",
+            ),
+        )
+        self.assertEqual(
+            segments["aegisops_alert"]["authority_posture"],
+            "authoritative_aegisops_record",
+        )
+        self.assertEqual(
+            segments["wazuh_signal"]["authority_posture"],
+            "subordinate_context",
+        )
+        self.assertEqual(
+            segments["shuffle_receipt"]["authority_posture"],
+            "subordinate_context",
+        )
+        self.assertEqual(segments["reconciliation"]["state"], "normal")
+        self.assertEqual(
+            segments["recommendation"]["backend_record_binding"]["record_id"],
+            recommendation.recommendation_id,
+        )
+        self.assertEqual(
+            segments["action_request"]["backend_record_binding"]["record_id"],
+            action_request.action_request_id,
+        )
+        self.assertEqual(
+            segments["approval"]["backend_record_binding"]["record_id"],
+            approval.approval_decision_id,
+        )
+        self.assertNotIn(
+            "recommendation-phase563-sibling",
+            {
+                segment["backend_record_binding"].get("record_id")
+                for segment in projection["segments"]
+            },
+        )
+
+    def test_case_timeline_keeps_missing_and_degraded_segments_visible(self) -> None:
+        _store, service, promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        degraded_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase563-degraded",
+                source_record_id="source-phase563-degraded",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="wazuh",
+                collector_identity="collector://wazuh/replay",
+                acquired_at=_reviewed_at,
+                derivation_relationship="reviewed_case_attachment",
+                lifecycle_state="collected",
+                provenance={},
+            )
+        )
+        promoted_case = service.persist_record(
+            replace(
+                promoted_case,
+                evidence_ids=(
+                    *promoted_case.evidence_ids,
+                    degraded_evidence.evidence_id,
+                ),
+            )
+        )
+
+        projection = service.inspect_case_detail(
+            promoted_case.case_id
+        ).case_timeline_projection
+        segments = {segment["segment"]: segment for segment in projection["segments"]}
+
+        self.assertEqual(segments["ai_summary"]["state"], "missing")
+        self.assertEqual(segments["recommendation"]["state"], "missing")
+        self.assertEqual(segments["action_request"]["state"], "missing")
+        self.assertEqual(segments["approval"]["state"], "missing")
+        self.assertEqual(segments["shuffle_receipt"]["state"], "missing")
+        self.assertEqual(segments["evidence"]["state"], "degraded")
+        self.assertTrue(segments["evidence"]["operator_visible"])
+        self.assertEqual(
+            segments["evidence"]["incomplete_reason"],
+            "missing_provenance",
+        )
+
+    def test_case_timeline_rejects_sibling_timestamp_and_ai_output_inference(self) -> None:
+        store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        sibling_evidence = service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-phase563-sibling",
+                source_record_id="source-phase563-sibling",
+                alert_id="alert-phase563-sibling",
+                case_id=None,
+                source_system="wazuh",
+                collector_identity="collector://wazuh/replay",
+                acquired_at=reviewed_at,
+                derivation_relationship="same_timestamp_only",
+                lifecycle_state="collected",
+                provenance={
+                    "classification": "reviewed-derived",
+                    "source_id": "source-phase563-sibling",
+                    "timestamp": reviewed_at.isoformat(),
+                    "reviewed_by": "analyst-001",
+                    "source_family": "wazuh",
+                },
+            )
+        )
+        service.persist_record(
+            RecommendationRecord(
+                recommendation_id="recommendation-phase563-ai-only",
+                lead_id=None,
+                hunt_run_id=None,
+                alert_id="alert-phase563-ai-only",
+                case_id=None,
+                ai_trace_id=None,
+                review_owner="assistant",
+                intended_outcome="AI text mentions the case title but has no binding.",
+                lifecycle_state="under_review",
+                reviewed_context=promoted_case.reviewed_context,
+            )
+        )
+
+        projection = service.inspect_case_detail(
+            promoted_case.case_id
+        ).case_timeline_projection
+        bindings = {
+            segment["backend_record_binding"].get("record_id")
+            for segment in projection["segments"]
+        }
+
+        self.assertNotIn(sibling_evidence.evidence_id, bindings)
+        self.assertNotIn("recommendation-phase563-ai-only", bindings)
+        self.assertEqual(
+            store.list(EvidenceRecord)[-1].evidence_id,
+            sibling_evidence.evidence_id,
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/control-plane/tests/test_phase56_3_case_timeline_projection.py
+++ b/control-plane/tests/test_phase56_3_case_timeline_projection.py
@@ -264,6 +264,137 @@ class Phase563CaseTimelineProjectionTests(ServicePersistenceTestBase):
             "missing_provenance",
         )
 
+    def test_case_timeline_marks_bound_out_of_contract_subordinate_segments_unsupported(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        target_scope = {"asset_id": "asset-phase563-unsupported-001"}
+        approved_payload = _phase20_notify_identity_owner_payload(
+            recipient_identity="identity-owner-phase563-unsupported-001",
+            case_id=promoted_case.case_id,
+            alert_id=promoted_case.alert_id,
+            finding_id=promoted_case.finding_id,
+            source_record_id="recommendation-phase563-unsupported-001",
+            recommendation_id="recommendation-phase563-unsupported-001",
+            linked_evidence_ids=(evidence_id,),
+        )
+        payload_hash = _approved_binding_hash(
+            target_scope=target_scope,
+            approved_payload=approved_payload,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="n8n",
+        )
+        approval = service.persist_record(
+            ApprovalDecisionRecord(
+                approval_decision_id="approval-phase563-unsupported-001",
+                action_request_id="action-request-phase563-unsupported-001",
+                approver_identities=("approver-001",),
+                target_snapshot=target_scope,
+                payload_hash=payload_hash,
+                decided_at=reviewed_at,
+                lifecycle_state="approved",
+            )
+        )
+        action_request = service.persist_record(
+            ActionRequestRecord(
+                action_request_id="action-request-phase563-unsupported-001",
+                approval_decision_id=approval.approval_decision_id,
+                case_id=promoted_case.case_id,
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                idempotency_key="idempotency-phase563-unsupported-001",
+                target_scope=target_scope,
+                payload_hash=payload_hash,
+                requested_at=reviewed_at + timedelta(minutes=1),
+                expires_at=None,
+                lifecycle_state="approved",
+                requester_identity="analyst-001",
+                requested_payload=approved_payload,
+                policy_evaluation={
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "n8n",
+                },
+            )
+        )
+        execution = service.persist_record(
+            ActionExecutionRecord(
+                action_execution_id="action-execution-phase563-unsupported-001",
+                action_request_id=action_request.action_request_id,
+                approval_decision_id=approval.approval_decision_id,
+                delegation_id="delegation-phase563-unsupported-001",
+                execution_surface_type="automation_substrate",
+                execution_surface_id="n8n",
+                execution_run_id="n8n-run-phase563-unsupported-001",
+                idempotency_key="execution-idempotency-phase563-unsupported-001",
+                target_scope=target_scope,
+                approved_payload=approved_payload,
+                payload_hash=payload_hash,
+                delegated_at=reviewed_at + timedelta(minutes=2),
+                expires_at=None,
+                provenance={
+                    "adapter": "n8n",
+                    "downstream_binding": {
+                        "system": "n8n",
+                        "execution_run_id": "n8n-run-phase563-unsupported-001",
+                    },
+                },
+                lifecycle_state="succeeded",
+            )
+        )
+        service.persist_record(
+            ReconciliationRecord(
+                reconciliation_id="reconciliation-phase563-unsupported-001",
+                subject_linkage={
+                    "case_ids": (promoted_case.case_id,),
+                    "alert_ids": (promoted_case.alert_id,),
+                    "action_request_ids": (action_request.action_request_id,),
+                    "approval_decision_ids": (approval.approval_decision_id,),
+                    "action_execution_ids": (execution.action_execution_id,),
+                    "source_systems": ("ticketing",),
+                    "substrate_detection_record_ids": (
+                        "ticket:phase563-unsupported-001",
+                    ),
+                },
+                alert_id=promoted_case.alert_id,
+                finding_id=promoted_case.finding_id,
+                analytic_signal_id=None,
+                execution_run_id=execution.execution_run_id,
+                linked_execution_run_ids=(execution.execution_run_id,),
+                correlation_key="phase563-unsupported-reconciliation",
+                first_seen_at=reviewed_at + timedelta(minutes=3),
+                last_seen_at=reviewed_at + timedelta(minutes=3),
+                ingest_disposition="matched",
+                mismatch_summary="",
+                compared_at=reviewed_at + timedelta(minutes=4),
+                lifecycle_state="matched",
+            )
+        )
+
+        projection = service.inspect_case_detail(
+            promoted_case.case_id
+        ).case_timeline_projection
+        segments = {segment["segment"]: segment for segment in projection["segments"]}
+
+        self.assertEqual(segments["wazuh_signal"]["state"], "unsupported")
+        self.assertIsNone(
+            segments["wazuh_signal"]["backend_record_binding"]["record_id"]
+        )
+        self.assertEqual(
+            segments["wazuh_signal"]["incomplete_reason"],
+            "unsupported_wazuh_binding",
+        )
+        self.assertEqual(segments["shuffle_receipt"]["state"], "unsupported")
+        self.assertEqual(
+            segments["shuffle_receipt"]["backend_record_binding"]["record_id"],
+            execution.action_execution_id,
+        )
+        self.assertEqual(
+            segments["shuffle_receipt"]["incomplete_reason"],
+            "unsupported_execution_surface:n8n",
+        )
+
     def test_case_timeline_rejects_sibling_timestamp_and_ai_output_inference(self) -> None:
         store, service, promoted_case, _evidence_id, reviewed_at = (
             self._build_phase19_in_scope_case()

--- a/control-plane/tests/test_phase56_3_case_timeline_projection_contract.py
+++ b/control-plane/tests/test_phase56_3_case_timeline_projection_contract.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CONTRACT_PATH = (
+    REPO_ROOT / "docs/deployment/case-timeline-authority-projection-contract.md"
+)
+ARTIFACT_PATH = (
+    REPO_ROOT
+    / "docs/deployment/profiles/smb-single-node/case-timeline-projection.yaml"
+)
+README_PATH = REPO_ROOT / "README.md"
+
+
+class Phase563CaseTimelineProjectionContractTests(unittest.TestCase):
+    @staticmethod
+    def _read(path: pathlib.Path) -> str:
+        if not path.exists():
+            raise AssertionError(f"expected file at {path.relative_to(REPO_ROOT)}")
+        return path.read_text(encoding="utf-8")
+
+    def test_contract_names_segments_states_and_authority_boundary(self) -> None:
+        text = self._read(CONTRACT_PATH)
+
+        for term in (
+            "Phase 56.3 Case Timeline Authority Projection Contract",
+            "wazuh_signal",
+            "aegisops_alert",
+            "evidence",
+            "ai_summary",
+            "recommendation",
+            "action_request",
+            "approval",
+            "shuffle_receipt",
+            "reconciliation",
+            "normal",
+            "missing",
+            "degraded",
+            "stale",
+            "mismatch",
+            "unsupported",
+            "Only AegisOps control-plane records carry",
+            "reject inferred linkage from sibling records",
+            "Missing, degraded, stale, mismatch, and unsupported segments remain visible",
+        ):
+            self.assertIn(term, text)
+
+    def test_artifact_names_segments_authority_postures_and_negative_cases(self) -> None:
+        text = self._read(ARTIFACT_PATH)
+
+        for term in (
+            "case_timeline_projection_contract_version: 2026-05-04",
+            "projection_owner: aegisops-control-plane",
+            "workflow_truth_source: aegisops-record-chain-only",
+            "projection_authority_allowed: false",
+            "inferred_linkage_allowed: false",
+            "authoritative_aegisops_record",
+            "subordinate_context",
+            "missing-backend-record-binding",
+            "inferred-sibling-linkage",
+            "wazuh-shuffle-ai-ticket-report-truth-overreach",
+            "stale-projection-as-current-truth",
+        ):
+            self.assertIn(term, text)
+
+        for segment in (
+            "wazuh_signal",
+            "aegisops_alert",
+            "evidence",
+            "ai_summary",
+            "recommendation",
+            "action_request",
+            "approval",
+            "shuffle_receipt",
+            "reconciliation",
+        ):
+            self.assertRegex(text, rf"(?m)^  - {segment}$")
+
+        for state in ("normal", "missing", "degraded", "stale", "mismatch", "unsupported"):
+            self.assertRegex(text, rf"(?m)^  - {state}$")
+
+    def test_readme_links_phase563_contract(self) -> None:
+        self.assertIn(
+            "docs/deployment/case-timeline-authority-projection-contract.md",
+            self._read(README_PATH),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/deployment/case-timeline-authority-projection-contract.md
+++ b/docs/deployment/case-timeline-authority-projection-contract.md
@@ -1,0 +1,73 @@
+# Phase 56.3 Case Timeline Authority Projection Contract
+
+- **Status**: Accepted contract
+- **Date**: 2026-05-04
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1190, #1191, #1193
+- **Related Baseline**: `docs/phase-51-6-authority-boundary-negative-test-policy.md`, `docs/deployment/today-view-backend-projection-contract.md`
+
+This contract defines the backend case timeline projection that separates authoritative AegisOps record truth from subordinate Wazuh, Shuffle, AI, ticket, and report context. The required structured artifact is `docs/deployment/profiles/smb-single-node/case-timeline-projection.yaml`.
+
+## 1. Purpose
+
+The case timeline projection gives operators one ordered case-detail surface for the reviewed workflow chain. It may organize context, but it cannot create, replace, infer, or complete workflow truth.
+
+The required timeline segments are:
+
+| Segment | Purpose | Authority posture |
+| --- | --- | --- |
+| wazuh_signal | Show the directly admitted Wazuh-origin signal context for the case. | Subordinate context; Wazuh state cannot become AegisOps alert, case, evidence, receipt, reconciliation, or closeout truth. |
+| aegisops_alert | Show the authoritative alert bound to the case. | Authoritative AegisOps alert record. |
+| evidence | Show directly linked AegisOps evidence and custody posture. | Authoritative AegisOps evidence record; external evidence systems stay subordinate. |
+| ai_summary | Show assistant summary or trace context. | Subordinate advisory context; AI cannot approve, execute, reconcile, close, gate, or mutate records. |
+| recommendation | Show directly linked recommendation context. | Subordinate advisory context until translated into explicit AegisOps action-review records. |
+| action_request | Show the reviewed action request. | Authoritative AegisOps action request record. |
+| approval | Show the approval decision. | Authoritative AegisOps approval decision record. |
+| shuffle_receipt | Show delegated execution receipt context. | Subordinate execution context bound through the AegisOps action execution record; Shuffle success cannot close or reconcile by itself. |
+| reconciliation | Show comparison and closeout readiness. | Authoritative AegisOps reconciliation record. |
+
+## 2. Authority Boundary
+
+Only AegisOps control-plane records carry alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, gate, release, or closeout truth.
+
+The timeline projection must reject inferred linkage from sibling records, parent records, timestamps, title text, UI cache, Wazuh state, Shuffle state, tickets, reports, or AI output. If a segment has no direct backend record binding, the segment remains visible with `missing`, `degraded`, `stale`, `mismatch`, or `unsupported` state instead of being silently treated as complete.
+
+## 3. Segment States
+
+| State | Required behavior |
+| --- | --- |
+| normal | A directly linked backend record exists and its authoritative lifecycle or subordinate context is current for display. |
+| missing | A required direct binding is absent. Keep the segment visible. |
+| degraded | A bound record exists but provenance, custody, source-health, advisory, or subordinate context is incomplete. |
+| stale | A bound authoritative record or receipt is stale. Do not treat cached projection output as current truth. |
+| mismatch | A bound reconciliation, receipt, or source-linkage record disagrees with the expected authoritative state. |
+| unsupported | A bound state is outside the reviewed Phase 56.3 contract. Keep the segment visible and do not infer success. |
+
+## 4. Projection Rules
+
+| Rule | Required behavior |
+| --- | --- |
+| all-required-segments-present | The backend projection and artifact name `wazuh_signal`, `aegisops_alert`, `evidence`, `ai_summary`, `recommendation`, `action_request`, `approval`, `shuffle_receipt`, and `reconciliation`. |
+| direct-binding-required | Every segment includes a backend record binding with a record family and record identifier or an explicit missing reason. |
+| authority-posture-required | Every segment labels `authoritative_aegisops_record` or `subordinate_context`. |
+| missing-degraded-visible | Missing, degraded, stale, mismatch, and unsupported segments remain visible and cannot be summarized away. |
+| no-inferred-linkage | Sibling, parent, timestamp, title, UI cache, Wazuh, Shuffle, ticket, report, or AI-output hints cannot bind a segment. |
+| no-projection-truth | Timeline projection output cannot close, approve, execute, reconcile, gate, release, mutate, or replace authoritative records. |
+
+## 5. Validation
+
+Run `PYTHONPATH=control-plane/tests python3 -m unittest control-plane.tests.test_phase56_3_case_timeline_projection`.
+
+Run `python3 -m unittest control-plane.tests.test_phase56_3_case_timeline_projection_contract`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1190 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1193 --config <supervisor-config-path>`.
+
+## 6. Non-Goals
+
+Phase 56.3 does not implement visual timeline UI, task cards, handoff view, admin/RBAC, supportability, reporting breadth, SOAR breadth, RC readiness, GA readiness, or commercial readiness.
+
+Phase 56.3 does not make UI cache, Wazuh state, Shuffle state, tickets, reports, AI output, verifier output, or issue-lint output authoritative AegisOps truth.

--- a/docs/deployment/profiles/smb-single-node/case-timeline-projection.yaml
+++ b/docs/deployment/profiles/smb-single-node/case-timeline-projection.yaml
@@ -1,0 +1,79 @@
+profile_id: smb-single-node
+case_timeline_projection_contract_version: 2026-05-04
+status: accepted-contract
+related_issues:
+  - 1190
+  - 1191
+  - 1193
+projection_owner: aegisops-control-plane
+workflow_truth_source: aegisops-record-chain-only
+authority_boundary: Case timeline projection is derived display context only; AegisOps records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, gate, release, and closeout truth.
+projection_authority_allowed: false
+inferred_linkage_allowed: false
+subordinate_surfaces_authority_allowed: false
+segments:
+  - wazuh_signal
+  - aegisops_alert
+  - evidence
+  - ai_summary
+  - recommendation
+  - action_request
+  - approval
+  - shuffle_receipt
+  - reconciliation
+states:
+  - normal
+  - missing
+  - degraded
+  - stale
+  - mismatch
+  - unsupported
+authority_postures:
+  authoritative_aegisops_record:
+    truth_source: aegisops-record-chain
+    projection_can_complete_segment: false
+  subordinate_context:
+    truth_source: directly-bound-context-only
+    projection_can_complete_segment: false
+segment_contracts:
+  wazuh_signal:
+    authority_posture: subordinate_context
+    backend_record_binding: aegisops-alert-admission-or-reconciliation-record
+    wazuh_state_authority_allowed: false
+  aegisops_alert:
+    authority_posture: authoritative_aegisops_record
+    backend_record_binding: aegisops-alert-record
+  evidence:
+    authority_posture: authoritative_aegisops_record
+    backend_record_binding: aegisops-evidence-record
+    missing_or_degraded_hidden_allowed: false
+  ai_summary:
+    authority_posture: subordinate_context
+    backend_record_binding: directly-linked-ai-trace-or-case-advisory-record
+    approval_execution_reconciliation_allowed: false
+  recommendation:
+    authority_posture: subordinate_context
+    backend_record_binding: directly-linked-recommendation-record
+    sibling_lineage_inference_allowed: false
+  action_request:
+    authority_posture: authoritative_aegisops_record
+    backend_record_binding: aegisops-action-request-record
+  approval:
+    authority_posture: authoritative_aegisops_record
+    backend_record_binding: aegisops-approval-decision-record
+  shuffle_receipt:
+    authority_posture: subordinate_context
+    backend_record_binding: aegisops-action-execution-record
+    shuffle_success_closeout_allowed: false
+  reconciliation:
+    authority_posture: authoritative_aegisops_record
+    backend_record_binding: aegisops-reconciliation-record
+negative_validation_tests:
+  - missing-required-segment
+  - missing-authority-posture
+  - missing-backend-record-binding
+  - inferred-sibling-linkage
+  - timestamp-title-ui-cache-linkage
+  - wazuh-shuffle-ai-ticket-report-truth-overreach
+  - missing-degraded-stale-mismatch-hidden-by-summary
+  - stale-projection-as-current-truth


### PR DESCRIPTION
## Summary
- add a Phase 56.3 case timeline projection to case detail snapshots with required authority/subordinate segments and direct backend bindings
- keep missing, degraded, stale, mismatch, and unsupported segment states visible without treating projection output as truth
- add the Phase 56.3 contract doc, SMB profile artifact, README link, and focused regression/contract tests

## Verification
- PYTHONPATH=control-plane/tests python3 -m unittest control-plane.tests.test_phase56_3_case_timeline_projection control-plane.tests.test_phase56_3_case_timeline_projection_contract
- PYTHONPATH=control-plane/tests python3 -m unittest control-plane.tests.test_phase25_osquery_host_context_validation control-plane.tests.test_cli_inspection_workflow_family
- bash scripts/verify-publishable-path-hygiene.sh
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1190 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.json
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1193 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.json
- PYTHONPATH=control-plane/tests python3 -m unittest discover -s control-plane/tests
- python3 -m py_compile control-plane/aegisops/control_plane/operator_inspection.py control-plane/aegisops/control_plane/runtime/service_snapshots.py control-plane/tests/test_phase56_3_case_timeline_projection.py control-plane/tests/test_phase56_3_case_timeline_projection_contract.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Case timeline projection added to case detail responses, showing ordered segments (wazuh_signal → reconciliation) with explicit states, authority posture indicators, and included in case detail snapshots.

* **Documentation**
  * New Phase 56.3 contract and deployment profile for timeline projection; README updated to reference the contract.

* **Tests**
  * Integration and contract tests added to validate projection segments, states, authority boundaries, and negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->