### PR TITLE
[codex] Add case timeline UI

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.casework.detail.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.detail.testSuite.tsx
@@ -152,10 +152,20 @@ export function registerOperatorRoutesCaseworkDetailTests() {
         expect(within(timeline).getAllByText(state).length).toBeGreaterThan(0);
         expect(within(timeline).getAllByText(`phase564_${state}`).length).toBeGreaterThan(0);
       }
+      for (const staleState of within(timeline).getAllByText("stale")) {
+        expect(staleState.closest(".MuiChip-root")).toHaveClass("MuiChip-colorWarning");
+      }
+      for (const unsupportedState of within(timeline).getAllByText("unsupported")) {
+        expect(unsupportedState.closest(".MuiChip-root")).toHaveClass("MuiChip-colorError");
+      }
       expect(screen.queryByText("Completed by timeline display")).not.toBeInTheDocument();
     });
 
     it.each([
+      [
+        "unsupported timeline contract version",
+        createCaseTimelineProjection({ contract_version: "phase-56-4" }),
+      ],
       [
         "cache-sourced timeline truth",
         createCaseTimelineProjection({ cache_sourced: true }),

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.detail.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.detail.testSuite.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
@@ -12,8 +12,217 @@ import {
   TestRouteNavigator,
 } from "./OperatorRoutes.testSupport";
 
+function createCaseTimelineProjection(overrides: Record<string, unknown> = {}) {
+  const segments = [
+    ["wazuh_signal", "subordinate_context", "normal", "reconciliation", "recon-123"],
+    ["aegisops_alert", "authoritative_aegisops_record", "normal", "alert", "alert-123"],
+    ["evidence", "authoritative_aegisops_record", "degraded", "evidence", "evidence-123"],
+    ["ai_summary", "subordinate_context", "missing", "ai_trace", null],
+    ["recommendation", "subordinate_context", "normal", "recommendation", "rec-123"],
+    ["action_request", "authoritative_aegisops_record", "normal", "action_request", "ar-123"],
+    ["approval", "authoritative_aegisops_record", "normal", "approval_decision", "approval-123"],
+    ["shuffle_receipt", "subordinate_context", "stale", "action_execution", "exec-123"],
+    ["reconciliation", "authoritative_aegisops_record", "mismatch", "reconciliation", "recon-123"],
+  ].map(([segment, authority_posture, state, record_family, record_id]) => ({
+    authority_posture,
+    backend_record_binding: {
+      direct_binding_required: true,
+      record_family,
+      record_id,
+    },
+    incomplete_reason: state === "normal" ? null : `phase564_${state}`,
+    operator_visible: true,
+    projection_can_complete_segment: false,
+    segment,
+    state,
+    truth_source: `aegisops_${record_family}_record`,
+  }));
+
+  return {
+    authority_boundary:
+      "Case timeline projection is derived display context only; AegisOps records remain authoritative.",
+    case_id: "case-456",
+    contract_version: "phase-56-3",
+    inferred_linkage_allowed: false,
+    projection_authority_allowed: false,
+    segments,
+    ...overrides,
+  };
+}
+
+function createCaseDetailPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    case_id: "case-456",
+    case_record: {
+      case_id: "case-456",
+      lifecycle_state: "pending_action",
+    },
+    case_timeline_projection: createCaseTimelineProjection(),
+    cross_source_timeline: [],
+    linked_alert_ids: ["alert-123"],
+    linked_alert_records: [],
+    linked_evidence_ids: ["evidence-123"],
+    linked_evidence_records: [],
+    linked_lead_ids: [],
+    linked_observation_ids: [],
+    linked_recommendation_ids: [],
+    linked_reconciliation_ids: ["recon-123"],
+    linked_reconciliation_records: [],
+    provenance_summary: {
+      authoritative_anchor: {
+        provenance_classification: "authoritative",
+        record_family: "case",
+        record_id: "case-456",
+        source_family: "aegisops",
+      },
+    },
+    ...overrides,
+  };
+}
+
 export function registerOperatorRoutesCaseworkDetailTests() {
   describe("casework detail routes", () => {
+    it("renders the reviewed case timeline chain in backend order with authority labels", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-case-detail": createCaseDetailPayload(),
+        }),
+      });
+
+      renderOperatorRoute("/operator/cases/case-456", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Case Detail" }),
+        ).toBeInTheDocument();
+      });
+
+      const timeline = screen.getByRole("table", {
+        name: "Reviewed case timeline",
+      });
+      const rows = within(timeline).getAllByRole("row").slice(1);
+
+      expect(rows.map((row) => within(row).getAllByRole("cell")[0]?.textContent)).toEqual([
+        "Wazuh Signal",
+        "Aegisops Alert",
+        "Evidence",
+        "Ai Summary",
+        "Recommendation",
+        "Action Request",
+        "Approval",
+        "Shuffle Receipt",
+        "Reconciliation",
+      ]);
+      expect(within(rows[0] as HTMLElement).getByText("Subordinate Context")).toBeInTheDocument();
+      expect(
+        within(rows[1] as HTMLElement).getByText("Authoritative Aegisops Record"),
+      ).toBeInTheDocument();
+      expect(
+        within(rows[7] as HTMLElement).getByText("Display cannot complete workflow truth"),
+      ).toBeInTheDocument();
+    });
+
+    it("keeps missing, degraded, stale, mismatch, and unsupported timeline segments visible", async () => {
+      const projection = createCaseTimelineProjection({
+        segments: createCaseTimelineProjection().segments.map((segment: unknown, index) => {
+          const record = segment as Record<string, unknown>;
+          const states = ["missing", "degraded", "stale", "mismatch", "unsupported"];
+          return {
+            ...record,
+            incomplete_reason: `phase564_${states[index % states.length]}`,
+            state: states[index % states.length],
+          };
+        }),
+      });
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-case-detail": createCaseDetailPayload({
+            case_timeline_projection: projection,
+          }),
+        }),
+      });
+
+      renderOperatorRoute("/operator/cases/case-456", dependencies);
+
+      const timeline = await screen.findByRole("table", {
+        name: "Reviewed case timeline",
+      });
+
+      for (const state of ["missing", "degraded", "stale", "mismatch", "unsupported"]) {
+        expect(within(timeline).getAllByText(state).length).toBeGreaterThan(0);
+        expect(within(timeline).getAllByText(`phase564_${state}`).length).toBeGreaterThan(0);
+      }
+      expect(screen.queryByText("Completed by timeline display")).not.toBeInTheDocument();
+    });
+
+    it.each([
+      [
+        "cache-sourced timeline truth",
+        createCaseTimelineProjection({ cache_sourced: true }),
+      ],
+      [
+        "unsupported segment type",
+        createCaseTimelineProjection({
+          segments: createCaseTimelineProjection().segments.map(
+            (segment: unknown, index) =>
+              index === 0
+                ? {
+                    ...(segment as Record<string, unknown>),
+                    segment: "browser_approval",
+                  }
+                : segment,
+          ),
+        }),
+      ],
+      [
+        "wrong authority label",
+        createCaseTimelineProjection({
+          segments: createCaseTimelineProjection().segments.map(
+            (segment: unknown, index) =>
+              index === 0
+                ? {
+                    ...(segment as Record<string, unknown>),
+                    authority_posture: "browser_truth",
+                  }
+                : segment,
+          ),
+        }),
+      ],
+      [
+        "display state as completion truth",
+        createCaseTimelineProjection({
+          segments: createCaseTimelineProjection().segments.map(
+            (segment: unknown, index) =>
+              index === 0
+                ? {
+                    ...(segment as Record<string, unknown>),
+                    projection_can_complete_segment: true,
+                  }
+                : segment,
+          ),
+        }),
+      ],
+    ])("fails closed on %s", async (_label, caseTimelineProjection) => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-case-detail": createCaseDetailPayload({
+            case_timeline_projection: caseTimelineProjection,
+          }),
+        }),
+      });
+
+      renderOperatorRoute("/operator/cases/case-456", dependencies);
+
+      expect(
+        await screen.findByText(
+          "Reviewed operator data could not be verified. The browser stayed fail-closed instead of rendering an untrusted record.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("table", { name: "Reviewed case timeline" }),
+      ).not.toBeInTheDocument();
+    });
+
     it("renders alert detail with authoritative and subordinate sections separated", async () => {
       const dependencies = createDefaultDependencies({
         fetchFn: createAuthorizedFetch({

--- a/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
@@ -171,6 +171,7 @@ export function CaseDetailPageBody({
               {caseTimelineSegments.map((segment, index) => {
                 const binding = asRecord(segment.backend_record_binding);
                 const state = asString(segment.state);
+                const stateTone = statusTone(state);
                 const authorityPosture = asString(segment.authority_posture);
 
                 return (
@@ -194,7 +195,7 @@ export function CaseDetailPageBody({
                     </TableCell>
                     <TableCell>
                       <Chip
-                        color={statusTone(state)}
+                        color={stateTone}
                         label={state ?? "unknown"}
                         size="small"
                         variant={state === "normal" ? "filled" : "outlined"}

--- a/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
@@ -1,4 +1,13 @@
-import { Stack, Table, TableBody, TableCell, TableHead, TableRow } from "@mui/material";
+import {
+  Chip,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
 import { useMemo, useState } from "react";
 import { CreateReviewedActionRequestCard } from "../../taskActions/actionRequestActionCards";
 import {
@@ -20,12 +29,14 @@ import {
   EmptyState,
   ErrorState,
   formatValue,
+  formatLabel,
   getPath,
   LoadingState,
   QueryStateNotice,
   RecordWarnings,
   SectionCard,
   StatusStrip,
+  statusTone,
   SubordinateLinks,
   type UnknownRecord,
   useOperatorRecord,
@@ -62,6 +73,8 @@ export function CaseDetailPageBody({
   const alertRecords = asRecordArray(data.linked_alert_records);
   const evidenceRecords = asRecordArray(data.linked_evidence_records);
   const timelineEntries = asRecordArray(data.cross_source_timeline);
+  const caseTimelineProjection = asRecord(data.case_timeline_projection);
+  const caseTimelineSegments = asRecordArray(caseTimelineProjection?.segments);
   const currentActionReview = asRecord(data.current_action_review);
   const linkedEvidenceIds = asStringArray(data.linked_evidence_ids);
   const linkedObservationIds = asStringArray(data.linked_observation_ids);
@@ -136,6 +149,77 @@ export function CaseDetailPageBody({
             ["Linked reconciliation ids", data.linked_reconciliation_ids],
           ]}
         />
+      </SectionCard>
+
+      <SectionCard
+        subtitle="Reviewed order comes from the backend projection. Timeline display, browser state, and cached UI data cannot approve, execute, reconcile, or complete work."
+        title="Reviewed case timeline"
+      >
+        {caseTimelineSegments.length > 0 ? (
+          <Table aria-label="Reviewed case timeline" size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Segment</TableCell>
+                <TableCell>Authority</TableCell>
+                <TableCell>State</TableCell>
+                <TableCell>Backend binding</TableCell>
+                <TableCell>Incomplete reason</TableCell>
+                <TableCell>Display boundary</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {caseTimelineSegments.map((segment, index) => {
+                const binding = asRecord(segment.backend_record_binding);
+                const state = asString(segment.state);
+                const authorityPosture = asString(segment.authority_posture);
+
+                return (
+                  <TableRow key={`${asString(segment.segment) ?? index}-${index}`}>
+                    <TableCell>{formatLabel(asString(segment.segment) ?? "unknown")}</TableCell>
+                    <TableCell>
+                      <Chip
+                        color={
+                          authorityPosture === "authoritative_aegisops_record"
+                            ? "primary"
+                            : "default"
+                        }
+                        label={formatLabel(authorityPosture ?? "unknown")}
+                        size="small"
+                        variant={
+                          authorityPosture === "authoritative_aegisops_record"
+                            ? "filled"
+                            : "outlined"
+                        }
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        color={statusTone(state)}
+                        label={state ?? "unknown"}
+                        size="small"
+                        variant={state === "normal" ? "filled" : "outlined"}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {formatValue([
+                        binding?.record_family,
+                        binding?.record_id,
+                      ])}
+                    </TableCell>
+                    <TableCell>{formatValue(segment.incomplete_reason)}</TableCell>
+                    <TableCell>
+                      <Typography color="text.secondary" variant="body2">
+                        Display cannot complete workflow truth
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        ) : (
+          <EmptyState message="No reviewed case timeline projection was returned." />
+        )}
       </SectionCard>
 
       <SectionCard

--- a/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
@@ -171,7 +171,12 @@ export function CaseDetailPageBody({
               {caseTimelineSegments.map((segment, index) => {
                 const binding = asRecord(segment.backend_record_binding);
                 const state = asString(segment.state);
-                const stateTone = statusTone(state);
+                const stateTone =
+                  state === "unsupported"
+                    ? "error"
+                    : state === "stale"
+                      ? "warning"
+                      : statusTone(state);
                 const authorityPosture = asString(segment.authority_posture);
 
                 return (

--- a/apps/operator-ui/src/app/operatorConsolePages/recordUtils.ts
+++ b/apps/operator-ui/src/app/operatorConsolePages/recordUtils.ts
@@ -88,7 +88,8 @@ export function statusTone(
     normalized.includes("forbidden") ||
     normalized.includes("mismatch") ||
     normalized.includes("missing") ||
-    normalized.includes("rejected")
+    normalized.includes("rejected") ||
+    normalized.includes("unsupported")
   ) {
     return "error";
   }
@@ -96,7 +97,8 @@ export function statusTone(
     normalized.includes("degraded") ||
     normalized.includes("pending") ||
     normalized.includes("delayed") ||
-    normalized.includes("expired")
+    normalized.includes("expired") ||
+    normalized.includes("stale")
   ) {
     return "warning";
   }

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -14,6 +14,32 @@ const TODAY_VIEW_LANES = [
   "ai_suggested_focus",
 ] as const;
 
+const CASE_TIMELINE_SEGMENTS = [
+  "wazuh_signal",
+  "aegisops_alert",
+  "evidence",
+  "ai_summary",
+  "recommendation",
+  "action_request",
+  "approval",
+  "shuffle_receipt",
+  "reconciliation",
+] as const;
+
+const CASE_TIMELINE_STATES = new Set([
+  "normal",
+  "missing",
+  "degraded",
+  "stale",
+  "mismatch",
+  "unsupported",
+]);
+
+const CASE_TIMELINE_AUTHORITY_POSTURES = new Set([
+  "authoritative_aegisops_record",
+  "subordinate_context",
+]);
+
 export async function getOneForStandardResource(
   fetchFn: typeof fetch,
   resource: StandardOperatorResourceName,
@@ -26,9 +52,130 @@ export async function getOneForStandardResource(
     return resolveReconciliationRecord(payload, params);
   }
 
+  if (resource === "cases") {
+    validateCaseTimelineProjection(payload, String(params.id).trim());
+  }
+
   return {
     data: normalizeRecord(resource, payload, binding.idField),
   };
+}
+
+function validateCaseTimelineProjection(payload: unknown, requestedCaseId: string) {
+  const response = asObject(
+    payload,
+    "Resource cases returned a malformed detail payload.",
+  );
+  const projectionValue = response.case_timeline_projection;
+
+  if (projectionValue === undefined || projectionValue === null) {
+    return;
+  }
+
+  const projection = asObject(
+    projectionValue,
+    "Resource cases case_timeline_projection must be an object.",
+  );
+  const caseId = asString(projection.case_id);
+  const contractVersion = asString(projection.contract_version);
+  const segments = Array.isArray(projection.segments)
+    ? projection.segments
+    : null;
+  const projectionSource = asString(projection.projection_source);
+
+  if (caseId === null || contractVersion === null || segments === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource cases case_timeline_projection is missing case_id, contract_version, or segments.",
+    );
+  }
+  if (caseId !== requestedCaseId) {
+    throw new OperatorDataProviderContractError(
+      `Resource cases case_timeline_projection requires case_id to match ${requestedCaseId}.`,
+    );
+  }
+  if (
+    (projection.cache_sourced !== undefined && projection.cache_sourced !== false) ||
+    (projection.stale_cache !== undefined && projection.stale_cache !== false) ||
+    ["browser_cache", "ui_cache", "cache"].includes(projectionSource ?? "")
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource cases rejects cache-sourced case timeline truth.",
+    );
+  }
+  if (
+    projection.projection_authority_allowed !== false ||
+    projection.inferred_linkage_allowed !== false
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource cases case_timeline_projection must reject projection authority and inferred linkage.",
+    );
+  }
+  if (segments.length !== CASE_TIMELINE_SEGMENTS.length) {
+    throw new OperatorDataProviderContractError(
+      "Resource cases case_timeline_projection must include every reviewed segment.",
+    );
+  }
+
+  segments.forEach((segmentValue, index) => {
+    const segment = asObject(
+      segmentValue,
+      "Resource cases case_timeline_projection segment must be an object.",
+    );
+    const segmentName = asString(segment.segment);
+    const state = asString(segment.state);
+    const authorityPosture = asString(segment.authority_posture);
+    const binding = asObject(
+      segment.backend_record_binding,
+      "Resource cases case_timeline_projection segment is missing backend_record_binding.",
+    );
+    const recordFamily = asString(binding.record_family);
+    const recordId = asString(binding.record_id);
+    const incompleteReason = asString(segment.incomplete_reason);
+
+    if (segmentName !== CASE_TIMELINE_SEGMENTS[index]) {
+      throw new OperatorDataProviderContractError(
+        "Resource cases case_timeline_projection segment order or type is unsupported.",
+      );
+    }
+    if (state === null || !CASE_TIMELINE_STATES.has(state)) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases case_timeline_projection segment ${segmentName} has unsupported state.`,
+      );
+    }
+    if (
+      authorityPosture === null ||
+      !CASE_TIMELINE_AUTHORITY_POSTURES.has(authorityPosture)
+    ) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases case_timeline_projection segment ${segmentName} has unsupported authority posture.`,
+      );
+    }
+    if (recordFamily === null) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases case_timeline_projection segment ${segmentName} is missing record_family.`,
+      );
+    }
+    if (binding.direct_binding_required !== true) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases case_timeline_projection segment ${segmentName} must require direct binding.`,
+      );
+    }
+    if (segment.operator_visible !== true) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases case_timeline_projection segment ${segmentName} must stay operator visible.`,
+      );
+    }
+    if (segment.projection_can_complete_segment !== false) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases case_timeline_projection segment ${segmentName} cannot complete workflow truth from display state.`,
+      );
+    }
+    if (recordId === null && incompleteReason === null) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases case_timeline_projection segment ${segmentName} without record_id requires incomplete_reason.`,
+      );
+    }
+  });
 }
 
 export async function getOneForAdvisoryOutput(

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -40,6 +40,8 @@ const CASE_TIMELINE_AUTHORITY_POSTURES = new Set([
   "subordinate_context",
 ]);
 
+const CASE_TIMELINE_CONTRACT_VERSION = "phase-56-3";
+
 export async function getOneForStandardResource(
   fetchFn: typeof fetch,
   resource: StandardOperatorResourceName,
@@ -86,6 +88,11 @@ function validateCaseTimelineProjection(payload: unknown, requestedCaseId: strin
   if (caseId === null || contractVersion === null || segments === null) {
     throw new OperatorDataProviderContractError(
       "Resource cases case_timeline_projection is missing case_id, contract_version, or segments.",
+    );
+  }
+  if (contractVersion !== CASE_TIMELINE_CONTRACT_VERSION) {
+    throw new OperatorDataProviderContractError(
+      `Resource cases case_timeline_projection requires contract_version ${CASE_TIMELINE_CONTRACT_VERSION}; received ${contractVersion}.`,
     );
   }
   if (caseId !== requestedCaseId) {


### PR DESCRIPTION
## Summary
- render the Phase 56.3 case timeline projection on case detail in reviewed backend order
- validate timeline projection shape before rendering, including authority posture, direct binding, cache-sourced truth, and display-completion guards
- add route tests for order, authority labels, degraded/missing visibility, and fail-closed negative cases

## Verification
- npm --prefix apps/operator-ui run typecheck
- npm --prefix apps/operator-ui test -- --run src/app/OperatorRoutes.test.tsx -t "case timeline|fails closed on cache-sourced|fails closed on unsupported segment type|fails closed on wrong authority label|fails closed on display state"
- npm --prefix apps/operator-ui test -- --run src/app/OperatorRoutes.test.tsx
- npm --prefix apps/operator-ui test -- --run src/dataProvider.test.ts
- npm --prefix apps/operator-ui test
- node dist/index.js issue-lint 1190 --config supervisor.config.aegisops.json
- node dist/index.js issue-lint 1194 --config supervisor.config.aegisops.json

Refs #1194
Part of #1190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Reviewed case timeline" section in case detail views showing ordered timeline segments with authority labels, state indicators, backend bindings, incomplete reasons, and empty-state handling.  
* **Behavior Change**
  * UI now "fails closed": when timeline data is invalid or untrusted a verification error is shown and the reviewed timeline is withheld.  
* **Tests**
  * Expanded tests for rendering, ordering, visibility of degraded/stale/unsupported segments and fail-closed scenarios.  
* **Style**
  * State tones updated to distinguish "stale" (warning) and "unsupported" (error).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->