### PR TITLE
Phase 56.6 business-hours handoff view

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.businessHoursHandoff.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.businessHoursHandoff.testSuite.tsx
@@ -1,0 +1,127 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createDefaultDependencies } from "./OperatorRoutes";
+import {
+  createAuthorizedFetch,
+  renderOperatorRoute,
+} from "./OperatorRoutes.testSupport";
+
+const normalBusinessHoursHandoff = {
+  authority_boundary:
+    "Business-hours handoff display is coordination guidance only; AegisOps records remain authoritative for lifecycle, approval, execution, reconciliation, evidence, audit, and closeout truth.",
+  business_hours_handoff_contract_version: "phase-56-6",
+  handoff_id: "handoff-2026-05-04",
+  handoff_state: "blocked",
+  items: [
+    {
+      ai_summary_handling: {
+        advisory_only: true,
+        posture: "accepted_for_reference",
+        summary_id: "ai-trace-accepted-101",
+      },
+      backend_record_binding: {
+        direct_binding_required: true,
+        record_family: "case",
+        record_id: "case-101",
+      },
+      blocked_owner: "analyst-001",
+      changed_work: "Case promoted and evidence review started.",
+      evidence_gaps: ["Missing endpoint custody record."],
+      follow_up: "Collect endpoint custody evidence before approval review.",
+      item_id: "handoff-item-101",
+      state: "unresolved",
+      title: "Continue investigation for case-101",
+    },
+    {
+      ai_summary_handling: {
+        advisory_only: true,
+        posture: "rejected_for_reference",
+        summary_id: "ai-trace-rejected-202",
+      },
+      backend_record_binding: {
+        direct_binding_required: true,
+        record_family: "action_request",
+        record_id: "action-request-202",
+      },
+      blocked_owner: "approver-002",
+      changed_work: "Containment request failed after approved execution path.",
+      evidence_gaps: ["Missing failed execution receipt."],
+      follow_up: "Re-review scope before retry or manual fallback.",
+      item_id: "handoff-item-202",
+      state: "failed",
+      title: "Failed containment needs owner follow-up",
+    },
+  ],
+  projection_authority_allowed: false,
+  read_only: true,
+  stale_cache: false,
+};
+
+export function registerOperatorRoutesBusinessHoursHandoffTests() {
+  describe("business-hours handoff route", () => {
+    it("renders unresolved and failed handoff items with explicit owners, evidence gaps, and advisory AI handling", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-business-hours-handoff": normalBusinessHoursHandoff,
+        }),
+      });
+
+      renderOperatorRoute("/operator/handoff", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Business-hours handoff" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Continue investigation for case-101")).toBeInTheDocument();
+      expect(
+        screen.getByText("Failed containment needs owner follow-up"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Owner: analyst-001")).toBeInTheDocument();
+      expect(screen.getByText("Owner: approver-002")).toBeInTheDocument();
+      expect(screen.getByText("Missing endpoint custody record.")).toBeInTheDocument();
+      expect(screen.getByText("Missing failed execution receipt.")).toBeInTheDocument();
+      expect(screen.getByText("AI accepted for reference")).toBeInTheDocument();
+      expect(screen.getByText("AI rejected for reference")).toBeInTheDocument();
+      expect(screen.getAllByText("Advisory only").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("State remains open").length).toBeGreaterThan(0);
+      expect(
+        screen.getByText(
+          "Handoff copy cannot close cases, approve actions, execute work, reconcile outcomes, satisfy audit evidence, or override backend records.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /close case/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /approve/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /execute/i })).toBeNull();
+    });
+
+    it("fails closed on stale cache-only handoff state", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-business-hours-handoff": {
+            ...normalBusinessHoursHandoff,
+            stale_cache: true,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/handoff", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", {
+            name: "Business-hours handoff unavailable",
+          }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Continue investigation for case-101")).toBeNull();
+      expect(
+        screen.getByText(
+          "The backend handoff projection was stale or malformed, so the browser refused to present it as current handoff guidance.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+}

--- a/apps/operator-ui/src/app/OperatorRoutes.businessHoursHandoff.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.businessHoursHandoff.testSuite.tsx
@@ -173,8 +173,12 @@ export function registerOperatorRoutesBusinessHoursHandoffTests() {
               {
                 ...normalBusinessHoursHandoff.items[0],
                 ai_summary_handling: {
-                  ...normalBusinessHoursHandoff.items[0].ai_summary_handling,
-                  posture: "missing",
+                  advisory_only:
+                    normalBusinessHoursHandoff.items[0].ai_summary_handling
+                      .advisory_only,
+                  summary_id:
+                    normalBusinessHoursHandoff.items[0].ai_summary_handling
+                      .summary_id,
                 },
               },
             ],

--- a/apps/operator-ui/src/app/OperatorRoutes.businessHoursHandoff.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.businessHoursHandoff.testSuite.tsx
@@ -10,7 +10,7 @@ const normalBusinessHoursHandoff = {
   authority_boundary:
     "Business-hours handoff display is coordination guidance only; AegisOps records remain authoritative for lifecycle, approval, execution, reconciliation, evidence, audit, and closeout truth.",
   business_hours_handoff_contract_version: "phase-56-6",
-  handoff_id: "handoff-2026-05-04",
+  handoff_id: "current",
   handoff_state: "blocked",
   items: [
     {
@@ -76,7 +76,19 @@ export function registerOperatorRoutesBusinessHoursHandoffTests() {
 
       expect(screen.getByText("Continue investigation for case-101")).toBeInTheDocument();
       expect(
+        screen.getByText("Case promoted and evidence review started."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Follow-up: Collect endpoint custody evidence before approval review."),
+      ).toBeInTheDocument();
+      expect(
         screen.getByText("Failed containment needs owner follow-up"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Containment request failed after approved execution path."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Follow-up: Re-review scope before retry or manual fallback."),
       ).toBeInTheDocument();
       expect(screen.getByText("Owner: analyst-001")).toBeInTheDocument();
       expect(screen.getByText("Owner: approver-002")).toBeInTheDocument();
@@ -102,6 +114,70 @@ export function registerOperatorRoutesBusinessHoursHandoffTests() {
           "/inspect-business-hours-handoff": {
             ...normalBusinessHoursHandoff,
             stale_cache: true,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/handoff", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", {
+            name: "Business-hours handoff unavailable",
+          }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Continue investigation for case-101")).toBeNull();
+      expect(
+        screen.getByText(
+          "The backend handoff projection was stale or malformed, so the browser refused to present it as current handoff guidance.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("fails closed when the backend handoff projection is not current", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-business-hours-handoff": {
+            ...normalBusinessHoursHandoff,
+            handoff_id: "handoff-2026-05-04",
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/handoff", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", {
+            name: "Business-hours handoff unavailable",
+          }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Continue investigation for case-101")).toBeNull();
+      expect(
+        screen.getByText(
+          "The backend handoff projection was stale or malformed, so the browser refused to present it as current handoff guidance.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("fails closed when AI summary posture is missing", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-business-hours-handoff": {
+            ...normalBusinessHoursHandoff,
+            items: [
+              {
+                ...normalBusinessHoursHandoff.items[0],
+                ai_summary_handling: {
+                  ...normalBusinessHoursHandoff.items[0].ai_summary_handling,
+                  posture: "missing",
+                },
+              },
+            ],
           },
         }),
       });

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -3,6 +3,7 @@ import { resetOperatorQueryCacheForTests } from "./operatorQueryCache";
 import { registerOperatorRoutesActionReviewTests } from "./OperatorRoutes.actionReview.testSuite";
 import { registerOperatorRoutesAssistantTests } from "./OperatorRoutes.assistant.testSuite";
 import { registerOperatorRoutesAuthAndShellTests } from "./OperatorRoutes.authAndShell.testSuite";
+import { registerOperatorRoutesBusinessHoursHandoffTests } from "./OperatorRoutes.businessHoursHandoff.testSuite";
 import { registerOperatorRoutesCaseworkTests } from "./OperatorRoutes.casework.testSuite";
 import { registerOperatorRoutesControlPlaneTests } from "./OperatorRoutes.controlPlane.testSuite";
 import { registerOperatorRoutesFirstLoginChecklistTests } from "./OperatorRoutes.firstLoginChecklist.testSuite";
@@ -20,4 +21,5 @@ describe("OperatorRoutes", () => {
   registerOperatorRoutesControlPlaneTests();
   registerOperatorRoutesFirstLoginChecklistTests();
   registerOperatorRoutesTodayTests();
+  registerOperatorRoutesBusinessHoursHandoffTests();
 });

--- a/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
@@ -207,7 +207,7 @@ export function registerOperatorRoutesTodayTests() {
       ).toHaveAttribute("href", "/operator/reconciliation");
       expect(
         screen.getByRole("link", { name: "Prepare handoff" }),
-      ).toHaveAttribute("href", "/operator/queue");
+      ).toHaveAttribute("href", "/operator/handoff");
 
       expect(screen.getAllByText("State remains unresolved").length).toBeGreaterThan(0);
       expect(

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -11,6 +11,7 @@ import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import GavelOutlinedIcon from "@mui/icons-material/GavelOutlined";
 import InboxOutlinedIcon from "@mui/icons-material/InboxOutlined";
 import InsightsOutlinedIcon from "@mui/icons-material/InsightsOutlined";
+import HandshakeOutlinedIcon from "@mui/icons-material/HandshakeOutlined";
 import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
 import PlaylistAddCheckOutlinedIcon from "@mui/icons-material/PlaylistAddCheckOutlined";
 import RuleFolderOutlinedIcon from "@mui/icons-material/RuleFolderOutlined";
@@ -90,6 +91,8 @@ const ReconciliationPage =
   lazyOperatorConsolePage("ReconciliationPage") as unknown as typeof import("./operatorConsolePages").ReconciliationPage;
 const TodayPage =
   lazyOperatorConsolePage("TodayPage") as unknown as typeof import("./operatorConsolePages").TodayPage;
+const BusinessHoursHandoffPage =
+  lazyOperatorConsolePage("BusinessHoursHandoffPage") as unknown as typeof import("./operatorConsolePages").BusinessHoursHandoffPage;
 
 function hasReviewedOperatorRole(
   operatorRoles: readonly string[],
@@ -155,6 +158,11 @@ function OperatorMenu({
         leftIcon={<InboxOutlinedIcon />}
         primaryText="Queue"
         to={buildOperatorShellPath(basePath, "queue")}
+      />
+      <Menu.Item
+        leftIcon={<HandshakeOutlinedIcon />}
+        primaryText="Handoff"
+        to={buildOperatorShellPath(basePath, "handoff")}
       />
       <Menu.Item
         leftIcon={<WarningAmberOutlinedIcon />}
@@ -402,6 +410,7 @@ function OperatorShellContent({
         <Routes>
           <Route element={<OverviewPage operatorRoles={operatorRoles} />} index />
           <Route element={<TodayPage />} path="today" />
+          <Route element={<BusinessHoursHandoffPage />} path="handoff" />
           <Route element={<QueuePage />} path="queue" />
           <Route element={<AlertIndexPage />} path="alerts" />
           <Route

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -1,5 +1,6 @@
 export { QueuePage } from "./operatorConsolePages/queuePages";
 export { TodayPage } from "./operatorConsolePages/todayPages";
+export { BusinessHoursHandoffPage } from "./operatorConsolePages/handoffPages";
 export {
   AlertDetailPage,
   CaseDetailPage,

--- a/apps/operator-ui/src/app/operatorConsolePages/handoffPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/handoffPages.tsx
@@ -1,0 +1,176 @@
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
+import { Alert, Chip, Grid, Stack, Typography } from "@mui/material";
+import { useMemo } from "react";
+import {
+  asRecord,
+  asRecordArray,
+  asString,
+  EmptyState,
+  LoadingState,
+  PageFrame,
+  SectionCard,
+  formatLabel,
+  statusTone,
+  useOperatorRecord,
+} from "./shared";
+
+function BusinessHoursHandoffUnavailable() {
+  return (
+    <PageFrame
+      subtitle="The browser refuses stale or malformed handoff projections."
+      title="Business-hours handoff unavailable"
+    >
+      <Alert severity="error" variant="outlined">
+        The backend handoff projection was stale or malformed, so the browser
+        refused to present it as current handoff guidance.
+      </Alert>
+    </PageFrame>
+  );
+}
+
+function aiSummaryLabel(posture: string | null) {
+  if (posture === "accepted_for_reference") {
+    return "AI accepted for reference";
+  }
+  if (posture === "rejected_for_reference") {
+    return "AI rejected for reference";
+  }
+  return "AI summary missing";
+}
+
+function HandoffItem({ item }: { item: Record<string, unknown> }) {
+  const title = asString(item.title) ?? "Untitled handoff item";
+  const state = asString(item.state);
+  const changedWork = asString(item.changed_work);
+  const blockedOwner = asString(item.blocked_owner);
+  const followUp = asString(item.follow_up);
+  const binding = asRecord(item.backend_record_binding);
+  const recordFamily = asString(binding?.record_family);
+  const recordId = asString(binding?.record_id);
+  const aiSummaryHandling = asRecord(item.ai_summary_handling);
+  const aiPosture = asString(aiSummaryHandling?.posture);
+  const evidenceGaps = Array.isArray(item.evidence_gaps)
+    ? item.evidence_gaps.filter((gap) => asString(gap) !== null)
+    : [];
+
+  return (
+    <Stack
+      spacing={1.25}
+      sx={{
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 1,
+        height: "100%",
+        p: 1.5,
+      }}
+    >
+      <Stack direction="row" flexWrap="wrap" gap={1}>
+        {state ? (
+          <Chip
+            color={statusTone(state)}
+            label={formatLabel(state)}
+            size="small"
+            variant="filled"
+          />
+        ) : null}
+        <Chip
+          color="warning"
+          label="State remains open"
+          size="small"
+          variant="outlined"
+        />
+        <Chip
+          color="info"
+          icon={<AutoAwesomeOutlinedIcon />}
+          label="Advisory only"
+          size="small"
+          variant="outlined"
+        />
+      </Stack>
+      <Typography variant="subtitle2">{title}</Typography>
+      <Typography color="text.secondary" variant="body2">
+        {changedWork}
+      </Typography>
+      <Typography variant="body2">Owner: {blockedOwner}</Typography>
+      <Typography color="text.secondary" variant="body2">
+        Follow-up: {followUp}
+      </Typography>
+      <Stack spacing={0.5}>
+        <Typography variant="caption">Evidence gaps</Typography>
+        {evidenceGaps.length > 0 ? (
+          evidenceGaps.map((gap) => (
+            <Typography color="text.secondary" key={String(gap)} variant="body2">
+              {String(gap)}
+            </Typography>
+          ))
+        ) : (
+          <Typography color="text.secondary" variant="body2">
+            No explicit evidence gaps in this handoff item.
+          </Typography>
+        )}
+      </Stack>
+      <Typography color="text.secondary" variant="caption">
+        Backend anchor: {recordFamily ?? "record"}:{recordId ?? "missing"}
+      </Typography>
+      <Typography color="text.secondary" variant="caption">
+        {aiSummaryLabel(aiPosture)}
+      </Typography>
+    </Stack>
+  );
+}
+
+export function BusinessHoursHandoffPage() {
+  const meta = useMemo(() => ({}), []);
+  const { data, error, loading } = useOperatorRecord(
+    "businessHoursHandoff",
+    "current",
+    meta,
+  );
+  const items = asRecordArray(data?.items);
+
+  if (loading && !data) {
+    return (
+      <PageFrame
+        subtitle="Loading the current backend-bound handoff projection."
+        title="Business-hours handoff"
+      >
+        <LoadingState label="Loading business-hours handoff" />
+      </PageFrame>
+    );
+  }
+
+  if (error) {
+    return <BusinessHoursHandoffUnavailable />;
+  }
+
+  return (
+    <PageFrame
+      subtitle="Part-time operator handoff guidance for changed work, blocked owners, follow-up, evidence gaps, and advisory AI summary handling."
+      title="Business-hours handoff"
+    >
+      <Stack spacing={3}>
+        <Alert severity="info" variant="outlined">
+          Handoff copy cannot close cases, approve actions, execute work,
+          reconcile outcomes, satisfy audit evidence, or override backend
+          records.
+        </Alert>
+        <SectionCard
+          subtitle="Unresolved and failed paths remain open until the backend record chain changes."
+          title="Handoff items"
+        >
+          {items.length > 0 ? (
+            <Grid container spacing={2}>
+              {items.map((item) => (
+                <Grid key={asString(item.item_id) ?? JSON.stringify(item)} size={{ xs: 12, md: 6 }}>
+                  <HandoffItem item={item} />
+                </Grid>
+              ))}
+            </Grid>
+          ) : (
+            <EmptyState message="No backend-bound handoff items are in the current projection." />
+          )}
+        </SectionCard>
+      </Stack>
+    </PageFrame>
+  );
+}

--- a/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
@@ -179,7 +179,7 @@ function buildOperatorTaskCards(
     {
       anchor: null,
       boundary:
-        "Open the reviewed queue for handoff context; handoff notes cannot close cases or override lifecycle state.",
+        "Open the reviewed handoff view; handoff notes cannot close cases or override lifecycle state.",
       label: "Prepare handoff",
       route: "/operator/handoff",
       state: null,

--- a/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
@@ -181,7 +181,7 @@ function buildOperatorTaskCards(
       boundary:
         "Open the reviewed queue for handoff context; handoff notes cannot close cases or override lifecycle state.",
       label: "Prepare handoff",
-      route: "/operator/queue",
+      route: "/operator/handoff",
       state: null,
       title: "Prepare handoff",
     },

--- a/apps/operator-ui/src/dataProvider.ts
+++ b/apps/operator-ui/src/dataProvider.ts
@@ -2,6 +2,7 @@ import type { DataProvider } from "react-admin";
 import {
   getOneForActionReview,
   getOneForAdvisoryOutput,
+  getOneForBusinessHoursHandoff,
   getOneForStandardResource,
   getOneForTodayView,
 } from "./operatorDataProvider/detailReaders";
@@ -61,6 +62,10 @@ export function createOperatorDataProvider({
 
       if (resource === "todayView") {
         return getOneForTodayView(fetchFn);
+      }
+
+      if (resource === "businessHoursHandoff") {
+        return getOneForBusinessHoursHandoff(fetchFn);
       }
 
       if (!isStandardResource(resource)) {

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -41,6 +41,19 @@ const CASE_TIMELINE_AUTHORITY_POSTURES = new Set([
 ]);
 
 const CASE_TIMELINE_CONTRACT_VERSION = "phase-56-3";
+const BUSINESS_HOURS_HANDOFF_CONTRACT_VERSION = "phase-56-6";
+
+const BUSINESS_HOURS_HANDOFF_STATES = new Set([
+  "unresolved",
+  "failed",
+  "blocked",
+]);
+
+const BUSINESS_HOURS_HANDOFF_AI_POSTURES = new Set([
+  "accepted_for_reference",
+  "rejected_for_reference",
+  "missing",
+]);
 
 export async function getOneForStandardResource(
   fetchFn: typeof fetch,
@@ -330,6 +343,124 @@ export async function getOneForTodayView(
       ...payload,
       id: "current",
       lanes: normalizedLanes,
+    },
+  };
+}
+
+function validateBusinessHoursHandoffItem(
+  item: unknown,
+): Record<string, unknown> {
+  const record = asObject(
+    item,
+    "Resource businessHoursHandoff returned a non-object item.",
+  );
+  const itemId = asString(record.item_id);
+  const title = asString(record.title);
+  const state = asString(record.state);
+  const changedWork = asString(record.changed_work);
+  const blockedOwner = asString(record.blocked_owner);
+  const followUp = asString(record.follow_up);
+  const binding = asObject(
+    record.backend_record_binding,
+    "Resource businessHoursHandoff item is missing backend_record_binding.",
+  );
+  const recordFamily = asString(binding.record_family);
+  const recordId = asString(binding.record_id);
+  const aiSummaryHandling = asObject(
+    record.ai_summary_handling,
+    "Resource businessHoursHandoff item is missing ai_summary_handling.",
+  );
+  const aiPosture = asString(aiSummaryHandling.posture);
+
+  if (
+    itemId === null ||
+    title === null ||
+    state === null ||
+    changedWork === null ||
+    blockedOwner === null ||
+    followUp === null
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource businessHoursHandoff item is missing item_id, title, state, changed_work, blocked_owner, or follow_up.",
+    );
+  }
+  if (!BUSINESS_HOURS_HANDOFF_STATES.has(state)) {
+    throw new OperatorDataProviderContractError(
+      `Resource businessHoursHandoff item ${itemId} has unsupported state.`,
+    );
+  }
+  if (binding.direct_binding_required !== true) {
+    throw new OperatorDataProviderContractError(
+      `Resource businessHoursHandoff item ${itemId} must require direct backend binding.`,
+    );
+  }
+  if (recordFamily === null || recordId === null) {
+    throw new OperatorDataProviderContractError(
+      `Resource businessHoursHandoff item ${itemId} is missing backend record family or id.`,
+    );
+  }
+  if (!Array.isArray(record.evidence_gaps)) {
+    throw new OperatorDataProviderContractError(
+      `Resource businessHoursHandoff item ${itemId} is missing evidence_gaps.`,
+    );
+  }
+  record.evidence_gaps.forEach((gap) => {
+    if (asString(gap) === null) {
+      throw new OperatorDataProviderContractError(
+        `Resource businessHoursHandoff item ${itemId} has a malformed evidence gap.`,
+      );
+    }
+  });
+  if (
+    aiSummaryHandling.advisory_only !== true ||
+    aiPosture === null ||
+    !BUSINESS_HOURS_HANDOFF_AI_POSTURES.has(aiPosture)
+  ) {
+    throw new OperatorDataProviderContractError(
+      `Resource businessHoursHandoff item ${itemId} must keep AI summary handling advisory and accepted/rejected posture explicit.`,
+    );
+  }
+
+  return record;
+}
+
+export async function getOneForBusinessHoursHandoff(
+  fetchFn: typeof fetch,
+): Promise<GetOneResult> {
+  const payload = asObject(
+    await fetchJson(fetchFn, "/inspect-business-hours-handoff"),
+    "Resource businessHoursHandoff returned a malformed detail payload.",
+  );
+  const handoffId = asString(payload.handoff_id);
+  const contractVersion = asString(payload.business_hours_handoff_contract_version);
+  const items = Array.isArray(payload.items) ? payload.items : null;
+
+  if (handoffId === null || contractVersion === null || items === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource businessHoursHandoff detail payload is missing handoff_id, contract version, or items.",
+    );
+  }
+  if (contractVersion !== BUSINESS_HOURS_HANDOFF_CONTRACT_VERSION) {
+    throw new OperatorDataProviderContractError(
+      `Resource businessHoursHandoff requires contract version ${BUSINESS_HOURS_HANDOFF_CONTRACT_VERSION}; received ${contractVersion}.`,
+    );
+  }
+  if (payload.stale_cache !== false) {
+    throw new OperatorDataProviderContractError(
+      "Resource businessHoursHandoff requires stale_cache=false and rejects stale or cache-only handoff guidance.",
+    );
+  }
+  if (payload.read_only !== true || payload.projection_authority_allowed !== false) {
+    throw new OperatorDataProviderContractError(
+      "Resource businessHoursHandoff must be read_only and reject projection authority.",
+    );
+  }
+
+  return {
+    data: {
+      ...payload,
+      id: "current",
+      items: items.map(validateBusinessHoursHandoffItem),
     },
   };
 }

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -52,7 +52,6 @@ const BUSINESS_HOURS_HANDOFF_STATES = new Set([
 const BUSINESS_HOURS_HANDOFF_AI_POSTURES = new Set([
   "accepted_for_reference",
   "rejected_for_reference",
-  "missing",
 ]);
 
 export async function getOneForStandardResource(
@@ -443,6 +442,11 @@ export async function getOneForBusinessHoursHandoff(
   if (contractVersion !== BUSINESS_HOURS_HANDOFF_CONTRACT_VERSION) {
     throw new OperatorDataProviderContractError(
       `Resource businessHoursHandoff requires contract version ${BUSINESS_HOURS_HANDOFF_CONTRACT_VERSION}; received ${contractVersion}.`,
+    );
+  }
+  if (handoffId !== "current") {
+    throw new OperatorDataProviderContractError(
+      `Resource businessHoursHandoff requires handoff_id current; received ${handoffId}.`,
     );
   }
   if (payload.stale_cache !== false) {

--- a/apps/operator-ui/src/operatorDataProvider/types.ts
+++ b/apps/operator-ui/src/operatorDataProvider/types.ts
@@ -8,6 +8,7 @@ export type OperatorResourceName =
   | "runtimeReadiness"
   | "reconciliations"
   | "todayView"
+  | "businessHoursHandoff"
   | "advisoryOutput"
   | "actionReview";
 
@@ -38,7 +39,7 @@ export interface StandardListReaderOptions {
 
 export type StandardOperatorResourceName = Exclude<
   OperatorResourceName,
-  "advisoryOutput" | "actionReview" | "todayView"
+  "advisoryOutput" | "actionReview" | "businessHoursHandoff" | "todayView"
 >;
 
 export type OperatorRecord = RaRecord;


### PR DESCRIPTION
## Summary
- add the read-only business-hours handoff operator route and menu entry
- add strict handoff projection validation for backend bindings, advisory AI accepted/rejected posture, and stale-cache rejection
- route the Today task card handoff action to the new handoff view

## Verification
- npm test -- src/app/OperatorRoutes.test.tsx -t "business-hours handoff"
- npm test -- src/app/OperatorRoutes.test.tsx -t "today workbench route"
- npm test -- src/app/OperatorRoutes.test.tsx
- npm run typecheck
- bash scripts/test-verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1190 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1196 --config <supervisor-config-path>

Closes #1196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Handoff page to view business-hours handoff items with status chips, owner, evidence-gap text, AI handling labels, guidance copy, backend reference info, loading and error states; action buttons (close/approve/execute) are intentionally not shown.

* **Navigation Updates**
  * "Prepare handoff" task now routes to the new Handoff page.

* **Data & Validation**
  * Added support and strict validation for the business-hours handoff resource in fetches.

* **Tests**
  * New test suite verifying rendering, AI labels, advisory/state messaging, unavailable-state behaviors and error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->