### PR TITLE
Phase 56.7 workbench navigation and health summary

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
@@ -203,6 +203,27 @@ export function registerOperatorRoutesAuthAndShellTests() {
     });
 
     expect(screen.queryByText(/action review/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Actions" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Automations" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Admin" })).toBeNull();
+    });
+
+    it("fails closed on analyst-only direct access to protected admin routes", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({}),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/admin"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Access denied" }),
+      ).toBeInTheDocument();
+    });
     });
 
     it("shows action-review navigation for reviewed approver sessions", async () => {
@@ -261,7 +282,7 @@ export function registerOperatorRoutesAuthAndShellTests() {
     expect(screen.getAllByText(/action review/i).length).toBeGreaterThan(0);
     });
 
-    it("uses the configured base path for reviewed operator navigation links", async () => {
+    it("uses the configured base path for reviewed operator navigation links and Phase 56.7 workbench aliases", async () => {
     const dependencies = createDefaultDependencies({
       config: {
         basePath: "/reviewed-operator",
@@ -289,21 +310,55 @@ export function registerOperatorRoutesAuthAndShellTests() {
       ).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("menuitem", { name: "Queue" })).toHaveAttribute(
-      "href",
-      expect.stringContaining("/reviewed-operator/queue"),
+    [
+      ["Today", "/reviewed-operator/today"],
+      ["Queue", "/reviewed-operator/queue"],
+      ["Cases", "/reviewed-operator/cases"],
+      ["Actions", "/reviewed-operator/actions"],
+      ["Sources", "/reviewed-operator/sources"],
+      ["Automations", "/reviewed-operator/automations"],
+      ["Reports", "/reviewed-operator/reports"],
+      ["Health", "/reviewed-operator/health"],
+    ].forEach(([label, href]) => {
+      expect(screen.getByRole("menuitem", { name: label })).toHaveAttribute(
+        "href",
+        expect.stringContaining(href),
+      );
+    });
+    expect(screen.queryByRole("menuitem", { name: "Admin" })).toBeNull();
+    });
+
+    it("shows Admin navigation only for backend canonical platform_admin sessions", async () => {
+    const dependencies = createDefaultDependencies({
+      config: {
+        basePath: "/reviewed-operator",
+      },
+      fetchFn: createAuthorizedFetch(
+        {},
+        {
+          identity: "platform.admin@example.com",
+          provider: "authentik",
+          roles: ["platform_admin"],
+          subject: "operator-44",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/reviewed-operator"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
     );
-    expect(screen.getByRole("menuitem", { name: "Alerts" })).toHaveAttribute(
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Protected operator shell" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("menuitem", { name: "Admin" })).toHaveAttribute(
       "href",
-      expect.stringContaining("/reviewed-operator/alerts"),
-    );
-    expect(screen.getByRole("menuitem", { name: "Cases" })).toHaveAttribute(
-      "href",
-      expect.stringContaining("/reviewed-operator/cases"),
-    );
-    expect(screen.getByRole("menuitem", { name: "Action Review" })).toHaveAttribute(
-      "href",
-      expect.stringContaining("/reviewed-operator/action-review"),
+      expect.stringContaining("/reviewed-operator/admin"),
     );
     });
 

--- a/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
@@ -195,6 +195,46 @@ export function registerOperatorRoutesTodayTests() {
       expect(screen.queryByRole("button", { name: /reconcile/i })).toBeNull();
     });
 
+    it("renders an explicit unavailable health summary when readiness diagnostics return no reviewed record", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-today-view": normalTodayProjection,
+        }),
+      });
+      dependencies.dataProvider = {
+        ...dependencies.dataProvider,
+        getList: vi.fn(async (resource, params) => {
+          if (resource === "runtimeReadiness") {
+            return {
+              data: [],
+              total: 0,
+            };
+          }
+
+          return createDefaultDependencies({
+            fetchFn: createAuthorizedFetch({
+              "/inspect-today-view": normalTodayProjection,
+            }),
+          }).dataProvider.getList(resource, params);
+        }),
+      };
+
+      renderOperatorRoute("/operator/today", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Workbench health summary" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(
+          "Workbench health summary is unavailable because readiness diagnostics returned no reviewed record.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Status: ready")).not.toBeInTheDocument();
+    });
+
     it("renders bounded operator task cards that route to existing reviewed surfaces only", async () => {
       const dependencies = createDefaultDependencies({
         fetchFn: createAuthorizedFetch({

--- a/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx
@@ -138,6 +138,16 @@ export function registerOperatorRoutesTodayTests() {
     it("renders normal work focus, stale and degraded badges, gaps, mismatches, approvals, and advisory AI focus", async () => {
       const dependencies = createDefaultDependencies({
         fetchFn: createAuthorizedFetch({
+          "/diagnostics/readiness": createReadinessResponse({
+            assistant: {
+              authority_mode: "advisory_only",
+              availability: "available",
+              enablement: "enabled",
+              mainline_dependency: "non_blocking",
+              readiness: "degraded",
+              reason: "reviewed_assistant_provider_lagging",
+            },
+          }),
           "/inspect-today-view": normalTodayProjection,
         }),
       });
@@ -163,6 +173,16 @@ export function registerOperatorRoutesTodayTests() {
       ).toBeInTheDocument();
       expect(
         screen.getByText("Review case-101 before lunch handoff"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Workbench health summary" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Status: ready")).toBeInTheDocument();
+      expect(screen.getByText("Assistant readiness: degraded")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Health summary is backend-bound operator context only; it cannot satisfy release, readiness, audit, approval, execution, reconciliation, or closeout gates.",
+        ),
       ).toBeInTheDocument();
       expect(screen.getAllByText("Stale").length).toBeGreaterThan(0);
       expect(screen.getAllByText("Degraded").length).toBeGreaterThan(0);

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -8,13 +8,18 @@ import {
 } from "react";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
+import AdminPanelSettingsOutlinedIcon from "@mui/icons-material/AdminPanelSettingsOutlined";
+import AssessmentOutlinedIcon from "@mui/icons-material/AssessmentOutlined";
+import BuildCircleOutlinedIcon from "@mui/icons-material/BuildCircleOutlined";
 import GavelOutlinedIcon from "@mui/icons-material/GavelOutlined";
+import HealthAndSafetyOutlinedIcon from "@mui/icons-material/HealthAndSafetyOutlined";
 import InboxOutlinedIcon from "@mui/icons-material/InboxOutlined";
 import InsightsOutlinedIcon from "@mui/icons-material/InsightsOutlined";
 import HandshakeOutlinedIcon from "@mui/icons-material/HandshakeOutlined";
 import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
 import PlaylistAddCheckOutlinedIcon from "@mui/icons-material/PlaylistAddCheckOutlined";
 import RuleFolderOutlinedIcon from "@mui/icons-material/RuleFolderOutlined";
+import SensorsOutlinedIcon from "@mui/icons-material/SensorsOutlined";
 import TodayOutlinedIcon from "@mui/icons-material/TodayOutlined";
 import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
 import {
@@ -117,6 +122,10 @@ function canInspectActionReviewDetail(operatorRoles: readonly string[]) {
   return hasReviewedOperatorRole(operatorRoles);
 }
 
+function canViewAdmin(operatorRoles: readonly string[]) {
+  return operatorRoles.some((role) => role.toLowerCase() === "platform_admin");
+}
+
 function buildOperatorShellPath(basePath: string, path = "") {
   if (!path) {
     return basePath;
@@ -145,6 +154,7 @@ function OperatorMenu({
   operatorRoles: readonly string[];
 }) {
   const showActionReview = canBrowseActionReview(operatorRoles);
+  const showAdmin = canViewAdmin(operatorRoles);
 
   return (
     <Menu>
@@ -160,6 +170,47 @@ function OperatorMenu({
         to={buildOperatorShellPath(basePath, "queue")}
       />
       <Menu.Item
+        leftIcon={<InsightsOutlinedIcon />}
+        primaryText="Cases"
+        to={buildOperatorShellPath(basePath, "cases")}
+      />
+      {showActionReview ? (
+        <Menu.Item
+          leftIcon={<GavelOutlinedIcon />}
+          primaryText="Actions"
+          to={buildOperatorShellPath(basePath, "actions")}
+        />
+      ) : null}
+      <Menu.Item
+        leftIcon={<SensorsOutlinedIcon />}
+        primaryText="Sources"
+        to={buildOperatorShellPath(basePath, "sources")}
+      />
+      {showActionReview ? (
+        <Menu.Item
+          leftIcon={<BuildCircleOutlinedIcon />}
+          primaryText="Automations"
+          to={buildOperatorShellPath(basePath, "automations")}
+        />
+      ) : null}
+      <Menu.Item
+        leftIcon={<AssessmentOutlinedIcon />}
+        primaryText="Reports"
+        to={buildOperatorShellPath(basePath, "reports")}
+      />
+      {showAdmin ? (
+        <Menu.Item
+          leftIcon={<AdminPanelSettingsOutlinedIcon />}
+          primaryText="Admin"
+          to={buildOperatorShellPath(basePath, "admin")}
+        />
+      ) : null}
+      <Menu.Item
+        leftIcon={<HealthAndSafetyOutlinedIcon />}
+        primaryText="Health"
+        to={buildOperatorShellPath(basePath, "health")}
+      />
+      <Menu.Item
         leftIcon={<HandshakeOutlinedIcon />}
         primaryText="Handoff"
         to={buildOperatorShellPath(basePath, "handoff")}
@@ -168,11 +219,6 @@ function OperatorMenu({
         leftIcon={<WarningAmberOutlinedIcon />}
         primaryText="Alerts"
         to={buildOperatorShellPath(basePath, "alerts")}
-      />
-      <Menu.Item
-        leftIcon={<InsightsOutlinedIcon />}
-        primaryText="Cases"
-        to={buildOperatorShellPath(basePath, "cases")}
       />
       <Menu.Item
         leftIcon={<LinkOutlinedIcon />}
@@ -377,12 +423,14 @@ function DeferredPageFallback() {
 function OperatorShellContent({
   basePath,
   canInspectActionReview,
+  canViewAdmin,
   canViewActionReview,
   operatorIdentity,
   operatorRoles,
 }: {
   basePath: string;
   canInspectActionReview: boolean;
+  canViewAdmin: boolean;
   canViewActionReview: boolean;
   operatorIdentity: string;
   operatorRoles: string[];
@@ -426,11 +474,40 @@ function OperatorShellContent({
           <Route element={<ProvenanceIndexPage />} path="provenance/:family" />
           <Route element={<ProvenancePage />} path="provenance/:family/:recordId" />
           <Route element={<ReadinessPage />} path="readiness" />
+          <Route element={<ReadinessPage />} path="health" />
+          <Route element={<ReadinessPage />} path="sources" />
+          <Route
+            element={
+              canViewActionReview ? (
+                <ReadinessPage />
+              ) : (
+                <Navigate
+                  replace
+                  to={buildOperatorShellPath(basePath, "forbidden")}
+                />
+              )
+            }
+            path="automations"
+          />
           <Route
             element={<FirstLoginChecklistPage />}
             path="first-login-checklist"
           />
           <Route element={<ReconciliationPage />} path="reconciliation" />
+          <Route element={<ReconciliationPage />} path="reports" />
+          <Route
+            element={
+              canViewAdmin ? (
+                <OverviewPage operatorRoles={operatorRoles} />
+              ) : (
+                <Navigate
+                  replace
+                  to={buildOperatorShellPath(basePath, "forbidden")}
+                />
+              )
+            }
+            path="admin"
+          />
           <Route element={<AssistantAdvisoryPage />} path="assistant" />
           <Route
             element={<AssistantAdvisoryPage />}
@@ -451,6 +528,22 @@ function OperatorShellContent({
               )
             }
             path="action-review"
+          />
+          <Route
+            element={
+              canViewActionReview ? (
+                <ActionReviewPage
+                  operatorIdentity={operatorIdentity}
+                  operatorRoles={operatorRoles}
+                />
+              ) : (
+                <Navigate
+                  replace
+                  to={buildOperatorShellPath(basePath, "forbidden")}
+                />
+              )
+            }
+            path="actions"
           />
           <Route
             element={
@@ -497,6 +590,7 @@ export function OperatorShell({
 }) {
   const canViewActionReview = canBrowseActionReview(operatorRoles);
   const canInspectActionReview = canInspectActionReviewDetail(operatorRoles);
+  const canViewAdminSurface = canViewAdmin(operatorRoles);
 
   return (
     <AdminContext
@@ -515,6 +609,7 @@ export function OperatorShell({
             <OperatorShellContent
               basePath={basePath}
               canInspectActionReview={canInspectActionReview}
+              canViewAdmin={canViewAdminSurface}
               canViewActionReview={canViewActionReview}
               operatorIdentity={operatorIdentity}
               operatorRoles={operatorRoles}

--- a/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
@@ -9,11 +9,16 @@ import {
   EmptyState,
   ErrorState,
   formatLabel,
+  getPath,
   LoadingState,
   PageFrame,
+  QueryStateNotice,
   SectionCard,
   statusTone,
+  StatusStrip,
+  useOperatorList,
   useOperatorRecord,
+  ValueList,
 } from "./shared";
 
 const TODAY_LANES = [
@@ -260,6 +265,72 @@ function OperatorTaskCards({
   );
 }
 
+function WorkbenchHealthSummary() {
+  const filter = useMemo(() => ({}), []);
+  const sort = useMemo(
+    () => ({
+      field: "status",
+      order: "ASC" as const,
+    }),
+    [],
+  );
+  const { data, error, loading, refreshing } = useOperatorList(
+    "runtimeReadiness",
+    filter,
+    sort,
+    1,
+  );
+  const record = data?.[0] ?? null;
+  const reviewPathHealth = asRecord(getPath(record, "metrics.review_path_health"));
+  const sourceHealth = asRecord(getPath(record, "metrics.source_health"));
+  const automationHealth = asRecord(
+    getPath(record, "metrics.automation_substrate_health"),
+  );
+  const assistantHealth = asRecord(
+    getPath(record, "metrics.optional_extensions.extensions.assistant"),
+  );
+
+  return (
+    <SectionCard
+      subtitle="Backend readiness diagnostics are summarized for daily operator context only."
+      title="Workbench health summary"
+    >
+      {loading && !record ? <LoadingState label="Loading workbench health summary" /> : null}
+      {error && !record ? <ErrorState error={error} /> : null}
+      {record ? (
+        <Stack spacing={2}>
+          <QueryStateNotice error={error} refreshing={refreshing} />
+          <Alert severity="info" variant="outlined">
+            Health summary is backend-bound operator context only; it cannot
+            satisfy release, readiness, audit, approval, execution,
+            reconciliation, or closeout gates.
+          </Alert>
+          <StatusStrip
+            values={[
+              ["Status", asString(record.status)],
+              ["Review path", asString(reviewPathHealth?.overall_state)],
+              ["Source health", asString(sourceHealth?.overall_state)],
+              [
+                "Automation health",
+                asString(automationHealth?.overall_state),
+              ],
+              ["Assistant readiness", asString(assistantHealth?.readiness)],
+            ]}
+          />
+          <ValueList
+            entries={[
+              ["Tracked sources", sourceHealth?.tracked_sources],
+              ["Tracked automation surfaces", automationHealth?.tracked_surfaces],
+              ["Assistant availability", assistantHealth?.availability],
+              ["Assistant status source", assistantHealth?.reason],
+            ]}
+          />
+        </Stack>
+      ) : null}
+    </SectionCard>
+  );
+}
+
 function TodayLaneItem({
   item,
   lane,
@@ -389,6 +460,8 @@ export function TodayPage() {
           AI focus hints are advisory-only and cannot approve, close, execute,
           reconcile, gate, release, or mutate work.
         </Alert>
+
+        <WorkbenchHealthSummary />
 
         <OperatorTaskCards cards={buildOperatorTaskCards(lanes)} />
 

--- a/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx
@@ -326,6 +326,8 @@ function WorkbenchHealthSummary() {
             ]}
           />
         </Stack>
+      ) : !loading && !error ? (
+        <EmptyState message="Workbench health summary is unavailable because readiness diagnostics returned no reviewed record." />
       ) : null}
     </SectionCard>
   );


### PR DESCRIPTION
## Summary
- Adds Phase 56.7 workbench navigation aliases for Today, Queue, Cases, Actions, Sources, Automations, Reports, Admin, and Health.
- Preserves role-gated protected surfaces for Actions, Automations, and Admin.
- Adds a Today workbench health summary derived from backend readiness diagnostics with explicit non-authority boundaries.

## Verification
- npm test -- --run src/app/OperatorRoutes.test.tsx
- npm run typecheck
- npm run build
- node dist/index.js issue-lint 1190 --config supervisor.config.aegisops.json
- node dist/index.js issue-lint 1197 --config supervisor.config.aegisops.json

Closes #1197
Part of #1190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin navigation appears only for platform administrators; protected admin routes show an “Access denied” page for others.
  * Operator menu expanded with Actions, Automations, and Sources entries.
  * Workbench health summary added to Today page, showing overall status, component readiness, and explanatory messages (including degraded or unavailable states).

* **Tests**
  * Added coverage verifying analyst-only views hide admin/actions/automations menu items and protected-route behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->