### PR TITLE
Phase 56.8 closeout evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Canonical cross-phase boundary reference:
 - [Phase 55.7 closeout evaluation](docs/phase-55-closeout-evaluation.md) records the guided first-user journey outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 56/57/58/60/66 handoff.
 - [Phase 56.1 Today view backend projection contract](docs/deployment/today-view-backend-projection-contract.md) defines priority, stale work, pending approvals, degraded sources, reconciliation mismatches, evidence gaps, and advisory-only AI focus lanes for the Daily SOC Workbench backend projection.
 - [Phase 56.3 case timeline authority projection contract](docs/deployment/case-timeline-authority-projection-contract.md) defines Wazuh signal, alert, evidence, AI summary, recommendation, action request, approval, Shuffle receipt, and reconciliation timeline segments with explicit authority posture and direct backend record binding.
+- [Phase 56.8 closeout evaluation](docs/phase-56-closeout-evaluation.md) records the Daily SOC Workbench outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 57/58/59/60/66 handoff.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
@@ -132,6 +133,8 @@ The Phase 55.7 closeout evaluation is defined by the [Phase 55.7 closeout evalua
 The Phase 56.1 Today view backend projection contract is defined by the [Phase 56.1 Today view backend projection contract](docs/deployment/today-view-backend-projection-contract.md).
 
 The Phase 56.3 case timeline authority projection contract is defined by the [Phase 56.3 case timeline authority projection contract](docs/deployment/case-timeline-authority-projection-contract.md).
+
+The Phase 56.8 closeout evaluation is defined by the [Phase 56.8 closeout evaluation](docs/phase-56-closeout-evaluation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-56-closeout-evaluation.md
+++ b/docs/phase-56-closeout-evaluation.md
@@ -1,0 +1,143 @@
+# Phase 56 Closeout Evaluation
+
+- **Status**: Accepted as Daily SOC Workbench MVP evidence and handoff baseline; Phase 57, Phase 58, Phase 59, Phase 60, and Phase 66 can consume the bounded Phase 56 operator workflow evidence with explicit retained blockers.
+- **Date**: 2026-05-04
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1190, #1191, #1192, #1193, #1194, #1195, #1196, #1197, #1198
+
+## Verdict
+
+Phase 56 is accepted as the Daily SOC Workbench MVP for the `smb-single-node` profile before admin, supportability, reporting breadth, SOAR breadth, RC, Beta, GA, or commercial replacement expansion.
+
+The accepted workbench consists of the Today view backend projection contract, Today view UI, case timeline authority projection, case timeline UI, operator task cards, business-hours handoff view, workbench navigation, and health summary.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+
+Today cards, task cards, case timeline display state, business-hours handoff copy, health summary, navigation state, stale UI cache, browser state, AI-suggested focus, Wazuh state, Shuffle state, tickets, reports, verifier output, and issue-lint output remain subordinate context or validation evidence.
+
+The Phase 56 operator surfaces must reject stale UI cache, unsupported role navigation, malformed projections, inferred timeline linkage, task-card completion shortcuts, handoff copy as closeout truth, health summary as gate truth, and authority confusion.
+
+This closeout does not claim Phase 57 admin/RBAC/source/action policy is complete, Phase 58 supportability is complete, Phase 59 AI daily operations is complete, Phase 60 audit or reporting breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1190 | Epic: Phase 56 Daily SOC Workbench MVP | Open until #1198 lands; accepted when this closeout, focused verifier, Phase 56 verifiers, backend projection tests, operator UI workflow tests, path hygiene, and issue-lint pass. |
+| #1191 | Phase 56.1 Today view backend projection contract | Closed. `docs/deployment/today-view-backend-projection-contract.md`, `docs/deployment/profiles/smb-single-node/today-view-projection.yaml`, `control-plane/tests/test_phase56_1_today_projection_contract.py`, and `scripts/verify-phase-56-1-today-view-projection-contract.sh` define priority, stale work, pending approvals, degraded sources, reconciliation mismatches, evidence gaps, advisory-only AI focus, and stale projection refusal. |
+| #1192 | Phase 56.2 Today view UI | Closed. `apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx` and `apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx` render Today work focus, degraded and stale badges, empty state, advisory AI focus, and stale-cache refusal. |
+| #1193 | Phase 56.3 case timeline authority/subordinate projection | Closed. `docs/deployment/case-timeline-authority-projection-contract.md`, `docs/deployment/profiles/smb-single-node/case-timeline-projection.yaml`, `control-plane/aegisops/control_plane/operator_inspection.py`, and focused projection tests define Wazuh signal, AegisOps alert, evidence, AI summary, recommendation, action request, approval, Shuffle receipt, and reconciliation segments with direct backend record binding. |
+| #1194 | Phase 56.4 case timeline UI | Closed. `apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx` and `apps/operator-ui/src/app/OperatorRoutes.casework.detail.testSuite.tsx` render the reviewed case chain with authority labels, missing/degraded states, and cache/malformed-data refusal. |
+| #1195 | Phase 56.5 operator task cards | Closed. `apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx` and `apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx` add repeated-work task cards that route to reviewed surfaces without new write authority or optimistic completion truth. |
+| #1196 | Phase 56.6 business-hours handoff view | Closed. `apps/operator-ui/src/app/operatorConsolePages/handoffPages.tsx` and `apps/operator-ui/src/app/OperatorRoutes.businessHoursHandoff.testSuite.tsx` show changed work, blocked items, owner follow-up, evidence gaps, and accepted/rejected AI summary posture while rejecting stale/cache-only handoff state. |
+| #1197 | Phase 56.7 workbench navigation and health summary | Closed. `apps/operator-ui/src/app/OperatorShell.tsx` and `apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx` cover Today, Queue, Cases, Actions, Sources, Automations, Reports, Admin, and Health navigation with role-based visibility and backend-bound health summary. |
+| #1198 | Phase 56.8 Phase 56 closeout evaluation | Open until this document and focused closeout verifier land. |
+
+## Daily SOC Workbench Behavior Before And After
+
+| Surface | Before Phase 56 | After Phase 56 |
+| --- | --- | --- |
+| Today backend projection | Phase 55 had a guided first-user journey but no Daily SOC Workbench projection contract. | Phase 56.1 defines Today lanes for priority, stale work, pending approvals, degraded sources, reconciliation mismatches, evidence gaps, and advisory-only AI focus. |
+| Today UI | Operators had first-login guidance and case/action surfaces, but no Today starting point for repeated daily review. | Phase 56.2 renders Today work focus, empty state, degraded/stale badges, pending approvals, mismatches, evidence gaps, advisory AI focus, and stale-cache refusal. |
+| Case timeline projection | Case detail records existed, but the required authority/subordinate timeline projection was not the Phase 56 reviewed contract. | Phase 56.3 projects Wazuh signal, AegisOps alert, evidence, AI summary, recommendation, action request, approval, Shuffle receipt, and reconciliation with authority posture and direct backend record binding. |
+| Case timeline UI | Case detail views did not show the reviewed Phase 56 chain with visual authority distinction. | Phase 56.4 renders the reviewed chain order, authority labels, missing/degraded states, and refuses malformed or cache-sourced timeline truth. |
+| Operator task cards | Repeated daily work required operators to discover existing routes manually. | Phase 56.5 adds guidance cards for stale work, pending approvals, evidence gaps, degraded sources, mismatches, and handoff while preserving backend reread and existing authority surfaces. |
+| Business-hours handoff | Phase 55 provided first-user journey evidence but no bounded handoff view for part-time operators. | Phase 56.6 renders changed, blocked, owner, evidence-gap, and AI-summary accepted/rejected handoff context without making handoff copy closeout truth. |
+| Navigation and health summary | The operator shell did not expose the full Daily SOC Workbench route set and health summary in the Phase 56 shape. | Phase 56.7 exposes Today, Queue, Cases, Actions, Sources, Automations, Reports, Admin, and Health navigation with role visibility and backend-bound health summary. |
+| Authority boundary | Phase 51.6, Phase 54, and Phase 55 supplied the prior boundary. | Phase 56 preserves control-plane authority and proves Today cards, task cards, timeline UI, handoff copy, navigation state, health summary, AI, Wazuh, Shuffle, tickets, reports, verifier output, and issue-lint output remain subordinate. |
+
+## Changed Files
+
+Phase 56 materially added or tightened these repo-owned surfaces:
+
+- `docs/deployment/today-view-backend-projection-contract.md`
+- `docs/deployment/profiles/smb-single-node/today-view-projection.yaml`
+- `scripts/verify-phase-56-1-today-view-projection-contract.sh`
+- `scripts/test-verify-phase-56-1-today-view-projection-contract.sh`
+- `control-plane/tests/test_phase56_1_today_projection_contract.py`
+- `control-plane/aegisops/control_plane/operator_inspection.py`
+- `control-plane/aegisops/control_plane/runtime/service_snapshots.py`
+- `control-plane/tests/test_phase56_3_case_timeline_projection.py`
+- `control-plane/tests/test_phase56_3_case_timeline_projection_contract.py`
+- `docs/deployment/case-timeline-authority-projection-contract.md`
+- `docs/deployment/profiles/smb-single-node/case-timeline-projection.yaml`
+- `apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.casework.detail.testSuite.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.businessHoursHandoff.testSuite.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.test.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.testSupport.tsx`
+- `apps/operator-ui/src/app/OperatorShell.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages/handoffPages.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages/recordUtils.ts`
+- `apps/operator-ui/src/dataProvider.ts`
+- `apps/operator-ui/src/operatorDataProvider/detailReaders.ts`
+- `apps/operator-ui/src/operatorDataProvider/types.ts`
+- `docs/phase-56-closeout-evaluation.md`
+- `scripts/verify-phase-56-8-closeout-evaluation.sh`
+- `scripts/test-verify-phase-56-8-closeout-evaluation.sh`
+
+## Verifier Evidence
+
+Focused Phase 56 verifiers passed or must pass before this closeout is accepted:
+
+- `bash scripts/verify-phase-56-1-today-view-projection-contract.sh`
+- `bash scripts/test-verify-phase-56-1-today-view-projection-contract.sh`
+- `python -m unittest control-plane/tests/test_phase56_1_today_projection_contract.py`
+- `python -m unittest control-plane/tests/test_phase56_3_case_timeline_projection.py control-plane/tests/test_phase56_3_case_timeline_projection_contract.py`
+- `npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx`
+- `npm run test --workspace @aegisops/operator-ui -- caseworkActionCards`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `bash scripts/verify-phase-56-8-closeout-evaluation.sh`
+- `bash scripts/test-verify-phase-56-8-closeout-evaluation.sh`
+
+Focused negative-test evidence includes:
+
+- Today backend projection tests cover stale projection output, AI focus as authority, Wazuh/Shuffle/ticket closeout shortcuts, and Today summary state as approval/execution/reconciliation truth.
+- Today UI tests reject stale cache or malformed backend data and fail closed when a reread fails after cached data exists.
+- Case timeline projection tests reject inferred sibling linkage and keep missing/degraded segments visible.
+- Case timeline UI tests reject cache-sourced timeline truth, unsupported segments, wrong authority posture, and UI display state as approval/execution/reconciliation truth.
+- Operator task-card tests reject task-card state as authority and optimistic completion without backend reread.
+- Business-hours handoff tests reject handoff copy as closeout truth, AI summary as authority, ticket state as case truth, stale cache as current handoff, and unresolved failed paths as completed.
+- Navigation and health summary tests reject unsupported role access, hidden protected-surface bypass, health summary as gate truth, and stale UI state as current health authority.
+
+Issue-lint evidence for #1190 through #1198:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1190 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1191 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1192 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1193 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1194 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1195 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1196 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1197 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1198 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+
+## Accepted Limitations
+
+- Phase 56 does not implement Phase 57 admin/RBAC/source/action policy UI MVP, installer packaging, or customer-ready distribution.
+- Phase 56 does not implement Phase 58 supportability, doctor completeness, backup/restore support operations, support bundles, support diagnostics, break-glass support workflows, or customer support operations.
+- Phase 56 does not implement Phase 59 AI governance expansion, AI daily-operations breadth, AI approval authority, AI execution authority, or AI reconciliation authority.
+- Phase 56 does not implement Phase 60 audit export administration, commercial reporting breadth, executive reporting completeness, compliance reporting completeness, report custody, retention, or production report templates.
+- Phase 56 does not implement broad SOAR workflow catalog coverage, marketplace breadth, every action-family expectation, or standalone Shuffle replacement.
+- Phase 56 does not implement Phase 66 RC proof, RC readiness, GA readiness, Beta readiness, self-service commercial readiness, or commercial replacement readiness.
+- Phase 56 does not make Today cards, task cards, case timeline display state, business-hours handoff copy, health summary, navigation state, browser state, UI cache, AI output, Wazuh state, Shuffle state, ticket state, report state, verifier output, issue-lint output, or operator-facing summaries authoritative AegisOps truth.
+
+## Phase 57, Phase 58, Phase 59, Phase 60, And Phase 66 Handoff
+
+Phase 57 can consume the Phase 56 workbench navigation, Today cards, and reviewed route set as operator-entry context. Phase 57 must still implement admin/RBAC/source/action policy MVP and packaging scope explicitly. Phase 56 does not complete Phase 57 admin/RBAC or packaging.
+
+Phase 58 can consume the Phase 56 health summary and degraded-source copy as supportability inputs. Phase 58 must still implement support playbooks, customer-safe diagnostics, backup/restore rehearsals, break-glass support flows, support bundles, and escalation evidence. Phase 56 does not complete Phase 58 supportability.
+
+Phase 59 can consume the Phase 56 advisory-only AI focus and accepted/rejected AI summary handling as bounded operator-context evidence. Phase 59 must still implement AI daily-operations governance and expanded AI guardrails explicitly. Phase 56 does not complete Phase 59 AI daily operations.
+
+Phase 60 can consume the Phase 56 case timeline, reconciliation mismatch, evidence-gap, and handoff surfaces as workflow context for reporting design. Phase 60 must still implement audit export administration, commercial reporting breadth, executive reporting, compliance reporting, custody, retention, and production report templates. Phase 56 does not complete Phase 60 audit or reporting breadth.
+
+Phase 66 can consume the Phase 56 Daily SOC Workbench MVP as one prerequisite evidence packet for RC proof. Phase 66 must still prove RC gate criteria, production-readiness evidence, upgrade/rollback posture, supportability, security review, packaging, and end-to-end first-user and daily-operator behavior under the approved RC gate. Phase 56 does not complete Phase 66 RC proof.
+
+## Closeout Boundary
+
+This closeout is release and planning evidence only. It does not choose a new runtime configuration, create new admin/support/reporting/SOAR implementation work, approve commercial reporting breadth, approve RC or GA readiness, change authority custody, or claim Beta, RC, GA, or commercial replacement readiness.

--- a/scripts/test-verify-phase-56-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-56-8-closeout-evaluation.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-56-8-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-56-closeout-evaluation.md" "${target}/docs/phase-56-closeout-evaluation.md"
+  cp "${repo_root}/README.md" "${target}/README.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+cp "${repo_root}/README.md" "${missing_doc_repo}/README.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 56 closeout evaluation: docs/phase-56-closeout-evaluation.md"
+
+missing_readme_canonical_bullet_repo="${workdir}/missing-readme-canonical-bullet"
+copy_valid_repo "${missing_readme_canonical_bullet_repo}"
+perl -0pi -e 's/- \[Phase 56\.8 closeout evaluation\]\(docs\/phase-56-closeout-evaluation\.md\)( records the Daily SOC Workbench outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 57\/58\/59\/60\/66 handoff\.)/- Phase 56.8 closeout evaluation$1/' \
+  "${missing_readme_canonical_bullet_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_canonical_bullet_repo}" \
+  "Missing README canonical cross-phase boundary bullet: - [Phase 56.8 closeout evaluation](docs/phase-56-closeout-evaluation.md)"
+
+missing_readme_product_positioning_repo="${workdir}/missing-readme-product-positioning"
+copy_valid_repo "${missing_readme_product_positioning_repo}"
+perl -0pi -e 's/The Phase 56\.8 closeout evaluation is defined by the \[Phase 56\.8 closeout evaluation\]\(docs\/phase-56-closeout-evaluation\.md\)\./The Phase 56.8 closeout evaluation is defined by the Phase 56.8 closeout evaluation./' \
+  "${missing_readme_product_positioning_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_product_positioning_repo}" \
+  "Missing README Product positioning reference: The Phase 56.8 closeout evaluation is defined by the [Phase 56.8 closeout evaluation](docs/phase-56-closeout-evaluation.md)."
+
+missing_authority_repo="${workdir}/missing-authority"
+copy_valid_repo "${missing_authority_repo}"
+perl -0pi -e 's/AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth\.//' \
+  "${missing_authority_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_authority_repo}" \
+  "Missing required Phase 56 closeout term in docs/phase-56-closeout-evaluation.md: AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth."
+
+missing_today_row_repo="${workdir}/missing-today-row"
+copy_valid_repo "${missing_today_row_repo}"
+perl -0pi -e 's/\| Today UI \| Operators had first-login guidance and case\/action surfaces, but no Today starting point for repeated daily review\. \| Phase 56\.2 renders Today work focus, empty state, degraded\/stale badges, pending approvals, mismatches, evidence gaps, advisory AI focus, and stale-cache refusal\. \|\n//' \
+  "${missing_today_row_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_today_row_repo}" \
+  'Missing required Phase 56 closeout term in docs/phase-56-closeout-evaluation.md: | Today UI | Operators had first-login guidance and case/action surfaces, but no Today starting point for repeated daily review. | Phase 56.2 renders Today work focus, empty state, degraded/stale badges, pending approvals, mismatches, evidence gaps, advisory AI focus, and stale-cache refusal. |'
+
+missing_negative_evidence_repo="${workdir}/missing-negative-evidence"
+copy_valid_repo "${missing_negative_evidence_repo}"
+perl -0pi -e 's/Today UI tests reject stale cache or malformed backend data and fail closed when a reread fails after cached data exists\.//' \
+  "${missing_negative_evidence_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_negative_evidence_repo}" \
+  "Missing required Phase 56 closeout term in docs/phase-56-closeout-evaluation.md: Today UI tests reject stale cache or malformed backend data and fail closed when a reread fails after cached data exists."
+
+missing_phase59_handoff_repo="${workdir}/missing-phase59-handoff"
+copy_valid_repo "${missing_phase59_handoff_repo}"
+perl -0pi -e 's/Phase 59 can consume the Phase 56 advisory-only AI focus and accepted\/rejected AI summary handling as bounded operator-context evidence\.//' \
+  "${missing_phase59_handoff_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_phase59_handoff_repo}" \
+  "Missing required Phase 56 closeout term in docs/phase-56-closeout-evaluation.md: Phase 59 can consume the Phase 56 advisory-only AI focus and accepted/rejected AI summary handling as bounded operator-context evidence."
+
+missing_issue_lint_repo="${workdir}/missing-issue-lint"
+copy_valid_repo "${missing_issue_lint_repo}"
+perl -0pi -e 's/^- `node <codex-supervisor-root>\/dist\/index\.js issue-lint 1197 --config <supervisor-config-path>`: .*?\n//m' \
+  "${missing_issue_lint_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_issue_lint_repo}" \
+  "Missing required Phase 56 closeout term in docs/phase-56-closeout-evaluation.md: node <codex-supervisor-root>/dist/index.js issue-lint 1197 --config <supervisor-config-path>"
+
+phase57_overclaim_repo="${workdir}/phase57-overclaim"
+copy_valid_repo "${phase57_overclaim_repo}"
+printf '%s\n' "Phase 57 admin/RBAC/source/action policy is complete" >>"${phase57_overclaim_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${phase57_overclaim_repo}" \
+  "Forbidden Phase 56 closeout evaluation claim: Phase 57 admin/RBAC/source/action policy is complete"
+
+phase58_overclaim_repo="${workdir}/phase58-overclaim"
+copy_valid_repo "${phase58_overclaim_repo}"
+printf '%s\n' "Phase 58 supportability is complete" >>"${phase58_overclaim_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${phase58_overclaim_repo}" \
+  "Forbidden Phase 56 closeout evaluation claim: Phase 58 supportability is complete"
+
+phase60_overclaim_repo="${workdir}/phase60-overclaim"
+copy_valid_repo "${phase60_overclaim_repo}"
+printf '%s\n' "Phase 60 audit or reporting breadth is complete" >>"${phase60_overclaim_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${phase60_overclaim_repo}" \
+  "Forbidden Phase 56 closeout evaluation claim: Phase 60 audit or reporting breadth is complete"
+
+commercial_overclaim_repo="${workdir}/commercial-overclaim"
+copy_valid_repo "${commercial_overclaim_repo}"
+printf '%s\n' "Phase 56 proves commercial replacement readiness" >>"${commercial_overclaim_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${commercial_overclaim_repo}" \
+  "Forbidden Phase 56 closeout evaluation claim: Phase 56 proves commercial replacement readiness"
+
+ui_truth_repo="${workdir}/ui-truth"
+copy_valid_repo "${ui_truth_repo}"
+printf '%s\n' "Stale UI cache is current workflow truth" >>"${ui_truth_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${ui_truth_repo}" \
+  "Forbidden Phase 56 closeout evaluation claim: Stale UI cache is current workflow truth"
+
+handoff_truth_repo="${workdir}/handoff-truth"
+copy_valid_repo "${handoff_truth_repo}"
+printf '%s\n' "Business-hours handoff copy is closeout truth" >>"${handoff_truth_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${handoff_truth_repo}" \
+  "Forbidden Phase 56 closeout evaluation claim: Business-hours handoff copy is closeout truth"
+
+health_truth_repo="${workdir}/health-truth"
+copy_valid_repo "${health_truth_repo}"
+printf '%s\n' "Health summary is release gate truth" >>"${health_truth_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${health_truth_repo}" \
+  "Forbidden Phase 56 closeout evaluation claim: Health summary is release gate truth"
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+mac_home_prefix="/""Users/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${mac_home_prefix}" >>"${absolute_path_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 56 closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 56 closeout evaluation verifier tests passed."

--- a/scripts/test-verify-phase-56-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-56-8-closeout-evaluation.sh
@@ -174,4 +174,20 @@ assert_fails_with \
   "${absolute_path_repo}" \
   "Forbidden Phase 56 closeout evaluation: workstation-local absolute path detected"
 
+absolute_path_windows_backslash_repo="${workdir}/absolute-path-windows-backslash"
+copy_valid_repo "${absolute_path_windows_backslash_repo}"
+windows_drive="C:"
+windows_home_dir="Users"
+printf 'Run %s\\%s\\example\\Dev\\codex-supervisor\\dist\\index.js.\n' "${windows_drive}" "${windows_home_dir}" >>"${absolute_path_windows_backslash_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_windows_backslash_repo}" \
+  "Forbidden Phase 56 closeout evaluation: workstation-local absolute path detected"
+
+absolute_path_windows_slash_repo="${workdir}/absolute-path-windows-slash"
+copy_valid_repo "${absolute_path_windows_slash_repo}"
+printf 'Run %s/%s/example/Dev/codex-supervisor/dist/index.js.\n' "${windows_drive}" "${windows_home_dir}" >>"${absolute_path_windows_slash_repo}/docs/phase-56-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_windows_slash_repo}" \
+  "Forbidden Phase 56 closeout evaluation: workstation-local absolute path detected"
+
 echo "Phase 56 closeout evaluation verifier tests passed."

--- a/scripts/verify-phase-56-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-56-8-closeout-evaluation.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-56-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${file}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 56 closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -s "${readme_path}" ]]; then
+  echo "Missing README for Phase 56 closeout link check: README.md" >&2
+  exit 1
+fi
+
+require_phrase "${readme_path}" "- [Phase 56.8 closeout evaluation](docs/phase-56-closeout-evaluation.md)" "README canonical cross-phase boundary bullet"
+require_phrase "${readme_path}" "The Phase 56.8 closeout evaluation is defined by the [Phase 56.8 closeout evaluation](docs/phase-56-closeout-evaluation.md)." "README Product positioning reference"
+
+required_phrases=()
+while IFS= read -r phrase; do
+  required_phrases+=("${phrase}")
+done <<'EOF'
+# Phase 56 Closeout Evaluation
+**Status**: Accepted as Daily SOC Workbench MVP evidence and handoff baseline; Phase 57, Phase 58, Phase 59, Phase 60, and Phase 66 can consume the bounded Phase 56 operator workflow evidence with explicit retained blockers.
+**Related Issues**: #1190, #1191, #1192, #1193, #1194, #1195, #1196, #1197, #1198
+Phase 56 is accepted as the Daily SOC Workbench MVP for the `smb-single-node` profile before admin, supportability, reporting breadth, SOAR breadth, RC, Beta, GA, or commercial replacement expansion.
+AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit, limitation, release, gate, and closeout truth.
+Today cards, task cards, case timeline display state, business-hours handoff copy, health summary, navigation state, stale UI cache, browser state, AI-suggested focus, Wazuh state, Shuffle state, tickets, reports, verifier output, and issue-lint output remain subordinate context or validation evidence.
+The Phase 56 operator surfaces must reject stale UI cache, unsupported role navigation, malformed projections, inferred timeline linkage, task-card completion shortcuts, handoff copy as closeout truth, health summary as gate truth, and authority confusion.
+This closeout does not claim Phase 57 admin/RBAC/source/action policy is complete, Phase 58 supportability is complete, Phase 59 AI daily operations is complete, Phase 60 audit or reporting breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability.
+| #1190 | Epic: Phase 56 Daily SOC Workbench MVP | Open until #1198 lands; accepted when this closeout, focused verifier, Phase 56 verifiers, backend projection tests, operator UI workflow tests, path hygiene, and issue-lint pass. |
+| #1191 | Phase 56.1 Today view backend projection contract | Closed.
+| #1192 | Phase 56.2 Today view UI | Closed.
+| #1193 | Phase 56.3 case timeline authority/subordinate projection | Closed.
+| #1194 | Phase 56.4 case timeline UI | Closed.
+| #1195 | Phase 56.5 operator task cards | Closed.
+| #1196 | Phase 56.6 business-hours handoff view | Closed.
+| #1197 | Phase 56.7 workbench navigation and health summary | Closed.
+| #1198 | Phase 56.8 Phase 56 closeout evaluation | Open until this document and focused closeout verifier land. |
+| Today backend projection | Phase 55 had a guided first-user journey but no Daily SOC Workbench projection contract. | Phase 56.1 defines Today lanes for priority, stale work, pending approvals, degraded sources, reconciliation mismatches, evidence gaps, and advisory-only AI focus. |
+| Today UI | Operators had first-login guidance and case/action surfaces, but no Today starting point for repeated daily review. | Phase 56.2 renders Today work focus, empty state, degraded/stale badges, pending approvals, mismatches, evidence gaps, advisory AI focus, and stale-cache refusal. |
+| Case timeline projection | Case detail records existed, but the required authority/subordinate timeline projection was not the Phase 56 reviewed contract. | Phase 56.3 projects Wazuh signal, AegisOps alert, evidence, AI summary, recommendation, action request, approval, Shuffle receipt, and reconciliation with authority posture and direct backend record binding. |
+| Case timeline UI | Case detail views did not show the reviewed Phase 56 chain with visual authority distinction. | Phase 56.4 renders the reviewed chain order, authority labels, missing/degraded states, and refuses malformed or cache-sourced timeline truth. |
+| Operator task cards | Repeated daily work required operators to discover existing routes manually. | Phase 56.5 adds guidance cards for stale work, pending approvals, evidence gaps, degraded sources, mismatches, and handoff while preserving backend reread and existing authority surfaces. |
+| Business-hours handoff | Phase 55 provided first-user journey evidence but no bounded handoff view for part-time operators. | Phase 56.6 renders changed, blocked, owner, evidence-gap, and AI-summary accepted/rejected handoff context without making handoff copy closeout truth. |
+| Navigation and health summary | The operator shell did not expose the full Daily SOC Workbench route set and health summary in the Phase 56 shape. | Phase 56.7 exposes Today, Queue, Cases, Actions, Sources, Automations, Reports, Admin, and Health navigation with role visibility and backend-bound health summary. |
+`docs/deployment/today-view-backend-projection-contract.md`
+`docs/deployment/profiles/smb-single-node/today-view-projection.yaml`
+`control-plane/tests/test_phase56_1_today_projection_contract.py`
+`control-plane/tests/test_phase56_3_case_timeline_projection.py`
+`control-plane/tests/test_phase56_3_case_timeline_projection_contract.py`
+`apps/operator-ui/src/app/OperatorRoutes.today.testSuite.tsx`
+`apps/operator-ui/src/app/OperatorRoutes.casework.detail.testSuite.tsx`
+`apps/operator-ui/src/app/OperatorRoutes.businessHoursHandoff.testSuite.tsx`
+`apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx`
+`apps/operator-ui/src/app/operatorConsolePages/todayPages.tsx`
+`apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx`
+`apps/operator-ui/src/app/operatorConsolePages/handoffPages.tsx`
+`docs/phase-56-closeout-evaluation.md`
+`scripts/verify-phase-56-8-closeout-evaluation.sh`
+`scripts/test-verify-phase-56-8-closeout-evaluation.sh`
+`bash scripts/verify-phase-56-1-today-view-projection-contract.sh`
+`bash scripts/test-verify-phase-56-1-today-view-projection-contract.sh`
+`python -m unittest control-plane/tests/test_phase56_1_today_projection_contract.py`
+`python -m unittest control-plane/tests/test_phase56_3_case_timeline_projection.py control-plane/tests/test_phase56_3_case_timeline_projection_contract.py`
+`npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx`
+`npm run test --workspace @aegisops/operator-ui -- caseworkActionCards`
+`bash scripts/verify-publishable-path-hygiene.sh`
+`bash scripts/verify-phase-56-8-closeout-evaluation.sh`
+`bash scripts/test-verify-phase-56-8-closeout-evaluation.sh`
+Today backend projection tests cover stale projection output, AI focus as authority, Wazuh/Shuffle/ticket closeout shortcuts, and Today summary state as approval/execution/reconciliation truth.
+Today UI tests reject stale cache or malformed backend data and fail closed when a reread fails after cached data exists.
+Case timeline projection tests reject inferred sibling linkage and keep missing/degraded segments visible.
+Case timeline UI tests reject cache-sourced timeline truth, unsupported segments, wrong authority posture, and UI display state as approval/execution/reconciliation truth.
+Operator task-card tests reject task-card state as authority and optimistic completion without backend reread.
+Business-hours handoff tests reject handoff copy as closeout truth, AI summary as authority, ticket state as case truth, stale cache as current handoff, and unresolved failed paths as completed.
+Navigation and health summary tests reject unsupported role access, hidden protected-surface bypass, health summary as gate truth, and stale UI state as current health authority.
+node <codex-supervisor-root>/dist/index.js issue-lint 1190 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1191 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1192 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1193 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1194 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1195 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1196 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1197 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1198 --config <supervisor-config-path>
+execution_ready=yes
+missing_required=none
+missing_recommended=none
+metadata_errors=none
+high_risk_blocking_ambiguity=none
+Phase 56 does not implement Phase 57 admin/RBAC/source/action policy UI MVP, installer packaging, or customer-ready distribution.
+Phase 56 does not implement Phase 58 supportability, doctor completeness, backup/restore support operations, support bundles, support diagnostics, break-glass support workflows, or customer support operations.
+Phase 56 does not implement Phase 59 AI governance expansion, AI daily-operations breadth, AI approval authority, AI execution authority, or AI reconciliation authority.
+Phase 56 does not implement Phase 60 audit export administration, commercial reporting breadth, executive reporting completeness, compliance reporting completeness, report custody, retention, or production report templates.
+Phase 56 does not implement broad SOAR workflow catalog coverage, marketplace breadth, every action-family expectation, or standalone Shuffle replacement.
+Phase 56 does not implement Phase 66 RC proof, RC readiness, GA readiness, Beta readiness, self-service commercial readiness, or commercial replacement readiness.
+Phase 57 can consume the Phase 56 workbench navigation, Today cards, and reviewed route set as operator-entry context.
+Phase 56 does not complete Phase 57 admin/RBAC or packaging.
+Phase 58 can consume the Phase 56 health summary and degraded-source copy as supportability inputs.
+Phase 56 does not complete Phase 58 supportability.
+Phase 59 can consume the Phase 56 advisory-only AI focus and accepted/rejected AI summary handling as bounded operator-context evidence.
+Phase 56 does not complete Phase 59 AI daily operations.
+Phase 60 can consume the Phase 56 case timeline, reconciliation mismatch, evidence-gap, and handoff surfaces as workflow context for reporting design.
+Phase 56 does not complete Phase 60 audit or reporting breadth.
+Phase 66 can consume the Phase 56 Daily SOC Workbench MVP as one prerequisite evidence packet for RC proof.
+Phase 56 does not complete Phase 66 RC proof.
+This closeout is release and planning evidence only.
+EOF
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 56 closeout term in ${doc_path}"
+done
+
+mac_home_prefix="$(printf '/%s/' 'Users')"
+unix_home_prefix="$(printf '/%s/' 'home')"
+windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
+absolute_path_pattern="(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}" "${readme_path}"; then
+  echo "Forbidden Phase 56 closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+allowed_non_claim_line="This closeout does not claim Phase 57 admin/RBAC/source/action policy is complete, Phase 58 supportability is complete, Phase 59 AI daily operations is complete, Phase 60 audit or reporting breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability."
+
+for forbidden in \
+  "Phase 57 admin/RBAC/source/action policy is complete" \
+  "Phase 58 supportability is complete" \
+  "Phase 59 AI daily operations is complete" \
+  "Phase 60 audit or reporting breadth is complete" \
+  "Phase 66 RC proof is complete" \
+  "AegisOps is Beta" \
+  "AegisOps is RC" \
+  "AegisOps is GA" \
+  "AegisOps is self-service commercially ready" \
+  "AegisOps is a commercial replacement for every SIEM/SOAR capability" \
+  "Phase 56 proves Beta readiness" \
+  "Phase 56 proves RC readiness" \
+  "Phase 56 proves GA readiness" \
+  "Phase 56 proves commercial replacement readiness" \
+  "Today cards are workflow truth" \
+  "Task cards are workflow truth" \
+  "Case timeline display state is workflow truth" \
+  "Business-hours handoff copy is closeout truth" \
+  "Health summary is release gate truth" \
+  "Navigation state is access authority" \
+  "Stale UI cache is current workflow truth" \
+  "AI-suggested focus is authority" \
+  "Wazuh state is AegisOps workflow truth" \
+  "Shuffle state is AegisOps workflow truth" \
+  "Ticket state is case truth" \
+  "Report state is audit truth"; do
+  if grep -Fxv -- "${allowed_non_claim_line}" "${absolute_doc_path}" | grep -Fq -- "${forbidden}"; then
+    echo "Forbidden Phase 56 closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 56 closeout evaluation records Daily SOC Workbench outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 57/58/59/60/66 handoff."


### PR DESCRIPTION
## Summary
- Add the Phase 56 closeout evaluation for the Daily SOC Workbench MVP.
- Add a focused closeout verifier and verifier self-test for required evidence, path hygiene, and authority-boundary overclaim rejection.
- Register the Phase 56.8 closeout in README cross-phase references.

## Verification
- bash scripts/verify-phase-56-8-closeout-evaluation.sh
- bash scripts/test-verify-phase-56-8-closeout-evaluation.sh
- bash scripts/verify-publishable-path-hygiene.sh
- bash scripts/verify-phase-56-1-today-view-projection-contract.sh
- bash scripts/test-verify-phase-56-1-today-view-projection-contract.sh
- python3 -m unittest control-plane/tests/test_phase56_1_today_projection_contract.py
- cd control-plane/tests && python3 -m unittest test_phase56_3_case_timeline_projection.py test_phase56_3_case_timeline_projection_contract.py
- npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx
- npm run test --workspace @aegisops/operator-ui -- caseworkActionCards.test.tsx
- node <codex-supervisor-root>/dist/index.js issue-lint 1190-1198 --config <supervisor-config-path> (run per issue; all clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 56.8 closeout evaluation docs: MVP acceptance, child-issue outcomes, behavior before/after matrix, verdict, accepted limitations, verifier evidence checklist, changed-files list, and handoff guidance; updated README phase index to include Phase 56.8.

* **Tests**
  * Added a verification test suite to validate Phase 56.8 closeout documentation integrity, including positive and negative cases for required phrases, forbidden claims, and environment-local path checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->