### PR TITLE
Phase 57.1 RBAC role matrix contract

### DIFF
--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -55,6 +55,7 @@ import {
 } from "./operatorUiEvents";
 import { TaskActionClientProvider } from "../taskActions/taskActionPrimitives";
 import type { OperatorTaskActionClient } from "../taskActions/taskActionClient";
+import { anyRoleHasSurfaceAccess } from "../auth/roleMatrix";
 
 const loadOperatorConsolePages = () => import("./operatorConsolePages");
 
@@ -113,8 +114,17 @@ function hasReviewedOperatorRole(
 }
 
 function canBrowseActionReview(operatorRoles: readonly string[]) {
-  return operatorRoles.some((role) =>
-    ["approver", "platform_admin"].includes(role),
+  return (
+    anyRoleHasSurfaceAccess(
+      operatorRoles,
+      "actionApprovalDecision",
+      "allowed",
+    ) ||
+    anyRoleHasSurfaceAccess(
+      operatorRoles,
+      "platformAdministration",
+      "admin_only",
+    )
   );
 }
 
@@ -123,7 +133,11 @@ function canInspectActionReviewDetail(operatorRoles: readonly string[]) {
 }
 
 function canViewAdmin(operatorRoles: readonly string[]) {
-  return operatorRoles.some((role) => role.toLowerCase() === "platform_admin");
+  return anyRoleHasSurfaceAccess(
+    operatorRoles,
+    "platformAdministration",
+    "admin_only",
+  );
 }
 
 function buildOperatorShellPath(basePath: string, path = "") {

--- a/apps/operator-ui/src/app/operatorConsolePages/actionReviewSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/actionReviewSurfaces.tsx
@@ -9,9 +9,14 @@ import {
   type UnknownRecord,
 } from "./recordUtils";
 import { SectionCard, StatusStrip, ValueList } from "./pageChrome";
+import { anyRoleHasSurfaceAccess } from "../../auth/roleMatrix";
 
 export function canRecordActionApprovalDecision(operatorRoles: readonly string[]) {
-  return operatorRoles.some((role) => role.toLowerCase() === "approver");
+  return anyRoleHasSurfaceAccess(
+    operatorRoles,
+    "actionApprovalDecision",
+    "allowed",
+  );
 }
 
 export function approvalLifecycleExplanation(approvalState: string | null) {

--- a/apps/operator-ui/src/auth/config.ts
+++ b/apps/operator-ui/src/auth/config.ts
@@ -1,3 +1,5 @@
+import { RBAC_ROLE_IDS } from "./roleMatrix";
+
 export interface OperatorUiConfig {
   allowedRoles: string[];
   basePath: string;
@@ -6,11 +8,7 @@ export interface OperatorUiConfig {
   sessionPath: string;
 }
 
-const DEFAULT_ALLOWED_ROLES = [
-  "analyst",
-  "approver",
-  "platform_admin",
-];
+const DEFAULT_ALLOWED_ROLES = [...RBAC_ROLE_IDS];
 
 export function createOperatorUiConfig(
   overrides: Partial<OperatorUiConfig> = {},

--- a/apps/operator-ui/src/auth/roleMatrix.test.ts
+++ b/apps/operator-ui/src/auth/roleMatrix.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  RBAC_ROLE_IDS,
+  RBAC_ROLE_MATRIX,
+  anyRoleHasSurfaceAccess,
+  getRbacRoleContract,
+} from "./roleMatrix";
+
+describe("Phase 57.1 RBAC role matrix", () => {
+  it("names every required commercial RBAC role", () => {
+    expect(RBAC_ROLE_IDS).toEqual([
+      "platform_admin",
+      "analyst",
+      "approver",
+      "read_only_auditor",
+      "support_operator",
+      "external_collaborator",
+    ]);
+  });
+
+  it("covers allowed, denied, read-only, admin-only, support-only, and no-authority behavior", () => {
+    const observedAccess = new Set(
+      Object.values(RBAC_ROLE_MATRIX).flatMap((contract) =>
+        Object.values(contract.surfaces),
+      ),
+    );
+
+    expect(observedAccess).toEqual(
+      new Set([
+        "allowed",
+        "denied",
+        "read_only",
+        "admin_only",
+        "support_only",
+        "no_authority",
+      ]),
+    );
+  });
+
+  it("keeps support and external roles out of workflow authority", () => {
+    for (const role of ["support_operator", "external_collaborator"]) {
+      const contract = getRbacRoleContract(role);
+
+      expect(contract?.workflowAuthority).toBe(false);
+      expect(contract?.surfaces.actionApprovalDecision).toBe("denied");
+      expect(contract?.surfaces.actionRequestSubmission).toBe("denied");
+      expect(contract?.surfaces.workflowAuthorityOverride).toBe("denied");
+      expect(contract?.surfaces.historicalTruthRewrite).toBe("denied");
+    }
+  });
+
+  it("does not treat platform administration as approval authority", () => {
+    expect(
+      anyRoleHasSurfaceAccess(
+        ["platform_admin"],
+        "platformAdministration",
+        "admin_only",
+      ),
+    ).toBe(true);
+    expect(
+      anyRoleHasSurfaceAccess(
+        ["platform_admin"],
+        "actionApprovalDecision",
+        "allowed",
+      ),
+    ).toBe(false);
+  });
+
+  it("separates analyst request authority from approver decision authority", () => {
+    expect(
+      anyRoleHasSurfaceAccess(
+        ["analyst"],
+        "actionRequestSubmission",
+        "allowed",
+      ),
+    ).toBe(true);
+    expect(
+      anyRoleHasSurfaceAccess(
+        ["analyst"],
+        "actionApprovalDecision",
+        "allowed",
+      ),
+    ).toBe(false);
+    expect(
+      anyRoleHasSurfaceAccess(
+        ["approver"],
+        "actionApprovalDecision",
+        "allowed",
+      ),
+    ).toBe(true);
+    expect(
+      anyRoleHasSurfaceAccess(
+        ["approver"],
+        "actionRequestSubmission",
+        "allowed",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps read-only auditor and external collaborator write-forbidden", () => {
+    for (const role of ["read_only_auditor", "external_collaborator"]) {
+      const contract = getRbacRoleContract(role);
+
+      expect(contract?.surfaces.workbenchInspection).toBe("read_only");
+      expect(contract?.surfaces.investigationNotes).toBe("read_only");
+      expect(contract?.surfaces.actionRequestSubmission).toBe("denied");
+      expect(contract?.surfaces.actionApprovalDecision).toBe("denied");
+    }
+  });
+});

--- a/apps/operator-ui/src/auth/roleMatrix.ts
+++ b/apps/operator-ui/src/auth/roleMatrix.ts
@@ -1,0 +1,174 @@
+export const RBAC_ROLE_IDS = [
+  "platform_admin",
+  "analyst",
+  "approver",
+  "read_only_auditor",
+  "support_operator",
+  "external_collaborator",
+] as const;
+
+export type RbacRoleId = (typeof RBAC_ROLE_IDS)[number];
+
+export type RbacSurfaceAccess =
+  | "allowed"
+  | "denied"
+  | "read_only"
+  | "admin_only"
+  | "support_only"
+  | "no_authority";
+
+export interface RbacRoleContract {
+  description: string;
+  surfaces: {
+    actionApprovalDecision: RbacSurfaceAccess;
+    actionRequestSubmission: RbacSurfaceAccess;
+    auditExport: RbacSurfaceAccess;
+    externalCollaboration: RbacSurfaceAccess;
+    historicalTruthRewrite: RbacSurfaceAccess;
+    investigationNotes: RbacSurfaceAccess;
+    platformAdministration: RbacSurfaceAccess;
+    supportDiagnostics: RbacSurfaceAccess;
+    workbenchInspection: RbacSurfaceAccess;
+    workflowAuthorityOverride: RbacSurfaceAccess;
+  };
+  workflowAuthority: false;
+}
+
+export const RBAC_ROLE_MATRIX: Record<RbacRoleId, RbacRoleContract> = {
+  platform_admin: {
+    description:
+      "Operates platform configuration and identity wiring without becoming workflow truth.",
+    surfaces: {
+      actionApprovalDecision: "denied",
+      actionRequestSubmission: "denied",
+      auditExport: "admin_only",
+      externalCollaboration: "denied",
+      historicalTruthRewrite: "denied",
+      investigationNotes: "read_only",
+      platformAdministration: "admin_only",
+      supportDiagnostics: "denied",
+      workbenchInspection: "read_only",
+      workflowAuthorityOverride: "denied",
+    },
+    workflowAuthority: false,
+  },
+  analyst: {
+    description:
+      "Reviews assigned workflow records and submits approval-bound action requests.",
+    surfaces: {
+      actionApprovalDecision: "denied",
+      actionRequestSubmission: "allowed",
+      auditExport: "denied",
+      externalCollaboration: "denied",
+      historicalTruthRewrite: "denied",
+      investigationNotes: "allowed",
+      platformAdministration: "denied",
+      supportDiagnostics: "denied",
+      workbenchInspection: "allowed",
+      workflowAuthorityOverride: "denied",
+    },
+    workflowAuthority: false,
+  },
+  approver: {
+    description:
+      "Records reviewed approval decisions on approval-bound requests in assigned scope.",
+    surfaces: {
+      actionApprovalDecision: "allowed",
+      actionRequestSubmission: "denied",
+      auditExport: "denied",
+      externalCollaboration: "denied",
+      historicalTruthRewrite: "denied",
+      investigationNotes: "read_only",
+      platformAdministration: "denied",
+      supportDiagnostics: "denied",
+      workbenchInspection: "read_only",
+      workflowAuthorityOverride: "denied",
+    },
+    workflowAuthority: false,
+  },
+  read_only_auditor: {
+    description:
+      "Inspects reviewed workflow and audit surfaces without write authority.",
+    surfaces: {
+      actionApprovalDecision: "denied",
+      actionRequestSubmission: "denied",
+      auditExport: "read_only",
+      externalCollaboration: "denied",
+      historicalTruthRewrite: "denied",
+      investigationNotes: "read_only",
+      platformAdministration: "denied",
+      supportDiagnostics: "denied",
+      workbenchInspection: "read_only",
+      workflowAuthorityOverride: "denied",
+    },
+    workflowAuthority: false,
+  },
+  support_operator: {
+    description:
+      "Runs customer-safe diagnostics and support workflows without approval or closeout authority.",
+    surfaces: {
+      actionApprovalDecision: "denied",
+      actionRequestSubmission: "denied",
+      auditExport: "denied",
+      externalCollaboration: "denied",
+      historicalTruthRewrite: "denied",
+      investigationNotes: "read_only",
+      platformAdministration: "denied",
+      supportDiagnostics: "support_only",
+      workbenchInspection: "read_only",
+      workflowAuthorityOverride: "denied",
+    },
+    workflowAuthority: false,
+  },
+  external_collaborator: {
+    description:
+      "Supplies bounded collaboration context without AegisOps workflow authority.",
+    surfaces: {
+      actionApprovalDecision: "denied",
+      actionRequestSubmission: "denied",
+      auditExport: "denied",
+      externalCollaboration: "no_authority",
+      historicalTruthRewrite: "denied",
+      investigationNotes: "read_only",
+      platformAdministration: "denied",
+      supportDiagnostics: "denied",
+      workbenchInspection: "read_only",
+      workflowAuthorityOverride: "denied",
+    },
+    workflowAuthority: false,
+  },
+};
+
+export function normalizeRbacRole(role: string): string {
+  return role.trim().toLowerCase();
+}
+
+export function isCommercialRbacRole(role: string): role is RbacRoleId {
+  return Object.prototype.hasOwnProperty.call(
+    RBAC_ROLE_MATRIX,
+    normalizeRbacRole(role),
+  );
+}
+
+export function getRbacRoleContract(role: string): RbacRoleContract | null {
+  const normalizedRole = normalizeRbacRole(role);
+  return isCommercialRbacRole(normalizedRole)
+    ? RBAC_ROLE_MATRIX[normalizedRole]
+    : null;
+}
+
+export function roleHasSurfaceAccess(
+  role: string,
+  surface: keyof RbacRoleContract["surfaces"],
+  access: RbacSurfaceAccess,
+): boolean {
+  return getRbacRoleContract(role)?.surfaces[surface] === access;
+}
+
+export function anyRoleHasSurfaceAccess(
+  roles: readonly string[],
+  surface: keyof RbacRoleContract["surfaces"],
+  access: RbacSurfaceAccess,
+): boolean {
+  return roles.some((role) => roleHasSurfaceAccess(role, surface, access));
+}

--- a/apps/operator-ui/src/auth/session.test.ts
+++ b/apps/operator-ui/src/auth/session.test.ts
@@ -53,6 +53,39 @@ describe("createSessionStore", () => {
     });
   });
 
+  it("accepts every Phase 57.1 commercial RBAC matrix role by default", async () => {
+    const config = createOperatorUiConfig();
+    const sessionStore = createSessionStore({
+      config,
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          identity: "auditor@example.com",
+          provider: "authentik",
+          roles: [
+            "platform_admin",
+            "analyst",
+            "approver",
+            "read_only_auditor",
+            "support_operator",
+            "external_collaborator",
+          ],
+          subject: "operator-57-1",
+        }),
+      ),
+    });
+
+    await expect(sessionStore.getSession()).resolves.toMatchObject({
+      roles: [
+        "platform_admin",
+        "analyst",
+        "approver",
+        "read_only_auditor",
+        "support_operator",
+        "external_collaborator",
+      ],
+    });
+  });
+
   it("clears a cached session when a forced refresh returns unauthenticated", async () => {
     const config = createOperatorUiConfig({
       allowedRoles: ["analyst"],

--- a/docs/phase-57-1-rbac-role-matrix-contract.md
+++ b/docs/phase-57-1-rbac-role-matrix-contract.md
@@ -1,0 +1,74 @@
+# Phase 57.1 RBAC Role Matrix Contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-04
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-49-production-rbac-auth-hardening-contract.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`, `docs/phase-55-closeout-evaluation.md`, `docs/phase-56-closeout-evaluation.md`
+- **Related Issues**: #1207, #1208
+
+## 1. Purpose
+
+This contract defines the minimum commercial RBAC role matrix before user, role, source, action policy, retention, audit export, and AI enablement administration expands.
+
+The RBAC matrix defines access and policy posture only. It cannot rewrite historical workflow truth or make support or external users authoritative for approval, execution, reconciliation, audit, release, gate, or closeout truth.
+
+## 2. Role Matrix
+
+| Role | Workbench inspection | Investigation notes | Action request submission | Action approval decision | Platform administration | Support diagnostics | Audit export | External collaboration | Workflow authority override | Historical truth rewrite |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `platform_admin` | read-only | read-only | denied | denied | admin-only | denied | admin-only | denied | denied | denied |
+| `analyst` | allowed | allowed | allowed | denied | denied | denied | denied | denied | denied | denied |
+| `approver` | read-only | read-only | denied | allowed | denied | denied | denied | denied | denied | denied |
+| `read_only_auditor` | read-only | read-only | denied | denied | denied | denied | read-only | denied | denied | denied |
+| `support_operator` | read-only | read-only | denied | denied | denied | support-only | denied | denied | denied | denied |
+| `external_collaborator` | read-only | read-only | denied | denied | denied | denied | denied | no-authority | denied | denied |
+
+## 3. Required Behavior
+
+The matrix covers allowed, denied, read-only, admin-only, support-only, and no-authority behavior.
+
+Platform admin access is admin-only for configuration and audit-export posture; it is not approval, execution, reconciliation, closeout, release, or gate authority.
+
+Analyst access can submit approval-bound action requests in assigned scope, but analyst access cannot approve approval-sensitive work or rewrite workflow truth.
+
+Approver access can record reviewed approval decisions in assigned scope, but approver access cannot submit its own approval-bound request through role confusion or execute actions as the approving human.
+
+Read-only auditor access can inspect reviewed workflow and audit surfaces, but it cannot write investigation notes, submit action requests, approve actions, operate support diagnostics, administer the platform, or rewrite historical truth.
+
+Support operator access is support-only for customer-safe diagnostics and cannot receive workflow authority for approval, execution, reconciliation, audit, release, gate, or closeout truth.
+
+External collaborator access is no-authority collaboration context and cannot receive workflow authority for approval, execution, reconciliation, audit, release, gate, or closeout truth.
+
+## 4. Authority Boundary
+
+Backend authorization remains the enforcement boundary for protected reads, write-capable operator actions, approval decisions, action execution delegation, reconciliation closeout, audit export, support diagnostics, and administration.
+
+Browser route gating, UI menu visibility, role cache, support text, external collaborator context, ticket state, assistant output, downstream receipts, and operator-facing summaries are subordinate surfaces only.
+
+If browser role cache and backend authorization disagree, the backend denial wins and the browser must preserve the denial explicitly instead of rendering guessed or cached protected content.
+
+Admin configuration cannot rewrite historical workflow truth, lifecycle state, approval state, action execution state, reconciliation state, audit-export truth, release truth, gate truth, or closeout truth.
+
+## 5. Negative Tests
+
+Negative tests must reject support operator workflow authority, external collaborator workflow authority, UI role cache as authority, self-approval through role confusion, and admin configuration rewriting historical truth.
+
+Negative tests must cite `docs/phase-51-6-authority-boundary-negative-test-policy.md` for UI cache, browser state, tickets, assistant output, downstream receipts, demo data, and other subordinate shortcut rejection when those surfaces are touched.
+
+## 6. Scope Boundaries
+
+This contract does not implement user or role administration, source administration, action policy administration, retention administration, audit export administration, AI enablement administration, tenant modeling, supportability breadth, reporting breadth, SOAR breadth, RC readiness, GA readiness, or commercial replacement claims.
+
+Existing backend authority and reread-after-write posture remain unchanged.
+
+## 7. Verification Commands
+
+Run `npm test --workspace apps/operator-ui -- --run src/auth/roleMatrix.test.ts src/auth/session.test.ts`.
+
+Run `bash scripts/verify-phase-57-1-rbac-role-matrix-contract.sh`.
+
+Run `bash scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1207 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1208 --config <supervisor-config-path>`.

--- a/scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh
+++ b/scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh
@@ -96,7 +96,7 @@ assert_fails_with \
 
 local_path_repo="${workdir}/local-path"
 copy_artifacts "${local_path_repo}"
-printf '\nLocal debug path: /Users/example/AegisOps\n' >> \
+printf '\nLocal debug path: %s\n' "/""Users/example/AegisOps" >> \
   "${local_path_repo}/docs/phase-57-1-rbac-role-matrix-contract.md"
 assert_fails_with \
   "${local_path_repo}" \

--- a/scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh
+++ b/scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh
@@ -76,6 +76,22 @@ assert_fails_with \
   "${missing_role_repo}" \
   'Missing Phase 57.1 RBAC role matrix contract statement: | `support_operator` | read-only | read-only | denied | denied | denied | support-only | denied | denied | denied | denied |'
 
+missing_role_object_repo="${workdir}/missing-support-role-object"
+copy_artifacts "${missing_role_object_repo}"
+perl -0pi -e 's/\n  support_operator: \{\n.*?\n  \},\n  external_collaborator:/\n  external_collaborator:/s' \
+  "${missing_role_object_repo}/apps/operator-ui/src/auth/roleMatrix.ts"
+assert_fails_with \
+  "${missing_role_object_repo}" \
+  "Missing Phase 57.1 RBAC role in executable matrix: support_operator"
+
+workflow_authority_repo="${workdir}/support-workflow-authority"
+copy_artifacts "${workflow_authority_repo}"
+perl -0pi -e 's/(support_operator: \{\n.*?workflowAuthority: )false/$1true/s' \
+  "${workflow_authority_repo}/apps/operator-ui/src/auth/roleMatrix.ts"
+assert_fails_with \
+  "${workflow_authority_repo}" \
+  "Missing fail-closed workflowAuthority=false posture for RBAC role: support_operator"
+
 missing_negative_repo="${workdir}/missing-negative"
 copy_artifacts "${missing_negative_repo}"
 perl -0pi -e 's/Negative tests must reject support operator workflow authority, external collaborator workflow authority, UI role cache as authority, self-approval through role confusion, and admin configuration rewriting historical truth\.//g' \
@@ -97,6 +113,10 @@ assert_fails_with \
 local_path_repo="${workdir}/local-path"
 copy_artifacts "${local_path_repo}"
 printf '\nLocal debug path: %s\n' "/""Users/example/AegisOps" >> \
+  "${local_path_repo}/docs/phase-57-1-rbac-role-matrix-contract.md"
+printf '\nLocal debug path: %s\n' "/""home/example/AegisOps" >> \
+  "${local_path_repo}/docs/phase-57-1-rbac-role-matrix-contract.md"
+printf '\nLocal debug path: %s\n' "C:""\\Users\\example\\AegisOps" >> \
   "${local_path_repo}/docs/phase-57-1-rbac-role-matrix-contract.md"
 assert_fails_with \
   "${local_path_repo}" \

--- a/scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh
+++ b/scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-57-1-rbac-role-matrix-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+copy_artifacts() {
+  local target="$1"
+
+  mkdir -p \
+    "${target}/docs" \
+    "${target}/apps/operator-ui/src/auth" \
+    "${target}/scripts"
+  cp "${repo_root}/docs/phase-57-1-rbac-role-matrix-contract.md" \
+    "${target}/docs/phase-57-1-rbac-role-matrix-contract.md"
+  cp "${repo_root}/apps/operator-ui/src/auth/roleMatrix.ts" \
+    "${target}/apps/operator-ui/src/auth/roleMatrix.ts"
+  cp "${repo_root}/apps/operator-ui/src/auth/roleMatrix.test.ts" \
+    "${target}/apps/operator-ui/src/auth/roleMatrix.test.ts"
+  cp "${repo_root}/apps/operator-ui/src/auth/session.test.ts" \
+    "${target}/apps/operator-ui/src/auth/session.test.ts"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+copy_artifacts "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+copy_artifacts "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-57-1-rbac-role-matrix-contract.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 57.1 RBAC role matrix contract"
+
+missing_role_repo="${workdir}/missing-support-role"
+copy_artifacts "${missing_role_repo}"
+perl -0pi -e 's/"support_operator",//g; s/\| `support_operator` \| read-only \| read-only \| denied \| denied \| denied \| support-only \| denied \| denied \| denied \| denied \|\n//g' \
+  "${missing_role_repo}/apps/operator-ui/src/auth/roleMatrix.ts" \
+  "${missing_role_repo}/docs/phase-57-1-rbac-role-matrix-contract.md"
+assert_fails_with \
+  "${missing_role_repo}" \
+  'Missing Phase 57.1 RBAC role matrix contract statement: | `support_operator` | read-only | read-only | denied | denied | denied | support-only | denied | denied | denied | denied |'
+
+missing_negative_repo="${workdir}/missing-negative"
+copy_artifacts "${missing_negative_repo}"
+perl -0pi -e 's/Negative tests must reject support operator workflow authority, external collaborator workflow authority, UI role cache as authority, self-approval through role confusion, and admin configuration rewriting historical truth\.//g' \
+  "${missing_negative_repo}/docs/phase-57-1-rbac-role-matrix-contract.md"
+assert_fails_with \
+  "${missing_negative_repo}" \
+  "Missing Phase 57.1 RBAC role matrix contract statement: Negative tests must reject support operator workflow authority, external collaborator workflow authority, UI role cache as authority, self-approval through role confusion, and admin configuration rewriting historical truth."
+
+missing_access_repo="${workdir}/missing-no-authority"
+copy_artifacts "${missing_access_repo}"
+perl -0pi -e 's/"no_authority"/"denied"/g; s/no-authority/denied/g' \
+  "${missing_access_repo}/apps/operator-ui/src/auth/roleMatrix.ts" \
+  "${missing_access_repo}/apps/operator-ui/src/auth/roleMatrix.test.ts" \
+  "${missing_access_repo}/docs/phase-57-1-rbac-role-matrix-contract.md"
+assert_fails_with \
+  "${missing_access_repo}" \
+  'Missing Phase 57.1 RBAC role matrix contract statement: | `external_collaborator` | read-only | read-only | denied | denied | denied | denied | denied | no-authority | denied | denied |'
+
+local_path_repo="${workdir}/local-path"
+copy_artifacts "${local_path_repo}"
+printf '\nLocal debug path: /Users/example/AegisOps\n' >> \
+  "${local_path_repo}/docs/phase-57-1-rbac-role-matrix-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "Phase 57.1 RBAC artifacts contain workstation-local absolute paths"
+
+echo "verify-phase-57-1-rbac-role-matrix-contract tests passed"

--- a/scripts/verify-phase-57-1-rbac-role-matrix-contract.sh
+++ b/scripts/verify-phase-57-1-rbac-role-matrix-contract.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-57-1-rbac-role-matrix-contract.md"
+matrix_path="${repo_root}/apps/operator-ui/src/auth/roleMatrix.ts"
+matrix_test_path="${repo_root}/apps/operator-ui/src/auth/roleMatrix.test.ts"
+session_test_path="${repo_root}/apps/operator-ui/src/auth/session.test.ts"
+
+required_headings=(
+  "# Phase 57.1 RBAC Role Matrix Contract"
+  "## 1. Purpose"
+  "## 2. Role Matrix"
+  "## 3. Required Behavior"
+  "## 4. Authority Boundary"
+  "## 5. Negative Tests"
+  "## 6. Scope Boundaries"
+  "## 7. Verification Commands"
+)
+
+required_doc_phrases=(
+  "This contract defines the minimum commercial RBAC role matrix before user, role, source, action policy, retention, audit export, and AI enablement administration expands."
+  "The RBAC matrix defines access and policy posture only. It cannot rewrite historical workflow truth or make support or external users authoritative for approval, execution, reconciliation, audit, release, gate, or closeout truth."
+  '| `platform_admin` | read-only | read-only | denied | denied | admin-only | denied | admin-only | denied | denied | denied |'
+  '| `analyst` | allowed | allowed | allowed | denied | denied | denied | denied | denied | denied | denied |'
+  '| `approver` | read-only | read-only | denied | allowed | denied | denied | denied | denied | denied | denied |'
+  '| `read_only_auditor` | read-only | read-only | denied | denied | denied | denied | read-only | denied | denied | denied |'
+  '| `support_operator` | read-only | read-only | denied | denied | denied | support-only | denied | denied | denied | denied |'
+  '| `external_collaborator` | read-only | read-only | denied | denied | denied | denied | denied | no-authority | denied | denied |'
+  "The matrix covers allowed, denied, read-only, admin-only, support-only, and no-authority behavior."
+  "Support operator access is support-only for customer-safe diagnostics and cannot receive workflow authority for approval, execution, reconciliation, audit, release, gate, or closeout truth."
+  "External collaborator access is no-authority collaboration context and cannot receive workflow authority for approval, execution, reconciliation, audit, release, gate, or closeout truth."
+  "Backend authorization remains the enforcement boundary for protected reads, write-capable operator actions, approval decisions, action execution delegation, reconciliation closeout, audit export, support diagnostics, and administration."
+  "If browser role cache and backend authorization disagree, the backend denial wins and the browser must preserve the denial explicitly instead of rendering guessed or cached protected content."
+  "Admin configuration cannot rewrite historical workflow truth, lifecycle state, approval state, action execution state, reconciliation state, audit-export truth, release truth, gate truth, or closeout truth."
+  "Negative tests must reject support operator workflow authority, external collaborator workflow authority, UI role cache as authority, self-approval through role confusion, and admin configuration rewriting historical truth."
+  "Existing backend authority and reread-after-write posture remain unchanged."
+  'Run `npm test --workspace apps/operator-ui -- --run src/auth/roleMatrix.test.ts src/auth/session.test.ts`.'
+  'Run `bash scripts/verify-phase-57-1-rbac-role-matrix-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1207 --config <supervisor-config-path>`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1208 --config <supervisor-config-path>`.'
+)
+
+required_roles=(
+  "platform_admin"
+  "analyst"
+  "approver"
+  "read_only_auditor"
+  "support_operator"
+  "external_collaborator"
+)
+
+required_access_values=(
+  "allowed"
+  "denied"
+  "read_only"
+  "admin_only"
+  "support_only"
+  "no_authority"
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 57.1 RBAC role matrix contract: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${matrix_path}" ]]; then
+  echo "Missing Phase 57.1 executable role matrix: ${matrix_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${matrix_test_path}" ]]; then
+  echo "Missing Phase 57.1 role matrix tests: ${matrix_test_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${session_test_path}" ]]; then
+  echo "Missing reviewed session role coverage tests: ${session_test_path}" >&2
+  exit 1
+fi
+
+for heading in "${required_headings[@]}"; do
+  if ! grep -Fxq -- "${heading}" "${doc_path}"; then
+    echo "Missing Phase 57.1 RBAC role matrix contract heading: ${heading}" >&2
+    exit 1
+  fi
+done
+
+for phrase in "${required_doc_phrases[@]}"; do
+  if ! grep -Fxq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 57.1 RBAC role matrix contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for role in "${required_roles[@]}"; do
+  if ! grep -Fq -- "\"${role}\"" "${matrix_path}"; then
+    echo "Missing Phase 57.1 RBAC role in executable matrix: ${role}" >&2
+    exit 1
+  fi
+  if ! grep -Fq -- "\`${role}\`" "${doc_path}"; then
+    echo "Missing Phase 57.1 RBAC role in contract table: ${role}" >&2
+    exit 1
+  fi
+  if ! grep -Fq -- "\"${role}\"" "${matrix_test_path}" "${session_test_path}"; then
+    echo "Missing Phase 57.1 RBAC role in focused tests: ${role}" >&2
+    exit 1
+  fi
+done
+
+for access in "${required_access_values[@]}"; do
+  if ! grep -Fq -- "\"${access}\"" "${matrix_path}" "${matrix_test_path}"; then
+    echo "Missing Phase 57.1 RBAC access behavior in executable matrix/tests: ${access}" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Fq -- "workflowAuthority: false" "${matrix_path}"; then
+  echo "Missing fail-closed workflowAuthority=false posture in executable role matrix" >&2
+  exit 1
+fi
+
+if grep -R -nE '/Users/[^[:space:]]+|/home/[^[:space:]]+|C:\\\\Users\\\\' \
+  "${doc_path}" "${matrix_path}" "${matrix_test_path}" "${session_test_path}" >&2; then
+  echo "Phase 57.1 RBAC artifacts contain workstation-local absolute paths" >&2
+  exit 1
+fi
+
+echo "Phase 57.1 RBAC role matrix contract is present with executable role coverage and authority-boundary negative posture."

--- a/scripts/verify-phase-57-1-rbac-role-matrix-contract.sh
+++ b/scripts/verify-phase-57-1-rbac-role-matrix-contract.sh
@@ -122,7 +122,11 @@ if ! grep -Fq -- "workflowAuthority: false" "${matrix_path}"; then
   exit 1
 fi
 
-if grep -R -nE '/Users/[^[:space:]]+|/home/[^[:space:]]+|C:\\\\Users\\\\' \
+mac_home_root="/""Users/"
+linux_home_root="/""home/"
+windows_user_root="C:""\\\\Users\\\\"
+
+if grep -R -nE "${mac_home_root}[^[:space:]]+|${linux_home_root}[^[:space:]]+|${windows_user_root}" \
   "${doc_path}" "${matrix_path}" "${matrix_test_path}" "${session_test_path}" >&2; then
   echo "Phase 57.1 RBAC artifacts contain workstation-local absolute paths" >&2
   exit 1

--- a/scripts/verify-phase-57-1-rbac-role-matrix-contract.sh
+++ b/scripts/verify-phase-57-1-rbac-role-matrix-contract.sh
@@ -61,6 +61,43 @@ required_access_values=(
   "no_authority"
 )
 
+role_has_workflow_authority_false() {
+  local role="$1"
+
+  awk -v role="${role}" '
+    BEGIN {
+      depth = 0
+      finished = 0
+      found = 0
+      in_role = 0
+      saw_role = 0
+    }
+    $0 ~ "^[[:space:]]*" role ":[[:space:]]*\\{" {
+      in_role = 1
+      saw_role = 1
+    }
+    in_role {
+      if ($0 ~ /^[[:space:]]*workflowAuthority:[[:space:]]*false,?[[:space:]]*$/) {
+        found = 1
+      }
+
+      line = $0
+      opens = gsub(/\{/, "{", line)
+      line = $0
+      closes = gsub(/\}/, "}", line)
+      depth += opens - closes
+
+      if (depth == 0) {
+        finished = 1
+        in_role = 0
+      }
+    }
+    END {
+      exit(saw_role && finished && found ? 0 : 1)
+    }
+  ' "${matrix_path}"
+}
+
 if [[ ! -f "${doc_path}" ]]; then
   echo "Missing Phase 57.1 RBAC role matrix contract: ${doc_path}" >&2
   exit 1
@@ -96,7 +133,7 @@ for phrase in "${required_doc_phrases[@]}"; do
 done
 
 for role in "${required_roles[@]}"; do
-  if ! grep -Fq -- "\"${role}\"" "${matrix_path}"; then
+  if ! grep -Eq -- "^[[:space:]]*${role}:[[:space:]]*\\{" "${matrix_path}"; then
     echo "Missing Phase 57.1 RBAC role in executable matrix: ${role}" >&2
     exit 1
   fi
@@ -108,19 +145,22 @@ for role in "${required_roles[@]}"; do
     echo "Missing Phase 57.1 RBAC role in focused tests: ${role}" >&2
     exit 1
   fi
-done
-
-for access in "${required_access_values[@]}"; do
-  if ! grep -Fq -- "\"${access}\"" "${matrix_path}" "${matrix_test_path}"; then
-    echo "Missing Phase 57.1 RBAC access behavior in executable matrix/tests: ${access}" >&2
+  if ! role_has_workflow_authority_false "${role}"; then
+    echo "Missing fail-closed workflowAuthority=false posture for RBAC role: ${role}" >&2
     exit 1
   fi
 done
 
-if ! grep -Fq -- "workflowAuthority: false" "${matrix_path}"; then
-  echo "Missing fail-closed workflowAuthority=false posture in executable role matrix" >&2
-  exit 1
-fi
+for access in "${required_access_values[@]}"; do
+  if ! grep -Fq -- "\"${access}\"" "${matrix_path}"; then
+    echo "Missing Phase 57.1 RBAC access behavior in executable matrix: ${access}" >&2
+    exit 1
+  fi
+  if ! grep -Fq -- "\"${access}\"" "${matrix_test_path}"; then
+    echo "Missing Phase 57.1 RBAC access behavior in role matrix tests: ${access}" >&2
+    exit 1
+  fi
+done
 
 mac_home_root="/""Users/"
 linux_home_root="/""home/"


### PR DESCRIPTION
## Summary
- add the Phase 57.1 RBAC role matrix contract doc and verifier
- add executable operator UI role matrix coverage for platform admin, analyst, approver, read-only auditor, support operator, and external collaborator
- keep approval decisions tied to approver matrix authority while preserving platform admin navigation visibility without approval authority

## Verification
- npm test --workspace apps/operator-ui -- --run src/auth/roleMatrix.test.ts src/auth/session.test.ts src/app/OperatorRoutes.test.tsx src/app/OperatorRoutes.actionReview.testSuite.tsx
- npm run typecheck --workspace apps/operator-ui
- bash scripts/verify-phase-57-1-rbac-role-matrix-contract.sh && bash scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh
- python3 -m unittest discover -s control-plane/tests -p 'test_phase56_3_case_timeline_projection_contract.py'
- node <codex-supervisor-root>/dist/index.js issue-lint 1207 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1208 --config <supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a formal RBAC role matrix and applied it to operator UI permission checks for finer-grained access control.

* **Tests**
  * Added focused tests validating role definitions, surface access modes, and session role handling.

* **Documentation**
  * Added Phase 57.1 RBAC role matrix contract with required behaviors, verification guidance, and scope/authority notes.

* **Chores**
  * Added verifier scripts to automate contract and matrix consistency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->