### PR TITLE
Phase 57.2 user and role admin surface

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { createDefaultDependencies, OperatorRoutes } from "./OperatorRoutes";
 import {
@@ -10,6 +11,7 @@ import {
   createAuthorizedFetch,
   createOptionalExtensionPayload,
   createReadinessResponse,
+  TestRouteNavigator,
   jsonResponse,
 } from "./OperatorRoutes.testSupport";
 
@@ -360,6 +362,105 @@ export function registerOperatorRoutesAuthAndShellTests() {
       "href",
       expect.stringContaining("/reviewed-operator/admin"),
     );
+    });
+
+    it("renders the user and role admin surface only for platform admins", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {},
+        {
+          identity: "platform.admin@example.com",
+          provider: "authentik",
+          roles: ["platform_admin"],
+          subject: "operator-44",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/admin"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "User and role administration" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Users")).toBeInTheDocument();
+    expect(screen.getByText("Roles")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "User and role changes are reviewed policy/config state only; they cannot rewrite historical workflow truth.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Stale browser role cache is never authority. Backend reread and denial remain decisive.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/tenant/i)).not.toBeInTheDocument();
+    });
+
+    it("fails closed when stale platform-admin browser state reaches the admin route", async () => {
+    const user = userEvent.setup();
+    let sessionRequests = 0;
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation((input) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/operator/session")) {
+        sessionRequests += 1;
+
+        return Promise.resolve(
+          jsonResponse(
+            sessionRequests === 1
+              ? {
+                  identity: "platform.admin@example.com",
+                  provider: "authentik",
+                  roles: ["platform_admin"],
+                  subject: "operator-44",
+                }
+              : {
+                  identity: "analyst@example.com",
+                  provider: "authentik",
+                  roles: ["analyst"],
+                  subject: "operator-7",
+                },
+          ),
+        );
+      }
+
+      if (url.startsWith("/diagnostics/readiness")) {
+        return Promise.resolve(jsonResponse(createReadinessResponse()));
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator"]}>
+        <TestRouteNavigator />
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Protected operator shell" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Go to admin" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Access denied" }),
+      ).toBeInTheDocument();
+    });
+    expect(sessionRequests).toBeGreaterThanOrEqual(2);
     });
 
     it("renders an explicit unsupported-route outcome for unknown operator shell paths", async () => {

--- a/apps/operator-ui/src/app/OperatorRoutes.testSupport.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.testSupport.tsx
@@ -169,6 +169,9 @@ export function TestRouteNavigator() {
       <button onClick={() => navigate("/operator/today")} type="button">
         Go to Today
       </button>
+      <button onClick={() => navigate("/operator/admin")} type="button">
+        Go to admin
+      </button>
     </>
   );
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.tsx
@@ -285,6 +285,7 @@ function ProtectedOperatorRoute({
       onEventLogEntriesChange={onEventLogEntriesChange}
       operatorIdentity={session?.identity ?? ""}
       operatorRoles={session?.roles ?? []}
+      sessionStore={sessionStore}
       taskActionClient={taskActionClient}
     />
   );

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -56,6 +56,7 @@ import {
 import { TaskActionClientProvider } from "../taskActions/taskActionPrimitives";
 import type { OperatorTaskActionClient } from "../taskActions/taskActionClient";
 import { anyRoleHasSurfaceAccess } from "../auth/roleMatrix";
+import type { SessionStore } from "../auth/session";
 
 const loadOperatorConsolePages = () => import("./operatorConsolePages");
 
@@ -99,6 +100,8 @@ const TodayPage =
   lazyOperatorConsolePage("TodayPage") as unknown as typeof import("./operatorConsolePages").TodayPage;
 const BusinessHoursHandoffPage =
   lazyOperatorConsolePage("BusinessHoursHandoffPage") as unknown as typeof import("./operatorConsolePages").BusinessHoursHandoffPage;
+const UserRoleAdminPage =
+  lazyOperatorConsolePage("UserRoleAdminPage") as unknown as typeof import("./operatorConsolePages").UserRoleAdminPage;
 
 function hasReviewedOperatorRole(
   operatorRoles: readonly string[],
@@ -434,6 +437,51 @@ function DeferredPageFallback() {
   );
 }
 
+function AdminPolicyRoute({
+  basePath,
+  sessionStore,
+}: {
+  basePath: string;
+  sessionStore: SessionStore;
+}) {
+  const [status, setStatus] = useState<"loading" | "authorized" | "forbidden">(
+    "loading",
+  );
+
+  useEffect(() => {
+    let active = true;
+
+    void sessionStore
+      .getSession({ force: true })
+      .then((session) => {
+        if (!active) {
+          return;
+        }
+
+        setStatus(canViewAdmin(session.roles) ? "authorized" : "forbidden");
+      })
+      .catch(() => {
+        if (active) {
+          setStatus("forbidden");
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [sessionStore]);
+
+  if (status === "loading") {
+    return <DeferredPageFallback />;
+  }
+
+  if (status === "forbidden") {
+    return <Navigate replace to={buildOperatorShellPath(basePath, "forbidden")} />;
+  }
+
+  return <UserRoleAdminPage />;
+}
+
 function OperatorShellContent({
   basePath,
   canInspectActionReview,
@@ -441,6 +489,7 @@ function OperatorShellContent({
   canViewActionReview,
   operatorIdentity,
   operatorRoles,
+  sessionStore,
 }: {
   basePath: string;
   canInspectActionReview: boolean;
@@ -448,6 +497,7 @@ function OperatorShellContent({
   canViewActionReview: boolean;
   operatorIdentity: string;
   operatorRoles: string[];
+  sessionStore: SessionStore;
 }) {
   const location = useLocation();
   const { recordRouteView } = useOperatorUiEventLog();
@@ -512,7 +562,10 @@ function OperatorShellContent({
           <Route
             element={
               canViewAdmin ? (
-                <OverviewPage operatorRoles={operatorRoles} />
+                <AdminPolicyRoute
+                  basePath={basePath}
+                  sessionStore={sessionStore}
+                />
               ) : (
                 <Navigate
                   replace
@@ -592,6 +645,7 @@ export function OperatorShell({
   operatorIdentity,
   operatorRoles,
   onEventLogEntriesChange,
+  sessionStore,
   taskActionClient,
 }: {
   authProvider: AuthProvider;
@@ -600,6 +654,7 @@ export function OperatorShell({
   onEventLogEntriesChange?: OperatorUiEventLogObserver;
   operatorIdentity: string;
   operatorRoles: string[];
+  sessionStore: SessionStore;
   taskActionClient: OperatorTaskActionClient;
 }) {
   const canViewActionReview = canBrowseActionReview(operatorRoles);
@@ -627,6 +682,7 @@ export function OperatorShell({
               canViewActionReview={canViewActionReview}
               operatorIdentity={operatorIdentity}
               operatorRoles={operatorRoles}
+              sessionStore={sessionStore}
             />
           </Layout>
         </TaskActionClientProvider>

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -13,6 +13,7 @@ export {
 export { ActionReviewPage } from "./operatorConsolePages/actionReviewPages";
 export { AssistantAdvisoryPage } from "./operatorConsolePages/assistantPages";
 export { FirstLoginChecklistPage } from "./operatorConsolePages/firstLoginChecklistPages";
+export { UserRoleAdminPage } from "./operatorConsolePages/adminPages";
 export {
   ProvenancePage,
   ReadinessPage,

--- a/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
@@ -1,0 +1,150 @@
+import {
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { RBAC_ROLE_MATRIX, type RbacRoleId } from "../../auth/roleMatrix";
+
+const ADMIN_ROLE_IDS: RbacRoleId[] = [
+  "platform_admin",
+  "analyst",
+  "approver",
+  "read_only_auditor",
+  "support_operator",
+  "external_collaborator",
+];
+
+const ADMIN_USERS = [
+  {
+    email: "platform.admin@example.com",
+    role: "platform_admin",
+    status: "Reviewed admin policy",
+  },
+  {
+    email: "analyst@example.com",
+    role: "analyst",
+    status: "Reviewed operator policy",
+  },
+  {
+    email: "approver@example.com",
+    role: "approver",
+    status: "Reviewed approval policy",
+  },
+] as const;
+
+function formatAccess(value: string) {
+  return value
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function UserRoleAdminPage() {
+  return (
+    <Stack spacing={3} sx={{ p: 3 }}>
+      <Stack spacing={1}>
+        <Typography component="h1" variant="h4">
+          User and role administration
+        </Typography>
+        <Typography color="text.secondary" variant="body1">
+          User and role changes are reviewed policy/config state only; they
+          cannot rewrite historical workflow truth.
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Stale browser role cache is never authority. Backend reread and denial
+          remain decisive.
+        </Typography>
+      </Stack>
+
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, lg: 5 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Stack spacing={0.5}>
+                  <Typography component="h2" variant="h5">
+                    Users
+                  </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Minimum reviewed account bindings for the operator console.
+                    The backend remains the source of effective access.
+                  </Typography>
+                </Stack>
+                <Divider />
+                {ADMIN_USERS.map((user) => (
+                  <Stack key={user.email} spacing={0.75}>
+                    <Stack
+                      alignItems="center"
+                      direction={{ xs: "column", sm: "row" }}
+                      justifyContent="space-between"
+                      spacing={1}
+                    >
+                      <Typography fontWeight={600}>{user.email}</Typography>
+                      <Chip label={user.status} size="small" />
+                    </Stack>
+                    <Typography color="text.secondary" variant="body2">
+                      Assigned role: {user.role}
+                    </Typography>
+                  </Stack>
+                ))}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 7 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Stack spacing={0.5}>
+                  <Typography component="h2" variant="h5">
+                    Roles
+                  </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Phase 57.1 role matrix values are rendered as policy posture,
+                    not workflow authority or approval truth.
+                  </Typography>
+                </Stack>
+                <Divider />
+                {ADMIN_ROLE_IDS.map((roleId) => {
+                  const contract = RBAC_ROLE_MATRIX[roleId];
+
+                  return (
+                    <Stack key={roleId} spacing={1}>
+                      <Stack
+                        alignItems="center"
+                        direction={{ xs: "column", sm: "row" }}
+                        justifyContent="space-between"
+                        spacing={1}
+                      >
+                        <Typography fontWeight={600}>{roleId}</Typography>
+                        <Chip
+                          color={
+                            roleId === "platform_admin" ? "primary" : "default"
+                          }
+                          label={formatAccess(contract.surfaces.platformAdministration)}
+                          size="small"
+                        />
+                      </Stack>
+                      <Typography color="text.secondary" variant="body2">
+                        {contract.description}
+                      </Typography>
+                      <Typography color="text.secondary" variant="body2">
+                        Historical truth rewrite:{" "}
+                        {formatAccess(contract.surfaces.historicalTruthRewrite)}
+                      </Typography>
+                    </Stack>
+                  );
+                })}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a platform-admin-only user and role administration page for reviewed policy/config posture
- Reread backend session authority before rendering the admin route so stale browser role state fails closed
- Cover platform-admin access, non-admin denial, unsupported roles, stale cache denial, and no tenant-model UI claims

## Verification
- npm test --workspace apps/operator-ui -- --run src/app/OperatorRoutes.test.tsx
- npm test --workspace apps/operator-ui -- --run src/auth/roleMatrix.test.ts src/auth/session.test.ts
- npm run typecheck --workspace apps/operator-ui
- npm run build --workspace apps/operator-ui
- node <codex-supervisor-root>/dist/index.js issue-lint 1207 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1209 --config <supervisor-config-path>

Closes #1209
Part of #1207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user and role administration interface accessible to platform administrators.
  * Implemented session revalidation for secure admin access control, ensuring access is verified on each request.
  * Admin panel displays administrator users and assigned roles.

* **Tests**
  * Added comprehensive test coverage for admin access permissions and session validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->