### PR TITLE
Phase 57.3 source profile admin surface

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
@@ -404,6 +404,51 @@ export function registerOperatorRoutesAuthAndShellTests() {
     expect(screen.queryByText(/tenant/i)).not.toBeInTheDocument();
     });
 
+    it("renders bounded source profile administration for platform admins", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {},
+        {
+          identity: "platform.admin@example.com",
+          provider: "authentik",
+          roles: ["platform_admin"],
+          subject: "operator-44",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/admin"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Source profile administration" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Wazuh SMB single-node")).toBeInTheDocument();
+    expect(screen.getByText("Create: reviewed source profile draft")).toBeInTheDocument();
+    expect(screen.getByText("Update: reviewed posture change")).toBeInTheDocument();
+    expect(screen.getByText("Disable: source admission blocked")).toBeInTheDocument();
+    expect(screen.getByText("Degraded: visible subordinate context")).toBeInTheDocument();
+    expect(screen.getByText("Audit trail")).toBeInTheDocument();
+    expect(screen.getByText("Future reviewed sources")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Source profile state configures source admission posture only; it cannot become signal, alert, case, evidence, workflow, release, gate, or closeout truth.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Stale source admin UI or browser cache is never authority. Backend record-chain reread remains decisive before source admission or workflow use.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/marketplace/i)).not.toBeInTheDocument();
+    });
+
     it("fails closed when stale platform-admin browser state reaches the admin route", async () => {
     const user = userEvent.setup();
     let sessionRequests = 0;

--- a/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Card,
   CardContent,
   Chip,
@@ -36,11 +37,155 @@ const ADMIN_USERS = [
   },
 ] as const;
 
+const SOURCE_PROFILE_STATES = [
+  {
+    label: "Create: reviewed source profile draft",
+    posture:
+      "New profile requests stay blocked until source family, custody, parser, provenance, and admission boundaries are reviewed.",
+  },
+  {
+    label: "Update: reviewed posture change",
+    posture:
+      "Version, intake, credential, and source-health posture changes require explicit reviewed evidence and audit linkage.",
+  },
+  {
+    label: "Disable: source admission blocked",
+    posture:
+      "Disabled profiles block future source admission without rewriting historical alerts, cases, evidence, or reconciliation records.",
+  },
+  {
+    label: "Degraded: visible subordinate context",
+    posture:
+      "Degraded posture stays visible to operators as source-health context only and cannot advance workflow state.",
+  },
+] as const;
+
+const SOURCE_PROFILE_AUDIT_TRAIL = [
+  "Created by reviewed platform_admin session",
+  "Changed fields and reason captured",
+  "Disable or degraded transition records source admission impact",
+  "Backend record-chain reread required before workflow use",
+] as const;
+
+const FUTURE_SOURCE_POSTURE = [
+  "Explicit reviewed source-family identifier",
+  "Parser and provenance evidence present",
+  "Credential custody reference reviewed",
+  "No source profile state promoted to record-chain truth",
+] as const;
+
 function formatAccess(value: string) {
   return value
     .split("_")
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+function SourceProfileAdministrationPage() {
+  return (
+    <Stack spacing={2}>
+      <Stack spacing={0.5}>
+        <Typography component="h2" variant="h5">
+          Source profile administration
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Source profile state configures source admission posture only; it
+          cannot become signal, alert, case, evidence, workflow, release, gate,
+          or closeout truth.
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Stale source admin UI or browser cache is never authority. Backend
+          record-chain reread remains decisive before source admission or
+          workflow use.
+        </Typography>
+      </Stack>
+
+      <Alert severity="info" variant="outlined">
+        Wazuh profile administration remains bounded to reviewed source profile
+        expectations; unsupported source onboarding and broad source catalog
+        claims stay out of this surface.
+      </Alert>
+
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, lg: 5 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Stack
+                  alignItems="center"
+                  direction={{ xs: "column", sm: "row" }}
+                  justifyContent="space-between"
+                  spacing={1}
+                >
+                  <Stack spacing={0.5}>
+                    <Typography fontWeight={700}>Wazuh SMB single-node</Typography>
+                    <Typography color="text.secondary" variant="body2">
+                      Reviewed source profile for the Phase 53 Wazuh substrate
+                      contract and source-health posture.
+                    </Typography>
+                  </Stack>
+                  <Chip color="success" label="Reviewed" size="small" />
+                </Stack>
+                <Divider />
+                <Stack spacing={1}>
+                  {SOURCE_PROFILE_STATES.map((state) => (
+                    <Stack key={state.label} spacing={0.5}>
+                      <Typography fontWeight={600} variant="body2">
+                        {state.label}
+                      </Typography>
+                      <Typography color="text.secondary" variant="body2">
+                        {state.posture}
+                      </Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 3.5 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Audit trail
+                </Typography>
+                <Divider />
+                <Stack spacing={1}>
+                  {SOURCE_PROFILE_AUDIT_TRAIL.map((entry) => (
+                    <Typography key={entry} variant="body2">
+                      {entry}
+                    </Typography>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 3.5 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Future reviewed sources
+                </Typography>
+                <Divider />
+                <Stack spacing={1}>
+                  {FUTURE_SOURCE_POSTURE.map((entry) => (
+                    <Typography key={entry} variant="body2">
+                      {entry}
+                    </Typography>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
 }
 
 export function UserRoleAdminPage() {
@@ -145,6 +290,8 @@ export function UserRoleAdminPage() {
           </Card>
         </Grid>
       </Grid>
+
+      <SourceProfileAdministrationPage />
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Add a bounded source profile administration panel to the guarded platform-admin route.
- Cover Wazuh create, update, disable, degraded, audit-trail, future reviewed-source, and stale UI/cache non-authority posture.
- Add focused OperatorRoutes coverage for the Phase 57.3 admin surface.

## Verification
- `npm run test --workspace @aegisops/operator-ui -- src/app/OperatorRoutes.test.tsx`
- `npm run typecheck --workspace @aegisops/operator-ui`
- `bash scripts/verify-phase-53-6-wazuh-source-health-projection.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1207 --config <supervisor-config-path>`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1210 --config <supervisor-config-path>`

## Limitations
- This is a bounded admin posture surface, not broad source onboarding or source catalog scope.
- Source profile state remains subordinate to the AegisOps record chain and cannot rewrite historical alerts, cases, evidence, or workflow truth.

Closes #1210
Part of #1207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Source Profile Administration page for managing source profiles with create, update, disable, and status tracking capabilities.
  * Added audit trail functionality for tracking profile changes and modifications.
  * Included future reviewed sources management section.

* **Tests**
  * Added test coverage verifying platform admin access to Source Profile Administration page and expected functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->