### PR TITLE
Phase 57.4 action policy admin surface

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
@@ -479,6 +479,8 @@ export function registerOperatorRoutesAuthAndShellTests() {
     expect(screen.getByText("Soft Write")).toBeInTheDocument();
     expect(screen.getAllByText("Allowed by default")).toHaveLength(2);
     expect(screen.getAllByText("Disabled by default")).toHaveLength(2);
+    expect(screen.getByText("Controlled")).toBeInTheDocument();
+    expect(screen.getByText("Hard Write")).toBeInTheDocument();
     expect(screen.getByText("Degraded until reviewed")).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
@@ -449,6 +449,51 @@ export function registerOperatorRoutesAuthAndShellTests() {
     expect(screen.queryByText(/marketplace/i)).not.toBeInTheDocument();
     });
 
+    it("renders bounded action policy administration for default low-risk postures", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {},
+        {
+          identity: "platform.admin@example.com",
+          provider: "authentik",
+          roles: ["platform_admin"],
+          subject: "operator-44",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/admin"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Action policy administration" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Read")).toBeInTheDocument();
+    expect(screen.getByText("Notify")).toBeInTheDocument();
+    expect(screen.getByText("Soft Write")).toBeInTheDocument();
+    expect(screen.getAllByText("Allowed by default")).toHaveLength(2);
+    expect(screen.getAllByText("Disabled by default")).toHaveLength(2);
+    expect(screen.getByText("Degraded until reviewed")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Controlled and Hard Write default enablement is rejected; those action families remain approval-bound and backend-enforced.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Action policy admin config is eligible posture only; stale UI or cache state cannot approve, execute, reconcile, mutate substrates, or rewrite historical receipts.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Policy audit trail")).toBeInTheDocument();
+    expect(screen.queryByText(/broad SOAR catalog/i)).not.toBeInTheDocument();
+    });
+
     it("fails closed when stale platform-admin browser state reaches the admin route", async () => {
     const user = userEvent.setup();
     let sessionRequests = 0;

--- a/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
@@ -74,6 +74,45 @@ const FUTURE_SOURCE_POSTURE = [
   "No source profile state promoted to record-chain truth",
 ] as const;
 
+const ACTION_POLICY_POSTURES = [
+  {
+    family: "Read",
+    posture: "Allowed by default",
+    description:
+      "Eligible for policy-authorized enrichment only when request context and execution logging stay complete.",
+  },
+  {
+    family: "Notify",
+    posture: "Allowed by default",
+    description:
+      "Eligible for reviewed notification posture when recipient, message intent, and escalation path are explicit.",
+  },
+  {
+    family: "Soft Write",
+    posture: "Degraded until reviewed",
+    description:
+      "Coordination writes stay disabled or degraded until the exact reversible action pattern and evidence path are reviewed.",
+  },
+] as const;
+
+const DISABLED_ACTION_POLICY_POSTURES = [
+  {
+    family: "Controlled",
+    posture: "Disabled by default",
+  },
+  {
+    family: "Hard Write",
+    posture: "Disabled by default",
+  },
+] as const;
+
+const ACTION_POLICY_AUDIT_TRAIL = [
+  "Policy posture change reason captured",
+  "Changed by reviewed platform_admin session",
+  "Default enablement decision and effective state recorded",
+  "Backend authorization reread required before action use",
+] as const;
+
 function formatAccess(value: string) {
   return value
     .split("_")
@@ -174,6 +213,127 @@ function SourceProfileAdministrationPage() {
                 <Divider />
                 <Stack spacing={1}>
                   {FUTURE_SOURCE_POSTURE.map((entry) => (
+                    <Typography key={entry} variant="body2">
+                      {entry}
+                    </Typography>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
+}
+
+function ActionPolicyAdministrationPage() {
+  return (
+    <Stack spacing={2}>
+      <Stack spacing={0.5}>
+        <Typography component="h2" variant="h5">
+          Action policy administration
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Action policy admin config is eligible posture only; stale UI or
+          cache state cannot approve, execute, reconcile, mutate substrates, or
+          rewrite historical receipts.
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Existing approval, execution, and reconciliation authority remains
+          backend-owned and reread from the authoritative record chain.
+        </Typography>
+      </Stack>
+
+      <Alert severity="warning" variant="outlined">
+        Controlled and Hard Write default enablement is rejected; those action
+        families remain approval-bound and backend-enforced.
+      </Alert>
+
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, lg: 5 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Default low-risk posture
+                </Typography>
+                <Divider />
+                <Stack spacing={1.5}>
+                  {ACTION_POLICY_POSTURES.map((policy) => (
+                    <Stack key={policy.family} spacing={0.75}>
+                      <Stack
+                        alignItems="center"
+                        direction={{ xs: "column", sm: "row" }}
+                        justifyContent="space-between"
+                        spacing={1}
+                      >
+                        <Typography fontWeight={600}>{policy.family}</Typography>
+                        <Chip
+                          color={
+                            policy.posture === "Allowed by default"
+                              ? "success"
+                              : "warning"
+                          }
+                          label={policy.posture}
+                          size="small"
+                        />
+                      </Stack>
+                      <Typography color="text.secondary" variant="body2">
+                        {policy.description}
+                      </Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 3.5 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Rejected default enablement
+                </Typography>
+                <Divider />
+                <Stack spacing={1}>
+                  {DISABLED_ACTION_POLICY_POSTURES.map((policy) => (
+                    <Stack
+                      alignItems="center"
+                      direction={{ xs: "column", sm: "row" }}
+                      justifyContent="space-between"
+                      key={policy.family}
+                      spacing={1}
+                    >
+                      <Typography fontWeight={600} variant="body2">
+                        {policy.family}
+                      </Typography>
+                      <Chip
+                        color="error"
+                        label={policy.posture}
+                        size="small"
+                        variant="outlined"
+                      />
+                    </Stack>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 3.5 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Policy audit trail
+                </Typography>
+                <Divider />
+                <Stack spacing={1}>
+                  {ACTION_POLICY_AUDIT_TRAIL.map((entry) => (
                     <Typography key={entry} variant="body2">
                       {entry}
                     </Typography>
@@ -292,6 +452,8 @@ export function UserRoleAdminPage() {
       </Grid>
 
       <SourceProfileAdministrationPage />
+
+      <ActionPolicyAdministrationPage />
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- add the Phase 57.4 action policy administration section to the platform admin surface
- show Read, Notify, and Soft Write default posture with audit-trail context
- explicitly reject Controlled and Hard Write default enablement and keep UI/cache state non-authoritative

## Verification
- npm test --workspace apps/operator-ui -- --run src/app/OperatorRoutes.test.tsx
- npm run typecheck --workspace apps/operator-ui
- node dist/index.js issue-lint 1207 --config supervisor.config.aegisops.json
- node dist/index.js issue-lint 1211 --config supervisor.config.aegisops.json

Closes #1211
Part of #1207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Action Policy Administration interface for platform admins: permission controls, default posture indicators, rejection messaging for default enablement, and an audit trail view.

* **Tests**
  * Added UI tests covering access to the Action Policy Administration page and verifying presence of policy controls, posture counts, audit messaging, and excluded catalog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->