### PR TITLE
Phase 57.5 retention policy admin surface

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
@@ -496,6 +496,59 @@ export function registerOperatorRoutesAuthAndShellTests() {
     expect(screen.queryByText(/broad SOAR catalog/i)).not.toBeInTheDocument();
     });
 
+    it("renders bounded retention policy administration without deletion or historical rewrite authority", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {},
+        {
+          identity: "platform.admin@example.com",
+          provider: "authentik",
+          roles: ["platform_admin"],
+          subject: "operator-44",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/admin"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Retention policy administration" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("Alerts").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Cases").length).toBeGreaterThan(0);
+    expect(screen.getByText("Evidence")).toBeInTheDocument();
+    expect(screen.getByText("AI traces")).toBeInTheDocument();
+    expect(screen.getByText("Audit exports")).toBeInTheDocument();
+    expect(screen.getByText("Execution receipts")).toBeInTheDocument();
+    expect(screen.getAllByText("Reconciliations").length).toBeGreaterThan(0);
+    expect(screen.getByText("Locked")).toBeInTheDocument();
+    expect(screen.getByText("Export pending")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getAllByText("Denied").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(
+        "Retention policy admin config can define posture and review windows only; it cannot delete locked or export-pending records, close active workflow records, erase audit truth, or rewrite historical record chains.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Stale retention admin cache is never authority. Backend authoritative lifecycle state and record-chain reread remain decisive before any future purge candidate can be considered.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Unsafe deletion rejected")).toBeInTheDocument();
+    expect(screen.getByText("Historical rewrite rejected")).toBeInTheDocument();
+    expect(screen.getByText("Policy-as-closeout rejected")).toBeInTheDocument();
+    expect(screen.queryByText(/production purge automation/i)).not.toBeInTheDocument();
+    });
+
     it("fails closed when stale platform-admin browser state reaches the admin route", async () => {
     const user = userEvent.setup();
     let sessionRequests = 0;

--- a/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
@@ -113,6 +113,72 @@ const ACTION_POLICY_AUDIT_TRAIL = [
   "Backend authorization reread required before action use",
 ] as const;
 
+const RETENTION_RECORD_FAMILIES = [
+  {
+    family: "Alerts",
+    posture: "Preserve authoritative detection linkage",
+  },
+  {
+    family: "Cases",
+    posture: "Preserve workflow lifecycle and closeout truth",
+  },
+  {
+    family: "Evidence",
+    posture: "Preserve custody, provenance, and subordinate context",
+  },
+  {
+    family: "AI traces",
+    posture: "Preserve advisory-only trace boundaries",
+  },
+  {
+    family: "Audit exports",
+    posture: "Preserve export custody and audit reconstruction",
+  },
+  {
+    family: "Execution receipts",
+    posture: "Preserve execution outcome and receipt lineage",
+  },
+  {
+    family: "Reconciliations",
+    posture: "Preserve mismatch and terminal reconciliation truth",
+  },
+] as const;
+
+const RETENTION_STATE_POSTURES = [
+  {
+    state: "Locked",
+    posture: "Deletion rejected while the authoritative record is locked.",
+    color: "error",
+  },
+  {
+    state: "Export pending",
+    posture: "Deletion rejected until export custody is resolved.",
+    color: "error",
+  },
+  {
+    state: "Expired",
+    posture: "Eligible for future review only after authoritative reread.",
+    color: "warning",
+  },
+  {
+    state: "Active",
+    posture: "Policy cannot close or advance active workflow records.",
+    color: "primary",
+  },
+  {
+    state: "Denied",
+    posture: "Denied disposition remains preserved audit truth.",
+    color: "default",
+  },
+] as const;
+
+const RETENTION_NEGATIVE_POSTURES = [
+  "Unsafe deletion rejected",
+  "Historical rewrite rejected",
+  "Policy-as-closeout rejected",
+  "Stale retention cache rejected",
+] as const;
+
 function formatAccess(value: string) {
   return value
     .split("_")
@@ -348,6 +414,117 @@ function ActionPolicyAdministrationPage() {
   );
 }
 
+function RetentionPolicyAdministrationPage() {
+  return (
+    <Stack spacing={2}>
+      <Stack spacing={0.5}>
+        <Typography component="h2" variant="h5">
+          Retention policy administration
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Retention policy admin config can define posture and review windows
+          only; it cannot delete locked or export-pending records, close active
+          workflow records, erase audit truth, or rewrite historical record
+          chains.
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Stale retention admin cache is never authority. Backend authoritative
+          lifecycle state and record-chain reread remain decisive before any
+          future purge candidate can be considered.
+        </Typography>
+      </Stack>
+
+      <Alert severity="warning" variant="outlined">
+        Retention administration leaves runtime purge jobs, customer-specific
+        retention modeling, broad reporting, and RC/GA readiness outside this
+        surface.
+      </Alert>
+
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, lg: 5 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Record families
+                </Typography>
+                <Divider />
+                <Stack spacing={1.25}>
+                  {RETENTION_RECORD_FAMILIES.map((recordFamily) => (
+                    <Stack key={recordFamily.family} spacing={0.5}>
+                      <Typography fontWeight={600} variant="body2">
+                        {recordFamily.family}
+                      </Typography>
+                      <Typography color="text.secondary" variant="body2">
+                        {recordFamily.posture}
+                      </Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 4 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Retention states
+                </Typography>
+                <Divider />
+                <Stack spacing={1.25}>
+                  {RETENTION_STATE_POSTURES.map((state) => (
+                    <Stack key={state.state} spacing={0.75}>
+                      <Chip
+                        color={
+                          state.color as
+                            | "default"
+                            | "error"
+                            | "primary"
+                            | "warning"
+                        }
+                        label={state.state}
+                        size="small"
+                        sx={{ alignSelf: "flex-start" }}
+                        variant={state.color === "default" ? "outlined" : "filled"}
+                      />
+                      <Typography color="text.secondary" variant="body2">
+                        {state.posture}
+                      </Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 3 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Fail-closed checks
+                </Typography>
+                <Divider />
+                <Stack spacing={1}>
+                  {RETENTION_NEGATIVE_POSTURES.map((posture) => (
+                    <Typography key={posture} variant="body2">
+                      {posture}
+                    </Typography>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
+}
+
 export function UserRoleAdminPage() {
   return (
     <Stack spacing={3} sx={{ p: 3 }}>
@@ -454,6 +631,8 @@ export function UserRoleAdminPage() {
       <SourceProfileAdministrationPage />
 
       <ActionPolicyAdministrationPage />
+
+      <RetentionPolicyAdministrationPage />
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Add a bounded retention policy administration section to the platform-admin surface.
- Cover alerts, cases, evidence, AI traces, audit exports, execution receipts, and reconciliations.
- Show locked, export-pending, expired, active, and denied retention states with fail-closed negative postures.

## Verification
- npm --prefix apps/operator-ui test -- OperatorRoutes.test.tsx -t "renders bounded retention policy administration"
- npm --prefix apps/operator-ui test -- OperatorRoutes.test.tsx
- npm --prefix apps/operator-ui run typecheck
- node dist/index.js issue-lint 1207 --config "$CODEX_SUPERVISOR_CONFIG"
- node dist/index.js issue-lint 1212 --config "$CODEX_SUPERVISOR_CONFIG"

Closes #1212
Part of #1207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Retention Policy Administration interface for platform administrators to manage retention policies, record families, states, and associated safety controls in the operator console.

* **Tests**
  * Added test coverage verifying retention policy administration UI renders correctly for platform-admin sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->