### PR TITLE
Phase 57.6: Add audit export admin surface

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
@@ -529,7 +529,9 @@ export function registerOperatorRoutesAuthAndShellTests() {
     expect(screen.getByText("Execution receipts")).toBeInTheDocument();
     expect(screen.getAllByText("Reconciliations").length).toBeGreaterThan(0);
     expect(screen.getByText("Locked")).toBeInTheDocument();
-    expect(screen.getAllByText("Export pending").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("Deletion rejected until export custody is resolved."),
+    ).toBeInTheDocument();
     expect(screen.getByText("Expired")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.getAllByText("Denied").length).toBeGreaterThan(0);
@@ -577,8 +579,16 @@ export function registerOperatorRoutesAuthAndShellTests() {
     expect(screen.getByText("Normal")).toBeInTheDocument();
     expect(screen.getByText("Empty")).toBeInTheDocument();
     expect(screen.getByText("Degraded")).toBeInTheDocument();
-    expect(screen.getAllByText("Denied").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Export pending").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(
+        "Denied role access cannot request export configuration or view protected output.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Pending generated output cannot be treated as audit, workflow, release, gate, or closeout truth.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("platform_admin: Admin Only")).toBeInTheDocument();
     expect(screen.getByText("read_only_auditor: Read Only")).toBeInTheDocument();
     expect(screen.getByText("analyst: Denied")).toBeInTheDocument();

--- a/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx
@@ -529,7 +529,7 @@ export function registerOperatorRoutesAuthAndShellTests() {
     expect(screen.getByText("Execution receipts")).toBeInTheDocument();
     expect(screen.getAllByText("Reconciliations").length).toBeGreaterThan(0);
     expect(screen.getByText("Locked")).toBeInTheDocument();
-    expect(screen.getByText("Export pending")).toBeInTheDocument();
+    expect(screen.getAllByText("Export pending").length).toBeGreaterThan(0);
     expect(screen.getByText("Expired")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.getAllByText("Denied").length).toBeGreaterThan(0);
@@ -547,6 +547,55 @@ export function registerOperatorRoutesAuthAndShellTests() {
     expect(screen.getByText("Historical rewrite rejected")).toBeInTheDocument();
     expect(screen.getByText("Policy-as-closeout rejected")).toBeInTheDocument();
     expect(screen.queryByText(/production purge automation/i)).not.toBeInTheDocument();
+    });
+
+    it("renders bounded audit export administration with role-gated derived export states", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {},
+        {
+          identity: "platform.admin@example.com",
+          provider: "authentik",
+          roles: ["platform_admin"],
+          subject: "operator-44",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/admin"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Audit export administration" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Normal")).toBeInTheDocument();
+    expect(screen.getByText("Empty")).toBeInTheDocument();
+    expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(screen.getAllByText("Denied").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Export pending").length).toBeGreaterThan(0);
+    expect(screen.getByText("platform_admin: Admin Only")).toBeInTheDocument();
+    expect(screen.getByText("read_only_auditor: Read Only")).toBeInTheDocument();
+    expect(screen.getByText("analyst: Denied")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Audit export admin config can request export windows and custody posture only; it cannot rewrite historical audit records, workflow records, release gates, or closeout truth.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Generated exports remain derived evidence from authoritative AegisOps records and must be reread from one committed backend snapshot.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Export config as audit truth rejected")).toBeInTheDocument();
+    expect(screen.getByText("Export output as workflow truth rejected")).toBeInTheDocument();
+    expect(screen.getByText("Stale export cache as authority rejected")).toBeInTheDocument();
+    expect(screen.queryByText(/compliance report template/i)).not.toBeInTheDocument();
     });
 
     it("fails closed when stale platform-admin browser state reaches the admin route", async () => {

--- a/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx
@@ -179,6 +179,55 @@ const RETENTION_NEGATIVE_POSTURES = [
   "Stale retention cache rejected",
 ] as const;
 
+const AUDIT_EXPORT_STATES = [
+  {
+    state: "Normal",
+    posture:
+      "Reviewed export window is ready to derive evidence from authoritative records.",
+    color: "success",
+  },
+  {
+    state: "Empty",
+    posture:
+      "No eligible authoritative records are present; empty export remains explicit.",
+    color: "default",
+  },
+  {
+    state: "Degraded",
+    posture:
+      "Export remains blocked or marked degraded when snapshot or custody signals are incomplete.",
+    color: "warning",
+  },
+  {
+    state: "Denied",
+    posture:
+      "Denied role access cannot request export configuration or view protected output.",
+    color: "error",
+  },
+  {
+    state: "Export pending",
+    posture:
+      "Pending generated output cannot be treated as audit, workflow, release, gate, or closeout truth.",
+    color: "error",
+  },
+] as const;
+
+const AUDIT_EXPORT_ACCESS_ROLES: RbacRoleId[] = [
+  "platform_admin",
+  "read_only_auditor",
+  "analyst",
+  "approver",
+  "support_operator",
+  "external_collaborator",
+];
+
+const AUDIT_EXPORT_NEGATIVE_POSTURES = [
+  "Export config as audit truth rejected",
+  "Export output as workflow truth rejected",
+  "Denied role access rejected",
+  "Stale export cache as authority rejected",
+] as const;
+
 function formatAccess(value: string) {
   return value
     .split("_")
@@ -525,6 +574,119 @@ function RetentionPolicyAdministrationPage() {
   );
 }
 
+function AuditExportAdministrationPage() {
+  return (
+    <Stack spacing={2}>
+      <Stack spacing={0.5}>
+        <Typography component="h2" variant="h5">
+          Audit export administration
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Audit export admin config can request export windows and custody
+          posture only; it cannot rewrite historical audit records, workflow
+          records, release gates, or closeout truth.
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          Generated exports remain derived evidence from authoritative AegisOps
+          records and must be reread from one committed backend snapshot.
+        </Typography>
+      </Stack>
+
+      <Alert severity="info" variant="outlined">
+        This surface does not add commercial reporting breadth, compliance
+        templates, support bundles, production report custody, or RC/GA
+        readiness claims.
+      </Alert>
+
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, lg: 5 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Export states
+                </Typography>
+                <Divider />
+                <Stack spacing={1.25}>
+                  {AUDIT_EXPORT_STATES.map((state) => (
+                    <Stack key={state.state} spacing={0.75}>
+                      <Chip
+                        color={
+                          state.color as
+                            | "default"
+                            | "error"
+                            | "success"
+                            | "warning"
+                        }
+                        label={state.state}
+                        size="small"
+                        sx={{ alignSelf: "flex-start" }}
+                        variant={state.color === "default" ? "outlined" : "filled"}
+                      />
+                      <Typography color="text.secondary" variant="body2">
+                        {state.posture}
+                      </Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 4 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  RBAC export access
+                </Typography>
+                <Divider />
+                <Stack spacing={1}>
+                  {AUDIT_EXPORT_ACCESS_ROLES.map((roleId) => (
+                    <Stack
+                      alignItems="center"
+                      direction={{ xs: "column", sm: "row" }}
+                      justifyContent="space-between"
+                      key={roleId}
+                      spacing={1}
+                    >
+                      <Typography fontWeight={600} variant="body2">
+                        {roleId}:{" "}
+                        {formatAccess(RBAC_ROLE_MATRIX[roleId].surfaces.auditExport)}
+                      </Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 3 }}>
+          <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+            <CardContent>
+              <Stack spacing={2}>
+                <Typography component="h3" variant="h6">
+                  Fail-closed checks
+                </Typography>
+                <Divider />
+                <Stack spacing={1}>
+                  {AUDIT_EXPORT_NEGATIVE_POSTURES.map((posture) => (
+                    <Typography key={posture} variant="body2">
+                      {posture}
+                    </Typography>
+                  ))}
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
+}
+
 export function UserRoleAdminPage() {
   return (
     <Stack spacing={3} sx={{ p: 3 }}>
@@ -633,6 +795,8 @@ export function UserRoleAdminPage() {
       <ActionPolicyAdministrationPage />
 
       <RetentionPolicyAdministrationPage />
+
+      <AuditExportAdministrationPage />
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Add a bounded audit export administration section to the existing platform admin page.
- Render normal, empty, degraded, denied, and export-pending export states as derived/admin posture only.
- Show audit export RBAC access from the Phase 57.1 role matrix and keep fail-closed negative checks visible.

## Verification
- npm test --workspace apps/operator-ui -- --run src/app/OperatorRoutes.test.tsx
- npm test --workspace apps/operator-ui -- --run src/auth/roleMatrix.test.ts
- python3 -m unittest control-plane/tests/test_phase49_audit_export_retention_baseline.py
- npm run typecheck --workspace apps/operator-ui
- node <codex-supervisor-root>/dist/index.js issue-lint 1207 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1213 --config <supervisor-config-path>

## Scope Boundaries
- Export config cannot rewrite historical audit or workflow records.
- Export output remains derived evidence only.
- Commercial reporting breadth, compliance report templates, support bundles, production report custody, and RC/GA readiness remain out of scope.

Closes #1213
Part of #1207


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Audit Export Administration page in the operator console with role-based access surfaces and visible export state indicators.

* **Tests**
  * Expanded retention policy tests to assert deletion is blocked until export custody is resolved.
  * Added comprehensive tests for audit export administration covering role-specific access, state labels, rejection messages, and absence of the compliance report template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->