### PR TITLE
Phase 57.8 closeout evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Canonical cross-phase boundary reference:
 - [Phase 56.1 Today view backend projection contract](docs/deployment/today-view-backend-projection-contract.md) defines priority, stale work, pending approvals, degraded sources, reconciliation mismatches, evidence gaps, and advisory-only AI focus lanes for the Daily SOC Workbench backend projection.
 - [Phase 56.3 case timeline authority projection contract](docs/deployment/case-timeline-authority-projection-contract.md) defines Wazuh signal, alert, evidence, AI summary, recommendation, action request, approval, Shuffle receipt, and reconciliation timeline segments with explicit authority posture and direct backend record binding.
 - [Phase 56.8 closeout evaluation](docs/phase-56-closeout-evaluation.md) records the Daily SOC Workbench outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 57/58/59/60/66 handoff.
+- [Phase 57.8 closeout evaluation](docs/phase-57-closeout-evaluation.md) records the commercial administration MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 58/59/60/66 handoff.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
 - [Phase 53.5 Wazuh agent enrollment helper contract](docs/deployment/wazuh-agent-enrollment-helper-contract.md) defines the one-endpoint enrollment helper posture, prerequisites, rollback notes, safety warnings, and fleet-management exclusion for the Wazuh profile.
@@ -135,6 +136,8 @@ The Phase 56.1 Today view backend projection contract is defined by the [Phase 5
 The Phase 56.3 case timeline authority projection contract is defined by the [Phase 56.3 case timeline authority projection contract](docs/deployment/case-timeline-authority-projection-contract.md).
 
 The Phase 56.8 closeout evaluation is defined by the [Phase 56.8 closeout evaluation](docs/phase-56-closeout-evaluation.md).
+
+The Phase 57.8 closeout evaluation is defined by the [Phase 57.8 closeout evaluation](docs/phase-57-closeout-evaluation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-57-closeout-evaluation.md
+++ b/docs/phase-57-closeout-evaluation.md
@@ -1,0 +1,136 @@
+# Phase 57 Closeout Evaluation
+
+- **Status**: Accepted as commercial administration MVP evidence and handoff baseline; Phase 58, Phase 59, Phase 60, and Phase 66 can consume the bounded Phase 57 admin evidence with explicit retained blockers.
+- **Date**: 2026-05-04
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1207, #1208, #1209, #1210, #1211, #1212, #1213, #1214, #1215
+
+## Verdict
+
+Phase 57 is accepted as the Admin / RBAC / Source / Action Policy UI MVP before supportability, AI daily operations, reporting breadth, SOAR breadth, RC, Beta, GA, or commercial replacement expansion.
+
+The accepted administration MVP consists of the RBAC role matrix, user and role admin surface, source profile admin surface, action policy admin surface, retention policy admin surface, audit export admin surface, and AI enablement admin posture.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit event truth, limitation, release, gate, and closeout truth.
+
+RBAC docs, admin configuration, user and role state, source profile state, action policy state, retention policy state, audit export configuration, AI enablement posture, UI cache, browser state, verifier output, and issue-lint output remain subordinate configuration, policy posture, or validation evidence.
+
+The Phase 57 admin surfaces must reject support operator workflow authority, external collaborator workflow authority, role UI cache as authority, admin config rewriting historical records, Controlled / Hard Write default enablement, unsafe retention deletion, audit export authority confusion, AI scope creep, and historical workflow rewrite.
+
+This closeout does not claim Phase 58 supportability is complete, Phase 59 AI daily operations is complete, Phase 60 audit or reporting breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1207 | Epic: Phase 57 Admin / RBAC / Source / Action Policy UI MVP | Open until #1215 lands; accepted when this closeout, focused verifier, RBAC/admin/export/retention/AI tests, path hygiene, and issue-lint pass. |
+| #1208 | Phase 57.1 Add RBAC role matrix contract | Closed. `docs/phase-57-1-rbac-role-matrix-contract.md`, `apps/operator-ui/src/auth/roleMatrix.ts`, `apps/operator-ui/src/auth/roleMatrix.test.ts`, `apps/operator-ui/src/auth/session.test.ts`, and the focused verifier define platform admin, analyst, approver, read-only auditor, support operator, and external collaborator access without workflow authority override. |
+| #1209 | Phase 57.2 Add user and role admin surface | Closed. `apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx`, `apps/operator-ui/src/app/OperatorRoutes.tsx`, and `apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx` render minimum user and role administration for platform admins without tenant-model expansion or historical truth rewrite authority. |
+| #1210 | Phase 57.3 Add source profile admin surface | Closed. `apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx` and focused admin route tests render Wazuh and future reviewed source posture for create, update, disable, degraded, and audit-trail states without broad source marketplace claims. |
+| #1211 | Phase 57.4 Add action policy admin surface | Closed. `apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx` and focused admin route tests render Read, Notify, and Soft Write posture while rejecting Controlled and Hard Write default enablement. |
+| #1212 | Phase 57.5 Add retention policy admin surface | Closed. `apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx` and focused admin route tests render alerts, cases, evidence, AI traces, audit exports, execution receipts, and reconciliation retention posture with locked, export-pending, expired, active, and denied state handling. |
+| #1213 | Phase 57.6 Add audit export admin surface | Closed. `apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx` and focused admin route tests render minimum audit export configuration and role-gated access posture for normal, empty, degraded, denied, and export-pending states. |
+| #1214 | Phase 57.7 Add AI enablement admin toggle | Closed. `control-plane/aegisops/control_plane/config.py`, `control-plane/aegisops/control_plane/assistant/assistant_context.py`, `control-plane/aegisops/control_plane/runtime/readiness_operability.py`, and focused tests add enabled, disabled, and degraded AI posture without new AI feature, approval, execution, or reconciliation authority. |
+| #1215 | Phase 57.8 Phase 57 closeout evaluation | Open until this document and focused closeout verifier land. |
+
+## Commercial Administration Behavior Before And After
+
+| Surface | Before Phase 57 | After Phase 57 |
+| --- | --- | --- |
+| RBAC role matrix | Phase 56 had operator route sets and backend-bound health context, but no commercial admin role matrix. | Phase 57.1 defines platform admin, analyst, approver, read-only auditor, support operator, and external collaborator roles with support/external workflow authority denied. |
+| User and role admin | Commercial user and role posture still depended on low-level or implicit configuration. | Phase 57.2 renders minimum user and role administration for platform admins without tenant-model expansion or historical truth rewrite authority. |
+| Source profile admin | Source posture was represented by reviewed Wazuh contracts, but no bounded admin surface. | Phase 57.3 renders Wazuh and future reviewed source profile posture for create, update, disable, degraded, and audit-trail states without source marketplace claims. |
+| Action policy admin | Default action policy posture was not visible in the commercial admin surface. | Phase 57.4 renders Read, Notify, and Soft Write posture while rejecting Controlled and Hard Write default enablement. |
+| Retention policy admin | Retention families existed as baseline policy, but not as commercial admin posture. | Phase 57.5 renders alerts, cases, evidence, AI traces, audit exports, execution receipts, and reconciliation retention posture with locked, export-pending, expired, active, and denied states. |
+| Audit export admin | Audit export posture was not visible in the admin MVP. | Phase 57.6 renders minimum audit export configuration and access posture for normal, empty, degraded, denied, and export-pending states. |
+| AI enablement admin | AI posture was advisory but not explicitly controlled by admin enablement state. | Phase 57.7 adds enabled, disabled, and degraded AI enablement posture without new AI features, approval authority, execution authority, or reconciliation authority. |
+| Authority boundary | Phase 51.6, Phase 55, and Phase 56 supplied the prior boundary. | Phase 57 preserves control-plane authority and proves RBAC docs, admin config, user/role state, source profile state, action policy state, retention policy state, audit export config, AI enablement posture, UI cache, verifier output, and issue-lint output remain subordinate. |
+
+## Changed Files
+
+Phase 57 materially added or tightened these repo-owned surfaces:
+
+- `docs/phase-57-1-rbac-role-matrix-contract.md`
+- `apps/operator-ui/src/auth/roleMatrix.ts`
+- `apps/operator-ui/src/auth/roleMatrix.test.ts`
+- `apps/operator-ui/src/auth/session.test.ts`
+- `apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.tsx`
+- `apps/operator-ui/src/app/OperatorShell.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages.tsx`
+- `apps/operator-ui/src/app/optionalExtensionVisibility.tsx`
+- `apps/operator-ui/src/app/optionalExtensionVisibility.test.tsx`
+- `control-plane/aegisops/control_plane/config.py`
+- `control-plane/aegisops/control_plane/assistant/assistant_context.py`
+- `control-plane/aegisops/control_plane/assistant/live_assistant_workflow.py`
+- `control-plane/aegisops/control_plane/runtime/readiness_operability.py`
+- `control-plane/config/local.env.sample`
+- `control-plane/deployment/first-boot/bootstrap.env.sample`
+- `control-plane/tests/test_phase57_7_ai_enablement_admin_toggle.py`
+- `scripts/verify-control-plane-runtime-skeleton.sh`
+- `scripts/test-verify-control-plane-runtime-skeleton.sh`
+- `docs/phase-57-closeout-evaluation.md`
+- `scripts/verify-phase-57-8-closeout-evaluation.sh`
+- `scripts/test-verify-phase-57-8-closeout-evaluation.sh`
+
+## Verifier Evidence
+
+Focused Phase 57 verifiers passed or must pass before this closeout is accepted:
+
+- `bash scripts/verify-phase-57-1-rbac-role-matrix-contract.sh`
+- `bash scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh`
+- `npm test --workspace apps/operator-ui -- --run src/auth/roleMatrix.test.ts src/auth/session.test.ts`
+- `npm test --workspace apps/operator-ui -- --run src/app/OperatorRoutes.test.tsx`
+- `python -m unittest control-plane/tests/test_phase57_7_ai_enablement_admin_toggle.py`
+- `npm test --workspace apps/operator-ui -- --run src/app/optionalExtensionVisibility.test.tsx`
+- `bash scripts/verify-control-plane-runtime-skeleton.sh`
+- `bash scripts/test-verify-control-plane-runtime-skeleton.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `bash scripts/verify-phase-57-8-closeout-evaluation.sh`
+- `bash scripts/test-verify-phase-57-8-closeout-evaluation.sh`
+
+Focused negative-test evidence includes:
+
+- RBAC tests cover every Phase 57 commercial role and keep workflowAuthority false for platform admin, analyst, approver, read-only auditor, support operator, and external collaborator role matrix entries.
+- User and role admin tests reject stale platform-admin browser state when backend reread returns an analyst session.
+- Source profile admin tests reject source profile state as signal, alert, case, evidence, workflow, release, gate, or closeout truth and keep broad source marketplace claims absent.
+- Action policy admin tests reject Controlled and Hard Write default enablement and reject action policy config as approval, execution, reconciliation, substrate mutation, or historical receipt truth.
+- Retention policy admin tests reject locked or export-pending deletion, active workflow closure, audit erasure, historical record-chain rewrite, policy-as-closeout, and stale retention cache authority.
+- Audit export admin tests reject export config as audit truth, generated export output as workflow truth, denied role access, stale export cache authority, and compliance reporting breadth claims.
+- AI enablement tests reject feature expansion values, disabled or degraded trace reads, AI approval authority, AI execution authority, AI reconciliation authority, and workflow loss when AI is disabled.
+
+Issue-lint evidence for #1207 through #1215:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1207 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1208 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1209 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1210 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1211 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1212 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1213 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1214 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1215 --config <supervisor-config-path>`: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, `high_risk_blocking_ambiguity=none`.
+
+## Accepted Limitations
+
+- Phase 57 does not implement Phase 58 supportability, doctor completeness, backup/restore support operations, support bundles, support diagnostics, break-glass support workflows, or customer support operations.
+- Phase 57 does not implement Phase 59 AI governance expansion, AI daily-operations breadth, AI approval authority, AI execution authority, or AI reconciliation authority.
+- Phase 57 does not implement Phase 60 audit export administration breadth, commercial reporting breadth, executive reporting completeness, compliance reporting completeness, report custody, or production report templates.
+- Phase 57 does not implement broad SIEM source marketplace breadth, broad SOAR workflow catalog coverage, marketplace breadth, every action-family expectation, or standalone Wazuh or Shuffle replacement.
+- Phase 57 does not implement Phase 66 RC proof, RC readiness, GA readiness, Beta readiness, self-service commercial readiness, or commercial replacement readiness.
+- Phase 57 does not make admin UI/config, RBAC docs, user role state, source profile state, action policy config, retention policy config, audit export config, AI enablement state, UI cache, browser state, verifier output, issue-lint output, or operator-facing summaries authoritative AegisOps truth.
+
+## Phase 58, Phase 59, Phase 60, And Phase 66 Handoff
+
+Phase 58 can consume the Phase 57 admin route, AI disabled/degraded posture, source profile posture, audit export posture, and role matrix as supportability inputs. Phase 58 must still implement doctor output, backup/restore support operations, support bundles, customer-safe diagnostics, break-glass support workflows, and escalation evidence. Phase 57 does not complete Phase 58 supportability.
+
+Phase 59 can consume the Phase 57 AI enablement posture as bounded enablement evidence. Phase 59 must still implement AI governance expansion, AI daily-operations breadth, agent/tool registry posture, trace governance, citation requirements, and expanded AI guardrails explicitly. Phase 57 does not complete Phase 59 AI daily operations.
+
+Phase 60 can consume the Phase 57 retention and audit export administration posture as reporting design input. Phase 60 must still implement audit export administration breadth, commercial reporting breadth, executive reporting, compliance reporting, custody, retention execution, and production report templates. Phase 57 does not complete Phase 60 audit or reporting breadth.
+
+Phase 66 can consume the Phase 57 commercial administration MVP as one prerequisite evidence packet for RC proof. Phase 66 must still prove RC gate criteria, production-readiness evidence, upgrade/rollback posture, supportability, security review, packaging, first-user behavior, daily-operator behavior, and admin behavior under the approved RC gate. Phase 57 does not complete Phase 66 RC proof.
+
+## Closeout Boundary
+
+This closeout is release and planning evidence only. It does not choose a new runtime configuration, create new admin/support/reporting/SOAR implementation work, expand AI features, approve commercial reporting breadth, approve RC or GA readiness, change authority custody, or claim Beta, RC, GA, or commercial replacement readiness.

--- a/scripts/test-verify-phase-57-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-57-8-closeout-evaluation.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-57-8-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-57-closeout-evaluation.md" "${target}/docs/phase-57-closeout-evaluation.md"
+  cp "${repo_root}/README.md" "${target}/README.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+cp "${repo_root}/README.md" "${missing_doc_repo}/README.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 57 closeout evaluation: docs/phase-57-closeout-evaluation.md"
+
+missing_readme_canonical_bullet_repo="${workdir}/missing-readme-canonical-bullet"
+copy_valid_repo "${missing_readme_canonical_bullet_repo}"
+perl -0pi -e 's/- \[Phase 57\.8 closeout evaluation\]\(docs\/phase-57-closeout-evaluation\.md\)( records the commercial administration MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 58\/59\/60\/66 handoff\.)/- Phase 57.8 closeout evaluation$1/' \
+  "${missing_readme_canonical_bullet_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_canonical_bullet_repo}" \
+  "Missing README canonical cross-phase boundary bullet: - [Phase 57.8 closeout evaluation](docs/phase-57-closeout-evaluation.md)"
+
+missing_readme_product_positioning_repo="${workdir}/missing-readme-product-positioning"
+copy_valid_repo "${missing_readme_product_positioning_repo}"
+perl -0pi -e 's/The Phase 57\.8 closeout evaluation is defined by the \[Phase 57\.8 closeout evaluation\]\(docs\/phase-57-closeout-evaluation\.md\)\./The Phase 57.8 closeout evaluation is defined by the Phase 57.8 closeout evaluation./' \
+  "${missing_readme_product_positioning_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_product_positioning_repo}" \
+  "Missing README Product positioning reference: The Phase 57.8 closeout evaluation is defined by the [Phase 57.8 closeout evaluation](docs/phase-57-closeout-evaluation.md)."
+
+missing_authority_repo="${workdir}/missing-authority"
+copy_valid_repo "${missing_authority_repo}"
+perl -0pi -e 's/AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit event truth, limitation, release, gate, and closeout truth\.//' \
+  "${missing_authority_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_authority_repo}" \
+  "Missing required Phase 57 closeout term in docs/phase-57-closeout-evaluation.md: AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit event truth, limitation, release, gate, and closeout truth."
+
+missing_source_row_repo="${workdir}/missing-source-row"
+copy_valid_repo "${missing_source_row_repo}"
+perl -0pi -e 's/\| Source profile admin \| Source posture was represented by reviewed Wazuh contracts, but no bounded admin surface\. \| Phase 57\.3 renders Wazuh and future reviewed source profile posture for create, update, disable, degraded, and audit-trail states without source marketplace claims\. \|\n//' \
+  "${missing_source_row_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_source_row_repo}" \
+  'Missing required Phase 57 closeout term in docs/phase-57-closeout-evaluation.md: | Source profile admin | Source posture was represented by reviewed Wazuh contracts, but no bounded admin surface. | Phase 57.3 renders Wazuh and future reviewed source profile posture for create, update, disable, degraded, and audit-trail states without source marketplace claims. |'
+
+missing_negative_evidence_repo="${workdir}/missing-negative-evidence"
+copy_valid_repo "${missing_negative_evidence_repo}"
+perl -0pi -e 's/Retention policy admin tests reject locked or export-pending deletion, active workflow closure, audit erasure, historical record-chain rewrite, policy-as-closeout, and stale retention cache authority\.//' \
+  "${missing_negative_evidence_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_negative_evidence_repo}" \
+  "Missing required Phase 57 closeout term in docs/phase-57-closeout-evaluation.md: Retention policy admin tests reject locked or export-pending deletion, active workflow closure, audit erasure, historical record-chain rewrite, policy-as-closeout, and stale retention cache authority."
+
+missing_phase59_handoff_repo="${workdir}/missing-phase59-handoff"
+copy_valid_repo "${missing_phase59_handoff_repo}"
+perl -0pi -e 's/Phase 59 can consume the Phase 57 AI enablement posture as bounded enablement evidence\.//' \
+  "${missing_phase59_handoff_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_phase59_handoff_repo}" \
+  "Missing required Phase 57 closeout term in docs/phase-57-closeout-evaluation.md: Phase 59 can consume the Phase 57 AI enablement posture as bounded enablement evidence."
+
+missing_issue_lint_repo="${workdir}/missing-issue-lint"
+copy_valid_repo "${missing_issue_lint_repo}"
+perl -0pi -e 's/^- `node <codex-supervisor-root>\/dist\/index\.js issue-lint 1214 --config <supervisor-config-path>`: .*?\n//m' \
+  "${missing_issue_lint_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_issue_lint_repo}" \
+  "Missing required Phase 57 closeout term in docs/phase-57-closeout-evaluation.md: node <codex-supervisor-root>/dist/index.js issue-lint 1214 --config <supervisor-config-path>"
+
+phase58_overclaim_repo="${workdir}/phase58-overclaim"
+copy_valid_repo "${phase58_overclaim_repo}"
+printf '%s\n' "Phase 58 supportability is complete" >>"${phase58_overclaim_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${phase58_overclaim_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: Phase 58 supportability is complete"
+
+phase59_overclaim_repo="${workdir}/phase59-overclaim"
+copy_valid_repo "${phase59_overclaim_repo}"
+printf '%s\n' "Phase 59 AI daily operations is complete" >>"${phase59_overclaim_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${phase59_overclaim_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: Phase 59 AI daily operations is complete"
+
+phase60_overclaim_repo="${workdir}/phase60-overclaim"
+copy_valid_repo "${phase60_overclaim_repo}"
+printf '%s\n' "Phase 60 audit or reporting breadth is complete" >>"${phase60_overclaim_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${phase60_overclaim_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: Phase 60 audit or reporting breadth is complete"
+
+commercial_overclaim_repo="${workdir}/commercial-overclaim"
+copy_valid_repo "${commercial_overclaim_repo}"
+printf '%s\n' "Phase 57 proves commercial replacement readiness" >>"${commercial_overclaim_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${commercial_overclaim_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: Phase 57 proves commercial replacement readiness"
+
+support_authority_repo="${workdir}/support-authority"
+copy_valid_repo "${support_authority_repo}"
+printf '%s\n' "Support operator workflow authority is enabled" >>"${support_authority_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${support_authority_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: Support operator workflow authority is enabled"
+
+hard_write_repo="${workdir}/hard-write"
+copy_valid_repo "${hard_write_repo}"
+printf '%s\n' "Hard Write default enablement is allowed" >>"${hard_write_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${hard_write_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: Hard Write default enablement is allowed"
+
+retention_delete_repo="${workdir}/retention-delete"
+copy_valid_repo "${retention_delete_repo}"
+printf '%s\n' "Retention policy deletes locked records" >>"${retention_delete_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${retention_delete_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: Retention policy deletes locked records"
+
+audit_truth_repo="${workdir}/audit-truth"
+copy_valid_repo "${audit_truth_repo}"
+printf '%s\n' "Audit export config is audit truth" >>"${audit_truth_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${audit_truth_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: Audit export config is audit truth"
+
+ai_scope_repo="${workdir}/ai-scope"
+copy_valid_repo "${ai_scope_repo}"
+printf '%s\n' "AI enablement toggle adds new AI features" >>"${ai_scope_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${ai_scope_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: AI enablement toggle adds new AI features"
+
+admin_truth_repo="${workdir}/admin-truth"
+copy_valid_repo "${admin_truth_repo}"
+printf '%s\n' "Admin config rewrites historical workflow truth" >>"${admin_truth_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${admin_truth_repo}" \
+  "Forbidden Phase 57 closeout evaluation claim: Admin config rewrites historical workflow truth"
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+mac_home_prefix="/""Users/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${mac_home_prefix}" >>"${absolute_path_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 57 closeout evaluation: workstation-local absolute path detected"
+
+absolute_path_windows_backslash_repo="${workdir}/absolute-path-windows-backslash"
+copy_valid_repo "${absolute_path_windows_backslash_repo}"
+windows_drive="C:"
+windows_home_dir="Users"
+printf 'Run %s\\%s\\example\\Dev\\codex-supervisor\\dist\\index.js.\n' "${windows_drive}" "${windows_home_dir}" >>"${absolute_path_windows_backslash_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_windows_backslash_repo}" \
+  "Forbidden Phase 57 closeout evaluation: workstation-local absolute path detected"
+
+absolute_path_windows_slash_repo="${workdir}/absolute-path-windows-slash"
+copy_valid_repo "${absolute_path_windows_slash_repo}"
+printf 'Run %s/%s/example/Dev/codex-supervisor/dist/index.js.\n' "${windows_drive}" "${windows_home_dir}" >>"${absolute_path_windows_slash_repo}/docs/phase-57-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_windows_slash_repo}" \
+  "Forbidden Phase 57 closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 57 closeout evaluation verifier tests passed."

--- a/scripts/test-verify-phase-57-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-57-8-closeout-evaluation.sh
@@ -54,6 +54,15 @@ valid_repo="${workdir}/valid"
 copy_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
 
+url_path_repo="${workdir}/url-path"
+copy_valid_repo "${url_path_repo}"
+printf '%s\n' \
+  "Reference URL: https://example.com/home/docs/phase-57-closeout" \
+  "Reference URL: https://example.com/Users/docs/phase-57-closeout" \
+  "Reference URL: https://example.com/C:/Users/docs/phase-57-closeout" \
+  >>"${url_path_repo}/docs/phase-57-closeout-evaluation.md"
+assert_passes "${url_path_repo}"
+
 missing_doc_repo="${workdir}/missing-doc"
 mkdir -p "${missing_doc_repo}/docs"
 cp "${repo_root}/README.md" "${missing_doc_repo}/README.md"

--- a/scripts/verify-phase-57-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-57-8-closeout-evaluation.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-57-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${file}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 57 closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -s "${readme_path}" ]]; then
+  echo "Missing README for Phase 57 closeout link check: README.md" >&2
+  exit 1
+fi
+
+require_phrase "${readme_path}" "- [Phase 57.8 closeout evaluation](docs/phase-57-closeout-evaluation.md)" "README canonical cross-phase boundary bullet"
+require_phrase "${readme_path}" "The Phase 57.8 closeout evaluation is defined by the [Phase 57.8 closeout evaluation](docs/phase-57-closeout-evaluation.md)." "README Product positioning reference"
+
+required_phrases=()
+while IFS= read -r phrase; do
+  required_phrases+=("${phrase}")
+done <<'EOF'
+# Phase 57 Closeout Evaluation
+**Status**: Accepted as commercial administration MVP evidence and handoff baseline; Phase 58, Phase 59, Phase 60, and Phase 66 can consume the bounded Phase 57 admin evidence with explicit retained blockers.
+**Related Issues**: #1207, #1208, #1209, #1210, #1211, #1212, #1213, #1214, #1215
+Phase 57 is accepted as the Admin / RBAC / Source / Action Policy UI MVP before supportability, AI daily operations, reporting breadth, SOAR breadth, RC, Beta, GA, or commercial replacement expansion.
+AegisOps control-plane records remain authoritative for alert, case, evidence, recommendation, action review, approval, action request, delegation, execution receipt, reconciliation, audit event truth, limitation, release, gate, and closeout truth.
+RBAC docs, admin configuration, user and role state, source profile state, action policy state, retention policy state, audit export configuration, AI enablement posture, UI cache, browser state, verifier output, and issue-lint output remain subordinate configuration, policy posture, or validation evidence.
+The Phase 57 admin surfaces must reject support operator workflow authority, external collaborator workflow authority, role UI cache as authority, admin config rewriting historical records, Controlled / Hard Write default enablement, unsafe retention deletion, audit export authority confusion, AI scope creep, and historical workflow rewrite.
+This closeout does not claim Phase 58 supportability is complete, Phase 59 AI daily operations is complete, Phase 60 audit or reporting breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability.
+| #1207 | Epic: Phase 57 Admin / RBAC / Source / Action Policy UI MVP | Open until #1215 lands; accepted when this closeout, focused verifier, RBAC/admin/export/retention/AI tests, path hygiene, and issue-lint pass. |
+| #1208 | Phase 57.1 Add RBAC role matrix contract | Closed.
+| #1209 | Phase 57.2 Add user and role admin surface | Closed.
+| #1210 | Phase 57.3 Add source profile admin surface | Closed.
+| #1211 | Phase 57.4 Add action policy admin surface | Closed.
+| #1212 | Phase 57.5 Add retention policy admin surface | Closed.
+| #1213 | Phase 57.6 Add audit export admin surface | Closed.
+| #1214 | Phase 57.7 Add AI enablement admin toggle | Closed.
+| #1215 | Phase 57.8 Phase 57 closeout evaluation | Open until this document and focused closeout verifier land. |
+| RBAC role matrix | Phase 56 had operator route sets and backend-bound health context, but no commercial admin role matrix. | Phase 57.1 defines platform admin, analyst, approver, read-only auditor, support operator, and external collaborator roles with support/external workflow authority denied. |
+| User and role admin | Commercial user and role posture still depended on low-level or implicit configuration. | Phase 57.2 renders minimum user and role administration for platform admins without tenant-model expansion or historical truth rewrite authority. |
+| Source profile admin | Source posture was represented by reviewed Wazuh contracts, but no bounded admin surface. | Phase 57.3 renders Wazuh and future reviewed source profile posture for create, update, disable, degraded, and audit-trail states without source marketplace claims. |
+| Action policy admin | Default action policy posture was not visible in the commercial admin surface. | Phase 57.4 renders Read, Notify, and Soft Write posture while rejecting Controlled and Hard Write default enablement. |
+| Retention policy admin | Retention families existed as baseline policy, but not as commercial admin posture. | Phase 57.5 renders alerts, cases, evidence, AI traces, audit exports, execution receipts, and reconciliation retention posture with locked, export-pending, expired, active, and denied states. |
+| Audit export admin | Audit export posture was not visible in the admin MVP. | Phase 57.6 renders minimum audit export configuration and access posture for normal, empty, degraded, denied, and export-pending states. |
+| AI enablement admin | AI posture was advisory but not explicitly controlled by admin enablement state. | Phase 57.7 adds enabled, disabled, and degraded AI enablement posture without new AI features, approval authority, execution authority, or reconciliation authority. |
+`docs/phase-57-1-rbac-role-matrix-contract.md`
+`apps/operator-ui/src/auth/roleMatrix.ts`
+`apps/operator-ui/src/auth/roleMatrix.test.ts`
+`apps/operator-ui/src/auth/session.test.ts`
+`apps/operator-ui/src/app/operatorConsolePages/adminPages.tsx`
+`apps/operator-ui/src/app/OperatorRoutes.authAndShell.testSuite.tsx`
+`apps/operator-ui/src/app/OperatorRoutes.tsx`
+`apps/operator-ui/src/app/OperatorShell.tsx`
+`apps/operator-ui/src/app/optionalExtensionVisibility.tsx`
+`apps/operator-ui/src/app/optionalExtensionVisibility.test.tsx`
+`control-plane/aegisops/control_plane/config.py`
+`control-plane/aegisops/control_plane/assistant/assistant_context.py`
+`control-plane/aegisops/control_plane/runtime/readiness_operability.py`
+`control-plane/tests/test_phase57_7_ai_enablement_admin_toggle.py`
+`docs/phase-57-closeout-evaluation.md`
+`scripts/verify-phase-57-8-closeout-evaluation.sh`
+`scripts/test-verify-phase-57-8-closeout-evaluation.sh`
+`bash scripts/verify-phase-57-1-rbac-role-matrix-contract.sh`
+`bash scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh`
+`npm test --workspace apps/operator-ui -- --run src/auth/roleMatrix.test.ts src/auth/session.test.ts`
+`npm test --workspace apps/operator-ui -- --run src/app/OperatorRoutes.test.tsx`
+`python -m unittest control-plane/tests/test_phase57_7_ai_enablement_admin_toggle.py`
+`npm test --workspace apps/operator-ui -- --run src/app/optionalExtensionVisibility.test.tsx`
+`bash scripts/verify-control-plane-runtime-skeleton.sh`
+`bash scripts/test-verify-control-plane-runtime-skeleton.sh`
+`bash scripts/verify-publishable-path-hygiene.sh`
+`bash scripts/verify-phase-57-8-closeout-evaluation.sh`
+`bash scripts/test-verify-phase-57-8-closeout-evaluation.sh`
+RBAC tests cover every Phase 57 commercial role and keep workflowAuthority false for platform admin, analyst, approver, read-only auditor, support operator, and external collaborator role matrix entries.
+User and role admin tests reject stale platform-admin browser state when backend reread returns an analyst session.
+Source profile admin tests reject source profile state as signal, alert, case, evidence, workflow, release, gate, or closeout truth and keep broad source marketplace claims absent.
+Action policy admin tests reject Controlled and Hard Write default enablement and reject action policy config as approval, execution, reconciliation, substrate mutation, or historical receipt truth.
+Retention policy admin tests reject locked or export-pending deletion, active workflow closure, audit erasure, historical record-chain rewrite, policy-as-closeout, and stale retention cache authority.
+Audit export admin tests reject export config as audit truth, generated export output as workflow truth, denied role access, stale export cache authority, and compliance reporting breadth claims.
+AI enablement tests reject feature expansion values, disabled or degraded trace reads, AI approval authority, AI execution authority, AI reconciliation authority, and workflow loss when AI is disabled.
+node <codex-supervisor-root>/dist/index.js issue-lint 1207 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1208 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1209 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1210 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1211 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1212 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1213 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1214 --config <supervisor-config-path>
+node <codex-supervisor-root>/dist/index.js issue-lint 1215 --config <supervisor-config-path>
+execution_ready=yes
+missing_required=none
+missing_recommended=none
+metadata_errors=none
+high_risk_blocking_ambiguity=none
+Phase 57 does not implement Phase 58 supportability, doctor completeness, backup/restore support operations, support bundles, support diagnostics, break-glass support workflows, or customer support operations.
+Phase 57 does not implement Phase 59 AI governance expansion, AI daily-operations breadth, AI approval authority, AI execution authority, or AI reconciliation authority.
+Phase 57 does not implement Phase 60 audit export administration breadth, commercial reporting breadth, executive reporting completeness, compliance reporting completeness, report custody, or production report templates.
+Phase 57 does not implement broad SIEM source marketplace breadth, broad SOAR workflow catalog coverage, marketplace breadth, every action-family expectation, or standalone Wazuh or Shuffle replacement.
+Phase 57 does not implement Phase 66 RC proof, RC readiness, GA readiness, Beta readiness, self-service commercial readiness, or commercial replacement readiness.
+Phase 58 can consume the Phase 57 admin route, AI disabled/degraded posture, source profile posture, audit export posture, and role matrix as supportability inputs.
+Phase 57 does not complete Phase 58 supportability.
+Phase 59 can consume the Phase 57 AI enablement posture as bounded enablement evidence.
+Phase 57 does not complete Phase 59 AI daily operations.
+Phase 60 can consume the Phase 57 retention and audit export administration posture as reporting design input.
+Phase 57 does not complete Phase 60 audit or reporting breadth.
+Phase 66 can consume the Phase 57 commercial administration MVP as one prerequisite evidence packet for RC proof.
+Phase 57 does not complete Phase 66 RC proof.
+This closeout is release and planning evidence only.
+EOF
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 57 closeout term in ${doc_path}"
+done
+
+mac_home_prefix="$(printf '/%s/' 'Users')"
+unix_home_prefix="$(printf '/%s/' 'home')"
+windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
+absolute_path_pattern="(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}" "${readme_path}"; then
+  echo "Forbidden Phase 57 closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+allowed_non_claim_line="This closeout does not claim Phase 58 supportability is complete, Phase 59 AI daily operations is complete, Phase 60 audit or reporting breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability."
+
+for forbidden in \
+  "Phase 58 supportability is complete" \
+  "Phase 59 AI daily operations is complete" \
+  "Phase 60 audit or reporting breadth is complete" \
+  "Phase 66 RC proof is complete" \
+  "AegisOps is Beta" \
+  "AegisOps is RC" \
+  "AegisOps is GA" \
+  "AegisOps is self-service commercially ready" \
+  "AegisOps is a commercial replacement for every SIEM/SOAR capability" \
+  "Phase 57 proves Beta readiness" \
+  "Phase 57 proves RC readiness" \
+  "Phase 57 proves GA readiness" \
+  "Phase 57 proves commercial replacement readiness" \
+  "Support operator workflow authority is enabled" \
+  "External collaborator workflow authority is enabled" \
+  "Controlled default enablement is allowed" \
+  "Hard Write default enablement is allowed" \
+  "Retention policy deletes locked records" \
+  "Retention policy deletes export-pending records" \
+  "Audit export config is audit truth" \
+  "AI enablement toggle adds new AI features" \
+  "Admin config rewrites historical workflow truth" \
+  "Admin UI state is workflow truth" \
+  "RBAC docs are workflow truth" \
+  "User role state is workflow truth" \
+  "Source profile state is signal truth" \
+  "Action policy config is execution truth" \
+  "AI enablement state is AI approval authority"; do
+  if grep -Fxv -- "${allowed_non_claim_line}" "${absolute_doc_path}" | grep -Fq -- "${forbidden}"; then
+    echo "Forbidden Phase 57 closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 57 closeout evaluation records commercial admin MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 58/59/60/66 handoff."

--- a/scripts/verify-phase-57-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-57-8-closeout-evaluation.sh
@@ -134,7 +134,8 @@ mac_home_prefix="$(printf '/%s/' 'Users')"
 unix_home_prefix="$(printf '/%s/' 'home')"
 windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
 windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
-absolute_path_pattern="(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+absolute_path_boundary='(^|[[:space:]`"'\''(<[{=])'
+absolute_path_pattern="${absolute_path_boundary}(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
 if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}" "${readme_path}"; then
   echo "Forbidden Phase 57 closeout evaluation: workstation-local absolute path detected" >&2
   exit 1


### PR DESCRIPTION
## Summary
- add Phase 57 closeout evaluation for the commercial admin MVP
- add focused Phase 57.8 verifier and negative self-test fixtures
- link the closeout from README canonical boundary references

## Verification
- bash scripts/verify-phase-57-8-closeout-evaluation.sh
- bash scripts/test-verify-phase-57-8-closeout-evaluation.sh
- bash scripts/verify-phase-57-1-rbac-role-matrix-contract.sh
- bash scripts/test-verify-phase-57-1-rbac-role-matrix-contract.sh
- bash scripts/verify-publishable-path-hygiene.sh
- npm test --workspace apps/operator-ui -- --run src/auth/roleMatrix.test.ts src/auth/session.test.ts
- npm test --workspace apps/operator-ui -- --run src/app/OperatorRoutes.test.tsx
- npm test --workspace apps/operator-ui -- --run src/app/optionalExtensionVisibility.test.tsx
- python3 -m unittest control-plane/tests/test_phase57_7_ai_enablement_admin_toggle.py
- bash scripts/verify-control-plane-runtime-skeleton.sh
- bash scripts/test-verify-control-plane-runtime-skeleton.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1207 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1208 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1209 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1210 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1211 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1212 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1213 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1214 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1215 --config <supervisor-config-path>

Closes #1215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 57.8 closeout reference to the README
  * Added a comprehensive Phase 57 closeout evaluation document covering acceptance, verdicts, per-issue outcomes, before/after behavior, limitations, and handoff details

* **Tests**
  * Added an automated verifier and end-to-end test harness to validate Phase 57 closeout documentation completeness, correctness, and forbidden-claim/path checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->