### PR TITLE
Phase 58.1: Add aegisops doctor contract

### DIFF
--- a/control-plane/aegisops/control_plane/api/cli.py
+++ b/control-plane/aegisops/control_plane/api/cli.py
@@ -11,6 +11,7 @@ from .entrypoint_support import (
     parse_datetime_arg,
     read_json_file,
 )
+from ..runtime.doctor_contract import build_doctor_snapshot
 from ..service import AegisOpsControlPlaneService
 
 
@@ -67,6 +68,10 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser(
         "run-authoritative-restore-drill",
         help="Reread the restored authoritative record chain through reviewed service inspections.",
+    )
+    subparsers.add_parser(
+        "doctor",
+        help="Render the read-only Phase 58.1 supportability doctor contract.",
     )
     subparsers.add_parser(
         "inspect-analyst-queue",
@@ -512,6 +517,11 @@ def run_command(
             return service.run_authoritative_restore_drill().to_dict()
         except (LookupError, ValueError) as exc:
             _usage_error(parser, str(exc))
+    if command == "doctor":
+        return build_doctor_snapshot(
+            config=service._config,
+            readiness_payload=service.inspect_readiness_diagnostics().to_dict(),
+        ).to_dict()
     if command == "inspect-analyst-queue":
         return service.inspect_analyst_queue().to_dict()
     if command == "inspect-alert-detail":

--- a/control-plane/aegisops/control_plane/api/http_runtime_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_runtime_surface.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
+from ..runtime.doctor_contract import build_doctor_snapshot
+
 if TYPE_CHECKING:
     from ..service import AegisOpsControlPlaneService
 
@@ -11,6 +13,7 @@ RUNTIME_READ_PATHS = frozenset(
     {
         "/runtime",
         "/diagnostics/readiness",
+        "/diagnostics/doctor",
         "/admin/bootstrap-status",
     }
 )
@@ -26,6 +29,12 @@ def runtime_read_response(
 
     if request_path == "/diagnostics/readiness":
         return HTTPStatus.OK, service.inspect_readiness_diagnostics().to_dict()
+
+    if request_path == "/diagnostics/doctor":
+        return HTTPStatus.OK, build_doctor_snapshot(
+            config=service._config,
+            readiness_payload=service.inspect_readiness_diagnostics().to_dict(),
+        ).to_dict()
 
     if request_path == "/admin/bootstrap-status":
         return HTTPStatus.OK, _admin_bootstrap_status_payload(service)

--- a/control-plane/aegisops/control_plane/runtime/doctor_contract.py
+++ b/control-plane/aegisops/control_plane/runtime/doctor_contract.py
@@ -76,7 +76,7 @@ def build_doctor_snapshot(
             "source": "current_readiness_diagnostics_snapshot",
             "operator_action": (
                 "review_degraded_or_unavailable_state_recommendations"
-                if overall_posture != "available"
+                if overall_posture in {"degraded", "unavailable"}
                 else "continue_observing_without_mutation"
             ),
         },
@@ -146,9 +146,9 @@ def _wazuh_state(config: Any, metrics: Mapping[str, object]) -> dict[str, object
         "available",
         "wazuh_ingest_contract_configured",
         (
-            "Wazuh ingest prerequisites are configured"
+            "Wazuh ingest prerequisites are configured; no stale Wazuh source is currently reported."
             if tracked_sources
-            else "Wazuh ingest prerequisites are configured; no stale Wazuh source is currently reported."
+            else "Wazuh ingest prerequisites are configured"
         ),
         "continue_observing_without_mutation",
     )
@@ -335,13 +335,15 @@ def _execution_receipt_state(metrics: Mapping[str, object]) -> dict[str, object]
     unresolved_reconciliation_count = sum(
         _int_value(reconciliations.get(name)) for name in ("pending", "mismatched", "stale")
     )
-    if _int_value(reconciliations.get("stale")) or _int_value(
-        reconciliations.get("mismatched")
+    if (
+        _int_value(reconciliations.get("pending"))
+        or _int_value(reconciliations.get("stale"))
+        or _int_value(reconciliations.get("mismatched"))
     ):
         return _state(
             "degraded",
             "receipt_reconciliation_degraded",
-            "Execution receipt reconciliation is stale or mismatched.",
+            "Execution receipt reconciliation is pending, stale, or mismatched.",
             "obtain_authoritative_receipt_before_closeout",
         )
     if active_execution_count and not terminal_execution_count:

--- a/control-plane/aegisops/control_plane/runtime/doctor_contract.py
+++ b/control-plane/aegisops/control_plane/runtime/doctor_contract.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .runtime_boundary import _is_missing_runtime_binding
+from .service_snapshots import DoctorSnapshot
+
+DOCTOR_POSTURE_SEMANTICS = (
+    "available",
+    "degraded",
+    "unavailable",
+    "not_applicable",
+)
+
+DOCTOR_STATE_FAMILIES = (
+    "control_plane",
+    "wazuh",
+    "shuffle",
+    "database",
+    "proxy",
+    "stale_source",
+    "ai_enablement",
+    "evidence_availability",
+    "workflow_template",
+    "execution_receipt",
+)
+
+_NEGATIVE_AUTHORITY = (
+    "automatic_repair",
+    "workflow_truth",
+    "release_truth",
+    "restore_truth",
+    "gate_truth",
+    "authoritative_record_mutation",
+)
+
+_POSTURE_SEVERITY = {
+    "available": 0,
+    "not_applicable": 0,
+    "degraded": 1,
+    "unavailable": 2,
+}
+
+
+def build_doctor_snapshot(
+    *,
+    config: Any,
+    readiness_payload: Mapping[str, object],
+) -> DoctorSnapshot:
+    metrics = _mapping(readiness_payload.get("metrics"))
+    states = {
+        "control_plane": _control_plane_state(readiness_payload),
+        "wazuh": _wazuh_state(config, metrics),
+        "shuffle": _shuffle_state(config, metrics),
+        "database": _database_state(readiness_payload),
+        "proxy": _proxy_state(config),
+        "stale_source": _stale_source_state(metrics),
+        "ai_enablement": _ai_enablement_state(config),
+        "evidence_availability": _evidence_availability_state(metrics),
+        "workflow_template": _workflow_template_state(config, metrics),
+        "execution_receipt": _execution_receipt_state(metrics),
+    }
+    overall_posture = _worst_posture(
+        state["posture"] for state in states.values()
+    )
+    return DoctorSnapshot(
+        read_only=True,
+        contract="phase58_1_aegisops_doctor",
+        authority_boundary="explanatory_subordinate",
+        mutates_authoritative_records=False,
+        posture_semantics=DOCTOR_POSTURE_SEMANTICS,
+        summary={
+            "overall_posture": overall_posture,
+            "state_family_count": len(states),
+            "source": "current_readiness_diagnostics_snapshot",
+            "operator_action": (
+                "review_degraded_or_unavailable_state_recommendations"
+                if overall_posture != "available"
+                else "continue_observing_without_mutation"
+            ),
+        },
+        states=states,
+        negative_authority=_NEGATIVE_AUTHORITY,
+        recommended_next_steps=tuple(
+            {
+                "state_family": family,
+                "posture": state["posture"],
+                "action": state["recommended_action"],
+            }
+            for family, state in states.items()
+            if state["posture"] in {"degraded", "unavailable"}
+        ),
+    )
+
+
+def _control_plane_state(readiness_payload: Mapping[str, object]) -> dict[str, object]:
+    status = readiness_payload.get("status")
+    if status == "ready":
+        return _state(
+            "available",
+            "readiness_ready",
+            "Control-plane readiness admits runtime traffic.",
+            "continue_observing_without_mutation",
+        )
+    if status in {"degraded", "stale"}:
+        return _state(
+            "degraded",
+            f"readiness_{status}",
+            "Control-plane readiness is degraded or stale.",
+            "inspect_readiness_diagnostics_and_resolve_blockers",
+        )
+    return _state(
+        "unavailable",
+        "missing_or_untrusted_readiness_status",
+        "Control-plane readiness is missing, malformed, or failing closed.",
+        "restore_trusted_readiness_prerequisites_before_progression",
+    )
+
+
+def _wazuh_state(config: Any, metrics: Mapping[str, object]) -> dict[str, object]:
+    source_health = _mapping(metrics.get("source_health"))
+    sources = _mapping(source_health.get("sources"))
+    wazuh_source = _mapping(sources.get("wazuh"))
+    tracked_sources = _int_value(source_health.get("tracked_sources"))
+    if _missing_config(config, "wazuh_ingest_shared_secret") or _missing_config(
+        config,
+        "wazuh_ingest_reverse_proxy_secret",
+    ):
+        return _state(
+            "unavailable",
+            "missing_wazuh_ingest_secret_or_proxy_secret",
+            "Wazuh ingest cannot be trusted without both reviewed secrets.",
+            "wire_reviewed_wazuh_secret_bindings",
+        )
+    if wazuh_source:
+        source_state = str(wazuh_source.get("state", "")).strip()
+        if source_state in {"degraded", "stale", "unresolved"}:
+            return _state(
+                "degraded",
+                f"wazuh_source_{source_state}",
+                "Wazuh source health is visible but degraded.",
+                "refresh_wazuh_source_health_evidence",
+            )
+    return _state(
+        "available",
+        "wazuh_ingest_contract_configured",
+        (
+            "Wazuh ingest prerequisites are configured"
+            if tracked_sources
+            else "Wazuh ingest prerequisites are configured; no stale Wazuh source is currently reported."
+        ),
+        "continue_observing_without_mutation",
+    )
+
+
+def _shuffle_state(config: Any, metrics: Mapping[str, object]) -> dict[str, object]:
+    executions = _mapping(metrics.get("action_executions"))
+    active_count = sum(
+        _int_value(executions.get(name)) for name in ("dispatching", "queued", "running")
+    )
+    if _missing_config(config, "shuffle_base_url"):
+        if active_count:
+            return _state(
+                "unavailable",
+                "missing_shuffle_binding_for_active_execution",
+                "Active execution receipt review needs a configured Shuffle boundary.",
+                "wire_reviewed_shuffle_binding_before_receipt_review",
+            )
+        return _state(
+            "not_applicable",
+            "no_active_shuffle_execution",
+            "No active Shuffle execution is currently being diagnosed.",
+            "no_operator_action",
+        )
+    return _state(
+        "available",
+        "shuffle_binding_configured",
+        "Shuffle boundary is configured for execution receipt visibility.",
+        "continue_observing_without_mutation",
+    )
+
+
+def _database_state(readiness_payload: Mapping[str, object]) -> dict[str, object]:
+    if not isinstance(readiness_payload.get("metrics"), Mapping):
+        return _state(
+            "unavailable",
+            "missing_readiness_metrics",
+            "Database-backed readiness metrics are missing or malformed.",
+            "restore_database_readiness_snapshot_before_progression",
+        )
+    return _state(
+        "available",
+        "readiness_metrics_loaded",
+        "Database-backed readiness metrics were read without mutation.",
+        "continue_observing_without_mutation",
+    )
+
+
+def _proxy_state(config: Any) -> dict[str, object]:
+    host = str(getattr(config, "host", "")).strip()
+    if host in {"127.0.0.1", "localhost", "::1"}:
+        return _state(
+            "available",
+            "loopback_operator_surface",
+            "Runtime surface is bound to loopback for local operation.",
+            "continue_observing_without_mutation",
+        )
+    if _missing_config(config, "protected_surface_reverse_proxy_secret"):
+        return _state(
+            "unavailable",
+            "missing_protected_surface_proxy_secret",
+            "Non-loopback runtime access requires a reviewed proxy boundary.",
+            "wire_reviewed_proxy_secret_before_exposure",
+        )
+    return _state(
+        "available",
+        "protected_surface_proxy_configured",
+        "Protected-surface proxy boundary is configured.",
+        "continue_observing_without_mutation",
+    )
+
+
+def _stale_source_state(metrics: Mapping[str, object]) -> dict[str, object]:
+    source_health = _mapping(metrics.get("source_health"))
+    tracked_sources = _int_value(source_health.get("tracked_sources"))
+    overall_state = str(source_health.get("overall_state", "")).strip()
+    if not tracked_sources:
+        return _state(
+            "not_applicable",
+            "no_source_health_records",
+            "No source-health records are currently tracked.",
+            "no_operator_action",
+        )
+    if overall_state in {"degraded", "stale", "failed", "unknown"}:
+        return _state(
+            "degraded",
+            f"source_health_{overall_state}",
+            "Tracked source health is degraded, stale, or ambiguous.",
+            "refresh_source_health_or_preserve_degraded_visibility",
+        )
+    return _state(
+        "available",
+        "source_health_current",
+        "Tracked source health is current enough for visibility.",
+        "continue_observing_without_mutation",
+    )
+
+
+def _ai_enablement_state(config: Any) -> dict[str, object]:
+    posture = str(getattr(config, "ai_enablement_posture", "")).strip()
+    if posture == "enabled":
+        return _state(
+            "available",
+            "ai_enabled",
+            "AI enablement posture is enabled.",
+            "continue_observing_without_mutation",
+        )
+    if posture == "disabled":
+        return _state(
+            "not_applicable",
+            "ai_disabled",
+            "AI assistance is intentionally disabled.",
+            "keep_ai_paths_subordinate_and_disabled",
+        )
+    if posture == "degraded":
+        return _state(
+            "degraded",
+            "ai_degraded",
+            "AI assistance is configured as degraded.",
+            "preserve_manual_review_and_subordinate_ai_visibility",
+        )
+    return _state(
+        "unavailable",
+        "malformed_ai_enablement_posture",
+        "AI posture is missing or malformed.",
+        "correct_reviewed_ai_enablement_configuration",
+    )
+
+
+def _evidence_availability_state(metrics: Mapping[str, object]) -> dict[str, object]:
+    alerts = _mapping(metrics.get("alerts"))
+    cases = _mapping(metrics.get("cases"))
+    tracked_records = _int_value(alerts.get("total")) + _int_value(cases.get("total"))
+    if tracked_records:
+        return _state(
+            "available",
+            "authoritative_records_have_evidence_surface",
+            "Authoritative case or alert records are available for evidence inspection.",
+            "continue_observing_without_mutation",
+        )
+    return _state(
+        "not_applicable",
+        "no_authoritative_records_requiring_evidence",
+        "No case or alert records currently require evidence availability diagnosis.",
+        "no_operator_action",
+    )
+
+
+def _workflow_template_state(config: Any, metrics: Mapping[str, object]) -> dict[str, object]:
+    action_requests = _mapping(metrics.get("action_requests"))
+    active_count = sum(
+        _int_value(action_requests.get(name))
+        for name in ("pending_approval", "approved", "executing", "unresolved")
+    )
+    if _missing_config(config, "n8n_base_url"):
+        if active_count:
+            return _state(
+                "degraded",
+                "missing_workflow_template_binding_for_active_review",
+                "Active reviewed work exists without a configured workflow-template surface.",
+                "verify_reviewed_workflow_template_binding",
+            )
+        return _state(
+            "not_applicable",
+            "no_active_workflow_template_review",
+            "No active workflow template mismatch is currently diagnosed.",
+            "no_operator_action",
+        )
+    return _state(
+        "available",
+        "workflow_template_surface_configured",
+        "Workflow template surface is configured for reviewed checks.",
+        "continue_observing_without_mutation",
+    )
+
+
+def _execution_receipt_state(metrics: Mapping[str, object]) -> dict[str, object]:
+    executions = _mapping(metrics.get("action_executions"))
+    reconciliations = _mapping(metrics.get("reconciliations"))
+    active_execution_count = sum(
+        _int_value(executions.get(name)) for name in ("dispatching", "queued", "running")
+    )
+    terminal_execution_count = _int_value(executions.get("terminal"))
+    unresolved_reconciliation_count = sum(
+        _int_value(reconciliations.get(name)) for name in ("pending", "mismatched", "stale")
+    )
+    if _int_value(reconciliations.get("stale")) or _int_value(
+        reconciliations.get("mismatched")
+    ):
+        return _state(
+            "degraded",
+            "receipt_reconciliation_degraded",
+            "Execution receipt reconciliation is stale or mismatched.",
+            "obtain_authoritative_receipt_before_closeout",
+        )
+    if active_execution_count and not terminal_execution_count:
+        return _state(
+            "unavailable",
+            "missing_execution_receipt_signal",
+            "Execution is active without a terminal receipt signal.",
+            "wait_for_or_collect_reviewed_execution_receipt",
+        )
+    if terminal_execution_count and not unresolved_reconciliation_count:
+        return _state(
+            "available",
+            "execution_receipts_reconciled",
+            "Execution receipts have no unresolved reconciliation state.",
+            "continue_observing_without_mutation",
+        )
+    return _state(
+        "not_applicable",
+        "no_execution_receipt_under_review",
+        "No execution receipt is currently under review.",
+        "no_operator_action",
+    )
+
+
+def _state(
+    posture: str,
+    reason: str,
+    explanation: str,
+    recommended_action: str,
+) -> dict[str, object]:
+    if posture not in DOCTOR_POSTURE_SEMANTICS:
+        posture = "unavailable"
+        reason = "malformed_doctor_posture"
+        recommended_action = "repair_doctor_contract_before_use"
+    return {
+        "posture": posture,
+        "reason": reason,
+        "explanation": explanation,
+        "recommended_action": recommended_action,
+        "authoritative": False,
+    }
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _int_value(value: object) -> int:
+    return value if isinstance(value, int) and value >= 0 else 0
+
+
+def _missing_config(config: Any, field_name: str) -> bool:
+    return _is_missing_runtime_binding(getattr(config, field_name, ""))
+
+
+def _worst_posture(postures: object) -> str:
+    normalized = [
+        posture
+        for posture in postures
+        if isinstance(posture, str) and posture in DOCTOR_POSTURE_SEMANTICS
+    ]
+    if not normalized:
+        return "unavailable"
+    return max(
+        normalized,
+        key=lambda posture: _POSTURE_SEVERITY.get(posture, 2),
+    )
+
+
+__all__ = [
+    "DOCTOR_POSTURE_SEMANTICS",
+    "DOCTOR_STATE_FAMILIES",
+    "build_doctor_snapshot",
+]

--- a/control-plane/aegisops/control_plane/runtime/service_snapshots.py
+++ b/control-plane/aegisops/control_plane/runtime/service_snapshots.py
@@ -455,6 +455,22 @@ class ReadinessDiagnosticsSnapshot:
         )
 
 
+@dataclass(frozen=True)
+class DoctorSnapshot:
+    read_only: bool
+    contract: str
+    authority_boundary: str
+    mutates_authoritative_records: bool
+    posture_semantics: tuple[str, ...]
+    summary: dict[str, object]
+    states: dict[str, dict[str, object]]
+    negative_authority: tuple[str, ...]
+    recommended_next_steps: tuple[dict[str, object], ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(asdict(self))
+
+
 __all__ = [
     "ActionReviewDetailSnapshot",
     "AdvisoryInspectionSnapshot",
@@ -463,6 +479,7 @@ __all__ = [
     "AnalystQueueSnapshot",
     "AuthenticatedRuntimePrincipal",
     "CaseDetailSnapshot",
+    "DoctorSnapshot",
     "LiveAssistantWorkflowSnapshot",
     "ReadinessDiagnosticsSnapshot",
     "RecommendationDraftSnapshot",

--- a/control-plane/tests/test_phase21_runtime_auth_validation.py
+++ b/control-plane/tests/test_phase21_runtime_auth_validation.py
@@ -112,6 +112,7 @@ class Phase21RuntimeAuthValidationTests(unittest.TestCase):
                 {
                     "/runtime",
                     "/diagnostics/readiness",
+                    "/diagnostics/doctor",
                     "/admin/bootstrap-status",
                 }
             ),

--- a/control-plane/tests/test_phase58_1_doctor_contract.py
+++ b/control-plane/tests/test_phase58_1_doctor_contract.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import io
+import json
+import pathlib
+import sys
+from types import SimpleNamespace
+import unittest
+
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+CONTROL_PLANE_ROOT = TESTS_ROOT.parent
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))
+
+from aegisops.control_plane.api.http_runtime_surface import runtime_read_response
+from aegisops.control_plane.runtime.doctor_contract import build_doctor_snapshot
+
+from _cli_inspection_support import *  # noqa: F403
+
+
+class Phase581DoctorContractTests(ControlPlaneCliInspectionTestBase):
+    def test_doctor_cli_renders_bounded_non_mutating_contract(self) -> None:
+        _store, service, _case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        before_counts = {
+            family: len(service.inspect_records(family).records)
+            for family in (
+                "alert",
+                "case",
+                "evidence",
+                "action_request",
+                "action_execution",
+                "reconciliation",
+            )
+        }
+        stdout = io.StringIO()
+
+        main.main(["doctor"], stdout=stdout, service=service)
+
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["read_only"])
+        self.assertFalse(payload["mutates_authoritative_records"])
+        self.assertEqual(payload["authority_boundary"], "explanatory_subordinate")
+        self.assertEqual(
+            payload["posture_semantics"],
+            ["available", "degraded", "unavailable", "not_applicable"],
+        )
+        required_families = {
+            "control_plane",
+            "wazuh",
+            "shuffle",
+            "database",
+            "proxy",
+            "stale_source",
+            "ai_enablement",
+            "evidence_availability",
+            "workflow_template",
+            "execution_receipt",
+        }
+        self.assertEqual(set(payload["states"]), required_families)
+        self.assertEqual(payload["states"]["control_plane"]["posture"], "available")
+        self.assertEqual(payload["states"]["wazuh"]["posture"], "available")
+        self.assertEqual(payload["states"]["shuffle"]["posture"], "not_applicable")
+        self.assertEqual(payload["states"]["execution_receipt"]["posture"], "not_applicable")
+        self.assertEqual(payload["summary"]["overall_posture"], "available")
+        self.assertIn("automatic_repair", payload["negative_authority"])
+        self.assertIn("release_truth", payload["negative_authority"])
+        self.assertIn("workflow_truth", payload["negative_authority"])
+        after_counts = {
+            family: len(service.inspect_records(family).records)
+            for family in before_counts
+        }
+        self.assertEqual(after_counts, before_counts)
+
+    def test_doctor_http_runtime_surface_exposes_same_read_only_contract(self) -> None:
+        _store, service, _case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+
+        status, payload = runtime_read_response(
+            service=service,
+            request_path="/diagnostics/doctor",
+        )
+
+        self.assertEqual(status.value, 200)
+        self.assertTrue(payload["read_only"])
+        self.assertEqual(payload["contract"], "phase58_1_aegisops_doctor")
+        self.assertFalse(payload["mutates_authoritative_records"])
+
+    def test_doctor_contract_reports_degraded_source_and_ai_without_authority(self) -> None:
+        payload = self._build_doctor_payload(
+            config_overrides={"ai_enablement_posture": "degraded"},
+            metrics_overrides={
+                "source_health": {
+                    "tracked_sources": 1,
+                    "overall_state": "degraded",
+                    "sources": {
+                        "wazuh": {
+                            "state": "degraded",
+                            "reason": "source_health_signal_stale",
+                        }
+                    },
+                }
+            },
+        )
+
+        self.assertEqual(payload["summary"]["overall_posture"], "degraded")
+        self.assertEqual(payload["states"]["stale_source"]["posture"], "degraded")
+        self.assertEqual(payload["states"]["ai_enablement"]["posture"], "degraded")
+        self.assertFalse(payload["states"]["stale_source"]["authoritative"])
+        self.assertIn("stale_source", self._recommended_families(payload))
+        self.assertIn("ai_enablement", self._recommended_families(payload))
+
+    def test_doctor_contract_fails_closed_for_missing_or_malformed_signals(self) -> None:
+        payload = build_doctor_snapshot(
+            config=self._doctor_config(),
+            readiness_payload={"read_only": True, "status": "optimistic"},
+        ).to_dict()
+
+        self.assertEqual(payload["summary"]["overall_posture"], "unavailable")
+        self.assertEqual(payload["states"]["control_plane"]["posture"], "unavailable")
+        self.assertEqual(payload["states"]["database"]["posture"], "unavailable")
+        self.assertIn("control_plane", self._recommended_families(payload))
+        self.assertIn("database", self._recommended_families(payload))
+
+    def test_doctor_contract_blocks_missing_execution_receipt_success_inference(self) -> None:
+        payload = self._build_doctor_payload(
+            metrics_overrides={
+                "action_executions": {
+                    "total": 1,
+                    "dispatching": 0,
+                    "queued": 0,
+                    "running": 1,
+                    "terminal": 0,
+                },
+                "reconciliations": {
+                    "total": 0,
+                    "pending": 0,
+                    "mismatched": 0,
+                    "stale": 0,
+                    "by_ingest_disposition": {},
+                },
+            },
+        )
+
+        self.assertEqual(payload["summary"]["overall_posture"], "unavailable")
+        self.assertEqual(payload["states"]["execution_receipt"]["posture"], "unavailable")
+        self.assertEqual(
+            payload["states"]["execution_receipt"]["reason"],
+            "missing_execution_receipt_signal",
+        )
+        self.assertIn("execution_receipt", self._recommended_families(payload))
+
+    def test_doctor_contract_rejects_missing_wazuh_prerequisite_as_unavailable(self) -> None:
+        payload = self._build_doctor_payload(
+            config_overrides={"wazuh_ingest_shared_secret": ""}
+        )
+
+        self.assertEqual(payload["summary"]["overall_posture"], "unavailable")
+        self.assertEqual(payload["states"]["wazuh"]["posture"], "unavailable")
+        self.assertEqual(
+            payload["states"]["wazuh"]["reason"],
+            "missing_wazuh_ingest_secret_or_proxy_secret",
+        )
+
+    @staticmethod
+    def _doctor_config(**overrides: object) -> SimpleNamespace:
+        values = {
+            "host": "127.0.0.1",
+            "postgres_dsn": "postgresql://control-plane.local/aegisops",
+            "opensearch_url": "https://opensearch.local",
+            "n8n_base_url": "<set-me>",
+            "shuffle_base_url": "<set-me>",
+            "wazuh_ingest_shared_secret": "reviewed-shared-secret",  # noqa: S106 - fixture
+            "wazuh_ingest_reverse_proxy_secret": "reviewed-proxy-secret",  # noqa: S106 - fixture
+            "protected_surface_reverse_proxy_secret": "",
+            "ai_enablement_posture": "enabled",
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    def _build_doctor_payload(
+        self,
+        *,
+        config_overrides: dict[str, object] | None = None,
+        metrics_overrides: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        metrics = {
+            "alerts": {"total": 1},
+            "cases": {"total": 1, "open": 1},
+            "action_requests": {
+                "total": 0,
+                "pending_approval": 0,
+                "approved": 0,
+                "executing": 0,
+                "unresolved": 0,
+            },
+            "action_executions": {
+                "total": 0,
+                "dispatching": 0,
+                "queued": 0,
+                "running": 0,
+                "terminal": 0,
+            },
+            "reconciliations": {
+                "total": 0,
+                "pending": 0,
+                "mismatched": 0,
+                "stale": 0,
+                "by_ingest_disposition": {},
+            },
+            "source_health": {
+                "tracked_sources": 1,
+                "overall_state": "healthy",
+                "sources": {"wazuh": {"state": "healthy"}},
+            },
+        }
+        if metrics_overrides:
+            metrics.update(metrics_overrides)
+        return build_doctor_snapshot(
+            config=self._doctor_config(**(config_overrides or {})),
+            readiness_payload={
+                "read_only": True,
+                "status": "ready",
+                "metrics": metrics,
+            },
+        ).to_dict()
+
+    @staticmethod
+    def _recommended_families(payload: dict[str, object]) -> set[str]:
+        return {
+            str(entry["state_family"])
+            for entry in payload["recommended_next_steps"]
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase58_1_doctor_contract.py
+++ b/control-plane/tests/test_phase58_1_doctor_contract.py
@@ -6,6 +6,7 @@ import pathlib
 import sys
 from types import SimpleNamespace
 import unittest
+from unittest import mock
 
 TESTS_ROOT = pathlib.Path(__file__).resolve().parent
 CONTROL_PLANE_ROOT = TESTS_ROOT.parent
@@ -15,6 +16,7 @@ if str(TESTS_ROOT) not in sys.path:
     sys.path.insert(0, str(TESTS_ROOT))
 
 from aegisops.control_plane.api.http_runtime_surface import runtime_read_response
+from aegisops.control_plane.runtime import doctor_contract
 from aegisops.control_plane.runtime.doctor_contract import build_doctor_snapshot
 
 from _cli_inspection_support import *  # noqa: F403
@@ -154,6 +156,36 @@ class Phase581DoctorContractTests(ControlPlaneCliInspectionTestBase):
         )
         self.assertIn("execution_receipt", self._recommended_families(payload))
 
+    def test_doctor_contract_degrades_pending_terminal_receipt_reconciliation(
+        self,
+    ) -> None:
+        payload = self._build_doctor_payload(
+            metrics_overrides={
+                "action_executions": {
+                    "total": 1,
+                    "dispatching": 0,
+                    "queued": 0,
+                    "running": 0,
+                    "terminal": 1,
+                },
+                "reconciliations": {
+                    "total": 1,
+                    "pending": 1,
+                    "mismatched": 0,
+                    "stale": 0,
+                    "by_ingest_disposition": {},
+                },
+            },
+        )
+
+        self.assertEqual(payload["summary"]["overall_posture"], "degraded")
+        self.assertEqual(payload["states"]["execution_receipt"]["posture"], "degraded")
+        self.assertEqual(
+            payload["states"]["execution_receipt"]["reason"],
+            "receipt_reconciliation_degraded",
+        )
+        self.assertIn("execution_receipt", self._recommended_families(payload))
+
     def test_doctor_contract_rejects_missing_wazuh_prerequisite_as_unavailable(self) -> None:
         payload = self._build_doctor_payload(
             config_overrides={"wazuh_ingest_shared_secret": ""}
@@ -164,6 +196,44 @@ class Phase581DoctorContractTests(ControlPlaneCliInspectionTestBase):
         self.assertEqual(
             payload["states"]["wazuh"]["reason"],
             "missing_wazuh_ingest_secret_or_proxy_secret",
+        )
+
+    def test_doctor_contract_wazuh_explanation_reflects_tracked_sources(self) -> None:
+        tracked_payload = self._build_doctor_payload()
+        untracked_payload = self._build_doctor_payload(
+            metrics_overrides={
+                "source_health": {
+                    "tracked_sources": 0,
+                    "overall_state": "",
+                    "sources": {},
+                },
+            },
+        )
+
+        self.assertEqual(
+            tracked_payload["states"]["wazuh"]["explanation"],
+            (
+                "Wazuh ingest prerequisites are configured; "
+                "no stale Wazuh source is currently reported."
+            ),
+        )
+        self.assertEqual(
+            untracked_payload["states"]["wazuh"]["explanation"],
+            "Wazuh ingest prerequisites are configured",
+        )
+
+    def test_doctor_summary_treats_not_applicable_as_safe_operator_path(self) -> None:
+        with mock.patch.object(
+            doctor_contract,
+            "_worst_posture",
+            return_value="not_applicable",
+        ):
+            payload = self._build_doctor_payload()
+
+        self.assertEqual(payload["summary"]["overall_posture"], "not_applicable")
+        self.assertEqual(
+            payload["summary"]["operator_action"],
+            "continue_observing_without_mutation",
         )
 
     @staticmethod

--- a/docs/phase-58-1-aegisops-doctor-contract.md
+++ b/docs/phase-58-1-aegisops-doctor-contract.md
@@ -1,0 +1,59 @@
+# Phase 58.1 AegisOps Doctor Contract
+
+## Purpose
+
+`aegisops doctor` is a read-only supportability surface for explaining common
+operator states before broader Phase 58 support bundle, backup, restore,
+upgrade, rollback, and UI work expands.
+
+The doctor output is subordinate context. It can explain state and recommend
+safe next steps, but it cannot approve, execute, reconcile, close, restore,
+upgrade, roll back, release, gate, or mutate authoritative AegisOps records.
+
+## Runtime Surfaces
+
+- CLI: `python3 control-plane/main.py doctor`
+- HTTP: `GET /diagnostics/doctor`
+
+Both surfaces render the same JSON contract and are non-mutating.
+
+## Posture Semantics
+
+- `available`: the checked supportability signal is present and usable as
+  explanatory context.
+- `degraded`: the signal exists but is stale, mismatched, partial, or explicitly
+  degraded.
+- `unavailable`: the signal is missing, malformed, blocked by a missing
+  prerequisite, or unsafe to infer.
+- `not_applicable`: the family has no current record or runtime activity that
+  needs diagnosis.
+
+## State Families
+
+The contract always names these state families:
+
+- `control_plane`
+- `wazuh`
+- `shuffle`
+- `database`
+- `proxy`
+- `stale_source`
+- `ai_enablement`
+- `evidence_availability`
+- `workflow_template`
+- `execution_receipt`
+
+## Negative Authority
+
+Doctor output must not be treated as:
+
+- automatic repair authority
+- workflow truth
+- release truth
+- restore truth
+- gate truth
+- authority to mutate control-plane records
+
+Missing provenance, malformed readiness payloads, missing Wazuh prerequisites,
+missing execution receipts, and degraded AI or source-health signals fail closed
+to `unavailable` or `degraded`; they do not infer success.


### PR DESCRIPTION
## Summary
- add the Phase 58.1 read-only doctor contract and `doctor` CLI command
- expose the same non-mutating contract at `/diagnostics/doctor`
- document posture semantics, state families, and negative authority

## Tests
- `python3 -m unittest control-plane/tests/test_phase58_1_doctor_contract.py`
- `python3 -m unittest control-plane.tests.test_phase21_runtime_auth_validation.Phase21RuntimeAuthValidationTests.test_http_runtime_status_routes_are_declared_outside_handler_dispatch`
- `python3 -m unittest control-plane/tests/test_service_readiness_projection.py control-plane/tests/test_cli_inspection_restore_readiness.py control-plane/tests/test_service_restore_readiness_boundaries.py`
- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'`
- `bash scripts/verify-maintainability-hotspots.sh`
- local reproduction of the full `docs-and-skeleton` workflow command sequence
- `bash scripts/verify-publishable-path-hygiene.sh .`
- `python3 -m compileall -q control-plane/aegisops/control_plane/runtime/doctor_contract.py control-plane/aegisops/control_plane/api/cli.py control-plane/aegisops/control_plane/api/http_runtime_surface.py control-plane/aegisops/control_plane/service.py control-plane/tests/test_phase58_1_doctor_contract.py control-plane/tests/test_phase21_runtime_auth_validation.py`
- `git diff --check`
- `node dist/index.js issue-lint 1236 --config supervisor.config.aegisops.coderabbit.json`
- `node dist/index.js issue-lint 1235 --config supervisor.config.aegisops.coderabbit.json`

Closes #1236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `doctor` CLI command and `/diagnostics/doctor` HTTP endpoint for system diagnostics
  * Provides a read-only supportability snapshot reporting health status across control-plane, integrations, and data components
  * Health statuses include available, degraded, unavailable, and not_applicable

* **Documentation**
  * Added Phase 58.1 AegisOps Doctor Contract documentation

* **Tests**
  * Added comprehensive test coverage for the doctor contract functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->