### PR TITLE
Phase 58.2: Add doctor explanation outputs

### DIFF
--- a/control-plane/aegisops/control_plane/runtime/doctor_contract.py
+++ b/control-plane/aegisops/control_plane/runtime/doctor_contract.py
@@ -26,6 +26,19 @@ DOCTOR_STATE_FAMILIES = (
     "execution_receipt",
 )
 
+DOCTOR_SUPPORT_LINKS = {
+    "control_plane": "docs/runbook.md#24-ready-to-operate-checks",
+    "wazuh": "docs/deployment/wazuh-source-health-projection-contract.md",
+    "shuffle": "docs/phase-54-closeout-evaluation.md#phase-55-phase-58-and-phase-66-handoff",
+    "database": "docs/runbook.md#22-reviewed-startup-sequence",
+    "proxy": "docs/network-exposure-and-access-path-policy.md#2-approved-reverse-proxy-access-model",
+    "stale_source": "docs/deployment/wazuh-source-health-projection-contract.md",
+    "ai_enablement": "docs/phase-57-closeout-evaluation.md#phase-58-phase-59-phase-60-and-phase-66-handoff",
+    "evidence_availability": "docs/requirements-baseline.md#3-authoritative-record-chain",
+    "workflow_template": "docs/phase-52-1-cli-command-contract.md",
+    "execution_receipt": "docs/phase-52-1-cli-command-contract.md",
+}
+
 _NEGATIVE_AUTHORITY = (
     "automatic_repair",
     "workflow_truth",
@@ -49,7 +62,7 @@ def build_doctor_snapshot(
     readiness_payload: Mapping[str, object],
 ) -> DoctorSnapshot:
     metrics = _mapping(readiness_payload.get("metrics"))
-    states = {
+    raw_states = {
         "control_plane": _control_plane_state(readiness_payload),
         "wazuh": _wazuh_state(config, metrics),
         "shuffle": _shuffle_state(config, metrics),
@@ -60,6 +73,10 @@ def build_doctor_snapshot(
         "evidence_availability": _evidence_availability_state(metrics),
         "workflow_template": _workflow_template_state(config, metrics),
         "execution_receipt": _execution_receipt_state(metrics),
+    }
+    states = {
+        family: _with_doctor_guidance(family, state)
+        for family, state in raw_states.items()
     }
     overall_posture = _worst_posture(
         state["posture"] for state in states.values()
@@ -87,6 +104,8 @@ def build_doctor_snapshot(
                 "state_family": family,
                 "posture": state["posture"],
                 "action": state["recommended_action"],
+                "safe_next_steps": state["safe_next_steps"],
+                "support_link": state["support_link"],
             }
             for family, state in states.items()
             if state["posture"] in {"degraded", "unavailable"}
@@ -279,8 +298,17 @@ def _ai_enablement_state(config: Any) -> dict[str, object]:
 
 
 def _evidence_availability_state(metrics: Mapping[str, object]) -> dict[str, object]:
-    alerts = _mapping(metrics.get("alerts"))
-    cases = _mapping(metrics.get("cases"))
+    alerts_raw = metrics.get("alerts")
+    cases_raw = metrics.get("cases")
+    if not isinstance(alerts_raw, Mapping) or not isinstance(cases_raw, Mapping):
+        return _state(
+            "unavailable",
+            "missing_evidence_availability_metrics",
+            "Evidence availability cannot be explained because alert or case metrics are missing.",
+            "restore_authoritative_evidence_metrics_before_progression",
+        )
+    alerts = _mapping(alerts_raw)
+    cases = _mapping(cases_raw)
     tracked_records = _int_value(alerts.get("total")) + _int_value(cases.get("total"))
     if tracked_records:
         return _state(
@@ -387,6 +415,118 @@ def _state(
     }
 
 
+def _with_doctor_guidance(
+    family: str,
+    state: dict[str, object],
+) -> dict[str, object]:
+    posture = str(state.get("posture", "unavailable"))
+    reason = str(state.get("reason", "missing_doctor_reason"))
+    state = dict(state)
+    state["support_link"] = DOCTOR_SUPPORT_LINKS.get(
+        family,
+        "docs/phase-58-1-aegisops-doctor-contract.md",
+    )
+    state["safe_next_steps"] = _safe_next_steps(family, posture, reason)
+    return state
+
+
+def _safe_next_steps(
+    family: str,
+    posture: str,
+    reason: str,
+) -> list[str]:
+    by_reason = {
+        "missing_wazuh_ingest_secret_or_proxy_secret": [
+            "Verify the reviewed Wazuh ingest secret references and proxy binding in the runtime configuration.",
+            "Rerun doctor after the bindings are present; do not paste secret values into tickets or support output.",
+        ],
+        "wazuh_source_degraded": [
+            "Refresh Wazuh manager, indexer, dashboard, intake, and parser source-health evidence.",
+            "Keep Wazuh visibility marked degraded until the reviewed source-health record becomes current.",
+        ],
+        "wazuh_source_stale": [
+            "Refresh Wazuh source-health evidence from the reviewed profile surface.",
+            "Preserve the stale state in handoff notes until a current record is available.",
+        ],
+        "wazuh_source_unresolved": [
+            "Inspect the unresolved Wazuh source-health reason before relying on detector visibility.",
+            "Escalate the unresolved source-health record instead of inferring a healthy ingest path.",
+        ],
+        "missing_shuffle_binding_for_active_execution": [
+            "Wire the reviewed Shuffle boundary before reviewing active execution receipts.",
+            "Keep execution receipt closeout blocked until the authoritative execution record has a trusted receipt signal.",
+        ],
+        "missing_readiness_metrics": [
+            "Restore the database-backed readiness snapshot before treating runtime diagnostics as usable.",
+            "Check startup and database prerequisites; do not infer readiness from partial diagnostic text.",
+        ],
+        "missing_protected_surface_proxy_secret": [
+            "Bind the protected-surface reverse-proxy secret before exposing a non-loopback runtime surface.",
+            "Keep non-loopback access blocked until the reviewed proxy boundary is configured.",
+        ],
+        "source_health_degraded": [
+            "Refresh the directly linked source-health record and keep degraded visibility in operator output.",
+            "Do not generalize a sibling or older source-health record to this diagnosis.",
+        ],
+        "source_health_stale": [
+            "Collect a current source-health record from the reviewed substrate profile.",
+            "Keep the stale state visible until a fresh authoritative source-health projection replaces it.",
+        ],
+        "source_health_failed": [
+            "Investigate the failed source-health projection before using substrate visibility for support decisions.",
+            "Escalate the failed source-health record rather than assuming partial evidence is enough.",
+        ],
+        "source_health_unknown": [
+            "Treat ambiguous source health as degraded and collect a reviewed source-health projection.",
+            "Do not infer substrate readiness from names, paths, comments, or nearby records.",
+        ],
+        "ai_disabled": [
+            "Keep AI assistance disabled and use the manual analyst review path.",
+            "Only enable AI through the reviewed configuration process; AI output remains advisory after enablement.",
+        ],
+        "ai_degraded": [
+            "Preserve manual review as the operating path while AI is degraded.",
+            "Use AI diagnostics only as advisory context; do not let AI guidance close approvals, executions, or reconciliations.",
+        ],
+        "malformed_ai_enablement_posture": [
+            "Correct the reviewed AI enablement setting before showing AI guidance as available.",
+            "Keep AI advisory paths blocked until the posture is explicit and trusted.",
+        ],
+        "missing_evidence_availability_metrics": [
+            "Restore alert and case evidence metrics from the authoritative record store.",
+            "Do not claim evidence availability from partial metrics or support notes.",
+        ],
+        "missing_workflow_template_binding_for_active_review": [
+            "Verify the reviewed workflow-template binding for active review work.",
+            "Keep workflow-template guidance advisory and do not treat doctor output as workflow authority.",
+        ],
+        "missing_execution_receipt_signal": [
+            "Wait for or collect the reviewed terminal execution receipt from the execution boundary.",
+            "Keep closeout blocked until the authoritative execution and reconciliation records agree.",
+        ],
+        "receipt_reconciliation_degraded": [
+            "Resolve pending, stale, or mismatched receipt reconciliation against the authoritative records.",
+            "Do not close the workflow from doctor guidance; use the reviewed reconciliation path.",
+        ],
+    }
+    if reason in by_reason:
+        return by_reason[reason]
+    if posture == "available":
+        return [
+            "Continue observing from the reviewed diagnostics surface.",
+            "Do not mutate authoritative records from doctor output.",
+        ]
+    if posture == "not_applicable":
+        return [
+            "No operator action is required for this family right now.",
+            "Rerun doctor after new authoritative records or runtime activity appear.",
+        ]
+    return [
+        f"Inspect the {family} diagnostic reason before progressing support work.",
+        "Keep the state blocked or degraded until a trusted prerequisite is present.",
+    ]
+
+
 def _mapping(value: object) -> Mapping[str, object]:
     return value if isinstance(value, Mapping) else {}
 
@@ -416,5 +556,6 @@ def _worst_posture(postures: object) -> str:
 __all__ = [
     "DOCTOR_POSTURE_SEMANTICS",
     "DOCTOR_STATE_FAMILIES",
+    "DOCTOR_SUPPORT_LINKS",
     "build_doctor_snapshot",
 ]

--- a/control-plane/tests/test_phase58_1_doctor_contract.py
+++ b/control-plane/tests/test_phase58_1_doctor_contract.py
@@ -227,7 +227,7 @@ class Phase581DoctorContractTests(ControlPlaneCliInspectionTestBase):
     ) -> None:
         payload = self._build_doctor_payload(
             config_overrides={
-                "host": "0.0.0.0",
+                "host": "10.0.0.1",
                 "protected_surface_reverse_proxy_secret": "",
                 "wazuh_ingest_shared_secret": "",
                 "shuffle_base_url": "",

--- a/control-plane/tests/test_phase58_1_doctor_contract.py
+++ b/control-plane/tests/test_phase58_1_doctor_contract.py
@@ -222,6 +222,84 @@ class Phase581DoctorContractTests(ControlPlaneCliInspectionTestBase):
             "Wazuh ingest prerequisites are configured",
         )
 
+    def test_doctor_contract_explains_required_broken_families_with_safe_next_steps(
+        self,
+    ) -> None:
+        payload = self._build_doctor_payload(
+            config_overrides={
+                "host": "0.0.0.0",
+                "protected_surface_reverse_proxy_secret": "",
+                "wazuh_ingest_shared_secret": "",
+                "shuffle_base_url": "",
+                "n8n_base_url": "",
+                "ai_enablement_posture": "degraded",
+            },
+            metrics_overrides={
+                "alerts": {"total": 0},
+                "cases": {"total": 0},
+                "action_requests": {
+                    "total": 1,
+                    "pending_approval": 1,
+                    "approved": 0,
+                    "executing": 0,
+                    "unresolved": 0,
+                },
+                "action_executions": {
+                    "total": 1,
+                    "dispatching": 0,
+                    "queued": 0,
+                    "running": 1,
+                    "terminal": 0,
+                },
+                "reconciliations": {
+                    "total": 0,
+                    "pending": 0,
+                    "mismatched": 0,
+                    "stale": 0,
+                    "by_ingest_disposition": {},
+                },
+                "source_health": {
+                    "tracked_sources": 1,
+                    "overall_state": "unknown",
+                    "sources": {
+                        "wazuh": {
+                            "state": "degraded",
+                            "reason": "source_health_signal_stale",
+                        }
+                    },
+                },
+            },
+        )
+
+        expected_broken_families = {
+            "wazuh",
+            "shuffle",
+            "proxy",
+            "stale_source",
+            "ai_enablement",
+            "workflow_template",
+            "execution_receipt",
+        }
+        for family in expected_broken_families:
+            state = payload["states"][family]
+            self.assertIn(state["posture"], {"degraded", "unavailable"})
+            self.assertIsInstance(state["safe_next_steps"], list)
+            self.assertGreaterEqual(len(state["safe_next_steps"]), 2)
+            self.assertTrue(state["support_link"].startswith("docs/"))
+            self.assertIn(family, self._recommended_families(payload))
+
+        rendered_payload = json.dumps(payload, sort_keys=True)
+        rejected_fragments = (
+            "automatically repair",
+            "workflow truth",
+            "/".join(("", "Users", "")),
+            "C:" + "\\" + "Users" + "\\",
+            "reviewed-shared-secret",
+            "reviewed-proxy-secret",
+        )
+        for fragment in rejected_fragments:
+            self.assertNotIn(fragment, rendered_payload)
+
     def test_doctor_summary_treats_not_applicable_as_safe_operator_path(self) -> None:
         with mock.patch.object(
             doctor_contract,

--- a/docs/phase-58-1-aegisops-doctor-contract.md
+++ b/docs/phase-58-1-aegisops-doctor-contract.md
@@ -43,6 +43,24 @@ The contract always names these state families:
 - `workflow_template`
 - `execution_receipt`
 
+## Explanation Outputs
+
+Each state family includes human-readable advisory guidance:
+
+- `explanation`: a short operator-facing description of the observed state.
+- `safe_next_steps`: bounded support steps that preserve the current posture,
+  fail closed on missing prerequisites, and avoid automatic repair claims.
+- `support_link`: a repo-relative documentation pointer for the relevant
+  support boundary.
+
+Recommended next-step entries repeat the same safe next steps and support link
+for every `degraded` or `unavailable` family so CLI and HTTP clients can render
+the support guidance without treating it as workflow truth.
+
+The guidance must not expose secrets, workstation-local paths, customer-private
+payloads, raw forwarded identity hints, or support text that claims doctor can
+repair, approve, execute, reconcile, restore, release, gate, or close work.
+
 ## Negative Authority
 
 Doctor output must not be treated as:


### PR DESCRIPTION
## Summary
- Adds safe human-readable next steps and repo-relative support links to every doctor state family.
- Includes the same guidance in degraded/unavailable `recommended_next_steps` entries for CLI and HTTP consumers.
- Documents the advisory-only explanation output fields and safety limits.

## Verification
- `python3 control-plane/tests/test_phase58_1_doctor_contract.py`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1237 --config <supervisor-config-path>`

Closes #1237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Doctor now provides support links and safe next steps alongside diagnostic states to guide operators toward resolution.

* **Bug Fixes**
  * Doctor validates metrics availability; returns clear guidance when metrics are missing or malformed.

* **Documentation**
  * Added specification for doctor command output format, including explanations, next steps, and support guidance per state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->