### PR TITLE
Phase 58.3: Add backup command contract

### DIFF
--- a/control-plane/aegisops/control_plane/config.py
+++ b/control-plane/aegisops/control_plane/config.py
@@ -254,6 +254,8 @@ class RuntimeConfig:
     ai_enablement_posture: str = "enabled"
     control_plane_change_state: str = "verified_current"
     control_plane_change_evidence_id: str = ""
+    control_plane_source_revision: str = "unknown"
+    deployment_profile: str = "unreviewed"
 
     @classmethod
     def from_env(
@@ -375,4 +377,14 @@ class RuntimeConfig:
                 "AEGISOPS_CONTROL_PLANE_CHANGE_EVIDENCE_ID",
                 cls.control_plane_change_evidence_id,
             ).strip(),
+            control_plane_source_revision=source.get(
+                "AEGISOPS_CONTROL_PLANE_SOURCE_REVISION",
+                cls.control_plane_source_revision,
+            ).strip()
+            or cls.control_plane_source_revision,
+            deployment_profile=source.get(
+                "AEGISOPS_CONTROL_PLANE_DEPLOYMENT_PROFILE",
+                cls.deployment_profile,
+            ).strip()
+            or cls.deployment_profile,
         )

--- a/control-plane/aegisops/control_plane/runtime/restore_readiness.py
+++ b/control-plane/aegisops/control_plane/runtime/restore_readiness.py
@@ -122,6 +122,8 @@ class RestoreReadinessService:
                 )
             ),
             derive_readiness_status=derive_readiness_status,
+            backup_source_revision=config.control_plane_source_revision,
+            backup_profile=config.deployment_profile,
             authoritative_record_chain_record_types=(
                 authoritative_record_chain_record_types
             ),

--- a/control-plane/aegisops/control_plane/runtime/restore_readiness_backup_restore.py
+++ b/control-plane/aegisops/control_plane/runtime/restore_readiness_backup_restore.py
@@ -79,6 +79,8 @@ class _BackupRestoreFlow:
             [Any, list[dict[str, object]]], dict[str, object]
         ],
         derive_readiness_status: Callable[..., str],
+        backup_source_revision: str,
+        backup_profile: str,
         authoritative_record_chain_record_types: tuple[Type[ControlPlaneRecord], ...],
         authoritative_record_chain_backup_schema_version: str,
         authoritative_primary_id_field_by_family: Mapping[str, str],
@@ -106,6 +108,8 @@ class _BackupRestoreFlow:
             build_readiness_review_path_health
         )
         self._derive_readiness_status = derive_readiness_status
+        self._backup_source_revision = backup_source_revision
+        self._backup_profile = backup_profile
         self._backup_payload_codec = BackupPayloadCodec()
         self._authoritative_record_chain_record_types = (
             authoritative_record_chain_record_types
@@ -154,12 +158,56 @@ class _BackupRestoreFlow:
                     for record in persisted_records
                 ]
                 record_families[family] = records
-        return {
+        created_at = datetime.now(timezone.utc).isoformat()
+        backup_payload = {
             "backup_schema_version": self._authoritative_record_chain_backup_schema_version,
-            "created_at": datetime.now(timezone.utc).isoformat(),
+            "created_at": created_at,
             "persistence_mode": self._store.persistence_mode,
             "record_families": record_families,
             "record_counts": record_counts,
+        }
+        backup_payload["backup_manifest"] = self._build_backup_manifest(
+            created_at=created_at,
+            record_counts=record_counts,
+        )
+        return backup_payload
+
+    def _build_backup_manifest(
+        self,
+        *,
+        created_at: str,
+        record_counts: Mapping[str, int],
+    ) -> dict[str, object]:
+        return {
+            "manifest_schema_version": "phase58.backup-command-manifest.v1",
+            "generated_at": created_at,
+            "backup_schema_version": (
+                self._authoritative_record_chain_backup_schema_version
+            ),
+            "custody_metadata": {
+                "purpose": "custody_and_recovery_evidence",
+                "source_revision": self._backup_source_revision,
+                "profile": self._backup_profile,
+                "timestamp": created_at,
+                "persistence_mode": self._store.persistence_mode,
+            },
+            "record_family_counts": dict(record_counts),
+            "total_record_count": sum(record_counts.values()),
+            "redaction_expectations": {
+                "plaintext_secrets_allowed": False,
+                "secrets_excluded": True,
+                "customer_private_raw_payloads_excluded": True,
+                "workstation_local_paths_excluded": True,
+            },
+            "authority_boundary": (
+                "backup_manifest_is_custody_and_recovery_evidence_only"
+            ),
+            "non_authority_uses": (
+                "close_workflows",
+                "approve_releases",
+                "prove_restore_success",
+                "replace_authoritative_aegisops_records",
+            ),
         }
 
     def restore_authoritative_record_chain_backup(

--- a/control-plane/tests/_cli_inspection_support.py
+++ b/control-plane/tests/_cli_inspection_support.py
@@ -76,27 +76,31 @@ class ControlPlaneCliInspectionTestBase(unittest.TestCase):
         store: object | None = None,
         host: str | None = None,
         port: int | None = None,
+        config: RuntimeConfig | None = None,
     ) -> tuple[object, AegisOpsControlPlaneService, CaseRecord, str, datetime]:
         if store is None:
             store, _ = make_store()
+        runtime_config = config or RuntimeConfig(
+            host="127.0.0.1" if host is None else host,
+            port=0 if port is None else port,
+            postgres_dsn="postgresql://control-plane.local/aegisops",
+            wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+            wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+            admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
+            break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
+        )
         service = AegisOpsControlPlaneService(
-            RuntimeConfig(
-                host="127.0.0.1" if host is None else host,
-                port=0 if port is None else port,
-                postgres_dsn="postgresql://control-plane.local/aegisops",
-                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
-                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
-                admin_bootstrap_token="reviewed-admin-bootstrap-token",  # noqa: S106 - test fixture secret
-                break_glass_token="reviewed-break-glass-token",  # noqa: S106 - test fixture secret
-            ),
+            runtime_config,
             store=store,
         )
         reviewed_at = datetime(2026, 4, 7, 9, 30, tzinfo=timezone.utc)
         admitted = service.ingest_wazuh_alert(
             raw_alert=_load_wazuh_fixture("github-audit-alert.json"),
-            authorization_header="Bearer reviewed-shared-secret",  # noqa: S106 - test fixture secret
+            authorization_header=f"Bearer {runtime_config.wazuh_ingest_shared_secret}",
             forwarded_proto="https",
-            reverse_proxy_secret_header="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+            reverse_proxy_secret_header=(
+                runtime_config.wazuh_ingest_reverse_proxy_secret
+            ),
             peer_addr="127.0.0.1",
         )
         promoted_case = service.promote_alert_to_case(admitted.alert.alert_id)

--- a/control-plane/tests/test_cli_inspection_restore_readiness.py
+++ b/control-plane/tests/test_cli_inspection_restore_readiness.py
@@ -100,6 +100,84 @@ class CliInspectionRestoreReadinessTests(ControlPlaneCliInspectionTestBase):
             drill_payload["verified_recommendation_ids"],
         )
 
+    def test_backup_command_renders_manifest_custody_metadata_without_secrets(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case(
+                config=RuntimeConfig(
+                    postgres_dsn="postgresql://backup-contract.local/aegisops",
+                    wazuh_ingest_shared_secret=(
+                        "phase58-wazuh-shared-secret"  # noqa: S106 - leak sentinel
+                    ),
+                    wazuh_ingest_reverse_proxy_secret=(
+                        "phase58-wazuh-proxy-secret"  # noqa: S106 - leak sentinel
+                    ),
+                    protected_surface_reverse_proxy_secret=(
+                        "phase58-protected-proxy-secret"  # noqa: S106 - leak sentinel
+                    ),
+                    admin_bootstrap_token=(
+                        "phase58-admin-bootstrap-token"  # noqa: S106 - leak sentinel
+                    ),
+                    break_glass_token=(
+                        "phase58-break-glass-token"  # noqa: S106 - leak sentinel
+                    ),
+                    control_plane_source_revision="phase58-source-revision-001",
+                    deployment_profile="single-customer",
+                )
+            )
+        )
+        stdout = io.StringIO()
+
+        main.main(["backup-authoritative-record-chain"], stdout=stdout, service=service)
+
+        backup_payload = json.loads(stdout.getvalue())
+        manifest = backup_payload["backup_manifest"]
+        self.assertEqual(
+            manifest["manifest_schema_version"],
+            "phase58.backup-command-manifest.v1",
+        )
+        self.assertEqual(
+            manifest["custody_metadata"]["source_revision"],
+            "phase58-source-revision-001",
+        )
+        self.assertEqual(manifest["custody_metadata"]["profile"], "single-customer")
+        self.assertEqual(
+            manifest["record_family_counts"],
+            backup_payload["record_counts"],
+        )
+        self.assertEqual(manifest["record_family_counts"]["case"], 1)
+        self.assertEqual(
+            manifest["authority_boundary"],
+            "backup_manifest_is_custody_and_recovery_evidence_only",
+        )
+        self.assertFalse(
+            manifest["redaction_expectations"]["plaintext_secrets_allowed"]
+        )
+        self.assertTrue(manifest["redaction_expectations"]["secrets_excluded"])
+        self.assertTrue(
+            manifest["redaction_expectations"][
+                "customer_private_raw_payloads_excluded"
+            ]
+        )
+        self.assertIn(
+            promoted_case.case_id,
+            [
+                record["case_id"]
+                for record in backup_payload["record_families"]["case"]
+            ],
+        )
+        manifest_text = json.dumps(manifest, sort_keys=True)
+        for forbidden in (
+            "phase58-wazuh-shared-secret",
+            "phase58-wazuh-proxy-secret",
+            "phase58-protected-proxy-secret",
+            "phase58-admin-bootstrap-token",
+            "phase58-break-glass-token",
+            "postgresql://backup-contract.local/aegisops",
+        ):
+            self.assertNotIn(forbidden, manifest_text)
+
     def test_backup_authoritative_record_chain_reports_usage_error_on_invalid_backup(
         self,
     ) -> None:

--- a/control-plane/tests/test_runtime_skeleton.py
+++ b/control-plane/tests/test_runtime_skeleton.py
@@ -115,6 +115,17 @@ class RuntimeSkeletonTests(unittest.TestCase):
             "reviewed-proxy-secret",
         )
 
+    def test_runtime_config_parses_backup_manifest_metadata_from_env(self) -> None:
+        config = RuntimeConfig.from_env(
+            {
+                "AEGISOPS_CONTROL_PLANE_SOURCE_REVISION": "phase58-source-001",
+                "AEGISOPS_CONTROL_PLANE_DEPLOYMENT_PROFILE": "single-customer",
+            }
+        )
+
+        self.assertEqual(config.control_plane_source_revision, "phase58-source-001")
+        self.assertEqual(config.deployment_profile, "single-customer")
+
     def test_runtime_config_parses_trusted_proxy_cidrs_from_env(self) -> None:
         config = RuntimeConfig.from_env(
             {

--- a/docs/phase-58-3-backup-command-contract.md
+++ b/docs/phase-58-3-backup-command-contract.md
@@ -1,0 +1,80 @@
+# Phase 58.3 Backup Command Contract
+
+## Purpose
+
+`backup-authoritative-record-chain` emits the reviewed authoritative record-chain
+backup payload plus a product-facing backup manifest for custody and recovery
+evidence.
+
+The backup manifest is subordinate evidence only. It can help operators identify
+the backup payload, source revision, deployment profile, timestamp, custody
+posture, and record-family counts, but it cannot close workflows, approve
+releases, prove restore success, complete restore execution, satisfy release
+gates, or replace authoritative AegisOps records.
+
+## Runtime Surface
+
+- CLI: `python3 control-plane/main.py backup-authoritative-record-chain`
+- Output format: JSON.
+- Restore input compatibility: the existing `record_families` and
+  `record_counts` payload remains the authoritative restore input.
+
+## Manifest Fields
+
+The backup output includes `backup_manifest` with:
+
+- `manifest_schema_version`: `phase58.backup-command-manifest.v1`.
+- `generated_at`: ISO 8601 UTC timestamp for the command output.
+- `backup_schema_version`: authoritative record-chain backup schema.
+- `custody_metadata`: custody and recovery metadata.
+- `custody_metadata.purpose`: `custody_and_recovery_evidence`.
+- `custody_metadata.source_revision`: reviewed source revision from
+  `AEGISOPS_CONTROL_PLANE_SOURCE_REVISION`, or `unknown` when not provided.
+- `custody_metadata.profile`: reviewed deployment profile from
+  `AEGISOPS_CONTROL_PLANE_DEPLOYMENT_PROFILE`, or `unreviewed` when not provided.
+- `custody_metadata.timestamp`: manifest timestamp.
+- `custody_metadata.persistence_mode`: current persistence mode.
+- `record_family_counts`: copy of the authoritative `record_counts` values.
+- `total_record_count`: sum of all record-family counts.
+- `redaction_expectations`: explicit exclusion posture for sensitive material.
+- `authority_boundary`: `backup_manifest_is_custody_and_recovery_evidence_only`.
+- `non_authority_uses`: forbidden uses the manifest cannot satisfy.
+
+## Redaction Expectations
+
+The manifest must not contain plaintext secrets, DSNs, private keys,
+authorization headers, raw customer-private payloads, workstation-local absolute
+paths, placeholder credentials treated as valid credentials, or unreviewed
+customer evidence.
+
+The manifest records redaction posture only; it does not certify that a restore
+has succeeded. Restore success remains proven by the reviewed restore path,
+clean-state validation, and authoritative AegisOps record-chain checks.
+
+## Authority Boundary
+
+AegisOps alert, case, evidence, approval, action-request, execution,
+reconciliation, audit, release, gate, limitation, and closeout records remain
+authoritative.
+
+Backup output and manifests are custody and recovery evidence only. They do not
+become workflow truth, restore truth, release truth, gate truth, approval truth,
+execution truth, reconciliation truth, or support-bundle truth.
+
+## Non-Goals
+
+Phase 58.3 does not implement enterprise backup scheduling, live restore
+execution, support bundle generation, new release gates, new workflow truth,
+customer-private raw payload export, plaintext secret storage, or multi-customer
+backup administration.
+
+## Validation
+
+Run:
+
+- `python3 -m unittest control-plane.tests.test_cli_inspection_restore_readiness.CliInspectionRestoreReadinessTests.test_backup_command_renders_manifest_custody_metadata_without_secrets`
+- `python3 -m unittest control-plane.tests.test_service_restore_backup_codec`
+- `bash scripts/verify-phase-58-3-backup-command-contract.sh`
+- `bash scripts/test-verify-phase-58-3-backup-command-contract.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1238 --config <supervisor-config-path>`

--- a/scripts/test-verify-phase-58-3-backup-command-contract.sh
+++ b/scripts/test-verify-phase-58-3-backup-command-contract.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-58-3-backup-command-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-58-3-backup-command-contract.md" \
+    "${target}/docs/phase-58-3-backup-command-contract.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-58-3-backup-command-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/phase-58-3-backup-command-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 58.3 backup command contract"
+
+missing_boundary_repo="${workdir}/missing-boundary"
+create_valid_repo "${missing_boundary_repo}"
+remove_text_from_contract "${missing_boundary_repo}" \
+  "The backup manifest is subordinate evidence only."
+assert_fails_with \
+  "${missing_boundary_repo}" \
+  "Missing Phase 58.3 backup command contract statement: The backup manifest is subordinate evidence only."
+
+missing_redaction_repo="${workdir}/missing-redaction"
+create_valid_repo "${missing_redaction_repo}"
+remove_text_from_contract "${missing_redaction_repo}" \
+  "The manifest must not contain plaintext secrets, DSNs, private keys,"
+assert_fails_with \
+  "${missing_redaction_repo}" \
+  "Missing Phase 58.3 backup command contract statement: The manifest must not contain plaintext secrets, DSNs, private keys,"
+
+authority_overclaim_repo="${workdir}/authority-overclaim"
+create_valid_repo "${authority_overclaim_repo}"
+printf '%s\n' "Backup manifest proves restore success." \
+  >>"${authority_overclaim_repo}/docs/phase-58-3-backup-command-contract.md"
+assert_fails_with \
+  "${authority_overclaim_repo}" \
+  "Forbidden Phase 58.3 backup command contract claim: backup manifest proves restore success"
+
+enterprise_overclaim_repo="${workdir}/enterprise-overclaim"
+create_valid_repo "${enterprise_overclaim_repo}"
+printf '%s\n' "Enterprise backup scheduling platform is included." \
+  >>"${enterprise_overclaim_repo}/docs/phase-58-3-backup-command-contract.md"
+assert_fails_with \
+  "${enterprise_overclaim_repo}" \
+  "Forbidden Phase 58.3 backup command contract claim: enterprise backup scheduling platform"
+
+workstation_path_repo="${workdir}/workstation-path"
+create_valid_repo "${workstation_path_repo}"
+printf '%s\n' "Use /Users/example/aegisops-backups as the target." \
+  >>"${workstation_path_repo}/docs/phase-58-3-backup-command-contract.md"
+assert_fails_with \
+  "${workstation_path_repo}" \
+  "Forbidden Phase 58.3 backup command contract claim: workstation-local path"
+
+echo "Phase 58.3 backup command contract verifier rejects missing custody, redaction, authority, enterprise-overclaim, and workstation-path cases."

--- a/scripts/test-verify-phase-58-3-backup-command-contract.sh
+++ b/scripts/test-verify-phase-58-3-backup-command-contract.sh
@@ -100,7 +100,8 @@ assert_fails_with \
 
 workstation_path_repo="${workdir}/workstation-path"
 create_valid_repo "${workstation_path_repo}"
-printf '%s\n' "Use /Users/example/aegisops-backups as the target." \
+macos_home_fragment="/""Users/example"
+printf '%s\n' "Use ${macos_home_fragment}/aegisops-backups as the target." \
   >>"${workstation_path_repo}/docs/phase-58-3-backup-command-contract.md"
 assert_fails_with \
   "${workstation_path_repo}" \

--- a/scripts/verify-phase-58-3-backup-command-contract.sh
+++ b/scripts/verify-phase-58-3-backup-command-contract.sh
@@ -63,7 +63,11 @@ for forbidden in \
   fi
 done
 
-if grep -Eq '/Users/[^[:space:]]+|/home/[^[:space:]]+|C:\\Users\\' <<<"${doc_text}"; then
+macos_home_pattern="/""Users/[^[:space:]]+"
+linux_home_pattern="/""home/[^[:space:]]+"
+windows_home_pattern="C:""\\\\Users\\\\"
+
+if grep -Eq "${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern}" <<<"${doc_text}"; then
   echo "Forbidden Phase 58.3 backup command contract claim: workstation-local path" >&2
   exit 1
 fi

--- a/scripts/verify-phase-58-3-backup-command-contract.sh
+++ b/scripts/verify-phase-58-3-backup-command-contract.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-58-3-backup-command-contract.md"
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 58.3 backup command contract: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_text="$(<"${doc_path}")"
+
+required_phrases=(
+  "# Phase 58.3 Backup Command Contract"
+  '`backup-authoritative-record-chain` emits the reviewed authoritative record-chain'
+  "backup payload plus a product-facing backup manifest for custody and recovery"
+  "evidence."
+  "The backup manifest is subordinate evidence only."
+  "the backup payload, source revision, deployment profile, timestamp, custody"
+  "posture, and record-family counts, but it cannot close workflows, approve"
+  "releases, prove restore success, complete restore execution, satisfy release"
+  "gates, or replace authoritative AegisOps records."
+  "- CLI: \`python3 control-plane/main.py backup-authoritative-record-chain\`"
+  "- Restore input compatibility: the existing \`record_families\` and"
+  "- \`manifest_schema_version\`: \`phase58.backup-command-manifest.v1\`."
+  "- \`custody_metadata.source_revision\`: reviewed source revision from"
+  "- \`custody_metadata.profile\`: reviewed deployment profile from"
+  "- \`record_family_counts\`: copy of the authoritative \`record_counts\` values."
+  "- \`total_record_count\`: sum of all record-family counts."
+  "- \`redaction_expectations\`: explicit exclusion posture for sensitive material."
+  "- \`authority_boundary\`: \`backup_manifest_is_custody_and_recovery_evidence_only\`."
+  "The manifest must not contain plaintext secrets, DSNs, private keys,"
+  "authorization headers, raw customer-private payloads, workstation-local absolute"
+  "The manifest records redaction posture only; it does not certify that a restore"
+  "Backup output and manifests are custody and recovery evidence only."
+  "Phase 58.3 does not implement enterprise backup scheduling, live restore"
+  "python3 -m unittest control-plane.tests.test_cli_inspection_restore_readiness.CliInspectionRestoreReadinessTests.test_backup_command_renders_manifest_custody_metadata_without_secrets"
+  "python3 -m unittest control-plane.tests.test_service_restore_backup_codec"
+  "bash scripts/verify-publishable-path-hygiene.sh"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1238 --config <supervisor-config-path>"
+)
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_text}"; then
+    echo "Missing Phase 58.3 backup command contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for forbidden in \
+  "backup manifest is workflow truth" \
+  "backup manifest proves restore success" \
+  "backup manifest approves releases" \
+  "enterprise backup scheduling platform" \
+  "plaintext secrets are stored" \
+  "customer-private raw payloads are exported" \
+  "support bundle generation is implemented"; do
+  if grep -Fqi -- "${forbidden}" <<<"${doc_text}"; then
+    echo "Forbidden Phase 58.3 backup command contract claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+if grep -Eq '/Users/[^[:space:]]+|/home/[^[:space:]]+|C:\\Users\\' <<<"${doc_text}"; then
+  echo "Forbidden Phase 58.3 backup command contract claim: workstation-local path" >&2
+  exit 1
+fi
+
+echo "Phase 58.3 backup command contract defines manifest custody fields, redaction expectations, and subordinate authority boundaries."


### PR DESCRIPTION
## Summary
- add Phase 58.3 backup manifest metadata to `backup-authoritative-record-chain` output
- add source revision/profile config fields for custody metadata
- document and verify the backup command contract, redaction expectations, and non-authority boundary

## Verification
- `python3 -m unittest control-plane.tests.test_cli_inspection_restore_readiness.CliInspectionRestoreReadinessTests.test_backup_command_renders_manifest_custody_metadata_without_secrets control-plane.tests.test_cli_inspection_restore_readiness.CliInspectionRestoreReadinessTests.test_backup_and_restore_drill_commands_render_recovery_payloads control-plane.tests.test_runtime_skeleton.RuntimeSkeletonTests.test_runtime_config_parses_backup_manifest_metadata_from_env`
- `python3 -m unittest control-plane.tests.test_service_restore_backup_codec`
- `bash scripts/verify-phase-58-3-backup-command-contract.sh && bash scripts/test-verify-phase-58-3-backup-command-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1238 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.coderabbit.json`

Closes #1238