### PR TITLE
Phase 58.4 add restore dry-run contract

### DIFF
--- a/control-plane/aegisops/control_plane/api/cli.py
+++ b/control-plane/aegisops/control_plane/api/cli.py
@@ -65,6 +65,28 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Path to the reviewed authoritative backup JSON payload.",
     )
+    restore_dry_run = subparsers.add_parser(
+        "dry-run-authoritative-record-chain-restore",
+        help="Validate restore preflight evidence without mutating the control-plane store.",
+    )
+    restore_dry_run.add_argument(
+        "--input",
+        required=True,
+        help="Path to the reviewed authoritative backup JSON payload.",
+    )
+    restore_dry_run.add_argument(
+        "--expected-source-revision",
+        help="Optional source revision that must match backup custody metadata.",
+    )
+    restore_dry_run.add_argument(
+        "--expected-profile",
+        help="Optional deployment profile that must match backup custody metadata.",
+    )
+    restore_dry_run.add_argument(
+        "--max-age-hours",
+        type=int,
+        help="Optional maximum backup age in hours for stale snapshot rejection.",
+    )
     subparsers.add_parser(
         "run-authoritative-restore-drill",
         help="Reread the restored authoritative record chain through reviewed service inspections.",
@@ -510,6 +532,17 @@ def run_command(
             return service.restore_authoritative_record_chain_backup(
                 read_json_file_fn(parsed.input)
             ).to_dict()
+        except (LookupError, ValueError) as exc:
+            _usage_error(parser, str(exc))
+    if command == "dry-run-authoritative-record-chain-restore":
+        try:
+            diagnostics_service = service._runtime_restore_readiness_diagnostics_service
+            return diagnostics_service.dry_run_authoritative_record_chain_restore(
+                read_json_file_fn(parsed.input),
+                expected_source_revision=parsed.expected_source_revision,
+                expected_profile=parsed.expected_profile,
+                max_age_hours=parsed.max_age_hours,
+            )
         except (LookupError, ValueError) as exc:
             _usage_error(parser, str(exc))
     if command == "run-authoritative-restore-drill":

--- a/control-plane/aegisops/control_plane/runtime/restore_readiness.py
+++ b/control-plane/aegisops/control_plane/runtime/restore_readiness.py
@@ -168,6 +168,21 @@ class RestoreReadinessService:
             backup_payload
         )
 
+    def dry_run_authoritative_record_chain_restore(
+        self,
+        backup_payload: Mapping[str, object],
+        *,
+        expected_source_revision: str | None = None,
+        expected_profile: str | None = None,
+        max_age_hours: int | None = None,
+    ) -> dict[str, object]:
+        return self._backup_restore_flow.dry_run_authoritative_record_chain_restore(
+            backup_payload,
+            expected_source_revision=expected_source_revision,
+            expected_profile=expected_profile,
+            max_age_hours=max_age_hours,
+        )
+
     def restore_drill_snapshot_transaction(self) -> Iterator[None]:
         return self._backup_restore_flow.restore_drill_snapshot_transaction()
 

--- a/control-plane/aegisops/control_plane/runtime/restore_readiness_backup_restore.py
+++ b/control-plane/aegisops/control_plane/runtime/restore_readiness_backup_restore.py
@@ -65,6 +65,13 @@ class _RestoreDrillVerifiedIds:
     reconciliation_ids: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class _ParsedRestorePayload:
+    parsed_records: dict[str, tuple[ControlPlaneRecord, ...]]
+    restored_record_counts: dict[str, int]
+    backup_created_at: datetime | None
+
+
 class _BackupRestoreFlow:
     def __init__(
         self,
@@ -214,6 +221,59 @@ class _BackupRestoreFlow:
         self,
         backup_payload: Mapping[str, object],
     ) -> Any:
+        parsed_payload = self._parse_and_validate_restore_payload(backup_payload)
+        with self._store.transaction(isolation_level="SERIALIZABLE"):
+            self.require_empty_authoritative_restore_target()
+            for record_type in self._authoritative_record_chain_record_types:
+                for record in parsed_payload.parsed_records[record_type.record_family]:
+                    self._store.save(record)
+            restore_drill = self.run_authoritative_restore_drill(
+                require_lifecycle_transition_history=True
+            )
+        return self._restore_summary_snapshot_factory(
+            read_only=True,
+            restored_record_counts=parsed_payload.restored_record_counts,
+            restore_drill=restore_drill,
+        )
+
+    def dry_run_authoritative_record_chain_restore(
+        self,
+        backup_payload: Mapping[str, object],
+        *,
+        expected_source_revision: str | None = None,
+        expected_profile: str | None = None,
+        max_age_hours: int | None = None,
+    ) -> dict[str, object]:
+        parsed_payload = self._parse_and_validate_restore_payload(backup_payload)
+        self._validate_restore_dry_run_manifest(
+            backup_payload,
+            backup_created_at=parsed_payload.backup_created_at,
+            expected_source_revision=expected_source_revision,
+            expected_profile=expected_profile,
+            max_age_hours=max_age_hours,
+        )
+        self.require_empty_authoritative_restore_target()
+        return {
+            "read_only": True,
+            "dry_run_state": "clean",
+            "record_counts": dict(parsed_payload.restored_record_counts),
+            "sample_record_ids": self._sample_restore_record_ids(
+                parsed_payload.parsed_records
+            ),
+            "backup_created_at": (
+                parsed_payload.backup_created_at.isoformat()
+                if parsed_payload.backup_created_at is not None
+                else None
+            ),
+            "authority_boundary": "restore_dry_run_is_preflight_evidence_only",
+            "can_prove_live_restore_completion": False,
+            "mutates_authoritative_records": False,
+        }
+
+    def _parse_and_validate_restore_payload(
+        self,
+        backup_payload: Mapping[str, object],
+    ) -> _ParsedRestorePayload:
         if not isinstance(backup_payload, Mapping):
             raise ValueError("restore payload must be a JSON object")
         backup_schema_version = backup_payload.get("backup_schema_version")
@@ -300,19 +360,64 @@ class _BackupRestoreFlow:
             require_lifecycle_transition_history=True,
             restored_record_counts=restored_record_counts,
         )
-        with self._store.transaction(isolation_level="SERIALIZABLE"):
-            self.require_empty_authoritative_restore_target()
-            for record_type in self._authoritative_record_chain_record_types:
-                for record in parsed_records[record_type.record_family]:
-                    self._store.save(record)
-            restore_drill = self.run_authoritative_restore_drill(
-                require_lifecycle_transition_history=True
-            )
-        return self._restore_summary_snapshot_factory(
-            read_only=True,
+        return _ParsedRestorePayload(
+            parsed_records=parsed_records,
             restored_record_counts=restored_record_counts,
-            restore_drill=restore_drill,
+            backup_created_at=backup_created_at,
         )
+
+    def _validate_restore_dry_run_manifest(
+        self,
+        backup_payload: Mapping[str, object],
+        *,
+        backup_created_at: datetime | None,
+        expected_source_revision: str | None,
+        expected_profile: str | None,
+        max_age_hours: int | None,
+    ) -> None:
+        manifest = backup_payload.get("backup_manifest")
+        if not isinstance(manifest, Mapping):
+            raise ValueError("restore dry-run requires backup_manifest provenance")
+        if (
+            manifest.get("authority_boundary")
+            != "backup_manifest_is_custody_and_recovery_evidence_only"
+        ):
+            raise ValueError(
+                "restore dry-run requires backup manifest subordinate authority boundary"
+            )
+        custody_metadata = manifest.get("custody_metadata")
+        if not isinstance(custody_metadata, Mapping):
+            raise ValueError("restore dry-run requires backup custody metadata")
+        if expected_source_revision is not None and (
+            custody_metadata.get("source_revision") != expected_source_revision
+        ):
+            raise ValueError("restore dry-run source revision mismatch")
+        if expected_profile is not None and (
+            custody_metadata.get("profile") != expected_profile
+        ):
+            raise ValueError("restore dry-run deployment profile mismatch")
+        if max_age_hours is not None:
+            if max_age_hours <= 0:
+                raise ValueError("restore dry-run max_age_hours must be positive")
+            if backup_created_at is None:
+                raise ValueError("restore dry-run requires created_at for stale check")
+            stale_before = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
+            if backup_created_at < stale_before:
+                raise ValueError("restore dry-run snapshot is stale")
+
+    def _sample_restore_record_ids(
+        self,
+        parsed_records: Mapping[str, tuple[ControlPlaneRecord, ...]],
+    ) -> dict[str, tuple[str, ...]]:
+        sample_record_ids: dict[str, tuple[str, ...]] = {}
+        for family, records in parsed_records.items():
+            id_field = self._authoritative_primary_id_field_by_family.get(family)
+            if id_field is None:
+                continue
+            sample_record_ids[family] = tuple(
+                str(getattr(record, id_field)) for record in records[:3]
+            )
+        return sample_record_ids
 
     @contextmanager
     def restore_drill_snapshot_transaction(self) -> Iterator[None]:

--- a/control-plane/aegisops/control_plane/runtime/runtime_restore_readiness_diagnostics.py
+++ b/control-plane/aegisops/control_plane/runtime/runtime_restore_readiness_diagnostics.py
@@ -64,6 +64,21 @@ class RuntimeRestoreReadinessDiagnosticsService:
             backup_payload
         )
 
+    def dry_run_authoritative_record_chain_restore(
+        self,
+        backup_payload: Mapping[str, object],
+        *,
+        expected_source_revision: str | None = None,
+        expected_profile: str | None = None,
+        max_age_hours: int | None = None,
+    ) -> dict[str, object]:
+        return self._restore_readiness_service.dry_run_authoritative_record_chain_restore(
+            backup_payload,
+            expected_source_revision=expected_source_revision,
+            expected_profile=expected_profile,
+            max_age_hours=max_age_hours,
+        )
+
     @contextmanager
     def restore_drill_snapshot_transaction(self) -> Iterator[None]:
         with self._restore_readiness_service.restore_drill_snapshot_transaction():

--- a/control-plane/tests/_cli_inspection_support.py
+++ b/control-plane/tests/_cli_inspection_support.py
@@ -39,6 +39,7 @@ from aegisops.control_plane.models import (
 )
 from aegisops.control_plane.service import (
     AegisOpsControlPlaneService,
+    AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES,
     AuthenticatedRuntimePrincipal,
 )
 from postgres_test_support import make_store

--- a/control-plane/tests/test_cli_inspection_restore_readiness.py
+++ b/control-plane/tests/test_cli_inspection_restore_readiness.py
@@ -194,6 +194,72 @@ class CliInspectionRestoreReadinessTests(ControlPlaneCliInspectionTestBase):
         self.assertEqual(exc.exception.code, 2)
         self.assertIn("backup invariants failed closed", stderr.getvalue())
 
+    def test_restore_dry_run_command_renders_preflight_evidence_without_mutation(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+        stdout = io.StringIO()
+
+        with mock.patch.object(main, "_read_json_file", return_value=backup):
+            main.main(
+                [
+                    "dry-run-authoritative-record-chain-restore",
+                    "--input",
+                    "authoritative-backup.json",
+                    "--expected-source-revision",
+                    backup["backup_manifest"]["custody_metadata"]["source_revision"],
+                    "--expected-profile",
+                    backup["backup_manifest"]["custody_metadata"]["profile"],
+                    "--max-age-hours",
+                    "24",
+                ],
+                stdout=stdout,
+                service=restored_service,
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["read_only"])
+        self.assertEqual(payload["dry_run_state"], "clean")
+        self.assertFalse(payload["mutates_authoritative_records"])
+        self.assertFalse(payload["can_prove_live_restore_completion"])
+        self.assertIn(promoted_case.case_id, payload["sample_record_ids"]["case"])
+        for record_type in AUTHORITATIVE_RECORD_CHAIN_RECORD_TYPES:
+            self.assertEqual(restored_store.list(record_type), ())
+
+    def test_restore_dry_run_command_reports_usage_error_on_failed_preflight(
+        self,
+    ) -> None:
+        service = mock.Mock()
+        diagnostics_service = mock.Mock()
+        diagnostics_service.dry_run_authoritative_record_chain_restore.side_effect = (
+            ValueError("restore dry-run snapshot is stale")
+        )
+        service._runtime_restore_readiness_diagnostics_service = diagnostics_service
+        stderr = io.StringIO()
+
+        with mock.patch.object(main, "_read_json_file", return_value={}):
+            with mock.patch.object(sys, "stderr", stderr):
+                with self.assertRaises(SystemExit) as exc:
+                    main.main(
+                        [
+                            "dry-run-authoritative-record-chain-restore",
+                            "--input",
+                            "authoritative-backup.json",
+                        ],
+                        service=service,
+                    )
+
+        self.assertEqual(exc.exception.code, 2)
+        self.assertIn("restore dry-run snapshot is stale", stderr.getvalue())
+
     def test_restore_authoritative_record_chain_reports_usage_error_on_lookup_failure(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_restore_backup_codec.py
+++ b/control-plane/tests/test_service_restore_backup_codec.py
@@ -38,6 +38,164 @@ from _restore_readiness_test_support import (
 
 
 class RestoreBackupCodecTests(ServicePersistenceTestBase):
+    def _dry_run_restore(
+        self,
+        service: AegisOpsControlPlaneService,
+        backup: Mapping[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        diagnostics_service = service._runtime_restore_readiness_diagnostics_service
+        return diagnostics_service.dry_run_authoritative_record_chain_restore(
+            backup,
+            **kwargs,
+        )
+
+    def test_restore_dry_run_accepts_clean_backup_without_mutating_target(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        dry_run = self._dry_run_restore(restored_service, backup)
+
+        self.assertTrue(dry_run["read_only"])
+        self.assertEqual(dry_run["dry_run_state"], "clean")
+        self.assertEqual(
+            dry_run["record_counts"]["case"],
+            backup["record_counts"]["case"],
+        )
+        self.assertIn(promoted_case.case_id, dry_run["sample_record_ids"]["case"])
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_restore_dry_run_rejects_missing_manifest_provenance(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        del backup["backup_manifest"]
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "restore dry-run requires backup_manifest provenance",
+        ):
+            self._dry_run_restore(restored_service, backup)
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_restore_dry_run_rejects_mismatched_custody_metadata(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["backup_manifest"]["custody_metadata"][
+            "source_revision"
+        ] = "phase58-source-a"
+        backup["backup_manifest"]["custody_metadata"]["profile"] = "single-customer"
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "restore dry-run source revision mismatch",
+        ):
+            self._dry_run_restore(
+                restored_service,
+                backup,
+                expected_source_revision="phase58-source-b",
+                expected_profile="single-customer",
+            )
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_restore_dry_run_rejects_duplicate_snapshot_identifiers(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["record_families"]["alert"].append(
+            dict(backup["record_families"]["alert"][0])
+        )
+        backup["record_counts"]["alert"] = len(backup["record_families"]["alert"])
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"duplicate alert identifiers .*restored_record_counts\['alert'\]=2",
+        ):
+            self._dry_run_restore(restored_service, backup)
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_restore_dry_run_rejects_stale_snapshot(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+        backup["created_at"] = datetime(2000, 1, 1, tzinfo=timezone.utc).isoformat()
+        backup["backup_manifest"]["generated_at"] = backup["created_at"]
+        backup["backup_manifest"]["custody_metadata"]["timestamp"] = backup[
+            "created_at"
+        ]
+
+        restored_store, _ = make_store()
+        restored_service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=restored_store,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "restore dry-run snapshot is stale",
+        ):
+            self._dry_run_restore(
+                restored_service,
+                backup,
+                max_age_hours=24,
+            )
+        self._assert_authoritative_store_empty(restored_store)
+
+    def test_restore_dry_run_rejects_unsafe_non_empty_target_without_mutation(
+        self,
+    ) -> None:
+        _store, service, _promoted_case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        backup = service.export_authoritative_record_chain_backup()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "authoritative restore target must be empty before restore",
+        ):
+            self._dry_run_restore(service, backup)
+
     def test_service_phase21_genuine_legacy_restore_round_trips_into_v2_transition_history(
         self,
     ) -> None:

--- a/docs/phase-58-4-restore-dry-run-contract.md
+++ b/docs/phase-58-4-restore-dry-run-contract.md
@@ -1,0 +1,96 @@
+# Phase 58.4 Restore Dry-Run Contract
+
+## Purpose
+
+`dry-run-authoritative-record-chain-restore` validates a reviewed
+authoritative record-chain backup payload before any live restore operation is
+allowed.
+
+Restore dry-run output is preflight evidence only. It can show that the backup
+payload parsed, matched expected custody metadata, passed restore validation,
+was not stale under the requested age policy, and targeted an empty restore
+store. It cannot prove live restore completion, close workflows, satisfy release
+gates, approve operations, replace a restore drill, or mutate authoritative
+AegisOps records.
+
+## Runtime Surface
+
+- CLI: `python3 control-plane/main.py dry-run-authoritative-record-chain-restore --input <authoritative-backup.json>`.
+- Optional source binding: `--expected-source-revision <source-revision>`.
+- Optional profile binding: `--expected-profile <deployment-profile>`.
+- Optional staleness policy: `--max-age-hours <positive-hours>`.
+- Output format: JSON.
+- Live restore command remains `python3 control-plane/main.py restore-authoritative-record-chain --input <authoritative-backup.json>`.
+
+## Inputs
+
+The dry-run input is the Phase 58.3 authoritative backup command output:
+
+- `backup_schema_version`: reviewed authoritative record-chain schema version.
+- `created_at`: ISO 8601 backup timestamp used when stale checking is requested.
+- `record_families`: authoritative record-chain records grouped by family.
+- `record_counts`: declared record count for each family.
+- `backup_manifest`: custody and recovery evidence manifest.
+- `backup_manifest.authority_boundary`: must be `backup_manifest_is_custody_and_recovery_evidence_only`.
+- `backup_manifest.custody_metadata.source_revision`: compared with `--expected-source-revision` when provided.
+- `backup_manifest.custody_metadata.profile`: compared with `--expected-profile` when provided.
+
+Missing provenance, unsupported record families, malformed record shapes,
+missing required links, mismatched record counts, duplicate identifiers, stale
+timestamps, and non-empty restore targets fail closed.
+
+## Outputs
+
+A clean dry-run returns:
+
+- `read_only`: `true`.
+- `dry_run_state`: `clean`.
+- `record_counts`: validated record-family counts.
+- `sample_record_ids`: bounded sample of parsed record identifiers by family.
+- `backup_created_at`: parsed backup timestamp.
+- `authority_boundary`: `restore_dry_run_is_preflight_evidence_only`.
+- `can_prove_live_restore_completion`: `false`.
+- `mutates_authoritative_records`: `false`.
+
+The command returns a usage error instead of success for `missing`,
+`mismatched`, `duplicate`, `stale`, and `unsafe` snapshots.
+
+## Failure States
+
+| State | Rejected condition | Required behavior |
+| --- | --- | --- |
+| `missing` | Payload, `record_families`, `record_counts`, `backup_manifest`, custody metadata, or required links are absent. | Fail closed before any durable write. |
+| `mismatched` | Record counts, expected source revision, expected profile, lifecycle state, approval binding, execution binding, or reconciliation binding disagree. | Fail closed before any durable write. |
+| `duplicate` | Authoritative identifiers or execution run identifiers are duplicated. | Fail closed before any durable write. |
+| `stale` | `--max-age-hours` is set and `created_at` is older than the requested policy. | Fail closed before any durable write. |
+| `unsafe` | Restore target already contains authoritative records or the manifest boundary claims authority beyond custody evidence. | Fail closed before any durable write. |
+
+## Authority Boundary
+
+A dry-run never writes records, never performs live restore execution, and never
+marks restore success. Restore acceptance still requires the reviewed live
+restore path, restore drill, clean-state validation, and authoritative
+AegisOps record-chain checks after the restore.
+
+Restore dry-run evidence must not be used as workflow truth, release truth,
+gate truth, approval truth, execution truth, reconciliation truth, restore
+completion truth, or customer support truth.
+
+## Non-Goals
+
+Phase 58.4 does not implement destructive restore, schema migration, backup
+scheduling, release-gate automation, support bundle generation, customer-private
+payload export, direct database mutation bypasses, or restore dry-run output as
+restore completion evidence.
+
+## Validation
+
+Run:
+
+- `python3 -m unittest control-plane.tests.test_service_restore_backup_codec`
+- `python3 -m unittest control-plane.tests.test_cli_inspection_restore_readiness.CliInspectionRestoreReadinessTests.test_restore_dry_run_command_renders_preflight_evidence_without_mutation`
+- `python3 -m unittest control-plane.tests.test_cli_inspection_restore_readiness.CliInspectionRestoreReadinessTests.test_restore_dry_run_command_reports_usage_error_on_failed_preflight`
+- `bash scripts/verify-phase-58-4-restore-dry-run-contract.sh`
+- `bash scripts/test-verify-phase-58-4-restore-dry-run-contract.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1239 --config <supervisor-config-path>`

--- a/scripts/test-verify-phase-58-4-restore-dry-run-contract.sh
+++ b/scripts/test-verify-phase-58-4-restore-dry-run-contract.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-58-4-restore-dry-run-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-58-4-restore-dry-run-contract.md" \
+    "${target}/docs/phase-58-4-restore-dry-run-contract.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-58-4-restore-dry-run-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/phase-58-4-restore-dry-run-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 58.4 restore dry-run contract"
+
+missing_boundary_repo="${workdir}/missing-boundary"
+create_valid_repo "${missing_boundary_repo}"
+remove_text_from_contract "${missing_boundary_repo}" \
+  "Restore dry-run output is preflight evidence only."
+assert_fails_with \
+  "${missing_boundary_repo}" \
+  "Missing Phase 58.4 restore dry-run contract statement: Restore dry-run output is preflight evidence only."
+
+missing_failure_state_repo="${workdir}/missing-failure-state"
+create_valid_repo "${missing_failure_state_repo}"
+remove_text_from_contract "${missing_failure_state_repo}" \
+  "| \`stale\` | \`--max-age-hours\` is set and \`created_at\` is older than the requested policy. | Fail closed before any durable write. |"
+assert_fails_with \
+  "${missing_failure_state_repo}" \
+  "Missing Phase 58.4 restore dry-run contract statement: | \`stale\` | \`--max-age-hours\` is set and \`created_at\` is older than the requested policy. | Fail closed before any durable write. |"
+
+authority_overclaim_repo="${workdir}/authority-overclaim"
+create_valid_repo "${authority_overclaim_repo}"
+printf '%s\n' "Dry-run proves live restore completion." \
+  >>"${authority_overclaim_repo}/docs/phase-58-4-restore-dry-run-contract.md"
+assert_fails_with \
+  "${authority_overclaim_repo}" \
+  "Forbidden Phase 58.4 restore dry-run contract claim: dry-run proves live restore completion"
+
+release_gate_overclaim_repo="${workdir}/release-gate-overclaim"
+create_valid_repo "${release_gate_overclaim_repo}"
+printf '%s\n' "Restore dry-run satisfies release gates." \
+  >>"${release_gate_overclaim_repo}/docs/phase-58-4-restore-dry-run-contract.md"
+assert_fails_with \
+  "${release_gate_overclaim_repo}" \
+  "Forbidden Phase 58.4 restore dry-run contract claim: restore dry-run satisfies release gates"
+
+workstation_path_repo="${workdir}/workstation-path"
+create_valid_repo "${workstation_path_repo}"
+macos_home_fragment="/""Users/example"
+printf '%s\n' "Use ${macos_home_fragment}/aegisops-restore-dry-run.json as the retained evidence path." \
+  >>"${workstation_path_repo}/docs/phase-58-4-restore-dry-run-contract.md"
+assert_fails_with \
+  "${workstation_path_repo}" \
+  "Forbidden Phase 58.4 restore dry-run contract claim: workstation-local path"
+
+echo "Phase 58.4 restore dry-run contract verifier rejects missing contract, missing boundary, missing failure states, overclaims, and workstation paths."

--- a/scripts/verify-phase-58-4-restore-dry-run-contract.sh
+++ b/scripts/verify-phase-58-4-restore-dry-run-contract.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-58-4-restore-dry-run-contract.md"
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 58.4 restore dry-run contract: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_text="$(<"${doc_path}")"
+
+required_phrases=(
+  "# Phase 58.4 Restore Dry-Run Contract"
+  '`dry-run-authoritative-record-chain-restore` validates a reviewed'
+  "Restore dry-run output is preflight evidence only."
+  "It cannot prove live restore completion, close workflows, satisfy release"
+  "- CLI: \`python3 control-plane/main.py dry-run-authoritative-record-chain-restore --input <authoritative-backup.json>\`."
+  "- Optional source binding: \`--expected-source-revision <source-revision>\`."
+  "- Optional profile binding: \`--expected-profile <deployment-profile>\`."
+  "- Optional staleness policy: \`--max-age-hours <positive-hours>\`."
+  "- Live restore command remains \`python3 control-plane/main.py restore-authoritative-record-chain --input <authoritative-backup.json>\`."
+  "- \`backup_manifest.authority_boundary\`: must be \`backup_manifest_is_custody_and_recovery_evidence_only\`."
+  "Missing provenance, unsupported record families, malformed record shapes,"
+  "- \`dry_run_state\`: \`clean\`."
+  "- \`authority_boundary\`: \`restore_dry_run_is_preflight_evidence_only\`."
+  "- \`can_prove_live_restore_completion\`: \`false\`."
+  "- \`mutates_authoritative_records\`: \`false\`."
+  "The command returns a usage error instead of success for \`missing\`,"
+  "| \`missing\` | Payload, \`record_families\`, \`record_counts\`, \`backup_manifest\`, custody metadata, or required links are absent. | Fail closed before any durable write. |"
+  "| \`mismatched\` | Record counts, expected source revision, expected profile, lifecycle state, approval binding, execution binding, or reconciliation binding disagree. | Fail closed before any durable write. |"
+  "| \`duplicate\` | Authoritative identifiers or execution run identifiers are duplicated. | Fail closed before any durable write. |"
+  "| \`stale\` | \`--max-age-hours\` is set and \`created_at\` is older than the requested policy. | Fail closed before any durable write. |"
+  "| \`unsafe\` | Restore target already contains authoritative records or the manifest boundary claims authority beyond custody evidence. | Fail closed before any durable write. |"
+  "A dry-run never writes records, never performs live restore execution, and never"
+  "Restore dry-run evidence must not be used as workflow truth, release truth,"
+  "Phase 58.4 does not implement destructive restore, schema migration, backup"
+  "python3 -m unittest control-plane.tests.test_service_restore_backup_codec"
+  "bash scripts/verify-publishable-path-hygiene.sh"
+  "node <codex-supervisor-root>/dist/index.js issue-lint 1239 --config <supervisor-config-path>"
+)
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_text}"; then
+    echo "Missing Phase 58.4 restore dry-run contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for forbidden in \
+  "dry-run proves live restore completion" \
+  "dry-run completes restore" \
+  "restore dry-run is workflow truth" \
+  "restore dry-run satisfies release gates" \
+  "destructive restore is implemented" \
+  "customer-private raw payloads are exported" \
+  "support bundle generation is implemented"; do
+  if grep -Fqi -- "${forbidden}" <<<"${doc_text}"; then
+    echo "Forbidden Phase 58.4 restore dry-run contract claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+macos_home_pattern="/""Users/[^[:space:]]+"
+linux_home_pattern="/""home/[^[:space:]]+"
+windows_home_pattern="C:""\\\\Users\\\\"
+
+if grep -Eq "${macos_home_pattern}|${linux_home_pattern}|${windows_home_pattern}" <<<"${doc_text}"; then
+  echo "Forbidden Phase 58.4 restore dry-run contract claim: workstation-local path" >&2
+  exit 1
+fi
+
+echo "Phase 58.4 restore dry-run contract defines inputs, outputs, failure states, and subordinate authority boundaries."


### PR DESCRIPTION
## Summary
- add a read-only authoritative record-chain restore dry-run service and CLI command
- validate backup provenance, expected source/profile bindings, staleness, duplicate/mismatched/missing payloads, and unsafe non-empty targets before any restore write
- document the Phase 58.4 contract and add verifier scripts for authority/path hygiene

## Verification
- python3 -m unittest control-plane.tests.test_service_restore_backup_codec
- python3 -m unittest control-plane.tests.test_cli_inspection_restore_readiness
- python3 -m unittest control-plane.tests.test_service_restore_validation
- python3 -m unittest control-plane.tests.test_service_restore_readiness_boundaries
- python3 -m unittest control-plane.tests.test_service_restore_runtime_visibility
- python3 -m unittest control-plane.tests.test_service_persistence_restore_readiness
- python3 -m compileall -q control-plane/aegisops/control_plane control-plane/tests
- bash scripts/verify-phase-58-4-restore-dry-run-contract.sh
- bash scripts/test-verify-phase-58-4-restore-dry-run-contract.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1239 --config <supervisor-config-path>

Closes #1239
