### PR TITLE
Phase 58.6 support bundle redaction contract

### DIFF
--- a/docs/phase-58-6-support-bundle-redaction-contract.md
+++ b/docs/phase-58-6-support-bundle-redaction-contract.md
@@ -1,0 +1,140 @@
+# Phase 58.6 Support Bundle And Redaction Contract
+
+## Purpose
+
+Phase 58.6 defines the support bundle contract for customer-safe diagnostic
+evidence. A support bundle is redacted diagnostic evidence only. It can help a
+bounded support collaborator understand environment class, version posture,
+doctor output, backup and restore evidence references, reviewed limitations,
+and reproduction context without exposing customer-private operational data.
+
+Support bundles cannot approve, execute, reconcile, release, close, restore, or
+replace authoritative AegisOps records. They are not workflow truth, release
+truth, gate truth, restore truth, audit truth, closeout truth, customer-support
+truth, or operator authority.
+
+## Runtime Surface
+
+No remote upload service, background collector, direct database export,
+substrate log scraper, support operator workflow, or support authority path is
+introduced by this contract.
+
+Future reviewed bundle output may be retained as Markdown, JSON, or archive
+evidence after redaction and scanning. The Phase 58.6 runtime posture is
+contract validation only:
+
+- Contract verifier: `bash scripts/verify-phase-58-6-support-bundle-redaction-contract.sh`.
+- Focused verifier regression: `bash scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh`.
+- Path hygiene: `bash scripts/verify-publishable-path-hygiene.sh`.
+- Issue lint: `node <codex-supervisor-root>/dist/index.js issue-lint 1241 --config <supervisor-config-path>`.
+
+## Allowed Bundle Contents
+
+| Content | Required boundary |
+| --- | --- |
+| `environment_class` | Reviewed profile, deployment class, or lab class only; no tenant inference from path shape, ticket title, or host name. |
+| `component_versions` | AegisOps-owned component and package versions after reviewed redaction; no floating `latest` claims as evidence. |
+| `doctor_summary` | Phase 58.1 doctor output or summarized health state after redaction; not authoritative workflow or release truth. |
+| `backup_restore_references` | Links to Phase 58.3 backup custody evidence and Phase 58.4 restore dry-run evidence; not raw backup payloads. |
+| `upgrade_rollback_references` | Links to Phase 58.5 upgrade and rollback planning evidence; not proof of live upgrade or rollback completion. |
+| `known_limitations` | Reviewed limitations, non-goals, unsafe states, retained manual steps, and owner references. |
+| `reproduction_steps` | Operator-reviewed reproduction steps with customer names, private payloads, tickets, credentials, and workstation paths removed. |
+| `bounded_metadata` | Sanitized timestamps, record counts, schema versions, source families, and evidence identifiers directly linked to authoritative records. |
+| `redaction_manifest` | Redaction families applied, scan result, retained limitations, and explicit subordinate-evidence boundary. |
+
+## Forbidden Bundle Contents
+
+| Content | Required behavior |
+| --- | --- |
+| `secrets` | Reject or redact API keys, shared secrets, passwords, private keys, signing keys, bootstrap tokens, session material, and env-secret values. |
+| `workstation_local_paths` | Reject or redact macOS, Linux, and Windows user-profile paths; use repo-relative paths, documented env vars, or placeholders. |
+| `customer_private_raw_payloads` | Reject raw alerts, raw logs, raw tickets, raw webhook bodies, raw event payloads, and customer-private source payloads by default. |
+| `ticket_private_content` | Reject private ticket comments, customer names, customer screenshots, chat excerpts, support notes, and operator-only escalation text. |
+| `tokens_and_headers` | Reject authorization headers, cookies, bearer tokens, forwarded headers, raw host or tenant hints, and client-supplied identity fields. |
+| `cert_material` | Reject certificates, private keys, CSRs, keystores, truststores, and inline PEM blocks unless replaced with reviewed fingerprints. |
+| `raw_credentials` | Reject usernames paired with passwords, connection strings containing credentials, service-account secrets, and placeholder credentials. |
+| `authority_claims` | Reject bundle-as-workflow-truth, support-as-operator, support-as-approver, support-as-release-gate, or support-as-restore-truth claims. |
+
+## Redaction Rules
+
+| Family | Redaction rule |
+| --- | --- |
+| `secret_values` | Replace secret-looking values with `[REDACTED:secret]` and fail closed when the value remains recoverable in output. |
+| `workstation_paths` | Replace user-home absolute paths with `[REDACTED:workstation-path]`; retain only repo-relative paths or placeholders. |
+| `private_payloads` | Summarize payload type, source family, authoritative record link, and bounded counts; do not retain raw payload bodies by default. |
+| `ticket_private_content` | Replace private ticket text with `[REDACTED:ticket-private-content]` and retain only public ticket identifiers or reviewed references. |
+| `tokens_and_headers` | Remove authorization, cookie, forwarded, tenant, host, proto, and user-id headers unless a trusted boundary normalized them first. |
+| `certs_and_keys` | Replace cert and key material with reviewed fingerprints, expiry metadata, issuer class, or custody references. |
+| `credentials` | Remove usernames paired with passwords, credential-bearing URLs, DSNs, and placeholder credentials from retained output. |
+| `customer_identifiers` | Replace customer names, tenant names, account names, private host names, email addresses, and screenshots with reviewed placeholders. |
+
+## Failure States
+
+| State | Rejected condition | Required behavior |
+| --- | --- | --- |
+| `secret_leakage` | Bundle output contains secret-looking values, tokens, auth headers, cookies, private keys, cert material, credential-bearing DSNs, or placeholder credentials. | Reject the bundle before retention or sharing. |
+| `workstation_path_leakage` | Bundle output contains macOS, Linux, or Windows workstation-local user-profile paths. | Reject the bundle and require repo-relative paths, env vars, or placeholders. |
+| `private_payload_leakage` | Bundle output contains raw customer payloads, raw logs, raw tickets, raw webhook bodies, screenshots, or private support notes. | Reject the bundle and retain bounded summaries only. |
+| `authority_expansion` | Bundle output is presented as workflow, release, gate, restore, audit, closeout, approval, execution, reconciliation, or operator truth. | Reject the bundle and preserve authoritative AegisOps record-chain truth. |
+| `support_operator_expansion` | Support collaborator access is treated as operator, approver, administrator, substrate operator, or direct backend authority. | Reject the bundle and require a reviewed authority contract. |
+| `missing_redaction_manifest` | Redaction families, scan result, subordinate boundary, or retained limitations are absent. | Reject the bundle until the manifest is complete. |
+| `mixed_snapshot_bundle` | Bundle assembles records from different committed snapshots without detecting or rejecting mixed-state evidence. | Reject the bundle before retention or sharing. |
+
+## Authority Boundary
+
+Support bundles are subordinate diagnostic evidence. AegisOps control-plane
+records remain authoritative for alert, case, evidence, approval, action
+request, execution receipt, reconciliation, audit, limitation, release, gate,
+restore, workflow, and closeout truth.
+
+Support bundle validation cannot approve remediation, execute actions, reconcile
+actions, close cases, satisfy Pilot, Beta, RC, or GA gates, prove backup or
+restore success, prove upgrade or rollback success, mutate substrate state,
+grant support operator authority, or replace customer-owned decisions.
+
+When provenance, record linkage, snapshot consistency, redaction status,
+secret-scan status, support scope, or authority-boundary signals are missing,
+malformed, placeholder-like, or only partially trusted, validation fails closed.
+
+## Retention Boundary
+
+A retained support bundle must include a redaction manifest, scan result,
+creation timestamp, environment class, reviewed owner, evidence links, retained
+limitations, and explicit subordinate-evidence boundary. Retention is allowed
+only after secret-looking value scanning, workstation-local path scanning,
+private-payload review, ticket-private-content review, token and header review,
+cert material review, credential review, and authority-boundary review pass.
+
+## Negative Tests
+
+The verifier must reject:
+
+- secret leakage;
+- workstation-local path leakage;
+- customer-private raw payload leakage;
+- ticket-private content leakage;
+- token and header leakage;
+- cert material leakage;
+- raw credential leakage;
+- missing redaction manifest;
+- support bundle as workflow, release, gate, restore, audit, or closeout truth;
+- support operator authority expansion;
+- mixed-snapshot bundle claims.
+
+## Non-Goals
+
+Phase 58.6 does not implement remote support upload, support portal workflow,
+customer-private raw log inclusion by default, support operator authority, live
+backend access for support collaborators, substrate operation, action approval,
+action execution, reconciliation, release-gate automation, restore execution,
+backup execution, upgrade execution, rollback execution, audit export, or
+support bundle output as authoritative workflow truth.
+
+## Validation
+
+Run:
+
+- `bash scripts/verify-phase-58-6-support-bundle-redaction-contract.sh`
+- `bash scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1241 --config <supervisor-config-path>`

--- a/scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh
+++ b/scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh
@@ -120,6 +120,13 @@ assert_fails_with \
   "${secret_value_repo}" \
   "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value"
 
+short_password_repo="${workdir}/short-password"
+create_valid_repo "${short_password_repo}"
+append_to_contract "${short_password_repo}" "password=abc123"
+assert_fails_with \
+  "${short_password_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value"
+
 authorization_header_repo="${workdir}/authorization-header"
 create_valid_repo "${authorization_header_repo}"
 append_to_contract "${authorization_header_repo}" "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456"
@@ -169,6 +176,21 @@ linux_home_fragment="/""home/example"
 append_to_contract "${linux_workstation_path_repo}" "Retain ${linux_home_fragment}/support-bundle/raw.log as evidence."
 assert_fails_with \
   "${linux_workstation_path_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: workstation-local path"
+
+file_uri_linux_workstation_path_repo="${workdir}/file-uri-linux-workstation-path"
+create_valid_repo "${file_uri_linux_workstation_path_repo}"
+file_scheme="file://"
+append_to_contract "${file_uri_linux_workstation_path_repo}" "Retain ${file_scheme}${linux_home_fragment}/support-bundle/raw.log as evidence."
+assert_fails_with \
+  "${file_uri_linux_workstation_path_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: workstation-local path"
+
+file_uri_macos_workstation_path_repo="${workdir}/file-uri-macos-workstation-path"
+create_valid_repo "${file_uri_macos_workstation_path_repo}"
+append_to_contract "${file_uri_macos_workstation_path_repo}" "Retain ${file_scheme}${macos_home_fragment}/support-bundle/raw.log as evidence."
+assert_fails_with \
+  "${file_uri_macos_workstation_path_repo}" \
   "Forbidden Phase 58.6 support bundle redaction contract claim: workstation-local path"
 
 windows_workstation_path_repo="${workdir}/windows-workstation-path"

--- a/scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh
+++ b/scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-58-6-support-bundle-redaction-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-58-6-support-bundle-redaction-contract.md" \
+    "${target}/docs/phase-58-6-support-bundle-redaction-contract.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_text_from_contract() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-58-6-support-bundle-redaction-contract.md"
+}
+
+append_to_contract() {
+  local target="$1"
+  local text="$2"
+
+  printf '%s\n' "${text}" \
+    >>"${target}/docs/phase-58-6-support-bundle-redaction-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+external_url_repo="${workdir}/external-url"
+create_valid_repo "${external_url_repo}"
+append_to_contract \
+  "${external_url_repo}" \
+  "Use https://example.com/home/docs/support-bundle-contract.md as reviewed external reference context."
+assert_passes "${external_url_repo}"
+
+missing_contract_repo="${workdir}/missing-contract"
+create_valid_repo "${missing_contract_repo}"
+rm "${missing_contract_repo}/docs/phase-58-6-support-bundle-redaction-contract.md"
+assert_fails_with \
+  "${missing_contract_repo}" \
+  "Missing Phase 58.6 support bundle redaction contract"
+
+missing_allowed_content_repo="${workdir}/missing-allowed-content"
+create_valid_repo "${missing_allowed_content_repo}"
+remove_text_from_contract "${missing_allowed_content_repo}" \
+  "| \`redaction_manifest\` | Redaction families applied, scan result, retained limitations, and explicit subordinate-evidence boundary. |"
+assert_fails_with \
+  "${missing_allowed_content_repo}" \
+  "Missing Phase 58.6 support bundle redaction contract statement: | \`redaction_manifest\` | Redaction families applied, scan result, retained limitations, and explicit subordinate-evidence boundary. |"
+
+missing_forbidden_content_repo="${workdir}/missing-forbidden-content"
+create_valid_repo "${missing_forbidden_content_repo}"
+remove_text_from_contract "${missing_forbidden_content_repo}" \
+  "| \`tokens_and_headers\` | Reject authorization headers, cookies, bearer tokens, forwarded headers, raw host or tenant hints, and client-supplied identity fields. |"
+assert_fails_with \
+  "${missing_forbidden_content_repo}" \
+  "Missing Phase 58.6 support bundle redaction contract statement: | \`tokens_and_headers\` | Reject authorization headers, cookies, bearer tokens, forwarded headers, raw host or tenant hints, and client-supplied identity fields. |"
+
+missing_redaction_rule_repo="${workdir}/missing-redaction-rule"
+create_valid_repo "${missing_redaction_rule_repo}"
+remove_text_from_contract "${missing_redaction_rule_repo}" \
+  "| \`certs_and_keys\` | Replace cert and key material with reviewed fingerprints, expiry metadata, issuer class, or custody references. |"
+assert_fails_with \
+  "${missing_redaction_rule_repo}" \
+  "Missing Phase 58.6 support bundle redaction contract statement: | \`certs_and_keys\` | Replace cert and key material with reviewed fingerprints, expiry metadata, issuer class, or custody references. |"
+
+missing_failure_state_repo="${workdir}/missing-failure-state"
+create_valid_repo "${missing_failure_state_repo}"
+remove_text_from_contract "${missing_failure_state_repo}" \
+  "| \`private_payload_leakage\` | Bundle output contains raw customer payloads, raw logs, raw tickets, raw webhook bodies, screenshots, or private support notes. | Reject the bundle and retain bounded summaries only. |"
+assert_fails_with \
+  "${missing_failure_state_repo}" \
+  "Missing Phase 58.6 support bundle redaction contract statement: | \`private_payload_leakage\` | Bundle output contains raw customer payloads, raw logs, raw tickets, raw webhook bodies, screenshots, or private support notes. | Reject the bundle and retain bounded summaries only. |"
+
+secret_value_repo="${workdir}/secret-value"
+create_valid_repo "${secret_value_repo}"
+append_to_contract "${secret_value_repo}" "support_password = ExampleSecretValue12345"
+assert_fails_with \
+  "${secret_value_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value"
+
+authorization_header_repo="${workdir}/authorization-header"
+create_valid_repo "${authorization_header_repo}"
+append_to_contract "${authorization_header_repo}" "Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456"
+assert_fails_with \
+  "${authorization_header_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value"
+
+credential_url_repo="${workdir}/credential-url"
+create_valid_repo "${credential_url_repo}"
+append_to_contract "${credential_url_repo}" "postgres://support:credentialvalue12345@db.internal/aegisops"
+assert_fails_with \
+  "${credential_url_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value"
+
+cert_material_repo="${workdir}/cert-material"
+create_valid_repo "${cert_material_repo}"
+append_to_contract "${cert_material_repo}" "-----BEGIN CERTIFICATE-----"
+assert_fails_with \
+  "${cert_material_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value"
+
+private_key_repo="${workdir}/private-key"
+create_valid_repo "${private_key_repo}"
+append_to_contract "${private_key_repo}" "-----BEGIN PRIVATE KEY-----"
+assert_fails_with \
+  "${private_key_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value"
+
+workstation_path_repo="${workdir}/workstation-path"
+create_valid_repo "${workstation_path_repo}"
+macos_home_fragment="/""Users/example"
+append_to_contract "${workstation_path_repo}" "Retain ${macos_home_fragment}/support-bundle/raw.log as evidence."
+assert_fails_with \
+  "${workstation_path_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: workstation-local path"
+
+linux_workstation_path_repo="${workdir}/linux-workstation-path"
+create_valid_repo "${linux_workstation_path_repo}"
+linux_home_fragment="/""home/example"
+append_to_contract "${linux_workstation_path_repo}" "Retain ${linux_home_fragment}/support-bundle/raw.log as evidence."
+assert_fails_with \
+  "${linux_workstation_path_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: workstation-local path"
+
+windows_workstation_path_repo="${workdir}/windows-workstation-path"
+create_valid_repo "${windows_workstation_path_repo}"
+windows_home_fragment="D:""\\Users\\example"
+append_to_contract "${windows_workstation_path_repo}" "Retain ${windows_home_fragment}\\support-bundle\\raw.log as evidence."
+assert_fails_with \
+  "${windows_workstation_path_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: workstation-local path"
+
+windows_slash_workstation_path_repo="${workdir}/windows-slash-workstation-path"
+create_valid_repo "${windows_slash_workstation_path_repo}"
+slash="/"
+windows_slash_home_fragment="C:${slash}Users${slash}example"
+append_to_contract "${windows_slash_workstation_path_repo}" "Retain ${windows_slash_home_fragment}/support-bundle/raw.log as evidence."
+assert_fails_with \
+  "${windows_slash_workstation_path_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: workstation-local path"
+
+workflow_truth_repo="${workdir}/workflow-truth"
+create_valid_repo "${workflow_truth_repo}"
+append_to_contract "${workflow_truth_repo}" "Support bundle is workflow truth."
+assert_fails_with \
+  "${workflow_truth_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: support bundle is workflow truth"
+
+private_payload_repo="${workdir}/private-payload"
+create_valid_repo "${private_payload_repo}"
+append_to_contract "${private_payload_repo}" "Raw customer payloads are included by default."
+assert_fails_with \
+  "${private_payload_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: raw customer payloads are included by default"
+
+private_ticket_repo="${workdir}/private-ticket"
+create_valid_repo "${private_ticket_repo}"
+append_to_contract "${private_ticket_repo}" "Private ticket contents are included by default."
+assert_fails_with \
+  "${private_ticket_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: private ticket contents are included by default"
+
+support_operator_repo="${workdir}/support-operator"
+create_valid_repo "${support_operator_repo}"
+append_to_contract "${support_operator_repo}" "Support collaborator is an operator."
+assert_fails_with \
+  "${support_operator_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: support collaborator is an operator"
+
+echo "Phase 58.6 support bundle redaction contract verifier rejects missing coverage, secret-looking values, workstation paths, private payloads, and authority expansion."

--- a/scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh
+++ b/scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh
@@ -127,6 +127,13 @@ assert_fails_with \
   "${authorization_header_repo}" \
   "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value"
 
+basic_authorization_header_repo="${workdir}/basic-authorization-header"
+create_valid_repo "${basic_authorization_header_repo}"
+append_to_contract "${basic_authorization_header_repo}" "Authorization: Basic dXNlcjpwYXNzMTIzNDU2"
+assert_fails_with \
+  "${basic_authorization_header_repo}" \
+  "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value"
+
 credential_url_repo="${workdir}/credential-url"
 create_valid_repo "${credential_url_repo}"
 append_to_contract "${credential_url_repo}" "postgres://support:credentialvalue12345@db.internal/aegisops"

--- a/scripts/verify-phase-58-6-support-bundle-redaction-contract.sh
+++ b/scripts/verify-phase-58-6-support-bundle-redaction-contract.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-58-6-support-bundle-redaction-contract.md"
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 58.6 support bundle redaction contract: ${doc_path}" >&2
+  exit 1
+fi
+
+doc_text="$(<"${doc_path}")"
+
+required_phrases=(
+  "# Phase 58.6 Support Bundle And Redaction Contract"
+  "Phase 58.6 defines the support bundle contract for customer-safe diagnostic"
+  "A support bundle is redacted diagnostic evidence only."
+  "Support bundles cannot approve, execute, reconcile, release, close, restore, or"
+  "replace authoritative AegisOps records."
+  "No remote upload service, background collector, direct database export,"
+  "- Contract verifier: \`bash scripts/verify-phase-58-6-support-bundle-redaction-contract.sh\`."
+  "- Focused verifier regression: \`bash scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh\`."
+  "- Path hygiene: \`bash scripts/verify-publishable-path-hygiene.sh\`."
+  "- Issue lint: \`node <codex-supervisor-root>/dist/index.js issue-lint 1241 --config <supervisor-config-path>\`."
+  "| \`environment_class\` | Reviewed profile, deployment class, or lab class only; no tenant inference from path shape, ticket title, or host name. |"
+  "| \`component_versions\` | AegisOps-owned component and package versions after reviewed redaction; no floating \`latest\` claims as evidence. |"
+  "| \`doctor_summary\` | Phase 58.1 doctor output or summarized health state after redaction; not authoritative workflow or release truth. |"
+  "| \`backup_restore_references\` | Links to Phase 58.3 backup custody evidence and Phase 58.4 restore dry-run evidence; not raw backup payloads. |"
+  "| \`upgrade_rollback_references\` | Links to Phase 58.5 upgrade and rollback planning evidence; not proof of live upgrade or rollback completion. |"
+  "| \`known_limitations\` | Reviewed limitations, non-goals, unsafe states, retained manual steps, and owner references. |"
+  "| \`reproduction_steps\` | Operator-reviewed reproduction steps with customer names, private payloads, tickets, credentials, and workstation paths removed. |"
+  "| \`bounded_metadata\` | Sanitized timestamps, record counts, schema versions, source families, and evidence identifiers directly linked to authoritative records. |"
+  "| \`redaction_manifest\` | Redaction families applied, scan result, retained limitations, and explicit subordinate-evidence boundary. |"
+  "| \`secrets\` | Reject or redact API keys, shared secrets, passwords, private keys, signing keys, bootstrap tokens, session material, and env-secret values. |"
+  "| \`workstation_local_paths\` | Reject or redact macOS, Linux, and Windows user-profile paths; use repo-relative paths, documented env vars, or placeholders. |"
+  "| \`customer_private_raw_payloads\` | Reject raw alerts, raw logs, raw tickets, raw webhook bodies, raw event payloads, and customer-private source payloads by default. |"
+  "| \`ticket_private_content\` | Reject private ticket comments, customer names, customer screenshots, chat excerpts, support notes, and operator-only escalation text. |"
+  "| \`tokens_and_headers\` | Reject authorization headers, cookies, bearer tokens, forwarded headers, raw host or tenant hints, and client-supplied identity fields. |"
+  "| \`cert_material\` | Reject certificates, private keys, CSRs, keystores, truststores, and inline PEM blocks unless replaced with reviewed fingerprints. |"
+  "| \`raw_credentials\` | Reject usernames paired with passwords, connection strings containing credentials, service-account secrets, and placeholder credentials. |"
+  "| \`authority_claims\` | Reject bundle-as-workflow-truth, support-as-operator, support-as-approver, support-as-release-gate, or support-as-restore-truth claims. |"
+  "| \`secret_values\` | Replace secret-looking values with \`[REDACTED:secret]\` and fail closed when the value remains recoverable in output. |"
+  "| \`workstation_paths\` | Replace user-home absolute paths with \`[REDACTED:workstation-path]\`; retain only repo-relative paths or placeholders. |"
+  "| \`private_payloads\` | Summarize payload type, source family, authoritative record link, and bounded counts; do not retain raw payload bodies by default. |"
+  "| \`ticket_private_content\` | Replace private ticket text with \`[REDACTED:ticket-private-content]\` and retain only public ticket identifiers or reviewed references. |"
+  "| \`tokens_and_headers\` | Remove authorization, cookie, forwarded, tenant, host, proto, and user-id headers unless a trusted boundary normalized them first. |"
+  "| \`certs_and_keys\` | Replace cert and key material with reviewed fingerprints, expiry metadata, issuer class, or custody references. |"
+  "| \`credentials\` | Remove usernames paired with passwords, credential-bearing URLs, DSNs, and placeholder credentials from retained output. |"
+  "| \`customer_identifiers\` | Replace customer names, tenant names, account names, private host names, email addresses, and screenshots with reviewed placeholders. |"
+  "| \`secret_leakage\` | Bundle output contains secret-looking values, tokens, auth headers, cookies, private keys, cert material, credential-bearing DSNs, or placeholder credentials. | Reject the bundle before retention or sharing. |"
+  "| \`workstation_path_leakage\` | Bundle output contains macOS, Linux, or Windows workstation-local user-profile paths. | Reject the bundle and require repo-relative paths, env vars, or placeholders. |"
+  "| \`private_payload_leakage\` | Bundle output contains raw customer payloads, raw logs, raw tickets, raw webhook bodies, screenshots, or private support notes. | Reject the bundle and retain bounded summaries only. |"
+  "| \`authority_expansion\` | Bundle output is presented as workflow, release, gate, restore, audit, closeout, approval, execution, reconciliation, or operator truth. | Reject the bundle and preserve authoritative AegisOps record-chain truth. |"
+  "| \`support_operator_expansion\` | Support collaborator access is treated as operator, approver, administrator, substrate operator, or direct backend authority. | Reject the bundle and require a reviewed authority contract. |"
+  "| \`missing_redaction_manifest\` | Redaction families, scan result, subordinate boundary, or retained limitations are absent. | Reject the bundle until the manifest is complete. |"
+  "| \`mixed_snapshot_bundle\` | Bundle assembles records from different committed snapshots without detecting or rejecting mixed-state evidence. | Reject the bundle before retention or sharing. |"
+  "Support bundles are subordinate diagnostic evidence."
+  "Support bundle validation cannot approve remediation, execute actions, reconcile"
+  "When provenance, record linkage, snapshot consistency, redaction status,"
+  "A retained support bundle must include a redaction manifest, scan result,"
+  "secret-looking value scanning, workstation-local path scanning,"
+  "- secret leakage;"
+  "- workstation-local path leakage;"
+  "- customer-private raw payload leakage;"
+  "- ticket-private content leakage;"
+  "- token and header leakage;"
+  "- cert material leakage;"
+  "- raw credential leakage;"
+  "- missing redaction manifest;"
+  "- support bundle as workflow, release, gate, restore, audit, or closeout truth;"
+  "- support operator authority expansion;"
+  "- mixed-snapshot bundle claims."
+  "Phase 58.6 does not implement remote support upload, support portal workflow,"
+  "support bundle output as authoritative workflow truth."
+  "- \`bash scripts/verify-phase-58-6-support-bundle-redaction-contract.sh\`"
+  "- \`bash scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh\`"
+  "- \`bash scripts/verify-publishable-path-hygiene.sh\`"
+  "- \`node <codex-supervisor-root>/dist/index.js issue-lint 1241 --config <supervisor-config-path>\`"
+)
+
+for phrase in "${required_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" <<<"${doc_text}"; then
+    echo "Missing Phase 58.6 support bundle redaction contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+for forbidden in \
+  "support bundle is workflow truth" \
+  "support bundle is release truth" \
+  "support bundle is gate truth" \
+  "support bundle is restore truth" \
+  "support bundle is audit truth" \
+  "support bundle is closeout truth" \
+  "support bundle output is authoritative workflow truth" \
+  "support collaborator is an operator" \
+  "support collaborator can approve actions" \
+  "support collaborator can execute actions" \
+  "support collaborator can reconcile actions" \
+  "support collaborator can close cases" \
+  "raw customer payloads are included by default" \
+  "private ticket contents are included by default" \
+  "authorization headers are retained" \
+  "cert material is retained" \
+  "raw credentials are retained" \
+  "remote support upload is implemented" \
+  "support portal workflow is implemented" \
+  "direct backend access for support is implemented"; do
+  if grep -Fqi -- "${forbidden}" <<<"${doc_text}"; then
+    echo "Forbidden Phase 58.6 support bundle redaction contract claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+local_path_prefix="(^|[[:space:]\`\"'(<])"
+unix_home_pattern="${local_path_prefix}/(Users|home)/"
+windows_home_pattern="${local_path_prefix}[A-Za-z]:[\\\\/][Uu][Ss][Ee][Rr][Ss][\\\\/]"
+
+if grep -Eq "${unix_home_pattern}|${windows_home_pattern}" <<<"${doc_text}"; then
+  echo "Forbidden Phase 58.6 support bundle redaction contract claim: workstation-local path" >&2
+  exit 1
+fi
+
+if DOC_TEXT="${doc_text}" python3 - <<'PY'
+import os
+import re
+import sys
+
+text = os.environ["DOC_TEXT"]
+patterns = (
+    re.compile(r"(?i)\bauthorization\s*:\s*bearer\s+[A-Za-z0-9_+./=-]{12,}"),
+    re.compile(
+        r"""(?ix)
+        (
+            authorization|bearer|cookie|password|passwd|secret|
+            api[_ -]?key|token|private[_ -]?key|client[_ -]?secret
+        )
+        \s*[:=]\s*
+        ["']?[A-Za-z0-9_+./=-]{12,}
+        """
+    ),
+    re.compile(r"[a-zA-Z][a-zA-Z0-9+.-]*://[^\s/:@]+:[^\s@]+@"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(r"-----BEGIN CERTIFICATE-----"),
+)
+
+sys.exit(0 if any(pattern.search(text) for pattern in patterns) else 1)
+PY
+then
+  echo "Forbidden Phase 58.6 support bundle redaction contract claim: secret-looking value" >&2
+  exit 1
+fi
+
+echo "Phase 58.6 support bundle redaction contract defines allowed contents, forbidden contents, redaction families, and subordinate authority boundaries."

--- a/scripts/verify-phase-58-6-support-bundle-redaction-contract.sh
+++ b/scripts/verify-phase-58-6-support-bundle-redaction-contract.sh
@@ -129,7 +129,7 @@ import sys
 
 text = os.environ["DOC_TEXT"]
 patterns = (
-    re.compile(r"(?i)\bauthorization\s*:\s*bearer\s+[A-Za-z0-9_+./=-]{12,}"),
+    re.compile(r"(?i)\bauthorization\s*:\s*(?:bearer|basic)\s+[A-Za-z0-9_+./=-]{12,}"),
     re.compile(
         r"""(?ix)
         (

--- a/scripts/verify-phase-58-6-support-bundle-redaction-contract.sh
+++ b/scripts/verify-phase-58-6-support-bundle-redaction-contract.sh
@@ -116,8 +116,9 @@ done
 local_path_prefix="(^|[[:space:]\`\"'(<])"
 unix_home_pattern="${local_path_prefix}/(Users|home)/"
 windows_home_pattern="${local_path_prefix}[A-Za-z]:[\\\\/][Uu][Ss][Ee][Rr][Ss][\\\\/]"
+file_uri_home_pattern="file://([^[:space:]\`\"'()<>]*/)?(Users|home)/"
 
-if grep -Eq "${unix_home_pattern}|${windows_home_pattern}" <<<"${doc_text}"; then
+if grep -Eiq "${unix_home_pattern}|${windows_home_pattern}|${file_uri_home_pattern}" <<<"${doc_text}"; then
   echo "Forbidden Phase 58.6 support bundle redaction contract claim: workstation-local path" >&2
   exit 1
 fi
@@ -137,7 +138,7 @@ patterns = (
             api[_ -]?key|token|private[_ -]?key|client[_ -]?secret
         )
         \s*[:=]\s*
-        ["']?[A-Za-z0-9_+./=-]{12,}
+        ["']?[A-Za-z0-9_+./=-]{4,}
         """
     ),
     re.compile(r"[a-zA-Z][a-zA-Z0-9+.-]*://[^\s/:@]+:[^\s@]+@"),


### PR DESCRIPTION
Refs #1241

## Summary
- Add the Phase 58.6 support bundle and redaction contract with allowed and forbidden bundle contents.
- Define fail-closed redaction families for secrets, workstation-local paths, private payloads, private tickets, tokens, headers, cert material, credentials, and authority expansion.
- Add focused verifier coverage and negative fixtures for missing contract coverage, secret-looking values, workstation-local paths, private payloads, private ticket content, and support operator expansion.

## Verification
- `bash scripts/verify-phase-58-6-support-bundle-redaction-contract.sh`
- `bash scripts/test-verify-phase-58-6-support-bundle-redaction-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `git diff --cached --check`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1241 --config <supervisor-config-path>`