### PR TITLE
59.1: Add AI agent registry contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Canonical cross-phase boundary reference:
 - [Phase 56.8 closeout evaluation](docs/phase-56-closeout-evaluation.md) records the Daily SOC Workbench outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 57/58/59/60/66 handoff.
 - [Phase 57.8 closeout evaluation](docs/phase-57-closeout-evaluation.md) records the commercial administration MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 58/59/60/66 handoff.
 - [Phase 58.8 closeout evaluation](docs/phase-58-closeout-evaluation.md) records the supportability MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 59/60/66 handoff.
+- [Phase 59.1 agent registry contract](docs/phase-59-1-agent-registry-contract.md) defines the required AI agent registry fields, citation requirements, disallowed authority, and advisory-only authority ceiling.
 - [Phase 58.5 upgrade and rollback plan contract](docs/phase-58-5-upgrade-rollback-plan-contract.md) defines reviewed upgrade-plan and rollback-plan evidence fields, failure states, and authority boundaries without implementing live upgrade or rollback execution.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
@@ -142,6 +143,8 @@ The Phase 56.8 closeout evaluation is defined by the [Phase 56.8 closeout evalua
 The Phase 57.8 closeout evaluation is defined by the [Phase 57.8 closeout evaluation](docs/phase-57-closeout-evaluation.md).
 
 The Phase 58.8 closeout evaluation is defined by the [Phase 58.8 closeout evaluation](docs/phase-58-closeout-evaluation.md).
+
+The Phase 59.1 agent registry contract is defined by the [Phase 59.1 agent registry contract](docs/phase-59-1-agent-registry-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/control-plane/aegisops/control_plane/publishable_paths.py
+++ b/control-plane/aegisops/control_plane/publishable_paths.py
@@ -10,7 +10,9 @@ ALLOWLIST_MARKER = "publishable-path-hygiene: allowlist"
 _MAC_HOME_PREFIX = "/" + "Users" + "/"
 
 _WINDOWS_USER_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]+Users[\\/]+[^\\/]+(?:[\\/](?P<rest>.*))?$")
-_UNIX_USER_PATH_IN_TEXT_RE = re.compile(r"/(?:Users|home)/[^/\s]+(?:/[^\s]*)?")
+_UNIX_USER_PATH_IN_TEXT_RE = re.compile(
+    r"(?:/(?:Users|home)/[^/\s]+(?:/[^\s]*)?|/root/[^\s]*)"
+)
 _WINDOWS_USER_PATH_IN_TEXT_RE = re.compile(
     r"(?i)[A-Z]:[\\/]+Users[\\/]+[^\\/\s]+(?:[\\/][^\s]*)?"
 )
@@ -37,18 +39,24 @@ def _has_windows_drive_prefix(text: str, start: int) -> bool:
 
 
 def is_workstation_local_path(text: str) -> bool:
-    for match in _WINDOWS_USER_PATH_IN_TEXT_RE.finditer(text):
-        if _has_text_path_boundary(text, match.start()):
-            return True
+    candidates = [text]
+    json_unescaped_slashes = text.replace(r"\/", "/")
+    if json_unescaped_slashes != text:
+        candidates.append(json_unescaped_slashes)
 
-    for match in _UNIX_USER_PATH_IN_TEXT_RE.finditer(text):
-        if not _has_text_path_boundary(text, match.start()):
-            continue
-        if match.group(0).startswith(_MAC_HOME_PREFIX) and _has_windows_drive_prefix(
-            text, match.start()
-        ):
-            continue
-        return True
+    for candidate in candidates:
+        for match in _WINDOWS_USER_PATH_IN_TEXT_RE.finditer(candidate):
+            if _has_text_path_boundary(candidate, match.start()):
+                return True
+
+        for match in _UNIX_USER_PATH_IN_TEXT_RE.finditer(candidate):
+            if not _has_text_path_boundary(candidate, match.start()):
+                continue
+            if match.group(0).startswith(
+                _MAC_HOME_PREFIX
+            ) and _has_windows_drive_prefix(candidate, match.start()):
+                continue
+            return True
 
     return False
 

--- a/control-plane/tests/test_publishable_path_hygiene.py
+++ b/control-plane/tests/test_publishable_path_hygiene.py
@@ -22,17 +22,43 @@ UNIX_HOME_PATH = "/home/alice/project/docs"  # publishable-path-hygiene: allowli
 WINDOWS_USERS_PATH = r"C:\Users\alice\project\docs"  # publishable-path-hygiene: allowlist
 WINDOWS_USERS_PATH_POSIX = "C:/Users/alice/project/docs"  # publishable-path-hygiene: allowlist
 OFFENDER_PATH = "/Users/alice/private/project"  # publishable-path-hygiene: allowlist
+ROOT_PATH = "/root/private/project"  # publishable-path-hygiene: allowlist
 
 
 class PublishablePathHygieneTests(unittest.TestCase):
     def test_detects_unix_and_windows_workstation_paths_in_text(self) -> None:
+        escaped_slash = r"\/"
         self.assertTrue(is_workstation_local_path(UNIX_USERS_PATH))
         self.assertTrue(is_workstation_local_path(f"see {UNIX_HOME_PATH} for details"))
         self.assertTrue(is_workstation_local_path(f"path:{UNIX_HOME_PATH}"))
         self.assertTrue(is_workstation_local_path(f"path:{UNIX_USERS_PATH}"))
+        self.assertTrue(is_workstation_local_path(f"path:{ROOT_PATH}"))
         self.assertTrue(is_workstation_local_path(WINDOWS_USERS_PATH))
         self.assertTrue(is_workstation_local_path(f"path={WINDOWS_USERS_PATH_POSIX}"))
         self.assertTrue(is_workstation_local_path(f"path:{WINDOWS_USERS_PATH_POSIX}"))
+        self.assertTrue(
+            is_workstation_local_path(
+                f"path:{escaped_slash}Users{escaped_slash}alice"
+                f"{escaped_slash}project{escaped_slash}docs"
+            )
+        )
+        self.assertTrue(
+            is_workstation_local_path(
+                f"path:{escaped_slash}home{escaped_slash}alice"
+                f"{escaped_slash}project{escaped_slash}docs"
+            )
+        )
+        self.assertTrue(
+            is_workstation_local_path(
+                f"path:{escaped_slash}root{escaped_slash}private{escaped_slash}docs"
+            )
+        )
+        self.assertTrue(
+            is_workstation_local_path(
+                f"path=C:{escaped_slash}Users{escaped_slash}alice"
+                f"{escaped_slash}project{escaped_slash}docs"
+            )
+        )
 
     def test_ignores_urls_and_non_user_windows_paths(self) -> None:
         self.assertFalse(

--- a/docs/automation/ai-agent-registry.json
+++ b/docs/automation/ai-agent-registry.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": "2026-05-11.phase-59.1",
+  "phase": "59.1",
+  "registry_status": "accepted_contract_slice",
+  "authority_boundary": "AI registry rows are subordinate policy context only. AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.",
+  "agents": [
+    {
+      "agent_name": "analyst_assistant_context_agent",
+      "purpose": "Assemble cited read-only context for one reviewed AegisOps control-plane record so an operator can inspect linked alert, case, evidence, recommendation, action, receipt, and reconciliation context.",
+      "allowed_tools": [
+        "inspect_assistant_context",
+        "read_reviewed_control_plane_records",
+        "assemble_cited_context",
+        "identify_evidence_gaps"
+      ],
+      "disallowed_tools": [
+        "approve_action",
+        "execute_action",
+        "reconcile_execution",
+        "close_case",
+        "activate_detector",
+        "create_source_truth",
+        "bypass_policy"
+      ],
+      "record_families": [
+        "alert",
+        "case",
+        "evidence",
+        "recommendation",
+        "action_request",
+        "approval_decision",
+        "action_execution",
+        "reconciliation",
+        "ai_trace"
+      ],
+      "citation_requirements": [
+        "record_family must identify the directly linked AegisOps record family",
+        "record_id must identify the directly linked AegisOps record",
+        "evidence_reference must identify the reviewed evidence or explicit evidence gap"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    },
+    {
+      "agent_name": "live_assistant_summary_agent",
+      "purpose": "Draft a bounded cited summary from reviewed control-plane context while preserving unresolved questions when evidence is missing, stale, conflicting, or untrusted.",
+      "allowed_tools": [
+        "run_live_assistant_workflow",
+        "draft_cited_summary",
+        "surface_unresolved_questions",
+        "record_ai_trace_context"
+      ],
+      "disallowed_tools": [
+        "approve_action",
+        "execute_action",
+        "reconcile_execution",
+        "close_case",
+        "activate_detector",
+        "create_source_truth",
+        "bypass_policy"
+      ],
+      "record_families": [
+        "alert",
+        "case",
+        "evidence",
+        "recommendation",
+        "ai_trace"
+      ],
+      "citation_requirements": [
+        "record_family must identify the reviewed AegisOps record family behind each summary claim",
+        "record_id must identify the reviewed AegisOps record behind each summary claim",
+        "evidence_reference must identify reviewed linked evidence, refused evidence, or an explicit gap"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    },
+    {
+      "agent_name": "advisory_action_request_drafting_agent",
+      "purpose": "Prepare reviewable action-request draft text from cited advisory context without approving, dispatching, or treating the draft as action truth.",
+      "allowed_tools": [
+        "render_recommendation_draft",
+        "prepare_reviewable_action_request_draft",
+        "cite_advisory_context",
+        "surface_required_human_review"
+      ],
+      "disallowed_tools": [
+        "approve_action",
+        "execute_action",
+        "reconcile_execution",
+        "close_case",
+        "activate_detector",
+        "create_source_truth",
+        "bypass_policy"
+      ],
+      "record_families": [
+        "case",
+        "evidence",
+        "recommendation",
+        "action_request",
+        "approval_decision",
+        "ai_trace"
+      ],
+      "citation_requirements": [
+        "record_family must identify the case, recommendation, evidence, or action-request family being drafted from",
+        "record_id must identify the directly linked reviewed record used by the draft",
+        "evidence_reference must identify the reviewed evidence, limitation, or missing-evidence prerequisite"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    },
+    {
+      "agent_name": "today_focus_advisory_agent",
+      "purpose": "Suggest advisory focus lanes for daily workbench projection from directly linked backend records without making the projection current, terminal, approval, execution, or reconciliation truth.",
+      "allowed_tools": [
+        "inspect_today_projection",
+        "draft_focus_lane_summary",
+        "identify_stale_or_degraded_sources",
+        "cite_direct_backend_record"
+      ],
+      "disallowed_tools": [
+        "approve_action",
+        "execute_action",
+        "reconcile_execution",
+        "close_case",
+        "activate_detector",
+        "create_source_truth",
+        "bypass_policy"
+      ],
+      "record_families": [
+        "alert",
+        "case",
+        "evidence",
+        "recommendation",
+        "approval_decision",
+        "action_execution",
+        "reconciliation",
+        "source_health"
+      ],
+      "citation_requirements": [
+        "record_family must identify the directly linked backend record family behind a focus lane",
+        "record_id must identify the directly linked backend record behind a focus lane",
+        "evidence_reference must identify linked evidence, degraded-source evidence, or explicit missing evidence"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    }
+  ]
+}

--- a/docs/phase-59-1-agent-registry-contract.md
+++ b/docs/phase-59-1-agent-registry-contract.md
@@ -1,0 +1,75 @@
+# Phase 59.1 Agent Registry Contract
+
+- **Status**: Accepted registry contract slice
+- **Date**: 2026-05-11
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1252, #1253
+
+This contract defines the required registry fields for every AegisOps AI agent before Phase 59 expands tool registry, trace lifecycle, disabled or degraded mode, prompt fixtures, stale or conflicting evidence fixtures, trace queue, or closeout work.
+
+It is limited to the Phase 59.1 registry contract. It does not implement new model routing, provider selection, tool execution, trace queue behavior, disabled-mode behavior, daily AI operations, approval, execution, reconciliation, case closure, detector activation, source truth, production write authority, or commercial-readiness claims.
+
+## 1. Required Registry Fields
+
+Every registry row must include agent name, purpose, allowed tools, disallowed tools, record families, citation requirements, and authority ceiling.
+
+The executable registry lives in `docs/automation/ai-agent-registry.json`.
+
+The registry is a repo-owned policy artifact. It is not runtime truth, workflow truth, approval truth, execution truth, reconciliation truth, release truth, gate truth, or source truth.
+
+## 2. Authority Boundary
+
+AI remains advisory, registered, audited, cited, and subordinate to reviewed AegisOps records.
+
+No agent registry row may grant approval, execution, reconciliation, case-closure, detector-activation, source-truth, production write, policy-bypass, or authority-widening capability.
+
+Allowed tools are limited to read-only inspection, cited context assembly, advisory summary drafting, evidence-gap identification, safe next-step drafting, and reviewable action-request draft preparation inside existing reviewed AegisOps record boundaries.
+
+Disallowed tools must explicitly include approval, execution, reconciliation, case closure, detector activation, source-truth creation, and policy bypass.
+
+This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md` for AI approval, execution, reconciliation, case closure, detector activation, and source-truth refusal.
+
+## 3. Registered Agents
+
+The initial registry covers the AI surfaces already present in the reviewed product path:
+
+| Agent | Purpose | Authority ceiling |
+| --- | --- | --- |
+| `analyst_assistant_context_agent` | Assemble cited context for one reviewed control-plane record. | Advisory only, subordinate to AegisOps records. |
+| `live_assistant_summary_agent` | Draft a bounded cited summary from reviewed context. | Advisory only, subordinate to AegisOps records. |
+| `advisory_action_request_drafting_agent` | Prepare reviewable action-request draft text from cited advisory context. | Advisory only, subordinate to AegisOps records. |
+| `today_focus_advisory_agent` | Suggest focus lanes for daily workbench projection from directly linked backend records. | Advisory only, subordinate to AegisOps records. |
+
+These names identify contract rows, not autonomous actors with independent authority.
+
+## 4. Verifier Requirements
+
+The registry verifier must fail when:
+
+- the contract doc is missing;
+- the registry artifact is missing or invalid JSON;
+- any registry row is missing agent name, purpose, allowed tools, disallowed tools, record families, citation requirements, or authority ceiling;
+- any registry row grants approval, execution, reconciliation, case-closure, detector-activation, source-truth, production write, policy-bypass, or authority-widening capability;
+- any registry row omits citation requirements for `record_family`, `record_id`, or `evidence_reference`;
+- any registry row omits disallowed approval, execution, reconciliation, case closure, detector activation, source-truth creation, or policy-bypass tools;
+- publishable artifacts contain workstation-local absolute paths.
+
+## 5. Validation
+
+Run `bash scripts/verify-phase-59-1-agent-registry-contract.sh`.
+
+Run `bash scripts/test-verify-phase-59-1-agent-registry-contract.sh`.
+
+Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1253 --config <supervisor-config-path>`.
+
+## 6. Non-Goals
+
+- No new production write authority is introduced.
+- No AI output, trace state, citation, registry row, verifier output, issue-lint output, browser state, UI state, demo data, Wazuh state, Shuffle state, ticket state, optional evidence, or prompt text becomes authoritative workflow truth.
+- No Phase 60 daily AI operations behavior is implemented.
+- No model/provider selection, billing, prompt marketplace, tool marketplace, or agent ecosystem breadth is implemented.
+- No approval, execution, reconciliation, case closure, detector activation, source-truth creation, or policy bypass is delegated to AI.

--- a/scripts/test-verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/test-verify-phase-59-1-agent-registry-contract.sh
@@ -81,6 +81,8 @@ elif mutation == "allowed_execution_tool":
     registry["agents"][0]["allowed_tools"].append("execute_action")
 elif mutation == "allowed_policy_bypass_tool":
     registry["agents"][0]["allowed_tools"].append("policy-bypass")
+elif mutation == "allowed_policy_bypass_phrase_tool":
+    registry["agents"][0]["allowed_tools"].append("policy bypass")
 elif mutation == "missing_disallowed_execution":
     registry["agents"][0]["disallowed_tools"].remove("execute_action")
 elif mutation == "missing_record_id_citation":
@@ -196,6 +198,13 @@ mutate_registry "${allowed_policy_bypass_repo}" "allowed_policy_bypass_tool"
 assert_fails_with \
   "${allowed_policy_bypass_repo}" \
   "has forbidden allowed tool: policy-bypass"
+
+allowed_policy_bypass_phrase_repo="${workdir}/allowed-policy-bypass-phrase"
+create_valid_repo "${allowed_policy_bypass_phrase_repo}"
+mutate_registry "${allowed_policy_bypass_phrase_repo}" "allowed_policy_bypass_phrase_tool"
+assert_fails_with \
+  "${allowed_policy_bypass_phrase_repo}" \
+  "has forbidden allowed tool: policy bypass"
 
 missing_disallowed_repo="${workdir}/missing-disallowed-execution"
 create_valid_repo "${missing_disallowed_repo}"

--- a/scripts/test-verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/test-verify-phase-59-1-agent-registry-contract.sh
@@ -81,6 +81,8 @@ elif mutation == "allowed_execution_tool":
     registry["agents"][0]["allowed_tools"].append("execute_action")
 elif mutation == "allowed_policy_bypass_tool":
     registry["agents"][0]["allowed_tools"].append("policy-bypass")
+elif mutation == "allowed_policy_bypass_underscore_tool":
+    registry["agents"][0]["allowed_tools"].append("policy_bypass")
 elif mutation == "allowed_policy_bypass_phrase_tool":
     registry["agents"][0]["allowed_tools"].append("policy bypass")
 elif mutation == "missing_disallowed_execution":
@@ -198,6 +200,13 @@ mutate_registry "${allowed_policy_bypass_repo}" "allowed_policy_bypass_tool"
 assert_fails_with \
   "${allowed_policy_bypass_repo}" \
   "has forbidden allowed tool: policy-bypass"
+
+allowed_policy_bypass_underscore_repo="${workdir}/allowed-policy-bypass-underscore"
+create_valid_repo "${allowed_policy_bypass_underscore_repo}"
+mutate_registry "${allowed_policy_bypass_underscore_repo}" "allowed_policy_bypass_underscore_tool"
+assert_fails_with \
+  "${allowed_policy_bypass_underscore_repo}" \
+  "has forbidden allowed tool: policy_bypass"
 
 allowed_policy_bypass_phrase_repo="${workdir}/allowed-policy-bypass-phrase"
 create_valid_repo "${allowed_policy_bypass_phrase_repo}"

--- a/scripts/test-verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/test-verify-phase-59-1-agent-registry-contract.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-59-1-agent-registry-contract.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/automation"
+  printf '%s\n' \
+    "# AegisOps" \
+    "See [Phase 59.1 agent registry contract](docs/phase-59-1-agent-registry-contract.md)." \
+    >"${target}/README.md"
+  cp "${repo_root}/docs/phase-59-1-agent-registry-contract.md" \
+    "${target}/docs/phase-59-1-agent-registry-contract.md"
+  cp "${repo_root}/docs/automation/ai-agent-registry.json" \
+    "${target}/docs/automation/ai-agent-registry.json"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+mutate_registry() {
+  local target="$1"
+  local mutation="$2"
+
+  python3 - "${target}/docs/automation/ai-agent-registry.json" "${mutation}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+mutation = sys.argv[2]
+registry = json.loads(path.read_text(encoding="utf-8"))
+
+if mutation == "missing_authority_ceiling":
+    registry["agents"][0].pop("authority_ceiling", None)
+elif mutation == "missing_citation_requirements":
+    registry["agents"][0].pop("citation_requirements", None)
+elif mutation == "authority_expansion":
+    registry["agents"][0]["authority_ceiling"] = "may_approve_actions"
+elif mutation == "allowed_execution_tool":
+    registry["agents"][0]["allowed_tools"].append("execute_action")
+elif mutation == "missing_disallowed_execution":
+    registry["agents"][0]["disallowed_tools"].remove("execute_action")
+elif mutation == "missing_record_id_citation":
+    registry["agents"][0]["citation_requirements"] = [
+        value for value in registry["agents"][0]["citation_requirements"]
+        if "record_id" not in value
+    ]
+else:
+    raise SystemExit(f"unknown mutation: {mutation}")
+
+path.write_text(json.dumps(registry, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+PY
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-59-1-agent-registry-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-59-1-agent-registry-contract.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 59.1 agent registry contract doc"
+
+missing_registry_repo="${workdir}/missing-registry"
+create_valid_repo "${missing_registry_repo}"
+rm "${missing_registry_repo}/docs/automation/ai-agent-registry.json"
+assert_fails_with \
+  "${missing_registry_repo}" \
+  "Missing Phase 59.1 AI agent registry"
+
+missing_contract_field_repo="${workdir}/missing-contract-field"
+create_valid_repo "${missing_contract_field_repo}"
+remove_text_from_doc "${missing_contract_field_repo}" \
+  "Every registry row must include agent name, purpose, allowed tools, disallowed tools, record families, citation requirements, and authority ceiling."
+assert_fails_with \
+  "${missing_contract_field_repo}" \
+  "Missing Phase 59.1 agent registry contract statement: Every registry row must include agent name"
+
+missing_authority_repo="${workdir}/missing-authority"
+create_valid_repo "${missing_authority_repo}"
+mutate_registry "${missing_authority_repo}" "missing_authority_ceiling"
+assert_fails_with \
+  "${missing_authority_repo}" \
+  "is missing field(s): authority_ceiling"
+
+missing_citations_repo="${workdir}/missing-citations"
+create_valid_repo "${missing_citations_repo}"
+mutate_registry "${missing_citations_repo}" "missing_citation_requirements"
+assert_fails_with \
+  "${missing_citations_repo}" \
+  "is missing field(s): citation_requirements"
+
+authority_expansion_repo="${workdir}/authority-expansion"
+create_valid_repo "${authority_expansion_repo}"
+mutate_registry "${authority_expansion_repo}" "authority_expansion"
+assert_fails_with \
+  "${authority_expansion_repo}" \
+  "must keep the advisory-only authority ceiling"
+
+allowed_execution_repo="${workdir}/allowed-execution"
+create_valid_repo "${allowed_execution_repo}"
+mutate_registry "${allowed_execution_repo}" "allowed_execution_tool"
+assert_fails_with \
+  "${allowed_execution_repo}" \
+  "has forbidden allowed tool: execute_action"
+
+missing_disallowed_repo="${workdir}/missing-disallowed-execution"
+create_valid_repo "${missing_disallowed_repo}"
+mutate_registry "${missing_disallowed_repo}" "missing_disallowed_execution"
+assert_fails_with \
+  "${missing_disallowed_repo}" \
+  "is missing disallowed tool(s): execute_action"
+
+missing_record_id_repo="${workdir}/missing-record-id-citation"
+create_valid_repo "${missing_record_id_repo}"
+mutate_registry "${missing_record_id_repo}" "missing_record_id_citation"
+assert_fails_with \
+  "${missing_record_id_repo}" \
+  "citation requirements must include record_id"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf '/%s/%s/%s\n' "Users" "example" "private.txt" \
+  >>"${local_path_repo}/docs/phase-59-1-agent-registry-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "workstation-local absolute path detected"
+
+echo "Phase 59.1 agent registry verifier rejects missing fields, authority expansion, missing citations, unsafe tools, and local paths."

--- a/scripts/test-verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/test-verify-phase-59-1-agent-registry-contract.sh
@@ -17,6 +17,9 @@ create_valid_repo() {
   local target="$1"
 
   mkdir -p "${target}/docs/automation"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
   printf '%s\n' \
     "# AegisOps" \
     "See [Phase 59.1 agent registry contract](docs/phase-59-1-agent-registry-contract.md)." \
@@ -25,6 +28,8 @@ create_valid_repo() {
     "${target}/docs/phase-59-1-agent-registry-contract.md"
   cp "${repo_root}/docs/automation/ai-agent-registry.json" \
     "${target}/docs/automation/ai-agent-registry.json"
+  git -C "${target}" add README.md docs/phase-59-1-agent-registry-contract.md \
+    docs/automation/ai-agent-registry.json
 }
 
 assert_passes() {
@@ -74,6 +79,8 @@ elif mutation == "authority_expansion":
     registry["agents"][0]["authority_ceiling"] = "may_approve_actions"
 elif mutation == "allowed_execution_tool":
     registry["agents"][0]["allowed_tools"].append("execute_action")
+elif mutation == "allowed_policy_bypass_tool":
+    registry["agents"][0]["allowed_tools"].append("policy-bypass")
 elif mutation == "missing_disallowed_execution":
     registry["agents"][0]["disallowed_tools"].remove("execute_action")
 elif mutation == "missing_record_id_citation":
@@ -96,10 +103,28 @@ elif mutation == "json_escaped_windows_path":
     registry["agents"][0]["purpose"] += (
         " See C:" + slash + "Users" + slash + "example" + slash + "private.txt."
     )
+elif mutation == "json_escaped_unix_path":
+    registry["agents"][0]["purpose"] += " See /" + "Users/example/private.txt."
+elif mutation == "json_escaped_windows_slash_path":
+    registry["agents"][0]["purpose"] += " See C:/" + "Users/example/private.txt."
 else:
     raise SystemExit(f"unknown mutation: {mutation}")
 
-path.write_text(json.dumps(registry, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+output = json.dumps(registry, indent=2, sort_keys=False) + "\n"
+if mutation == "json_escaped_unix_path":
+    escaped_slash = "\\/"
+    output = output.replace(
+        "/" + "Users/example/private.txt",
+        escaped_slash + "Users" + escaped_slash + "example" + escaped_slash + "private.txt",
+    )
+elif mutation == "json_escaped_windows_slash_path":
+    escaped_slash = "\\/"
+    output = output.replace(
+        "C:/" + "Users/example/private.txt",
+        "C:" + escaped_slash + "Users" + escaped_slash + "example" + escaped_slash + "private.txt",
+    )
+
+path.write_text(output, encoding="utf-8")
 PY
 }
 
@@ -165,6 +190,13 @@ assert_fails_with \
   "${allowed_execution_repo}" \
   "has forbidden allowed tool: execute_action"
 
+allowed_policy_bypass_repo="${workdir}/allowed-policy-bypass"
+create_valid_repo "${allowed_policy_bypass_repo}"
+mutate_registry "${allowed_policy_bypass_repo}" "allowed_policy_bypass_tool"
+assert_fails_with \
+  "${allowed_policy_bypass_repo}" \
+  "has forbidden allowed tool: policy-bypass"
+
 missing_disallowed_repo="${workdir}/missing-disallowed-execution"
 create_valid_repo "${missing_disallowed_repo}"
 mutate_registry "${missing_disallowed_repo}" "missing_disallowed_execution"
@@ -222,6 +254,38 @@ create_valid_repo "${json_escaped_windows_path_repo}"
 mutate_registry "${json_escaped_windows_path_repo}" "json_escaped_windows_path"
 assert_fails_with \
   "${json_escaped_windows_path_repo}" \
+  "workstation-local absolute path detected"
+
+json_escaped_unix_path_repo="${workdir}/json-escaped-unix-path"
+create_valid_repo "${json_escaped_unix_path_repo}"
+mutate_registry "${json_escaped_unix_path_repo}" "json_escaped_unix_path"
+assert_fails_with \
+  "${json_escaped_unix_path_repo}" \
+  "workstation-local absolute path detected"
+
+json_escaped_windows_slash_path_repo="${workdir}/json-escaped-windows-slash-path"
+create_valid_repo "${json_escaped_windows_slash_path_repo}"
+mutate_registry "${json_escaped_windows_slash_path_repo}" "json_escaped_windows_slash_path"
+assert_fails_with \
+  "${json_escaped_windows_slash_path_repo}" \
+  "workstation-local absolute path detected"
+
+colon_boundary_path_repo="${workdir}/colon-boundary-path"
+create_valid_repo "${colon_boundary_path_repo}"
+printf 'path:/%s/%s/%s\n' "Users" "example" "private.txt" \
+  >>"${colon_boundary_path_repo}/docs/phase-59-1-agent-registry-contract.md"
+assert_fails_with \
+  "${colon_boundary_path_repo}" \
+  "workstation-local absolute path detected"
+
+publishable_surface_path_repo="${workdir}/publishable-surface-path"
+create_valid_repo "${publishable_surface_path_repo}"
+mkdir -p "${publishable_surface_path_repo}/scripts"
+printf 'echo /%s/%s/%s\n' "Users" "example" "private.txt" \
+  >"${publishable_surface_path_repo}/scripts/phase-59-1-leaky.sh"
+git -C "${publishable_surface_path_repo}" add scripts/phase-59-1-leaky.sh
+assert_fails_with \
+  "${publishable_surface_path_repo}" \
   "workstation-local absolute path detected"
 
 echo "Phase 59.1 agent registry verifier rejects missing fields, authority expansion, missing citations, unsafe tools, and local paths."

--- a/scripts/test-verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/test-verify-phase-59-1-agent-registry-contract.sh
@@ -81,6 +81,21 @@ elif mutation == "missing_record_id_citation":
         value for value in registry["agents"][0]["citation_requirements"]
         if "record_id" not in value
     ]
+elif mutation == "missing_required_agent":
+    registry["agents"] = [
+        agent
+        for agent in registry["agents"]
+        if agent["agent_name"] != "today_focus_advisory_agent"
+    ]
+elif mutation == "unexpected_agent":
+    extra_agent = dict(registry["agents"][0])
+    extra_agent["agent_name"] = "phase_60_daily_operations_agent"
+    registry["agents"].append(extra_agent)
+elif mutation == "json_escaped_windows_path":
+    slash = chr(92)
+    registry["agents"][0]["purpose"] += (
+        " See C:" + slash + "Users" + slash + "example" + slash + "private.txt."
+    )
 else:
     raise SystemExit(f"unknown mutation: {mutation}")
 
@@ -164,12 +179,49 @@ assert_fails_with \
   "${missing_record_id_repo}" \
   "citation requirements must include record_id"
 
+missing_required_agent_repo="${workdir}/missing-required-agent"
+create_valid_repo "${missing_required_agent_repo}"
+mutate_registry "${missing_required_agent_repo}" "missing_required_agent"
+assert_fails_with \
+  "${missing_required_agent_repo}" \
+  "is missing required agent(s): today_focus_advisory_agent"
+
+unexpected_agent_repo="${workdir}/unexpected-agent"
+create_valid_repo "${unexpected_agent_repo}"
+mutate_registry "${unexpected_agent_repo}" "unexpected_agent"
+assert_fails_with \
+  "${unexpected_agent_repo}" \
+  "contains unexpected agent(s) for this slice: phase_60_daily_operations_agent"
+
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"
 printf '/%s/%s/%s\n' "Users" "example" "private.txt" \
   >>"${local_path_repo}/docs/phase-59-1-agent-registry-contract.md"
 assert_fails_with \
   "${local_path_repo}" \
+  "workstation-local absolute path detected"
+
+root_local_path_repo="${workdir}/root-local-path"
+create_valid_repo "${root_local_path_repo}"
+printf '/%s/%s\n' "root" "private.txt" \
+  >>"${root_local_path_repo}/docs/phase-59-1-agent-registry-contract.md"
+assert_fails_with \
+  "${root_local_path_repo}" \
+  "workstation-local absolute path detected"
+
+readme_local_path_repo="${workdir}/readme-local-path"
+create_valid_repo "${readme_local_path_repo}"
+printf '/%s/%s/%s\n' "Users" "example" "private.txt" \
+  >>"${readme_local_path_repo}/README.md"
+assert_fails_with \
+  "${readme_local_path_repo}" \
+  "workstation-local absolute path detected"
+
+json_escaped_windows_path_repo="${workdir}/json-escaped-windows-path"
+create_valid_repo "${json_escaped_windows_path_repo}"
+mutate_registry "${json_escaped_windows_path_repo}" "json_escaped_windows_path"
+assert_fails_with \
+  "${json_escaped_windows_path_repo}" \
   "workstation-local absolute path detected"
 
 echo "Phase 59.1 agent registry verifier rejects missing fields, authority expansion, missing citations, unsafe tools, and local paths."

--- a/scripts/verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/verify-phase-59-1-agent-registry-contract.sh
@@ -116,6 +116,12 @@ required_disallowed = {
     "create_source_truth",
     "bypass_policy",
 }
+
+
+def normalize_tool_name(tool_name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", tool_name.lower()).strip("_")
+
+
 forbidden_authority_terms = (
     "approve",
     "approval",
@@ -130,14 +136,14 @@ forbidden_authority_terms = (
     "source_truth",
     "production_write",
     "bypass_policy",
+    "policy-bypass",
     "policy_bypass",
+    "policy bypass",
     "authority_widening",
 )
-forbidden_allowed_tool_fragments = frozenset(forbidden_authority_terms)
-
-
-def normalize_tool_name(tool_name: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "_", tool_name.lower()).strip("_")
+forbidden_allowed_tool_fragments = frozenset(
+    normalize_tool_name(term) for term in forbidden_authority_terms
+)
 
 seen_names: set[str] = set()
 for index, agent in enumerate(agents, start=1):

--- a/scripts/verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/verify-phase-59-1-agent-registry-contract.sh
@@ -49,6 +49,7 @@ done
 
 python3 - "${registry_path}" <<'PY'
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -115,7 +116,7 @@ required_disallowed = {
     "create_source_truth",
     "bypass_policy",
 }
-forbidden_fragments = (
+forbidden_authority_terms = (
     "approve",
     "approval",
     "execute",
@@ -132,6 +133,11 @@ forbidden_fragments = (
     "policy_bypass",
     "authority_widening",
 )
+forbidden_allowed_tool_fragments = frozenset(forbidden_authority_terms)
+
+
+def normalize_tool_name(tool_name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", tool_name.lower()).strip("_")
 
 seen_names: set[str] = set()
 for index, agent in enumerate(agents, start=1):
@@ -189,8 +195,8 @@ for index, agent in enumerate(agents, start=1):
         )
 
     for allowed_tool in agent["allowed_tools"]:
-        normalized = allowed_tool.lower().replace("-", "_").replace(" ", "_")
-        for fragment in forbidden_fragments:
+        normalized = normalize_tool_name(allowed_tool)
+        for fragment in forbidden_allowed_tool_fragments:
             if fragment in normalized:
                 raise SystemExit(
                     f"Phase 59.1 AI agent {name} has forbidden allowed tool: {allowed_tool}"

--- a/scripts/verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/verify-phase-59-1-agent-registry-contract.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-59-1-agent-registry-contract.md"
+registry_path="${repo_root}/docs/automation/ai-agent-registry.json"
+readme_path="${repo_root}/README.md"
+
+required_doc_phrases=(
+  "# Phase 59.1 Agent Registry Contract"
+  "- **Status**: Accepted registry contract slice"
+  "- **Related Issues**: #1252, #1253"
+  "This contract defines the required registry fields for every AegisOps AI agent before Phase 59 expands tool registry, trace lifecycle, disabled or degraded mode, prompt fixtures, stale or conflicting evidence fixtures, trace queue, or closeout work."
+  "Every registry row must include agent name, purpose, allowed tools, disallowed tools, record families, citation requirements, and authority ceiling."
+  'The executable registry lives in `docs/automation/ai-agent-registry.json`.'
+  "AI remains advisory, registered, audited, cited, and subordinate to reviewed AegisOps records."
+  "No agent registry row may grant approval, execution, reconciliation, case-closure, detector-activation, source-truth, production write, policy-bypass, or authority-widening capability."
+  'This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md` for AI approval, execution, reconciliation, case closure, detector activation, and source-truth refusal.'
+  'Run `bash scripts/verify-phase-59-1-agent-registry-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-59-1-agent-registry-contract.sh`.'
+  'Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.'
+  'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1253 --config <supervisor-config-path>`.'
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 59.1 agent registry contract doc: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${registry_path}" ]]; then
+  echo "Missing Phase 59.1 AI agent registry: ${registry_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 59.1 agent registry link check: ${readme_path}" >&2
+  exit 1
+fi
+
+for phrase in "${required_doc_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 59.1 agent registry contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+python3 - "${registry_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+registry_path = Path(sys.argv[1])
+try:
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"Invalid Phase 59.1 AI agent registry JSON: {exc}") from exc
+
+if not isinstance(registry, dict):
+    raise SystemExit("Phase 59.1 AI agent registry must be a JSON object.")
+
+required_root = {
+    "schema_version",
+    "phase",
+    "registry_status",
+    "authority_boundary",
+    "agents",
+}
+missing_root = sorted(required_root - registry.keys())
+if missing_root:
+    raise SystemExit(
+        "Phase 59.1 AI agent registry is missing root field(s): "
+        + ", ".join(missing_root)
+    )
+
+if registry["phase"] != "59.1":
+    raise SystemExit("Phase 59.1 AI agent registry phase must be 59.1.")
+
+if registry["registry_status"] != "accepted_contract_slice":
+    raise SystemExit(
+        "Phase 59.1 AI agent registry status must be accepted_contract_slice."
+    )
+
+agents = registry["agents"]
+if not isinstance(agents, list) or not agents:
+    raise SystemExit("Phase 59.1 AI agent registry must contain at least one agent.")
+
+required_agent_fields = {
+    "agent_name",
+    "purpose",
+    "allowed_tools",
+    "disallowed_tools",
+    "record_families",
+    "citation_requirements",
+    "authority_ceiling",
+}
+required_disallowed = {
+    "approve_action",
+    "execute_action",
+    "reconcile_execution",
+    "close_case",
+    "activate_detector",
+    "create_source_truth",
+    "bypass_policy",
+}
+forbidden_fragments = (
+    "approve",
+    "approval",
+    "execute",
+    "execution",
+    "reconcile",
+    "reconciliation",
+    "close_case",
+    "case_closure",
+    "activate_detector",
+    "detector_activation",
+    "source_truth",
+    "production_write",
+    "bypass_policy",
+    "authority_widening",
+)
+
+seen_names: set[str] = set()
+for index, agent in enumerate(agents, start=1):
+    if not isinstance(agent, dict):
+        raise SystemExit(f"Phase 59.1 AI agent row {index} must be an object.")
+
+    missing = sorted(required_agent_fields - agent.keys())
+    if missing:
+        raise SystemExit(
+            f"Phase 59.1 AI agent row {index} is missing field(s): "
+            + ", ".join(missing)
+        )
+
+    name = agent["agent_name"]
+    if not isinstance(name, str) or not name.strip():
+        raise SystemExit(f"Phase 59.1 AI agent row {index} has invalid agent_name.")
+    if name in seen_names:
+        raise SystemExit(f"Duplicate Phase 59.1 AI agent name: {name}")
+    seen_names.add(name)
+
+    for field in ("purpose", "authority_ceiling"):
+        value = agent[field]
+        if not isinstance(value, str) or not value.strip():
+            raise SystemExit(
+                f"Phase 59.1 AI agent {name} has invalid {field}."
+            )
+
+    if agent["authority_ceiling"] != "advisory_only_subordinate_to_aegisops_records":
+        raise SystemExit(
+            f"Phase 59.1 AI agent {name} must keep the advisory-only authority ceiling."
+        )
+
+    for field in (
+        "allowed_tools",
+        "disallowed_tools",
+        "record_families",
+        "citation_requirements",
+    ):
+        values = agent[field]
+        if (
+            not isinstance(values, list)
+            or not values
+            or any(not isinstance(value, str) or not value.strip() for value in values)
+        ):
+            raise SystemExit(
+                f"Phase 59.1 AI agent {name} must include non-empty string list {field}."
+            )
+
+    disallowed = set(agent["disallowed_tools"])
+    missing_disallowed = sorted(required_disallowed - disallowed)
+    if missing_disallowed:
+        raise SystemExit(
+            f"Phase 59.1 AI agent {name} is missing disallowed tool(s): "
+            + ", ".join(missing_disallowed)
+        )
+
+    for allowed_tool in agent["allowed_tools"]:
+        normalized = allowed_tool.lower().replace("-", "_").replace(" ", "_")
+        for fragment in forbidden_fragments:
+            if fragment in normalized:
+                raise SystemExit(
+                    f"Phase 59.1 AI agent {name} has forbidden allowed tool: {allowed_tool}"
+                )
+
+    citation_terms = " ".join(agent["citation_requirements"]).lower()
+    for required_term in ("record_family", "record_id", "evidence_reference"):
+        if required_term not in citation_terms:
+            raise SystemExit(
+                f"Phase 59.1 AI agent {name} citation requirements must include {required_term}."
+            )
+PY
+
+mac_user_home="$(printf '/%s/' 'Users')"
+unix_user_home="$(printf '/%s/' 'home')"
+windows_user_profile_backslash="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_user_profile_slash="$(printf '[A-Za-z]:/%s/' 'Users')"
+path_token_boundary="(^|[[:space:]\`'\"(<{=])"
+local_path_token="(${mac_user_home}|${unix_user_home}|${windows_user_profile_backslash}|${windows_user_profile_slash})[^[:space:]\`'\" )>}]*"
+
+if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" \
+  "${doc_path}" "${registry_path}"; then
+  echo "Forbidden Phase 59.1 agent registry artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    !in_fenced_block { print }
+  ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/phase-59-1-agent-registry-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 59.1 agent registry contract." >&2
+  exit 1
+fi
+
+echo "Phase 59.1 AI agent registry contract is present with required fields, citations, and advisory-only authority ceilings."

--- a/scripts/verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/verify-phase-59-1-agent-registry-contract.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+tool_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${tool_root}}"
 doc_path="${repo_root}/docs/phase-59-1-agent-registry-contract.md"
 registry_path="${repo_root}/docs/automation/ai-agent-registry.json"
 readme_path="${repo_root}/README.md"
@@ -128,6 +129,7 @@ forbidden_fragments = (
     "source_truth",
     "production_write",
     "bypass_policy",
+    "policy_bypass",
     "authority_widening",
 )
 
@@ -215,17 +217,11 @@ if unexpected_agents:
     )
 PY
 
-mac_user_home="$(printf '/%s/' 'Users')"
-unix_user_home="$(printf '/%s/' 'home')"
-root_user_home="$(printf '/%s/' 'root')"
-windows_user_profile_backslash="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
-windows_user_profile_backslash_json="$(printf '[A-Za-z]:\\\\\\\\%s\\\\\\\\' 'Users')"
-windows_user_profile_slash="$(printf '[A-Za-z]:/%s/' 'Users')"
-path_token_boundary="(^|[[:space:]\`'\"(<{=])"
-local_path_token="(${mac_user_home}|${unix_user_home}|${root_user_home}|${windows_user_profile_backslash_json}|${windows_user_profile_backslash}|${windows_user_profile_slash})[^[:space:]\`'\" )>}]*"
-
-if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" \
-  "${doc_path}" "${registry_path}" "${readme_path}"; then
+path_hygiene_stderr="$(mktemp)"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${tool_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" \
+  >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
   echo "Forbidden Phase 59.1 agent registry artifact: workstation-local absolute path detected" >&2
   exit 1
 fi

--- a/scripts/verify-phase-59-1-agent-registry-contract.sh
+++ b/scripts/verify-phase-59-1-agent-registry-contract.sh
@@ -83,9 +83,19 @@ if registry["registry_status"] != "accepted_contract_slice":
     )
 
 agents = registry["agents"]
-if not isinstance(agents, list) or not agents:
-    raise SystemExit("Phase 59.1 AI agent registry must contain at least one agent.")
+if not isinstance(agents, list):
+    raise SystemExit("Phase 59.1 AI agent registry agents field must be a list.")
+if not agents:
+    raise SystemExit(
+        "Phase 59.1 AI agent registry must contain the required initial agent set."
+    )
 
+required_agent_names = {
+    "analyst_assistant_context_agent",
+    "live_assistant_summary_agent",
+    "advisory_action_request_drafting_agent",
+    "today_focus_advisory_agent",
+}
 required_agent_fields = {
     "agent_name",
     "purpose",
@@ -190,17 +200,32 @@ for index, agent in enumerate(agents, start=1):
             raise SystemExit(
                 f"Phase 59.1 AI agent {name} citation requirements must include {required_term}."
             )
+
+missing_required_agents = sorted(required_agent_names - seen_names)
+unexpected_agents = sorted(seen_names - required_agent_names)
+if missing_required_agents:
+    raise SystemExit(
+        "Phase 59.1 AI agent registry is missing required agent(s): "
+        + ", ".join(missing_required_agents)
+    )
+if unexpected_agents:
+    raise SystemExit(
+        "Phase 59.1 AI agent registry contains unexpected agent(s) for this slice: "
+        + ", ".join(unexpected_agents)
+    )
 PY
 
 mac_user_home="$(printf '/%s/' 'Users')"
 unix_user_home="$(printf '/%s/' 'home')"
+root_user_home="$(printf '/%s/' 'root')"
 windows_user_profile_backslash="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_user_profile_backslash_json="$(printf '[A-Za-z]:\\\\\\\\%s\\\\\\\\' 'Users')"
 windows_user_profile_slash="$(printf '[A-Za-z]:/%s/' 'Users')"
 path_token_boundary="(^|[[:space:]\`'\"(<{=])"
-local_path_token="(${mac_user_home}|${unix_user_home}|${windows_user_profile_backslash}|${windows_user_profile_slash})[^[:space:]\`'\" )>}]*"
+local_path_token="(${mac_user_home}|${unix_user_home}|${root_user_home}|${windows_user_profile_backslash_json}|${windows_user_profile_backslash}|${windows_user_profile_slash})[^[:space:]\`'\" )>}]*"
 
 if grep -Eq "(${path_token_boundary}${local_path_token}|file:///?${local_path_token})" \
-  "${doc_path}" "${registry_path}"; then
+  "${doc_path}" "${registry_path}" "${readme_path}"; then
   echo "Forbidden Phase 59.1 agent registry artifact: workstation-local absolute path detected" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Add the Phase 59.1 agent registry contract doc and README cross-reference.
- Add a structured repo-owned AI agent registry with required fields, citation requirements, disallowed authority, and advisory-only authority ceilings.
- Add a focused verifier plus negative verifier self-test for missing fields, unsafe tools, authority expansion, citations, and path hygiene.

## Verification
- bash scripts/verify-phase-59-1-agent-registry-contract.sh
- bash scripts/test-verify-phase-59-1-agent-registry-contract.sh
- bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node dist/index.js issue-lint 1252 --config supervisor.config.codex.json
- node dist/index.js issue-lint 1253 --config supervisor.config.codex.json
- git diff --check

Part of: #1252
Closes: #1253