### PR TITLE
Add Phase 59.2 AI tool registry contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Canonical cross-phase boundary reference:
 - [Phase 57.8 closeout evaluation](docs/phase-57-closeout-evaluation.md) records the commercial administration MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 58/59/60/66 handoff.
 - [Phase 58.8 closeout evaluation](docs/phase-58-closeout-evaluation.md) records the supportability MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 59/60/66 handoff.
 - [Phase 59.1 agent registry contract](docs/phase-59-1-agent-registry-contract.md) defines the required AI agent registry fields, citation requirements, disallowed authority, and advisory-only authority ceiling.
+- [Phase 59.2 tool registry contract](docs/phase-59-2-tool-registry-contract.md) defines the required AI tool registry fields, allowed record families, citation requirements, audit fields, disallowed authority, and advisory-only authority ceiling.
 - [Phase 58.5 upgrade and rollback plan contract](docs/phase-58-5-upgrade-rollback-plan-contract.md) defines reviewed upgrade-plan and rollback-plan evidence fields, failure states, and authority boundaries without implementing live upgrade or rollback execution.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
@@ -145,6 +146,8 @@ The Phase 57.8 closeout evaluation is defined by the [Phase 57.8 closeout evalua
 The Phase 58.8 closeout evaluation is defined by the [Phase 58.8 closeout evaluation](docs/phase-58-closeout-evaluation.md).
 
 The Phase 59.1 agent registry contract is defined by the [Phase 59.1 agent registry contract](docs/phase-59-1-agent-registry-contract.md).
+
+The Phase 59.2 tool registry contract is defined by the [Phase 59.2 tool registry contract](docs/phase-59-2-tool-registry-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/automation/ai-tool-registry.json
+++ b/docs/automation/ai-tool-registry.json
@@ -1,0 +1,284 @@
+{
+  "schema_version": "2026-05-11.phase-59.2",
+  "phase": "59.2",
+  "registry_status": "accepted_contract_slice",
+  "authority_boundary": "AI tool registry rows are subordinate policy context only. AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.",
+  "tools": [
+    {
+      "tool_name": "safe_query",
+      "purpose": "Prepare read-only scoped query plans and retrieve reviewed control-plane records without widening scope beyond explicit record bindings.",
+      "allowed_record_families": [
+        "alert",
+        "case",
+        "evidence",
+        "recommendation",
+        "action_request",
+        "approval_decision",
+        "action_execution",
+        "reconciliation",
+        "source_health",
+        "ai_trace"
+      ],
+      "required_citations": [
+        "record_family must identify the directly linked AegisOps record family used by the query",
+        "record_id must identify the directly linked AegisOps record used by the query",
+        "evidence_reference must identify reviewed evidence, refused evidence, or an explicit evidence gap"
+      ],
+      "audit_fields": [
+        "tool_name",
+        "agent_name",
+        "trace_id",
+        "requested_by",
+        "record_family",
+        "record_id",
+        "citation_ids",
+        "decision",
+        "timestamp"
+      ],
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    },
+    {
+      "tool_name": "evidence_lookup",
+      "purpose": "Retrieve directly linked reviewed evidence, evidence custody notes, or explicit evidence gaps for one reviewed record.",
+      "allowed_record_families": [
+        "alert",
+        "case",
+        "evidence",
+        "recommendation",
+        "action_request",
+        "ai_trace"
+      ],
+      "required_citations": [
+        "record_family must identify the directly linked record family behind the evidence lookup",
+        "record_id must identify the directly linked reviewed record behind the evidence lookup",
+        "evidence_reference must identify the reviewed evidence record, custody note, or explicit missing-evidence prerequisite"
+      ],
+      "audit_fields": [
+        "tool_name",
+        "agent_name",
+        "trace_id",
+        "requested_by",
+        "record_family",
+        "record_id",
+        "citation_ids",
+        "decision",
+        "timestamp"
+      ],
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    },
+    {
+      "tool_name": "source_health_lookup",
+      "purpose": "Retrieve source-health context from directly linked backend source-health records without treating source status as workflow truth.",
+      "allowed_record_families": [
+        "source_health",
+        "alert",
+        "case",
+        "evidence",
+        "ai_trace"
+      ],
+      "required_citations": [
+        "record_family must identify the source-health or reviewed control-plane record family",
+        "record_id must identify the directly linked backend record",
+        "evidence_reference must identify source-health evidence, degraded-source evidence, or an explicit missing-health prerequisite"
+      ],
+      "audit_fields": [
+        "tool_name",
+        "agent_name",
+        "trace_id",
+        "requested_by",
+        "record_family",
+        "record_id",
+        "citation_ids",
+        "decision",
+        "timestamp"
+      ],
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    },
+    {
+      "tool_name": "runbook_lookup",
+      "purpose": "Retrieve reviewed runbook and operating guidance references for operator review without changing record state.",
+      "allowed_record_families": [
+        "runbook",
+        "case",
+        "evidence",
+        "recommendation",
+        "source_health",
+        "ai_trace"
+      ],
+      "required_citations": [
+        "record_family must identify the reviewed runbook or directly linked control-plane record family",
+        "record_id must identify the reviewed runbook section or directly linked AegisOps record",
+        "evidence_reference must identify the runbook reference, linked evidence, or explicit missing-guidance prerequisite"
+      ],
+      "audit_fields": [
+        "tool_name",
+        "agent_name",
+        "trace_id",
+        "requested_by",
+        "record_family",
+        "record_id",
+        "citation_ids",
+        "decision",
+        "timestamp"
+      ],
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    },
+    {
+      "tool_name": "recommendation_draft",
+      "purpose": "Draft reviewable recommendation text from cited records while preserving unresolved evidence gaps and human review requirements.",
+      "allowed_record_families": [
+        "case",
+        "evidence",
+        "recommendation",
+        "source_health",
+        "ai_trace"
+      ],
+      "required_citations": [
+        "record_family must identify the directly linked record family behind each recommendation claim",
+        "record_id must identify the reviewed record behind each recommendation claim",
+        "evidence_reference must identify reviewed evidence, a limitation, or a missing-evidence prerequisite"
+      ],
+      "audit_fields": [
+        "tool_name",
+        "agent_name",
+        "trace_id",
+        "requested_by",
+        "record_family",
+        "record_id",
+        "citation_ids",
+        "decision",
+        "timestamp"
+      ],
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    },
+    {
+      "tool_name": "action_request_draft",
+      "purpose": "Draft reviewable action-request text from cited advisory context while requiring a separate AegisOps review path before dispatch.",
+      "allowed_record_families": [
+        "case",
+        "evidence",
+        "recommendation",
+        "action_request",
+        "approval_decision",
+        "ai_trace"
+      ],
+      "required_citations": [
+        "record_family must identify the case, recommendation, evidence, or action-request family being drafted from",
+        "record_id must identify the directly linked reviewed record used by the draft",
+        "evidence_reference must identify reviewed evidence, limitation, or missing-evidence prerequisite"
+      ],
+      "audit_fields": [
+        "tool_name",
+        "agent_name",
+        "trace_id",
+        "requested_by",
+        "record_family",
+        "record_id",
+        "citation_ids",
+        "decision",
+        "timestamp"
+      ],
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    },
+    {
+      "tool_name": "doctor_explanation",
+      "purpose": "Explain supportability and doctor findings from cited checks, records, and limitations without making readiness or gate truth.",
+      "allowed_record_families": [
+        "source_health",
+        "limitation",
+        "gate",
+        "release",
+        "case",
+        "evidence",
+        "ai_trace"
+      ],
+      "required_citations": [
+        "record_family must identify the doctor check, limitation, gate, source-health, or reviewed record family",
+        "record_id must identify the directly linked check, limitation, gate, source-health, or reviewed record",
+        "evidence_reference must identify cited check output, reviewed evidence, limitation, or explicit missing prerequisite"
+      ],
+      "audit_fields": [
+        "tool_name",
+        "agent_name",
+        "trace_id",
+        "requested_by",
+        "record_family",
+        "record_id",
+        "citation_ids",
+        "decision",
+        "timestamp"
+      ],
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass"
+      ],
+      "authority_ceiling": "advisory_only_subordinate_to_aegisops_records"
+    }
+  ]
+}

--- a/docs/phase-59-2-tool-registry-contract.md
+++ b/docs/phase-59-2-tool-registry-contract.md
@@ -1,0 +1,78 @@
+# Phase 59.2 Tool Registry Contract
+
+- **Status**: Accepted registry contract slice
+- **Date**: 2026-05-11
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1252, #1254
+
+This contract defines the required registry fields for every AegisOps AI tool before Phase 59 expands trace lifecycle, disabled or degraded mode, prompt fixtures, stale or conflicting evidence fixtures, trace queue, closeout work, or Phase 60 daily AI operations.
+
+It is limited to the Phase 59.2 tool registry contract. It does not implement new model routing, provider selection, tool execution, trace queue behavior, disabled-mode behavior, daily AI operations, approval, execution, reconciliation, case closure, detector activation, source truth, production write authority, or commercial-readiness claims.
+
+## 1. Required Registry Fields
+
+Every tool registry row must include tool name, purpose, allowed record families, required citations, audit fields, disallowed authority, and authority ceiling.
+
+The executable registry lives in `docs/automation/ai-tool-registry.json`.
+
+The registry is a repo-owned policy artifact. It is not runtime truth, workflow truth, approval truth, execution truth, reconciliation truth, release truth, gate truth, closeout truth, or source truth.
+
+## 2. Authority Boundary
+
+AI remains advisory, registered, audited, cited, and subordinate to reviewed AegisOps records.
+
+No tool registry row may grant approval, execution, reconciliation, case-closure, detector-activation, source-truth, production write, policy-bypass, or authority-widening capability.
+
+Registered tools may query reviewed records, look up evidence, look up source health, look up runbooks, draft recommendations, draft action requests, and explain doctor findings only when the output is cited, audited, and subordinate to explicit AegisOps records.
+
+This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md` for AI approval, execution, reconciliation, case closure, detector activation, and source-truth refusal.
+
+## 3. Registered Tools
+
+The initial registry covers the AI tool surfaces needed by the Phase 59 governance foundation:
+
+| Tool | Purpose | Authority ceiling |
+| --- | --- | --- |
+| `safe_query` | Read-only scoped query planning and retrieval against reviewed records. | Advisory only, subordinate to AegisOps records. |
+| `evidence_lookup` | Retrieve directly linked reviewed evidence or explicit evidence gaps. | Advisory only, subordinate to AegisOps records. |
+| `source_health_lookup` | Retrieve source-health context from directly linked backend records. | Advisory only, subordinate to AegisOps records. |
+| `runbook_lookup` | Retrieve reviewed runbook and operating guidance references. | Advisory only, subordinate to AegisOps records. |
+| `recommendation_draft` | Draft reviewable recommendation text from cited context. | Advisory only, subordinate to AegisOps records. |
+| `action_request_draft` | Draft reviewable action-request text without approval or dispatch. | Advisory only, subordinate to AegisOps records. |
+| `doctor_explanation` | Explain supportability and doctor findings from cited records and checks. | Advisory only, subordinate to AegisOps records. |
+
+These names identify contract rows, not autonomous tools with independent authority.
+
+## 4. Verifier Requirements
+
+The registry verifier must fail when:
+
+- the contract doc is missing;
+- the registry artifact is missing or invalid JSON;
+- any tool registry row is missing tool name, purpose, allowed record families, required citations, audit fields, disallowed authority, or authority ceiling;
+- any tool registry row grants approval, execution, reconciliation, case-closure, detector-activation, source-truth, production write, policy-bypass, or authority-widening capability;
+- any tool registry row omits citation requirements for `record_family`, `record_id`, or `evidence_reference`;
+- any tool registry row omits audit fields for `tool_name`, `agent_name`, `trace_id`, `requested_by`, `record_family`, `record_id`, `citation_ids`, `decision`, or `timestamp`;
+- any tool registry row omits disallowed approval, execution, reconciliation, case closure, detector activation, source-truth creation, production write, or policy-bypass authority;
+- any registry artifact contains an unregistered tool for this slice;
+- publishable artifacts contain workstation-local absolute paths.
+
+## 5. Validation
+
+Run `bash scripts/verify-phase-59-2-tool-registry-contract.sh`.
+
+Run `bash scripts/test-verify-phase-59-2-tool-registry-contract.sh`.
+
+Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1254 --config <supervisor-config-path>`.
+
+## 6. Non-Goals
+
+- No new production write authority is introduced.
+- No AI output, trace state, citation, registry row, verifier output, issue-lint output, browser state, UI state, demo data, Wazuh state, Shuffle state, ticket state, optional evidence, or prompt text becomes authoritative workflow truth.
+- No Phase 60 daily AI operations behavior is implemented.
+- No model/provider selection, billing, prompt marketplace, tool marketplace, or agent ecosystem breadth is implemented.
+- No approval, execution, reconciliation, case closure, detector activation, source-truth creation, production write, or policy bypass is delegated to AI.

--- a/scripts/test-verify-phase-59-2-tool-registry-contract.sh
+++ b/scripts/test-verify-phase-59-2-tool-registry-contract.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-59-2-tool-registry-contract.sh"
+
+if [[ ! -x "${verifier}" ]]; then
+  echo "Missing executable Phase 59.2 tool registry verifier: ${verifier}" >&2
+  exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/automation"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+  printf '%s\n' \
+    "# AegisOps" \
+    "See [Phase 59.2 tool registry contract](docs/phase-59-2-tool-registry-contract.md)." \
+    >"${target}/README.md"
+  cp "${repo_root}/docs/phase-59-2-tool-registry-contract.md" \
+    "${target}/docs/phase-59-2-tool-registry-contract.md"
+  cp "${repo_root}/docs/automation/ai-tool-registry.json" \
+    "${target}/docs/automation/ai-tool-registry.json"
+  git -C "${target}" add README.md docs/phase-59-2-tool-registry-contract.md \
+    docs/automation/ai-tool-registry.json
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+mutate_registry() {
+  local target="$1"
+  local mutation="$2"
+
+  python3 - "${target}/docs/automation/ai-tool-registry.json" "${mutation}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+mutation = sys.argv[2]
+registry = json.loads(path.read_text(encoding="utf-8"))
+
+if mutation == "missing_tool_name":
+    registry["tools"][0].pop("tool_name", None)
+elif mutation == "missing_audit_fields":
+    registry["tools"][0].pop("audit_fields", None)
+elif mutation == "missing_citations":
+    registry["tools"][0].pop("required_citations", None)
+elif mutation == "missing_record_families":
+    registry["tools"][0].pop("allowed_record_families", None)
+elif mutation == "missing_disallowed_authority":
+    registry["tools"][0].pop("disallowed_authority", None)
+elif mutation == "authority_expansion":
+    registry["tools"][0]["authority_ceiling"] = "may_execute_actions"
+elif mutation == "missing_record_id_citation":
+    registry["tools"][0]["required_citations"] = [
+        value for value in registry["tools"][0]["required_citations"]
+        if "record_id" not in value
+    ]
+elif mutation == "missing_trace_audit":
+    registry["tools"][0]["audit_fields"].remove("trace_id")
+elif mutation == "missing_case_closure_refusal":
+    registry["tools"][0]["disallowed_authority"].remove("case_closure")
+elif mutation == "missing_required_tool":
+    registry["tools"] = [
+        tool
+        for tool in registry["tools"]
+        if tool["tool_name"] != "doctor_explanation"
+    ]
+elif mutation == "unexpected_tool":
+    extra_tool = dict(registry["tools"][0])
+    extra_tool["tool_name"] = "autonomous_case_closure"
+    registry["tools"].append(extra_tool)
+elif mutation == "json_escaped_windows_path":
+    slash = chr(92)
+    registry["tools"][0]["purpose"] += (
+        " See C:" + slash + "Users" + slash + "example" + slash + "private.txt."
+    )
+elif mutation == "json_escaped_unix_path":
+    registry["tools"][0]["purpose"] += " See /" + "Users/example/private.txt."
+else:
+    raise SystemExit(f"unknown mutation: {mutation}")
+
+path.write_text(json.dumps(registry, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+PY
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-59-2-tool-registry-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-59-2-tool-registry-contract.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 59.2 tool registry contract doc"
+
+missing_registry_repo="${workdir}/missing-registry"
+create_valid_repo "${missing_registry_repo}"
+rm "${missing_registry_repo}/docs/automation/ai-tool-registry.json"
+assert_fails_with \
+  "${missing_registry_repo}" \
+  "Missing Phase 59.2 AI tool registry"
+
+missing_contract_field_repo="${workdir}/missing-contract-field"
+create_valid_repo "${missing_contract_field_repo}"
+remove_text_from_doc "${missing_contract_field_repo}" \
+  "Every tool registry row must include tool name, purpose, allowed record families, required citations, audit fields, disallowed authority, and authority ceiling."
+assert_fails_with \
+  "${missing_contract_field_repo}" \
+  "Missing Phase 59.2 tool registry contract statement: Every tool registry row must include tool name"
+
+for mutation in \
+  missing_tool_name \
+  missing_audit_fields \
+  missing_citations \
+  missing_record_families \
+  missing_disallowed_authority
+do
+  mutated_repo="${workdir}/${mutation}"
+  create_valid_repo "${mutated_repo}"
+  mutate_registry "${mutated_repo}" "${mutation}"
+  assert_fails_with "${mutated_repo}" "is missing field(s):"
+done
+
+authority_expansion_repo="${workdir}/authority-expansion"
+create_valid_repo "${authority_expansion_repo}"
+mutate_registry "${authority_expansion_repo}" "authority_expansion"
+assert_fails_with \
+  "${authority_expansion_repo}" \
+  "must keep the advisory-only authority ceiling"
+
+missing_record_id_repo="${workdir}/missing-record-id-citation"
+create_valid_repo "${missing_record_id_repo}"
+mutate_registry "${missing_record_id_repo}" "missing_record_id_citation"
+assert_fails_with \
+  "${missing_record_id_repo}" \
+  "citation requirements must include record_id"
+
+missing_trace_audit_repo="${workdir}/missing-trace-audit"
+create_valid_repo "${missing_trace_audit_repo}"
+mutate_registry "${missing_trace_audit_repo}" "missing_trace_audit"
+assert_fails_with \
+  "${missing_trace_audit_repo}" \
+  "is missing audit field(s): trace_id"
+
+missing_case_closure_repo="${workdir}/missing-case-closure-refusal"
+create_valid_repo "${missing_case_closure_repo}"
+mutate_registry "${missing_case_closure_repo}" "missing_case_closure_refusal"
+assert_fails_with \
+  "${missing_case_closure_repo}" \
+  "is missing disallowed authority: case_closure"
+
+missing_required_tool_repo="${workdir}/missing-required-tool"
+create_valid_repo "${missing_required_tool_repo}"
+mutate_registry "${missing_required_tool_repo}" "missing_required_tool"
+assert_fails_with \
+  "${missing_required_tool_repo}" \
+  "is missing required tool(s): doctor_explanation"
+
+unexpected_tool_repo="${workdir}/unexpected-tool"
+create_valid_repo "${unexpected_tool_repo}"
+mutate_registry "${unexpected_tool_repo}" "unexpected_tool"
+assert_fails_with \
+  "${unexpected_tool_repo}" \
+  "contains unexpected tool(s) for this slice: autonomous_case_closure"
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf '/%s/%s/%s\n' "Users" "example" "private.txt" \
+  >>"${local_path_repo}/docs/phase-59-2-tool-registry-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "workstation-local absolute path detected"
+
+json_escaped_windows_path_repo="${workdir}/json-escaped-windows-path"
+create_valid_repo "${json_escaped_windows_path_repo}"
+mutate_registry "${json_escaped_windows_path_repo}" "json_escaped_windows_path"
+assert_fails_with \
+  "${json_escaped_windows_path_repo}" \
+  "workstation-local absolute path detected"
+
+json_escaped_unix_path_repo="${workdir}/json-escaped-unix-path"
+create_valid_repo "${json_escaped_unix_path_repo}"
+mutate_registry "${json_escaped_unix_path_repo}" "json_escaped_unix_path"
+assert_fails_with \
+  "${json_escaped_unix_path_repo}" \
+  "workstation-local absolute path detected"
+
+echo "Phase 59.2 tool registry verifier rejects unregistered tools, missing fields, missing citations, missing audit, authority expansion, and local paths."

--- a/scripts/verify-phase-59-2-tool-registry-contract.sh
+++ b/scripts/verify-phase-59-2-tool-registry-contract.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tool_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${tool_root}}"
+doc_path="${repo_root}/docs/phase-59-2-tool-registry-contract.md"
+registry_path="${repo_root}/docs/automation/ai-tool-registry.json"
+readme_path="${repo_root}/README.md"
+
+required_doc_phrases=(
+  "# Phase 59.2 Tool Registry Contract"
+  "- **Status**: Accepted registry contract slice"
+  "- **Related Issues**: #1252, #1254"
+  "This contract defines the required registry fields for every AegisOps AI tool before Phase 59 expands trace lifecycle, disabled or degraded mode, prompt fixtures, stale or conflicting evidence fixtures, trace queue, closeout work, or Phase 60 daily AI operations."
+  "Every tool registry row must include tool name, purpose, allowed record families, required citations, audit fields, disallowed authority, and authority ceiling."
+  'The executable registry lives in `docs/automation/ai-tool-registry.json`.'
+  "AI remains advisory, registered, audited, cited, and subordinate to reviewed AegisOps records."
+  "No tool registry row may grant approval, execution, reconciliation, case-closure, detector-activation, source-truth, production write, policy-bypass, or authority-widening capability."
+  'This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md` for AI approval, execution, reconciliation, case closure, detector activation, and source-truth refusal.'
+  'Run `bash scripts/verify-phase-59-2-tool-registry-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-59-2-tool-registry-contract.sh`.'
+  'Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.'
+  'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1254 --config <supervisor-config-path>`.'
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 59.2 tool registry contract doc: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${registry_path}" ]]; then
+  echo "Missing Phase 59.2 AI tool registry: ${registry_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 59.2 tool registry link check: ${readme_path}" >&2
+  exit 1
+fi
+
+for phrase in "${required_doc_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 59.2 tool registry contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+python3 - "${registry_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+registry_path = Path(sys.argv[1])
+try:
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"Invalid Phase 59.2 AI tool registry JSON: {exc}") from exc
+
+if not isinstance(registry, dict):
+    raise SystemExit("Phase 59.2 AI tool registry must be a JSON object.")
+
+required_root = {
+    "schema_version",
+    "phase",
+    "registry_status",
+    "authority_boundary",
+    "tools",
+}
+missing_root = sorted(required_root - registry.keys())
+if missing_root:
+    raise SystemExit(
+        "Phase 59.2 AI tool registry is missing root field(s): "
+        + ", ".join(missing_root)
+    )
+
+if registry["phase"] != "59.2":
+    raise SystemExit("Phase 59.2 AI tool registry phase must be 59.2.")
+
+if registry["registry_status"] != "accepted_contract_slice":
+    raise SystemExit(
+        "Phase 59.2 AI tool registry status must be accepted_contract_slice."
+    )
+
+tools = registry["tools"]
+if not isinstance(tools, list):
+    raise SystemExit("Phase 59.2 AI tool registry tools field must be a list.")
+if not tools:
+    raise SystemExit(
+        "Phase 59.2 AI tool registry must contain the required initial tool set."
+    )
+
+required_tool_names = {
+    "safe_query",
+    "evidence_lookup",
+    "source_health_lookup",
+    "runbook_lookup",
+    "recommendation_draft",
+    "action_request_draft",
+    "doctor_explanation",
+}
+required_tool_fields = {
+    "tool_name",
+    "purpose",
+    "allowed_record_families",
+    "required_citations",
+    "audit_fields",
+    "disallowed_authority",
+    "authority_ceiling",
+}
+required_audit_fields = {
+    "tool_name",
+    "agent_name",
+    "trace_id",
+    "requested_by",
+    "record_family",
+    "record_id",
+    "citation_ids",
+    "decision",
+    "timestamp",
+}
+required_disallowed_authority = {
+    "approval",
+    "execution",
+    "reconciliation",
+    "case_closure",
+    "detector_activation",
+    "source_truth_creation",
+    "production_write",
+    "policy_bypass",
+}
+
+seen_names: set[str] = set()
+for index, tool in enumerate(tools, start=1):
+    if not isinstance(tool, dict):
+        raise SystemExit(f"Phase 59.2 AI tool row {index} must be an object.")
+
+    missing = sorted(required_tool_fields - tool.keys())
+    if missing:
+        raise SystemExit(
+            f"Phase 59.2 AI tool row {index} is missing field(s): "
+            + ", ".join(missing)
+        )
+
+    name = tool["tool_name"]
+    if not isinstance(name, str) or not name.strip():
+        raise SystemExit(f"Phase 59.2 AI tool row {index} has invalid tool_name.")
+    if name in seen_names:
+        raise SystemExit(f"Duplicate Phase 59.2 AI tool name: {name}")
+    seen_names.add(name)
+
+    for field in ("purpose", "authority_ceiling"):
+        value = tool[field]
+        if not isinstance(value, str) or not value.strip():
+            raise SystemExit(f"Phase 59.2 AI tool {name} has invalid {field}.")
+
+    if tool["authority_ceiling"] != "advisory_only_subordinate_to_aegisops_records":
+        raise SystemExit(
+            f"Phase 59.2 AI tool {name} must keep the advisory-only authority ceiling."
+        )
+
+    for field in (
+        "allowed_record_families",
+        "required_citations",
+        "audit_fields",
+        "disallowed_authority",
+    ):
+        values = tool[field]
+        if (
+            not isinstance(values, list)
+            or not values
+            or any(not isinstance(value, str) or not value.strip() for value in values)
+        ):
+            raise SystemExit(
+                f"Phase 59.2 AI tool {name} must include non-empty string list {field}."
+            )
+
+    missing_audit = sorted(required_audit_fields - set(tool["audit_fields"]))
+    if missing_audit:
+        raise SystemExit(
+            f"Phase 59.2 AI tool {name} is missing audit field(s): "
+            + ", ".join(missing_audit)
+        )
+
+    missing_disallowed = sorted(
+        required_disallowed_authority - set(tool["disallowed_authority"])
+    )
+    if missing_disallowed:
+        raise SystemExit(
+            f"Phase 59.2 AI tool {name} is missing disallowed authority: "
+            + ", ".join(missing_disallowed)
+        )
+
+    citation_terms = " ".join(tool["required_citations"]).lower()
+    for required_term in ("record_family", "record_id", "evidence_reference"):
+        if required_term not in citation_terms:
+            raise SystemExit(
+                f"Phase 59.2 AI tool {name} citation requirements must include {required_term}."
+            )
+
+missing_required_tools = sorted(required_tool_names - seen_names)
+unexpected_tools = sorted(seen_names - required_tool_names)
+if missing_required_tools:
+    raise SystemExit(
+        "Phase 59.2 AI tool registry is missing required tool(s): "
+        + ", ".join(missing_required_tools)
+    )
+if unexpected_tools:
+    raise SystemExit(
+        "Phase 59.2 AI tool registry contains unexpected tool(s) for this slice: "
+        + ", ".join(unexpected_tools)
+    )
+PY
+
+path_hygiene_stderr="$(mktemp)"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${tool_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" \
+  >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 59.2 tool registry artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    !in_fenced_block { print }
+  ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/phase-59-2-tool-registry-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 59.2 tool registry contract." >&2
+  exit 1
+fi
+
+echo "Phase 59.2 AI tool registry contract is present with required fields, citations, audit fields, and advisory-only authority ceilings."


### PR DESCRIPTION
## Summary
- Add Phase 59.2 AI tool registry contract doc and structured registry artifact.
- Add verifier and verifier self-test for registered tools, required citations, audit fields, disallowed authority, and path hygiene.
- Link the contract from README.

## Verification
- bash scripts/test-verify-phase-59-2-tool-registry-contract.sh
- bash scripts/verify-phase-59-2-tool-registry-contract.sh
- bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh
- bash scripts/verify-publishable-path-hygiene.sh
- bash scripts/verify-phase-59-1-agent-registry-contract.sh
- bash scripts/test-verify-phase-59-1-agent-registry-contract.sh
- git diff --check
- node <codex-supervisor-root>/dist/index.js issue-lint 1254 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1252 --config <supervisor-config-path>

Closes #1254