### PR TITLE
[codex] Add AI trace lifecycle contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Canonical cross-phase boundary reference:
 - [Phase 58.8 closeout evaluation](docs/phase-58-closeout-evaluation.md) records the supportability MVP outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 59/60/66 handoff.
 - [Phase 59.1 agent registry contract](docs/phase-59-1-agent-registry-contract.md) defines the required AI agent registry fields, citation requirements, disallowed authority, and advisory-only authority ceiling.
 - [Phase 59.2 tool registry contract](docs/phase-59-2-tool-registry-contract.md) defines the required AI tool registry fields, allowed record families, citation requirements, audit fields, disallowed authority, and advisory-only authority ceiling.
+- [Phase 59.3 AI trace lifecycle contract](docs/phase-59-3-ai-trace-lifecycle-contract.md) defines created, reviewed, accepted, corrected, rejected, and expired trace states with registered linkage, citations, review metadata, expiration handling, and advisory-only authority.
 - [Phase 58.5 upgrade and rollback plan contract](docs/phase-58-5-upgrade-rollback-plan-contract.md) defines reviewed upgrade-plan and rollback-plan evidence fields, failure states, and authority boundaries without implementing live upgrade or rollback execution.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
@@ -148,6 +149,8 @@ The Phase 58.8 closeout evaluation is defined by the [Phase 58.8 closeout evalua
 The Phase 59.1 agent registry contract is defined by the [Phase 59.1 agent registry contract](docs/phase-59-1-agent-registry-contract.md).
 
 The Phase 59.2 tool registry contract is defined by the [Phase 59.2 tool registry contract](docs/phase-59-2-tool-registry-contract.md).
+
+The Phase 59.3 AI trace lifecycle contract is defined by the [Phase 59.3 AI trace lifecycle contract](docs/phase-59-3-ai-trace-lifecycle-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/automation/ai-trace-lifecycle.json
+++ b/docs/automation/ai-trace-lifecycle.json
@@ -107,7 +107,7 @@
       "allowed_from": [
         "reviewed"
       ],
-      "terminal": true,
+      "terminal": false,
       "registered_agents": [
         "analyst_assistant_context_agent",
         "live_assistant_summary_agent",
@@ -157,7 +157,7 @@
       "allowed_from": [
         "reviewed"
       ],
-      "terminal": true,
+      "terminal": false,
       "registered_agents": [
         "analyst_assistant_context_agent",
         "live_assistant_summary_agent",

--- a/docs/automation/ai-trace-lifecycle.json
+++ b/docs/automation/ai-trace-lifecycle.json
@@ -1,0 +1,434 @@
+{
+  "schema_version": "2026-05-11.phase-59.3",
+  "phase": "59.3",
+  "contract_status": "accepted_contract_slice",
+  "authority_boundary": "AI trace lifecycle rows are subordinate policy context only. AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.",
+  "lifecycle_states": [
+    {
+      "state": "created",
+      "purpose": "Record that a registered AI agent used registered AI tools to produce cited advisory output for one directly linked reviewed AegisOps record.",
+      "allowed_from": [],
+      "terminal": false,
+      "registered_agents": [
+        "analyst_assistant_context_agent",
+        "live_assistant_summary_agent",
+        "advisory_action_request_drafting_agent",
+        "today_focus_advisory_agent"
+      ],
+      "registered_tools": [
+        "safe_query",
+        "evidence_lookup",
+        "source_health_lookup",
+        "runbook_lookup",
+        "recommendation_draft",
+        "action_request_draft",
+        "doctor_explanation"
+      ],
+      "required_linkage": [
+        "registered_agent_name",
+        "registered_tool_names",
+        "trace_id",
+        "reviewed_record_family",
+        "reviewed_record_id",
+        "citation_ids",
+        "evidence_reference",
+        "created_by",
+        "created_at",
+        "expires_at"
+      ],
+      "reviewer_action_metadata_required": false,
+      "expiration_handling": "expires_at is required at creation and the trace must move to expired when freshness is exceeded before acceptance.",
+      "authority_effect": "advisory_only_no_workflow_mutation",
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass",
+        "workflow_truth"
+      ]
+    },
+    {
+      "state": "reviewed",
+      "purpose": "Record that an operator inspected the trace linkage, citations, freshness, unresolved questions, and authority boundary before choosing a review outcome.",
+      "allowed_from": [
+        "created"
+      ],
+      "terminal": false,
+      "registered_agents": [
+        "analyst_assistant_context_agent",
+        "live_assistant_summary_agent",
+        "advisory_action_request_drafting_agent",
+        "today_focus_advisory_agent"
+      ],
+      "registered_tools": [
+        "safe_query",
+        "evidence_lookup",
+        "source_health_lookup",
+        "runbook_lookup",
+        "recommendation_draft",
+        "action_request_draft",
+        "doctor_explanation"
+      ],
+      "required_linkage": [
+        "registered_agent_name",
+        "registered_tool_names",
+        "trace_id",
+        "reviewed_record_family",
+        "reviewed_record_id",
+        "citation_ids",
+        "evidence_reference",
+        "reviewer_id",
+        "review_action_id",
+        "reviewed_at",
+        "expires_at"
+      ],
+      "reviewer_action_metadata_required": true,
+      "expiration_handling": "reviewed traces remain subject to expires_at and must become expired if not accepted, corrected, or rejected before freshness is exceeded.",
+      "authority_effect": "advisory_only_no_workflow_mutation",
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass",
+        "workflow_truth"
+      ]
+    },
+    {
+      "state": "accepted",
+      "purpose": "Record that an operator accepted the trace as advisory context for the linked reviewed record while leaving AegisOps workflow records authoritative.",
+      "allowed_from": [
+        "reviewed"
+      ],
+      "terminal": true,
+      "registered_agents": [
+        "analyst_assistant_context_agent",
+        "live_assistant_summary_agent",
+        "advisory_action_request_drafting_agent",
+        "today_focus_advisory_agent"
+      ],
+      "registered_tools": [
+        "safe_query",
+        "evidence_lookup",
+        "source_health_lookup",
+        "runbook_lookup",
+        "recommendation_draft",
+        "action_request_draft",
+        "doctor_explanation"
+      ],
+      "required_linkage": [
+        "registered_agent_name",
+        "registered_tool_names",
+        "trace_id",
+        "reviewed_record_family",
+        "reviewed_record_id",
+        "citation_ids",
+        "evidence_reference",
+        "reviewer_id",
+        "review_action_id",
+        "accepted_at",
+        "expires_at"
+      ],
+      "reviewer_action_metadata_required": true,
+      "expiration_handling": "accepted advisory context remains non-authoritative and becomes expired advisory context when expires_at is exceeded.",
+      "authority_effect": "advisory_only_no_workflow_mutation",
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass",
+        "workflow_truth"
+      ]
+    },
+    {
+      "state": "corrected",
+      "purpose": "Record that an operator corrected the advisory trace output with explicit reviewer/action metadata, citations, and reviewed record linkage.",
+      "allowed_from": [
+        "reviewed"
+      ],
+      "terminal": true,
+      "registered_agents": [
+        "analyst_assistant_context_agent",
+        "live_assistant_summary_agent",
+        "advisory_action_request_drafting_agent",
+        "today_focus_advisory_agent"
+      ],
+      "registered_tools": [
+        "safe_query",
+        "evidence_lookup",
+        "source_health_lookup",
+        "runbook_lookup",
+        "recommendation_draft",
+        "action_request_draft",
+        "doctor_explanation"
+      ],
+      "required_linkage": [
+        "registered_agent_name",
+        "registered_tool_names",
+        "trace_id",
+        "reviewed_record_family",
+        "reviewed_record_id",
+        "citation_ids",
+        "evidence_reference",
+        "reviewer_id",
+        "review_action_id",
+        "correction_summary",
+        "corrected_at",
+        "expires_at"
+      ],
+      "reviewer_action_metadata_required": true,
+      "expiration_handling": "corrected advisory context remains non-authoritative and becomes expired advisory context when expires_at is exceeded.",
+      "authority_effect": "advisory_only_no_workflow_mutation",
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass",
+        "workflow_truth"
+      ]
+    },
+    {
+      "state": "rejected",
+      "purpose": "Record that an operator rejected the trace as unusable advisory context while retaining audit evidence of why it was rejected.",
+      "allowed_from": [
+        "reviewed"
+      ],
+      "terminal": true,
+      "registered_agents": [
+        "analyst_assistant_context_agent",
+        "live_assistant_summary_agent",
+        "advisory_action_request_drafting_agent",
+        "today_focus_advisory_agent"
+      ],
+      "registered_tools": [
+        "safe_query",
+        "evidence_lookup",
+        "source_health_lookup",
+        "runbook_lookup",
+        "recommendation_draft",
+        "action_request_draft",
+        "doctor_explanation"
+      ],
+      "required_linkage": [
+        "registered_agent_name",
+        "registered_tool_names",
+        "trace_id",
+        "reviewed_record_family",
+        "reviewed_record_id",
+        "citation_ids",
+        "evidence_reference",
+        "reviewer_id",
+        "review_action_id",
+        "rejection_reason",
+        "rejected_at",
+        "expires_at"
+      ],
+      "reviewer_action_metadata_required": true,
+      "expiration_handling": "rejected traces stay auditable and cannot become accepted without a new cited trace lifecycle.",
+      "authority_effect": "advisory_only_no_workflow_mutation",
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass",
+        "workflow_truth"
+      ]
+    },
+    {
+      "state": "expired",
+      "purpose": "Record that the trace passed its freshness boundary and cannot be accepted, corrected, or used as current advisory context without a new cited trace.",
+      "allowed_from": [
+        "created",
+        "reviewed",
+        "accepted",
+        "corrected"
+      ],
+      "terminal": true,
+      "registered_agents": [
+        "analyst_assistant_context_agent",
+        "live_assistant_summary_agent",
+        "advisory_action_request_drafting_agent",
+        "today_focus_advisory_agent"
+      ],
+      "registered_tools": [
+        "safe_query",
+        "evidence_lookup",
+        "source_health_lookup",
+        "runbook_lookup",
+        "recommendation_draft",
+        "action_request_draft",
+        "doctor_explanation"
+      ],
+      "required_linkage": [
+        "registered_agent_name",
+        "registered_tool_names",
+        "trace_id",
+        "reviewed_record_family",
+        "reviewed_record_id",
+        "citation_ids",
+        "evidence_reference",
+        "expires_at",
+        "expired_at",
+        "expiration_reason"
+      ],
+      "reviewer_action_metadata_required": false,
+      "expiration_handling": "expired traces are terminal for the current lifecycle and require a new created trace with current citations for further review.",
+      "authority_effect": "advisory_only_no_workflow_mutation",
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "production_write",
+        "policy_bypass",
+        "workflow_truth"
+      ]
+    }
+  ],
+  "allowed_transitions": [
+    {
+      "from_state": "created",
+      "to_state": "reviewed",
+      "required_trigger": "operator review starts from a cited trace linked to a reviewed AegisOps record",
+      "required_metadata": [
+        "reviewer_id",
+        "review_action_id",
+        "reviewed_at"
+      ],
+      "authority_effect": "advisory_only_no_workflow_mutation"
+    },
+    {
+      "from_state": "created",
+      "to_state": "expired",
+      "required_trigger": "expires_at was reached before operator review outcome",
+      "required_metadata": [
+        "expires_at",
+        "expired_at",
+        "expiration_reason"
+      ],
+      "authority_effect": "advisory_only_no_workflow_mutation"
+    },
+    {
+      "from_state": "reviewed",
+      "to_state": "accepted",
+      "required_trigger": "operator accepts trace as advisory context only",
+      "required_metadata": [
+        "reviewer_id",
+        "review_action_id",
+        "accepted_at"
+      ],
+      "authority_effect": "advisory_only_no_workflow_mutation"
+    },
+    {
+      "from_state": "reviewed",
+      "to_state": "corrected",
+      "required_trigger": "operator records corrected advisory output",
+      "required_metadata": [
+        "reviewer_id",
+        "review_action_id",
+        "correction_summary",
+        "corrected_at"
+      ],
+      "authority_effect": "advisory_only_no_workflow_mutation"
+    },
+    {
+      "from_state": "reviewed",
+      "to_state": "rejected",
+      "required_trigger": "operator rejects trace as unusable advisory context",
+      "required_metadata": [
+        "reviewer_id",
+        "review_action_id",
+        "rejection_reason",
+        "rejected_at"
+      ],
+      "authority_effect": "advisory_only_no_workflow_mutation"
+    },
+    {
+      "from_state": "reviewed",
+      "to_state": "expired",
+      "required_trigger": "expires_at was reached before accepted, corrected, or rejected outcome",
+      "required_metadata": [
+        "expires_at",
+        "expired_at",
+        "expiration_reason"
+      ],
+      "authority_effect": "advisory_only_no_workflow_mutation"
+    },
+    {
+      "from_state": "accepted",
+      "to_state": "expired",
+      "required_trigger": "accepted advisory context exceeded freshness boundary",
+      "required_metadata": [
+        "expires_at",
+        "expired_at",
+        "expiration_reason"
+      ],
+      "authority_effect": "advisory_only_no_workflow_mutation"
+    },
+    {
+      "from_state": "corrected",
+      "to_state": "expired",
+      "required_trigger": "corrected advisory context exceeded freshness boundary",
+      "required_metadata": [
+        "expires_at",
+        "expired_at",
+        "expiration_reason"
+      ],
+      "authority_effect": "advisory_only_no_workflow_mutation"
+    }
+  ],
+  "trace_review_queue_skeleton": {
+    "phase": "59.7",
+    "implementation_status": "deferred_skeleton_only",
+    "required_fields": [
+      "trace_id",
+      "state",
+      "reviewed_record_family",
+      "reviewed_record_id",
+      "registered_agent_name",
+      "registered_tool_names",
+      "citation_ids",
+      "expires_at",
+      "review_required"
+    ],
+    "non_authoritative_surfaces": [
+      "queue_order",
+      "badge_text",
+      "cache_state",
+      "browser_state",
+      "trace_state"
+    ]
+  },
+  "forbidden_authority_states": [
+    "approval",
+    "execution",
+    "reconciliation",
+    "case_closure",
+    "detector_activation",
+    "source_truth_creation",
+    "production_write",
+    "policy_bypass",
+    "workflow_truth"
+  ]
+}

--- a/docs/phase-59-3-ai-trace-lifecycle-contract.md
+++ b/docs/phase-59-3-ai-trace-lifecycle-contract.md
@@ -1,0 +1,99 @@
+# Phase 59.3 AI Trace Lifecycle Contract
+
+- **Status**: Accepted lifecycle contract slice
+- **Date**: 2026-05-11
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1252, #1255
+
+This contract defines the AI trace lifecycle states for created, reviewed, accepted, corrected, rejected, and expired traces before Phase 59 expands disabled or degraded mode, prompt fixtures, stale or conflicting evidence fixtures, trace queue UI/API implementation, closeout work, or Phase 60 daily AI operations.
+
+It is limited to the Phase 59.3 AI trace lifecycle contract. It does not implement new model routing, provider selection, tool execution, trace queue behavior, disabled-mode behavior, daily AI operations, approval, execution, reconciliation, case closure, detector activation, source truth, production write authority, or commercial-readiness claims.
+
+## 1. Required Lifecycle Fields
+
+Every AI trace lifecycle state must require registered agent linkage, registered tool linkage, citations, reviewed record family and identifier linkage, expiration handling, and advisory-only authority.
+
+The executable lifecycle artifact lives in `docs/automation/ai-trace-lifecycle.json`.
+
+The lifecycle artifact is a repo-owned policy artifact. It is not runtime truth, workflow truth, approval truth, execution truth, reconciliation truth, release truth, gate truth, closeout truth, or source truth.
+
+## 2. Authority Boundary
+
+AI remains advisory, registered, audited, cited, and subordinate to reviewed AegisOps records.
+
+No AI trace lifecycle state or transition may grant approval, execution, reconciliation, case-closure, detector-activation, source-truth, production write, policy-bypass, or authority-widening capability.
+
+Accepted and corrected AI trace states mean only that an operator reviewed the trace as advisory context. They do not close cases, approve actions, execute actions, reconcile receipts, activate detectors, create source truth, or promote trace output over the reviewed AegisOps record chain.
+
+Rejected and expired AI trace states must preserve auditability while keeping the trace unusable as accepted advisory context until a new cited trace is created and reviewed.
+
+This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md` for AI approval, execution, reconciliation, case closure, detector activation, and source-truth refusal.
+
+## 3. Lifecycle States
+
+| State | Meaning | Authority ceiling |
+| --- | --- | --- |
+| `created` | Trace was produced by a registered agent through registered tools against a directly linked reviewed record and citations. | Advisory only, subordinate to AegisOps records. |
+| `reviewed` | Operator review has inspected the trace, citations, linkage, freshness, and unresolved questions. | Advisory only, subordinate to AegisOps records. |
+| `accepted` | Operator accepted the trace as advisory context for the reviewed record. | Advisory only, subordinate to AegisOps records. |
+| `corrected` | Operator corrected the trace while preserving reviewer/action metadata and citations. | Advisory only, subordinate to AegisOps records. |
+| `rejected` | Operator rejected the trace as unusable advisory context. | Advisory only, subordinate to AegisOps records. |
+| `expired` | Trace passed its expiration boundary and cannot be accepted without a new cited trace lifecycle. | Advisory only, subordinate to AegisOps records. |
+
+These names identify trace review states, not workflow states with independent authority.
+
+## 4. Transition Rules
+
+Allowed transitions are limited to:
+
+- `created` to `reviewed`;
+- `created` to `expired`;
+- `reviewed` to `accepted`;
+- `reviewed` to `corrected`;
+- `reviewed` to `rejected`;
+- `reviewed` to `expired`;
+- `accepted` to `expired`;
+- `corrected` to `expired`.
+
+Review outcome transitions must include reviewer/action metadata. Expiration transitions must include expiration metadata. No transition may mutate alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, closeout, detector, or source-truth records.
+
+## 5. Trace Review Queue Skeleton
+
+The Phase 59.3 contract only reserves the trace review queue inputs needed by Phase 59.7: `trace_id`, `state`, `reviewed_record_family`, `reviewed_record_id`, `registered_agent_name`, `registered_tool_names`, `citation_ids`, `expires_at`, and `review_required`.
+
+The queue skeleton is not a production UI/API implementation and must not treat queue ordering, badge text, cache state, browser state, or trace state as workflow truth.
+
+## 6. Verifier Requirements
+
+The lifecycle verifier must fail when:
+
+- the contract doc is missing;
+- the lifecycle artifact is missing or invalid JSON;
+- any lifecycle state is missing created, reviewed, accepted, corrected, rejected, or expired coverage;
+- any lifecycle state omits registered agent linkage, registered tool linkage, citation linkage, reviewed record family and identifier linkage, or expiration handling;
+- any lifecycle state references an unregistered agent or tool;
+- review outcome states omit reviewer/action metadata requirements;
+- allowed transitions omit required lifecycle paths or allow expired traces to become accepted without a new trace;
+- any lifecycle state or transition grants approval, execution, reconciliation, case closure, detector activation, source-truth creation, production write, policy bypass, workflow truth, or authority widening;
+- publishable artifacts contain workstation-local absolute paths.
+
+## 7. Validation
+
+Run `bash scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh`.
+
+Run `bash scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh`.
+
+Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1255 --config <supervisor-config-path>`.
+
+## 8. Non-Goals
+
+- No new production write authority is introduced.
+- No AI output, trace state, citation, registry row, lifecycle artifact, verifier output, issue-lint output, browser state, UI state, demo data, Wazuh state, Shuffle state, ticket state, optional evidence, or prompt text becomes authoritative workflow truth.
+- No Phase 59.7 trace review queue UI/API implementation is introduced.
+- No Phase 60 daily AI operations behavior is implemented.
+- No model/provider selection, billing, prompt marketplace, tool marketplace, or agent ecosystem breadth is implemented.
+- No approval, execution, reconciliation, case closure, detector activation, source-truth creation, production write, or policy bypass is delegated to AI.

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -68,6 +68,16 @@ assert_fails_with() {
   fi
 }
 
+assert_mutation_fails_with() {
+  local mutation="$1"
+  local expected="$2"
+  local mutated_repo="${workdir}/${mutation}"
+
+  create_valid_repo "${mutated_repo}"
+  mutate_lifecycle "${mutated_repo}" "${mutation}"
+  assert_fails_with "${mutated_repo}" "${expected}"
+}
+
 mutate_lifecycle() {
   local target="$1"
   local mutation="$2"
@@ -85,6 +95,7 @@ states = lifecycle["lifecycle_states"]
 created = next(state for state in states if state["state"] == "created")
 accepted = next(state for state in states if state["state"] == "accepted")
 corrected = next(state for state in states if state["state"] == "corrected")
+rejected = next(state for state in states if state["state"] == "rejected")
 reviewed = next(state for state in states if state["state"] == "reviewed")
 
 if mutation == "missing_created_state":
@@ -118,11 +129,33 @@ elif mutation == "missing_transition":
     ]
 elif mutation == "terminal_state_with_outgoing_transition":
     accepted["terminal"] = True
-elif mutation == "missing_state_specific_linkage":
+elif mutation == "missing_reviewed_state_linkage":
+    reviewed["required_linkage"] = [
+        value for value in reviewed["required_linkage"] if value != "reviewed_at"
+    ]
+elif mutation == "missing_accepted_state_linkage":
+    accepted["required_linkage"] = [
+        value for value in accepted["required_linkage"] if value != "accepted_at"
+    ]
+elif mutation == "missing_corrected_state_linkage":
     corrected["required_linkage"] = [
         value for value in corrected["required_linkage"] if value != "corrected_at"
     ]
-elif mutation == "missing_transition_specific_metadata":
+elif mutation == "missing_rejected_state_linkage":
+    rejected["required_linkage"] = [
+        value for value in rejected["required_linkage"] if value != "rejected_at"
+    ]
+elif mutation == "missing_reviewed_transition_metadata":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "created"
+        and transition["to_state"] == "reviewed"
+    )
+    transition["required_metadata"] = [
+        value for value in transition["required_metadata"] if value != "reviewed_at"
+    ]
+elif mutation == "missing_accepted_transition_metadata":
     transition = next(
         transition
         for transition in lifecycle["allowed_transitions"]
@@ -132,8 +165,40 @@ elif mutation == "missing_transition_specific_metadata":
     transition["required_metadata"] = [
         value for value in transition["required_metadata"] if value != "accepted_at"
     ]
+elif mutation == "missing_corrected_transition_metadata":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "corrected"
+    )
+    transition["required_metadata"] = [
+        value for value in transition["required_metadata"] if value != "corrected_at"
+    ]
+elif mutation == "missing_rejected_transition_metadata":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "rejected"
+    )
+    transition["required_metadata"] = [
+        value for value in transition["required_metadata"] if value != "rejected_at"
+    ]
 elif mutation == "allowed_from_drift":
     accepted["allowed_from"] = ["created"]
+elif mutation == "invalid_allowed_from_state":
+    accepted["allowed_from"] = ["unknown_review_state"]
+elif mutation == "unexpected_transition_pair":
+    lifecycle["allowed_transitions"].append(
+        {
+            "from_state": "accepted",
+            "to_state": "reviewed",
+            "required_trigger": "invalid review rewind",
+            "required_metadata": ["reviewer_id", "review_action_id", "reviewed_at"],
+            "authority_effect": "advisory_only_no_workflow_mutation",
+        }
+    )
 elif mutation == "expiry_can_accept":
     lifecycle["allowed_transitions"].append(
         {
@@ -200,10 +265,6 @@ for mutation in \
   missing_expiration \
   authority_expansion \
   missing_transition \
-  terminal_state_with_outgoing_transition \
-  missing_state_specific_linkage \
-  missing_transition_specific_metadata \
-  allowed_from_drift \
   expiry_can_accept \
   reviewed_truth_claim
 do
@@ -212,6 +273,43 @@ do
   mutate_lifecycle "${mutated_repo}" "${mutation}"
   assert_fails_with "${mutated_repo}" "Phase 59.3"
 done
+
+assert_mutation_fails_with \
+  terminal_state_with_outgoing_transition \
+  "Phase 59.3 AI trace lifecycle state accepted terminal flag must be false while outgoing transitions exist."
+assert_mutation_fails_with \
+  missing_reviewed_state_linkage \
+  "Phase 59.3 AI trace lifecycle state reviewed is missing state-specific linkage field(s): reviewed_at"
+assert_mutation_fails_with \
+  missing_accepted_state_linkage \
+  "Phase 59.3 AI trace lifecycle state accepted is missing state-specific linkage field(s): accepted_at"
+assert_mutation_fails_with \
+  missing_corrected_state_linkage \
+  "Phase 59.3 AI trace lifecycle state corrected is missing state-specific linkage field(s): corrected_at"
+assert_mutation_fails_with \
+  missing_rejected_state_linkage \
+  "Phase 59.3 AI trace lifecycle state rejected is missing state-specific linkage field(s): rejected_at"
+assert_mutation_fails_with \
+  missing_reviewed_transition_metadata \
+  "Phase 59.3 AI trace lifecycle transition created->reviewed is missing transition-specific metadata: reviewed_at"
+assert_mutation_fails_with \
+  missing_accepted_transition_metadata \
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted is missing transition-specific metadata: accepted_at"
+assert_mutation_fails_with \
+  missing_corrected_transition_metadata \
+  "Phase 59.3 AI trace lifecycle transition reviewed->corrected is missing transition-specific metadata: corrected_at"
+assert_mutation_fails_with \
+  missing_rejected_transition_metadata \
+  "Phase 59.3 AI trace lifecycle transition reviewed->rejected is missing transition-specific metadata: rejected_at"
+assert_mutation_fails_with \
+  invalid_allowed_from_state \
+  "Phase 59.3 AI trace lifecycle state accepted references invalid allowed_from state: unknown_review_state"
+assert_mutation_fails_with \
+  allowed_from_drift \
+  "Phase 59.3 AI trace lifecycle state accepted allowed_from must match transition graph: expected reviewed; got created"
+assert_mutation_fails_with \
+  unexpected_transition_pair \
+  "Phase 59.3 AI trace lifecycle contains unexpected transition for this slice: accepted->reviewed"
 
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -403,13 +403,13 @@ assert_mutation_fails_with \
   "Duplicate Phase 59.3 AI trace lifecycle transition: reviewed->accepted"
 assert_mutation_fails_with \
   empty_required_trigger \
-  "Phase 59.3 AI trace lifecycle transition reviewed->accepted must include non-empty required_trigger."
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted required_trigger must be a non-empty string."
 assert_mutation_fails_with \
   non_string_required_trigger \
-  "Phase 59.3 AI trace lifecycle transition reviewed->accepted must include non-empty required_trigger."
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted required_trigger must be a non-empty string."
 assert_mutation_fails_with \
   authority_trigger_claim \
-  "Phase 59.3 AI trace lifecycle transition reviewed->accepted contains forbidden authority claim in required_trigger."
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted required_trigger contains forbidden authority claim."
 assert_mutation_fails_with \
   queue_extra_required_field \
   "Phase 59.3 trace review queue skeleton required_fields contains extra field(s): case_closure_state"

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -84,6 +84,7 @@ lifecycle = json.loads(path.read_text(encoding="utf-8"))
 states = lifecycle["lifecycle_states"]
 created = next(state for state in states if state["state"] == "created")
 accepted = next(state for state in states if state["state"] == "accepted")
+corrected = next(state for state in states if state["state"] == "corrected")
 reviewed = next(state for state in states if state["state"] == "reviewed")
 
 if mutation == "missing_created_state":
@@ -115,6 +116,24 @@ elif mutation == "missing_transition":
             and transition["to_state"] == "corrected"
         )
     ]
+elif mutation == "terminal_state_with_outgoing_transition":
+    accepted["terminal"] = True
+elif mutation == "missing_state_specific_linkage":
+    corrected["required_linkage"] = [
+        value for value in corrected["required_linkage"] if value != "corrected_at"
+    ]
+elif mutation == "missing_transition_specific_metadata":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "accepted"
+    )
+    transition["required_metadata"] = [
+        value for value in transition["required_metadata"] if value != "accepted_at"
+    ]
+elif mutation == "allowed_from_drift":
+    accepted["allowed_from"] = ["created"]
 elif mutation == "expiry_can_accept":
     lifecycle["allowed_transitions"].append(
         {
@@ -181,6 +200,10 @@ for mutation in \
   missing_expiration \
   authority_expansion \
   missing_transition \
+  terminal_state_with_outgoing_transition \
+  missing_state_specific_linkage \
+  missing_transition_specific_metadata \
+  allowed_from_drift \
   expiry_can_accept \
   reviewed_truth_claim
 do

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -191,6 +191,14 @@ elif mutation == "missing_rejected_transition_metadata":
     transition["required_metadata"] = [
         value for value in transition["required_metadata"] if value != "rejected_at"
     ]
+elif mutation == "duplicate_transition_metadata":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "accepted"
+    )
+    transition["required_metadata"].append("accepted_at")
 elif mutation == "allowed_from_drift":
     accepted["allowed_from"] = ["created"]
 elif mutation == "invalid_allowed_from_state":
@@ -235,6 +243,8 @@ elif mutation == "queue_extra_required_field":
     )
 elif mutation == "queue_non_string_required_field":
     lifecycle["trace_review_queue_skeleton"]["required_fields"].append(42)
+elif mutation == "queue_duplicate_required_field":
+    lifecycle["trace_review_queue_skeleton"]["required_fields"].append("trace_id")
 elif mutation == "queue_missing_non_authoritative_surface":
     lifecycle["trace_review_queue_skeleton"]["non_authoritative_surfaces"] = [
         surface
@@ -246,6 +256,10 @@ elif mutation == "queue_missing_non_authoritative_surface":
 elif mutation == "queue_extra_non_authoritative_surface":
     lifecycle["trace_review_queue_skeleton"]["non_authoritative_surfaces"].append(
         "workflow_truth"
+    )
+elif mutation == "queue_duplicate_non_authoritative_surface":
+    lifecycle["trace_review_queue_skeleton"]["non_authoritative_surfaces"].append(
+        "trace_state"
     )
 elif mutation == "expiry_can_accept":
     lifecycle["allowed_transitions"].append(
@@ -359,6 +373,9 @@ assert_mutation_fails_with \
   missing_rejected_transition_metadata \
   "Phase 59.3 AI trace lifecycle transition reviewed->rejected is missing transition-specific metadata: rejected_at"
 assert_mutation_fails_with \
+  duplicate_transition_metadata \
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted required_metadata must not contain duplicate value(s): accepted_at"
+assert_mutation_fails_with \
   invalid_allowed_from_state \
   "Phase 59.3 AI trace lifecycle state accepted references invalid allowed_from state: unknown_review_state"
 assert_mutation_fails_with \
@@ -383,11 +400,17 @@ assert_mutation_fails_with \
   queue_non_string_required_field \
   "Phase 59.3 trace review queue skeleton required_fields must be a string list."
 assert_mutation_fails_with \
+  queue_duplicate_required_field \
+  "Phase 59.3 trace review queue skeleton required_fields must not contain duplicate value(s): trace_id"
+assert_mutation_fails_with \
   queue_missing_non_authoritative_surface \
   "Phase 59.3 trace review queue skeleton is missing non-authoritative surface(s): trace_state"
 assert_mutation_fails_with \
   queue_extra_non_authoritative_surface \
   "Phase 59.3 trace review queue skeleton contains extra non-authoritative surface(s): workflow_truth"
+assert_mutation_fails_with \
+  queue_duplicate_non_authoritative_surface \
+  "Phase 59.3 trace review queue skeleton non_authoritative_surfaces must not contain duplicate value(s): trace_state"
 
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -412,22 +412,22 @@ assert_mutation_fails_with \
   "Phase 59.3 AI trace lifecycle transition reviewed->accepted contains forbidden authority claim in required_trigger."
 assert_mutation_fails_with \
   queue_extra_required_field \
-  "Phase 59.3 trace review queue skeleton contains extra field(s): case_closure_state"
+  "Phase 59.3 trace review queue skeleton required_fields contains extra field(s): case_closure_state"
 assert_mutation_fails_with \
   queue_missing_required_field \
-  "Phase 59.3 trace review queue skeleton is missing field(s): review_required"
+  "Phase 59.3 trace review queue skeleton required_fields is missing field(s): review_required"
 assert_mutation_fails_with \
   queue_non_string_required_field \
-  "Phase 59.3 trace review queue skeleton required_fields must be a string list."
+  "Phase 59.3 trace review queue skeleton required_fields must be a non-empty string list."
 assert_mutation_fails_with \
   queue_duplicate_required_field \
   "Phase 59.3 trace review queue skeleton required_fields must not contain duplicate value(s): trace_id"
 assert_mutation_fails_with \
   queue_missing_non_authoritative_surface \
-  "Phase 59.3 trace review queue skeleton is missing non-authoritative surface(s): trace_state"
+  "Phase 59.3 trace review queue skeleton non_authoritative_surfaces is missing field(s): trace_state"
 assert_mutation_fails_with \
   queue_extra_non_authoritative_surface \
-  "Phase 59.3 trace review queue skeleton contains extra non-authoritative surface(s): workflow_truth"
+  "Phase 59.3 trace review queue skeleton non_authoritative_surfaces contains extra field(s): workflow_truth"
 assert_mutation_fails_with \
   queue_duplicate_non_authoritative_surface \
   "Phase 59.3 trace review queue skeleton non_authoritative_surfaces must not contain duplicate value(s): trace_state"

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -102,6 +102,12 @@ if mutation == "missing_created_state":
     lifecycle["lifecycle_states"] = [
         state for state in states if state["state"] != "created"
     ]
+elif mutation == "schema_version_drift":
+    lifecycle["schema_version"] = "bogus"
+elif mutation == "null_authority_boundary":
+    lifecycle["authority_boundary"] = None
+elif mutation == "weak_authority_boundary":
+    lifecycle["authority_boundary"] = "AI trace lifecycle contract."
 elif mutation == "missing_registered_agent":
     created["registered_agents"] = []
 elif mutation == "unregistered_tool":
@@ -199,6 +205,48 @@ elif mutation == "unexpected_transition_pair":
             "authority_effect": "advisory_only_no_workflow_mutation",
         }
     )
+elif mutation == "duplicate_transition_pair":
+    reviewed_to_accepted = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "accepted"
+    )
+    lifecycle["allowed_transitions"].append(dict(reviewed_to_accepted))
+elif mutation == "empty_required_trigger":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "accepted"
+    )
+    transition["required_trigger"] = ""
+elif mutation == "authority_trigger_claim":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "accepted"
+    )
+    transition["required_trigger"] = "AI may approve case closure"
+elif mutation == "queue_extra_required_field":
+    lifecycle["trace_review_queue_skeleton"]["required_fields"].append(
+        "case_closure_state"
+    )
+elif mutation == "queue_non_string_required_field":
+    lifecycle["trace_review_queue_skeleton"]["required_fields"].append(42)
+elif mutation == "queue_missing_non_authoritative_surface":
+    lifecycle["trace_review_queue_skeleton"]["non_authoritative_surfaces"] = [
+        surface
+        for surface in lifecycle["trace_review_queue_skeleton"][
+            "non_authoritative_surfaces"
+        ]
+        if surface != "trace_state"
+    ]
+elif mutation == "queue_extra_non_authoritative_surface":
+    lifecycle["trace_review_queue_skeleton"]["non_authoritative_surfaces"].append(
+        "workflow_truth"
+    )
 elif mutation == "expiry_can_accept":
     lifecycle["allowed_transitions"].append(
         {
@@ -278,6 +326,15 @@ assert_mutation_fails_with \
   terminal_state_with_outgoing_transition \
   "Phase 59.3 AI trace lifecycle state accepted terminal flag must be false while outgoing transitions exist."
 assert_mutation_fails_with \
+  schema_version_drift \
+  "Phase 59.3 AI trace lifecycle schema_version must be 2026-05-11.phase-59.3."
+assert_mutation_fails_with \
+  null_authority_boundary \
+  "Phase 59.3 AI trace lifecycle authority_boundary must be a non-empty string."
+assert_mutation_fails_with \
+  weak_authority_boundary \
+  "Phase 59.3 AI trace lifecycle authority_boundary must preserve subordinate AegisOps authority semantics."
+assert_mutation_fails_with \
   missing_reviewed_state_linkage \
   "Phase 59.3 AI trace lifecycle state reviewed is missing state-specific linkage field(s): reviewed_at"
 assert_mutation_fails_with \
@@ -310,6 +367,27 @@ assert_mutation_fails_with \
 assert_mutation_fails_with \
   unexpected_transition_pair \
   "Phase 59.3 AI trace lifecycle contains unexpected transition for this slice: accepted->reviewed"
+assert_mutation_fails_with \
+  duplicate_transition_pair \
+  "Duplicate Phase 59.3 AI trace lifecycle transition: reviewed->accepted"
+assert_mutation_fails_with \
+  empty_required_trigger \
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted must include non-empty required_trigger."
+assert_mutation_fails_with \
+  authority_trigger_claim \
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted contains forbidden authority claim in required_trigger."
+assert_mutation_fails_with \
+  queue_extra_required_field \
+  "Phase 59.3 trace review queue skeleton contains extra field(s): case_closure_state"
+assert_mutation_fails_with \
+  queue_non_string_required_field \
+  "Phase 59.3 trace review queue skeleton required_fields must be a string list."
+assert_mutation_fails_with \
+  queue_missing_non_authoritative_surface \
+  "Phase 59.3 trace review queue skeleton is missing non-authoritative surface(s): trace_state"
+assert_mutation_fails_with \
+  queue_extra_non_authoritative_surface \
+  "Phase 59.3 trace review queue skeleton contains extra non-authoritative surface(s): workflow_truth"
 
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -110,6 +110,8 @@ elif mutation == "weak_authority_boundary":
     lifecycle["authority_boundary"] = "AI trace lifecycle contract."
 elif mutation == "authority_boundary_expansion":
     lifecycle["authority_boundary"] += " AI may approve actions."
+elif mutation == "authority_boundary_broader_expansion":
+    lifecycle["authority_boundary"] += " operator can approve case closure."
 elif mutation == "missing_registered_agent":
     created["registered_agents"] = []
 elif mutation == "unregistered_tool":
@@ -394,6 +396,9 @@ assert_mutation_fails_with \
   "Phase 59.3 AI trace lifecycle authority_boundary must preserve subordinate AegisOps authority semantics."
 assert_mutation_fails_with \
   authority_boundary_expansion \
+  "Phase 59.3 AI trace lifecycle authority_boundary contains forbidden authority claim."
+assert_mutation_fails_with \
+  authority_boundary_broader_expansion \
   "Phase 59.3 AI trace lifecycle authority_boundary contains forbidden authority claim."
 assert_mutation_fails_with \
   missing_reviewed_state_linkage \

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh"
+
+if [[ ! -x "${verifier}" ]]; then
+  echo "Missing executable Phase 59.3 AI trace lifecycle verifier: ${verifier}" >&2
+  exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/automation"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+  printf '%s\n' \
+    "# AegisOps" \
+    "See [Phase 59.3 AI trace lifecycle contract](docs/phase-59-3-ai-trace-lifecycle-contract.md)." \
+    >"${target}/README.md"
+  cp "${repo_root}/docs/phase-59-3-ai-trace-lifecycle-contract.md" \
+    "${target}/docs/phase-59-3-ai-trace-lifecycle-contract.md"
+  cp "${repo_root}/docs/automation/ai-agent-registry.json" \
+    "${target}/docs/automation/ai-agent-registry.json"
+  cp "${repo_root}/docs/automation/ai-tool-registry.json" \
+    "${target}/docs/automation/ai-tool-registry.json"
+  cp "${repo_root}/docs/automation/ai-trace-lifecycle.json" \
+    "${target}/docs/automation/ai-trace-lifecycle.json"
+  git -C "${target}" add README.md docs/phase-59-3-ai-trace-lifecycle-contract.md \
+    docs/automation/ai-agent-registry.json docs/automation/ai-tool-registry.json \
+    docs/automation/ai-trace-lifecycle.json
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+mutate_lifecycle() {
+  local target="$1"
+  local mutation="$2"
+
+  python3 - "${target}/docs/automation/ai-trace-lifecycle.json" "${mutation}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+mutation = sys.argv[2]
+lifecycle = json.loads(path.read_text(encoding="utf-8"))
+
+states = lifecycle["lifecycle_states"]
+created = next(state for state in states if state["state"] == "created")
+accepted = next(state for state in states if state["state"] == "accepted")
+reviewed = next(state for state in states if state["state"] == "reviewed")
+
+if mutation == "missing_created_state":
+    lifecycle["lifecycle_states"] = [
+        state for state in states if state["state"] != "created"
+    ]
+elif mutation == "missing_registered_agent":
+    created["registered_agents"] = []
+elif mutation == "unregistered_tool":
+    created["registered_tools"].append("autonomous_case_closure")
+elif mutation == "missing_citation":
+    created["required_linkage"] = [
+        value for value in created["required_linkage"] if "citation_ids" not in value
+    ]
+elif mutation == "missing_reviewer_metadata":
+    accepted["reviewer_action_metadata_required"] = False
+elif mutation == "missing_expiration":
+    created["required_linkage"] = [
+        value for value in created["required_linkage"] if "expires_at" not in value
+    ]
+elif mutation == "authority_expansion":
+    accepted["authority_effect"] = "may_close_case"
+elif mutation == "missing_transition":
+    lifecycle["allowed_transitions"] = [
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if not (
+            transition["from_state"] == "reviewed"
+            and transition["to_state"] == "corrected"
+        )
+    ]
+elif mutation == "expiry_can_accept":
+    lifecycle["allowed_transitions"].append(
+        {
+            "from_state": "expired",
+            "to_state": "accepted",
+            "required_trigger": "late operator acceptance",
+            "required_metadata": ["reviewer_id", "review_action_id"],
+            "authority_effect": "advisory_only_no_workflow_mutation",
+        }
+    )
+elif mutation == "reviewed_truth_claim":
+    reviewed["purpose"] += " This state becomes workflow truth."
+elif mutation == "json_escaped_windows_path":
+    created["purpose"] += " See C:" + chr(92) + "Users" + chr(92) + "example" + chr(92) + "trace.txt."
+elif mutation == "json_escaped_unix_path":
+    created["purpose"] += " See /" + "Users/example/trace.txt."
+else:
+    raise SystemExit(f"unknown mutation: {mutation}")
+
+path.write_text(json.dumps(lifecycle, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+PY
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-59-3-ai-trace-lifecycle-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-59-3-ai-trace-lifecycle-contract.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 59.3 AI trace lifecycle contract doc"
+
+missing_lifecycle_repo="${workdir}/missing-lifecycle"
+create_valid_repo "${missing_lifecycle_repo}"
+rm "${missing_lifecycle_repo}/docs/automation/ai-trace-lifecycle.json"
+assert_fails_with \
+  "${missing_lifecycle_repo}" \
+  "Missing Phase 59.3 AI trace lifecycle artifact"
+
+missing_contract_field_repo="${workdir}/missing-contract-field"
+create_valid_repo "${missing_contract_field_repo}"
+remove_text_from_doc "${missing_contract_field_repo}" \
+  "Every AI trace lifecycle state must require registered agent linkage, registered tool linkage, citations, reviewed record family and identifier linkage, expiration handling, and advisory-only authority."
+assert_fails_with \
+  "${missing_contract_field_repo}" \
+  "Missing Phase 59.3 AI trace lifecycle contract statement: Every AI trace lifecycle state"
+
+for mutation in \
+  missing_created_state \
+  missing_registered_agent \
+  unregistered_tool \
+  missing_citation \
+  missing_reviewer_metadata \
+  missing_expiration \
+  authority_expansion \
+  missing_transition \
+  expiry_can_accept \
+  reviewed_truth_claim
+do
+  mutated_repo="${workdir}/${mutation}"
+  create_valid_repo "${mutated_repo}"
+  mutate_lifecycle "${mutated_repo}" "${mutation}"
+  assert_fails_with "${mutated_repo}" "Phase 59.3"
+done
+
+local_path_repo="${workdir}/local-path"
+create_valid_repo "${local_path_repo}"
+printf '/%s/%s/%s\n' "Users" "example" "trace.txt" \
+  >>"${local_path_repo}/docs/phase-59-3-ai-trace-lifecycle-contract.md"
+assert_fails_with \
+  "${local_path_repo}" \
+  "workstation-local absolute path detected"
+
+json_escaped_windows_path_repo="${workdir}/json-escaped-windows-path"
+create_valid_repo "${json_escaped_windows_path_repo}"
+mutate_lifecycle "${json_escaped_windows_path_repo}" "json_escaped_windows_path"
+assert_fails_with \
+  "${json_escaped_windows_path_repo}" \
+  "workstation-local absolute path detected"
+
+json_escaped_unix_path_repo="${workdir}/json-escaped-unix-path"
+create_valid_repo "${json_escaped_unix_path_repo}"
+mutate_lifecycle "${json_escaped_unix_path_repo}" "json_escaped_unix_path"
+assert_fails_with \
+  "${json_escaped_unix_path_repo}" \
+  "workstation-local absolute path detected"
+
+echo "Phase 59.3 AI trace lifecycle verifier rejects missing states, unregistered linkage, missing citations, missing review or expiration handling, authority expansion, invalid transitions, truth claims, and local paths."

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -108,6 +108,8 @@ elif mutation == "null_authority_boundary":
     lifecycle["authority_boundary"] = None
 elif mutation == "weak_authority_boundary":
     lifecycle["authority_boundary"] = "AI trace lifecycle contract."
+elif mutation == "authority_boundary_expansion":
+    lifecycle["authority_boundary"] += " AI may approve actions."
 elif mutation == "missing_registered_agent":
     created["registered_agents"] = []
 elif mutation == "unregistered_tool":
@@ -245,6 +247,22 @@ elif mutation == "authority_trigger_claim":
         and transition["to_state"] == "accepted"
     )
     transition["required_trigger"] = "AI may approve case closure"
+elif mutation == "authority_trigger_whitespace_claim":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "accepted"
+    )
+    transition["required_trigger"] = "AI may\t\tapprove case closure"
+elif mutation == "broader_authority_trigger_claim":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "accepted"
+    )
+    transition["required_trigger"] = "operator can approve case closure"
 elif mutation == "queue_extra_required_field":
     lifecycle["trace_review_queue_skeleton"]["required_fields"].append(
         "case_closure_state"
@@ -275,6 +293,18 @@ elif mutation == "queue_duplicate_non_authoritative_surface":
     lifecycle["trace_review_queue_skeleton"]["non_authoritative_surfaces"].append(
         "trace_state"
     )
+elif mutation == "forbidden_authority_missing":
+    lifecycle["forbidden_authority_states"] = [
+        value
+        for value in lifecycle["forbidden_authority_states"]
+        if value != "workflow_truth"
+    ]
+elif mutation == "forbidden_authority_extra":
+    lifecycle["forbidden_authority_states"].append("autonomous_case_closure")
+elif mutation == "forbidden_authority_non_string":
+    lifecycle["forbidden_authority_states"].append(42)
+elif mutation == "forbidden_authority_duplicate":
+    lifecycle["forbidden_authority_states"].append("approval")
 elif mutation == "expiry_can_accept":
     lifecycle["allowed_transitions"].append(
         {
@@ -363,6 +393,9 @@ assert_mutation_fails_with \
   weak_authority_boundary \
   "Phase 59.3 AI trace lifecycle authority_boundary must preserve subordinate AegisOps authority semantics."
 assert_mutation_fails_with \
+  authority_boundary_expansion \
+  "Phase 59.3 AI trace lifecycle authority_boundary contains forbidden authority claim."
+assert_mutation_fails_with \
   missing_reviewed_state_linkage \
   "Phase 59.3 AI trace lifecycle state reviewed is missing state-specific linkage field(s): reviewed_at"
 assert_mutation_fails_with \
@@ -411,6 +444,12 @@ assert_mutation_fails_with \
   authority_trigger_claim \
   "Phase 59.3 AI trace lifecycle transition reviewed->accepted required_trigger contains forbidden authority claim."
 assert_mutation_fails_with \
+  authority_trigger_whitespace_claim \
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted required_trigger contains forbidden authority claim."
+assert_mutation_fails_with \
+  broader_authority_trigger_claim \
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted required_trigger contains forbidden authority claim."
+assert_mutation_fails_with \
   queue_extra_required_field \
   "Phase 59.3 trace review queue skeleton required_fields contains extra field(s): case_closure_state"
 assert_mutation_fails_with \
@@ -431,6 +470,18 @@ assert_mutation_fails_with \
 assert_mutation_fails_with \
   queue_duplicate_non_authoritative_surface \
   "Phase 59.3 trace review queue skeleton non_authoritative_surfaces must not contain duplicate value(s): trace_state"
+assert_mutation_fails_with \
+  forbidden_authority_missing \
+  "Phase 59.3 AI trace lifecycle forbidden_authority_states is missing field(s): workflow_truth"
+assert_mutation_fails_with \
+  forbidden_authority_extra \
+  "Phase 59.3 AI trace lifecycle forbidden_authority_states contains extra field(s): autonomous_case_closure"
+assert_mutation_fails_with \
+  forbidden_authority_non_string \
+  "Phase 59.3 AI trace lifecycle forbidden_authority_states must be a non-empty string list."
+assert_mutation_fails_with \
+  forbidden_authority_duplicate \
+  "Phase 59.3 AI trace lifecycle forbidden_authority_states must not contain duplicate value(s): approval"
 
 local_path_repo="${workdir}/local-path"
 create_valid_repo "${local_path_repo}"

--- a/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -229,6 +229,14 @@ elif mutation == "empty_required_trigger":
         and transition["to_state"] == "accepted"
     )
     transition["required_trigger"] = ""
+elif mutation == "non_string_required_trigger":
+    transition = next(
+        transition
+        for transition in lifecycle["allowed_transitions"]
+        if transition["from_state"] == "reviewed"
+        and transition["to_state"] == "accepted"
+    )
+    transition["required_trigger"] = 42
 elif mutation == "authority_trigger_claim":
     transition = next(
         transition
@@ -241,6 +249,12 @@ elif mutation == "queue_extra_required_field":
     lifecycle["trace_review_queue_skeleton"]["required_fields"].append(
         "case_closure_state"
     )
+elif mutation == "queue_missing_required_field":
+    lifecycle["trace_review_queue_skeleton"]["required_fields"] = [
+        value
+        for value in lifecycle["trace_review_queue_skeleton"]["required_fields"]
+        if value != "review_required"
+    ]
 elif mutation == "queue_non_string_required_field":
     lifecycle["trace_review_queue_skeleton"]["required_fields"].append(42)
 elif mutation == "queue_duplicate_required_field":
@@ -391,11 +405,17 @@ assert_mutation_fails_with \
   empty_required_trigger \
   "Phase 59.3 AI trace lifecycle transition reviewed->accepted must include non-empty required_trigger."
 assert_mutation_fails_with \
+  non_string_required_trigger \
+  "Phase 59.3 AI trace lifecycle transition reviewed->accepted must include non-empty required_trigger."
+assert_mutation_fails_with \
   authority_trigger_claim \
   "Phase 59.3 AI trace lifecycle transition reviewed->accepted contains forbidden authority claim in required_trigger."
 assert_mutation_fails_with \
   queue_extra_required_field \
   "Phase 59.3 trace review queue skeleton contains extra field(s): case_closure_state"
+assert_mutation_fails_with \
+  queue_missing_required_field \
+  "Phase 59.3 trace review queue skeleton is missing field(s): review_required"
 assert_mutation_fails_with \
   queue_non_string_required_field \
   "Phase 59.3 trace review queue skeleton required_fields must be a string list."

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -102,9 +102,28 @@ if missing_root:
 if lifecycle["phase"] != "59.3":
     raise SystemExit("Phase 59.3 AI trace lifecycle phase must be 59.3.")
 
+if lifecycle["schema_version"] != "2026-05-11.phase-59.3":
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle schema_version must be 2026-05-11.phase-59.3."
+    )
+
 if lifecycle["contract_status"] != "accepted_contract_slice":
     raise SystemExit(
         "Phase 59.3 AI trace lifecycle status must be accepted_contract_slice."
+    )
+
+authority_boundary = lifecycle["authority_boundary"]
+if not isinstance(authority_boundary, str) or not authority_boundary.strip():
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle authority_boundary must be a non-empty string."
+    )
+authority_boundary_lower = authority_boundary.casefold()
+if (
+    "subordinate" not in authority_boundary_lower
+    or "aegisops records remain authoritative" not in authority_boundary_lower
+):
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle authority_boundary must preserve subordinate AegisOps authority semantics."
     )
 
 states = lifecycle["lifecycle_states"]
@@ -409,6 +428,21 @@ for index, transition in enumerate(transitions, start=1):
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle contains unexpected transition for this slice: {from_state}->{to_state}"
         )
+    if transition_pair in seen_transitions:
+        raise SystemExit(
+            f"Duplicate Phase 59.3 AI trace lifecycle transition: {from_state}->{to_state}"
+        )
+
+    trigger = transition["required_trigger"]
+    if not isinstance(trigger, str) or not trigger.strip():
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must include non-empty required_trigger."
+        )
+    trigger_lowered = trigger.casefold().replace("-", "_").replace(" ", "_")
+    if any(fragment in trigger_lowered for fragment in forbidden_claim_fragments):
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} contains forbidden authority claim in required_trigger."
+        )
 
     if transition["authority_effect"] != "advisory_only_no_workflow_mutation":
         raise SystemExit(
@@ -508,13 +542,61 @@ required_queue_fields = {
     "review_required",
 }
 queue_fields = queue.get("required_fields")
-if not isinstance(queue_fields, list):
-    raise SystemExit("Phase 59.3 trace review queue skeleton required_fields must be a list.")
-missing_queue = sorted(required_queue_fields - set(queue_fields))
+if (
+    not isinstance(queue_fields, list)
+    or any(not isinstance(value, str) or not value.strip() for value in queue_fields)
+):
+    raise SystemExit(
+        "Phase 59.3 trace review queue skeleton required_fields must be a string list."
+    )
+actual_queue_fields = set(queue_fields)
+missing_queue = sorted(required_queue_fields - actual_queue_fields)
 if missing_queue:
     raise SystemExit(
         "Phase 59.3 trace review queue skeleton is missing field(s): "
         + ", ".join(missing_queue)
+    )
+extra_queue = sorted(actual_queue_fields - required_queue_fields)
+if extra_queue:
+    raise SystemExit(
+        "Phase 59.3 trace review queue skeleton contains extra field(s): "
+        + ", ".join(extra_queue)
+    )
+
+required_non_authoritative_surfaces = {
+    "queue_order",
+    "badge_text",
+    "cache_state",
+    "browser_state",
+    "trace_state",
+}
+non_authoritative_surfaces = queue.get("non_authoritative_surfaces")
+if (
+    not isinstance(non_authoritative_surfaces, list)
+    or any(
+        not isinstance(value, str) or not value.strip()
+        for value in non_authoritative_surfaces
+    )
+):
+    raise SystemExit(
+        "Phase 59.3 trace review queue skeleton non_authoritative_surfaces must be a string list."
+    )
+actual_non_authoritative_surfaces = set(non_authoritative_surfaces)
+missing_non_authoritative = sorted(
+    required_non_authoritative_surfaces - actual_non_authoritative_surfaces
+)
+if missing_non_authoritative:
+    raise SystemExit(
+        "Phase 59.3 trace review queue skeleton is missing non-authoritative surface(s): "
+        + ", ".join(missing_non_authoritative)
+    )
+extra_non_authoritative = sorted(
+    actual_non_authoritative_surfaces - required_non_authoritative_surfaces
+)
+if extra_non_authoritative:
+    raise SystemExit(
+        "Phase 59.3 trace review queue skeleton contains extra non-authoritative surface(s): "
+        + ", ".join(extra_non_authoritative)
     )
 
 missing_forbidden = sorted(

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -63,10 +63,36 @@ python3 - "${lifecycle_path}" "${agent_registry_path}" "${tool_registry_path}" <
 import json
 import sys
 from pathlib import Path
+from collections import Counter
 
 lifecycle_path = Path(sys.argv[1])
 agent_registry_path = Path(sys.argv[2])
 tool_registry_path = Path(sys.argv[3])
+expected_schema_version = "2026-05-11.phase-59.3"
+
+
+def require_non_empty_string(value, description: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f"{description} must be a non-empty string.")
+    return value
+
+
+def require_non_empty_string_list(value, description: str) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or not item.strip() for item in value)
+    ):
+        raise SystemExit(f"{description} must be a non-empty string list.")
+    return value
+
+
+def require_no_duplicate_strings(values: list[str], description: str) -> None:
+    duplicates = sorted(item for item, count in Counter(values).items() if count > 1)
+    if duplicates:
+        raise SystemExit(
+            f"{description} must not contain duplicate value(s): " + ", ".join(duplicates)
+        )
 
 try:
     lifecycle = json.loads(lifecycle_path.read_text(encoding="utf-8"))
@@ -102,9 +128,9 @@ if missing_root:
 if lifecycle["phase"] != "59.3":
     raise SystemExit("Phase 59.3 AI trace lifecycle phase must be 59.3.")
 
-if lifecycle["schema_version"] != "2026-05-11.phase-59.3":
+if lifecycle["schema_version"] != expected_schema_version:
     raise SystemExit(
-        "Phase 59.3 AI trace lifecycle schema_version must be 2026-05-11.phase-59.3."
+        f"Phase 59.3 AI trace lifecycle schema_version must be {expected_schema_version}."
     )
 
 if lifecycle["contract_status"] != "accepted_contract_slice":
@@ -112,11 +138,10 @@ if lifecycle["contract_status"] != "accepted_contract_slice":
         "Phase 59.3 AI trace lifecycle status must be accepted_contract_slice."
     )
 
-authority_boundary = lifecycle["authority_boundary"]
-if not isinstance(authority_boundary, str) or not authority_boundary.strip():
-    raise SystemExit(
-        "Phase 59.3 AI trace lifecycle authority_boundary must be a non-empty string."
-    )
+authority_boundary = require_non_empty_string(
+    lifecycle["authority_boundary"],
+    "Phase 59.3 AI trace lifecycle authority_boundary",
+)
 authority_boundary_lower = authority_boundary.casefold()
 if (
     "subordinate" not in authority_boundary_lower
@@ -252,9 +277,10 @@ for index, state in enumerate(states, start=1):
     states_by_name[name] = state
 
     for field in ("purpose", "expiration_handling", "authority_effect"):
-        value = state[field]
-        if not isinstance(value, str) or not value.strip():
-            raise SystemExit(f"Phase 59.3 AI trace lifecycle state {name} has invalid {field}.")
+        value = require_non_empty_string(
+            state[field],
+            f"Phase 59.3 AI trace lifecycle state {name} {field}",
+        )
         lowered = value.casefold().replace("-", "_").replace(" ", "_")
         if any(fragment in lowered for fragment in forbidden_claim_fragments):
             if value != "advisory_only_no_workflow_mutation":
@@ -290,15 +316,14 @@ for index, state in enumerate(states, start=1):
         )
 
     for field in ("registered_agents", "registered_tools", "required_linkage", "disallowed_authority"):
-        values = state[field]
-        if (
-            not isinstance(values, list)
-            or not values
-            or any(not isinstance(value, str) or not value.strip() for value in values)
-        ):
-            raise SystemExit(
-                f"Phase 59.3 AI trace lifecycle state {name} must include non-empty string list {field}."
-            )
+        values = require_non_empty_string_list(
+            state[field],
+            f"Phase 59.3 AI trace lifecycle state {name} {field}",
+        )
+        require_no_duplicate_strings(
+            values,
+            f"Phase 59.3 AI trace lifecycle state {name} {field}",
+        )
 
     unknown_agents = sorted(set(state["registered_agents"]) - registered_agents)
     if unknown_agents:
@@ -372,7 +397,7 @@ required_transitions = {
     ("accepted", "expired"),
     ("corrected", "expired"),
 }
-seen_transitions: set[tuple[str, str]] = set()
+transition_rows_by_pair: dict[tuple[str, str], int] = {}
 required_transition_fields = {
     "from_state",
     "to_state",
@@ -428,7 +453,7 @@ for index, transition in enumerate(transitions, start=1):
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle contains unexpected transition for this slice: {from_state}->{to_state}"
         )
-    if transition_pair in seen_transitions:
+    if transition_pair in transition_rows_by_pair:
         raise SystemExit(
             f"Duplicate Phase 59.3 AI trace lifecycle transition: {from_state}->{to_state}"
         )
@@ -449,15 +474,14 @@ for index, transition in enumerate(transitions, start=1):
             f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must keep advisory-only authority."
         )
 
-    metadata = transition["required_metadata"]
-    if (
-        not isinstance(metadata, list)
-        or not metadata
-        or any(not isinstance(value, str) or not value.strip() for value in metadata)
-    ):
-        raise SystemExit(
-            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must include required metadata."
-        )
+    metadata = require_non_empty_string_list(
+        transition["required_metadata"],
+        f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} required_metadata",
+    )
+    require_no_duplicate_strings(
+        metadata,
+        f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} required_metadata",
+    )
 
     if to_state in {"accepted", "corrected", "rejected"}:
         missing_reviewer = sorted(required_reviewer_terms - set(metadata))
@@ -481,8 +505,9 @@ for index, transition in enumerate(transitions, start=1):
             + ", ".join(missing_transition_metadata)
         )
 
-    seen_transitions.add((from_state, to_state))
+    transition_rows_by_pair[transition_pair] = index
 
+seen_transitions = set(transition_rows_by_pair)
 missing_transitions = sorted(required_transitions - seen_transitions)
 unexpected_transitions = sorted(seen_transitions - required_transitions)
 if missing_transitions:
@@ -542,13 +567,16 @@ required_queue_fields = {
     "review_required",
 }
 queue_fields = queue.get("required_fields")
-if (
-    not isinstance(queue_fields, list)
-    or any(not isinstance(value, str) or not value.strip() for value in queue_fields)
+if not isinstance(queue_fields, list) or any(
+    not isinstance(value, str) or not value.strip() for value in queue_fields
 ):
     raise SystemExit(
         "Phase 59.3 trace review queue skeleton required_fields must be a string list."
     )
+require_no_duplicate_strings(
+    queue_fields,
+    "Phase 59.3 trace review queue skeleton required_fields",
+)
 actual_queue_fields = set(queue_fields)
 missing_queue = sorted(required_queue_fields - actual_queue_fields)
 if missing_queue:
@@ -571,16 +599,17 @@ required_non_authoritative_surfaces = {
     "trace_state",
 }
 non_authoritative_surfaces = queue.get("non_authoritative_surfaces")
-if (
-    not isinstance(non_authoritative_surfaces, list)
-    or any(
-        not isinstance(value, str) or not value.strip()
-        for value in non_authoritative_surfaces
-    )
+if not isinstance(non_authoritative_surfaces, list) or any(
+    not isinstance(value, str) or not value.strip()
+    for value in non_authoritative_surfaces
 ):
     raise SystemExit(
         "Phase 59.3 trace review queue skeleton non_authoritative_surfaces must be a string list."
     )
+require_no_duplicate_strings(
+    non_authoritative_surfaces,
+    "Phase 59.3 trace review queue skeleton non_authoritative_surfaces",
+)
 actual_non_authoritative_surfaces = set(non_authoritative_surfaces)
 missing_non_authoritative = sorted(
     required_non_authoritative_surfaces - actual_non_authoritative_surfaces

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -163,6 +163,26 @@ required_linkage_terms = {
 }
 review_outcome_states = {"reviewed", "accepted", "corrected", "rejected"}
 required_reviewer_terms = {"reviewer_id", "review_action_id"}
+required_state_linkage_terms = {
+    "created": {"created_by", "created_at", "expires_at"},
+    "reviewed": {"reviewer_id", "review_action_id", "reviewed_at", "expires_at"},
+    "accepted": {"reviewer_id", "review_action_id", "accepted_at", "expires_at"},
+    "corrected": {
+        "reviewer_id",
+        "review_action_id",
+        "correction_summary",
+        "corrected_at",
+        "expires_at",
+    },
+    "rejected": {
+        "reviewer_id",
+        "review_action_id",
+        "rejection_reason",
+        "rejected_at",
+        "expires_at",
+    },
+    "expired": {"expires_at", "expired_at", "expiration_reason"},
+}
 required_forbidden_authority = {
     "approval",
     "execution",
@@ -188,6 +208,7 @@ forbidden_claim_fragments = (
 )
 
 seen_states: set[str] = set()
+states_by_name: dict[str, dict] = {}
 for index, state in enumerate(states, start=1):
     if not isinstance(state, dict):
         raise SystemExit(f"Phase 59.3 AI trace lifecycle row {index} must be an object.")
@@ -204,7 +225,12 @@ for index, state in enumerate(states, start=1):
         raise SystemExit(f"Phase 59.3 AI trace lifecycle row {index} has invalid state.")
     if name in seen_states:
         raise SystemExit(f"Duplicate Phase 59.3 AI trace lifecycle state: {name}")
+    if name not in required_states:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle contains unexpected state for this slice: {name}"
+        )
     seen_states.add(name)
+    states_by_name[name] = state
 
     for field in ("purpose", "expiration_handling", "authority_effect"):
         value = state[field]
@@ -226,6 +252,15 @@ for index, state in enumerate(states, start=1):
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle state {name} must include list allowed_from."
         )
+    for predecessor in state["allowed_from"]:
+        if not isinstance(predecessor, str) or not predecessor.strip():
+            raise SystemExit(
+                f"Phase 59.3 AI trace lifecycle state {name} allowed_from must contain state names."
+            )
+        if predecessor not in required_states:
+            raise SystemExit(
+                f"Phase 59.3 AI trace lifecycle state {name} references invalid allowed_from state: {predecessor}"
+            )
     if not isinstance(state["terminal"], bool):
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle state {name} terminal must be boolean."
@@ -266,6 +301,12 @@ for index, state in enumerate(states, start=1):
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle state {name} is missing linkage field(s): "
             + ", ".join(missing_linkage)
+        )
+    missing_state_linkage = sorted(required_state_linkage_terms[name] - linkage_terms)
+    if missing_state_linkage:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} is missing state-specific linkage field(s): "
+            + ", ".join(missing_state_linkage)
         )
 
     if name in review_outcome_states:
@@ -320,6 +361,26 @@ required_transition_fields = {
     "required_metadata",
     "authority_effect",
 }
+required_transition_metadata_terms = {
+    ("created", "reviewed"): {"reviewer_id", "review_action_id", "reviewed_at"},
+    ("created", "expired"): {"expires_at", "expired_at", "expiration_reason"},
+    ("reviewed", "accepted"): {"reviewer_id", "review_action_id", "accepted_at"},
+    ("reviewed", "corrected"): {
+        "reviewer_id",
+        "review_action_id",
+        "correction_summary",
+        "corrected_at",
+    },
+    ("reviewed", "rejected"): {
+        "reviewer_id",
+        "review_action_id",
+        "rejection_reason",
+        "rejected_at",
+    },
+    ("reviewed", "expired"): {"expires_at", "expired_at", "expiration_reason"},
+    ("accepted", "expired"): {"expires_at", "expired_at", "expiration_reason"},
+    ("corrected", "expired"): {"expires_at", "expired_at", "expiration_reason"},
+}
 
 for index, transition in enumerate(transitions, start=1):
     if not isinstance(transition, dict):
@@ -373,6 +434,13 @@ for index, transition in enumerate(transitions, start=1):
                 f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} is missing expiration metadata: "
                 + ", ".join(missing_expiry)
             )
+    required_metadata_terms = required_transition_metadata_terms[(from_state, to_state)]
+    missing_transition_metadata = sorted(required_metadata_terms - set(metadata))
+    if missing_transition_metadata:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} is missing transition-specific metadata: "
+            + ", ".join(missing_transition_metadata)
+        )
 
     seen_transitions.add((from_state, to_state))
 
@@ -388,6 +456,31 @@ if unexpected_transitions:
         "Phase 59.3 AI trace lifecycle contains unexpected transition(s) for this slice: "
         + ", ".join(f"{src}->{dst}" for src, dst in unexpected_transitions)
     )
+for state_name in sorted(required_states):
+    expected_allowed_from = sorted(
+        from_state for from_state, to_state in seen_transitions if to_state == state_name
+    )
+    actual_allowed_from = sorted(states_by_name[state_name]["allowed_from"])
+    if actual_allowed_from != expected_allowed_from:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {state_name} allowed_from must match transition graph: "
+            + "expected "
+            + ", ".join(expected_allowed_from or ["<none>"])
+            + "; got "
+            + ", ".join(actual_allowed_from or ["<none>"])
+        )
+
+    has_outgoing_transition = any(
+        from_state == state_name for from_state, _to_state in seen_transitions
+    )
+    if has_outgoing_transition and states_by_name[state_name]["terminal"]:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {state_name} terminal flag must be false while outgoing transitions exist."
+        )
+    if not has_outgoing_transition and not states_by_name[state_name]["terminal"]:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {state_name} terminal flag must be true when no outgoing transitions exist."
+        )
 
 queue = lifecycle["trace_review_queue_skeleton"]
 if not isinstance(queue, dict):

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -77,6 +77,11 @@ def require_non_empty_string(value, description: str) -> str:
     return value
 
 
+def require_exact_value(value, expected, description: str) -> None:
+    if value != expected:
+        raise SystemExit(f"{description} must be {expected}.")
+
+
 def require_non_empty_string_list(value, description: str) -> list[str]:
     if (
         not isinstance(value, list)
@@ -107,6 +112,37 @@ def require_exact_string_set(value, expected: set[str], description: str) -> lis
         raise SystemExit(f"{description} contains extra field(s): " + ", ".join(extra))
     return values
 
+
+def require_allowed_from_for_state(
+    state_name: str,
+    value,
+    known_states: set[str],
+    expected_by_state: dict[str, list[str]],
+) -> None:
+    if not isinstance(value, list):
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {state_name} must include list allowed_from."
+        )
+    for predecessor in value:
+        if not isinstance(predecessor, str) or not predecessor.strip():
+            raise SystemExit(
+                f"Phase 59.3 AI trace lifecycle state {state_name} allowed_from must contain state names."
+            )
+        if predecessor not in known_states:
+            raise SystemExit(
+                f"Phase 59.3 AI trace lifecycle state {state_name} references invalid allowed_from state: {predecessor}"
+            )
+    actual_allowed_from = sorted(value)
+    expected_allowed_from = expected_by_state[state_name]
+    if actual_allowed_from != expected_allowed_from:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {state_name} allowed_from must match transition graph: "
+            + "expected "
+            + ", ".join(expected_allowed_from or ["<none>"])
+            + "; got "
+            + ", ".join(actual_allowed_from or ["<none>"])
+        )
+
 try:
     lifecycle = json.loads(lifecycle_path.read_text(encoding="utf-8"))
 except json.JSONDecodeError as exc:
@@ -121,7 +157,7 @@ except json.JSONDecodeError as exc:
 if not isinstance(lifecycle, dict):
     raise SystemExit("Phase 59.3 AI trace lifecycle artifact must be a JSON object.")
 
-required_root = {
+required_root = frozenset((
     "schema_version",
     "phase",
     "contract_status",
@@ -130,7 +166,7 @@ required_root = {
     "allowed_transitions",
     "trace_review_queue_skeleton",
     "forbidden_authority_states",
-}
+))
 missing_root = sorted(required_root - lifecycle.keys())
 if missing_root:
     raise SystemExit(
@@ -138,18 +174,21 @@ if missing_root:
         + ", ".join(missing_root)
     )
 
-if lifecycle["phase"] != "59.3":
-    raise SystemExit("Phase 59.3 AI trace lifecycle phase must be 59.3.")
-
-if lifecycle["schema_version"] != expected_schema_version:
-    raise SystemExit(
-        f"Phase 59.3 AI trace lifecycle schema_version must be {expected_schema_version}."
-    )
-
-if lifecycle["contract_status"] != "accepted_contract_slice":
-    raise SystemExit(
-        "Phase 59.3 AI trace lifecycle status must be accepted_contract_slice."
-    )
+require_exact_value(
+    lifecycle["phase"],
+    "59.3",
+    "Phase 59.3 AI trace lifecycle phase",
+)
+require_exact_value(
+    lifecycle["schema_version"],
+    expected_schema_version,
+    "Phase 59.3 AI trace lifecycle schema_version",
+)
+require_exact_value(
+    lifecycle["contract_status"],
+    "accepted_contract_slice",
+    "Phase 59.3 AI trace lifecycle status",
+)
 
 authority_boundary = require_non_empty_string(
     lifecycle["authority_boundary"],
@@ -224,7 +263,7 @@ required_state_fields = {
     "authority_effect",
     "disallowed_authority",
 }
-required_linkage_terms = {
+required_linkage_terms = frozenset((
     "registered_agent_name",
     "registered_tool_names",
     "trace_id",
@@ -233,7 +272,7 @@ required_linkage_terms = {
     "citation_ids",
     "evidence_reference",
     "expires_at",
-}
+))
 review_outcome_states = {"reviewed", "accepted", "corrected", "rejected"}
 required_reviewer_terms = {"reviewer_id", "review_action_id"}
 required_state_linkage_terms = {
@@ -280,6 +319,18 @@ forbidden_claim_fragments = (
     "policy_bypass",
 )
 
+
+def require_no_forbidden_authority_claim(
+    value: str,
+    description: str,
+    allowed_value=None,
+) -> None:
+    lowered = value.casefold().replace("-", "_").replace(" ", "_")
+    if any(fragment in lowered for fragment in forbidden_claim_fragments):
+        if allowed_value is None or value != allowed_value:
+            raise SystemExit(f"{description} contains forbidden authority claim.")
+
+
 seen_states: set[str] = set()
 states_by_name: dict[str, dict] = {}
 for index, state in enumerate(states, start=1):
@@ -310,41 +361,23 @@ for index, state in enumerate(states, start=1):
             state[field],
             f"Phase 59.3 AI trace lifecycle state {name} {field}",
         )
-        lowered = value.casefold().replace("-", "_").replace(" ", "_")
-        if any(fragment in lowered for fragment in forbidden_claim_fragments):
-            if value != "advisory_only_no_workflow_mutation":
-                raise SystemExit(
-                    f"Phase 59.3 AI trace lifecycle state {name} contains forbidden authority claim in {field}."
-                )
+        require_no_forbidden_authority_claim(
+            value,
+            f"Phase 59.3 AI trace lifecycle state {name} {field}",
+            allowed_value="advisory_only_no_workflow_mutation",
+        )
 
     if state["authority_effect"] != "advisory_only_no_workflow_mutation":
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle state {name} must keep advisory-only authority."
         )
 
-    if not isinstance(state["allowed_from"], list):
-        raise SystemExit(
-            f"Phase 59.3 AI trace lifecycle state {name} must include list allowed_from."
-        )
-    for predecessor in state["allowed_from"]:
-        if not isinstance(predecessor, str) or not predecessor.strip():
-            raise SystemExit(
-                f"Phase 59.3 AI trace lifecycle state {name} allowed_from must contain state names."
-            )
-        if predecessor not in required_states:
-            raise SystemExit(
-                f"Phase 59.3 AI trace lifecycle state {name} references invalid allowed_from state: {predecessor}"
-            )
-    actual_allowed_from = sorted(state["allowed_from"])
-    expected_allowed_from = required_allowed_from_by_state[name]
-    if actual_allowed_from != expected_allowed_from:
-        raise SystemExit(
-            f"Phase 59.3 AI trace lifecycle state {name} allowed_from must match transition graph: "
-            + "expected "
-            + ", ".join(expected_allowed_from or ["<none>"])
-            + "; got "
-            + ", ".join(actual_allowed_from or ["<none>"])
-        )
+    require_allowed_from_for_state(
+        name,
+        state["allowed_from"],
+        required_states,
+        required_allowed_from_by_state,
+    )
     if not isinstance(state["terminal"], bool):
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle state {name} terminal must be boolean."
@@ -468,13 +501,14 @@ for index, transition in enumerate(transitions, start=1):
     from_state = transition["from_state"]
     to_state = transition["to_state"]
     transition_pair = (from_state, to_state)
-    if from_state not in required_states or to_state not in required_states:
+    if not {from_state, to_state}.issubset(required_states):
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle transition {index} references invalid state."
         )
     if from_state == "expired":
         raise SystemExit("Phase 59.3 AI trace lifecycle must not transition from expired traces.")
-    if to_state in {"accepted", "corrected", "rejected"} and from_state != "reviewed":
+    to_state_is_review_outcome = to_state in {"accepted", "corrected", "rejected"}
+    if to_state_is_review_outcome and from_state != "reviewed":
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must go through reviewed."
         )
@@ -487,16 +521,14 @@ for index, transition in enumerate(transitions, start=1):
             f"Duplicate Phase 59.3 AI trace lifecycle transition: {from_state}->{to_state}"
         )
 
-    trigger = transition["required_trigger"]
-    if not isinstance(trigger, str) or not trigger.strip():
-        raise SystemExit(
-            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must include non-empty required_trigger."
-        )
-    trigger_lowered = trigger.casefold().replace("-", "_").replace(" ", "_")
-    if any(fragment in trigger_lowered for fragment in forbidden_claim_fragments):
-        raise SystemExit(
-            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} contains forbidden authority claim in required_trigger."
-        )
+    trigger = require_non_empty_string(
+        transition["required_trigger"],
+        f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} required_trigger",
+    )
+    require_no_forbidden_authority_claim(
+        trigger,
+        f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} required_trigger",
+    )
 
     if transition["authority_effect"] != "advisory_only_no_workflow_mutation":
         raise SystemExit(
@@ -512,20 +544,6 @@ for index, transition in enumerate(transitions, start=1):
         f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} required_metadata",
     )
 
-    if to_state in {"accepted", "corrected", "rejected"}:
-        missing_reviewer = sorted(required_reviewer_terms - set(metadata))
-        if missing_reviewer:
-            raise SystemExit(
-                f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} is missing reviewer metadata: "
-                + ", ".join(missing_reviewer)
-            )
-    if to_state == "expired":
-        missing_expiry = sorted({"expires_at", "expired_at", "expiration_reason"} - set(metadata))
-        if missing_expiry:
-            raise SystemExit(
-                f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} is missing expiration metadata: "
-                + ", ".join(missing_expiry)
-            )
     required_metadata_terms = required_transition_metadata_terms[transition_pair]
     missing_transition_metadata = sorted(required_metadata_terms - set(metadata))
     if missing_transition_metadata:

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -94,6 +94,19 @@ def require_no_duplicate_strings(values: list[str], description: str) -> None:
             f"{description} must not contain duplicate value(s): " + ", ".join(duplicates)
         )
 
+
+def require_exact_string_set(value, expected: set[str], description: str) -> list[str]:
+    values = require_non_empty_string_list(value, description)
+    require_no_duplicate_strings(values, description)
+    actual = set(values)
+    missing = sorted(expected - actual)
+    if missing:
+        raise SystemExit(f"{description} is missing field(s): " + ", ".join(missing))
+    extra = sorted(actual - expected)
+    if extra:
+        raise SystemExit(f"{description} contains extra field(s): " + ", ".join(extra))
+    return values
+
 try:
     lifecycle = json.loads(lifecycle_path.read_text(encoding="utf-8"))
 except json.JSONDecodeError as exc:
@@ -181,6 +194,22 @@ required_states = {
     "corrected",
     "rejected",
     "expired",
+}
+required_transitions = {
+    ("created", "reviewed"),
+    ("created", "expired"),
+    ("reviewed", "accepted"),
+    ("reviewed", "corrected"),
+    ("reviewed", "rejected"),
+    ("reviewed", "expired"),
+    ("accepted", "expired"),
+    ("corrected", "expired"),
+}
+required_allowed_from_by_state = {
+    state_name: sorted(
+        from_state for from_state, to_state in required_transitions if to_state == state_name
+    )
+    for state_name in required_states
 }
 required_state_fields = {
     "state",
@@ -306,6 +335,16 @@ for index, state in enumerate(states, start=1):
             raise SystemExit(
                 f"Phase 59.3 AI trace lifecycle state {name} references invalid allowed_from state: {predecessor}"
             )
+    actual_allowed_from = sorted(state["allowed_from"])
+    expected_allowed_from = required_allowed_from_by_state[name]
+    if actual_allowed_from != expected_allowed_from:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} allowed_from must match transition graph: "
+            + "expected "
+            + ", ".join(expected_allowed_from or ["<none>"])
+            + "; got "
+            + ", ".join(actual_allowed_from or ["<none>"])
+        )
     if not isinstance(state["terminal"], bool):
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle state {name} terminal must be boolean."
@@ -387,16 +426,6 @@ if unexpected_states:
         + ", ".join(unexpected_states)
     )
 
-required_transitions = {
-    ("created", "reviewed"),
-    ("created", "expired"),
-    ("reviewed", "accepted"),
-    ("reviewed", "corrected"),
-    ("reviewed", "rejected"),
-    ("reviewed", "expired"),
-    ("accepted", "expired"),
-    ("corrected", "expired"),
-}
 transition_rows_by_pair: dict[tuple[str, str], int] = {}
 required_transition_fields = {
     "from_state",
@@ -566,30 +595,11 @@ required_queue_fields = {
     "expires_at",
     "review_required",
 }
-queue_fields = queue.get("required_fields")
-if not isinstance(queue_fields, list) or any(
-    not isinstance(value, str) or not value.strip() for value in queue_fields
-):
-    raise SystemExit(
-        "Phase 59.3 trace review queue skeleton required_fields must be a string list."
-    )
-require_no_duplicate_strings(
-    queue_fields,
+require_exact_string_set(
+    queue.get("required_fields"),
+    required_queue_fields,
     "Phase 59.3 trace review queue skeleton required_fields",
 )
-actual_queue_fields = set(queue_fields)
-missing_queue = sorted(required_queue_fields - actual_queue_fields)
-if missing_queue:
-    raise SystemExit(
-        "Phase 59.3 trace review queue skeleton is missing field(s): "
-        + ", ".join(missing_queue)
-    )
-extra_queue = sorted(actual_queue_fields - required_queue_fields)
-if extra_queue:
-    raise SystemExit(
-        "Phase 59.3 trace review queue skeleton contains extra field(s): "
-        + ", ".join(extra_queue)
-    )
 
 required_non_authoritative_surfaces = {
     "queue_order",
@@ -598,35 +608,11 @@ required_non_authoritative_surfaces = {
     "browser_state",
     "trace_state",
 }
-non_authoritative_surfaces = queue.get("non_authoritative_surfaces")
-if not isinstance(non_authoritative_surfaces, list) or any(
-    not isinstance(value, str) or not value.strip()
-    for value in non_authoritative_surfaces
-):
-    raise SystemExit(
-        "Phase 59.3 trace review queue skeleton non_authoritative_surfaces must be a string list."
-    )
-require_no_duplicate_strings(
-    non_authoritative_surfaces,
+require_exact_string_set(
+    queue.get("non_authoritative_surfaces"),
+    required_non_authoritative_surfaces,
     "Phase 59.3 trace review queue skeleton non_authoritative_surfaces",
 )
-actual_non_authoritative_surfaces = set(non_authoritative_surfaces)
-missing_non_authoritative = sorted(
-    required_non_authoritative_surfaces - actual_non_authoritative_surfaces
-)
-if missing_non_authoritative:
-    raise SystemExit(
-        "Phase 59.3 trace review queue skeleton is missing non-authoritative surface(s): "
-        + ", ".join(missing_non_authoritative)
-    )
-extra_non_authoritative = sorted(
-    actual_non_authoritative_surfaces - required_non_authoritative_surfaces
-)
-if extra_non_authoritative:
-    raise SystemExit(
-        "Phase 59.3 trace review queue skeleton contains extra non-authoritative surface(s): "
-        + ", ".join(extra_non_authoritative)
-    )
 
 missing_forbidden = sorted(
     required_forbidden_authority - set(lifecycle["forbidden_authority_states"])

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -61,6 +61,7 @@ done
 
 python3 - "${lifecycle_path}" "${agent_registry_path}" "${tool_registry_path}" <<'PY'
 import json
+import re
 import sys
 from pathlib import Path
 from collections import Counter
@@ -332,15 +333,34 @@ required_forbidden_authority = {
 }
 forbidden_claim_fragments = (
     "may_approve",
+    "can_approve",
+    "approve_action",
+    "approve_actions",
+    "approve_case",
+    "approve_case_closure",
     "may_execute",
+    "can_execute",
+    "execute_action",
+    "execute_actions",
     "may_reconcile",
+    "can_reconcile",
+    "reconcile_receipt",
+    "reconcile_outcome",
     "may_close",
+    "can_close",
+    "close_case",
+    "close_cases",
     "may_activate",
+    "can_activate",
+    "activate_detector",
+    "activate_detectors",
+    "create_source_truth",
     "source_truth",
     "workflow_truth",
     "authority_widen",
     "production_write",
     "policy_bypass",
+    "bypass_policy",
 )
 
 
@@ -349,10 +369,16 @@ def require_no_forbidden_authority_claim(
     description: str,
     allowed_value=None,
 ) -> None:
-    lowered = value.casefold().replace("-", "_").replace(" ", "_")
+    lowered = re.sub(r"[^a-z0-9]+", "_", value.casefold()).strip("_")
     if any(fragment in lowered for fragment in forbidden_claim_fragments):
         if allowed_value is None or value != allowed_value:
             raise SystemExit(f"{description} contains forbidden authority claim.")
+
+
+require_no_forbidden_authority_claim(
+    authority_boundary,
+    "Phase 59.3 AI trace lifecycle authority_boundary",
+)
 
 
 seen_states: set[str] = set()
@@ -645,14 +671,11 @@ require_exact_string_set(
     "Phase 59.3 trace review queue skeleton non_authoritative_surfaces",
 )
 
-missing_forbidden = sorted(
-    required_forbidden_authority - set(lifecycle["forbidden_authority_states"])
+require_exact_string_set(
+    lifecycle["forbidden_authority_states"],
+    required_forbidden_authority,
+    "Phase 59.3 AI trace lifecycle forbidden_authority_states",
 )
-if missing_forbidden:
-    raise SystemExit(
-        "Phase 59.3 AI trace lifecycle forbidden authority list is missing: "
-        + ", ".join(missing_forbidden)
-    )
 PY
 
 path_hygiene_stderr="$(mktemp)"

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -100,6 +100,12 @@ def require_no_duplicate_strings(values: list[str], description: str) -> None:
         )
 
 
+def require_required_fields(row: dict, required: set[str], description: str) -> None:
+    missing = sorted(required - row.keys())
+    if missing:
+        raise SystemExit(f"{description}: " + ", ".join(missing))
+
+
 def require_exact_string_set(value, expected: set[str], description: str) -> list[str]:
     values = require_non_empty_string_list(value, description)
     require_no_duplicate_strings(values, description)
@@ -143,6 +149,25 @@ def require_allowed_from_for_state(
             + ", ".join(actual_allowed_from or ["<none>"])
         )
 
+
+def require_transition_boundary(
+    index: int,
+    from_state: str,
+    to_state: str,
+    known_states: set[str],
+) -> None:
+    if not {from_state, to_state}.issubset(known_states):
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {index} references invalid state."
+        )
+    if from_state == "expired":
+        raise SystemExit("Phase 59.3 AI trace lifecycle must not transition from expired traces.")
+    to_state_is_review_outcome = to_state in {"accepted", "corrected", "rejected"}
+    if to_state_is_review_outcome and from_state != "reviewed":
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must go through reviewed."
+        )
+
 try:
     lifecycle = json.loads(lifecycle_path.read_text(encoding="utf-8"))
 except json.JSONDecodeError as exc:
@@ -167,12 +192,11 @@ required_root = frozenset((
     "trace_review_queue_skeleton",
     "forbidden_authority_states",
 ))
-missing_root = sorted(required_root - lifecycle.keys())
-if missing_root:
-    raise SystemExit(
-        "Phase 59.3 AI trace lifecycle is missing root field(s): "
-        + ", ".join(missing_root)
-    )
+require_required_fields(
+    lifecycle,
+    required_root,
+    "Phase 59.3 AI trace lifecycle is missing root field(s)",
+)
 
 require_exact_value(
     lifecycle["phase"],
@@ -491,27 +515,16 @@ required_transition_metadata_terms = {
 for index, transition in enumerate(transitions, start=1):
     if not isinstance(transition, dict):
         raise SystemExit(f"Phase 59.3 AI trace lifecycle transition {index} must be an object.")
-    missing = sorted(required_transition_fields - transition.keys())
-    if missing:
-        raise SystemExit(
-            f"Phase 59.3 AI trace lifecycle transition {index} is missing field(s): "
-            + ", ".join(missing)
-        )
+    require_required_fields(
+        transition,
+        required_transition_fields,
+        f"Phase 59.3 AI trace lifecycle transition {index} is missing field(s)",
+    )
 
     from_state = transition["from_state"]
     to_state = transition["to_state"]
     transition_pair = (from_state, to_state)
-    if not {from_state, to_state}.issubset(required_states):
-        raise SystemExit(
-            f"Phase 59.3 AI trace lifecycle transition {index} references invalid state."
-        )
-    if from_state == "expired":
-        raise SystemExit("Phase 59.3 AI trace lifecycle must not transition from expired traces.")
-    to_state_is_review_outcome = to_state in {"accepted", "corrected", "rejected"}
-    if to_state_is_review_outcome and from_state != "reviewed":
-        raise SystemExit(
-            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must go through reviewed."
-        )
+    require_transition_boundary(index, from_state, to_state, required_states)
     if transition_pair not in required_transitions:
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle contains unexpected transition for this slice: {from_state}->{to_state}"

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -164,6 +164,19 @@ def require_no_forbidden_authority_claim(
             raise SystemExit(f"{description} contains forbidden authority claim.")
 
 
+def require_authority_boundary_contract(value, description: str) -> None:
+    authority_boundary = require_non_empty_string(value, description)
+    require_no_forbidden_authority_claim(authority_boundary, description)
+    authority_boundary_lower = authority_boundary.casefold()
+    if (
+        "subordinate" not in authority_boundary_lower
+        or "aegisops records remain authoritative" not in authority_boundary_lower
+    ):
+        raise SystemExit(
+            f"{description} must preserve subordinate AegisOps authority semantics."
+        )
+
+
 def require_allowed_from_for_state(
     state_name: str,
     value,
@@ -258,23 +271,10 @@ require_exact_value(
     "accepted_contract_slice",
     "Phase 59.3 AI trace lifecycle status",
 )
-
-authority_boundary = require_non_empty_string(
+require_authority_boundary_contract(
     lifecycle["authority_boundary"],
     "Phase 59.3 AI trace lifecycle authority_boundary",
 )
-require_no_forbidden_authority_claim(
-    authority_boundary,
-    "Phase 59.3 AI trace lifecycle authority_boundary",
-)
-authority_boundary_lower = authority_boundary.casefold()
-if (
-    "subordinate" not in authority_boundary_lower
-    or "aegisops records remain authoritative" not in authority_boundary_lower
-):
-    raise SystemExit(
-        "Phase 59.3 AI trace lifecycle authority_boundary must preserve subordinate AegisOps authority semantics."
-    )
 
 states = lifecycle["lifecycle_states"]
 if not isinstance(states, list) or not states:

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tool_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${tool_root}}"
+doc_path="${repo_root}/docs/phase-59-3-ai-trace-lifecycle-contract.md"
+lifecycle_path="${repo_root}/docs/automation/ai-trace-lifecycle.json"
+agent_registry_path="${repo_root}/docs/automation/ai-agent-registry.json"
+tool_registry_path="${repo_root}/docs/automation/ai-tool-registry.json"
+readme_path="${repo_root}/README.md"
+
+required_doc_phrases=(
+  "# Phase 59.3 AI Trace Lifecycle Contract"
+  "- **Status**: Accepted lifecycle contract slice"
+  "- **Related Issues**: #1252, #1255"
+  "This contract defines the AI trace lifecycle states for created, reviewed, accepted, corrected, rejected, and expired traces before Phase 59 expands disabled or degraded mode, prompt fixtures, stale or conflicting evidence fixtures, trace queue UI/API implementation, closeout work, or Phase 60 daily AI operations."
+  "Every AI trace lifecycle state must require registered agent linkage, registered tool linkage, citations, reviewed record family and identifier linkage, expiration handling, and advisory-only authority."
+  'The executable lifecycle artifact lives in `docs/automation/ai-trace-lifecycle.json`.'
+  "AI remains advisory, registered, audited, cited, and subordinate to reviewed AegisOps records."
+  "No AI trace lifecycle state or transition may grant approval, execution, reconciliation, case-closure, detector-activation, source-truth, production write, policy-bypass, or authority-widening capability."
+  'This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md` for AI approval, execution, reconciliation, case closure, detector activation, and source-truth refusal.'
+  'Run `bash scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh`.'
+  'Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.'
+  'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1255 --config <supervisor-config-path>`.'
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 59.3 AI trace lifecycle contract doc: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${lifecycle_path}" ]]; then
+  echo "Missing Phase 59.3 AI trace lifecycle artifact: ${lifecycle_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${agent_registry_path}" ]]; then
+  echo "Missing Phase 59.3 AI agent registry dependency: ${agent_registry_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${tool_registry_path}" ]]; then
+  echo "Missing Phase 59.3 AI tool registry dependency: ${tool_registry_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 59.3 AI trace lifecycle link check: ${readme_path}" >&2
+  exit 1
+fi
+
+for phrase in "${required_doc_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 59.3 AI trace lifecycle contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+python3 - "${lifecycle_path}" "${agent_registry_path}" "${tool_registry_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+lifecycle_path = Path(sys.argv[1])
+agent_registry_path = Path(sys.argv[2])
+tool_registry_path = Path(sys.argv[3])
+
+try:
+    lifecycle = json.loads(lifecycle_path.read_text(encoding="utf-8"))
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"Invalid Phase 59.3 AI trace lifecycle JSON: {exc}") from exc
+
+try:
+    agent_registry = json.loads(agent_registry_path.read_text(encoding="utf-8"))
+    tool_registry = json.loads(tool_registry_path.read_text(encoding="utf-8"))
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"Invalid Phase 59.3 registry dependency JSON: {exc}") from exc
+
+if not isinstance(lifecycle, dict):
+    raise SystemExit("Phase 59.3 AI trace lifecycle artifact must be a JSON object.")
+
+required_root = {
+    "schema_version",
+    "phase",
+    "contract_status",
+    "authority_boundary",
+    "lifecycle_states",
+    "allowed_transitions",
+    "trace_review_queue_skeleton",
+    "forbidden_authority_states",
+}
+missing_root = sorted(required_root - lifecycle.keys())
+if missing_root:
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle is missing root field(s): "
+        + ", ".join(missing_root)
+    )
+
+if lifecycle["phase"] != "59.3":
+    raise SystemExit("Phase 59.3 AI trace lifecycle phase must be 59.3.")
+
+if lifecycle["contract_status"] != "accepted_contract_slice":
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle status must be accepted_contract_slice."
+    )
+
+states = lifecycle["lifecycle_states"]
+if not isinstance(states, list) or not states:
+    raise SystemExit("Phase 59.3 AI trace lifecycle states field must be a list.")
+
+transitions = lifecycle["allowed_transitions"]
+if not isinstance(transitions, list) or not transitions:
+    raise SystemExit("Phase 59.3 AI trace lifecycle transitions field must be a list.")
+
+registered_agents = {
+    agent["agent_name"]
+    for agent in agent_registry.get("agents", [])
+    if isinstance(agent, dict) and isinstance(agent.get("agent_name"), str)
+}
+registered_tools = {
+    tool["tool_name"]
+    for tool in tool_registry.get("tools", [])
+    if isinstance(tool, dict) and isinstance(tool.get("tool_name"), str)
+}
+if not registered_agents:
+    raise SystemExit("Phase 59.3 registered agent dependency is empty.")
+if not registered_tools:
+    raise SystemExit("Phase 59.3 registered tool dependency is empty.")
+
+required_states = {
+    "created",
+    "reviewed",
+    "accepted",
+    "corrected",
+    "rejected",
+    "expired",
+}
+required_state_fields = {
+    "state",
+    "purpose",
+    "allowed_from",
+    "terminal",
+    "registered_agents",
+    "registered_tools",
+    "required_linkage",
+    "reviewer_action_metadata_required",
+    "expiration_handling",
+    "authority_effect",
+    "disallowed_authority",
+}
+required_linkage_terms = {
+    "registered_agent_name",
+    "registered_tool_names",
+    "trace_id",
+    "reviewed_record_family",
+    "reviewed_record_id",
+    "citation_ids",
+    "evidence_reference",
+    "expires_at",
+}
+review_outcome_states = {"reviewed", "accepted", "corrected", "rejected"}
+required_reviewer_terms = {"reviewer_id", "review_action_id"}
+required_forbidden_authority = {
+    "approval",
+    "execution",
+    "reconciliation",
+    "case_closure",
+    "detector_activation",
+    "source_truth_creation",
+    "production_write",
+    "policy_bypass",
+    "workflow_truth",
+}
+forbidden_claim_fragments = (
+    "may_approve",
+    "may_execute",
+    "may_reconcile",
+    "may_close",
+    "may_activate",
+    "source_truth",
+    "workflow_truth",
+    "authority_widen",
+    "production_write",
+    "policy_bypass",
+)
+
+seen_states: set[str] = set()
+for index, state in enumerate(states, start=1):
+    if not isinstance(state, dict):
+        raise SystemExit(f"Phase 59.3 AI trace lifecycle row {index} must be an object.")
+
+    missing = sorted(required_state_fields - state.keys())
+    if missing:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle row {index} is missing field(s): "
+            + ", ".join(missing)
+        )
+
+    name = state["state"]
+    if not isinstance(name, str) or not name.strip():
+        raise SystemExit(f"Phase 59.3 AI trace lifecycle row {index} has invalid state.")
+    if name in seen_states:
+        raise SystemExit(f"Duplicate Phase 59.3 AI trace lifecycle state: {name}")
+    seen_states.add(name)
+
+    for field in ("purpose", "expiration_handling", "authority_effect"):
+        value = state[field]
+        if not isinstance(value, str) or not value.strip():
+            raise SystemExit(f"Phase 59.3 AI trace lifecycle state {name} has invalid {field}.")
+        lowered = value.casefold().replace("-", "_").replace(" ", "_")
+        if any(fragment in lowered for fragment in forbidden_claim_fragments):
+            if value != "advisory_only_no_workflow_mutation":
+                raise SystemExit(
+                    f"Phase 59.3 AI trace lifecycle state {name} contains forbidden authority claim in {field}."
+                )
+
+    if state["authority_effect"] != "advisory_only_no_workflow_mutation":
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} must keep advisory-only authority."
+        )
+
+    if not isinstance(state["allowed_from"], list):
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} must include list allowed_from."
+        )
+    if not isinstance(state["terminal"], bool):
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} terminal must be boolean."
+        )
+    if not isinstance(state["reviewer_action_metadata_required"], bool):
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} reviewer metadata flag must be boolean."
+        )
+
+    for field in ("registered_agents", "registered_tools", "required_linkage", "disallowed_authority"):
+        values = state[field]
+        if (
+            not isinstance(values, list)
+            or not values
+            or any(not isinstance(value, str) or not value.strip() for value in values)
+        ):
+            raise SystemExit(
+                f"Phase 59.3 AI trace lifecycle state {name} must include non-empty string list {field}."
+            )
+
+    unknown_agents = sorted(set(state["registered_agents"]) - registered_agents)
+    if unknown_agents:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} references unregistered agent(s): "
+            + ", ".join(unknown_agents)
+        )
+
+    unknown_tools = sorted(set(state["registered_tools"]) - registered_tools)
+    if unknown_tools:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} references unregistered tool(s): "
+            + ", ".join(unknown_tools)
+        )
+
+    linkage_terms = set(state["required_linkage"])
+    missing_linkage = sorted(required_linkage_terms - linkage_terms)
+    if missing_linkage:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} is missing linkage field(s): "
+            + ", ".join(missing_linkage)
+        )
+
+    if name in review_outcome_states:
+        if not state["reviewer_action_metadata_required"]:
+            raise SystemExit(
+                f"Phase 59.3 AI trace lifecycle state {name} must require reviewer/action metadata."
+            )
+        missing_reviewer = sorted(required_reviewer_terms - linkage_terms)
+        if missing_reviewer:
+            raise SystemExit(
+                f"Phase 59.3 AI trace lifecycle state {name} is missing reviewer metadata field(s): "
+                + ", ".join(missing_reviewer)
+            )
+
+    missing_disallowed = sorted(
+        required_forbidden_authority - set(state["disallowed_authority"])
+    )
+    if missing_disallowed:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle state {name} is missing disallowed authority: "
+            + ", ".join(missing_disallowed)
+        )
+
+missing_states = sorted(required_states - seen_states)
+unexpected_states = sorted(seen_states - required_states)
+if missing_states:
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle is missing required state(s): "
+        + ", ".join(missing_states)
+    )
+if unexpected_states:
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle contains unexpected state(s) for this slice: "
+        + ", ".join(unexpected_states)
+    )
+
+required_transitions = {
+    ("created", "reviewed"),
+    ("created", "expired"),
+    ("reviewed", "accepted"),
+    ("reviewed", "corrected"),
+    ("reviewed", "rejected"),
+    ("reviewed", "expired"),
+    ("accepted", "expired"),
+    ("corrected", "expired"),
+}
+seen_transitions: set[tuple[str, str]] = set()
+required_transition_fields = {
+    "from_state",
+    "to_state",
+    "required_trigger",
+    "required_metadata",
+    "authority_effect",
+}
+
+for index, transition in enumerate(transitions, start=1):
+    if not isinstance(transition, dict):
+        raise SystemExit(f"Phase 59.3 AI trace lifecycle transition {index} must be an object.")
+    missing = sorted(required_transition_fields - transition.keys())
+    if missing:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {index} is missing field(s): "
+            + ", ".join(missing)
+        )
+
+    from_state = transition["from_state"]
+    to_state = transition["to_state"]
+    if from_state not in required_states or to_state not in required_states:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {index} references invalid state."
+        )
+    if from_state == "expired":
+        raise SystemExit("Phase 59.3 AI trace lifecycle must not transition from expired traces.")
+    if to_state in {"accepted", "corrected", "rejected"} and from_state != "reviewed":
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must go through reviewed."
+        )
+
+    if transition["authority_effect"] != "advisory_only_no_workflow_mutation":
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must keep advisory-only authority."
+        )
+
+    metadata = transition["required_metadata"]
+    if (
+        not isinstance(metadata, list)
+        or not metadata
+        or any(not isinstance(value, str) or not value.strip() for value in metadata)
+    ):
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must include required metadata."
+        )
+
+    if to_state in {"accepted", "corrected", "rejected"}:
+        missing_reviewer = sorted(required_reviewer_terms - set(metadata))
+        if missing_reviewer:
+            raise SystemExit(
+                f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} is missing reviewer metadata: "
+                + ", ".join(missing_reviewer)
+            )
+    if to_state == "expired":
+        missing_expiry = sorted({"expires_at", "expired_at", "expiration_reason"} - set(metadata))
+        if missing_expiry:
+            raise SystemExit(
+                f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} is missing expiration metadata: "
+                + ", ".join(missing_expiry)
+            )
+
+    seen_transitions.add((from_state, to_state))
+
+missing_transitions = sorted(required_transitions - seen_transitions)
+unexpected_transitions = sorted(seen_transitions - required_transitions)
+if missing_transitions:
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle is missing required transition(s): "
+        + ", ".join(f"{src}->{dst}" for src, dst in missing_transitions)
+    )
+if unexpected_transitions:
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle contains unexpected transition(s) for this slice: "
+        + ", ".join(f"{src}->{dst}" for src, dst in unexpected_transitions)
+    )
+
+queue = lifecycle["trace_review_queue_skeleton"]
+if not isinstance(queue, dict):
+    raise SystemExit("Phase 59.3 trace review queue skeleton must be an object.")
+if queue.get("phase") != "59.7":
+    raise SystemExit("Phase 59.3 trace review queue skeleton must point to Phase 59.7.")
+if queue.get("implementation_status") != "deferred_skeleton_only":
+    raise SystemExit(
+        "Phase 59.3 trace review queue skeleton must remain deferred_skeleton_only."
+    )
+required_queue_fields = {
+    "trace_id",
+    "state",
+    "reviewed_record_family",
+    "reviewed_record_id",
+    "registered_agent_name",
+    "registered_tool_names",
+    "citation_ids",
+    "expires_at",
+    "review_required",
+}
+queue_fields = queue.get("required_fields")
+if not isinstance(queue_fields, list):
+    raise SystemExit("Phase 59.3 trace review queue skeleton required_fields must be a list.")
+missing_queue = sorted(required_queue_fields - set(queue_fields))
+if missing_queue:
+    raise SystemExit(
+        "Phase 59.3 trace review queue skeleton is missing field(s): "
+        + ", ".join(missing_queue)
+    )
+
+missing_forbidden = sorted(
+    required_forbidden_authority - set(lifecycle["forbidden_authority_states"])
+)
+if missing_forbidden:
+    raise SystemExit(
+        "Phase 59.3 AI trace lifecycle forbidden authority list is missing: "
+        + ", ".join(missing_forbidden)
+    )
+PY
+
+path_hygiene_stderr="$(mktemp)"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${tool_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" \
+  >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 59.3 AI trace lifecycle artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    !in_fenced_block { print }
+  ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/phase-59-3-ai-trace-lifecycle-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 59.3 AI trace lifecycle contract." >&2
+  exit 1
+fi
+
+echo "Phase 59.3 AI trace lifecycle contract is present with required states, registered linkage, citations, review metadata, expiration handling, and advisory-only authority ceilings."

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -394,6 +394,7 @@ for index, transition in enumerate(transitions, start=1):
 
     from_state = transition["from_state"]
     to_state = transition["to_state"]
+    transition_pair = (from_state, to_state)
     if from_state not in required_states or to_state not in required_states:
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle transition {index} references invalid state."
@@ -403,6 +404,10 @@ for index, transition in enumerate(transitions, start=1):
     if to_state in {"accepted", "corrected", "rejected"} and from_state != "reviewed":
         raise SystemExit(
             f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} must go through reviewed."
+        )
+    if transition_pair not in required_transitions:
+        raise SystemExit(
+            f"Phase 59.3 AI trace lifecycle contains unexpected transition for this slice: {from_state}->{to_state}"
         )
 
     if transition["authority_effect"] != "advisory_only_no_workflow_mutation":
@@ -434,7 +439,7 @@ for index, transition in enumerate(transitions, start=1):
                 f"Phase 59.3 AI trace lifecycle transition {from_state}->{to_state} is missing expiration metadata: "
                 + ", ".join(missing_expiry)
             )
-    required_metadata_terms = required_transition_metadata_terms[(from_state, to_state)]
+    required_metadata_terms = required_transition_metadata_terms[transition_pair]
     missing_transition_metadata = sorted(required_metadata_terms - set(metadata))
     if missing_transition_metadata:
         raise SystemExit(

--- a/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
+++ b/scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
@@ -120,6 +120,50 @@ def require_exact_string_set(value, expected: set[str], description: str) -> lis
     return values
 
 
+forbidden_claim_fragments = (
+    "may_approve",
+    "can_approve",
+    "approve_action",
+    "approve_actions",
+    "approve_case",
+    "approve_case_closure",
+    "may_execute",
+    "can_execute",
+    "execute_action",
+    "execute_actions",
+    "may_reconcile",
+    "can_reconcile",
+    "reconcile_receipt",
+    "reconcile_outcome",
+    "may_close",
+    "can_close",
+    "close_case",
+    "close_cases",
+    "may_activate",
+    "can_activate",
+    "activate_detector",
+    "activate_detectors",
+    "create_source_truth",
+    "source_truth",
+    "workflow_truth",
+    "authority_widen",
+    "production_write",
+    "policy_bypass",
+    "bypass_policy",
+)
+
+
+def require_no_forbidden_authority_claim(
+    value: str,
+    description: str,
+    allowed_value=None,
+) -> None:
+    lowered = re.sub(r"[^a-z0-9]+", "_", value.casefold()).strip("_")
+    if any(fragment in lowered for fragment in forbidden_claim_fragments):
+        if allowed_value is None or value != allowed_value:
+            raise SystemExit(f"{description} contains forbidden authority claim.")
+
+
 def require_allowed_from_for_state(
     state_name: str,
     value,
@@ -217,6 +261,10 @@ require_exact_value(
 
 authority_boundary = require_non_empty_string(
     lifecycle["authority_boundary"],
+    "Phase 59.3 AI trace lifecycle authority_boundary",
+)
+require_no_forbidden_authority_claim(
+    authority_boundary,
     "Phase 59.3 AI trace lifecycle authority_boundary",
 )
 authority_boundary_lower = authority_boundary.casefold()
@@ -331,54 +379,6 @@ required_forbidden_authority = {
     "policy_bypass",
     "workflow_truth",
 }
-forbidden_claim_fragments = (
-    "may_approve",
-    "can_approve",
-    "approve_action",
-    "approve_actions",
-    "approve_case",
-    "approve_case_closure",
-    "may_execute",
-    "can_execute",
-    "execute_action",
-    "execute_actions",
-    "may_reconcile",
-    "can_reconcile",
-    "reconcile_receipt",
-    "reconcile_outcome",
-    "may_close",
-    "can_close",
-    "close_case",
-    "close_cases",
-    "may_activate",
-    "can_activate",
-    "activate_detector",
-    "activate_detectors",
-    "create_source_truth",
-    "source_truth",
-    "workflow_truth",
-    "authority_widen",
-    "production_write",
-    "policy_bypass",
-    "bypass_policy",
-)
-
-
-def require_no_forbidden_authority_claim(
-    value: str,
-    description: str,
-    allowed_value=None,
-) -> None:
-    lowered = re.sub(r"[^a-z0-9]+", "_", value.casefold()).strip("_")
-    if any(fragment in lowered for fragment in forbidden_claim_fragments):
-        if allowed_value is None or value != allowed_value:
-            raise SystemExit(f"{description} contains forbidden authority claim.")
-
-
-require_no_forbidden_authority_claim(
-    authority_boundary,
-    "Phase 59.3 AI trace lifecycle authority_boundary",
-)
 
 
 seen_states: set[str] = set()


### PR DESCRIPTION
## Summary
- Add the Phase 59.3 AI trace lifecycle contract for created, reviewed, accepted, corrected, rejected, and expired states.
- Add docs/automation/ai-trace-lifecycle.json with registered agent/tool linkage, citation requirements, reviewer metadata, expiration handling, allowed transitions, and advisory-only authority effects.
- Add verifier and mutation-based verifier test coverage, plus README links.

## Validation
- bash scripts/test-verify-phase-59-3-ai-trace-lifecycle-contract.sh
- bash scripts/verify-phase-59-3-ai-trace-lifecycle-contract.sh
- bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh
- bash scripts/verify-publishable-path-hygiene.sh
- bash scripts/verify-phase-59-1-agent-registry-contract.sh
- bash scripts/verify-phase-59-2-tool-registry-contract.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1255 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1252 --config <supervisor-config-path>

## Notes
- Phase 59.7 trace review queue UI/API remains deferred as a skeleton-only contract.
- No runtime schema, UI, approval, execution, reconciliation, case closure, detector activation, or source-truth authority was added.

Closes #1255