### PR TITLE
Phase 59.4 AI disabled/degraded mode contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Canonical cross-phase boundary reference:
 - [Phase 59.1 agent registry contract](docs/phase-59-1-agent-registry-contract.md) defines the required AI agent registry fields, citation requirements, disallowed authority, and advisory-only authority ceiling.
 - [Phase 59.2 tool registry contract](docs/phase-59-2-tool-registry-contract.md) defines the required AI tool registry fields, allowed record families, citation requirements, audit fields, disallowed authority, and advisory-only authority ceiling.
 - [Phase 59.3 AI trace lifecycle contract](docs/phase-59-3-ai-trace-lifecycle-contract.md) defines created, reviewed, accepted, corrected, rejected, and expired trace states with registered linkage, citations, review metadata, expiration handling, and advisory-only authority.
+- [Phase 59.4 AI disabled and degraded mode contract](docs/phase-59-4-ai-disabled-degraded-mode-contract.md) defines disabled and degraded AI posture, blocked AI generation, non-blocking workflow surfaces, operator explanations, and advisory-only authority.
 - [Phase 58.5 upgrade and rollback plan contract](docs/phase-58-5-upgrade-rollback-plan-contract.md) defines reviewed upgrade-plan and rollback-plan evidence fields, failure states, and authority boundaries without implementing live upgrade or rollback execution.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
@@ -151,6 +152,8 @@ The Phase 59.1 agent registry contract is defined by the [Phase 59.1 agent regis
 The Phase 59.2 tool registry contract is defined by the [Phase 59.2 tool registry contract](docs/phase-59-2-tool-registry-contract.md).
 
 The Phase 59.3 AI trace lifecycle contract is defined by the [Phase 59.3 AI trace lifecycle contract](docs/phase-59-3-ai-trace-lifecycle-contract.md).
+
+The Phase 59.4 AI disabled and degraded mode contract is defined by the [Phase 59.4 AI disabled and degraded mode contract](docs/phase-59-4-ai-disabled-degraded-mode-contract.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/automation/ai-disabled-degraded-mode-contract.json
+++ b/docs/automation/ai-disabled-degraded-mode-contract.json
@@ -7,10 +7,10 @@
     {
       "mode": "disabled",
       "trigger": "platform_admin_policy_disabled",
-      "operator_state": "AI advisory is disabled by platform-admin posture.",
+      "operator_state": "AI advisory unavailable because platform-admin posture disabled it.",
       "readiness_posture": "not_applicable",
       "reason": "ai_advisory_disabled_by_admin",
-      "explanation": "AI advisory generation is intentionally disabled. Continue queue, case, evidence review, action review, reconciliation, supportability, and admin work from authoritative AegisOps records.",
+      "explanation": "AI advisory unavailable because generation is intentionally disabled. Continue queue, case, evidence review, action review, reconciliation, supportability, and admin work from authoritative AegisOps records.",
       "safe_next_steps": [
         "Use queue and case records as the workflow source of truth.",
         "Review evidence, action requests, approvals, execution receipts, and reconciliation records directly.",
@@ -37,10 +37,10 @@
     {
       "mode": "degraded",
       "trigger": "ai_advisory_degraded_by_admin_or_runtime_health",
-      "operator_state": "AI advisory is degraded and unavailable for workflow reliance.",
+      "operator_state": "AI advisory degraded and unavailable for workflow reliance.",
       "readiness_posture": "degraded",
       "reason": "ai_advisory_degraded_by_admin",
-      "explanation": "AI advisory generation is degraded. Continue queue, case, evidence review, action review, reconciliation, supportability, and admin work from authoritative AegisOps records while AI advisory remains unavailable.",
+      "explanation": "AI advisory degraded. Continue queue, case, evidence review, action review, reconciliation, supportability, and admin work from authoritative AegisOps records.",
       "safe_next_steps": [
         "Treat AI advisory context as unavailable until a reviewed healthy posture returns.",
         "Use direct record inspection for queue, case, evidence, action, receipt, and reconciliation decisions.",
@@ -72,7 +72,7 @@
       "ai_dependency": "non_blocking",
       "disabled_mode_behavior": "queue remains available from authoritative records with AI advisory marked disabled",
       "degraded_mode_behavior": "queue remains available from authoritative records with AI advisory marked degraded",
-      "required_operator_explanation": "AI advisory unavailable; queue ordering and case state come from AegisOps records."
+      "required_operator_explanation": "AI advisory unavailable or degraded; queue ordering and case state come from authoritative AegisOps records."
     },
     {
       "surface": "case",
@@ -80,7 +80,7 @@
       "ai_dependency": "non_blocking",
       "disabled_mode_behavior": "case detail remains available from authoritative records with AI advisory marked disabled",
       "degraded_mode_behavior": "case detail remains available from authoritative records with AI advisory marked degraded",
-      "required_operator_explanation": "AI advisory unavailable; case lifecycle and linked evidence come from AegisOps records."
+      "required_operator_explanation": "AI advisory unavailable or degraded; case lifecycle and linked evidence come from authoritative AegisOps records."
     },
     {
       "surface": "evidence_review",
@@ -88,7 +88,7 @@
       "ai_dependency": "non_blocking",
       "disabled_mode_behavior": "evidence review remains available from authoritative evidence records with AI advisory marked disabled",
       "degraded_mode_behavior": "evidence review remains available from authoritative evidence records with AI advisory marked degraded",
-      "required_operator_explanation": "AI advisory unavailable; evidence custody and review state come from AegisOps records."
+      "required_operator_explanation": "AI advisory unavailable or degraded; evidence custody and review state come from authoritative AegisOps records."
     },
     {
       "surface": "action_review",
@@ -96,7 +96,7 @@
       "ai_dependency": "non_blocking",
       "disabled_mode_behavior": "action review remains available from action request and approval records with AI advisory marked disabled",
       "degraded_mode_behavior": "action review remains available from action request and approval records with AI advisory marked degraded",
-      "required_operator_explanation": "AI advisory unavailable; action review, approval, and dispatch posture come from AegisOps records."
+      "required_operator_explanation": "AI advisory unavailable or degraded; action review, approval, and dispatch posture come from authoritative AegisOps records."
     },
     {
       "surface": "reconciliation",
@@ -104,7 +104,7 @@
       "ai_dependency": "non_blocking",
       "disabled_mode_behavior": "reconciliation inspection remains available from execution receipt and reconciliation records with AI advisory marked disabled",
       "degraded_mode_behavior": "reconciliation inspection remains available from execution receipt and reconciliation records with AI advisory marked degraded",
-      "required_operator_explanation": "AI advisory unavailable; reconciliation outcome comes from AegisOps records."
+      "required_operator_explanation": "AI advisory unavailable or degraded; reconciliation outcome comes from authoritative AegisOps records."
     },
     {
       "surface": "doctor_supportability",
@@ -112,7 +112,7 @@
       "ai_dependency": "non_blocking",
       "disabled_mode_behavior": "doctor and supportability explanation fallback remains available with AI advisory marked disabled",
       "degraded_mode_behavior": "doctor and supportability explanation fallback remains available with AI advisory marked degraded",
-      "required_operator_explanation": "AI advisory unavailable; doctor output is bounded supportability context and not workflow truth."
+      "required_operator_explanation": "AI advisory unavailable or degraded; doctor output is bounded supportability context from authoritative AegisOps records and not workflow truth."
     },
     {
       "surface": "admin_enablement",
@@ -120,7 +120,7 @@
       "ai_dependency": "non_blocking",
       "disabled_mode_behavior": "admin enablement posture shows disabled state without unlocking AI generation",
       "degraded_mode_behavior": "admin enablement posture shows degraded state without unlocking AI generation",
-      "required_operator_explanation": "AI advisory unavailable state is controlled by reviewed admin enablement and does not grant workflow authority."
+      "required_operator_explanation": "AI advisory unavailable or degraded state is controlled by reviewed admin enablement and does not override authoritative AegisOps records or grant workflow authority."
     }
   ],
   "blocked_ai_outputs": [
@@ -140,7 +140,7 @@
   ],
   "operator_copy_rules": {
     "required_terms": [
-      "AI advisory unavailable",
+      "AI advisory unavailable or degraded",
       "authoritative AegisOps records"
     ],
     "forbidden_fragments": [

--- a/docs/automation/ai-disabled-degraded-mode-contract.json
+++ b/docs/automation/ai-disabled-degraded-mode-contract.json
@@ -1,0 +1,157 @@
+{
+  "schema_version": "2026-05-11.phase-59.4",
+  "phase": "59.4",
+  "contract_status": "accepted_contract_slice",
+  "authority_boundary": "AI disabled and degraded mode rows are subordinate policy context only. AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.",
+  "modes": [
+    {
+      "mode": "disabled",
+      "trigger": "platform_admin_policy_disabled",
+      "operator_state": "AI advisory is disabled by platform-admin posture.",
+      "readiness_posture": "not_applicable",
+      "reason": "ai_advisory_disabled_by_admin",
+      "explanation": "AI advisory generation is intentionally disabled. Continue queue, case, evidence review, action review, reconciliation, supportability, and admin work from authoritative AegisOps records.",
+      "safe_next_steps": [
+        "Use queue and case records as the workflow source of truth.",
+        "Review evidence, action requests, approvals, execution receipts, and reconciliation records directly.",
+        "Ask a platform admin to change the reviewed enablement posture before using AI advisory output."
+      ],
+      "ai_generation_allowed": false,
+      "trace_creation_allowed": false,
+      "recommendation_generation_allowed": false,
+      "action_draft_generation_allowed": false,
+      "authority_effect": "advisory_unavailable_no_workflow_mutation",
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "automatic_repair",
+        "production_write",
+        "policy_bypass",
+        "workflow_truth"
+      ]
+    },
+    {
+      "mode": "degraded",
+      "trigger": "ai_advisory_degraded_by_admin_or_runtime_health",
+      "operator_state": "AI advisory is degraded and unavailable for workflow reliance.",
+      "readiness_posture": "degraded",
+      "reason": "ai_advisory_degraded_by_admin",
+      "explanation": "AI advisory generation is degraded. Continue queue, case, evidence review, action review, reconciliation, supportability, and admin work from authoritative AegisOps records while AI advisory remains unavailable.",
+      "safe_next_steps": [
+        "Treat AI advisory context as unavailable until a reviewed healthy posture returns.",
+        "Use direct record inspection for queue, case, evidence, action, receipt, and reconciliation decisions.",
+        "Record any AI health follow-up as supportability context only."
+      ],
+      "ai_generation_allowed": false,
+      "trace_creation_allowed": false,
+      "recommendation_generation_allowed": false,
+      "action_draft_generation_allowed": false,
+      "authority_effect": "advisory_unavailable_no_workflow_mutation",
+      "disallowed_authority": [
+        "approval",
+        "execution",
+        "reconciliation",
+        "case_closure",
+        "detector_activation",
+        "source_truth_creation",
+        "automatic_repair",
+        "production_write",
+        "policy_bypass",
+        "workflow_truth"
+      ]
+    }
+  ],
+  "non_ai_workflow_surfaces": [
+    {
+      "surface": "queue",
+      "authoritative_source": "aegisops_case_and_alert_records",
+      "ai_dependency": "non_blocking",
+      "disabled_mode_behavior": "queue remains available from authoritative records with AI advisory marked disabled",
+      "degraded_mode_behavior": "queue remains available from authoritative records with AI advisory marked degraded",
+      "required_operator_explanation": "AI advisory unavailable; queue ordering and case state come from AegisOps records."
+    },
+    {
+      "surface": "case",
+      "authoritative_source": "aegisops_case_record",
+      "ai_dependency": "non_blocking",
+      "disabled_mode_behavior": "case detail remains available from authoritative records with AI advisory marked disabled",
+      "degraded_mode_behavior": "case detail remains available from authoritative records with AI advisory marked degraded",
+      "required_operator_explanation": "AI advisory unavailable; case lifecycle and linked evidence come from AegisOps records."
+    },
+    {
+      "surface": "evidence_review",
+      "authoritative_source": "aegisops_evidence_records",
+      "ai_dependency": "non_blocking",
+      "disabled_mode_behavior": "evidence review remains available from authoritative evidence records with AI advisory marked disabled",
+      "degraded_mode_behavior": "evidence review remains available from authoritative evidence records with AI advisory marked degraded",
+      "required_operator_explanation": "AI advisory unavailable; evidence custody and review state come from AegisOps records."
+    },
+    {
+      "surface": "action_review",
+      "authoritative_source": "aegisops_action_request_and_approval_records",
+      "ai_dependency": "non_blocking",
+      "disabled_mode_behavior": "action review remains available from action request and approval records with AI advisory marked disabled",
+      "degraded_mode_behavior": "action review remains available from action request and approval records with AI advisory marked degraded",
+      "required_operator_explanation": "AI advisory unavailable; action review, approval, and dispatch posture come from AegisOps records."
+    },
+    {
+      "surface": "reconciliation",
+      "authoritative_source": "aegisops_execution_receipt_and_reconciliation_records",
+      "ai_dependency": "non_blocking",
+      "disabled_mode_behavior": "reconciliation inspection remains available from execution receipt and reconciliation records with AI advisory marked disabled",
+      "degraded_mode_behavior": "reconciliation inspection remains available from execution receipt and reconciliation records with AI advisory marked degraded",
+      "required_operator_explanation": "AI advisory unavailable; reconciliation outcome comes from AegisOps records."
+    },
+    {
+      "surface": "doctor_supportability",
+      "authoritative_source": "aegisops_readiness_and_supportability_records",
+      "ai_dependency": "non_blocking",
+      "disabled_mode_behavior": "doctor and supportability explanation fallback remains available with AI advisory marked disabled",
+      "degraded_mode_behavior": "doctor and supportability explanation fallback remains available with AI advisory marked degraded",
+      "required_operator_explanation": "AI advisory unavailable; doctor output is bounded supportability context and not workflow truth."
+    },
+    {
+      "surface": "admin_enablement",
+      "authoritative_source": "reviewed_admin_enablement_posture",
+      "ai_dependency": "non_blocking",
+      "disabled_mode_behavior": "admin enablement posture shows disabled state without unlocking AI generation",
+      "degraded_mode_behavior": "admin enablement posture shows degraded state without unlocking AI generation",
+      "required_operator_explanation": "AI advisory unavailable state is controlled by reviewed admin enablement and does not grant workflow authority."
+    }
+  ],
+  "blocked_ai_outputs": [
+    "recommendation_generation",
+    "action_request_draft_generation",
+    "trace_creation",
+    "approval",
+    "execution",
+    "reconciliation",
+    "case_closure",
+    "detector_activation",
+    "source_truth_creation",
+    "automatic_repair",
+    "production_write",
+    "policy_bypass",
+    "workflow_truth"
+  ],
+  "operator_copy_rules": {
+    "required_terms": [
+      "AI advisory unavailable",
+      "authoritative AegisOps records"
+    ],
+    "forbidden_fragments": [
+      "AI approved",
+      "AI executed",
+      "AI reconciled",
+      "AI closed",
+      "AI activated",
+      "AI repaired",
+      "AI is workflow truth",
+      "automatic repair complete"
+    ]
+  }
+}

--- a/docs/automation/ai-disabled-degraded-mode-contract.json
+++ b/docs/automation/ai-disabled-degraded-mode-contract.json
@@ -39,7 +39,10 @@
       "trigger": "ai_advisory_degraded_by_admin_or_runtime_health",
       "operator_state": "AI advisory degraded and unavailable for workflow reliance.",
       "readiness_posture": "degraded",
-      "reason": "ai_advisory_degraded_by_admin",
+      "reason": [
+        "ai_advisory_degraded_by_admin",
+        "ai_advisory_degraded_by_runtime_health"
+      ],
       "explanation": "AI advisory degraded. Continue queue, case, evidence review, action review, reconciliation, supportability, and admin work from authoritative AegisOps records.",
       "safe_next_steps": [
         "Treat AI advisory context as unavailable until a reviewed healthy posture returns.",

--- a/docs/phase-59-4-ai-disabled-degraded-mode-contract.md
+++ b/docs/phase-59-4-ai-disabled-degraded-mode-contract.md
@@ -1,0 +1,90 @@
+# Phase 59.4 AI Disabled And Degraded Mode Contract
+
+- **Status**: Accepted disabled and degraded mode contract slice
+- **Date**: 2026-05-11
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1252, #1256
+
+This contract defines the AI disabled and degraded mode behavior before Phase 59 expands prompt fixtures, stale or conflicting evidence fixtures, trace queue UI/API implementation, closeout work, or Phase 60 daily AI operations.
+
+It is limited to the Phase 59.4 AI disabled and degraded mode contract. It does not implement new model routing, provider selection, tool execution, trace queue behavior, daily AI operations, approval, execution, reconciliation, case closure, detector activation, source truth, production write authority, or commercial-readiness claims.
+
+## 1. Required Mode Fields
+
+Every disabled or degraded mode row must include mode, trigger, operator state, readiness posture, blocked AI generation flags, reason, explanation, safe next steps, authority effect, and disallowed authority.
+
+The executable mode artifact lives in `docs/automation/ai-disabled-degraded-mode-contract.json`.
+
+The mode artifact is a repo-owned policy artifact. It is not runtime truth, workflow truth, approval truth, execution truth, reconciliation truth, release truth, gate truth, closeout truth, or source truth.
+
+## 2. Authority Boundary
+
+AI remains advisory, registered, audited, cited, and subordinate to reviewed AegisOps records when available, and it produces no recommendations, action drafts, or trace state when disabled or degraded.
+
+No disabled or degraded mode row may grant approval, execution, reconciliation, case-closure, detector-activation, source-truth, production write, policy-bypass, automatic repair, workflow truth, or authority-widening capability.
+
+Disabled and degraded AI posture must not block queue, case, evidence review, action review, reconciliation, doctor/supportability explanation fallback, or admin enablement posture surfaces that use authoritative AegisOps records.
+
+Operator-facing state must explain AI unavailability without implying AI approval, automatic repair, source truth, reconciliation truth, case closure, or workflow completion.
+
+This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md` for AI approval, execution, reconciliation, case closure, detector activation, and source-truth refusal.
+
+## 3. Disabled And Degraded Modes
+
+| Mode | Meaning | Required workflow posture |
+| --- | --- | --- |
+| `disabled` | Platform policy has intentionally disabled AI advisory generation. | Non-AI queue, case, evidence review, action review, reconciliation, supportability, and admin surfaces continue from authoritative records. |
+| `degraded` | AI advisory generation is operationally unavailable, stale, partially trusted, or otherwise not safe to use. | Non-AI workflow continues and AI output remains unavailable until a reviewed healthy posture returns. |
+
+These names identify AI advisory posture, not workflow lifecycle states with independent authority.
+
+## 4. Non-AI Workflow Surface Requirements
+
+The contract covers these non-AI surfaces:
+
+- queue;
+- case;
+- evidence review;
+- action review;
+- reconciliation;
+- doctor/supportability explanation fallback;
+- admin enablement posture.
+
+Each covered surface must keep its authoritative AegisOps record source, must declare AI as non-blocking, and must provide an operator-visible unavailable or degraded explanation when AI context is absent.
+
+## 5. Verifier Requirements
+
+The disabled/degraded verifier must fail when:
+
+- the contract doc is missing;
+- the mode artifact is missing or invalid JSON;
+- disabled or degraded mode coverage is missing;
+- any disabled or degraded mode allows AI generation, recommendation generation, action-draft generation, or trace creation;
+- any required non-AI workflow surface is missing or depends on AI;
+- disabled or degraded copy omits an operator-facing explanation;
+- disabled or degraded copy implies AI approval, execution, reconciliation, case closure, detector activation, source truth, automatic repair, workflow truth, or authority widening;
+- publishable artifacts contain workstation-local absolute paths.
+
+## 6. Validation
+
+Run `bash scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`.
+
+Run `bash scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`.
+
+Run `python3 -m unittest control-plane.tests.test_phase57_7_ai_enablement_admin_toggle`.
+
+Run `python3 -m unittest control-plane.tests.test_phase58_1_doctor_contract.Phase581DoctorContractTests.test_doctor_contract_reports_degraded_source_and_ai_without_authority`.
+
+Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1256 --config <supervisor-config-path>`.
+
+## 7. Non-Goals
+
+- No new production write authority is introduced.
+- No AI output, trace state, citation, registry row, mode artifact, verifier output, issue-lint output, browser state, UI state, demo data, Wazuh state, Shuffle state, ticket state, optional evidence, doctor output, supportability output, or prompt text becomes authoritative workflow truth.
+- No Phase 60 daily AI operations behavior is implemented.
+- No model/provider selection, billing, prompt marketplace, tool marketplace, or agent ecosystem breadth is implemented.
+- No approval, execution, reconciliation, case closure, detector activation, source-truth creation, automatic repair, production write, or policy bypass is delegated to AI.

--- a/docs/phase-59-4-ai-disabled-degraded-mode-contract.md
+++ b/docs/phase-59-4-ai-disabled-degraded-mode-contract.md
@@ -81,6 +81,8 @@ Run `bash scripts/verify-publishable-path-hygiene.sh`.
 
 Run `node <codex-supervisor-root>/dist/index.js issue-lint 1256 --config <supervisor-config-path>`.
 
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1252 --config <supervisor-config-path>`.
+
 ## 7. Non-Goals
 
 - No new production write authority is introduced.

--- a/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -195,6 +195,14 @@ assert_fails_with \
   "${missing_doctor_validation_repo}" \
   "Missing Phase 59.4 AI disabled/degraded mode contract statement: Run \`python3 -m unittest control-plane.tests.test_phase58_1_doctor_contract.Phase581DoctorContractTests.test_doctor_contract_reports_degraded_source_and_ai_without_authority\`."
 
+missing_epic_issue_lint_repo="${workdir}/missing-epic-issue-lint"
+create_valid_repo "${missing_epic_issue_lint_repo}"
+remove_text_from_doc "${missing_epic_issue_lint_repo}" \
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1252 --config <supervisor-config-path>`.'
+assert_fails_with \
+  "${missing_epic_issue_lint_repo}" \
+  "Missing Phase 59.4 AI disabled/degraded mode contract statement: Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1252 --config <supervisor-config-path>\`."
+
 runtime_health_reason_repo="${workdir}/runtime-health-reason"
 create_valid_repo "${runtime_health_reason_repo}"
 mutate_contract "${runtime_health_reason_repo}" "degraded_reason_runtime_health"

--- a/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -124,6 +124,8 @@ elif mutation == "disabled_trigger_degraded":
     disabled["trigger"] = "ai_advisory_degraded_by_admin_or_runtime_health"
 elif mutation == "degraded_reason_disabled":
     degraded["reason"] = "ai_advisory_disabled_by_admin"
+elif mutation == "degraded_reason_runtime_health":
+    degraded["reason"] = "ai_advisory_degraded_by_runtime_health"
 elif mutation == "mode_wrong_readiness":
     disabled["readiness_posture"] = "healthy_available"
 elif mutation == "degraded_claims_available_readiness":
@@ -184,6 +186,19 @@ remove_text_from_doc "${missing_contract_field_repo}" \
 assert_fails_with \
   "${missing_contract_field_repo}" \
   "Missing Phase 59.4 AI disabled/degraded mode contract statement: Every disabled or degraded mode row"
+
+missing_doctor_validation_repo="${workdir}/missing-doctor-validation"
+create_valid_repo "${missing_doctor_validation_repo}"
+remove_text_from_doc "${missing_doctor_validation_repo}" \
+  'Run `python3 -m unittest control-plane.tests.test_phase58_1_doctor_contract.Phase581DoctorContractTests.test_doctor_contract_reports_degraded_source_and_ai_without_authority`.'
+assert_fails_with \
+  "${missing_doctor_validation_repo}" \
+  "Missing Phase 59.4 AI disabled/degraded mode contract statement: Run \`python3 -m unittest control-plane.tests.test_phase58_1_doctor_contract.Phase581DoctorContractTests.test_doctor_contract_reports_degraded_source_and_ai_without_authority\`."
+
+runtime_health_reason_repo="${workdir}/runtime-health-reason"
+create_valid_repo "${runtime_health_reason_repo}"
+mutate_contract "${runtime_health_reason_repo}" "degraded_reason_runtime_health"
+assert_passes "${runtime_health_reason_repo}"
 
 for mutation in \
   missing_disabled_mode \
@@ -267,7 +282,7 @@ do
       assert_fails_with "${mutated_repo}" "AI mode disabled trigger must be platform_admin_policy_disabled"
       ;;
     degraded_reason_disabled)
-      assert_fails_with "${mutated_repo}" "AI mode degraded reason must be ai_advisory_degraded_by_admin"
+      assert_fails_with "${mutated_repo}" "AI mode degraded reason must be one of: ai_advisory_degraded_by_admin, ai_advisory_degraded_by_runtime_health"
       ;;
     mode_wrong_readiness)
       assert_fails_with "${mutated_repo}" "AI mode disabled readiness_posture must be not_applicable"

--- a/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -107,6 +107,8 @@ elif mutation == "missing_copy_rule":
     contract["operator_copy_rules"]["forbidden_fragments"].remove("AI is workflow truth")
 elif mutation == "missing_extended_copy_rule":
     contract["operator_copy_rules"]["forbidden_fragments"].remove("AI closed")
+elif mutation == "custom_required_term_missing_from_operator_copy":
+    contract["operator_copy_rules"]["required_terms"].append("reviewed fallback banner")
 elif mutation == "authority_boundary_forbidden_claim":
     contract["authority_boundary"] += " AI may execute actions."
 elif mutation == "authority_boundary_can_execute_claim":
@@ -187,21 +189,25 @@ assert_fails_with \
   "${missing_contract_field_repo}" \
   "Missing Phase 59.4 AI disabled/degraded mode contract statement: Every disabled or degraded mode row"
 
-missing_doctor_validation_repo="${workdir}/missing-doctor-validation"
-create_valid_repo "${missing_doctor_validation_repo}"
-remove_text_from_doc "${missing_doctor_validation_repo}" \
+validation_commands=(
+  'Run `bash scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`.'
+  'Run `python3 -m unittest control-plane.tests.test_phase57_7_ai_enablement_admin_toggle`.'
   'Run `python3 -m unittest control-plane.tests.test_phase58_1_doctor_contract.Phase581DoctorContractTests.test_doctor_contract_reports_degraded_source_and_ai_without_authority`.'
-assert_fails_with \
-  "${missing_doctor_validation_repo}" \
-  "Missing Phase 59.4 AI disabled/degraded mode contract statement: Run \`python3 -m unittest control-plane.tests.test_phase58_1_doctor_contract.Phase581DoctorContractTests.test_doctor_contract_reports_degraded_source_and_ai_without_authority\`."
-
-missing_epic_issue_lint_repo="${workdir}/missing-epic-issue-lint"
-create_valid_repo "${missing_epic_issue_lint_repo}"
-remove_text_from_doc "${missing_epic_issue_lint_repo}" \
+  'Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.'
+  'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1256 --config <supervisor-config-path>`.'
   'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1252 --config <supervisor-config-path>`.'
-assert_fails_with \
-  "${missing_epic_issue_lint_repo}" \
-  "Missing Phase 59.4 AI disabled/degraded mode contract statement: Run \`node <codex-supervisor-root>/dist/index.js issue-lint 1252 --config <supervisor-config-path>\`."
+)
+
+for index in "${!validation_commands[@]}"; do
+  missing_validation_command_repo="${workdir}/missing-validation-command-${index}"
+  create_valid_repo "${missing_validation_command_repo}"
+  remove_text_from_doc "${missing_validation_command_repo}" "${validation_commands[${index}]}"
+  assert_fails_with \
+    "${missing_validation_command_repo}" \
+    "Missing Phase 59.4 AI disabled/degraded mode contract statement: ${validation_commands[${index}]}"
+done
 
 runtime_health_reason_repo="${workdir}/runtime-health-reason"
 create_valid_repo "${runtime_health_reason_repo}"
@@ -219,6 +225,7 @@ for mutation in \
   missing_blocked_output \
   missing_copy_rule \
   missing_extended_copy_rule \
+  custom_required_term_missing_from_operator_copy \
   authority_boundary_forbidden_claim \
   authority_boundary_can_execute_claim \
   authority_boundary_allowed_execute_claim \
@@ -267,6 +274,9 @@ do
       ;;
     missing_extended_copy_rule)
       assert_fails_with "${mutated_repo}" "must forbid copy fragment: AI closed"
+      ;;
+    custom_required_term_missing_from_operator_copy)
+      assert_fails_with "${mutated_repo}" "operator-facing copy must include required copy term: reviewed fallback banner"
       ;;
     authority_boundary_forbidden_claim)
       assert_fails_with "${mutated_repo}" "authority_boundary must not include forbidden authority claim: ai may execute"

--- a/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -109,11 +109,19 @@ elif mutation == "missing_extended_copy_rule":
     contract["operator_copy_rules"]["forbidden_fragments"].remove("AI closed")
 elif mutation == "authority_boundary_forbidden_claim":
     contract["authority_boundary"] += " AI may execute actions."
+elif mutation == "authority_boundary_can_execute_claim":
+    contract["authority_boundary"] += " AI can execute actions."
 elif mutation == "mode_generic_posture":
     disabled["operator_state"] = "Normal operations continue."
     disabled["explanation"] = "Continue normal operations from authoritative AegisOps records."
+elif mutation == "mode_operator_state_missing_advisory_posture":
+    disabled["operator_state"] = "Disabled policy posture is shown."
+elif mutation == "mode_explanation_missing_advisory_posture":
+    disabled["explanation"] = "Disabled policy posture is shown from authoritative AegisOps records."
 elif mutation == "mode_wrong_readiness":
     disabled["readiness_posture"] = "healthy_available"
+elif mutation == "degraded_claims_available_readiness":
+    degraded["readiness_posture"] = "degraded_healthy_available"
 elif mutation == "operator_forbidden_fragment":
     disabled["explanation"] += " AI approved the workflow."
 elif mutation == "missing_operator_required_records":
@@ -183,8 +191,12 @@ for mutation in \
   missing_copy_rule \
   missing_extended_copy_rule \
   authority_boundary_forbidden_claim \
+  authority_boundary_can_execute_claim \
   mode_generic_posture \
+  mode_operator_state_missing_advisory_posture \
+  mode_explanation_missing_advisory_posture \
   mode_wrong_readiness \
+  degraded_claims_available_readiness \
   operator_forbidden_fragment \
   missing_operator_required_records \
   json_escaped_unix_path \
@@ -227,11 +239,23 @@ do
     authority_boundary_forbidden_claim)
       assert_fails_with "${mutated_repo}" "authority_boundary must not include forbidden authority claim: ai may execute"
       ;;
+    authority_boundary_can_execute_claim)
+      assert_fails_with "${mutated_repo}" "authority_boundary must not include forbidden authority claim: ai can execute"
+      ;;
     mode_generic_posture)
       assert_fails_with "${mutated_repo}" "AI mode disabled operator_state must state disabled semantics"
       ;;
+    mode_operator_state_missing_advisory_posture)
+      assert_fails_with "${mutated_repo}" "AI mode disabled operator_state must explain AI advisory unavailable or degraded posture"
+      ;;
+    mode_explanation_missing_advisory_posture)
+      assert_fails_with "${mutated_repo}" "AI mode disabled explanation must explain AI advisory unavailable or degraded posture"
+      ;;
     mode_wrong_readiness)
       assert_fails_with "${mutated_repo}" "AI mode disabled readiness_posture must not claim healthy or available posture"
+      ;;
+    degraded_claims_available_readiness)
+      assert_fails_with "${mutated_repo}" "AI mode degraded readiness_posture must not claim healthy or available AI posture"
       ;;
     operator_forbidden_fragment)
       assert_fails_with "${mutated_repo}" "operator-facing copy must not include forbidden authority claim: AI approved"

--- a/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh"
+
+if [[ ! -x "${verifier}" ]]; then
+  echo "Missing executable Phase 59.4 AI disabled/degraded mode verifier: ${verifier}" >&2
+  exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+create_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs/automation" "${target}/scripts"
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Codex Test"
+  git -C "${target}" config user.email "codex@example.com"
+  printf '%s\n' \
+    "# AegisOps" \
+    "See [Phase 59.4 AI disabled/degraded mode contract](docs/phase-59-4-ai-disabled-degraded-mode-contract.md)." \
+    >"${target}/README.md"
+  cp "${repo_root}/docs/phase-59-4-ai-disabled-degraded-mode-contract.md" \
+    "${target}/docs/phase-59-4-ai-disabled-degraded-mode-contract.md"
+  cp "${repo_root}/docs/automation/ai-disabled-degraded-mode-contract.json" \
+    "${target}/docs/automation/ai-disabled-degraded-mode-contract.json"
+  cp "${repo_root}/scripts/verify-publishable-path-hygiene.sh" \
+    "${target}/scripts/verify-publishable-path-hygiene.sh"
+  git -C "${target}" add README.md docs/phase-59-4-ai-disabled-degraded-mode-contract.md \
+    docs/automation/ai-disabled-degraded-mode-contract.json \
+    scripts/verify-publishable-path-hygiene.sh
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+mutate_contract() {
+  local target="$1"
+  local mutation="$2"
+
+  python3 - "${target}/docs/automation/ai-disabled-degraded-mode-contract.json" "${mutation}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+mutation = sys.argv[2]
+contract = json.loads(path.read_text(encoding="utf-8"))
+
+disabled = next(mode for mode in contract["modes"] if mode["mode"] == "disabled")
+degraded = next(mode for mode in contract["modes"] if mode["mode"] == "degraded")
+queue = next(surface for surface in contract["non_ai_workflow_surfaces"] if surface["surface"] == "queue")
+
+if mutation == "missing_disabled_mode":
+    contract["modes"] = [mode for mode in contract["modes"] if mode["mode"] != "disabled"]
+elif mutation == "allow_recommendation_generation":
+    disabled["recommendation_generation_allowed"] = True
+elif mutation == "allow_trace_creation":
+    degraded["trace_creation_allowed"] = True
+elif mutation == "missing_surface":
+    contract["non_ai_workflow_surfaces"] = [
+        surface
+        for surface in contract["non_ai_workflow_surfaces"]
+        if surface["surface"] != "reconciliation"
+    ]
+elif mutation == "ai_blocking_surface":
+    queue["ai_dependency"] = "required"
+elif mutation == "missing_operator_explanation":
+    queue["required_operator_explanation"] = ""
+elif mutation == "missing_disallowed_authority":
+    disabled["disallowed_authority"].remove("automatic_repair")
+elif mutation == "missing_blocked_output":
+    contract["blocked_ai_outputs"].remove("trace_creation")
+elif mutation == "missing_copy_rule":
+    contract["operator_copy_rules"]["forbidden_fragments"].remove("AI is workflow truth")
+elif mutation == "json_escaped_unix_path":
+    disabled["explanation"] += " See /" + "Users/example/private.txt."
+elif mutation == "json_escaped_windows_path":
+    slash = chr(92)
+    degraded["explanation"] += " See C:" + slash + "Users" + slash + "example" + slash + "private.txt."
+else:
+    raise SystemExit(f"unknown mutation: {mutation}")
+
+path.write_text(json.dumps(contract, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+PY
+}
+
+remove_text_from_doc() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-59-4-ai-disabled-degraded-mode-contract.md"
+}
+
+valid_repo="${workdir}/valid"
+create_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+create_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-59-4-ai-disabled-degraded-mode-contract.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 59.4 AI disabled/degraded mode contract doc"
+
+missing_artifact_repo="${workdir}/missing-artifact"
+create_valid_repo "${missing_artifact_repo}"
+rm "${missing_artifact_repo}/docs/automation/ai-disabled-degraded-mode-contract.json"
+assert_fails_with \
+  "${missing_artifact_repo}" \
+  "Missing Phase 59.4 AI disabled/degraded mode artifact"
+
+missing_contract_field_repo="${workdir}/missing-contract-field"
+create_valid_repo "${missing_contract_field_repo}"
+remove_text_from_doc "${missing_contract_field_repo}" \
+  "Every disabled or degraded mode row must include mode, trigger, operator state, readiness posture, blocked AI generation flags, reason, explanation, safe next steps, authority effect, and disallowed authority."
+assert_fails_with \
+  "${missing_contract_field_repo}" \
+  "Missing Phase 59.4 AI disabled/degraded mode contract statement: Every disabled or degraded mode row"
+
+for mutation in \
+  missing_disabled_mode \
+  allow_recommendation_generation \
+  allow_trace_creation \
+  missing_surface \
+  ai_blocking_surface \
+  missing_operator_explanation \
+  missing_disallowed_authority \
+  missing_blocked_output \
+  missing_copy_rule \
+  json_escaped_unix_path \
+  json_escaped_windows_path
+do
+  mutated_repo="${workdir}/${mutation}"
+  create_valid_repo "${mutated_repo}"
+  mutate_contract "${mutated_repo}" "${mutation}"
+  case "${mutation}" in
+    missing_disabled_mode)
+      assert_fails_with "${mutated_repo}" "is missing mode(s): disabled"
+      ;;
+    allow_recommendation_generation)
+      assert_fails_with "${mutated_repo}" "must keep recommendation_generation_allowed false"
+      ;;
+    allow_trace_creation)
+      assert_fails_with "${mutated_repo}" "must keep trace_creation_allowed false"
+      ;;
+    missing_surface)
+      assert_fails_with "${mutated_repo}" "is missing surface(s): reconciliation"
+      ;;
+    ai_blocking_surface)
+      assert_fails_with "${mutated_repo}" "must keep AI non-blocking"
+      ;;
+    missing_operator_explanation)
+      assert_fails_with "${mutated_repo}" "required_operator_explanation must be a non-empty string"
+      ;;
+    missing_disallowed_authority)
+      assert_fails_with "${mutated_repo}" "is missing disallowed authority: automatic_repair"
+      ;;
+    missing_blocked_output)
+      assert_fails_with "${mutated_repo}" "must include trace_creation"
+      ;;
+    missing_copy_rule)
+      assert_fails_with "${mutated_repo}" "must forbid copy fragment: AI is workflow truth"
+      ;;
+    json_escaped_unix_path|json_escaped_windows_path)
+      assert_fails_with "${mutated_repo}" "workstation-local absolute path detected"
+      ;;
+  esac
+done
+
+echo "Phase 59.4 AI disabled/degraded mode verifier rejects missing modes, enabled AI output, blocking workflow surfaces, weak copy rules, missing authority refusals, and local paths."

--- a/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -105,6 +105,21 @@ elif mutation == "missing_blocked_output":
     contract["blocked_ai_outputs"].remove("trace_creation")
 elif mutation == "missing_copy_rule":
     contract["operator_copy_rules"]["forbidden_fragments"].remove("AI is workflow truth")
+elif mutation == "missing_extended_copy_rule":
+    contract["operator_copy_rules"]["forbidden_fragments"].remove("AI closed")
+elif mutation == "authority_boundary_forbidden_claim":
+    contract["authority_boundary"] += " AI may execute actions."
+elif mutation == "mode_generic_posture":
+    disabled["operator_state"] = "Normal operations continue."
+    disabled["explanation"] = "Continue normal operations from authoritative AegisOps records."
+elif mutation == "mode_wrong_readiness":
+    disabled["readiness_posture"] = "healthy_available"
+elif mutation == "operator_forbidden_fragment":
+    disabled["explanation"] += " AI approved the workflow."
+elif mutation == "missing_operator_required_records":
+    queue["required_operator_explanation"] = "AI advisory unavailable; queue ordering and case state continue."
+elif mutation == "surface_degraded_operator_explanation":
+    queue["required_operator_explanation"] = "AI advisory degraded; queue ordering and case state come from authoritative AegisOps records."
 elif mutation == "json_escaped_unix_path":
     disabled["explanation"] += " See /" + "Users/example/private.txt."
 elif mutation == "json_escaped_windows_path":
@@ -128,6 +143,11 @@ remove_text_from_doc() {
 valid_repo="${workdir}/valid"
 create_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
+
+degraded_copy_repo="${workdir}/surface-degraded-operator-explanation"
+create_valid_repo "${degraded_copy_repo}"
+mutate_contract "${degraded_copy_repo}" "surface_degraded_operator_explanation"
+assert_passes "${degraded_copy_repo}"
 
 missing_doc_repo="${workdir}/missing-doc"
 create_valid_repo "${missing_doc_repo}"
@@ -161,6 +181,12 @@ for mutation in \
   missing_disallowed_authority \
   missing_blocked_output \
   missing_copy_rule \
+  missing_extended_copy_rule \
+  authority_boundary_forbidden_claim \
+  mode_generic_posture \
+  mode_wrong_readiness \
+  operator_forbidden_fragment \
+  missing_operator_required_records \
   json_escaped_unix_path \
   json_escaped_windows_path
 do
@@ -194,6 +220,24 @@ do
       ;;
     missing_copy_rule)
       assert_fails_with "${mutated_repo}" "must forbid copy fragment: AI is workflow truth"
+      ;;
+    missing_extended_copy_rule)
+      assert_fails_with "${mutated_repo}" "must forbid copy fragment: AI closed"
+      ;;
+    authority_boundary_forbidden_claim)
+      assert_fails_with "${mutated_repo}" "authority_boundary must not include forbidden authority claim: ai may execute"
+      ;;
+    mode_generic_posture)
+      assert_fails_with "${mutated_repo}" "AI mode disabled operator_state must state disabled semantics"
+      ;;
+    mode_wrong_readiness)
+      assert_fails_with "${mutated_repo}" "AI mode disabled readiness_posture must not claim healthy or available posture"
+      ;;
+    operator_forbidden_fragment)
+      assert_fails_with "${mutated_repo}" "operator-facing copy must not include forbidden authority claim: AI approved"
+      ;;
+    missing_operator_required_records)
+      assert_fails_with "${mutated_repo}" "operator explanation must direct operators to authoritative AegisOps records"
       ;;
     json_escaped_unix_path|json_escaped_windows_path)
       assert_fails_with "${mutated_repo}" "workstation-local absolute path detected"

--- a/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -111,6 +111,8 @@ elif mutation == "authority_boundary_forbidden_claim":
     contract["authority_boundary"] += " AI may execute actions."
 elif mutation == "authority_boundary_can_execute_claim":
     contract["authority_boundary"] += " AI can execute actions."
+elif mutation == "authority_boundary_allowed_execute_claim":
+    contract["authority_boundary"] += " AI is allowed to execute actions."
 elif mutation == "mode_generic_posture":
     disabled["operator_state"] = "Normal operations continue."
     disabled["explanation"] = "Continue normal operations from authoritative AegisOps records."
@@ -118,6 +120,10 @@ elif mutation == "mode_operator_state_missing_advisory_posture":
     disabled["operator_state"] = "Disabled policy posture is shown."
 elif mutation == "mode_explanation_missing_advisory_posture":
     disabled["explanation"] = "Disabled policy posture is shown from authoritative AegisOps records."
+elif mutation == "disabled_trigger_degraded":
+    disabled["trigger"] = "ai_advisory_degraded_by_admin_or_runtime_health"
+elif mutation == "degraded_reason_disabled":
+    degraded["reason"] = "ai_advisory_disabled_by_admin"
 elif mutation == "mode_wrong_readiness":
     disabled["readiness_posture"] = "healthy_available"
 elif mutation == "degraded_claims_available_readiness":
@@ -192,9 +198,12 @@ for mutation in \
   missing_extended_copy_rule \
   authority_boundary_forbidden_claim \
   authority_boundary_can_execute_claim \
+  authority_boundary_allowed_execute_claim \
   mode_generic_posture \
   mode_operator_state_missing_advisory_posture \
   mode_explanation_missing_advisory_posture \
+  disabled_trigger_degraded \
+  degraded_reason_disabled \
   mode_wrong_readiness \
   degraded_claims_available_readiness \
   operator_forbidden_fragment \
@@ -242,20 +251,29 @@ do
     authority_boundary_can_execute_claim)
       assert_fails_with "${mutated_repo}" "authority_boundary must not include forbidden authority claim: ai can execute"
       ;;
+    authority_boundary_allowed_execute_claim)
+      assert_fails_with "${mutated_repo}" "authority_boundary contains forbidden authority claim"
+      ;;
     mode_generic_posture)
-      assert_fails_with "${mutated_repo}" "AI mode disabled operator_state must state disabled semantics"
+      assert_fails_with "${mutated_repo}" "AI mode disabled operator_state must explain AI advisory disabled posture"
       ;;
     mode_operator_state_missing_advisory_posture)
-      assert_fails_with "${mutated_repo}" "AI mode disabled operator_state must explain AI advisory unavailable or degraded posture"
+      assert_fails_with "${mutated_repo}" "AI mode disabled operator_state must explain AI advisory disabled posture"
       ;;
     mode_explanation_missing_advisory_posture)
-      assert_fails_with "${mutated_repo}" "AI mode disabled explanation must explain AI advisory unavailable or degraded posture"
+      assert_fails_with "${mutated_repo}" "AI mode disabled explanation must explain AI advisory disabled posture"
+      ;;
+    disabled_trigger_degraded)
+      assert_fails_with "${mutated_repo}" "AI mode disabled trigger must be platform_admin_policy_disabled"
+      ;;
+    degraded_reason_disabled)
+      assert_fails_with "${mutated_repo}" "AI mode degraded reason must be ai_advisory_degraded_by_admin"
       ;;
     mode_wrong_readiness)
-      assert_fails_with "${mutated_repo}" "AI mode disabled readiness_posture must not claim healthy or available posture"
+      assert_fails_with "${mutated_repo}" "AI mode disabled readiness_posture must be not_applicable"
       ;;
     degraded_claims_available_readiness)
-      assert_fails_with "${mutated_repo}" "AI mode degraded readiness_posture must not claim healthy or available AI posture"
+      assert_fails_with "${mutated_repo}" "AI mode degraded readiness_posture must be degraded"
       ;;
     operator_forbidden_fragment)
       assert_fails_with "${mutated_repo}" "operator-facing copy must not include forbidden authority claim: AI approved"

--- a/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -50,6 +50,7 @@ done
 
 python3 - "${contract_path}" <<'PY'
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -136,6 +137,14 @@ required_forbidden_fragments = {
     "automatic repair complete",
 }
 contradictory_authority_claims = {
+    "ai can approve",
+    "ai can execute",
+    "ai can reconcile",
+    "ai can close",
+    "ai can activate",
+    "ai can create source truth",
+    "ai can repair",
+    "ai can bypass policy",
     "ai may approve",
     "ai may execute",
     "ai may reconcile",
@@ -144,6 +153,14 @@ contradictory_authority_claims = {
     "ai may create source truth",
     "ai may repair",
     "ai may bypass policy",
+    "ai approves",
+    "ai executes",
+    "ai reconciles",
+    "ai closes",
+    "ai activates",
+    "ai creates source truth",
+    "ai repairs",
+    "ai bypasses policy",
     "ai approved",
     "ai executed",
     "ai reconciled",
@@ -198,16 +215,16 @@ def require_authoritative_records(text: str, description: str) -> None:
             f"{description} must direct operators to authoritative AegisOps records."
         )
 
+def require_no_healthy_or_available_posture(text: str, description: str) -> None:
+    normalized = re.sub(r"[^a-z0-9]+", " ", text.casefold())
+    terms = set(normalized.split())
+    for forbidden in ("healthy", "available"):
+        if forbidden in terms:
+            raise SystemExit(
+                f"{description} must not claim healthy or available AI posture."
+            )
+
 def require_mode_specific_semantics(mode_name: str, mode: dict) -> None:
-    semantic_text = " ".join(
-        [
-            mode["trigger"],
-            mode["readiness_posture"],
-            mode["reason"],
-            mode["operator_state"],
-            mode["explanation"],
-        ]
-    ).casefold()
     if mode_name == "disabled":
         for field in ("trigger", "reason", "operator_state", "explanation"):
             if "disabled" not in mode[field].casefold():
@@ -226,11 +243,11 @@ def require_mode_specific_semantics(mode_name: str, mode: dict) -> None:
                 )
     else:
         return
-    for forbidden in ("healthy", "available"):
-        if forbidden in semantic_text and "unavailable" not in semantic_text:
-            raise SystemExit(
-                f"Phase 59.4 AI mode {mode_name} must not claim healthy or available AI posture."
-            )
+    for field in ("trigger", "readiness_posture", "reason", "operator_state", "explanation"):
+        require_no_healthy_or_available_posture(
+            mode[field],
+            f"Phase 59.4 AI mode {mode_name} {field}",
+        )
 
 copy_rules = contract["operator_copy_rules"]
 if not isinstance(copy_rules, dict):
@@ -312,10 +329,11 @@ for index, mode in enumerate(modes, start=1):
             " ".join(mode["safe_next_steps"]),
         ]
     )
-    require_ai_advisory_posture(
-        text,
-        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
-    )
+    for field in ("operator_state", "explanation"):
+        require_ai_advisory_posture(
+            mode[field],
+            f"Phase 59.4 AI mode {mode_name} {field}",
+        )
     require_authoritative_records(
         text,
         f"Phase 59.4 AI mode {mode_name} operator-facing copy",

--- a/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -125,6 +125,34 @@ required_disallowed = {
     "policy_bypass",
     "workflow_truth",
 }
+required_forbidden_fragments = {
+    "AI approved",
+    "AI executed",
+    "AI reconciled",
+    "AI closed",
+    "AI activated",
+    "AI repaired",
+    "AI is workflow truth",
+    "automatic repair complete",
+}
+contradictory_authority_claims = {
+    "ai may approve",
+    "ai may execute",
+    "ai may reconcile",
+    "ai may close",
+    "ai may activate",
+    "ai may create source truth",
+    "ai may repair",
+    "ai may bypass policy",
+    "ai approved",
+    "ai executed",
+    "ai reconciled",
+    "ai closed",
+    "ai activated",
+    "ai repaired",
+    "ai is workflow truth",
+    "automatic repair complete",
+}
 
 def require_non_empty_string(value, description: str) -> str:
     if not isinstance(value, str) or not value.strip():
@@ -139,6 +167,97 @@ def require_non_empty_string_list(value, description: str) -> list[str]:
     ):
         raise SystemExit(f"{description} must be a non-empty string list.")
     return value
+
+def require_no_forbidden_fragments(text: str, description: str, fragments: list[str]) -> None:
+    text_lower = text.casefold()
+    for fragment in fragments:
+        if fragment.casefold() in text_lower:
+            raise SystemExit(
+                f"{description} must not include forbidden authority claim: {fragment}"
+            )
+
+def require_ai_advisory_posture(text: str, description: str) -> None:
+    text_lower = text.casefold()
+    allowed_posture_terms = (
+        "ai advisory unavailable",
+        "ai advisory is unavailable",
+        "ai advisory disabled",
+        "ai advisory is disabled",
+        "ai advisory degraded",
+        "ai advisory is degraded",
+        "ai advisory unavailable or degraded",
+    )
+    if not any(term in text_lower for term in allowed_posture_terms):
+        raise SystemExit(
+            f"{description} must explain AI advisory unavailable or degraded posture."
+        )
+
+def require_authoritative_records(text: str, description: str) -> None:
+    if "authoritative aegisops records" not in text.casefold():
+        raise SystemExit(
+            f"{description} must direct operators to authoritative AegisOps records."
+        )
+
+def require_mode_specific_semantics(mode_name: str, mode: dict) -> None:
+    semantic_text = " ".join(
+        [
+            mode["trigger"],
+            mode["readiness_posture"],
+            mode["reason"],
+            mode["operator_state"],
+            mode["explanation"],
+        ]
+    ).casefold()
+    if mode_name == "disabled":
+        for field in ("trigger", "reason", "operator_state", "explanation"):
+            if "disabled" not in mode[field].casefold():
+                raise SystemExit(
+                    f"Phase 59.4 AI mode disabled {field} must state disabled semantics."
+                )
+        if mode["readiness_posture"] not in {"not_applicable", "disabled"}:
+            raise SystemExit(
+                "Phase 59.4 AI mode disabled readiness_posture must not claim healthy or available posture."
+            )
+    elif mode_name == "degraded":
+        for field in ("trigger", "readiness_posture", "reason", "operator_state", "explanation"):
+            if "degraded" not in mode[field].casefold():
+                raise SystemExit(
+                    f"Phase 59.4 AI mode degraded {field} must state degraded semantics."
+                )
+    else:
+        return
+    for forbidden in ("healthy", "available"):
+        if forbidden in semantic_text and "unavailable" not in semantic_text:
+            raise SystemExit(
+                f"Phase 59.4 AI mode {mode_name} must not claim healthy or available AI posture."
+            )
+
+copy_rules = contract["operator_copy_rules"]
+if not isinstance(copy_rules, dict):
+    raise SystemExit("Phase 59.4 operator_copy_rules must be an object.")
+required_terms = require_non_empty_string_list(
+    copy_rules.get("required_terms"),
+    "Phase 59.4 operator_copy_rules required_terms",
+)
+for term in ("AI advisory unavailable or degraded", "authoritative AegisOps records"):
+    if term not in required_terms:
+        raise SystemExit(
+            f"Phase 59.4 operator_copy_rules must require copy term: {term}"
+        )
+forbidden_fragments = require_non_empty_string_list(
+    copy_rules.get("forbidden_fragments"),
+    "Phase 59.4 operator_copy_rules forbidden_fragments",
+)
+for fragment in sorted(required_forbidden_fragments):
+    if fragment not in forbidden_fragments:
+        raise SystemExit(
+            f"Phase 59.4 operator_copy_rules must forbid copy fragment: {fragment}"
+        )
+require_no_forbidden_fragments(
+    boundary,
+    "Phase 59.4 AI disabled/degraded mode authority_boundary",
+    sorted(contradictory_authority_claims | {fragment.casefold() for fragment in forbidden_fragments}),
+)
 
 modes = contract["modes"]
 if not isinstance(modes, list):
@@ -161,6 +280,7 @@ for index, mode in enumerate(modes, start=1):
     for field in ("trigger", "operator_state", "readiness_posture", "reason", "explanation", "authority_effect"):
         require_non_empty_string(mode[field], f"Phase 59.4 AI mode {mode_name} {field}")
     require_non_empty_string_list(mode["safe_next_steps"], f"Phase 59.4 AI mode {mode_name} safe_next_steps")
+    require_mode_specific_semantics(mode_name, mode)
     for field in (
         "ai_generation_allowed",
         "trace_creation_allowed",
@@ -191,11 +311,20 @@ for index, mode in enumerate(modes, start=1):
             mode["explanation"],
             " ".join(mode["safe_next_steps"]),
         ]
-    ).casefold()
-    if "authoritative aegisops records" not in text and "aegisops records" not in text:
-        raise SystemExit(
-            f"Phase 59.4 AI mode {mode_name} must tell operators to use AegisOps records."
-        )
+    )
+    require_ai_advisory_posture(
+        text,
+        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
+    )
+    require_authoritative_records(
+        text,
+        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
+    )
+    require_no_forbidden_fragments(
+        text,
+        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
+        forbidden_fragments,
+    )
 
 missing_modes = sorted(required_modes - seen_modes)
 unexpected_modes = sorted(seen_modes - required_modes)
@@ -262,11 +391,26 @@ for index, surface in enumerate(surfaces, start=1):
             surface[field],
             f"Phase 59.4 non-AI workflow surface {surface_name} {field}",
         )
-    explanation = surface["required_operator_explanation"].casefold()
-    if "ai advisory unavailable" not in explanation:
-        raise SystemExit(
-            f"Phase 59.4 non-AI workflow surface {surface_name} must explain AI advisory unavailability."
-        )
+    operator_text = " ".join(
+        [
+            surface["disabled_mode_behavior"],
+            surface["degraded_mode_behavior"],
+            surface["required_operator_explanation"],
+        ]
+    )
+    require_ai_advisory_posture(
+        surface["required_operator_explanation"],
+        f"Phase 59.4 non-AI workflow surface {surface_name} operator explanation",
+    )
+    require_authoritative_records(
+        surface["required_operator_explanation"],
+        f"Phase 59.4 non-AI workflow surface {surface_name} operator explanation",
+    )
+    require_no_forbidden_fragments(
+        operator_text,
+        f"Phase 59.4 non-AI workflow surface {surface_name} operator-facing copy",
+        forbidden_fragments,
+    )
 
 missing_surfaces = sorted(required_surfaces - seen_surfaces)
 unexpected_surfaces = sorted(seen_surfaces - required_surfaces)
@@ -301,27 +445,6 @@ for required_block in (
             f"Phase 59.4 blocked_ai_outputs must include {required_block}."
         )
 
-copy_rules = contract["operator_copy_rules"]
-if not isinstance(copy_rules, dict):
-    raise SystemExit("Phase 59.4 operator_copy_rules must be an object.")
-required_terms = require_non_empty_string_list(
-    copy_rules.get("required_terms"),
-    "Phase 59.4 operator_copy_rules required_terms",
-)
-for term in ("AI advisory unavailable", "authoritative AegisOps records"):
-    if term not in required_terms:
-        raise SystemExit(
-            f"Phase 59.4 operator_copy_rules must require copy term: {term}"
-        )
-forbidden_fragments = require_non_empty_string_list(
-    copy_rules.get("forbidden_fragments"),
-    "Phase 59.4 operator_copy_rules forbidden_fragments",
-)
-for fragment in ("AI approved", "AI executed", "AI reconciled", "AI is workflow truth"):
-    if fragment not in forbidden_fragments:
-        raise SystemExit(
-            f"Phase 59.4 operator_copy_rules must forbid copy fragment: {fragment}"
-        )
 PY
 
 path_hygiene_stderr="$(mktemp)"

--- a/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -332,13 +332,14 @@ def require_mode_specific_semantics(mode_name: str, mode: dict) -> None:
 def require_mode_operator_copy_contract(
     mode_name: str,
     mode: dict,
+    safe_next_steps: list[str],
     forbidden_fragments: list[str],
 ) -> None:
     text = " ".join(
         [
             mode["operator_state"],
             mode["explanation"],
-            " ".join(mode["safe_next_steps"]),
+            " ".join(safe_next_steps),
         ]
     )
     for field in ("operator_state", "explanation"):
@@ -417,8 +418,17 @@ for index, mode in enumerate(modes, start=1):
     seen_modes.add(mode_name)
     for field in ("trigger", "operator_state", "readiness_posture", "reason", "explanation", "authority_effect"):
         require_non_empty_string(mode[field], f"Phase 59.4 AI mode {mode_name} {field}")
-    require_non_empty_string_list(mode["safe_next_steps"], f"Phase 59.4 AI mode {mode_name} safe_next_steps")
+    safe_next_steps = require_non_empty_string_list(
+        mode["safe_next_steps"],
+        f"Phase 59.4 AI mode {mode_name} safe_next_steps",
+    )
     require_mode_specific_semantics(mode_name, mode)
+    require_mode_operator_copy_contract(
+        mode_name,
+        mode,
+        safe_next_steps,
+        forbidden_fragments,
+    )
     for field in (
         "ai_generation_allowed",
         "trace_creation_allowed",
@@ -443,7 +453,6 @@ for index, mode in enumerate(modes, start=1):
             f"Phase 59.4 AI mode {mode_name} is missing disallowed authority: "
             + ", ".join(missing_disallowed)
         )
-    require_mode_operator_copy_contract(mode_name, mode, forbidden_fragments)
 
 missing_modes = sorted(required_modes - seen_modes)
 unexpected_modes = sorted(seen_modes - required_modes)

--- a/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tool_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${tool_root}}"
+doc_path="${repo_root}/docs/phase-59-4-ai-disabled-degraded-mode-contract.md"
+contract_path="${repo_root}/docs/automation/ai-disabled-degraded-mode-contract.json"
+readme_path="${repo_root}/README.md"
+
+required_doc_phrases=(
+  "# Phase 59.4 AI Disabled And Degraded Mode Contract"
+  "- **Status**: Accepted disabled and degraded mode contract slice"
+  "- **Related Issues**: #1252, #1256"
+  "This contract defines the AI disabled and degraded mode behavior before Phase 59 expands prompt fixtures, stale or conflicting evidence fixtures, trace queue UI/API implementation, closeout work, or Phase 60 daily AI operations."
+  "Every disabled or degraded mode row must include mode, trigger, operator state, readiness posture, blocked AI generation flags, reason, explanation, safe next steps, authority effect, and disallowed authority."
+  'The executable mode artifact lives in `docs/automation/ai-disabled-degraded-mode-contract.json`.'
+  "AI remains advisory, registered, audited, cited, and subordinate to reviewed AegisOps records when available, and it produces no recommendations, action drafts, or trace state when disabled or degraded."
+  "Disabled and degraded AI posture must not block queue, case, evidence review, action review, reconciliation, doctor/supportability explanation fallback, or admin enablement posture surfaces that use authoritative AegisOps records."
+  'This slice cites the Phase 51.6 authority-boundary negative-test policy in `docs/phase-51-6-authority-boundary-negative-test-policy.md` for AI approval, execution, reconciliation, case closure, detector activation, and source-truth refusal.'
+  'Run `bash scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`.'
+  'Run `bash scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`.'
+  'Run `python3 -m unittest control-plane.tests.test_phase57_7_ai_enablement_admin_toggle`.'
+  'Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.'
+  'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1256 --config <supervisor-config-path>`.'
+)
+
+if [[ ! -f "${doc_path}" ]]; then
+  echo "Missing Phase 59.4 AI disabled/degraded mode contract doc: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${contract_path}" ]]; then
+  echo "Missing Phase 59.4 AI disabled/degraded mode artifact: ${contract_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${readme_path}" ]]; then
+  echo "Missing README for Phase 59.4 AI disabled/degraded mode link check: ${readme_path}" >&2
+  exit 1
+fi
+
+for phrase in "${required_doc_phrases[@]}"; do
+  if ! grep -Fq -- "${phrase}" "${doc_path}"; then
+    echo "Missing Phase 59.4 AI disabled/degraded mode contract statement: ${phrase}" >&2
+    exit 1
+  fi
+done
+
+python3 - "${contract_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+contract_path = Path(sys.argv[1])
+try:
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"Invalid Phase 59.4 AI disabled/degraded mode JSON: {exc}") from exc
+
+if not isinstance(contract, dict):
+    raise SystemExit("Phase 59.4 AI disabled/degraded mode artifact must be a JSON object.")
+
+required_root = {
+    "schema_version",
+    "phase",
+    "contract_status",
+    "authority_boundary",
+    "modes",
+    "non_ai_workflow_surfaces",
+    "blocked_ai_outputs",
+    "operator_copy_rules",
+}
+missing_root = sorted(required_root - contract.keys())
+if missing_root:
+    raise SystemExit(
+        "Phase 59.4 AI disabled/degraded mode artifact is missing root field(s): "
+        + ", ".join(missing_root)
+    )
+
+if contract["schema_version"] != "2026-05-11.phase-59.4":
+    raise SystemExit("Phase 59.4 AI disabled/degraded mode schema_version is incorrect.")
+if contract["phase"] != "59.4":
+    raise SystemExit("Phase 59.4 AI disabled/degraded mode phase must be 59.4.")
+if contract["contract_status"] != "accepted_contract_slice":
+    raise SystemExit(
+        "Phase 59.4 AI disabled/degraded mode status must be accepted_contract_slice."
+    )
+
+boundary = contract["authority_boundary"]
+if not isinstance(boundary, str) or not boundary.strip():
+    raise SystemExit("Phase 59.4 AI disabled/degraded mode authority_boundary is invalid.")
+boundary_lower = boundary.casefold()
+if "subordinate" not in boundary_lower or "aegisops records remain authoritative" not in boundary_lower:
+    raise SystemExit(
+        "Phase 59.4 AI disabled/degraded mode authority boundary must preserve subordinate AegisOps authority semantics."
+    )
+
+required_modes = {"disabled", "degraded"}
+required_mode_fields = {
+    "mode",
+    "trigger",
+    "operator_state",
+    "readiness_posture",
+    "reason",
+    "explanation",
+    "safe_next_steps",
+    "ai_generation_allowed",
+    "trace_creation_allowed",
+    "recommendation_generation_allowed",
+    "action_draft_generation_allowed",
+    "authority_effect",
+    "disallowed_authority",
+}
+required_disallowed = {
+    "approval",
+    "execution",
+    "reconciliation",
+    "case_closure",
+    "detector_activation",
+    "source_truth_creation",
+    "automatic_repair",
+    "production_write",
+    "policy_bypass",
+    "workflow_truth",
+}
+
+def require_non_empty_string(value, description: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f"{description} must be a non-empty string.")
+    return value
+
+def require_non_empty_string_list(value, description: str) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or not item.strip() for item in value)
+    ):
+        raise SystemExit(f"{description} must be a non-empty string list.")
+    return value
+
+modes = contract["modes"]
+if not isinstance(modes, list):
+    raise SystemExit("Phase 59.4 AI disabled/degraded mode modes field must be a list.")
+
+seen_modes: set[str] = set()
+for index, mode in enumerate(modes, start=1):
+    if not isinstance(mode, dict):
+        raise SystemExit(f"Phase 59.4 AI mode row {index} must be an object.")
+    missing = sorted(required_mode_fields - mode.keys())
+    if missing:
+        raise SystemExit(
+            f"Phase 59.4 AI mode row {index} is missing field(s): "
+            + ", ".join(missing)
+        )
+    mode_name = require_non_empty_string(mode["mode"], f"Phase 59.4 AI mode row {index} mode")
+    if mode_name in seen_modes:
+        raise SystemExit(f"Duplicate Phase 59.4 AI mode: {mode_name}")
+    seen_modes.add(mode_name)
+    for field in ("trigger", "operator_state", "readiness_posture", "reason", "explanation", "authority_effect"):
+        require_non_empty_string(mode[field], f"Phase 59.4 AI mode {mode_name} {field}")
+    require_non_empty_string_list(mode["safe_next_steps"], f"Phase 59.4 AI mode {mode_name} safe_next_steps")
+    for field in (
+        "ai_generation_allowed",
+        "trace_creation_allowed",
+        "recommendation_generation_allowed",
+        "action_draft_generation_allowed",
+    ):
+        if mode[field] is not False:
+            raise SystemExit(
+                f"Phase 59.4 AI mode {mode_name} must keep {field} false."
+            )
+    if mode["authority_effect"] != "advisory_unavailable_no_workflow_mutation":
+        raise SystemExit(
+            f"Phase 59.4 AI mode {mode_name} must not mutate workflow authority."
+        )
+    disallowed = require_non_empty_string_list(
+        mode["disallowed_authority"],
+        f"Phase 59.4 AI mode {mode_name} disallowed_authority",
+    )
+    missing_disallowed = sorted(required_disallowed - set(disallowed))
+    if missing_disallowed:
+        raise SystemExit(
+            f"Phase 59.4 AI mode {mode_name} is missing disallowed authority: "
+            + ", ".join(missing_disallowed)
+        )
+    text = " ".join(
+        [
+            mode["operator_state"],
+            mode["explanation"],
+            " ".join(mode["safe_next_steps"]),
+        ]
+    ).casefold()
+    if "authoritative aegisops records" not in text and "aegisops records" not in text:
+        raise SystemExit(
+            f"Phase 59.4 AI mode {mode_name} must tell operators to use AegisOps records."
+        )
+
+missing_modes = sorted(required_modes - seen_modes)
+unexpected_modes = sorted(seen_modes - required_modes)
+if missing_modes:
+    raise SystemExit(
+        "Phase 59.4 AI disabled/degraded mode artifact is missing mode(s): "
+        + ", ".join(missing_modes)
+    )
+if unexpected_modes:
+    raise SystemExit(
+        "Phase 59.4 AI disabled/degraded mode artifact contains unexpected mode(s): "
+        + ", ".join(unexpected_modes)
+    )
+
+required_surfaces = {
+    "queue",
+    "case",
+    "evidence_review",
+    "action_review",
+    "reconciliation",
+    "doctor_supportability",
+    "admin_enablement",
+}
+required_surface_fields = {
+    "surface",
+    "authoritative_source",
+    "ai_dependency",
+    "disabled_mode_behavior",
+    "degraded_mode_behavior",
+    "required_operator_explanation",
+}
+surfaces = contract["non_ai_workflow_surfaces"]
+if not isinstance(surfaces, list):
+    raise SystemExit("Phase 59.4 non-AI workflow surfaces field must be a list.")
+
+seen_surfaces: set[str] = set()
+for index, surface in enumerate(surfaces, start=1):
+    if not isinstance(surface, dict):
+        raise SystemExit(f"Phase 59.4 non-AI workflow surface row {index} must be an object.")
+    missing = sorted(required_surface_fields - surface.keys())
+    if missing:
+        raise SystemExit(
+            f"Phase 59.4 non-AI workflow surface row {index} is missing field(s): "
+            + ", ".join(missing)
+        )
+    surface_name = require_non_empty_string(
+        surface["surface"],
+        f"Phase 59.4 non-AI workflow surface row {index} surface",
+    )
+    if surface_name in seen_surfaces:
+        raise SystemExit(f"Duplicate Phase 59.4 non-AI workflow surface: {surface_name}")
+    seen_surfaces.add(surface_name)
+    if surface["ai_dependency"] != "non_blocking":
+        raise SystemExit(
+            f"Phase 59.4 non-AI workflow surface {surface_name} must keep AI non-blocking."
+        )
+    for field in (
+        "authoritative_source",
+        "disabled_mode_behavior",
+        "degraded_mode_behavior",
+        "required_operator_explanation",
+    ):
+        require_non_empty_string(
+            surface[field],
+            f"Phase 59.4 non-AI workflow surface {surface_name} {field}",
+        )
+    explanation = surface["required_operator_explanation"].casefold()
+    if "ai advisory unavailable" not in explanation:
+        raise SystemExit(
+            f"Phase 59.4 non-AI workflow surface {surface_name} must explain AI advisory unavailability."
+        )
+
+missing_surfaces = sorted(required_surfaces - seen_surfaces)
+unexpected_surfaces = sorted(seen_surfaces - required_surfaces)
+if missing_surfaces:
+    raise SystemExit(
+        "Phase 59.4 non-AI workflow coverage is missing surface(s): "
+        + ", ".join(missing_surfaces)
+    )
+if unexpected_surfaces:
+    raise SystemExit(
+        "Phase 59.4 non-AI workflow coverage contains unexpected surface(s): "
+        + ", ".join(unexpected_surfaces)
+    )
+
+blocked_outputs = require_non_empty_string_list(
+    contract["blocked_ai_outputs"],
+    "Phase 59.4 blocked_ai_outputs",
+)
+missing_blocked = sorted(required_disallowed - set(blocked_outputs))
+if missing_blocked:
+    raise SystemExit(
+        "Phase 59.4 blocked_ai_outputs is missing blocked output(s): "
+        + ", ".join(missing_blocked)
+    )
+for required_block in (
+    "recommendation_generation",
+    "action_request_draft_generation",
+    "trace_creation",
+):
+    if required_block not in blocked_outputs:
+        raise SystemExit(
+            f"Phase 59.4 blocked_ai_outputs must include {required_block}."
+        )
+
+copy_rules = contract["operator_copy_rules"]
+if not isinstance(copy_rules, dict):
+    raise SystemExit("Phase 59.4 operator_copy_rules must be an object.")
+required_terms = require_non_empty_string_list(
+    copy_rules.get("required_terms"),
+    "Phase 59.4 operator_copy_rules required_terms",
+)
+for term in ("AI advisory unavailable", "authoritative AegisOps records"):
+    if term not in required_terms:
+        raise SystemExit(
+            f"Phase 59.4 operator_copy_rules must require copy term: {term}"
+        )
+forbidden_fragments = require_non_empty_string_list(
+    copy_rules.get("forbidden_fragments"),
+    "Phase 59.4 operator_copy_rules forbidden_fragments",
+)
+for fragment in ("AI approved", "AI executed", "AI reconciled", "AI is workflow truth"):
+    if fragment not in forbidden_fragments:
+        raise SystemExit(
+            f"Phase 59.4 operator_copy_rules must forbid copy fragment: {fragment}"
+        )
+PY
+
+path_hygiene_stderr="$(mktemp)"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${tool_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" \
+  >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 59.4 AI disabled/degraded mode artifact: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+readme_rendered_markdown="$(
+  awk '
+    /^[[:space:]]*(```|~~~)/ {
+      in_fenced_block = !in_fenced_block
+      next
+    }
+    !in_fenced_block { print }
+  ' "${readme_path}" | perl -pe 's/`[^`]*`//g'
+)"
+
+if ! grep -Eq '\[[^]]+\]\(docs/phase-59-4-ai-disabled-degraded-mode-contract\.md\)' <<<"${readme_rendered_markdown}"; then
+  echo "README must link the Phase 59.4 AI disabled/degraded mode contract." >&2
+  exit 1
+fi
+
+echo "Phase 59.4 AI disabled/degraded mode contract is present with blocked AI generation, non-blocking workflow surfaces, operator explanations, and advisory-only authority."

--- a/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -90,13 +90,6 @@ if contract["contract_status"] != "accepted_contract_slice":
     )
 
 boundary = contract["authority_boundary"]
-if not isinstance(boundary, str) or not boundary.strip():
-    raise SystemExit("Phase 59.4 AI disabled/degraded mode authority_boundary is invalid.")
-boundary_lower = boundary.casefold()
-if "subordinate" not in boundary_lower or "aegisops records remain authoritative" not in boundary_lower:
-    raise SystemExit(
-        "Phase 59.4 AI disabled/degraded mode authority boundary must preserve subordinate AegisOps authority semantics."
-    )
 
 required_modes = {"disabled", "degraded"}
 required_mode_fields = {
@@ -261,6 +254,23 @@ def require_no_forbidden_authority_claim(text: str, description: str) -> None:
     if any(fragment in normalized for fragment in forbidden_authority_fragments):
         raise SystemExit(f"{description} contains forbidden authority claim.")
 
+if not isinstance(boundary, str) or not boundary.strip():
+    raise SystemExit("Phase 59.4 AI disabled/degraded mode authority_boundary is invalid.")
+boundary_lower = boundary.casefold()
+if "subordinate" not in boundary_lower or "aegisops records remain authoritative" not in boundary_lower:
+    raise SystemExit(
+        "Phase 59.4 AI disabled/degraded mode authority boundary must preserve subordinate AegisOps authority semantics."
+    )
+require_no_forbidden_fragments(
+    boundary,
+    "Phase 59.4 AI disabled/degraded mode authority_boundary",
+    sorted(contradictory_authority_claims),
+)
+require_no_forbidden_authority_claim(
+    boundary,
+    "Phase 59.4 AI disabled/degraded mode authority_boundary",
+)
+
 def require_ai_advisory_posture(text: str, description: str) -> None:
     text_lower = text.casefold()
     allowed_posture_terms = (
@@ -318,6 +328,43 @@ def require_mode_specific_semantics(mode_name: str, mode: dict) -> None:
             mode[field],
             f"Phase 59.4 AI mode {mode_name} {field}",
         )
+
+def require_mode_operator_copy_contract(
+    mode_name: str,
+    mode: dict,
+    forbidden_fragments: list[str],
+) -> None:
+    text = " ".join(
+        [
+            mode["operator_state"],
+            mode["explanation"],
+            " ".join(mode["safe_next_steps"]),
+        ]
+    )
+    for field in ("operator_state", "explanation"):
+        require_ai_advisory_posture(
+            mode[field],
+            f"Phase 59.4 AI mode {mode_name} {field}",
+        )
+        if mode_name in expected_mode_values:
+            require_mode_operator_posture(
+                mode_name,
+                mode[field],
+                f"Phase 59.4 AI mode {mode_name} {field}",
+            )
+    require_authoritative_records(
+        text,
+        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
+    )
+    require_no_forbidden_fragments(
+        text,
+        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
+        forbidden_fragments,
+    )
+    require_no_forbidden_authority_claim(
+        text,
+        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
+    )
 
 copy_rules = contract["operator_copy_rules"]
 if not isinstance(copy_rules, dict):
@@ -396,31 +443,7 @@ for index, mode in enumerate(modes, start=1):
             f"Phase 59.4 AI mode {mode_name} is missing disallowed authority: "
             + ", ".join(missing_disallowed)
         )
-    text = " ".join(
-        [
-            mode["operator_state"],
-            mode["explanation"],
-            " ".join(mode["safe_next_steps"]),
-        ]
-    )
-    for field in ("operator_state", "explanation"):
-        require_ai_advisory_posture(
-            mode[field],
-            f"Phase 59.4 AI mode {mode_name} {field}",
-        )
-    require_authoritative_records(
-        text,
-        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
-    )
-    require_no_forbidden_fragments(
-        text,
-        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
-        forbidden_fragments,
-    )
-    require_no_forbidden_authority_claim(
-        text,
-        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
-    )
+    require_mode_operator_copy_contract(mode_name, mode, forbidden_fragments)
 
 missing_modes = sorted(required_modes - seen_modes)
 unexpected_modes = sorted(seen_modes - required_modes)

--- a/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -170,6 +170,69 @@ contradictory_authority_claims = {
     "ai is workflow truth",
     "automatic repair complete",
 }
+forbidden_authority_fragments = {
+    "ai_may_approve",
+    "ai_can_approve",
+    "ai_is_allowed_to_approve",
+    "ai_is_authorized_to_approve",
+    "ai_has_approval_authority",
+    "ai_may_execute",
+    "ai_can_execute",
+    "ai_is_allowed_to_execute",
+    "ai_is_authorized_to_execute",
+    "ai_has_execution_authority",
+    "ai_may_reconcile",
+    "ai_can_reconcile",
+    "ai_is_allowed_to_reconcile",
+    "ai_is_authorized_to_reconcile",
+    "ai_has_reconciliation_authority",
+    "ai_may_close",
+    "ai_can_close",
+    "ai_is_allowed_to_close",
+    "ai_is_authorized_to_close",
+    "ai_has_case_closure_authority",
+    "ai_may_activate",
+    "ai_can_activate",
+    "ai_is_allowed_to_activate",
+    "ai_is_authorized_to_activate",
+    "ai_has_detector_activation_authority",
+    "ai_may_create_source_truth",
+    "ai_can_create_source_truth",
+    "ai_is_allowed_to_create_source_truth",
+    "ai_is_authorized_to_create_source_truth",
+    "ai_may_repair",
+    "ai_can_repair",
+    "ai_is_allowed_to_repair",
+    "ai_is_authorized_to_repair",
+    "ai_may_bypass_policy",
+    "ai_can_bypass_policy",
+    "ai_is_allowed_to_bypass_policy",
+    "ai_is_authorized_to_bypass_policy",
+    "ai_is_workflow_truth",
+    "automatic_repair_complete",
+}
+expected_mode_values = {
+    "disabled": {
+        "trigger": "platform_admin_policy_disabled",
+        "readiness_posture": "not_applicable",
+        "reason": "ai_advisory_disabled_by_admin",
+        "operator_posture_terms": (
+            "ai advisory unavailable",
+            "ai advisory is unavailable",
+            "ai advisory disabled",
+            "ai advisory is disabled",
+        ),
+    },
+    "degraded": {
+        "trigger": "ai_advisory_degraded_by_admin_or_runtime_health",
+        "readiness_posture": "degraded",
+        "reason": "ai_advisory_degraded_by_admin",
+        "operator_posture_terms": (
+            "ai advisory degraded",
+            "ai advisory is degraded",
+        ),
+    },
+}
 
 def require_non_empty_string(value, description: str) -> str:
     if not isinstance(value, str) or not value.strip():
@@ -193,6 +256,11 @@ def require_no_forbidden_fragments(text: str, description: str, fragments: list[
                 f"{description} must not include forbidden authority claim: {fragment}"
             )
 
+def require_no_forbidden_authority_claim(text: str, description: str) -> None:
+    normalized = re.sub(r"[^a-z0-9]+", "_", text.casefold()).strip("_")
+    if any(fragment in normalized for fragment in forbidden_authority_fragments):
+        raise SystemExit(f"{description} contains forbidden authority claim.")
+
 def require_ai_advisory_posture(text: str, description: str) -> None:
     text_lower = text.casefold()
     allowed_posture_terms = (
@@ -208,6 +276,12 @@ def require_ai_advisory_posture(text: str, description: str) -> None:
         raise SystemExit(
             f"{description} must explain AI advisory unavailable or degraded posture."
         )
+
+def require_mode_operator_posture(mode_name: str, text: str, description: str) -> None:
+    text_lower = text.casefold()
+    posture_terms = expected_mode_values[mode_name]["operator_posture_terms"]
+    if not any(term in text_lower for term in posture_terms):
+        raise SystemExit(f"{description} must explain AI advisory {mode_name} posture.")
 
 def require_authoritative_records(text: str, description: str) -> None:
     if "authoritative aegisops records" not in text.casefold():
@@ -225,24 +299,20 @@ def require_no_healthy_or_available_posture(text: str, description: str) -> None
             )
 
 def require_mode_specific_semantics(mode_name: str, mode: dict) -> None:
-    if mode_name == "disabled":
-        for field in ("trigger", "reason", "operator_state", "explanation"):
-            if "disabled" not in mode[field].casefold():
-                raise SystemExit(
-                    f"Phase 59.4 AI mode disabled {field} must state disabled semantics."
-                )
-        if mode["readiness_posture"] not in {"not_applicable", "disabled"}:
-            raise SystemExit(
-                "Phase 59.4 AI mode disabled readiness_posture must not claim healthy or available posture."
-            )
-    elif mode_name == "degraded":
-        for field in ("trigger", "readiness_posture", "reason", "operator_state", "explanation"):
-            if "degraded" not in mode[field].casefold():
-                raise SystemExit(
-                    f"Phase 59.4 AI mode degraded {field} must state degraded semantics."
-                )
-    else:
+    expected = expected_mode_values.get(mode_name)
+    if expected is None:
         return
+    for field in ("trigger", "readiness_posture", "reason"):
+        if mode[field] != expected[field]:
+            raise SystemExit(
+                f"Phase 59.4 AI mode {mode_name} {field} must be {expected[field]}."
+            )
+    for field in ("operator_state", "explanation"):
+        require_mode_operator_posture(
+            mode_name,
+            mode[field],
+            f"Phase 59.4 AI mode {mode_name} {field}",
+        )
     for field in ("trigger", "readiness_posture", "reason", "operator_state", "explanation"):
         require_no_healthy_or_available_posture(
             mode[field],
@@ -274,6 +344,10 @@ require_no_forbidden_fragments(
     boundary,
     "Phase 59.4 AI disabled/degraded mode authority_boundary",
     sorted(contradictory_authority_claims | {fragment.casefold() for fragment in forbidden_fragments}),
+)
+require_no_forbidden_authority_claim(
+    boundary,
+    "Phase 59.4 AI disabled/degraded mode authority_boundary",
 )
 
 modes = contract["modes"]
@@ -342,6 +416,10 @@ for index, mode in enumerate(modes, start=1):
         text,
         f"Phase 59.4 AI mode {mode_name} operator-facing copy",
         forbidden_fragments,
+    )
+    require_no_forbidden_authority_claim(
+        text,
+        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
     )
 
 missing_modes = sorted(required_modes - seen_modes)
@@ -428,6 +506,10 @@ for index, surface in enumerate(surfaces, start=1):
         operator_text,
         f"Phase 59.4 non-AI workflow surface {surface_name} operator-facing copy",
         forbidden_fragments,
+    )
+    require_no_forbidden_authority_claim(
+        operator_text,
+        f"Phase 59.4 non-AI workflow surface {surface_name} operator-facing copy",
     )
 
 missing_surfaces = sorted(required_surfaces - seen_surfaces)

--- a/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -21,6 +21,7 @@ required_doc_phrases=(
   'Run `bash scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`.'
   'Run `bash scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`.'
   'Run `python3 -m unittest control-plane.tests.test_phase57_7_ai_enablement_admin_toggle`.'
+  'Run `python3 -m unittest control-plane.tests.test_phase58_1_doctor_contract.Phase581DoctorContractTests.test_doctor_contract_reports_degraded_source_and_ai_without_authority`.'
   'Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.'
   'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
   'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1256 --config <supervisor-config-path>`.'
@@ -208,7 +209,7 @@ expected_mode_values = {
     "disabled": {
         "trigger": "platform_admin_policy_disabled",
         "readiness_posture": "not_applicable",
-        "reason": "ai_advisory_disabled_by_admin",
+        "reasons": ("ai_advisory_disabled_by_admin",),
         "operator_posture_terms": (
             "ai advisory unavailable",
             "ai advisory is unavailable",
@@ -219,7 +220,10 @@ expected_mode_values = {
     "degraded": {
         "trigger": "ai_advisory_degraded_by_admin_or_runtime_health",
         "readiness_posture": "degraded",
-        "reason": "ai_advisory_degraded_by_admin",
+        "reasons": (
+            "ai_advisory_degraded_by_admin",
+            "ai_advisory_degraded_by_runtime_health",
+        ),
         "operator_posture_terms": (
             "ai advisory degraded",
             "ai advisory is degraded",
@@ -299,6 +303,19 @@ def require_authoritative_records(text: str, description: str) -> None:
             f"{description} must direct operators to authoritative AegisOps records."
         )
 
+def require_operator_required_terms(
+    text: str, description: str, required_terms: list[str]
+) -> None:
+    text_lower = text.casefold()
+    for term in required_terms:
+        term_lower = term.casefold()
+        if term == "AI advisory unavailable or degraded":
+            require_ai_advisory_posture(text, description)
+        elif term == "authoritative AegisOps records":
+            require_authoritative_records(text, description)
+        elif term_lower not in text_lower:
+            raise SystemExit(f"{description} must include required copy term: {term}")
+
 def require_no_healthy_or_available_posture(text: str, description: str) -> None:
     normalized = re.sub(r"[^a-z0-9]+", " ", text.casefold())
     terms = set(normalized.split())
@@ -308,25 +325,52 @@ def require_no_healthy_or_available_posture(text: str, description: str) -> None
                 f"{description} must not claim healthy or available AI posture."
             )
 
+def require_mode_reason_semantics(mode_name: str, value: object) -> list[str]:
+    expected = expected_mode_values.get(mode_name)
+    description = f"Phase 59.4 AI mode {mode_name} reason"
+    if expected is None:
+        return [require_non_empty_string(value, description)]
+    if isinstance(value, str):
+        reasons = [require_non_empty_string(value, description)]
+    elif isinstance(value, list):
+        reasons = require_non_empty_string_list(value, description)
+    else:
+        raise SystemExit(f"{description} must be a non-empty string or string list.")
+    allowed_reasons = set(expected["reasons"])
+    unexpected_reasons = sorted(set(reasons) - allowed_reasons)
+    if unexpected_reasons:
+        raise SystemExit(
+            f"{description} must be one of: {', '.join(expected['reasons'])}."
+        )
+    return reasons
+
 def require_mode_specific_semantics(mode_name: str, mode: dict) -> None:
     expected = expected_mode_values.get(mode_name)
     if expected is None:
         return
-    for field in ("trigger", "readiness_posture", "reason"):
+    for field in ("trigger", "readiness_posture"):
         if mode[field] != expected[field]:
             raise SystemExit(
                 f"Phase 59.4 AI mode {mode_name} {field} must be {expected[field]}."
             )
+    reasons = require_mode_reason_semantics(mode_name, mode["reason"])
     for field in ("operator_state", "explanation"):
         require_mode_operator_posture(
             mode_name,
             mode[field],
             f"Phase 59.4 AI mode {mode_name} {field}",
         )
-    for field in ("trigger", "readiness_posture", "reason", "operator_state", "explanation"):
+    posture_values = [
+        mode["trigger"],
+        mode["readiness_posture"],
+        *reasons,
+        mode["operator_state"],
+        mode["explanation"],
+    ]
+    for value in posture_values:
         require_no_healthy_or_available_posture(
-            mode[field],
-            f"Phase 59.4 AI mode {mode_name} {field}",
+            value,
+            f"Phase 59.4 AI mode {mode_name} posture field",
         )
 
 def require_mode_operator_copy_contract(
@@ -356,6 +400,11 @@ def require_mode_operator_copy_contract(
     require_authoritative_records(
         text,
         f"Phase 59.4 AI mode {mode_name} operator-facing copy",
+    )
+    require_operator_required_terms(
+        text,
+        f"Phase 59.4 AI mode {mode_name} operator-facing copy",
+        required_terms,
     )
     require_no_forbidden_fragments(
         text,
@@ -416,7 +465,7 @@ for index, mode in enumerate(modes, start=1):
     if mode_name in seen_modes:
         raise SystemExit(f"Duplicate Phase 59.4 AI mode: {mode_name}")
     seen_modes.add(mode_name)
-    for field in ("trigger", "operator_state", "readiness_posture", "reason", "explanation", "authority_effect"):
+    for field in ("trigger", "operator_state", "readiness_posture", "explanation", "authority_effect"):
         require_non_empty_string(mode[field], f"Phase 59.4 AI mode {mode_name} {field}")
     safe_next_steps = require_non_empty_string_list(
         mode["safe_next_steps"],
@@ -533,6 +582,11 @@ for index, surface in enumerate(surfaces, start=1):
     require_authoritative_records(
         surface["required_operator_explanation"],
         f"Phase 59.4 non-AI workflow surface {surface_name} operator explanation",
+    )
+    require_operator_required_terms(
+        surface["required_operator_explanation"],
+        f"Phase 59.4 non-AI workflow surface {surface_name} operator explanation",
+        required_terms,
     )
     require_no_forbidden_fragments(
         operator_text,

--- a/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
+++ b/scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh
@@ -25,6 +25,7 @@ required_doc_phrases=(
   'Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.'
   'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
   'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1256 --config <supervisor-config-path>`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1252 --config <supervisor-config-path>`.'
 )
 
 if [[ ! -f "${doc_path}" ]]; then
@@ -584,8 +585,8 @@ for index, surface in enumerate(surfaces, start=1):
         f"Phase 59.4 non-AI workflow surface {surface_name} operator explanation",
     )
     require_operator_required_terms(
-        surface["required_operator_explanation"],
-        f"Phase 59.4 non-AI workflow surface {surface_name} operator explanation",
+        operator_text,
+        f"Phase 59.4 non-AI workflow surface {surface_name} operator-facing copy",
         required_terms,
     )
     require_no_forbidden_fragments(


### PR DESCRIPTION
## Summary
- Adds the Phase 59.4 AI disabled/degraded mode contract doc and executable JSON artifact.
- Adds a verifier and verifier self-test for blocked AI generation, non-blocking workflow surfaces, operator explanations, authority refusals, and path hygiene.
- Links the contract from README.

## Verification
- `bash scripts/verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`
- `bash scripts/test-verify-phase-59-4-ai-disabled-degraded-mode-contract.sh`
- `python3 -m unittest control-plane.tests.test_phase57_7_ai_enablement_admin_toggle`
- `python3 -m unittest control-plane.tests.test_phase58_1_doctor_contract.Phase581DoctorContractTests.test_doctor_contract_reports_degraded_source_and_ai_without_authority`
- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `git diff --check`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1256 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.aegisops.json`

Closes #1256