### PR TITLE
Add AI trace review queue skeleton

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.assistant.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.assistant.testSuite.tsx
@@ -329,61 +329,62 @@ export function registerOperatorRoutesAssistantTests() {
     });
 
     it("renders the AI trace review queue skeleton with accepted rejected and corrected states", async () => {
-      const dependencies = createDefaultDependencies({
-        fetchFn: createAuthorizedFetch({
-          "/inspect-ai-trace-review-queue": {
-            read_only: true,
-            queue_name: "ai_trace_review",
-            total_records: 3,
-            state_counts: {
-              accepted: 1,
-              corrected: 1,
-              rejected: 1,
-            },
-            records: [
-              {
-                ai_trace_id: "ai-trace-review-accepted-001",
-                review_state: "accepted",
-                registered_agent_id: "agent-governed-summary-001",
-                registered_tool_id: "tool-case-summary-001",
-                reviewed_record_family: "case",
-                reviewed_record_id: "case-trace-review-001",
-                citations: ["case-trace-review-001", "evidence-trace-review-001"],
-                reviewer_note: "Accepted as cited context only; case truth stays authoritative.",
-                expiration_posture: "expires_with_reviewed_case",
-                authority_mode: "advisory_only",
-                authoritative_workflow_truth: false,
-                trace_link: "/operator/assistant/ai_trace/ai-trace-review-accepted-001",
-              },
-              {
-                ai_trace_id: "ai-trace-review-rejected-001",
-                review_state: "rejected",
-                registered_agent_id: "agent-governed-summary-001",
-                registered_tool_id: "tool-case-summary-001",
-                reviewed_record_family: "case",
-                reviewed_record_id: "case-trace-review-001",
-                citations: ["case-trace-review-001"],
-                reviewer_note: "Rejected because supporting citations were incomplete.",
-                expiration_posture: "expires_with_reviewed_case",
-                authority_mode: "advisory_only",
-                authoritative_workflow_truth: false,
-              },
-              {
-                ai_trace_id: "ai-trace-review-corrected-001",
-                review_state: "corrected",
-                registered_agent_id: "agent-governed-summary-001",
-                registered_tool_id: "tool-case-summary-001",
-                reviewed_record_family: "case",
-                reviewed_record_id: "case-trace-review-001",
-                citations: ["case-trace-review-001", "evidence-trace-review-001"],
-                reviewer_note: "Corrected by reviewer note before any downstream use.",
-                expiration_posture: "expires_with_reviewed_case",
-                authority_mode: "advisory_only",
-                authoritative_workflow_truth: false,
-              },
-            ],
+      const fetchFn = createAuthorizedFetch({
+        "/inspect-ai-trace-review-queue": {
+          read_only: true,
+          queue_name: "ai_trace_review",
+          total_records: 3,
+          state_counts: {
+            accepted: 1,
+            corrected: 1,
+            rejected: 1,
           },
-        }),
+          records: [
+            {
+              ai_trace_id: "ai-trace-review-accepted-001",
+              review_state: "accepted",
+              registered_agent_id: "agent-governed-summary-001",
+              registered_tool_id: "tool-case-summary-001",
+              reviewed_record_family: "case",
+              reviewed_record_id: "case-trace-review-001",
+              citations: ["case-trace-review-001", "evidence-trace-review-001"],
+              reviewer_note: "Accepted as cited context only; case truth stays authoritative.",
+              expiration_posture: "expires_with_reviewed_case",
+              authority_mode: "advisory_only",
+              authoritative_workflow_truth: false,
+              trace_link: "/operator/assistant/ai_trace/ai-trace-review-accepted-001",
+            },
+            {
+              ai_trace_id: "ai-trace-review-rejected-001",
+              review_state: "rejected",
+              registered_agent_id: "agent-governed-summary-001",
+              registered_tool_id: "tool-case-summary-001",
+              reviewed_record_family: "case",
+              reviewed_record_id: "case-trace-review-001",
+              citations: ["case-trace-review-001"],
+              reviewer_note: "Rejected because supporting citations were incomplete.",
+              expiration_posture: "expires_with_reviewed_case",
+              authority_mode: "advisory_only",
+              authoritative_workflow_truth: false,
+            },
+            {
+              ai_trace_id: "ai-trace-review-corrected-001",
+              review_state: "corrected",
+              registered_agent_id: "agent-governed-summary-001",
+              registered_tool_id: "tool-case-summary-001",
+              reviewed_record_family: "case",
+              reviewed_record_id: "case-trace-review-001",
+              citations: ["case-trace-review-001", "evidence-trace-review-001"],
+              reviewer_note: "Corrected by reviewer note before any downstream use.",
+              expiration_posture: "expires_with_reviewed_case",
+              authority_mode: "advisory_only",
+              authoritative_workflow_truth: false,
+            },
+          ],
+        },
+      });
+      const dependencies = createDefaultDependencies({
+        fetchFn,
       });
 
       render(
@@ -399,6 +400,9 @@ export function registerOperatorRoutesAssistantTests() {
       expect(screen.getAllByText("agent-governed-summary-001").length).toBeGreaterThan(0);
       expect(screen.getAllByText("tool-case-summary-001").length).toBeGreaterThan(0);
       expect(screen.getAllByText("case-trace-review-001").length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByRole("link", { name: "case-trace-review-001" })[0],
+      ).toHaveAttribute("href", "/operator/cases/case-trace-review-001");
       expect(screen.getAllByText("evidence-trace-review-001").length).toBeGreaterThan(0);
       expect(
         screen.getByText("Corrected by reviewer note before any downstream use."),
@@ -409,6 +413,15 @@ export function registerOperatorRoutesAssistantTests() {
       ).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
       expect(screen.queryByRole("button", { name: /execute/i })).not.toBeInTheDocument();
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/inspect-ai-trace-review-queue?order=ASC&page=1&per_page=500&sort=review_state",
+        {
+          credentials: "include",
+          headers: {
+            Accept: "application/json",
+          },
+        },
+      );
     });
 
     it("fails closed on unsupported assistant advisory route families", async () => {

--- a/apps/operator-ui/src/app/OperatorRoutes.assistant.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.assistant.testSuite.tsx
@@ -328,6 +328,89 @@ export function registerOperatorRoutesAssistantTests() {
       expect(screen.queryByRole("button", { name: /execute/i })).not.toBeInTheDocument();
     });
 
+    it("renders the AI trace review queue skeleton with accepted rejected and corrected states", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-ai-trace-review-queue": {
+            read_only: true,
+            queue_name: "ai_trace_review",
+            total_records: 3,
+            state_counts: {
+              accepted: 1,
+              corrected: 1,
+              rejected: 1,
+            },
+            records: [
+              {
+                ai_trace_id: "ai-trace-review-accepted-001",
+                review_state: "accepted",
+                registered_agent_id: "agent-governed-summary-001",
+                registered_tool_id: "tool-case-summary-001",
+                reviewed_record_family: "case",
+                reviewed_record_id: "case-trace-review-001",
+                citations: ["case-trace-review-001", "evidence-trace-review-001"],
+                reviewer_note: "Accepted as cited context only; case truth stays authoritative.",
+                expiration_posture: "expires_with_reviewed_case",
+                authority_mode: "advisory_only",
+                authoritative_workflow_truth: false,
+                trace_link: "/operator/assistant/ai_trace/ai-trace-review-accepted-001",
+              },
+              {
+                ai_trace_id: "ai-trace-review-rejected-001",
+                review_state: "rejected",
+                registered_agent_id: "agent-governed-summary-001",
+                registered_tool_id: "tool-case-summary-001",
+                reviewed_record_family: "case",
+                reviewed_record_id: "case-trace-review-001",
+                citations: ["case-trace-review-001"],
+                reviewer_note: "Rejected because supporting citations were incomplete.",
+                expiration_posture: "expires_with_reviewed_case",
+                authority_mode: "advisory_only",
+                authoritative_workflow_truth: false,
+              },
+              {
+                ai_trace_id: "ai-trace-review-corrected-001",
+                review_state: "corrected",
+                registered_agent_id: "agent-governed-summary-001",
+                registered_tool_id: "tool-case-summary-001",
+                reviewed_record_family: "case",
+                reviewed_record_id: "case-trace-review-001",
+                citations: ["case-trace-review-001", "evidence-trace-review-001"],
+                reviewer_note: "Corrected by reviewer note before any downstream use.",
+                expiration_posture: "expires_with_reviewed_case",
+                authority_mode: "advisory_only",
+                authoritative_workflow_truth: false,
+              },
+            ],
+          },
+        }),
+      });
+
+      render(
+        <MemoryRouter initialEntries={["/operator/assistant/trace-review"]}>
+          <OperatorRoutes dependencies={dependencies} />
+        </MemoryRouter>,
+      );
+
+      expect(await screen.findByRole("heading", { name: "AI Trace Review Queue" })).toBeInTheDocument();
+      expect(screen.getByText("Accepted")).toBeInTheDocument();
+      expect(screen.getByText("Rejected")).toBeInTheDocument();
+      expect(screen.getByText("Corrected")).toBeInTheDocument();
+      expect(screen.getAllByText("agent-governed-summary-001").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("tool-case-summary-001").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("case-trace-review-001").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("evidence-trace-review-001").length).toBeGreaterThan(0);
+      expect(
+        screen.getByText("Corrected by reviewer note before any downstream use."),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText("expires_with_reviewed_case").length).toBeGreaterThan(0);
+      expect(
+        screen.getByText(/Trace review state cannot approve actions/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /approve/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /execute/i })).not.toBeInTheDocument();
+    });
+
     it("fails closed on unsupported assistant advisory route families", async () => {
       const fetchFn = createAuthorizedFetch({});
       const dependencies = createDefaultDependencies({

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -74,6 +74,8 @@ function lazyOperatorConsolePage<T extends keyof Awaited<ReturnType<typeof loadO
 
 const ActionReviewPage =
   lazyOperatorConsolePage("ActionReviewPage") as unknown as typeof import("./operatorConsolePages").ActionReviewPage;
+const AITraceReviewQueuePage =
+  lazyOperatorConsolePage("AITraceReviewQueuePage") as unknown as typeof import("./operatorConsolePages").AITraceReviewQueuePage;
 const AssistantAdvisoryPage =
   lazyOperatorConsolePage("AssistantAdvisoryPage") as unknown as typeof import("./operatorConsolePages").AssistantAdvisoryPage;
 const AlertDetailPage =
@@ -261,6 +263,11 @@ function OperatorMenu({
         leftIcon={<AutoAwesomeOutlinedIcon />}
         primaryText="Assistant"
         to={buildOperatorShellPath(basePath, "assistant")}
+      />
+      <Menu.Item
+        leftIcon={<AutoAwesomeOutlinedIcon />}
+        primaryText="AI Trace Review"
+        to={buildOperatorShellPath(basePath, "assistant/trace-review")}
       />
       {showActionReview ? (
         <Menu.Item
@@ -576,6 +583,7 @@ function OperatorShellContent({
             path="admin"
           />
           <Route element={<AssistantAdvisoryPage />} path="assistant" />
+          <Route element={<AITraceReviewQueuePage />} path="assistant/trace-review" />
           <Route
             element={<AssistantAdvisoryPage />}
             path="assistant/:recordFamily/:recordId"

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -11,7 +11,10 @@ export {
   ProvenanceIndexPage,
 } from "./operatorConsolePages/drilldownIndexPages";
 export { ActionReviewPage } from "./operatorConsolePages/actionReviewPages";
-export { AssistantAdvisoryPage } from "./operatorConsolePages/assistantPages";
+export {
+  AITraceReviewQueuePage,
+  AssistantAdvisoryPage,
+} from "./operatorConsolePages/assistantPages";
 export { FirstLoginChecklistPage } from "./operatorConsolePages/firstLoginChecklistPages";
 export { UserRoleAdminPage } from "./operatorConsolePages/adminPages";
 export {

--- a/apps/operator-ui/src/app/operatorConsolePages/assistantPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/assistantPages.tsx
@@ -36,6 +36,7 @@ import {
   supportedAnchorRoute,
   SUPPORTED_ADVISORY_RECORD_FAMILIES,
   type UnknownRecord,
+  useOperatorList,
   useOperatorRecord,
   ValueList,
 } from "./shared";
@@ -366,6 +367,144 @@ export function AssistantAdvisoryPage() {
           )}
         </>
       )}
+    </PageFrame>
+  );
+}
+
+function reviewStateTone(state: string | null): "success" | "error" | "warning" | "default" {
+  if (state === "accepted") {
+    return "success";
+  }
+  if (state === "rejected") {
+    return "error";
+  }
+  if (state === "corrected") {
+    return "warning";
+  }
+  return "default";
+}
+
+export function AITraceReviewQueuePage() {
+  const filter = useMemo(() => ({}), []);
+  const sort = useMemo(
+    () => ({
+      field: "review_state",
+      order: "ASC" as const,
+    }),
+    [],
+  );
+  const { data, error, loading, refreshing } = useOperatorList(
+    "aiTraceReviewQueue",
+    filter,
+    sort,
+  );
+
+  return (
+    <PageFrame
+      subtitle="AI trace review remains cited, registered, and subordinate to reviewed AegisOps records."
+      title="AI Trace Review Queue"
+    >
+      {loading && !data ? <LoadingState label="Loading AI trace review queue" /> : null}
+      {error && !data ? <ErrorState error={error} /> : null}
+      {data ? <QueryStateNotice error={error} refreshing={refreshing} /> : null}
+      {data ? (
+        data.length > 0 ? (
+          <Stack spacing={3}>
+            <SectionCard
+              subtitle="Accepted, rejected, and corrected states are review context only; workflow truth stays on the anchored AegisOps records."
+              title="Trace review records"
+            >
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Trace</TableCell>
+                    <TableCell>State</TableCell>
+                    <TableCell>Registered agent</TableCell>
+                    <TableCell>Registered tool</TableCell>
+                    <TableCell>Reviewed record</TableCell>
+                    <TableCell>Citations</TableCell>
+                    <TableCell>Reviewer note</TableCell>
+                    <TableCell>Expiration</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {data.map((record) => {
+                    const traceId = asString(record.ai_trace_id) ?? "Unknown trace";
+                    const reviewState = asString(record.review_state);
+                    const reviewedFamily = asString(record.reviewed_record_family);
+                    const reviewedId = asString(record.reviewed_record_id);
+                    const traceLink = asString(record.trace_link);
+                    return (
+                      <TableRow hover key={traceId}>
+                        <TableCell>
+                          {traceLink ? (
+                            <AuditedRouteButton label="Open AI trace" to={traceLink}>
+                              {traceId}
+                            </AuditedRouteButton>
+                          ) : (
+                            traceId
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            color={reviewStateTone(reviewState)}
+                            label={formatLabel(reviewState ?? "pending_review")}
+                            size="small"
+                            variant={reviewState === "accepted" ? "filled" : "outlined"}
+                          />
+                        </TableCell>
+                        <TableCell>{asString(record.registered_agent_id) ?? "Missing"}</TableCell>
+                        <TableCell>{asString(record.registered_tool_id) ?? "Missing"}</TableCell>
+                        <TableCell>
+                          <Stack spacing={0.5}>
+                            <Typography variant="body2">
+                              {reviewedFamily ?? "Unknown family"}
+                            </Typography>
+                            <Typography color="text.secondary" variant="caption">
+                              {reviewedId ?? "Missing reviewed record id"}
+                            </Typography>
+                          </Stack>
+                        </TableCell>
+                        <TableCell>
+                          <Stack direction="row" flexWrap="wrap" gap={1}>
+                            {asStringArray(record.citations).map((citation) => (
+                              <Chip
+                                key={`${traceId}-${citation}`}
+                                label={citation}
+                                size="small"
+                                variant="outlined"
+                              />
+                            ))}
+                          </Stack>
+                        </TableCell>
+                        <TableCell>{asString(record.reviewer_note) ?? "No reviewer note"}</TableCell>
+                        <TableCell>{formatValue(record.expiration_posture)}</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </SectionCard>
+            <SectionCard
+              subtitle="The browser renders trace review state as subordinate context and exposes no approval, execution, reconciliation, or close-case controls."
+              title="Authority boundary"
+            >
+              <StatusStrip
+                values={[
+                  ["Read only", "true"],
+                  ["Authority mode", "advisory_only"],
+                  ["Workflow truth", "AegisOps authoritative records"],
+                ]}
+              />
+              <Alert severity="warning" variant="outlined">
+                Trace review state cannot approve actions, execute actions, reconcile outcomes, close cases, or create source truth.
+              </Alert>
+            </SectionCard>
+          </Stack>
+        ) : (
+          <EmptyState message="No AI trace review records were returned." />
+        )
+      ) : null}
     </PageFrame>
   );
 }

--- a/apps/operator-ui/src/app/operatorConsolePages/assistantPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/assistantPages.tsx
@@ -24,6 +24,7 @@ import {
   asString,
   asStringArray,
   AuditedRouteButton,
+  AuditedRouteLink,
   EmptyState,
   ErrorState,
   formatLabel,
@@ -40,6 +41,8 @@ import {
   useOperatorRecord,
   ValueList,
 } from "./shared";
+
+const AI_TRACE_REVIEW_QUEUE_PER_PAGE = 500;
 
 function AdvisoryDetailTable({ record }: { record: UnknownRecord }) {
   const rows = advisoryDetailRows(record);
@@ -397,6 +400,7 @@ export function AITraceReviewQueuePage() {
     "aiTraceReviewQueue",
     filter,
     sort,
+    AI_TRACE_REVIEW_QUEUE_PER_PAGE,
   );
 
   return (
@@ -433,6 +437,10 @@ export function AITraceReviewQueuePage() {
                     const reviewState = asString(record.review_state);
                     const reviewedFamily = asString(record.reviewed_record_family);
                     const reviewedId = asString(record.reviewed_record_id);
+                    const reviewedAnchorRoute = supportedAnchorRoute(
+                      reviewedFamily,
+                      reviewedId,
+                    );
                     const traceLink = asString(record.trace_link);
                     return (
                       <TableRow hover key={traceId}>
@@ -461,7 +469,16 @@ export function AITraceReviewQueuePage() {
                               {reviewedFamily ?? "Unknown family"}
                             </Typography>
                             <Typography color="text.secondary" variant="caption">
-                              {reviewedId ?? "Missing reviewed record id"}
+                              {reviewedAnchorRoute ? (
+                                <AuditedRouteLink
+                                  label={reviewedAnchorRoute.label}
+                                  to={reviewedAnchorRoute.to}
+                                >
+                                  {reviewedId ?? "Missing reviewed record id"}
+                                </AuditedRouteLink>
+                              ) : (
+                                (reviewedId ?? "Missing reviewed record id")
+                              )}
                             </Typography>
                           </Stack>
                         </TableCell>

--- a/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
+++ b/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
@@ -16,6 +16,11 @@ export const RESOURCE_BINDINGS: Record<
     listSemantics: "client",
     recordFamily: "alert",
   },
+  aiTraceReviewQueue: {
+    idField: "ai_trace_id",
+    listPath: "/inspect-ai-trace-review-queue",
+    listSemantics: "client",
+  },
   cases: {
     detailPath: "/inspect-case-detail",
     detailQueryKey: "case_id",

--- a/apps/operator-ui/src/operatorDataProvider/types.ts
+++ b/apps/operator-ui/src/operatorDataProvider/types.ts
@@ -2,6 +2,7 @@ import type { GetListParams, RaRecord } from "react-admin";
 
 export type OperatorResourceName =
   | "queue"
+  | "aiTraceReviewQueue"
   | "alerts"
   | "cases"
   | "firstLoginChecklist"

--- a/control-plane/aegisops/control_plane/api/cli.py
+++ b/control-plane/aegisops/control_plane/api/cli.py
@@ -604,9 +604,12 @@ def run_command(
     if command == "inspect-analyst-queue":
         return service.inspect_analyst_queue().to_dict()
     if command == "inspect-ai-trace-review-queue":
-        return (
-            service._operator_inspection_read_surface.inspect_ai_trace_review_queue().to_dict()
-        )
+        try:
+            return (
+                service._operator_inspection_read_surface.inspect_ai_trace_review_queue().to_dict()
+            )
+        except (LookupError, ValueError) as exc:
+            _usage_error(parser, str(exc))
     if command == "inspect-alert-detail":
         alert_id = normalize_alert_id(parsed.alert_id)
         if not alert_id:

--- a/control-plane/aegisops/control_plane/api/cli.py
+++ b/control-plane/aegisops/control_plane/api/cli.py
@@ -126,6 +126,10 @@ def build_parser() -> argparse.ArgumentParser:
         "inspect-analyst-queue",
         help="Render the business-hours analyst review queue view.",
     )
+    subparsers.add_parser(
+        "inspect-ai-trace-review-queue",
+        help="Render the read-only AI trace review queue skeleton.",
+    )
     inspect_alert_detail = subparsers.add_parser(
         "inspect-alert-detail",
         help="Render the reviewed Wazuh-backed alert detail view for one alert.",
@@ -599,6 +603,10 @@ def run_command(
             _usage_error(parser, str(exc))
     if command == "inspect-analyst-queue":
         return service.inspect_analyst_queue().to_dict()
+    if command == "inspect-ai-trace-review-queue":
+        return (
+            service._operator_inspection_read_surface.inspect_ai_trace_review_queue().to_dict()
+        )
     if command == "inspect-alert-detail":
         alert_id = normalize_alert_id(parsed.alert_id)
         if not alert_id:

--- a/control-plane/aegisops/control_plane/api/http_protected_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_protected_surface.py
@@ -20,6 +20,7 @@ PROTECTED_READ_ROLES_BY_PATH: dict[str, tuple[str, ...]] = {
     "/inspect-records": READ_ONLY_PROTECTED_ROLES,
     "/inspect-reconciliation-status": READ_ONLY_PROTECTED_ROLES,
     "/inspect-analyst-queue": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-ai-trace-review-queue": READ_ONLY_PROTECTED_ROLES,
     "/inspect-alert-detail": READ_ONLY_PROTECTED_ROLES,
     "/inspect-case-detail": READ_ONLY_PROTECTED_ROLES,
     "/inspect-action-review": READ_ONLY_PROTECTED_ROLES,

--- a/control-plane/aegisops/control_plane/api/http_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_surface.py
@@ -198,12 +198,17 @@ def _handle_inspect_ai_trace_review_queue(
     context: HttpSurfaceContext,
     principal: object,
 ) -> None:
+    try:
+        payload = (
+            context.service._operator_inspection_read_surface.inspect_ai_trace_review_queue().to_dict()
+        )
+    except (LookupError, ValueError) as exc:
+        _write_lookup_or_bad_request(handler, exc)
+        return
     _write_json(
         handler,
         HTTPStatus.OK,
-        (
-            context.service._operator_inspection_read_surface.inspect_ai_trace_review_queue().to_dict()
-        ),
+        payload,
     )
 
 

--- a/control-plane/aegisops/control_plane/api/http_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_surface.py
@@ -193,6 +193,20 @@ def _handle_inspect_analyst_queue(
     _write_json(handler, HTTPStatus.OK, context.service.inspect_analyst_queue().to_dict())
 
 
+def _handle_inspect_ai_trace_review_queue(
+    handler: BaseHTTPRequestHandler,
+    context: HttpSurfaceContext,
+    principal: object,
+) -> None:
+    _write_json(
+        handler,
+        HTTPStatus.OK,
+        (
+            context.service._operator_inspection_read_surface.inspect_ai_trace_review_queue().to_dict()
+        ),
+    )
+
+
 def _handle_inspect_alert_detail(
     handler: BaseHTTPRequestHandler,
     context: HttpSurfaceContext,
@@ -386,6 +400,7 @@ HTTP_GET_ROUTES: dict[str, GetRouteHandler] = {
     "/inspect-records": _handle_inspect_records,
     "/inspect-reconciliation-status": _handle_inspect_reconciliation_status,
     "/inspect-analyst-queue": _handle_inspect_analyst_queue,
+    "/inspect-ai-trace-review-queue": _handle_inspect_ai_trace_review_queue,
     "/inspect-alert-detail": _handle_inspect_alert_detail,
     "/inspect-case-detail": _handle_inspect_case_detail,
     "/inspect-action-review": _handle_inspect_action_review,

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -229,7 +229,7 @@ class OperatorInspectionReadSurface:
             (
                 *self._string_tuple_from_object(subject_linkage.get("citations")),
                 *self._string_tuple_from_object(advisory_draft.get("citations")),
-                *ai_trace.material_input_refs,
+                *self._string_tuple_from_object(ai_trace.material_input_refs),
             )
         )
         registered_agent_id = self._optional_string_from_mapping(

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Protocol, Type, TypeVar
 
@@ -19,6 +20,7 @@ from .models import (
     RecommendationRecord,
     ReconciliationRecord,
 )
+from .runtime.service_snapshots import AITraceReviewQueueSnapshot
 
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
@@ -184,6 +186,129 @@ class OperatorInspectionReadSurface:
         if alert.lifecycle_state == "investigating":
             return "investigating"
         return "triaged"
+
+    def inspect_ai_trace_review_queue(self) -> object:
+        records = tuple(
+            self._ai_trace_review_queue_record(record)
+            for record in self._service._store.list(AITraceRecord)
+        )
+        records = tuple(
+            sorted(
+                records,
+                key=lambda record: (
+                    str(record["review_state"]),
+                    str(record["ai_trace_id"]),
+                ),
+            )
+        )
+        state_counts = dict(
+            sorted(Counter(str(record["review_state"]) for record in records).items())
+        )
+        return AITraceReviewQueueSnapshot(
+            read_only=True,
+            queue_name="ai_trace_review",
+            total_records=len(records),
+            state_counts=state_counts,
+            records=records,
+        )
+
+    def _ai_trace_review_queue_record(
+        self,
+        ai_trace: AITraceRecord,
+    ) -> dict[str, object]:
+        subject_linkage = ai_trace.subject_linkage
+        advisory_draft = ai_trace.assistant_advisory_draft
+        review_state = self._ai_trace_queue_review_state(
+            lifecycle_state=ai_trace.lifecycle_state,
+            draft_review_state=self._optional_string_from_mapping(
+                advisory_draft,
+                "review_state",
+            ),
+        )
+        citations = self._dedupe_strings(
+            (
+                *self._string_tuple_from_object(subject_linkage.get("citations")),
+                *self._string_tuple_from_object(advisory_draft.get("citations")),
+                *ai_trace.material_input_refs,
+            )
+        )
+        registered_agent_id = self._optional_string_from_mapping(
+            subject_linkage,
+            "registered_agent_id",
+        )
+        registered_tool_id = self._optional_string_from_mapping(
+            subject_linkage,
+            "registered_tool_id",
+        )
+        reviewed_record_family = (
+            self._optional_string_from_mapping(subject_linkage, "reviewed_record_family")
+            or self._optional_string_from_mapping(subject_linkage, "source_record_family")
+        )
+        reviewed_record_id = (
+            self._optional_string_from_mapping(subject_linkage, "reviewed_record_id")
+            or self._optional_string_from_mapping(subject_linkage, "source_record_id")
+            or self._optional_string_from_mapping(subject_linkage, "source_case_id")
+            or self._optional_string_from_mapping(subject_linkage, "source_alert_id")
+        )
+        missing_required_fields = tuple(
+            field_name
+            for field_name, value in (
+                ("registered_agent_id", registered_agent_id),
+                ("registered_tool_id", registered_tool_id),
+                ("reviewed_record_family", reviewed_record_family),
+                ("reviewed_record_id", reviewed_record_id),
+                ("citations", citations),
+            )
+            if not value
+        )
+        if missing_required_fields:
+            raise ValueError(
+                "AI trace review queue requires registered agent, registered tool, "
+                "reviewed record, and citation anchors; missing "
+                + ", ".join(missing_required_fields)
+                + f" for ai_trace_id {ai_trace.ai_trace_id!r}"
+            )
+        return {
+            "read_only": True,
+            "ai_trace_id": ai_trace.ai_trace_id,
+            "review_state": review_state,
+            "lifecycle_state": ai_trace.lifecycle_state,
+            "registered_agent_id": registered_agent_id,
+            "registered_tool_id": registered_tool_id,
+            "model_identity": ai_trace.model_identity,
+            "prompt_version": ai_trace.prompt_version,
+            "generated_at": ai_trace.generated_at,
+            "reviewed_record_family": reviewed_record_family,
+            "reviewed_record_id": reviewed_record_id,
+            "citations": citations,
+            "reviewer_identity": ai_trace.reviewer_identity,
+            "reviewer_note": self._optional_string_from_mapping(
+                advisory_draft,
+                "reviewer_note",
+            ),
+            "expiration_posture": self._optional_string_from_mapping(
+                subject_linkage,
+                "expiration_posture",
+            )
+            or "inherits_reviewed_record_retention",
+            "authority_mode": "advisory_only",
+            "authoritative_workflow_truth": False,
+            "trace_link": f"/operator/assistant/ai_trace/{ai_trace.ai_trace_id}",
+        }
+
+    @staticmethod
+    def _ai_trace_queue_review_state(
+        *,
+        lifecycle_state: str,
+        draft_review_state: str | None,
+    ) -> str:
+        if draft_review_state in {"accepted", "rejected", "corrected"}:
+            return draft_review_state
+        if lifecycle_state == "accepted_for_reference":
+            return "accepted"
+        if lifecycle_state == "rejected_for_reference":
+            return "rejected"
+        return "pending_review"
 
     def _ai_trace_review_states(
         self,

--- a/control-plane/aegisops/control_plane/runtime/service_snapshots.py
+++ b/control-plane/aegisops/control_plane/runtime/service_snapshots.py
@@ -107,6 +107,26 @@ class AnalystQueueSnapshot:
 
 
 @dataclass(frozen=True)
+class AITraceReviewQueueSnapshot:
+    read_only: bool
+    queue_name: str
+    total_records: int
+    state_counts: dict[str, int]
+    records: tuple[dict[str, object], ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(
+            {
+                "read_only": self.read_only,
+                "queue_name": self.queue_name,
+                "total_records": self.total_records,
+                "state_counts": self.state_counts,
+                "records": self.records,
+            }
+        )
+
+
+@dataclass(frozen=True)
 class AlertDetailSnapshot:
     read_only: bool
     alert_id: str
@@ -473,6 +493,7 @@ class DoctorSnapshot:
 
 __all__ = [
     "ActionReviewDetailSnapshot",
+    "AITraceReviewQueueSnapshot",
     "AdvisoryInspectionSnapshot",
     "AlertDetailSnapshot",
     "AnalystAssistantContextSnapshot",

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -254,6 +254,137 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             ],
         )
 
+    def test_cli_renders_ai_trace_review_queue_skeleton(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        generated_at = datetime(2026, 5, 12, 10, 0, tzinfo=timezone.utc)
+        common_linkage = {
+            "source_case_id": "case-trace-review-001",
+            "registered_agent_id": "agent-governed-summary-001",
+            "registered_tool_id": "tool-case-summary-001",
+            "reviewed_record_family": "case",
+            "reviewed_record_id": "case-trace-review-001",
+            "expiration_posture": "expires_with_reviewed_case",
+        }
+        for trace_id, lifecycle_state, review_state, reviewer_note in (
+            (
+                "ai-trace-review-accepted-001",
+                "accepted_for_reference",
+                "accepted",
+                "Accepted as cited context only; case truth stays authoritative.",
+            ),
+            (
+                "ai-trace-review-rejected-001",
+                "rejected_for_reference",
+                "rejected",
+                "Rejected because supporting citations were incomplete.",
+            ),
+            (
+                "ai-trace-review-corrected-001",
+                "under_review",
+                "corrected",
+                "Corrected by reviewer note before any downstream use.",
+            ),
+        ):
+            service.persist_record(
+                AITraceRecord(
+                    ai_trace_id=trace_id,
+                    subject_linkage={
+                        **common_linkage,
+                        "citations": ("case-trace-review-001", "evidence-trace-review-001"),
+                    },
+                    model_identity="gpt-5.4",
+                    prompt_version="phase-59-trace-review-v1",
+                    generated_at=generated_at,
+                    material_input_refs=("evidence-trace-review-001",),
+                    reviewer_identity="analyst-001",
+                    lifecycle_state=lifecycle_state,
+                    assistant_advisory_draft={
+                        "status": "ready",
+                        "review_state": review_state,
+                        "reviewer_note": reviewer_note,
+                        "authority_mode": "advisory_only",
+                    },
+                )
+            )
+
+        stdout = io.StringIO()
+        main.main(["inspect-ai-trace-review-queue"], stdout=stdout, service=service)
+
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["read_only"])
+        self.assertEqual(payload["queue_name"], "ai_trace_review")
+        self.assertEqual(payload["total_records"], 3)
+        self.assertEqual(
+            payload["state_counts"],
+            {"accepted": 1, "corrected": 1, "rejected": 1},
+        )
+        records_by_state = {record["review_state"]: record for record in payload["records"]}
+        self.assertEqual(
+            records_by_state["accepted"]["registered_agent_id"],
+            "agent-governed-summary-001",
+        )
+        self.assertEqual(
+            records_by_state["rejected"]["registered_tool_id"],
+            "tool-case-summary-001",
+        )
+        self.assertEqual(records_by_state["corrected"]["reviewed_record_family"], "case")
+        self.assertEqual(
+            records_by_state["corrected"]["reviewer_note"],
+            "Corrected by reviewer note before any downstream use.",
+        )
+        self.assertEqual(
+            records_by_state["accepted"]["citations"],
+            ["case-trace-review-001", "evidence-trace-review-001"],
+        )
+        self.assertEqual(
+            records_by_state["accepted"]["expiration_posture"],
+            "expires_with_reviewed_case",
+        )
+        for record in payload["records"]:
+            self.assertTrue(record["read_only"])
+            self.assertEqual(record["authority_mode"], "advisory_only")
+            self.assertFalse(record["authoritative_workflow_truth"])
+
+    def test_ai_trace_review_queue_rejects_missing_registered_tool_or_citations(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-review-missing-registration-001",
+                subject_linkage={
+                    "source_case_id": "case-trace-review-001",
+                    "registered_agent_id": "agent-governed-summary-001",
+                    "reviewed_record_family": "case",
+                    "reviewed_record_id": "case-trace-review-001",
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-59-trace-review-v1",
+                generated_at=datetime(2026, 5, 12, 10, 0, tzinfo=timezone.utc),
+                material_input_refs=(),
+                reviewer_identity="analyst-001",
+                lifecycle_state="accepted_for_reference",
+                assistant_advisory_draft={
+                    "status": "ready",
+                    "review_state": "accepted",
+                    "reviewer_note": "Missing tool and citations must not render.",
+                    "authority_mode": "advisory_only",
+                },
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "missing registered_tool_id, citations",
+        ):
+            service._operator_inspection_read_surface.inspect_ai_trace_review_queue()
+
     def test_cli_renders_reviewed_wazuh_alert_detail_view(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -367,7 +367,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 model_identity="gpt-5.4",
                 prompt_version="phase-59-trace-review-v1",
                 generated_at=datetime(2026, 5, 12, 10, 0, tzinfo=timezone.utc),
-                material_input_refs=(),
+                material_input_refs=("   ",),
                 reviewer_identity="analyst-001",
                 lifecycle_state="accepted_for_reference",
                 assistant_advisory_draft={
@@ -384,6 +384,119 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             "missing registered_tool_id, citations",
         ):
             service._operator_inspection_read_surface.inspect_ai_trace_review_queue()
+
+    def test_cli_reports_ai_trace_review_queue_validation_error_as_usage_error(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-review-missing-registration-001",
+                subject_linkage={
+                    "source_case_id": "case-trace-review-001",
+                    "registered_agent_id": "agent-governed-summary-001",
+                    "reviewed_record_family": "case",
+                    "reviewed_record_id": "case-trace-review-001",
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-59-trace-review-v1",
+                generated_at=datetime(2026, 5, 12, 10, 0, tzinfo=timezone.utc),
+                material_input_refs=(),
+                reviewer_identity="analyst-001",
+                lifecycle_state="accepted_for_reference",
+                assistant_advisory_draft={
+                    "status": "ready",
+                    "review_state": "accepted",
+                    "reviewer_note": "Missing tool and citations must not render.",
+                    "authority_mode": "advisory_only",
+                },
+            )
+        )
+
+        stderr = io.StringIO()
+        with mock.patch("sys.stderr", stderr), self.assertRaises(SystemExit) as raised:
+            main.main(["inspect-ai-trace-review-queue"], stdout=io.StringIO(), service=service)
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("AI trace review queue requires", stderr.getvalue())
+        self.assertIn("missing registered_tool_id, citations", stderr.getvalue())
+
+    def test_http_ai_trace_review_queue_reports_validation_error_as_bad_request(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+            ),
+            store=store,
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-review-missing-registration-001",
+                subject_linkage={
+                    "source_case_id": "case-trace-review-001",
+                    "registered_agent_id": "agent-governed-summary-001",
+                    "reviewed_record_family": "case",
+                    "reviewed_record_id": "case-trace-review-001",
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-59-trace-review-v1",
+                generated_at=datetime(2026, 5, 12, 10, 0, tzinfo=timezone.utc),
+                material_input_refs=(),
+                reviewer_identity="analyst-001",
+                lifecycle_state="accepted_for_reference",
+                assistant_advisory_draft={
+                    "status": "ready",
+                    "review_state": "accepted",
+                    "reviewer_note": "Missing tool and citations must not render.",
+                    "authority_mode": "advisory_only",
+                },
+            )
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
+            service,
+            principal=REVIEWED_ANALYST_PRINCIPAL,
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+                with self.assertRaises(error.HTTPError) as raised:
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                        f"{base_url}/inspect-ai-trace-review-queue",
+                        timeout=2,
+                    )
+
+                self.assertEqual(raised.exception.code, 400)
+                payload = json.loads(raised.exception.read().decode("utf-8"))
+                self.assertEqual(payload["error"], "invalid_request")
+                self.assertIn("AI trace review queue requires", payload["message"])
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(1)
 
     def test_cli_renders_reviewed_wazuh_alert_detail_view(self) -> None:
         store, _ = make_store()


### PR DESCRIPTION
## Summary
- add a read-only AI trace review queue projection and CLI/HTTP route for accepted, rejected, and corrected trace review states
- expose the queue in the operator UI under Assistant with registered agent/tool, citations, reviewed record anchor, reviewer note, and expiration posture
- fail closed when required trace review registration, tool, citation, or reviewed-record anchors are missing

## Verification
- python3 -m unittest control-plane/tests/test_cli_inspection_workflow_family.py -k "ai_trace_review_queue"
- python3 -m unittest control-plane/tests/test_cli_inspection_workflow_family.py control-plane/tests/test_service_persistence_assistant_advisory.py control-plane/tests/test_publishable_path_hygiene.py
- npm test -- --run src/app/OperatorRoutes.test.tsx --testNamePattern "assistant routes"
- npm run typecheck --workspace @aegisops/operator-ui
- git diff --check
- node dist/index.js issue-lint 1259 --config supervisor.config.codex.json