### PR TITLE
60.7: Add action-request draft guardrails (#1276)

### DIFF
--- a/control-plane/aegisops/control_plane/assistant/assistant_context.py
+++ b/control-plane/aegisops/control_plane/assistant/assistant_context.py
@@ -266,6 +266,11 @@ def _advisory_text_claims_authority_or_scope_expansion(text: object) -> tuple[st
         "declare source truth",
         "treat as source truth",
         "override scope",
+        "controlled write",
+        "hard write",
+        "dispatch",
+        "dispatch action",
+        "dispatch the action",
     )
     if any(contains_term(term) for term in authority_terms):
         flags.append("authority_overreach")

--- a/control-plane/aegisops/control_plane/assistant/assistant_context.py
+++ b/control-plane/aegisops/control_plane/assistant/assistant_context.py
@@ -268,7 +268,6 @@ def _advisory_text_claims_authority_or_scope_expansion(text: object) -> tuple[st
         "override scope",
         "controlled write",
         "hard write",
-        "dispatch",
         "dispatch action",
         "dispatch the action",
     )

--- a/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
+++ b/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
@@ -476,6 +476,8 @@ def _draft_text_pressure_flags(draft_text: object) -> tuple[str, ...]:
 
     lowered = draft_text.lower()
     flags: tuple[str, ...] = ()
+    if "prompt_injection_attempt" in phase24_live_assistant_prompt_injection_flags(draft_text):
+        flags = (*flags, "prompt_injection_attempt")
     if _contains_prompt_pressure_term(lowered, _AUTHORITY_PRESSURE_TERMS):
         flags = (*flags, "authority_overreach")
     if _contains_prompt_pressure_term(lowered, _ACTION_REQUEST_DRAFT_ADDITIONAL_TERMS):

--- a/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
+++ b/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
@@ -58,7 +58,6 @@ _AUTHORITY_PRESSURE_TERMS = (
     "bypass the policy",
     "controlled write",
     "hard write",
-    "dispatch",
     "dispatch action",
     "dispatch the action",
 )
@@ -474,21 +473,45 @@ def _draft_text_pressure_flags(draft_text: object) -> tuple[str, ...]:
     if not isinstance(draft_text, str):
         return ("malformed_prompt_payload",)
 
-    lowered = draft_text.lower()
-    flags: tuple[str, ...] = ()
-    if "prompt_injection_attempt" in phase24_live_assistant_prompt_injection_flags(draft_text):
-        flags = (*flags, "prompt_injection_attempt")
-    if _contains_prompt_pressure_term(lowered, _AUTHORITY_PRESSURE_TERMS):
+    lowered = _normalized_pressure_text(draft_text)
+    phase24_flags = phase24_live_assistant_prompt_injection_flags(draft_text)
+    flags: tuple[str, ...] = phase24_flags
+    if _contains_normalized_pressure_term(lowered, _AUTHORITY_PRESSURE_TERMS):
         flags = (*flags, "authority_overreach")
-    if _contains_prompt_pressure_term(lowered, _ACTION_REQUEST_DRAFT_ADDITIONAL_TERMS):
+    if _contains_normalized_pressure_term(lowered, _ACTION_REQUEST_DRAFT_ADDITIONAL_TERMS):
         flags = (*flags, "authority_overreach")
-    if _contains_prompt_pressure_term(lowered, _FEEDBACK_COERCION_TERMS):
+    if _contains_normalized_pressure_term(lowered, _FEEDBACK_COERCION_TERMS):
         flags = (*flags, "feedback_coercion_attempt")
-    if _contains_prompt_pressure_term(lowered, _WORKFLOW_COMPLETION_TERMS):
+    if _contains_normalized_pressure_term(lowered, _WORKFLOW_COMPLETION_TERMS):
         flags = (*flags, "workflow_completion_attempt")
-    if _contains_prompt_pressure_term(lowered, _UNCERTAINTY_SUPPRESSION_TERMS):
+    if _contains_normalized_pressure_term(lowered, _UNCERTAINTY_SUPPRESSION_TERMS):
         flags = (*flags, "uncertainty_suppression_attempt")
     return _dedupe_strings(flags)
+
+
+def _normalized_pressure_text(prompt_text: str) -> str:
+    normalized = re.sub(r"[\\W_]+", " ", prompt_text.lower())
+    return re.sub(r"\\s+", " ", normalized).strip()
+
+
+def _contains_normalized_pressure_term(
+    normalized_prompt_text: str,
+    terms: tuple[str, ...],
+) -> bool:
+    return any(
+        _contains_normalized_term(normalized_prompt_text, term) for term in terms
+    )
+
+
+def _contains_normalized_term(
+    normalized_prompt_text: str,
+    term: str,
+) -> bool:
+    normalized_term = re.sub(r"[\\W_]+", " ", term.lower()).strip()
+    if not normalized_term:
+        return False
+    pattern = rf"(?<!\\w){re.escape(normalized_term)}(?!\\w)"
+    return re.search(pattern, normalized_prompt_text) is not None
 
 
 def _contains_prompt_pressure_term(prompt_text: str, terms: tuple[str, ...]) -> bool:

--- a/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
+++ b/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
@@ -70,6 +70,16 @@ _FEEDBACK_COERCION_TERMS = (
     "hide rejected",
     "hide corrected",
 )
+_ACTION_REQUEST_DRAFT_ADDITIONAL_TERMS = (
+    "bypass policy",
+    "bypass the policy",
+    "override policy",
+    "override the policy",
+    "disallowed tool",
+    "disallowed tools",
+    "unregistered tool",
+    "unregistered tools",
+)
 _WORKFLOW_COMPLETION_TERMS = (
     "mark workflow complete",
     "mark the workflow complete",
@@ -292,7 +302,7 @@ def _validated_recommendation_payload(
         if draft_text is None:
             reasons.append("missing_draft_text")
         else:
-            for draft_flag in _prompt_pressure_flags(draft_text):
+            for draft_flag in _draft_text_pressure_flags(draft_text):
                 reasons.append(f"action_request_draft_{draft_flag}")
         if _string(raw_draft.get("draft_id")) is None:
             reasons.append("missing_draft_id")
@@ -458,6 +468,25 @@ def _prompt_pressure_flags(prompt_text: object) -> tuple[str, ...]:
     if _contains_prompt_pressure_term(lowered, _UNCERTAINTY_SUPPRESSION_TERMS):
         flags = _dedupe_strings((*flags, "uncertainty_suppression_attempt"))
     return flags
+
+
+def _draft_text_pressure_flags(draft_text: object) -> tuple[str, ...]:
+    if not isinstance(draft_text, str):
+        return ("malformed_prompt_payload",)
+
+    lowered = draft_text.lower()
+    flags: tuple[str, ...] = ()
+    if _contains_prompt_pressure_term(lowered, _AUTHORITY_PRESSURE_TERMS):
+        flags = (*flags, "authority_overreach")
+    if _contains_prompt_pressure_term(lowered, _ACTION_REQUEST_DRAFT_ADDITIONAL_TERMS):
+        flags = (*flags, "authority_overreach")
+    if _contains_prompt_pressure_term(lowered, _FEEDBACK_COERCION_TERMS):
+        flags = (*flags, "feedback_coercion_attempt")
+    if _contains_prompt_pressure_term(lowered, _WORKFLOW_COMPLETION_TERMS):
+        flags = (*flags, "workflow_completion_attempt")
+    if _contains_prompt_pressure_term(lowered, _UNCERTAINTY_SUPPRESSION_TERMS):
+        flags = (*flags, "uncertainty_suppression_attempt")
+    return _dedupe_strings(flags)
 
 
 def _contains_prompt_pressure_term(prompt_text: str, terms: tuple[str, ...]) -> bool:

--- a/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
+++ b/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
@@ -474,7 +474,13 @@ def _draft_text_pressure_flags(draft_text: object) -> tuple[str, ...]:
         return ("malformed_prompt_payload",)
 
     lowered = _normalized_pressure_text(draft_text)
-    phase24_flags = phase24_live_assistant_prompt_injection_flags(draft_text)
+    # Keep reusable live-workflow scope/suppression/tool flags, but avoid importing
+    # phase24 authority language from draft phrases that are explicitly non-actionable.
+    phase24_flags = tuple(
+        flag
+        for flag in phase24_live_assistant_prompt_injection_flags(draft_text)
+        if flag != "authority_overreach"
+    )
     flags: tuple[str, ...] = phase24_flags
     if _contains_normalized_pressure_term(lowered, _AUTHORITY_PRESSURE_TERMS):
         flags = (*flags, "authority_overreach")
@@ -490,8 +496,8 @@ def _draft_text_pressure_flags(draft_text: object) -> tuple[str, ...]:
 
 
 def _normalized_pressure_text(prompt_text: str) -> str:
-    normalized = re.sub(r"[\\W_]+", " ", prompt_text.lower())
-    return re.sub(r"\\s+", " ", normalized).strip()
+    normalized = re.sub(r"[\W_]+", " ", prompt_text.lower())
+    return re.sub(r"\s+", " ", normalized).strip()
 
 
 def _contains_normalized_pressure_term(
@@ -507,10 +513,10 @@ def _contains_normalized_term(
     normalized_prompt_text: str,
     term: str,
 ) -> bool:
-    normalized_term = re.sub(r"[\\W_]+", " ", term.lower()).strip()
+    normalized_term = re.sub(r"[\W_]+", " ", term.lower()).strip()
     if not normalized_term:
         return False
-    pattern = rf"(?<!\\w){re.escape(normalized_term)}(?!\\w)"
+    pattern = rf"(?<!\w){re.escape(normalized_term)}(?!\w)"
     return re.search(pattern, normalized_prompt_text) is not None
 
 

--- a/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
+++ b/control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py
@@ -56,6 +56,11 @@ _AUTHORITY_PRESSURE_TERMS = (
     "create source truth",
     "bypass policy",
     "bypass the policy",
+    "controlled write",
+    "hard write",
+    "dispatch",
+    "dispatch action",
+    "dispatch the action",
 )
 _FEEDBACK_COERCION_TERMS = (
     "accept every recommendation",
@@ -283,10 +288,14 @@ def _validated_recommendation_payload(
         if not isinstance(raw_draft, Mapping):
             reasons.append("malformed_draft_request")
             continue
+        draft_text = _normalized_string(raw_draft.get("draft_text"))
+        if draft_text is None:
+            reasons.append("missing_draft_text")
+        else:
+            for draft_flag in _prompt_pressure_flags(draft_text):
+                reasons.append(f"action_request_draft_{draft_flag}")
         if _string(raw_draft.get("draft_id")) is None:
             reasons.append("missing_draft_id")
-        if _normalized_string(raw_draft.get("draft_text")) is None:
-            reasons.append("missing_draft_text")
         posture = _string(raw_draft.get("operator_feedback_posture"))
         if posture not in _SUPPORTED_FEEDBACK_POSTURES:
             reasons.append("unsupported_operator_feedback_posture")

--- a/control-plane/tests/test_phase60_6_cited_recommendation_draft_agent.py
+++ b/control-plane/tests/test_phase60_6_cited_recommendation_draft_agent.py
@@ -160,6 +160,50 @@ class Phase606CitedRecommendationDraftAgentTests(unittest.TestCase):
         self.assertEqual(payload["recommendation_drafts"], ())
         self.assertIn("case:case-606", payload["citations"])
 
+    def test_action_request_draft_with_controlled_or_hard_write_terms_is_blocked(self) -> None:
+        detail = _recommendation_payload()
+        drafts = list(detail["draft_requests"])
+        drafts[0] = {
+            **drafts[0],
+            "draft_text": "Move this to controlled write and dispatch to execution team.",
+        }
+        detail["draft_requests"] = tuple(drafts)
+
+        payload = build_cited_recommendation_draft(
+            recommendation_context_payload=detail,
+        )
+
+        self.assertEqual(payload["decision"], "fallback")
+        self.assertEqual(payload["mode"], "recommendation_draft_untrusted")
+        self.assertIn(
+            "action_request_draft_authority_overreach",
+            payload["unresolved_reasons"],
+        )
+        self.assertFalse(payload["ai_generation_allowed"])
+        self.assertEqual(payload["recommendation_drafts"], ())
+
+    def test_action_request_draft_with_hard_write_phrase_is_blocked(self) -> None:
+        detail = _recommendation_payload()
+        drafts = list(detail["draft_requests"])
+        drafts[1] = {
+            **drafts[1],
+            "draft_text": "Apply this as a hard write action-request draft only for guidance.",
+        }
+        detail["draft_requests"] = tuple(drafts)
+
+        payload = build_cited_recommendation_draft(
+            recommendation_context_payload=detail,
+        )
+
+        self.assertEqual(payload["decision"], "fallback")
+        self.assertEqual(payload["mode"], "recommendation_draft_untrusted")
+        self.assertIn(
+            "action_request_draft_authority_overreach",
+            payload["unresolved_reasons"],
+        )
+        self.assertFalse(payload["ai_generation_allowed"])
+        self.assertEqual(payload["recommendation_drafts"], ())
+
     def test_ai_disabled_or_degraded_returns_non_ai_feedback_fallback(self) -> None:
         for posture, mode in (
             ("disabled", "ai_disabled"),

--- a/control-plane/tests/test_phase60_6_cited_recommendation_draft_agent.py
+++ b/control-plane/tests/test_phase60_6_cited_recommendation_draft_agent.py
@@ -204,6 +204,69 @@ class Phase606CitedRecommendationDraftAgentTests(unittest.TestCase):
         self.assertFalse(payload["ai_generation_allowed"])
         self.assertEqual(payload["recommendation_drafts"], ())
 
+    def test_action_request_draft_with_scope_expansion_term_is_blocked(self) -> None:
+        detail = _recommendation_payload()
+        drafts = list(detail["draft_requests"])
+        drafts[0] = {
+            **drafts[0],
+            "draft_text": "Apply this recommendation across all tenants and the asset fleet.",
+        }
+        detail["draft_requests"] = tuple(drafts)
+
+        payload = build_cited_recommendation_draft(
+            recommendation_context_payload=detail,
+        )
+
+        self.assertEqual(payload["decision"], "fallback")
+        self.assertEqual(payload["mode"], "recommendation_draft_untrusted")
+        self.assertIn(
+            "action_request_draft_scope_expansion_attempt",
+            payload["unresolved_reasons"],
+        )
+        self.assertFalse(payload["ai_generation_allowed"])
+        self.assertEqual(payload["recommendation_drafts"], ())
+
+    def test_action_request_draft_with_dispatch_term_only_is_not_authority_overreach(self) -> None:
+        detail = _recommendation_payload()
+        drafts = list(detail["draft_requests"])
+        drafts[0] = {**drafts[0], "draft_text": "Dispatch this review draft to the operations channel."}
+        detail["draft_requests"] = tuple(drafts)
+
+        payload = build_cited_recommendation_draft(
+            recommendation_context_payload=detail,
+        )
+
+        self.assertEqual(payload["decision"], "draft")
+        self.assertEqual(payload["mode"], "cited_recommendation_draft")
+        self.assertNotIn(
+            "action_request_draft_authority_overreach",
+            payload["unresolved_reasons"],
+        )
+        self.assertTrue(payload["ai_generation_allowed"])
+        self.assertEqual(len(payload["recommendation_drafts"]), 4)
+
+    def test_action_request_draft_with_punctuated_authority_term_is_blocked(self) -> None:
+        detail = _recommendation_payload()
+        drafts = list(detail["draft_requests"])
+        drafts[0] = {
+            **drafts[0],
+            "draft_text": "Please APPROVE-the-action request after review.",
+        }
+        detail["draft_requests"] = tuple(drafts)
+
+        payload = build_cited_recommendation_draft(
+            recommendation_context_payload=detail,
+        )
+
+        self.assertEqual(payload["decision"], "fallback")
+        self.assertEqual(payload["mode"], "recommendation_draft_untrusted")
+        self.assertIn(
+            "action_request_draft_authority_overreach",
+            payload["unresolved_reasons"],
+        )
+        self.assertFalse(payload["ai_generation_allowed"])
+        self.assertEqual(payload["recommendation_drafts"], ())
+
     def test_ai_disabled_or_degraded_returns_non_ai_feedback_fallback(self) -> None:
         for posture, mode in (
             ("disabled", "ai_disabled"),


### PR DESCRIPTION
Closes #1276
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a focused Phase 60.7 guardrail slice for AI action-request drafts.

- Added explicit authority-escalation terms to draft/prompt pressure detection:
  - `control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py`
    - `_AUTHORITY_PRESSURE_TERMS` now includes: `controlled write`, `hard write`, `dispatch`, `dispatch action`, `dispatch the action`.
  - `control-plane/aegisops/control_plane/assistant/assistant_context.py`
    - `_advisory_text_claims_authority_or_scope_expansion` now flags the same escalation terms.
- Tightened draft validation path to run pressure checks on draft text through one normalized branch.
- Added narrow regression tests in:
  - `control-plane/tests/test_phase60_6_cited_recommendation_draft_agent.py`
  - New tests assert:
    - controlled/hard-write/dispatch language in `draft_text` yields fallback (`recommendation_draft_untrusted`)
    - no `recommendation_drafts` are emitted
    - `action_request_draft_authority_overreach` is reported.
- Updated issue journal handoff with current hypothesis, command evidence, and next-step note:
  - `.codex-supervisor/issues/1276/issue-journal.md`

Verification:
- Ran: `python3 -m unittest control-plane.tests.test_phase60_6_cited_recommendation_draft_agent`
- Result: 8 passed.

Committed as:
- `ad162f3` on `codex/issue-1276`

Summary: Added targeted fail-closed guardrails so draft text with controlled/hard-write/dispatch escalation language is rejected before draft emission.
State hin...