### PR TITLE
60.8: Add AI quality metrics report (#1277)

### DIFF
--- a/control-plane/aegisops/control_plane/api/cli.py
+++ b/control-plane/aegisops/control_plane/api/cli.py
@@ -130,6 +130,10 @@ def build_parser() -> argparse.ArgumentParser:
         "inspect-ai-trace-review-queue",
         help="Render the read-only AI trace review queue skeleton.",
     )
+    subparsers.add_parser(
+        "inspect-ai-quality-metrics",
+        help="Render read-only AI quality metrics for reviewed trace reporting.",
+    )
     inspect_alert_detail = subparsers.add_parser(
         "inspect-alert-detail",
         help="Render the reviewed Wazuh-backed alert detail view for one alert.",
@@ -608,6 +612,11 @@ def run_command(
             return (
                 service._operator_inspection_read_surface.inspect_ai_trace_review_queue().to_dict()
             )
+        except (LookupError, ValueError) as exc:
+            _usage_error(parser, str(exc))
+    if command == "inspect-ai-quality-metrics":
+        try:
+            return service.inspect_ai_quality_metrics().to_dict()
         except (LookupError, ValueError) as exc:
             _usage_error(parser, str(exc))
     if command == "inspect-alert-detail":

--- a/control-plane/aegisops/control_plane/api/cli.py
+++ b/control-plane/aegisops/control_plane/api/cli.py
@@ -616,7 +616,9 @@ def run_command(
             _usage_error(parser, str(exc))
     if command == "inspect-ai-quality-metrics":
         try:
-            return service.inspect_ai_quality_metrics().to_dict()
+            return (
+                service._operator_inspection_read_surface.inspect_ai_quality_metrics().to_dict()
+            )
         except (LookupError, ValueError) as exc:
             _usage_error(parser, str(exc))
     if command == "inspect-alert-detail":

--- a/control-plane/aegisops/control_plane/api/http_protected_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_protected_surface.py
@@ -21,6 +21,7 @@ PROTECTED_READ_ROLES_BY_PATH: dict[str, tuple[str, ...]] = {
     "/inspect-reconciliation-status": READ_ONLY_PROTECTED_ROLES,
     "/inspect-analyst-queue": READ_ONLY_PROTECTED_ROLES,
     "/inspect-ai-trace-review-queue": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-ai-quality-metrics": READ_ONLY_PROTECTED_ROLES,
     "/inspect-alert-detail": READ_ONLY_PROTECTED_ROLES,
     "/inspect-case-detail": READ_ONLY_PROTECTED_ROLES,
     "/inspect-action-review": READ_ONLY_PROTECTED_ROLES,

--- a/control-plane/aegisops/control_plane/api/http_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_surface.py
@@ -218,7 +218,9 @@ def _handle_inspect_ai_quality_metrics(
     principal: object,
 ) -> None:
     try:
-        payload = context.service.inspect_ai_quality_metrics().to_dict()
+        payload = (
+            context.service._operator_inspection_read_surface.inspect_ai_quality_metrics().to_dict()
+        )
     except (LookupError, ValueError) as exc:
         _write_lookup_or_bad_request(handler, exc)
         return

--- a/control-plane/aegisops/control_plane/api/http_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_surface.py
@@ -212,6 +212,23 @@ def _handle_inspect_ai_trace_review_queue(
     )
 
 
+def _handle_inspect_ai_quality_metrics(
+    handler: BaseHTTPRequestHandler,
+    context: HttpSurfaceContext,
+    principal: object,
+) -> None:
+    try:
+        payload = context.service.inspect_ai_quality_metrics().to_dict()
+    except (LookupError, ValueError) as exc:
+        _write_lookup_or_bad_request(handler, exc)
+        return
+    _write_json(
+        handler,
+        HTTPStatus.OK,
+        payload,
+    )
+
+
 def _handle_inspect_alert_detail(
     handler: BaseHTTPRequestHandler,
     context: HttpSurfaceContext,
@@ -406,6 +423,7 @@ HTTP_GET_ROUTES: dict[str, GetRouteHandler] = {
     "/inspect-reconciliation-status": _handle_inspect_reconciliation_status,
     "/inspect-analyst-queue": _handle_inspect_analyst_queue,
     "/inspect-ai-trace-review-queue": _handle_inspect_ai_trace_review_queue,
+    "/inspect-ai-quality-metrics": _handle_inspect_ai_quality_metrics,
     "/inspect-alert-detail": _handle_inspect_alert_detail,
     "/inspect-case-detail": _handle_inspect_case_detail,
     "/inspect-action-review": _handle_inspect_action_review,

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -324,7 +324,8 @@ class OperatorInspectionReadSurface:
                     ("citations", citations),
                 )
                 if (
-                    (isinstance(value, str) and not value.strip())
+                    value is None
+                    or (isinstance(value, str) and not value.strip())
                     or (isinstance(value, tuple) and not value)
                     or (isinstance(value, list) and not value)
                 )

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -21,6 +21,7 @@ from .models import (
     ReconciliationRecord,
 )
 from .runtime.service_snapshots import AITraceReviewQueueSnapshot
+from .runtime.service_snapshots import AIQualityMetricsSnapshot
 
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
@@ -210,6 +211,182 @@ class OperatorInspectionReadSurface:
             total_records=len(records),
             state_counts=state_counts,
             records=records,
+        )
+
+    def inspect_ai_quality_metrics(self) -> AIQualityMetricsSnapshot:
+        traces = self._service._store.list(AITraceRecord)
+        readiness = self._service.inspect_readiness_diagnostics()
+        optional_extensions = readiness.metrics.get("optional_extensions", {})
+        assistant_extension = (
+            optional_extensions.get("extensions", {}).get("assistant", {})
+            if isinstance(optional_extensions, Mapping)
+            else {}
+        )
+        if not isinstance(assistant_extension, Mapping):
+            assistant_extension = {}
+
+        prompt_pressure_reasons = frozenset(
+            {
+                "prompt_injection_attempt",
+                "authority_overreach",
+                "scope_expansion_attempt",
+                "tool_scope_expansion_attempt",
+                "record_family_expansion_attempt",
+                "citation_suppression_attempt",
+            }
+        )
+        trace_metrics: list[dict[str, object]] = []
+        total_records = len(traces)
+        citation_complete = 0
+        unresolved_count = 0
+        accepted_count = 0
+        corrected_count = 0
+        stale_evidence_count = 0
+        prompt_pressure_refusal_count = 0
+
+        for trace in traces:
+            subject_linkage = trace.subject_linkage
+            advisory_draft = trace.assistant_advisory_draft
+            review_state = self._ai_trace_queue_review_state(
+                lifecycle_state=trace.lifecycle_state,
+                draft_review_state=self._optional_string_from_mapping(
+                    advisory_draft,
+                    "review_state",
+                ),
+            )
+
+            citations = self._dedupe_strings(
+                (
+                    *self._string_tuple_from_object(subject_linkage.get("citations")),
+                    *self._string_tuple_from_object(advisory_draft.get("citations")),
+                    *self._string_tuple_from_object(trace.material_input_refs),
+                )
+            )
+            unresolved_reasons = self._string_tuple_from_object(
+                advisory_draft.get("unresolved_reasons")
+            )
+            provider_status = self._optional_string_from_mapping(
+                subject_linkage,
+                "provider_status",
+            )
+            provider_operational_quality = self._optional_string_from_mapping(
+                subject_linkage,
+                "provider_operational_quality",
+            )
+            draft_status = self._optional_string_from_mapping(
+                advisory_draft,
+                "status",
+            )
+            trace_states = self._ai_trace_review_states(
+                lifecycle_state=trace.lifecycle_state,
+                provider_status=provider_status,
+                provider_operational_quality=provider_operational_quality,
+                draft_status=draft_status,
+                unresolved_reasons=unresolved_reasons,
+            )
+            if "unresolved" in trace_states:
+                unresolved_count += 1
+            if review_state == "accepted":
+                accepted_count += 1
+            if review_state == "corrected":
+                corrected_count += 1
+
+            if "stale_evidence" in unresolved_reasons:
+                stale_evidence_count += 1
+            if unresolved_reasons and prompt_pressure_reasons.intersection(unresolved_reasons):
+                prompt_pressure_refusal_count += 1
+
+            registered_agent_id = self._optional_string_from_mapping(
+                subject_linkage,
+                "registered_agent_id",
+            )
+            registered_tool_id = self._optional_string_from_mapping(
+                subject_linkage,
+                "registered_tool_id",
+            )
+            reviewed_record_family = (
+                self._optional_string_from_mapping(subject_linkage, "reviewed_record_family")
+                or self._optional_string_from_mapping(subject_linkage, "source_record_family")
+            )
+            reviewed_record_id = (
+                self._optional_string_from_mapping(subject_linkage, "reviewed_record_id")
+                or self._optional_string_from_mapping(subject_linkage, "source_record_id")
+                or self._optional_string_from_mapping(subject_linkage, "source_case_id")
+                or self._optional_string_from_mapping(subject_linkage, "source_alert_id")
+            )
+            missing_required_fields = tuple(
+                field_name
+                for field_name, value in (
+                    ("registered_agent_id", registered_agent_id),
+                    ("registered_tool_id", registered_tool_id),
+                    ("reviewed_record_family", reviewed_record_family),
+                    ("reviewed_record_id", reviewed_record_id),
+                    ("citations", citations),
+                )
+                if (
+                    (isinstance(value, str) and not value.strip())
+                    or (isinstance(value, tuple) and not value)
+                    or (isinstance(value, list) and not value)
+                )
+            )
+            if not citations or "missing_supporting_citations" in unresolved_reasons or "missing_evidence_citation" in unresolved_reasons:
+                citation_complete += 0
+            else:
+                citation_complete += 1
+
+            if missing_required_fields:
+                missing_required = ", ".join(missing_required_fields)
+                trace_metrics.append(
+                    {
+                        "ai_trace_id": trace.ai_trace_id,
+                        "missing_required_fields": missing_required_fields,
+                        "missing_required_fields_text": missing_required,
+                        "review_state": review_state,
+                    }
+                )
+
+        def ratio(numerator: int, denominator: int) -> float:
+            if denominator <= 0:
+                return 0.0
+            return round(numerator / denominator, 4)
+
+        missing_citation_count = total_records - citation_complete
+        return AIQualityMetricsSnapshot(
+            read_only=True,
+            generated_at=datetime.now(timezone.utc),
+            assistant_operability=dict(assistant_extension),
+            citation_completeness={
+                "total_records": total_records,
+                "complete_citation_records": citation_complete,
+                "missing_citation_records": missing_citation_count,
+                "completeness_ratio": ratio(citation_complete, total_records),
+            },
+            unresolved_rate={
+                "total_records": total_records,
+                "unresolved_records": unresolved_count,
+                "unresolved_ratio": ratio(unresolved_count, total_records),
+            },
+            acceptance_rate={
+                "total_records": total_records,
+                "accepted_records": accepted_count,
+                "acceptance_ratio": ratio(accepted_count, total_records),
+            },
+            correction_rate={
+                "total_records": total_records,
+                "corrected_records": corrected_count,
+                "correction_ratio": ratio(corrected_count, total_records),
+            },
+            stale_evidence_usage={
+                "total_records": total_records,
+                "stale_evidence_records": stale_evidence_count,
+                "stale_evidence_ratio": ratio(stale_evidence_count, total_records),
+            },
+            prompt_pressure_refusal={
+                "total_records": total_records,
+                "prompt_pressure_records": prompt_pressure_refusal_count,
+                "prompt_pressure_ratio": ratio(prompt_pressure_refusal_count, total_records),
+            },
+            malformed_trace_records=tuple(trace_metrics),
         )
 
     def _ai_trace_review_queue_record(

--- a/control-plane/aegisops/control_plane/runtime/service_snapshots.py
+++ b/control-plane/aegisops/control_plane/runtime/service_snapshots.py
@@ -127,6 +127,36 @@ class AITraceReviewQueueSnapshot:
 
 
 @dataclass(frozen=True)
+class AIQualityMetricsSnapshot:
+    read_only: bool
+    generated_at: datetime
+    assistant_operability: dict[str, object]
+    citation_completeness: dict[str, object]
+    unresolved_rate: dict[str, object]
+    acceptance_rate: dict[str, object]
+    correction_rate: dict[str, object]
+    stale_evidence_usage: dict[str, object]
+    prompt_pressure_refusal: dict[str, object]
+    malformed_trace_records: tuple[dict[str, object], ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return _json_ready(
+            {
+                "read_only": self.read_only,
+                "generated_at": self.generated_at,
+                "assistant_operability": self.assistant_operability,
+                "citation_completeness": self.citation_completeness,
+                "unresolved_rate": self.unresolved_rate,
+                "acceptance_rate": self.acceptance_rate,
+                "correction_rate": self.correction_rate,
+                "stale_evidence_usage": self.stale_evidence_usage,
+                "prompt_pressure_refusal": self.prompt_pressure_refusal,
+                "malformed_trace_records": self.malformed_trace_records,
+            }
+        )
+
+
+@dataclass(frozen=True)
 class AlertDetailSnapshot:
     read_only: bool
     alert_id: str
@@ -494,6 +524,7 @@ class DoctorSnapshot:
 __all__ = [
     "ActionReviewDetailSnapshot",
     "AITraceReviewQueueSnapshot",
+    "AIQualityMetricsSnapshot",
     "AdvisoryInspectionSnapshot",
     "AlertDetailSnapshot",
     "AnalystAssistantContextSnapshot",

--- a/control-plane/aegisops/control_plane/service.py
+++ b/control-plane/aegisops/control_plane/service.py
@@ -68,7 +68,6 @@ from .runtime.service_snapshots import (
     AnalystQueueSnapshot,
     AuthenticatedRuntimePrincipal,
     CaseDetailSnapshot,
-    AIQualityMetricsSnapshot,
     LiveAssistantWorkflowSnapshot,
     ReadinessDiagnosticsSnapshot,
     RecommendationDraftSnapshot,
@@ -897,9 +896,6 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
 
     def inspect_analyst_queue(self) -> AnalystQueueSnapshot:
         return self._operator_inspection_read_surface.inspect_analyst_queue()
-
-    def inspect_ai_quality_metrics(self) -> AIQualityMetricsSnapshot:
-        return self._operator_inspection_read_surface.inspect_ai_quality_metrics()
 
     def inspect_alert_detail(self, alert_id: str) -> AlertDetailSnapshot:
         return self._operator_inspection_read_surface.inspect_alert_detail(alert_id)

--- a/control-plane/aegisops/control_plane/service.py
+++ b/control-plane/aegisops/control_plane/service.py
@@ -68,6 +68,7 @@ from .runtime.service_snapshots import (
     AnalystQueueSnapshot,
     AuthenticatedRuntimePrincipal,
     CaseDetailSnapshot,
+    AIQualityMetricsSnapshot,
     LiveAssistantWorkflowSnapshot,
     ReadinessDiagnosticsSnapshot,
     RecommendationDraftSnapshot,
@@ -896,6 +897,9 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
 
     def inspect_analyst_queue(self) -> AnalystQueueSnapshot:
         return self._operator_inspection_read_surface.inspect_analyst_queue()
+
+    def inspect_ai_quality_metrics(self) -> AIQualityMetricsSnapshot:
+        return self._operator_inspection_read_surface.inspect_ai_quality_metrics()
 
     def inspect_alert_detail(self, alert_id: str) -> AlertDetailSnapshot:
         return self._operator_inspection_read_surface.inspect_alert_detail(alert_id)

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -576,11 +576,16 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             "prompt_pressure_records": 1,
             "prompt_pressure_ratio": 0.2,
         })
-        malformed_trace_ids = {
-            malformed["ai_trace_id"] for malformed in payload["malformed_trace_records"]
+        malformed_trace_records = {
+            malformed["ai_trace_id"]: malformed for malformed in payload["malformed_trace_records"]
         }
-        self.assertIn("ai-trace-quality-malformed-001", malformed_trace_ids)
-        self.assertIn("ai-trace-quality-unresolved-001", malformed_trace_ids)
+        self.assertIn("ai-trace-quality-malformed-001", malformed_trace_records)
+        self.assertIn("ai-trace-quality-unresolved-001", malformed_trace_records)
+        malformed = malformed_trace_records["ai-trace-quality-malformed-001"]
+        self.assertEqual(
+            set(malformed["missing_required_fields"]),
+            {"registered_tool_id", "citations"},
+        )
 
     def test_cli_ai_quality_metrics_missing_citation_is_explicit(self) -> None:
         _, service, promoted_case, evidence_id, _ = (

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -423,6 +423,251 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
         self.assertIn("AI trace review queue requires", stderr.getvalue())
         self.assertIn("missing registered_tool_id, citations", stderr.getvalue())
 
+    def test_cli_renders_ai_quality_metrics(self) -> None:
+        _, service, promoted_case, evidence_id, _ = (
+            self._build_phase19_in_scope_case()
+        )
+        common_linkage = {
+            "source_case_id": promoted_case.case_id,
+            "registered_agent_id": "agent-governed-summary-001",
+            "registered_tool_id": "tool-case-summary-001",
+            "reviewed_record_family": "case",
+            "reviewed_record_id": promoted_case.case_id,
+            "expiration_posture": "inherits_reviewed_record_retention",
+        }
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-quality-accepted-001",
+                subject_linkage={
+                    **common_linkage,
+                    "citations": (promoted_case.case_id, evidence_id),
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-60-quality-v1",
+                generated_at=datetime(2026, 5, 13, 9, 0, tzinfo=timezone.utc),
+                material_input_refs=(evidence_id,),
+                reviewer_identity="analyst-001",
+                lifecycle_state="accepted_for_reference",
+                assistant_advisory_draft={
+                    "status": "ready",
+                    "review_state": "accepted",
+                },
+            )
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-quality-rejected-001",
+                subject_linkage={
+                    **common_linkage,
+                    "citations": (promoted_case.case_id,),
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-60-quality-v1",
+                generated_at=datetime(2026, 5, 13, 9, 5, tzinfo=timezone.utc),
+                material_input_refs=(promoted_case.case_id,),
+                reviewer_identity="analyst-001",
+                lifecycle_state="rejected_for_reference",
+                assistant_advisory_draft={
+                    "status": "ready",
+                    "review_state": "rejected",
+                },
+            )
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-quality-corrected-001",
+                subject_linkage={
+                    **common_linkage,
+                    "citations": (promoted_case.case_id,),
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-60-quality-v1",
+                generated_at=datetime(2026, 5, 13, 9, 10, tzinfo=timezone.utc),
+                material_input_refs=(promoted_case.case_id,),
+                reviewer_identity="analyst-001",
+                lifecycle_state="accepted_for_reference",
+                assistant_advisory_draft={
+                    "status": "ready",
+                    "review_state": "corrected",
+                },
+            )
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-quality-unresolved-001",
+                subject_linkage={
+                    **common_linkage,
+                    "citations": (),
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-60-quality-v1",
+                generated_at=datetime(2026, 5, 13, 9, 15, tzinfo=timezone.utc),
+                material_input_refs=("   ",),
+                reviewer_identity="analyst-001",
+                lifecycle_state="under_review",
+                assistant_advisory_draft={
+                    "status": "unresolved",
+                    "review_state": "unresolved",
+                    "unresolved_reasons": (
+                        "provider_generation_failed",
+                        "missing_supporting_citations",
+                        "stale_evidence",
+                        "prompt_injection_attempt",
+                    ),
+                },
+            )
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-quality-malformed-001",
+                subject_linkage={
+                    "source_case_id": promoted_case.case_id,
+                    "registered_agent_id": "agent-governed-summary-001",
+                    "reviewed_record_family": "case",
+                    "reviewed_record_id": promoted_case.case_id,
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-60-quality-v1",
+                generated_at=datetime(2026, 5, 13, 9, 20, tzinfo=timezone.utc),
+                material_input_refs=("   ",),
+                reviewer_identity="analyst-001",
+                lifecycle_state="accepted_for_reference",
+                assistant_advisory_draft={
+                    "status": "ready",
+                    "review_state": "accepted",
+                },
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(["inspect-ai-quality-metrics"], stdout=stdout, service=service)
+        payload = json.loads(stdout.getvalue())
+
+        self.assertTrue(payload["read_only"])
+        self.assertEqual(payload["assistant_operability"]["enablement"], "enabled")
+        self.assertEqual(payload["citation_completeness"], {
+            "total_records": 5,
+            "complete_citation_records": 3,
+            "missing_citation_records": 2,
+            "completeness_ratio": 0.6,
+        })
+        self.assertEqual(payload["unresolved_rate"], {
+            "total_records": 5,
+            "unresolved_records": 1,
+            "unresolved_ratio": 0.2,
+        })
+        self.assertEqual(payload["acceptance_rate"], {
+            "total_records": 5,
+            "accepted_records": 2,
+            "acceptance_ratio": 0.4,
+        })
+        self.assertEqual(payload["correction_rate"], {
+            "total_records": 5,
+            "corrected_records": 1,
+            "correction_ratio": 0.2,
+        })
+        self.assertEqual(payload["stale_evidence_usage"], {
+            "total_records": 5,
+            "stale_evidence_records": 1,
+            "stale_evidence_ratio": 0.2,
+        })
+        self.assertEqual(payload["prompt_pressure_refusal"], {
+            "total_records": 5,
+            "prompt_pressure_records": 1,
+            "prompt_pressure_ratio": 0.2,
+        })
+        malformed_trace_ids = {
+            malformed["ai_trace_id"] for malformed in payload["malformed_trace_records"]
+        }
+        self.assertIn("ai-trace-quality-malformed-001", malformed_trace_ids)
+        self.assertIn("ai-trace-quality-unresolved-001", malformed_trace_ids)
+
+    def test_cli_ai_quality_metrics_missing_citation_is_explicit(self) -> None:
+        _, service, promoted_case, evidence_id, _ = (
+            self._build_phase19_in_scope_case()
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-quality-missing-citation-001",
+                subject_linkage={
+                    "source_case_id": promoted_case.case_id,
+                    "registered_agent_id": "agent-governed-summary-001",
+                    "registered_tool_id": "tool-case-summary-001",
+                    "reviewed_record_family": "case",
+                    "reviewed_record_id": promoted_case.case_id,
+                    "citations": (),
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-60-quality-v1",
+                generated_at=datetime(2026, 5, 13, 9, 25, tzinfo=timezone.utc),
+                material_input_refs=("   ",),
+                reviewer_identity="analyst-001",
+                lifecycle_state="accepted_for_reference",
+                assistant_advisory_draft={"status": "ready", "review_state": "accepted"},
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(["inspect-ai-quality-metrics"], stdout=stdout, service=service)
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["citation_completeness"]["missing_citation_records"], 1)
+        self.assertEqual(payload["citation_completeness"]["completeness_ratio"], 0.0)
+        self.assertEqual(len(payload["malformed_trace_records"]), 1)
+        malformed = payload["malformed_trace_records"][0]
+        self.assertEqual(malformed["missing_required_fields"], ["citations"])
+        self.assertIn("citations", malformed["missing_required_fields_text"])
+
+    def test_cli_renders_ai_quality_metrics_for_degraded_and_disabled_ai_posture(
+        self,
+    ) -> None:
+        reviewed_record_id = "case-quality-posture-001"
+        for posture in ("degraded", "disabled"):
+            with self.subTest(ai_enablement_posture=posture):
+                store, _ = make_store()
+                service = AegisOpsControlPlaneService(
+                    RuntimeConfig(
+                        postgres_dsn="postgresql://control-plane.local/aegisops",
+                        ai_enablement_posture=posture,
+                    ),
+                    store=store,
+                )
+                service.persist_record(
+                    AITraceRecord(
+                        ai_trace_id=f"ai-trace-quality-{posture}-001",
+                        subject_linkage={
+                            "source_case_id": reviewed_record_id,
+                            "registered_agent_id": "agent-governed-summary-001",
+                            "registered_tool_id": "tool-case-summary-001",
+                            "reviewed_record_family": "case",
+                            "reviewed_record_id": reviewed_record_id,
+                            "citations": (reviewed_record_id,),
+                        },
+                        model_identity="gpt-5.4",
+                        prompt_version="phase-60-quality-v1",
+                        generated_at=datetime(2026, 5, 13, 9, 30, tzinfo=timezone.utc),
+                        material_input_refs=(reviewed_record_id,),
+                        reviewer_identity="analyst-001",
+                        lifecycle_state="accepted_for_reference",
+                        assistant_advisory_draft={
+                            "status": "ready",
+                            "review_state": "accepted",
+                        },
+                    )
+                )
+
+                stdout = io.StringIO()
+                main.main(["inspect-ai-quality-metrics"], stdout=stdout, service=service)
+                payload = json.loads(stdout.getvalue())
+
+                self.assertEqual(payload["assistant_operability"]["enablement"], posture)
+                if posture == "disabled":
+                    self.assertEqual(payload["assistant_operability"]["readiness"], "not_applicable")
+                    self.assertEqual(payload["assistant_operability"]["availability"], "unavailable")
+                else:
+                    self.assertEqual(payload["assistant_operability"]["readiness"], "degraded")
+                    self.assertEqual(payload["assistant_operability"]["availability"], "unavailable")
+
     def test_http_ai_trace_review_queue_reports_validation_error_as_bad_request(self) -> None:
         store, _ = make_store()
         service = AegisOpsControlPlaneService(
@@ -493,6 +738,82 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 payload = json.loads(raised.exception.read().decode("utf-8"))
                 self.assertEqual(payload["error"], "invalid_request")
                 self.assertIn("AI trace review queue requires", payload["message"])
+            finally:
+                if servers:
+                    servers[0].shutdown()
+                thread.join(1)
+
+    def test_http_ai_quality_metrics(self) -> None:
+        store, _ = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(
+                host="127.0.0.1",
+                port=0,
+                postgres_dsn="postgresql://control-plane.local/aegisops",
+                wazuh_ingest_shared_secret="reviewed-shared-secret",  # noqa: S106 - test fixture secret
+                wazuh_ingest_reverse_proxy_secret="reviewed-proxy-secret",  # noqa: S106 - test fixture secret
+            ),
+            store=store,
+        )
+        service.persist_record(
+            AITraceRecord(
+                ai_trace_id="ai-trace-quality-http-001",
+                subject_linkage={
+                    "source_case_id": "case-001",
+                    "registered_agent_id": "agent-governed-summary-001",
+                    "registered_tool_id": "tool-case-summary-001",
+                    "reviewed_record_family": "case",
+                    "reviewed_record_id": "case-001",
+                    "citations": ("case-001",),
+                },
+                model_identity="gpt-5.4",
+                prompt_version="phase-60-quality-v1",
+                generated_at=datetime(2026, 5, 13, 9, 35, tzinfo=timezone.utc),
+                material_input_refs=("case-001",),
+                reviewer_identity="analyst-001",
+                lifecycle_state="accepted_for_reference",
+                assistant_advisory_draft={
+                    "status": "ready",
+                    "review_state": "accepted",
+                },
+            )
+        )
+        servers: list[main.ThreadingHTTPServer] = []
+
+        class RecordingServer(main.ThreadingHTTPServer):
+            def __init__(self, server_address: tuple[str, int], handler_class: type) -> None:
+                super().__init__(server_address, handler_class)
+                servers.append(self)
+
+        with mock.patch.object(main, "ThreadingHTTPServer", RecordingServer), self._mock_authenticated_surface_access(
+            service,
+            principal=REVIEWED_ANALYST_PRINCIPAL,
+        ):
+            thread = threading.Thread(
+                target=main.run_control_plane_service,
+                args=(service,),
+                daemon=True,
+            )
+            thread.start()
+            try:
+                for _ in range(100):
+                    if servers:
+                        break
+                    thread.join(0.01)
+                self.assertTrue(servers, "expected test HTTP server to start")
+
+                base_url = f"http://127.0.0.1:{servers[0].server_port}"
+                response = json.loads(
+                    request.urlopen(  # noqa: S310 - local in-process test HTTP server
+                        f"{base_url}/inspect-ai-quality-metrics",
+                        timeout=2,
+                    )
+                    .read()
+                    .decode("utf-8")
+                )
+                self.assertTrue(response["read_only"])
+                self.assertEqual(response["assistant_operability"]["enablement"], "enabled")
+                self.assertEqual(response["acceptance_rate"]["total_records"], 1)
             finally:
                 if servers:
                     servers[0].shutdown()


### PR DESCRIPTION
Closes #1277
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed a focused checkpoint for issue **#1277** with AI quality metrics reporting as subordinate read-only inspection evidence, plus tests.

Commit: `6237b44` — “Add AI quality metrics inspection surfaces and focused tests”.

What changed:
- Added `AIQualityMetricsSnapshot` in `service_snapshots.py`
- Added `inspect_ai_quality_metrics()` in read surface and service facade
- Wired CLI command: `inspect-ai-quality-metrics`
- Added HTTP endpoint: `/inspect-ai-quality-metrics`
- Added protected route role mapping for read-only operator inspection access
- Added focused tests for:
  - normal + mixed trace metrics
  - explicit missing-citation handling
  - degraded/disabled AI operability reporting
  - HTTP route success path

Journal update:
- Updated `.codex-supervisor/issues/1277/issue-journal.md` `Codex Working Notes` with hypothesis, changes, blockers, verification gap, touched files, rollback concern, and last command.

Summary: Added repo-owned AI quality metrics reporting surface (citation completeness, unresolved/acceptance/correction/stale/prompt-pressure metrics), kept it as evidence/reporting only, and implemented focused regression coverage; committed as checkpoint.
State hint: implementing
Blocked reason: none
Tests: Ran focused `python3 -m unittest` cases in `test_cli_inspection_workflow_family` for metrics + existing AI trace queue regression cases; all passed.
Failure signature: none
Next action: Run issue-lint for #1277 (+ Epic #1269 if neede...