### PR TITLE
61.1: Add minimum source catalog contract (#1289)

### DIFF
--- a/control-plane/tests/test_phase61_source_catalog_contract.py
+++ b/control-plane/tests/test_phase61_source_catalog_contract.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+def _doc_path(relative_path: str) -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[2] / relative_path
+
+
+class Phase61SourceCatalogContractTests(unittest.TestCase):
+    catalog_doc = _doc_path("docs/phase-61-minimum-source-catalog-contract.md")
+    validation_doc = _doc_path("docs/phase-61-1-source-catalog-contract-validation.md")
+    github_pkg = _doc_path("docs/source-families/github-audit/onboarding-package.md")
+    entra_pkg = _doc_path("docs/source-families/entra-id/onboarding-package.md")
+    m365_pkg = _doc_path("docs/source-families/microsoft-365-audit/onboarding-package.md")
+    windows_pkg = _doc_path("docs/source-families/windows-security-and-endpoint/onboarding-package.md")
+
+    def test_phase61_catalog_document_exists(self) -> None:
+        for path in (
+            self.catalog_doc,
+            self.validation_doc,
+            self.github_pkg,
+            self.entra_pkg,
+            self.m365_pkg,
+            self.windows_pkg,
+        ):
+            self.assertTrue(path.exists(), f"expected {path} to exist")
+
+    def test_phase61_catalog_lists_minimum_families_and_key_fields(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+
+        required_family_headers = (
+            "`wazuh_detection` (Wazuh manager and agent origin telemetry)",
+            "`github_audit`",
+            "`microsoft_365_audit`",
+            "`entra_id`",
+            "`windows_security_endpoint`",
+        )
+
+        required_terms = (
+            "Reviewed owner",
+            "Authority posture",
+            "Evidence linkage",
+            "Source-health requirements",
+            "Explicit limitations",
+        )
+
+        for family_header in required_family_headers:
+            self.assertIn(family_header, catalog_text)
+
+        for term in required_terms:
+            self.assertIn(term, catalog_text)
+
+    def test_phase61_catalog_boundedness_rules_are_explicit(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+
+        bounded_terms = (
+            "This catalog must stay bounded to the five families above.",
+            "The catalog must reject claims that broaden into marketplace",
+            "Source-native alerts, statuses, and parser fields remain subordinate",
+            "No broad endpoint market",
+            "No raw Wazuh replacement",
+        )
+        for term in bounded_terms:
+            self.assertIn(term, catalog_text)
+
+    def test_phase61_catalog_rejects_out_of_scope_expansion(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+
+        forbidden_terms = (
+            "Phase 62",
+            "Phase 66",
+            "Beta",
+            "RC",
+            "GA",
+            "commercial replacement readiness",
+            "multi-site",
+            "raw SIEM replacement",
+            "broad SIEM source marketplace",
+            "broad source-marketplace",
+            "marketplace",
+        )
+        for term in forbidden_terms:
+            self.assertIn(
+                term,
+                catalog_text,
+                msg=(
+                    f"bounded catalog must explicitly reject out-of-scope claim: {term}"
+                ),
+            )
+
+    def test_phase61_validation_file_states_pass(self) -> None:
+        validation_text = self.validation_doc.read_text(encoding="utf-8")
+
+        required_headings = (
+            "# Phase 61.1 Source Catalog Contract Validation",
+            "- Validation status: PASS",
+            "## Required artifacts",
+            "## Outcome",
+            "## Cross-link Review",
+            "## Deviations",
+            "- No deviations.",
+            "Verification commands:",
+            "Run `bash scripts/verify-phase-61-1-source-catalog-contract.sh`.",
+        )
+        for heading in required_headings:
+            self.assertIn(heading, validation_text)
+
+    def test_phase61_out_of_scope_boundaries_are_explicit(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+
+        out_of_scope_terms = (
+            "Phase 62 automation breadth",
+            "Phase 66 RC proof",
+            "Beta/RC/GA",
+            "Source profile runtime onboarding",
+            "live source enrollment",
+            "live credentials",
+        )
+        for term in out_of_scope_terms:
+            self.assertIn(term, catalog_text)
+
+        validation_text = self.validation_doc.read_text(encoding="utf-8")
+        for term in (
+            "No Phase 62 automation breadth",
+            "no multi-site source management",
+            "no Phase 66 RC proof",
+            "no Beta/RC/GA claims",
+            "no commercial replacement readiness claim",
+        ):
+            self.assertIn(term, validation_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/phase-61-1-source-catalog-contract-validation.md
+++ b/docs/phase-61-1-source-catalog-contract-validation.md
@@ -1,0 +1,36 @@
+# Phase 61.1 Source Catalog Contract Validation
+
+- Validation date: 2026-05-15
+- Validation scope: Phase 61.1 minimum source catalog contract boundedness, authority posture, source-family coverage, and negative expansion rejection.
+- Baseline references: `docs/phase-61-minimum-source-catalog-contract.md`, `docs/source-onboarding-contract.md`, `docs/phase-14-identity-rich-source-family-design.md`, `docs/source-families/windows-security-and-endpoint/onboarding-package.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`.
+- Verification commands: `bash scripts/verify-phase-61-1-source-catalog-contract.sh`.
+- Validation status: PASS
+
+## Required artifacts
+
+- `docs/phase-61-minimum-source-catalog-contract.md`
+- `docs/source-families/github-audit/onboarding-package.md`
+- `docs/source-families/entra-id/onboarding-package.md`
+- `docs/source-families/microsoft-365-audit/onboarding-package.md`
+- `docs/source-families/windows-security-and-endpoint/onboarding-package.md`
+
+## Outcome
+
+The minimum catalog now explicitly covers the five minimum source families/pathways required for this phase: Wazuh manager/agents, GitHub audit, Entra ID, Microsoft 365 audit, and Windows endpoint detection-ready path.
+
+The catalog enforces authority-bounded behavior for source-native evidence, explicit missing-owner/health failure boundaries, and explicit rejection of broad market/replacement expansion.
+
+## Cross-link Review
+
+The contract remains aligned to `docs/source-onboarding-contract.md`, `docs/phase-14-identity-rich-source-family-design.md`, and `docs/phase-51-6-authority-boundary-negative-test-policy.md` for authority-boundary and authority-fail-closed expectations.
+
+## Deviations
+
+- No deviations.
+
+## Non-goals kept in scope boundaries
+
+- No Phase 62 automation breadth, no multi-site source management, no Phase 66 RC proof, no Beta/RC/GA claims, no commercial replacement readiness claim.
+- No broad source marketplace expansion, no raw SIEM replacement, no source-native authority shortcut for alert/alert workflow truth.
+
+- Run `bash scripts/verify-phase-61-1-source-catalog-contract.sh`.

--- a/docs/phase-61-minimum-source-catalog-contract.md
+++ b/docs/phase-61-minimum-source-catalog-contract.md
@@ -1,0 +1,43 @@
+# AegisOps Phase 61.1 Minimum Source Catalog Contract
+
+## 1. Purpose
+
+Phase 61 defines the minimum source catalog that Phase 61.1 accepts as reviewed source families for bounded SIEM replacement posture. It documents the required evidence, owner, source-health, authority, and limitation fields for each family before downstream detection and operator workflows can depend on it.
+
+This contract keeps Wazuh as the detection substrate and AegisOps as workflow authority.
+
+## 2. Approved Source Catalog Entries
+
+| Source Family | Reviewed owner | Authority posture | Evidence linkage | Source-health requirements | Explicit limitations |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| `wazuh_detection` (Wazuh manager and agent origin telemetry) | IT Operations, Information Systems Department | Wazuh alerts remain a reviewed detection substrate only. Wazuh status, manager status, or decoder status is subordinate evidence and does not become AegisOps alert, case, approval, action request, execution, reconciliation, audit, release, gate, or closeout truth. | Required fixtures: `control-plane/tests/fixtures/wazuh/agent-origin-alert.json`, `control-plane/tests/fixtures/wazuh/manager-origin-alert.json`; parser/provenance fields `rule.id`, `rule.level`, `rule.description`, `decoder.name`, `location`, `timestamp`; required reviewed correlation fields include accountable source identity, `agent.id`/`manager.name`, and `data.source_family`. | If `source_family` is `wazuh_detection`, adapter-level required provenance fields must remain present and verified (`data.product_profile`, `data.source_system == "wazuh"`, `data.source_id`, `data.wazuh_manager_id`, `data.wazuh_rule_id`, `data.wazuh_rule_level`, `data.ingest_channel`, `data.admission_channel`, `data.secret_custody_reference`, `data.proxy_route`, `data.reviewed_by`, and `data.event_timestamp`). | Not a source-marketplace claim. No standalone SIEM replacement, no raw Wazuh-to-workflow truth shortcuts, no production onboarding approval, and no direct source-owned workflow authority in this catalog slice. |
+| `github_audit` | IT Operations, Information Systems Department | `reviewed_context.source.source_family = github_audit` is source evidence context only. It supports analyst workload and detection prerequisites but does not become AegisOps workflow truth. | Onboarding package: `docs/source-families/github-audit/onboarding-package.md`; reviewed fixture: `control-plane/tests/fixtures/wazuh/github-audit-alert.json`; triage posture: `docs/source-families/github-audit/analyst-triage-runbook.md`. | Source-family acceptance requires explicit `source_family = "github_audit"`; accepted evidence coverage must include accountable source identity, actor identity, target identity, repository/org context, privilege-change context, and provenance fields. Missing ownership or malformed payload fields must keep the path rejected or reviewed as exception only. | Detection activation remains blocked until separate detector review and rollout review approve each candidate. No raw GitHub API actioning, no non-audit GitHub telemetry family expansion, and no claim of production-wide source marketplace scope. |
+| `microsoft_365_audit` | IT Operations, Information Systems Department | `reviewed_context.source.source_family = microsoft_365_audit` is reviewed evidence context only. It cannot grant AegisOps alert/case/action/reconciliation truth by itself. | Onboarding package: `docs/source-families/microsoft-365-audit/onboarding-package.md`; reviewed fixture: `control-plane/tests/fixtures/wazuh/microsoft-365-audit-alert.json`; triage posture: `docs/source-families/microsoft-365-audit/analyst-triage-runbook.md`. | Source-system and parser linkage must preserve tenant context, actor/target identity, authentication context, and parser/provenance linkage (rule/decode/time path) before detections may treat this family as a prerequisite. | This family remains `schema-reviewed` for Phase 61.1 and does not become automatically detection-ready for all Microsoft 365 workloads. No non-audit Microsoft 365 telemetry family expansion, no source-native status as workflow truth, no raw source actioning. |
+| `entra_id` | IT Operations, Information Systems Department | `reviewed_context.source.source_family = entra_id` is reviewed evidence context only. It remains advisory source context for workflow and case admission logic and never source truth. | Onboarding package: `docs/source-families/entra-id/onboarding-package.md`; reviewed fixture: `control-plane/tests/fixtures/wazuh/entra-id-alert.json`; triage posture: `docs/source-families/entra-id/analyst-triage-runbook.md`. | Source-system and parser linkage must preserve tenant/context + actor/target + request/correlation evidence and Wazuh provenance before any broader detection dependency is allowed. | Phase 61.1 accepts it as detection-ready but only within bounded evidence posture; no directory/action authority bypass, no non-audit Entra ID telemetry expansion, and no source-native workflow truth claim. |
+| `windows_security_endpoint` (Windows endpoint detection-ready path) | IT Operations, Information Systems Department | This is a Windows endpoint path entry mapped to `docs/source-families/windows-security-and-endpoint/onboarding-package.md`; it remains an evidence-path contract and does not grant direct workflow authority. | Onboarding package: `docs/source-families/windows-security-and-endpoint/onboarding-package.md`; reviewed fixtures: `ingest/replay/windows-security-and-endpoint/raw/*`, `ingest/replay/windows-security-and-endpoint/normalized/*`. | Windows endpoint path must preserve host identity, event classification, provenance, and timestamp semantics with explicit edge-case handling for missing actor and forwarded-timestamp cases before detections depend on those fields. | This family is bounded by explicit gaps: parser/version maturity, full process/network coverage, and remote-origin event continuity are out of scope in this slice. No broad endpoint market, no direct host-remediation actioning, and no workflow-truth authority inference from endpoint surface alone. |
+
+## 3. Catalog Boundedness Rules
+
+- This catalog must stay bounded to the five families above.
+- No raw SIEM replacement.
+- No raw Wazuh replacement of AegisOps workflow truth.
+- The catalog must reject claims that broaden into marketplace, replacement, or product-scope coverage.
+- No broad SIEM source marketplace expansion.
+- No broad source-marketplace expansion.
+- Source-native alerts, statuses, and parser fields remain subordinate evidence and cannot replace AegisOps record-chain truth.
+- Missing owner, missing source-health evidence, malformed provenance, or missing authority posture blocks admission of catalog claims for the slice.
+
+## 4. Out-of-scope for Phase 61.1
+
+- Phase 62 automation breadth, Phase 66 RC proof, Beta/RC/GA, commercial replacement readiness, raw SIEM replacement, raw Wazuh replacement of AegisOps workflow truth, and multi-site source management.
+- Source profile runtime onboarding, live credentials, and live source enrollment approval.
+
+## 5. Validation
+
+Run the Phase 61.1 source catalog verifier and focused tests before widening detector slices.
+
+- Run `bash scripts/verify-phase-61-1-source-catalog-contract.sh`.
+- Run `python3 -m unittest control-plane.tests.test_phase61_source_catalog_contract`.
+- Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.
+- Run `python3 -m unittest control-plane.tests.test_cross_boundary_negative_e2e_validation` with test subset for Wazuh source-bridge boundary failures.
+- Run `bash scripts/verify-publishable-path-hygiene.sh`.

--- a/scripts/verify-phase-61-1-source-catalog-contract.sh
+++ b/scripts/verify-phase-61-1-source-catalog-contract.sh
@@ -64,7 +64,7 @@ for phrase in "${required_validation_phrases[@]}"; do
   require_phrase "${validation_path}" "${phrase}"
 done
 
-python3 -m unittest control-plane.tests.test_phase61_source_catalog_contract >/tmp/phase61_source_catalog_tests.out
+(cd "${repo_root}" && python3 -m unittest control-plane.tests.test_phase61_source_catalog_contract) >/tmp/phase61_source_catalog_tests.out
 
 path_hygiene_stderr="${repo_root}/.tmp-phase61-path-hygiene.err"
 trap 'rm -f "${path_hygiene_stderr}"' EXIT

--- a/scripts/verify-phase-61-1-source-catalog-contract.sh
+++ b/scripts/verify-phase-61-1-source-catalog-contract.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+doc_path="${repo_root}/docs/phase-61-minimum-source-catalog-contract.md"
+validation_path="${repo_root}/docs/phase-61-1-source-catalog-contract-validation.md"
+policy_path="${repo_root}/docs/phase-51-6-authority-boundary-negative-test-policy.md"
+test_path="${repo_root}/control-plane/tests/test_phase61_source_catalog_contract.py"
+
+for path in "${doc_path}" "${validation_path}" "${policy_path}" "${test_path}"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing Phase 61 source catalog artifact: ${path}" >&2
+    exit 1
+  fi
+done
+
+require_phrase() {
+  local file_path="$1"
+  local expected="$2"
+  if ! grep -Fq -- "${expected}" "${file_path}"; then
+    echo "Missing Phase 61 source catalog statement in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+required_catalog_phrases=(
+  '# AegisOps Phase 61.1 Minimum Source Catalog Contract'
+  '## 2. Approved Source Catalog Entries'
+  '## 5. Validation'
+  '`wazuh_detection` (Wazuh manager and agent origin telemetry)'
+  '`github_audit`'
+  '`microsoft_365_audit`'
+  '`entra_id`'
+  '`windows_security_endpoint` (Windows endpoint detection-ready path)'
+  'Reviewed owner'
+  'Authority posture'
+  'Evidence linkage'
+  'Source-health requirements'
+  'Explicit limitations'
+  'This catalog must stay bounded to the five families above.'
+  'The catalog must reject claims that broaden into marketplace'
+  'No broad endpoint market'
+  'No raw SIEM replacement'
+  'Phase 62 automation breadth'
+)
+
+for phrase in "${required_catalog_phrases[@]}"; do
+  require_phrase "${doc_path}" "${phrase}"
+done
+
+required_validation_phrases=(
+  '# Phase 61.1 Source Catalog Contract Validation'
+  'Validation date:'
+  'Phase 61.1 minimum source catalog contract'
+  'Verification commands:'
+  'Run `bash scripts/verify-phase-61-1-source-catalog-contract.sh`.'
+  '- Validation status: PASS'
+  '## Deviations'
+  '- No deviations.'
+)
+
+for phrase in "${required_validation_phrases[@]}"; do
+  require_phrase "${validation_path}" "${phrase}"
+done
+
+python3 -m unittest control-plane.tests.test_phase61_source_catalog_contract >/tmp/phase61_source_catalog_tests.out
+
+path_hygiene_stderr="${repo_root}/.tmp-phase61-path-hygiene.err"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 61 source catalog absolute path usage detected" >&2
+  exit 1
+fi
+
+echo "Phase 61.1 source catalog contract and focused catalog tests pass."


### PR DESCRIPTION
Closes #1289
This PR was opened by codex-supervisor.
Latest Codex summary:

Summary: Added and committed Phase 61.1 minimum source catalog contract implementation with boundedness constraints and focused verification:
- `docs/phase-61-minimum-source-catalog-contract.md` (new)
- `docs/phase-61-1-source-catalog-contract-validation.md` (new)
- `control-plane/tests/test_phase61_source_catalog_contract.py` (new)
- `scripts/verify-phase-61-1-source-catalog-contract.sh` (new)
Commit: `2fa6df2`

State hint: blocked  
Blocked reason: verification  
Tests: `python3 -m unittest control-plane.tests.test_phase61_source_catalog_contract -v` (PASS), `bash scripts/verify-phase-61-1-source-catalog-contract.sh` (PASS), `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh` (PASS), `bash scripts/verify-publishable-path-hygiene.sh .` (PASS), `node dist/index.js issue-lint 1288 --config supervisor.config.codex.json` + `node dist/index.js issue-lint 1289 --config supervisor.config.codex.json` not runnable (`dist/index.js` missing); `npm run build` fails (`tsc: command not found`)  
Failure signature: `npm build blocked: dist/index.js missing; tsc: command not found`  
Next action: fix local Node toolchain/build path and rerun both issue-lint checks for `1288` and `1289`.