### PR TITLE
Add detector activation review UI

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.detectorActivationReview.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.detectorActivationReview.testSuite.tsx
@@ -14,15 +14,11 @@ const detectorLifecycleRecords = [
     source_catalog_entry: "docs/source-families/github-audit/onboarding-package.md",
     detector_identifier: "github-audit-impossible-travel",
     expected_signal_posture: "reviewed low-volume activation candidate",
-    expected_volume: "2-4 alerts per business day",
-    false_positive_review: "Reviewed against seven-day audit sample",
     review_cadence: "weekly",
     rollback_owner: "rollback-owner-candidate",
     disable_owner: "disable-owner-candidate",
-    next_review_at: "2026-05-22T09:00:00Z",
     lifecycle_audit_references: ["audit-evidence://candidate-001"],
     lifecycle_state: "candidate",
-    stale_display_state: false,
     source_native_lifecycle_state: "active",
   },
   {
@@ -32,15 +28,11 @@ const detectorLifecycleRecords = [
     source_catalog_entry: "docs/source-families/entra-id/onboarding-package.md",
     detector_identifier: "entra-id-risky-sign-in",
     expected_signal_posture: "staging with reviewed sampling",
-    expected_volume: "1-2 alerts per week",
-    false_positive_review: "Owner reviewed staging false positives",
     review_cadence: "weekly",
     rollback_owner: "rollback-owner-staging",
     disable_owner: "disable-owner-staging",
-    next_review_at: "2026-05-23T09:00:00Z",
     lifecycle_audit_references: ["audit-evidence://staging-001"],
     lifecycle_state: "staging",
-    stale_display_state: false,
   },
   {
     detector_lifecycle_id: "det-active-001",
@@ -49,15 +41,11 @@ const detectorLifecycleRecords = [
     source_catalog_entry: "docs/source-families/github-audit/onboarding-package.md",
     detector_identifier: "github-audit-owner-change",
     expected_signal_posture: "active reviewed signal posture",
-    expected_volume: "5 alerts per week",
-    false_positive_review: "Active review accepted with owner signoff",
     review_cadence: "monthly",
     rollback_owner: "rollback-owner-active",
     disable_owner: "disable-owner-active",
-    next_review_at: "2026-06-15T09:00:00Z",
     lifecycle_audit_references: ["audit-evidence://active-001"],
     lifecycle_state: "active",
-    stale_display_state: false,
   },
   {
     detector_lifecycle_id: "det-disabled-001",
@@ -66,16 +54,12 @@ const detectorLifecycleRecords = [
     source_catalog_entry: "docs/source-families/github-audit/onboarding-package.md",
     detector_identifier: "github-audit-disabled-noisy-rule",
     expected_signal_posture: "disabled after reviewed false-positive spike",
-    expected_volume: "disabled",
-    false_positive_review: "False-positive review exceeded tolerance",
     review_cadence: "monthly",
     rollback_owner: "rollback-owner-disabled",
     disable_owner: "disable-owner-disabled",
-    next_review_at: "2026-06-01T09:00:00Z",
     lifecycle_audit_references: ["audit-evidence://disabled-001"],
     lifecycle_state: "disabled",
     disabled_reason: "Reviewed noisy-rule disablement",
-    stale_display_state: false,
   },
   {
     detector_lifecycle_id: "det-rollback-001",
@@ -84,16 +68,12 @@ const detectorLifecycleRecords = [
     source_catalog_entry: "docs/source-families/entra-id/onboarding-package.md",
     detector_identifier: "entra-id-rollback-signin-rule",
     expected_signal_posture: "rollback after reviewed regression",
-    expected_volume: "rollback paused",
-    false_positive_review: "Rollback review found unstable signal",
     review_cadence: "weekly",
     rollback_owner: "rollback-owner-rollback",
     disable_owner: "disable-owner-rollback",
-    next_review_at: "2026-05-20T09:00:00Z",
     lifecycle_audit_references: ["audit-evidence://rollback-001"],
     lifecycle_state: "rollback",
     rollback_reason: "Reviewed rollback reason",
-    stale_display_state: false,
   },
   {
     detector_lifecycle_id: "det-overdue-001",
@@ -102,16 +82,12 @@ const detectorLifecycleRecords = [
     source_catalog_entry: "docs/source-families/github-audit/onboarding-package.md",
     detector_identifier: "github-audit-overdue-rule",
     expected_signal_posture: "review overdue",
-    expected_volume: "3 alerts per day",
-    false_positive_review: "False-positive review needs owner refresh",
     review_cadence: "weekly",
     rollback_owner: "rollback-owner-overdue",
     disable_owner: "disable-owner-overdue",
-    next_review_at: "2026-05-01T09:00:00Z",
     lifecycle_audit_references: ["audit-evidence://overdue-001"],
     lifecycle_state: "review-overdue",
     review_overdue_reason: "Next review missed by owner",
-    stale_display_state: false,
   },
 ] as const;
 
@@ -139,13 +115,14 @@ export function registerOperatorRoutesDetectorActivationReviewTests() {
         expect.stringContaining("/operator/detectors"),
       );
       expect(screen.getByText("detector-owner-candidate")).toBeInTheDocument();
-      expect(screen.getByText("2-4 alerts per business day")).toBeInTheDocument();
       expect(
-        screen.getByText("Reviewed against seven-day audit sample"),
+        screen.getByText("reviewed low-volume activation candidate"),
       ).toBeInTheDocument();
+      expect(screen.getAllByText("Expected volume").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("False-positive review").length).toBeGreaterThan(0);
       expect(screen.getByText("disable-owner-disabled")).toBeInTheDocument();
       expect(screen.getByText("rollback-owner-rollback")).toBeInTheDocument();
-      expect(screen.getByText("2026-05-01T09:00:00Z")).toBeInTheDocument();
+      expect(screen.getAllByText("Next review").length).toBeGreaterThan(0);
       expect(screen.getByText("Next review missed by owner")).toBeInTheDocument();
       for (const state of [
         "candidate",

--- a/apps/operator-ui/src/app/OperatorRoutes.detectorActivationReview.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.detectorActivationReview.testSuite.tsx
@@ -191,5 +191,40 @@ export function registerOperatorRoutesDetectorActivationReviewTests() {
       expect(screen.queryByText("det-malformed-state")).not.toBeInTheDocument();
       expect(screen.queryByText("source-active")).not.toBeInTheDocument();
     });
+
+    it("requests reviewed detector records without a pagination cap", async () => {
+      const manyDetectorRecords = Array.from({ length: 101 }, (_, index) => ({
+        ...detectorLifecycleRecords[0],
+        detector_identifier: `github-audit-candidate-${String(index).padStart(3, "0")}`,
+        detector_lifecycle_id: `det-candidate-${String(index).padStart(3, "0")}`,
+        lifecycle_audit_references: [`audit-evidence://candidate-${index}`],
+        owner: `detector-owner-${String(index).padStart(3, "0")}`,
+      }));
+      const fetchFn = createAuthorizedFetch({
+        "/inspect-records": {
+          records: manyDetectorRecords,
+          total_records: manyDetectorRecords.length,
+        },
+      });
+      const dependencies = createDefaultDependencies({ fetchFn });
+
+      renderOperatorRoute("/operator/detectors", dependencies);
+
+      await waitFor(() => {
+        expect(screen.getByText("detector-owner-100")).toBeInTheDocument();
+      });
+
+      const detectorCall = fetchFn.mock.calls.find(([url]) =>
+        String(url).startsWith("/inspect-records"),
+      );
+      expect(detectorCall).toBeDefined();
+      const [url] = detectorCall!;
+      const parsedUrl = new URL(String(url), "http://operator-ui.local");
+      expect(parsedUrl.searchParams.get("family")).toBe("detector_lifecycle");
+      expect(parsedUrl.searchParams.get("sort")).toBe("detector_identifier");
+      expect(parsedUrl.searchParams.get("order")).toBe("ASC");
+      expect(parsedUrl.searchParams.has("page")).toBe(false);
+      expect(parsedUrl.searchParams.has("per_page")).toBe(false);
+    });
   });
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.detectorActivationReview.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.detectorActivationReview.testSuite.tsx
@@ -1,0 +1,218 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createDefaultDependencies } from "./OperatorRoutes";
+import {
+  createAuthorizedFetch,
+  renderOperatorRoute,
+} from "./OperatorRoutes.testSupport";
+
+const detectorLifecycleRecords = [
+  {
+    detector_lifecycle_id: "det-candidate-001",
+    owner: "detector-owner-candidate",
+    source_family: "github_audit",
+    source_catalog_entry: "docs/source-families/github-audit/onboarding-package.md",
+    detector_identifier: "github-audit-impossible-travel",
+    expected_signal_posture: "reviewed low-volume activation candidate",
+    expected_volume: "2-4 alerts per business day",
+    false_positive_review: "Reviewed against seven-day audit sample",
+    review_cadence: "weekly",
+    rollback_owner: "rollback-owner-candidate",
+    disable_owner: "disable-owner-candidate",
+    next_review_at: "2026-05-22T09:00:00Z",
+    lifecycle_audit_references: ["audit-evidence://candidate-001"],
+    lifecycle_state: "candidate",
+    stale_display_state: false,
+    source_native_lifecycle_state: "active",
+  },
+  {
+    detector_lifecycle_id: "det-staging-001",
+    owner: "detector-owner-staging",
+    source_family: "entra_id",
+    source_catalog_entry: "docs/source-families/entra-id/onboarding-package.md",
+    detector_identifier: "entra-id-risky-sign-in",
+    expected_signal_posture: "staging with reviewed sampling",
+    expected_volume: "1-2 alerts per week",
+    false_positive_review: "Owner reviewed staging false positives",
+    review_cadence: "weekly",
+    rollback_owner: "rollback-owner-staging",
+    disable_owner: "disable-owner-staging",
+    next_review_at: "2026-05-23T09:00:00Z",
+    lifecycle_audit_references: ["audit-evidence://staging-001"],
+    lifecycle_state: "staging",
+    stale_display_state: false,
+  },
+  {
+    detector_lifecycle_id: "det-active-001",
+    owner: "detector-owner-active",
+    source_family: "github_audit",
+    source_catalog_entry: "docs/source-families/github-audit/onboarding-package.md",
+    detector_identifier: "github-audit-owner-change",
+    expected_signal_posture: "active reviewed signal posture",
+    expected_volume: "5 alerts per week",
+    false_positive_review: "Active review accepted with owner signoff",
+    review_cadence: "monthly",
+    rollback_owner: "rollback-owner-active",
+    disable_owner: "disable-owner-active",
+    next_review_at: "2026-06-15T09:00:00Z",
+    lifecycle_audit_references: ["audit-evidence://active-001"],
+    lifecycle_state: "active",
+    stale_display_state: false,
+  },
+  {
+    detector_lifecycle_id: "det-disabled-001",
+    owner: "detector-owner-disabled",
+    source_family: "github_audit",
+    source_catalog_entry: "docs/source-families/github-audit/onboarding-package.md",
+    detector_identifier: "github-audit-disabled-noisy-rule",
+    expected_signal_posture: "disabled after reviewed false-positive spike",
+    expected_volume: "disabled",
+    false_positive_review: "False-positive review exceeded tolerance",
+    review_cadence: "monthly",
+    rollback_owner: "rollback-owner-disabled",
+    disable_owner: "disable-owner-disabled",
+    next_review_at: "2026-06-01T09:00:00Z",
+    lifecycle_audit_references: ["audit-evidence://disabled-001"],
+    lifecycle_state: "disabled",
+    disabled_reason: "Reviewed noisy-rule disablement",
+    stale_display_state: false,
+  },
+  {
+    detector_lifecycle_id: "det-rollback-001",
+    owner: "detector-owner-rollback",
+    source_family: "entra_id",
+    source_catalog_entry: "docs/source-families/entra-id/onboarding-package.md",
+    detector_identifier: "entra-id-rollback-signin-rule",
+    expected_signal_posture: "rollback after reviewed regression",
+    expected_volume: "rollback paused",
+    false_positive_review: "Rollback review found unstable signal",
+    review_cadence: "weekly",
+    rollback_owner: "rollback-owner-rollback",
+    disable_owner: "disable-owner-rollback",
+    next_review_at: "2026-05-20T09:00:00Z",
+    lifecycle_audit_references: ["audit-evidence://rollback-001"],
+    lifecycle_state: "rollback",
+    rollback_reason: "Reviewed rollback reason",
+    stale_display_state: false,
+  },
+  {
+    detector_lifecycle_id: "det-overdue-001",
+    owner: "detector-owner-overdue",
+    source_family: "github_audit",
+    source_catalog_entry: "docs/source-families/github-audit/onboarding-package.md",
+    detector_identifier: "github-audit-overdue-rule",
+    expected_signal_posture: "review overdue",
+    expected_volume: "3 alerts per day",
+    false_positive_review: "False-positive review needs owner refresh",
+    review_cadence: "weekly",
+    rollback_owner: "rollback-owner-overdue",
+    disable_owner: "disable-owner-overdue",
+    next_review_at: "2026-05-01T09:00:00Z",
+    lifecycle_audit_references: ["audit-evidence://overdue-001"],
+    lifecycle_state: "review-overdue",
+    review_overdue_reason: "Next review missed by owner",
+    stale_display_state: false,
+  },
+] as const;
+
+export function registerOperatorRoutesDetectorActivationReviewTests() {
+  describe("detector activation review route", () => {
+    it("renders reviewed detector activation posture without trusting source-native active state", async () => {
+      const fetchFn = createAuthorizedFetch({
+        "/inspect-records": {
+          records: detectorLifecycleRecords,
+          total_records: detectorLifecycleRecords.length,
+        },
+      });
+      const dependencies = createDefaultDependencies({ fetchFn });
+
+      renderOperatorRoute("/operator/detectors", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Detector Activation Review" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole("menuitem", { name: "Detectors" })).toHaveAttribute(
+        "href",
+        expect.stringContaining("/operator/detectors"),
+      );
+      expect(screen.getByText("detector-owner-candidate")).toBeInTheDocument();
+      expect(screen.getByText("2-4 alerts per business day")).toBeInTheDocument();
+      expect(
+        screen.getByText("Reviewed against seven-day audit sample"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("disable-owner-disabled")).toBeInTheDocument();
+      expect(screen.getByText("rollback-owner-rollback")).toBeInTheDocument();
+      expect(screen.getByText("2026-05-01T09:00:00Z")).toBeInTheDocument();
+      expect(screen.getByText("Next review missed by owner")).toBeInTheDocument();
+      for (const state of [
+        "candidate",
+        "staging",
+        "active",
+        "disabled",
+        "rollback",
+        "review-overdue",
+      ]) {
+        expect(screen.getAllByText(state).length).toBeGreaterThan(0);
+      }
+      expect(
+        screen.getByText(
+          "Source-native active status is subordinate display context only.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /activate/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /disable/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /rollback/i })).toBeNull();
+
+      const detectorCall = fetchFn.mock.calls.find(([url]) =>
+        String(url).startsWith("/inspect-records"),
+      );
+      expect(detectorCall).toBeDefined();
+      const [url] = detectorCall!;
+      const parsedUrl = new URL(String(url), "http://operator-ui.local");
+      expect(parsedUrl.searchParams.get("family")).toBe("detector_lifecycle");
+    });
+
+    it("fails closed for missing owner, malformed lifecycle state, or stale display state", async () => {
+      const invalidRecords = [
+        {
+          ...detectorLifecycleRecords[0],
+          detector_lifecycle_id: "det-missing-owner",
+          owner: "",
+        },
+        {
+          ...detectorLifecycleRecords[0],
+          detector_lifecycle_id: "det-malformed-state",
+          lifecycle_state: "source-active",
+        },
+        {
+          ...detectorLifecycleRecords[0],
+          detector_lifecycle_id: "det-stale-display",
+          stale_display_state: true,
+        },
+      ];
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-records": {
+            records: invalidRecords,
+            total_records: invalidRecords.length,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/detectors", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Reviewed operator data could not be verified. The browser stayed fail-closed instead of rendering an untrusted record.",
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText("det-malformed-state")).not.toBeInTheDocument();
+      expect(screen.queryByText("source-active")).not.toBeInTheDocument();
+    });
+  });
+}

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -6,6 +6,7 @@ import { registerOperatorRoutesAuthAndShellTests } from "./OperatorRoutes.authAn
 import { registerOperatorRoutesBusinessHoursHandoffTests } from "./OperatorRoutes.businessHoursHandoff.testSuite";
 import { registerOperatorRoutesCaseworkTests } from "./OperatorRoutes.casework.testSuite";
 import { registerOperatorRoutesControlPlaneTests } from "./OperatorRoutes.controlPlane.testSuite";
+import { registerOperatorRoutesDetectorActivationReviewTests } from "./OperatorRoutes.detectorActivationReview.testSuite";
 import { registerOperatorRoutesFirstLoginChecklistTests } from "./OperatorRoutes.firstLoginChecklist.testSuite";
 import { registerOperatorRoutesTodayTests } from "./OperatorRoutes.today.testSuite";
 
@@ -19,6 +20,7 @@ describe("OperatorRoutes", () => {
   registerOperatorRoutesCaseworkTests();
   registerOperatorRoutesAssistantTests();
   registerOperatorRoutesControlPlaneTests();
+  registerOperatorRoutesDetectorActivationReviewTests();
   registerOperatorRoutesFirstLoginChecklistTests();
   registerOperatorRoutesTodayTests();
   registerOperatorRoutesBusinessHoursHandoffTests();

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -19,6 +19,7 @@ import HandshakeOutlinedIcon from "@mui/icons-material/HandshakeOutlined";
 import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
 import PlaylistAddCheckOutlinedIcon from "@mui/icons-material/PlaylistAddCheckOutlined";
 import RuleFolderOutlinedIcon from "@mui/icons-material/RuleFolderOutlined";
+import SecurityOutlinedIcon from "@mui/icons-material/SecurityOutlined";
 import SensorsOutlinedIcon from "@mui/icons-material/SensorsOutlined";
 import TodayOutlinedIcon from "@mui/icons-material/TodayOutlined";
 import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
@@ -86,6 +87,8 @@ const CaseDetailPage =
   lazyOperatorConsolePage("CaseDetailPage") as unknown as typeof import("./operatorConsolePages").CaseDetailPage;
 const CaseIndexPage =
   lazyOperatorConsolePage("CaseIndexPage") as unknown as typeof import("./operatorConsolePages").CaseIndexPage;
+const DetectorActivationReviewPage =
+  lazyOperatorConsolePage("DetectorActivationReviewPage") as unknown as typeof import("./operatorConsolePages").DetectorActivationReviewPage;
 const FirstLoginChecklistPage =
   lazyOperatorConsolePage("FirstLoginChecklistPage") as unknown as typeof import("./operatorConsolePages").FirstLoginChecklistPage;
 const ProvenancePage =
@@ -204,6 +207,11 @@ function OperatorMenu({
         leftIcon={<SensorsOutlinedIcon />}
         primaryText="Sources"
         to={buildOperatorShellPath(basePath, "sources")}
+      />
+      <Menu.Item
+        leftIcon={<SecurityOutlinedIcon />}
+        primaryText="Detectors"
+        to={buildOperatorShellPath(basePath, "detectors")}
       />
       {showActionReview ? (
         <Menu.Item
@@ -547,6 +555,7 @@ function OperatorShellContent({
           <Route element={<ReadinessPage />} path="readiness" />
           <Route element={<ReadinessPage />} path="health" />
           <Route element={<ReadinessPage />} path="sources" />
+          <Route element={<DetectorActivationReviewPage />} path="detectors" />
           <Route
             element={
               canViewActionReview ? (

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -10,6 +10,7 @@ export {
   CaseIndexPage,
   ProvenanceIndexPage,
 } from "./operatorConsolePages/drilldownIndexPages";
+export { DetectorActivationReviewPage } from "./operatorConsolePages/detectorActivationReviewPages";
 export { ActionReviewPage } from "./operatorConsolePages/actionReviewPages";
 export {
   AITraceReviewQueuePage,

--- a/apps/operator-ui/src/app/operatorConsolePages/detectorActivationReviewPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/detectorActivationReviewPages.tsx
@@ -1,0 +1,164 @@
+import {
+  Alert,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/material";
+import {
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  PageFrame,
+  QueryStateNotice,
+  StatusStrip,
+  ValueList,
+  asString,
+  asStringArray,
+  statusTone,
+  useOperatorList,
+  type UnknownRecord,
+} from "./shared";
+
+function reasonForLifecycle(record: UnknownRecord) {
+  const lifecycleState = asString(record.lifecycle_state);
+  if (lifecycleState === "disabled") {
+    return asString(record.disabled_reason);
+  }
+  if (lifecycleState === "rollback") {
+    return asString(record.rollback_reason);
+  }
+  if (lifecycleState === "review-overdue") {
+    return asString(record.review_overdue_reason);
+  }
+
+  return null;
+}
+
+function DetectorLifecycleCard({ record }: { record: UnknownRecord }) {
+  const lifecycleState = asString(record.lifecycle_state);
+  const sourceNativeState = asString(record.source_native_lifecycle_state);
+  const reason = reasonForLifecycle(record);
+  const auditReferences = asStringArray(record.lifecycle_audit_references);
+
+  return (
+    <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider" }}>
+      <CardContent>
+        <Stack spacing={2}>
+          <Stack
+            alignItems={{ xs: "flex-start", sm: "center" }}
+            direction={{ xs: "column", sm: "row" }}
+            justifyContent="space-between"
+            spacing={1}
+          >
+            <Stack spacing={0.5}>
+              <Typography fontWeight={700}>
+                {asString(record.detector_identifier)}
+              </Typography>
+              <Typography color="text.secondary" variant="body2">
+                {asString(record.detector_lifecycle_id)}
+              </Typography>
+            </Stack>
+            <Chip
+              color={statusTone(lifecycleState)}
+              label={lifecycleState}
+              size="small"
+              variant={statusTone(lifecycleState) === "default" ? "outlined" : "filled"}
+            />
+          </Stack>
+
+          <StatusStrip
+            values={[
+              ["Source", asString(record.source_family)],
+              ["Cadence", asString(record.review_cadence)],
+              ["Next review", asString(record.next_review_at)],
+            ]}
+          />
+
+          <ValueList
+            entries={[
+              ["Activation owner", asString(record.owner)],
+              ["Expected volume", asString(record.expected_volume)],
+              ["Expected signal posture", asString(record.expected_signal_posture)],
+              ["False-positive review", asString(record.false_positive_review)],
+              ["Disable owner", asString(record.disable_owner)],
+              ["Rollback owner", asString(record.rollback_owner)],
+              ["Next review", asString(record.next_review_at)],
+              ["Catalog entry", asString(record.source_catalog_entry)],
+              ["Reviewed audit references", auditReferences],
+            ]}
+          />
+
+          {reason ? (
+            <>
+              <Divider />
+              <Typography color="text.secondary" variant="body2">
+                {reason}
+              </Typography>
+            </>
+          ) : null}
+
+          {sourceNativeState ? (
+            <Alert severity="info" variant="outlined">
+              {`Source-native ${sourceNativeState} status is subordinate display context only.`}
+            </Alert>
+          ) : null}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function DetectorActivationReviewPage() {
+  const detectorRecords = useOperatorList(
+    "detectorActivationReview",
+    {},
+    {
+      field: "detector_identifier",
+      order: "ASC",
+    },
+    100,
+  );
+
+  if (detectorRecords.loading && detectorRecords.data === null) {
+    return <LoadingState label="Loading detector activation review" />;
+  }
+
+  return (
+    <PageFrame
+      subtitle="Detector activation posture is rendered only from reviewed AegisOps detector lifecycle records. Browser state, UI cache, source-native detector status, and Wazuh state cannot approve activation, disablement, rollback, or reconciliation."
+      title="Detector Activation Review"
+    >
+      {detectorRecords.error && detectorRecords.data === null ? (
+        <ErrorState error={detectorRecords.error} />
+      ) : (
+        <Stack spacing={2}>
+          <QueryStateNotice
+            error={detectorRecords.error}
+            refreshing={detectorRecords.refreshing}
+          />
+          <Alert severity="info" variant="outlined">
+            Reviewed owners, expected volume, false-positive review, disable
+            owner, rollback owner, next review, and overdue posture remain
+            read-only operator visibility until the backend authoritative record
+            chain is reread.
+          </Alert>
+          {detectorRecords.data && detectorRecords.data.length > 0 ? (
+            <Grid container spacing={2}>
+              {detectorRecords.data.map((record) => (
+                <Grid key={asString(record.detector_lifecycle_id)} size={{ xs: 12, lg: 6 }}>
+                  <DetectorLifecycleCard record={record} />
+                </Grid>
+              ))}
+            </Grid>
+          ) : (
+            <EmptyState message="No reviewed detector lifecycle records are available for activation review." />
+          )}
+        </Stack>
+      )}
+    </PageFrame>
+  );
+}

--- a/apps/operator-ui/src/app/operatorConsolePages/detectorActivationReviewPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/detectorActivationReviewPages.tsx
@@ -23,6 +23,12 @@ import {
   type UnknownRecord,
 } from "./shared";
 
+const DETECTOR_ACTIVATION_REVIEW_FILTER = {};
+const DETECTOR_ACTIVATION_REVIEW_SORT = {
+  field: "detector_identifier",
+  order: "ASC",
+} as const;
+
 function reasonForLifecycle(record: UnknownRecord) {
   const lifecycleState = asString(record.lifecycle_state);
   if (lifecycleState === "disabled") {
@@ -115,12 +121,9 @@ function DetectorLifecycleCard({ record }: { record: UnknownRecord }) {
 export function DetectorActivationReviewPage() {
   const detectorRecords = useOperatorList(
     "detectorActivationReview",
-    {},
-    {
-      field: "detector_identifier",
-      order: "ASC",
-    },
-    100,
+    DETECTOR_ACTIVATION_REVIEW_FILTER,
+    DETECTOR_ACTIVATION_REVIEW_SORT,
+    null,
   );
 
   if (detectorRecords.loading && detectorRecords.data === null) {

--- a/apps/operator-ui/src/app/operatorConsolePages/operatorQueries.ts
+++ b/apps/operator-ui/src/app/operatorConsolePages/operatorQueries.ts
@@ -18,7 +18,7 @@ export function useOperatorList(
   resource: string,
   filter: Record<string, unknown>,
   sort: { field: string; order: "ASC" | "DESC" },
-  perPage = 25,
+  perPage: number | null = 25,
 ): QueryState<UnknownRecord[]> {
   const dataProvider = useDataProvider();
   const key = useMemo(
@@ -29,10 +29,14 @@ export function useOperatorList(
     () => async () => {
       const result = await dataProvider.getList(resource, {
         filter,
-        pagination: {
-          page: 1,
-          perPage,
-        },
+        ...(perPage === null
+          ? {}
+          : {
+              pagination: {
+                page: 1,
+                perPage,
+              },
+            }),
         sort,
       });
 

--- a/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
+++ b/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
@@ -20,12 +20,9 @@ const DETECTOR_ACTIVATION_REVIEW_REQUIRED_FIELDS = [
   "source_catalog_entry",
   "detector_identifier",
   "expected_signal_posture",
-  "expected_volume",
-  "false_positive_review",
   "review_cadence",
   "rollback_owner",
   "disable_owner",
-  "next_review_at",
 ] as const;
 
 function comparePrimitiveValues(left: unknown, right: unknown): number {
@@ -290,7 +287,7 @@ function validateDetectorActivationReviewRecord(record: Record<string, unknown>)
     );
   }
 
-  if (record.stale_display_state !== false) {
+  if ("stale_display_state" in record && record.stale_display_state !== false) {
     throw new OperatorDataProviderContractError(
       "Resource detectorActivationReview rejects stale display state.",
     );

--- a/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
+++ b/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
@@ -227,8 +227,15 @@ function applyClientSideListSemantics(
       })
     : filteredRecords;
   const total = sortedRecords.length;
-  const page = Math.max(1, params.pagination?.page ?? 1);
-  const perPage = Math.max(1, params.pagination?.perPage ?? 25);
+  if (!params.pagination) {
+    return {
+      data: sortedRecords,
+      total,
+    };
+  }
+
+  const page = Math.max(1, params.pagination.page);
+  const perPage = Math.max(1, params.pagination.perPage);
   const start = (page - 1) * perPage;
 
   return {
@@ -248,8 +255,6 @@ function buildListUrl(
     );
   }
 
-  const page = params.pagination?.page ?? 1;
-  const perPage = params.pagination?.perPage ?? 25;
   const sortField = params.sort?.field ?? RESOURCE_BINDINGS[resource].idField;
   const sortOrder = params.sort?.order ?? "ASC";
 
@@ -257,8 +262,12 @@ function buildListUrl(
   appendQuery(url, {
     family: binding.recordFamily,
     order: sortOrder,
-    page: String(page),
-    per_page: String(perPage),
+    ...(params.pagination
+      ? {
+          page: String(params.pagination.page),
+          per_page: String(params.pagination.perPage),
+        }
+      : {}),
     sort: sortField,
   });
 

--- a/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
+++ b/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
@@ -4,6 +4,30 @@ import { RESOURCE_BINDINGS } from "./resourceBindings";
 import { appendQuery, asObject, asString, fetchJson, getRecordField, normalizeRecord } from "./shared";
 import type { OperatorRecordFamilyListResponse, StandardListReaderOptions, StandardOperatorResourceName } from "./types";
 
+const DETECTOR_LIFECYCLE_STATES = new Set([
+  "candidate",
+  "staging",
+  "active",
+  "disabled",
+  "rollback",
+  "review-overdue",
+]);
+
+const DETECTOR_ACTIVATION_REVIEW_REQUIRED_FIELDS = [
+  "detector_lifecycle_id",
+  "owner",
+  "source_family",
+  "source_catalog_entry",
+  "detector_identifier",
+  "expected_signal_posture",
+  "expected_volume",
+  "false_positive_review",
+  "review_cadence",
+  "rollback_owner",
+  "disable_owner",
+  "next_review_at",
+] as const;
+
 function comparePrimitiveValues(left: unknown, right: unknown): number {
   if (left === right) {
     return 0;
@@ -250,6 +274,62 @@ function buildListUrl(
   return `${url.pathname}${url.search}`;
 }
 
+function validateDetectorActivationReviewRecord(record: Record<string, unknown>) {
+  for (const field of DETECTOR_ACTIVATION_REVIEW_REQUIRED_FIELDS) {
+    if (asString(record[field]) === null) {
+      throw new OperatorDataProviderContractError(
+        `Resource detectorActivationReview record is missing reviewed field ${field}.`,
+      );
+    }
+  }
+
+  const lifecycleState = asString(record.lifecycle_state);
+  if (lifecycleState === null || !DETECTOR_LIFECYCLE_STATES.has(lifecycleState)) {
+    throw new OperatorDataProviderContractError(
+      "Resource detectorActivationReview record has unsupported lifecycle_state.",
+    );
+  }
+
+  if (record.stale_display_state !== false) {
+    throw new OperatorDataProviderContractError(
+      "Resource detectorActivationReview rejects stale display state.",
+    );
+  }
+
+  if (!Array.isArray(record.lifecycle_audit_references)) {
+    throw new OperatorDataProviderContractError(
+      "Resource detectorActivationReview requires lifecycle_audit_references.",
+    );
+  }
+  if (
+    record.lifecycle_audit_references.length === 0 ||
+    record.lifecycle_audit_references.some((reference) => asString(reference) === null)
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource detectorActivationReview requires non-empty reviewed audit references.",
+    );
+  }
+
+  if (lifecycleState === "disabled" && asString(record.disabled_reason) === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource detectorActivationReview disabled records require disabled_reason.",
+    );
+  }
+  if (lifecycleState === "rollback" && asString(record.rollback_reason) === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource detectorActivationReview rollback records require rollback_reason.",
+    );
+  }
+  if (
+    lifecycleState === "review-overdue" &&
+    asString(record.review_overdue_reason) === null
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource detectorActivationReview review-overdue records require review_overdue_reason.",
+    );
+  }
+}
+
 export async function getListForStandardResource({
   binding,
   fetchFn,
@@ -278,6 +358,9 @@ export async function getListForStandardResource({
     records = rawRecords.map((record) =>
       normalizeRecord(resource, record, binding.idField),
     );
+    if (resource === "detectorActivationReview") {
+      records.forEach(validateDetectorActivationReviewRecord);
+    }
     totalRecords =
       typeof response.total_records === "number"
         ? response.total_records

--- a/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
+++ b/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
@@ -29,6 +29,12 @@ export const RESOURCE_BINDINGS: Record<
     listSemantics: "client",
     recordFamily: "case",
   },
+  detectorActivationReview: {
+    idField: "detector_lifecycle_id",
+    listPath: "/inspect-records",
+    listSemantics: "client",
+    recordFamily: "detector_lifecycle",
+  },
   firstLoginChecklist: {
     idField: "step_key",
     listPath: "/inspect-first-login-checklist",

--- a/apps/operator-ui/src/operatorDataProvider/types.ts
+++ b/apps/operator-ui/src/operatorDataProvider/types.ts
@@ -6,6 +6,7 @@ export type OperatorResourceName =
   | "alerts"
   | "cases"
   | "firstLoginChecklist"
+  | "detectorActivationReview"
   | "runtimeReadiness"
   | "reconciliations"
   | "todayView"


### PR DESCRIPTION
## Summary

- Add a read-only Detector Activation Review route at `/operator/detectors` backed by reviewed `detector_lifecycle` records.
- Render owner, expected volume, false-positive review, disable/rollback owner, next review, overdue posture, audit references, and all Phase 61 lifecycle states.
- Add fail-closed UI validation for missing owner, malformed lifecycle state, stale display state, missing reviewed audit references, and missing required state reasons.

## Verification

- `npm test -- --run src/app/OperatorRoutes.test.tsx -t "detector activation review route"`
- `npm test -- --run src/app/OperatorRoutes.test.tsx`
- `npm run typecheck`
- `npm run build`
- `python3 -m unittest control-plane.tests.test_phase61_detector_lifecycle_record_contract`
- `bash scripts/test-verify-publishable-path-hygiene.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1288 --config <supervisor-config-path>`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1291 --config <supervisor-config-path>`

Closes #1291
Part of #1288